### PR TITLE
Added setting to colorize usernames who have not set own color.

### DIFF
--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -42,6 +42,8 @@ public:
     BoolSetting hideModerated = {"/appearance/messages/hideModerated", false};
     BoolSetting hideModerationActions = {
         "/appearance/messages/hideModerationActions", false};
+    BoolSetting colorizeNicknames = {
+        "/appearance/messages/colorizeNicknames", false};
 
     //    BoolSetting collapseLongMessages =
     //    {"/appearance/messages/collapseLongMessages", false};

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -217,6 +217,7 @@ void GeneralPage::initLayout(SettingsLayout &layout)
     // layout.addDropdown("Last read message style", {"Default"});
     layout.addCheckbox("Hide moderated messages", s.hideModerated);
     layout.addCheckbox("Hide moderation messages", s.hideModerationActions);
+    layout.addCheckbox("Colorize gray nicknames", s.colorizeNicknames);
     layout.addDropdown<int>(
         "Timeout stacking style", {"Stack", "Stack sparingly"},
         s.timeoutStackStyle, [](int index) { return index; },


### PR DESCRIPTION
This PR adds a new setting to colorize usernames who have not set own color like Twitch does.
It is not always convenient to communicate with gray users. =(
Different colors can help you find the right user faster.

To implement this feature I created a new singleton `UsernameColors` class  that stores the colors of all gray users in the `std::map<int, QColor>`.
I'm not quite sure about the implementation, so I need your opinion.

By the way, as far as I could test, a `if (iterator != this->tags.end())` condition never becomes false and a `iterator.value().toString()` just returns an empty string.