### PR TITLE
Remove unused variable

### DIFF
--- a/lib/appbase/BaseTheme.cpp
+++ b/lib/appbase/BaseTheme.cpp
@@ -62,7 +62,6 @@ void AB_THEME_CLASS::actuallyUpdate(double hue, double multiplier)
 
     /// WINDOW
     {
-        QColor bg =
 #ifdef Q_OS_LINUX
             this->window.background = lightWin ? "#fff" : QColor(61, 60, 56);
 #else


### PR DESCRIPTION
Fixes the following compiler warning:
```
../lib/appbase/BaseTheme.cpp: In member function ‘virtual void chatterino::BaseTheme::actuallyUpdate(double, double)’:
../lib/appbase/BaseTheme.cpp:65:16: warning: variable ‘bg’ set but not used [-Wunused-but-set-variable]
   65 |         QColor bg =
      |                ^~
```
Test compile with GCC 9 succeeded