### PR TITLE
manually send req, this ensures we send it before JOIN

### DIFF
--- a/src/providers/irc/AbstractIrcServer.cpp
+++ b/src/providers/irc/AbstractIrcServer.cpp
@@ -36,9 +36,9 @@ AbstractIrcServer::AbstractIrcServer()
     QObject::connect(this->readConnection_.get(),
                      &Communi::IrcConnection::privateMessageReceived,
                      [this](auto msg) { this->privateMessageReceived(msg); });
-    QObject::connect(this->readConnection_.get(),
-                     &Communi::IrcConnection::connected,
-                     [this] { this->onConnected(); });
+    QObject::connect(
+        this->readConnection_.get(), &Communi::IrcConnection::connected,
+        [this] { this->onConnected(this->readConnection_.get()); });
     QObject::connect(this->readConnection_.get(),
                      &Communi::IrcConnection::disconnected,
                      [this] { this->onDisconnected(); });
@@ -227,7 +227,7 @@ std::shared_ptr<Channel> AbstractIrcServer::getChannelOrEmpty(
     return Channel::getEmpty();
 }
 
-void AbstractIrcServer::onConnected()
+void AbstractIrcServer::onConnected(IrcConnection *connection)
 {
     std::lock_guard<std::mutex> lock(this->channelMutex);
 

--- a/src/providers/irc/AbstractIrcServer.hpp
+++ b/src/providers/irc/AbstractIrcServer.hpp
@@ -52,7 +52,7 @@ protected:
     virtual void messageReceived(Communi::IrcMessage *message);
     virtual void writeConnectionMessageReceived(Communi::IrcMessage *message);
 
-    virtual void onConnected();
+    virtual void onConnected(IrcConnection *connection);
     virtual void onDisconnected();
     virtual void onSocketError();
 

--- a/src/providers/twitch/TwitchServer.cpp
+++ b/src/providers/twitch/TwitchServer.cpp
@@ -90,13 +90,6 @@ void TwitchServer::initializeConnection(IrcConnection *connection, bool isRead,
         connection->setPassword(oauthToken);
     }
 
-    connection->sendCommand(
-        Communi::IrcCommand::createCapability("REQ", "twitch.tv/membership"));
-    connection->sendCommand(
-        Communi::IrcCommand::createCapability("REQ", "twitch.tv/commands"));
-    connection->sendCommand(
-        Communi::IrcCommand::createCapability("REQ", "twitch.tv/tags"));
-
     connection->setSecure(true);
 
     // https://dev.twitch.tv/docs/irc/guide/#connecting-to-twitch-irc
@@ -204,6 +197,13 @@ void TwitchServer::writeConnectionMessageReceived(Communi::IrcMessage *message)
 
         default:;
     }
+}
+
+void TwitchServer::onConnected(IrcConnection *connection)
+{
+    // connection in thise case is the read connection
+    connection->sendRaw(
+        "CAP REQ :twitch.tv/tags twitch.tv/commands twitch.tv/membership");
 }
 
 std::shared_ptr<Channel> TwitchServer::getCustomChannel(

--- a/src/providers/twitch/TwitchServer.hpp
+++ b/src/providers/twitch/TwitchServer.hpp
@@ -55,6 +55,8 @@ protected:
     virtual void writeConnectionMessageReceived(
         Communi::IrcMessage *message) override;
 
+    virtual void onConnected(IrcConnection *connection) override;
+
     virtual std::shared_ptr<Channel> getCustomChannel(
         const QString &channelname) override;
 


### PR DESCRIPTION
I send the connection itself as a parameter to onConnected now since TwitchServer could not access readConnection, the other alternatives/additions I can think of are:
keep current solution, but rename onConnected to onReadConnectionConnected
replace current solution, make readConnection protected so TwitchServer can access it

Fixes #1229 