### PR TITLE
Added new submenu in menu bar for OS X to switch tabs with hotkeys.

### DIFF
--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -346,12 +346,25 @@ void Window::addMenuBar()
     QMenuBar *mainMenu = new QMenuBar();
     mainMenu->setNativeMenuBar(true);
 
-    QMenu *menu = new QMenu(QString());
-    mainMenu->addMenu(menu);
+    // First menu.
+    QMenu *menu = mainMenu->addMenu(QString());
     QAction *prefs = menu->addAction(QString());
     prefs->setMenuRole(QAction::PreferencesRole);
     connect(prefs, &QAction::triggered, this,
             [] { SettingsDialog::showDialog(); });
+
+    // Window menu.
+    QMenu *windowMenu = mainMenu->addMenu(QString("Window"));
+
+    QAction *nextTab = windowMenu->addAction(QString("Select next tab"));
+    nextTab->setShortcuts({QKeySequence("Meta+Tab")});
+    connect(nextTab, &QAction::triggered, this,
+            [=] { this->notebook_->selectNextTab(); });
+
+    QAction *prevTab = windowMenu->addAction(QString("Select previous tab"));
+    prevTab->setShortcuts({QKeySequence("Meta+Shift+Tab")});
+    connect(prevTab, &QAction::triggered, this,
+            [=] { this->notebook_->selectPreviousTab(); });
 }
 
 #define UGLYMACROHACK1(s) #s


### PR DESCRIPTION
Unfortunately, Qt still has a [bug](https://bugreports.qt.io/browse/QTBUG-8596), so to solve [this](https://github.com/Chatterino/chatterino2/issues/1176) issue we need to add the shortcuted actions to the QMenuBar. This will cause the hotkeys to be repaired.

![image](https://user-images.githubusercontent.com/4051126/62424292-9d9b4a00-b6d5-11e9-8c9f-ef5798897771.png)
