### PR TITLE
Fix "Manage Accounts" button

### DIFF
--- a/src/widgets/AccountSwitchPopupWidget.cpp
+++ b/src/widgets/AccountSwitchPopupWidget.cpp
@@ -30,6 +30,7 @@ AccountSwitchPopupWidget::AccountSwitchPopupWidget(QWidget *parent)
     auto hbox = new QHBoxLayout();
     auto manageAccountsButton = new QPushButton(this);
     manageAccountsButton->setText("Manage Accounts");
+    manageAccountsButton->setFocusPolicy(Qt::NoFocus);
     hbox->addWidget(manageAccountsButton);
     vbox->addLayout(hbox);
 


### PR DESCRIPTION
This commit fixes the unresponsiveness of the "Manage Account" button (described in #1188).

Apparently, focus was lost when pressing down the mouse button. This is circumvented by setting the focus policy of the button to `Qt::NoFocus`.
The button then works as expected and opens the "Accounts" page in the preferences.