### PR TITLE
🐛 Fixed Travis build tagging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,12 @@ matrix:
         - ./linuxdeployqt-6-x86_64.AppImage ./resources/chatterino.desktop -no-translations -unsupported-allow-new-glibc -appimage -qmake=/opt/qt512/bin/qmake
         - mv Chatterino-*-x86_64.AppImage Chatterino-x86_64.AppImage
 
+      before_deploy:
+        - git config --global user.email "builds@travis-ci.com"
+        - git config --global user.name "Travis CI"
+        - export GIT_TAG=nightly-build
+        - git tag $GIT_TAG -f
+
       deploy:
        skip_cleanup:  true
        provider:      releases
@@ -57,6 +63,12 @@ matrix:
           --icon-size 50 \
           --app-drop-link 0 0 \
           chatterino-osx.dmg app/"
+
+      before_deploy:
+        - git config --global user.email "builds@travis-ci.com"
+        - git config --global user.name "Travis CI"
+        - export GIT_TAG=nightly-build
+        - git tag $GIT_TAG -f
 
       deploy:
         skip_cleanup: true


### PR DESCRIPTION
Accidentally removed the before_deploy step from Travis 