### PR TITLE
Added setting and functionality to highlight inline whispers

### DIFF
--- a/src/messages/Message.cpp
+++ b/src/messages/Message.cpp
@@ -21,7 +21,8 @@ Message::~Message()
 
 SBHighlight Message::getScrollBarHighlight() const
 {
-    if (this->flags.has(MessageFlag::Highlighted))
+    if (this->flags.has(MessageFlag::Highlighted) ||
+        this->flags.has(MessageFlag::HighlightedWhisper))
     {
         return SBHighlight(SBHighlight::Highlight);
     }

--- a/src/messages/Message.hpp
+++ b/src/messages/Message.hpp
@@ -30,7 +30,8 @@ enum class MessageFlag : uint32_t {
     DoNotLog = (1 << 13),
     AutoMod = (1 << 14),
     RecentMessage = (1 << 15),
-    Whisper = (1 << 16)
+    Whisper = (1 << 16),
+    HighlightedWhisper = (1 << 17),
 };
 using MessageFlags = FlagsEnum<MessageFlag>;
 

--- a/src/messages/layouts/MessageLayout.cpp
+++ b/src/messages/layouts/MessageLayout.cpp
@@ -250,7 +250,8 @@ void MessageLayout::updateBuffer(QPixmap *buffer, int /*messageIndex*/,
 
     // draw background
     QColor backgroundColor = app->themes->messages.backgrounds.regular;
-    if (this->message_->flags.has(MessageFlag::Highlighted) &&
+    if ((this->message_->flags.has(MessageFlag::Highlighted) ||
+         this->message_->flags.has(MessageFlag::HighlightedWhisper)) &&
         !this->flags.has(MessageLayoutFlag::IgnoreHighlights))
     {
         backgroundColor = app->themes->messages.backgrounds.highlighted;

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -184,6 +184,12 @@ MessagePtr TwitchMessageBuilder::build()
     // highlights
     this->parseHighlights(isPastMsg);
 
+    // highlighting incoming whispers if requested per setting
+    if (this->args.isReceivedWhisper && getSettings()->highlightInlineWhispers)
+    {
+        this->message().flags.set(MessageFlag::HighlightedWhisper, true);
+    }
+
     //    QString bits;
     auto iterator = this->tags.find("bits");
     if (iterator != this->tags.end())

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -160,6 +160,8 @@ public:
                                             false};
 
     BoolSetting inlineWhispers = {"/whispers/enableInlineWhispers", true};
+    BoolSetting highlightInlineWhispers = {"/whispers/highlightInlineWhispers",
+                                           false};
 
     /// Notifications
     BoolSetting notificationFlashTaskbar = {"/notifications/enableFlashTaskbar",

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -271,17 +271,19 @@ void GeneralPage::initLayout(SettingsLayout &layout)
     layout.addCheckbox("Double click links to open", s.linksDoubleClickOnly);
     layout.addCheckbox("Unshorten links", s.unshortLinks);
     layout.addCheckbox("Show live indicator in tabs", s.showTabLive);
-    layout.addDropdown<int>(
-        "Show emote preview in tooltip on hover",
-        {"Don't show", "Always show", "Hold shift"}, s.emotesTooltipPreview,
-        [](int index) { return index; }, [](auto args) { return args.index; },
-        false);
+    layout.addDropdown<int>("Show emote preview in tooltip on hover",
+                            {"Don't show", "Always show", "Hold shift"},
+                            s.emotesTooltipPreview,
+                            [](int index) { return index; },
+                            [](auto args) { return args.index; }, false);
 
     layout.addSpacing(16);
     layout.addSeperator();
 
     layout.addTitle2("Miscellaneous (Twitch)");
     layout.addCheckbox("Show twitch whispers inline", s.inlineWhispers);
+    layout.addCheckbox("Highlight received inline whispers",
+                       s.highlightInlineWhispers);
     layout.addCheckbox("Load message history on connect",
                        s.loadTwitchMessageHistoryOnConnect);
 


### PR DESCRIPTION
Inline whispers will be displayed with background color used for highlighting
Should fix #881 & #1068

New Flag was needed to differentiate between normal whisper (highlighted) and whisper with mention.

New Setting: (default value: off)
![grafik](https://user-images.githubusercontent.com/16636423/61185120-bde76400-a655-11e9-8e9c-45b3df30bde8.png)

New behaviour: (first whisper: off; second: on; third: whisper with mention)
![grafik](https://user-images.githubusercontent.com/16636423/61185167-35b58e80-a656-11e9-94c8-43c37343b4b7.png)

![grafik](https://user-images.githubusercontent.com/16636423/61185152-1dde0a80-a656-11e9-8ffc-8ffe3649d388.png)

