### PR TITLE
👷 Manage OpenSSL libs with conan

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.0.{build}
+version: "{build}"
 branches:
   only:
   - master
@@ -16,31 +16,23 @@ install:
     set PATH=%PATH%;%QTDIR%\bin
 
     call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
+
+    pip install conan -q
 build_script:
 - cmd: >-
-    curl -fsS -o openssl.7z https://pajlada.se/files/openssl.7z
-
-    7z x openssl.7z
-
     dir
 
     mkdir build
 
     cd build
 
-    qmake ../chatterino.pro BOOST_DIRECTORY="C:\Libraries\boost_1_64_0" BOOST_LIB_SUFFIX="lib64-msvc-14.1" OPENSSL_DIRECTORY="%APPVEYOR_BUILD_FOLDER%\openssl"  DEFINES+="CHATTERINO_NIGHTLY_VERSION_STRING=\\\"$$system(git describe --always)-$$system(git rev-list master --count)\\\""
+    conan install ..
+
+    qmake ../chatterino.pro BOOST_DIRECTORY="C:\Libraries\boost_1_64_0" BOOST_LIB_SUFFIX="lib64-msvc-14.1" DEFINES+="CHATTERINO_NIGHTLY_VERSION_STRING=\\\"$$system(git describe --always)-$$system(git rev-list master --count)\\\""
 
     set cl=/MP
 
     nmake /S /NOLOGO
-
-    git clone https://github.com/pajlada/chatterino2-dlls.git
-
-    mkdir Chatterino2
-
-    cp ../openssl/bin/libcrypto*.dll ../openssl/bin/libssl*.dll Chatterino2/
-
-    cp chatterino2-dlls/*.dll Chatterino2/
 
     windeployqt release/chatterino.exe --release --no-compiler-runtime --no-translations --no-opengl-sw --dir Chatterino2/
 

--- a/chatterino.pro
+++ b/chatterino.pro
@@ -38,8 +38,17 @@ include(lib/humanize.pri)
 DEFINES += IRC_NAMESPACE=Communi
 include(lib/libcommuni.pri)
 include(lib/websocketpp.pri)
-include(lib/openssl.pri)
 include(lib/wintoast.pri)
+
+exists( $$OUT_PWD/conanbuildinfo.pri ) {
+    message("Using conan packages")
+    CONFIG += conan_basic_setup
+    include($$OUT_PWD/conanbuildinfo.pri)
+    LIBS += -lGdi32
+}
+else{
+    include(lib/openssl.pri)
+}
 
 # Optional feature: QtWebEngine
 #exists ($(QTDIR)/include/QtWebEngine/QtWebEngine) {

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,0 +1,11 @@
+[requires]
+OpenSSL/1.0.2o@conan/stable
+
+[generators]
+qmake
+
+[options]
+OpenSSL:shared=True
+
+[imports]
+bin, *.dll -> ./Chatterino2 @ keep_path=False


### PR DESCRIPTION
Appveyor will now use Conan to install the OpenSSL library
To update the OpenSSL lib, replace the version number in `conanfile.txt` to a version available here: https://bintray.com/conan-community/conan/OpenSSL%3Aconan