### PR TITLE
(#1100) Clean TooltipPreviewImage on SplitHeader enterEvent

### DIFF
--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -10,6 +10,7 @@
 #include "singletons/Resources.hpp"
 #include "singletons/Settings.hpp"
 #include "singletons/Theme.hpp"
+#include "singletons/TooltipPreviewImage.hpp"
 #include "singletons/WindowManager.hpp"
 #include "util/LayoutCreator.hpp"
 #include "util/LayoutHelper.hpp"
@@ -599,6 +600,8 @@ void SplitHeader::enterEvent(QEvent *event)
 {
     if (!this->tooltipText_.isEmpty())
     {
+        TooltipPreviewImage::getInstance().setImage(nullptr);
+
         auto tooltip = TooltipWidget::getInstance();
         tooltip->moveTo(this, this->mapToGlobal(this->rect().bottomLeft()),
                         false);


### PR DESCRIPTION
Supa quick fix for #1100

Looks like this bug may come back in other places where we use `TooltipWidget`. For a permanent fix we have to go through all of the places that touch `TooltipWidget` and check if they clean the preview
image correctly.

It would be better to merge TooltipPreviewImage and TooltipWidget together and change `TooltipWidget::setText` to be

```c++
void TooltipWidget::setText(const QString &text, ImagePtr image = ptrnull);
```

But it's impossible right now, because TooltipWidget is located in appbase and `ImagePtr` is not visible there (it's located in the main chatterino repo). Plus we also need an access to `getApp()->windows->gifRepaintRequested`.

First step in implementing the permanent fix would be moving TooltipWidget to chatterino from appbase.

Any thoughts on the situation?