### PR TITLE
overrides QTextEdit insert methods

### DIFF
--- a/src/widgets/helper/ResizingTextEdit.cpp
+++ b/src/widgets/helper/ResizingTextEdit.cpp
@@ -228,6 +228,27 @@ void ResizingTextEdit::insertCompletion(const QString &completion)
     this->setTextCursor(tc);
 }
 
+bool ResizingTextEdit::canInsertFromMimeData(const QMimeData *source) const
+{
+    if (source->hasImage())
+    {
+        return false;
+    }
+    else if (source->hasFormat("text/plain"))
+    {
+        return true;
+    }
+    return false;
+}
+
+void ResizingTextEdit::insertFromMimeData(const QMimeData *source)
+{
+    if (!source->hasImage())
+    {
+        insertPlainText(source->text());
+    }
+}
+
 QCompleter *ResizingTextEdit::getCompleter() const
 {
     return this->completer_;

--- a/src/widgets/helper/ResizingTextEdit.hpp
+++ b/src/widgets/helper/ResizingTextEdit.hpp
@@ -30,6 +30,9 @@ protected:
     void focusInEvent(QFocusEvent *event) override;
     void focusOutEvent(QFocusEvent *event) override;
 
+    bool canInsertFromMimeData(const QMimeData *source) const override;
+    void insertFromMimeData(const QMimeData *source) override;
+
 private:
     // hadSpace is set to true in case the "textUnderCursor" word was after a
     // space


### PR DESCRIPTION
fixes Chatterino#635
prepares for future implementation of Chatterino#79

Was a little bit hard to find the right combination for now. Pasting images from clipboard surpasses the check for dragging images in canInsertFromMimeData OMGScoots