### PR TITLE
Fix emote copying

### DIFF
--- a/src/messages/layouts/MessageLayoutElement.cpp
+++ b/src/messages/layouts/MessageLayoutElement.cpp
@@ -81,12 +81,9 @@ void ImageLayoutElement::addCopyTextToString(QString &str, int from,
     const auto *emoteElement = dynamic_cast<EmoteElement *>(&this->getCreator());
     if (emoteElement) {
         str += emoteElement->getEmote()->getCopyString();
-    } else {
-        str += "not implemented";
-    }
-
-    if (this->hasTrailingSpace()) {
-        str += " ";
+        if (this->hasTrailingSpace()) {
+            str += " ";
+        }
     }
 }
 


### PR DESCRIPTION
now correctly copies emote names and leaves out badges' names