### PR TITLE
Make viewer list float

### DIFF
--- a/resources/contributors.txt
+++ b/resources/contributors.txt
@@ -25,12 +25,12 @@ nforro | https://github.com/nforro |  | Contributor
 vanolpfan | https://github.com/vanolpfan |  | Contributor
 23rd | https://github.com/23rd |  | Contributor
 machgo | https://github.com/machgo |  | Contributor
+TranRed | https://github.com/TranRed |  | Contributor
 Defman21 | https://github.com/Defman21 |  | Documentation
 Jarel1337 | https://github.com/Jarel1337 |  | Documentation
 Ian321 | https://github.com/Ian321 |  | Documentation
 Yardanico | https://github.com/Yardanico |  | Documentation
 huti26 | https://github.com/huti26 |  | Documentation
 chrisduerr | https://github.com/chrisduerr |  | Documentation
-TranRed | https://github.com/TranRed |  | Documentation
 
 # Add yourself right above this line

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -538,7 +538,7 @@ void Split::showViewerList()
     auto chattersList = new QListWidget();
     auto resultList = new QListWidget();
 
-    static QStringList labels = {"Broadcaster", "Vips",   "Moderators",
+    static QStringList labels = {"Broadcaster", "VIPs",   "Moderators",
                                  "Staff",       "Admins", "Global Moderators",
                                  "Viewers"};
     static QStringList jsonLabels = {"broadcaster", "vips",   "moderators",
@@ -631,7 +631,9 @@ void Split::showViewerList()
     multiWidget->setStyleSheet(this->theme->splits.input.styleSheet);
     multiWidget->setLayout(dockVbox);
     viewerDock->setWidget(multiWidget);
+    viewerDock->setFloating(true);
     viewerDock->show();
+    viewerDock->activateWindow();
 }
 
 void Split::copyToClipboard()


### PR DESCRIPTION
I realized, if you float the user list as a pop-up, it only looks half as horrible and people will be able to find the "close" button easier. 
This should be a little improvement until the actual refactoring happens.

default:
![grafik](https://user-images.githubusercontent.com/16636423/61181948-44d41680-a62d-11e9-8660-4629e1de05bf.png)

floated:
![grafik](https://user-images.githubusercontent.com/16636423/61181955-633a1200-a62d-11e9-9b58-aebdfb8d89fd.png)

It will open in the middle of your chatterino, like this:
(which I think is tolerable)
![grafik](https://user-images.githubusercontent.com/16636423/61181981-9d0b1880-a62d-11e9-8e81-b426719fd7e9.png)

