### PR TITLE
Added Subscribe option to split menu

### DIFF
--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -636,6 +636,16 @@ void Split::showViewerList()
     viewerDock->activateWindow();
 }
 
+void Split::openSubPage()
+{
+    ChannelPtr channel = this->getChannel();
+
+    if (auto twitchChannel = dynamic_cast<TwitchChannel *>(channel.get()))
+    {
+        QDesktopServices::openUrl(twitchChannel->subscriptionUrl());
+    }
+}
+
 void Split::copyToClipboard()
 {
     QApplication::clipboard()->setText(this->view_->getSelectedText());

--- a/src/widgets/splits/Split.hpp
+++ b/src/widgets/splits/Split.hpp
@@ -129,6 +129,7 @@ public slots:
     void copyToClipboard();
     void showSearch();
     void showViewerList();
+    void openSubPage();
     void reloadChannelAndSubscriberEmotes();
 };
 

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -284,8 +284,11 @@ std::unique_ptr<QMenu> SplitHeader::createMainMenu()
 
     // sub menu
     auto moreMenu = new QMenu("More", this);
+
     moreMenu->addAction("Show viewer list", this->split_,
                         &Split::showViewerList);
+
+    moreMenu->addAction("Subscribe", this->split_, &Split::openSubPage);
 
     auto action = new QAction(this);
     action->setText("Notify when live");


### PR DESCRIPTION
Added the option to visit the subscription page of a channel from chatterino. 

Non affiliate & non partner link will automatically redirect to the channel page for now. I don't know if and how we should prevent this. As far as I can tell from [here](https://dev.twitch.tv/docs/v5/reference/channels/) the channel type ("affiliate", "partner" or "") can only be accessed via oauth token.

New menu entry:
![grafik](https://user-images.githubusercontent.com/16636423/61325512-35172680-a815-11e9-939a-4ad3a1123ad0.png)

Will open following page:
![grafik](https://user-images.githubusercontent.com/16636423/61325608-6d1e6980-a815-11e9-9b15-8ef2ff46cca9.png)
