### PR TITLE
Moved to one place and simplified hotkeys of switching tabs.

### DIFF
--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -34,14 +34,6 @@ Notebook::Notebook(QWidget *parent)
     this->addButton_->setIcon(NotebookButton::Icon::Plus);
 
     this->addButton_->setHidden(true);
-
-    auto *shortcut_next = new QShortcut(QKeySequence("Ctrl+Tab"), this);
-    QObject::connect(shortcut_next, &QShortcut::activated,
-                     [this] { this->selectNextTab(); });
-
-    auto *shortcut_prev = new QShortcut(QKeySequence("Ctrl+Shift+Tab"), this);
-    QObject::connect(shortcut_prev, &QShortcut::activated,
-                     [this] { this->selectPreviousTab(); });
 }
 
 NotebookTab *Notebook::addPage(QWidget *page, QString title, bool select)

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -289,6 +289,11 @@ void Window::addShortcuts()
     createWindowShortcut(this, "CTRL+9",
                          [this] { this->notebook_->selectIndex(8); });
 
+    createWindowShortcut(this, "CTRL+TAB",
+                         [this] { this->notebook_->selectNextTab(); });
+    createWindowShortcut(this, "CTRL+SHIFT+TAB",
+                         [this] { this->notebook_->selectPreviousTab(); });
+
     // Zoom in
     {
         auto s = new QShortcut(QKeySequence::ZoomIn, this);

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -400,32 +400,6 @@ void SplitInput::installKeyPressedEvent()
                 }
             }
         }
-        else if (event->key() == Qt::Key_Tab)
-        {
-            if (event->modifiers() == Qt::ControlModifier)
-            {
-                SplitContainer *page =
-                    static_cast<SplitContainer *>(this->split_->parentWidget());
-
-                Notebook *notebook =
-                    static_cast<Notebook *>(page->parentWidget());
-
-                notebook->selectNextTab();
-            }
-        }
-        else if (event->key() == Qt::Key_Backtab)
-        {
-            if (event->modifiers() == (Qt::ControlModifier | Qt::ShiftModifier))
-            {
-                SplitContainer *page =
-                    static_cast<SplitContainer *>(this->split_->parentWidget());
-
-                Notebook *notebook =
-                    static_cast<Notebook *>(page->parentWidget());
-
-                notebook->selectPreviousTab();
-            }
-        }
         else if (event->key() == Qt::Key_C &&
                  event->modifiers() == Qt::ControlModifier)
         {


### PR DESCRIPTION
Currently, the tab switching hotkeys are in two places –– in `Notebook.cpp` (for empty tabs) and in `SplitInput.cpp` (with double casting =( ).
I don't see any reason to have such a complicated implementation of the switching tabs, so I moved the `Ctrl(+Shift)+Tab` hotkeys to one place next to the other tab hotkeys.