### PR TITLE
Added ability to open last tab with Ctrl+9.

### DIFF
--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -256,6 +256,17 @@ void Notebook::selectPreviousTab()
     this->select(this->items_[index].page);
 }
 
+void Notebook::selectLastTab()
+{
+    const auto size = this->items_.size();
+    if (size <= 1)
+    {
+        return;
+    }
+
+    this->select(this->items_[size - 1].page);
+}
+
 int Notebook::getPageCount() const
 {
     return this->items_.count();

--- a/src/widgets/Notebook.hpp
+++ b/src/widgets/Notebook.hpp
@@ -34,6 +34,7 @@ public:
     void selectIndex(int index);
     void selectNextTab();
     void selectPreviousTab();
+    void selectLastTab();
 
     int getPageCount() const;
     QWidget *getPageAt(int index) const;

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -287,7 +287,7 @@ void Window::addShortcuts()
     createWindowShortcut(this, "CTRL+8",
                          [this] { this->notebook_->selectIndex(7); });
     createWindowShortcut(this, "CTRL+9",
-                         [this] { this->notebook_->selectIndex(8); });
+                         [this] { this->notebook_->selectLastTab(); });
 
     // Zoom in
     {

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -270,22 +270,15 @@ void Window::addShortcuts()
         this->notebook_->getOrAddSelectedPage()->appendNewSplit(true);
     });
 
-    createWindowShortcut(this, "CTRL+1",
-                         [this] { this->notebook_->selectIndex(0); });
-    createWindowShortcut(this, "CTRL+2",
-                         [this] { this->notebook_->selectIndex(1); });
-    createWindowShortcut(this, "CTRL+3",
-                         [this] { this->notebook_->selectIndex(2); });
-    createWindowShortcut(this, "CTRL+4",
-                         [this] { this->notebook_->selectIndex(3); });
-    createWindowShortcut(this, "CTRL+5",
-                         [this] { this->notebook_->selectIndex(4); });
-    createWindowShortcut(this, "CTRL+6",
-                         [this] { this->notebook_->selectIndex(5); });
-    createWindowShortcut(this, "CTRL+7",
-                         [this] { this->notebook_->selectIndex(6); });
-    createWindowShortcut(this, "CTRL+8",
-                         [this] { this->notebook_->selectIndex(7); });
+    // CTRL + 1-8 to open corresponding tab.
+    for (auto i = 0; i < 8; i++)
+    {
+        char hotkey[7];
+        std::sprintf(hotkey, "CTRL+%d", i + 1);
+        const auto openTab = [this, i] { this->notebook_->selectIndex(i); };
+        createWindowShortcut(this, hotkey, openTab);
+    }
+
     createWindowShortcut(this, "CTRL+9",
                          [this] { this->notebook_->selectLastTab(); });
 


### PR DESCRIPTION
This simple PR brings a Chromium browser behavior pattern that allows us to open the last tab with `Ctrl + 9`.

UPD.
I added another commit to avoid a possible conflict from a new PR.
The second commit replaces the repetitive code of Ctrl+1-8 hotkeys with a single loop. 