### PR TITLE
Fix Settings UI inconsistencies

### DIFF
--- a/src/widgets/dialogs/SettingsDialog.cpp
+++ b/src/widgets/dialogs/SettingsDialog.cpp
@@ -54,7 +54,7 @@ void SettingsDialog::initUi()
         .withoutMargin()
         .assign(&this->ui_.tabContainer);
 
-    this->ui_.tabContainerContainer->layout()->setContentsMargins(8, 8, 0, 8);
+    this->ui_.tabContainerContainer->layout()->setContentsMargins(8, 8, 0, 39);
 
     this->layout()->setSpacing(0);
 
@@ -129,6 +129,7 @@ void SettingsDialog::addTabs()
 
     this->ui_.tabContainer->addStretch(1);
     this->addTab(new AboutPage, Qt::AlignBottom);
+    this->ui_.tabContainer->addSpacing(16);
 }
 
 void SettingsDialog::addTab(SettingsPage *page, Qt::Alignment alignment)

--- a/src/widgets/dialogs/SettingsDialog.cpp
+++ b/src/widgets/dialogs/SettingsDialog.cpp
@@ -38,7 +38,7 @@ SettingsDialog::SettingsDialog()
     this->overrideBackgroundColor_ = QColor("#111111");
     this->themeChangedEvent();
 
-    this->resize(766, 600);
+    this->resize(815, 600);
 }
 
 void SettingsDialog::initUi()

--- a/src/widgets/settingspages/AboutPage.cpp
+++ b/src/widgets/settingspages/AboutPage.cpp
@@ -205,10 +205,8 @@ void AboutPage::addLicense(QFormLayout *form, const QString &name,
 {
     auto *a = new QLabel("<a href=\"" + website + "\">" + name + "</a>");
     a->setOpenExternalLinks(true);
-    auto *b = new SignalLabel();
-    b->setText("<a href=\"" + licenseLink + "\">show license</a>");
-    b->setCursor(Qt::PointingHandCursor);
-    QObject::connect(b, &SignalLabel::mouseUp, [licenseLink] {
+    auto *b = new QLabel("<a href=\"" + licenseLink + "\">show license</a>");
+    QObject::connect(b, &QLabel::linkActivated, [licenseLink] {
         auto *edit = new QTextEdit;
 
         QFile file(licenseLink);


### PR DESCRIPTION
Hi! A while ago I saw streamer @rexim contributed to this project. I like the idea and although I'm not a C++ developer I wanted to contribute to chatterino as well. My changes are small and related to UI.

- Move "About" tab to make vertical margins consistent
- Increase settings window width to prevent creating horizontal scroll (It is caused by last line in "Attributions" group)
- Fix "show license" link width by using QLabel instead of custom SignalLabel (I couldn't find what's issue in SignalLabel)