### PR TITLE
Changed Download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Chatterino 2
 Chatterino 2 is the second installment of the Twitch chat client series "Chatterino". For now you can check out Chatterino 1 at [https://chatterino.com](https://chatterino.com).
 
 ## Downloading
-You can download the Chatterino 2 Beta over [here](https://chatterino.com/download/Chatterino2BetaInstaller.exe)
+You can download the latest Chatterino 2 build over [here](https://github.com/Chatterino/chatterino2/releases/tag/nightly-build)
 
 You might also need to install the [VC++ 2017 Redistributable](https://aka.ms/vs/15/release/vc_redist.x64.exe) from Microsoft if you do not have it installed already.  
 If you still receive an error about `MSVCR120.dll missing`, then you should install the [VC++ 2013 Restributable](https://download.microsoft.com/download/2/E/6/2E61CFA4-993B-4DD4-91DA-3737CD5CD6E3/vcredist_x64.exe


### PR DESCRIPTION
I think we should change the download link from beta to nightly, since I feel that 90% of problems/questions people have with/about beta are answered with "download latest nightly" anyway.