### PR TITLE
Improved dmg creation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,21 @@ addons:
     - rapidjson
     - qt
     - p7zip
-    
+    - create-dmg
+
 compiler: clang
 
 script:
   - mkdir build && cd build
   - /usr/local/opt/qt/bin/qmake .. && make -j8
-  - /usr/local/opt/qt/bin/macdeployqt chatterino.app -dmg
-  - mv chatterino.dmg chatterino-osx.dmg
+  - mkdir app
+  - mv chatterino.app app/
+  - "create-dmg \
+    --volname Chatterino2 \
+    --volicon ../resources/chatterino.icns \
+    --icon-size 50 \
+    --app-drop-link 0 0 \
+    chatterino-osx.dmg app/"
 
 before_deploy:
   - git config --global user.email "builds@travis-ci.com"


### PR DESCRIPTION
The current dmg is inconvenient for updates of Chatterino. =(
So I changed the way of dmg file creation ([create-dmg](https://github.com/andreyvit/create-dmg)) and added `/Applications` symlink.
Also this PR adds icon for Chatterino volume.

Before and after patch.
![image](https://user-images.githubusercontent.com/4051126/62409895-a06b4180-b5e6-11e9-9cc2-7820c971fc3e.png)

![image](https://user-images.githubusercontent.com/4051126/62409951-8f6f0000-b5e7-11e9-8de8-2fb8cedce71b.png)
