### PR TITLE
Fixed dmg Travis deployment.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,13 +65,16 @@ matrix:
         - mkdir build && cd build
         - dateOfBuild="CHATTERINO_NIGHTLY_VERSION_STRING=\"\\\"$(date +%d.%m.%Y)\\\"\""
         - /usr/local/opt/qt/bin/qmake .. DEFINES+=$dateOfBuild && make -j8
+        - /usr/local/opt/qt/bin/macdeployqt chatterino.app -dmg
         - mkdir app
-        - mv chatterino.app app/
+        - hdiutil attach chatterino.dmg
+        - cp -r /Volumes/chatterino/chatterino.app app/
         - "create-dmg \
           --volname Chatterino2 \
           --volicon ../resources/chatterino.icns \
           --icon-size 50 \
           --app-drop-link 0 0 \
+          --format UDBZ \
           chatterino-osx.dmg app/"
 
       before_deploy:


### PR DESCRIPTION
I accidentally found that [one](https://github.com/Chatterino/chatterino2/pull/1172) of my previous commits broke the dmg creation, sorry. =(
At the moment a size of the dmg file is 3.4 MB, so the app does not contain Qt dependencies. And it works if the user updates the previous version, but a clean install does not work.
So, we have to use the `macdeployqt` again.
This PR fixes the mac deployment in some tricky way — we call `macdeployqt` to create the dmg file with dependencies and after this we call `create-dmg` to create the final user-friendly dmg.
It may seem that this is an overhead deployment, but I think it's not a big problem while we use the CI. 