### PR TITLE
Make Emote Tab Completion Search for Substrings

### DIFF
--- a/src/common/CompletionModel.cpp
+++ b/src/common/CompletionModel.cpp
@@ -85,7 +85,7 @@ void CompletionModel::refresh(const QString &prefix)
         return;
 
     auto addString = [&](const QString &str, TaggedString::Type type) {
-        if (str.startsWith(prefix, Qt::CaseInsensitive))
+        if (str.contains(prefix, Qt::CaseInsensitive))
             this->items_.emplace(str + " ", type);
     };
 

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -99,6 +99,7 @@ public:
         "/behaviour/autocompletion/onlyFetchChattersForSmallerStreamers", true};
     IntSetting smallStreamerLimit = {
         "/behaviour/autocompletion/smallStreamerLimit", 1000};
+    BoolSetting prefixOnlyEmoteCompletion = {"/behaviour/autocompletion/prefixOnlyCompletion", true};
 
     BoolSetting pauseChatOnHover = {"/behaviour/pauseChatHover", false};
     BoolSetting autorun = {"/behaviour/autorun", false};

--- a/src/widgets/helper/ResizingTextEdit.cpp
+++ b/src/widgets/helper/ResizingTextEdit.cpp
@@ -1,6 +1,7 @@
 #include "widgets/helper/ResizingTextEdit.hpp"
 #include "common/Common.hpp"
 #include "common/CompletionModel.hpp"
+#include "singletons/Settings.hpp"
 
 namespace chatterino {
 
@@ -198,7 +199,16 @@ void ResizingTextEdit::setCompleter(QCompleter *c)
     this->completer_->setWidget(this);
     this->completer_->setCompletionMode(QCompleter::InlineCompletion);
     this->completer_->setCaseSensitivity(Qt::CaseInsensitive);
-    this->completer_->setFilterMode(Qt::MatchContains);
+
+    if (getSettings()->prefixOnlyEmoteCompletion)
+    {
+        this->completer_->setFilterMode(Qt::MatchStartsWith);
+    }
+    else
+    {
+        this->completer_->setFilterMode(Qt::MatchContains);
+    }
+
     QObject::connect(completer_,
                      static_cast<void (QCompleter::*)(const QString &)>(
                          &QCompleter::highlighted),

--- a/src/widgets/helper/ResizingTextEdit.cpp
+++ b/src/widgets/helper/ResizingTextEdit.cpp
@@ -198,6 +198,7 @@ void ResizingTextEdit::setCompleter(QCompleter *c)
     this->completer_->setWidget(this);
     this->completer_->setCompletionMode(QCompleter::InlineCompletion);
     this->completer_->setCaseSensitivity(Qt::CaseInsensitive);
+    this->completer_->setFilterMode(Qt::MatchContains);
     QObject::connect(completer_,
                      static_cast<void (QCompleter::*)(const QString &)>(
                          &QCompleter::highlighted),

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -20,6 +20,7 @@
     "https://addons.mozilla.org/en-US/firefox/addon/chatterino-native-host/"
 
 namespace chatterino {
+
 TitleLabel *SettingsLayout::addTitle(const QString &title)
 {
     auto label = new TitleLabel(title + ":");
@@ -282,7 +283,7 @@ void GeneralPage::initLayout(SettingsLayout &layout)
         {"Don't show", "Always show", "Hold shift"}, s.emotesTooltipPreview,
         [](int index) { return index; }, [](auto args) { return args.index; },
         false);
-    layout.addCheckbox("Only complete emote prefixes to their full names",
+    layout.addCheckbox("Only search for emote autocompletion at the start of emote names",
                        s.prefixOnlyEmoteCompletion);
 
     layout.addSpacing(16);

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -20,7 +20,6 @@
     "https://addons.mozilla.org/en-US/firefox/addon/chatterino-native-host/"
 
 namespace chatterino {
-
 TitleLabel *SettingsLayout::addTitle(const QString &title)
 {
     auto label = new TitleLabel(title + ":");
@@ -283,6 +282,8 @@ void GeneralPage::initLayout(SettingsLayout &layout)
         {"Don't show", "Always show", "Hold shift"}, s.emotesTooltipPreview,
         [](int index) { return index; }, [](auto args) { return args.index; },
         false);
+    layout.addCheckbox("Only complete emote prefixes to their full names",
+                       s.prefixOnlyEmoteCompletion);
 
     layout.addSpacing(16);
     layout.addSeperator();


### PR DESCRIPTION
### Description

At the moment, tab completion only considers emotes that start with the same prefix that is currently under the cursor.  This PR makes tab completion look for the current prefix at any position in emote names. This functionality has been requested in https://github.com/Chatterino/chatterino2/issues/591#issuecomment-431911018 and I certainly find it useful.

Note that this does not change the way username completion works. In order to complete a username, you will still have to type the actual start of the username. (**lada** would not complete to **pajlada**, for example.) 
I would prefer to keep it that way as user names generally don't really follow a pattern like emote names often do. (Like dance emotes often ending on "Pls".)

### Changes

Only minimal changes were required since Qt provides us with all necessary functionality already.
We change the check in the `addString` lambda from `QString::startsWith` to [`QString::contains`](https://doc.qt.io/qt-5/qstring.html#contains).

We also need to update the `filterMode` from `Qt::MatchStartWith` (the default value) to [`Qt::MatchContains`](https://doc.qt.io/qt-5/qt.html#MatchFlag-enum). This is done with [`QCompleter::setFilterMode`](https://doc.qt.io/qt-5/qcompleter.html#filterMode-prop).

### Examples

- In forsen's channel, tabbing on **pls** will cycle through **DonaldPls**, **forsenPls**, **GachiPls**, **nyanPls** and **SourPls**.

- As a forsen subscriber, tabbing on **sen1** will complete to **forsen1**.

- As a pajlada subscriber, tabbing on **shrug** will cycle through **pajaShrugL** and **pajaShrugR**. (Unless you are in a channel with more **shrug** emotes, of course.)

### Note

Please let me know your thoughts on this one, I would gladly appreciate any feedback.

~~Since this is my first time contributing, I am not sure whether this is the right branch to merge with. It looks to me like `master` should be merged back into `nightly` before accepting this PR?~~