### PR TITLE
Added build date in Chatterino title for all platforms of CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,8 @@ matrix:
         - sh ./.CI/InstallQTStylePlugins.sh
 
       script:
-        - /opt/qt512/bin/qmake CONFIG+=release PREFIX=/usr
+        - dateOfBuild="CHATTERINO_NIGHTLY_VERSION_STRING=\"\\\"$(date +%d.%m.%Y)\\\"\""
+        - /opt/qt512/bin/qmake CONFIG+=release PREFIX=/usr DEFINES+=$dateOfBuild
         - make -j$(nproc)
 
       before_deploy:
@@ -62,7 +63,8 @@ matrix:
 
       script:
         - mkdir build && cd build
-        - /usr/local/opt/qt/bin/qmake .. && make -j8
+        - dateOfBuild="CHATTERINO_NIGHTLY_VERSION_STRING=\"\\\"$(date +%d.%m.%Y)\\\"\""
+        - /usr/local/opt/qt/bin/qmake .. DEFINES+=$dateOfBuild && make -j8
         - mkdir app
         - mv chatterino.app app/
         - "create-dmg \

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,9 @@ build_script:
 
     conan install ..
 
-    qmake ../chatterino.pro DEFINES+="CHATTERINO_NIGHTLY_VERSION_STRING=\\\"$$system(git describe --always)-$$system(git rev-list master --count)\\\""
+    set dateOfBuild=%date:~7,2%.%date:~4,2%.%date:~10,4%
+
+    qmake ../chatterino.pro DEFINES+="CHATTERINO_NIGHTLY_VERSION_STRING=\\\"'$s%dateOfBuild% '$$system(git describe --always)-$$system(git rev-list master --count)\\\""
 
     set cl=/MP
 


### PR DESCRIPTION
This PR adds a build date in the title for CI builds.
I think it's much clearer for users to see how old their version is.
I didn't test it on Linux, but I believe `date +%d.%m.%Y` will work in the same way on Linux.

Windows.
![image](https://user-images.githubusercontent.com/4051126/62852663-b4075e00-bcf2-11e9-98c5-97dfa75bc2b6.png)
OS X.
![image](https://user-images.githubusercontent.com/4051126/62852680-c71a2e00-bcf2-11e9-9e6a-79b8c9d4a069.png)
