### PR TITLE
Fetch FFZ channel emotes with channel id instead of name

### DIFF
--- a/src/providers/ffz/FfzEmotes.cpp
+++ b/src/providers/ffz/FfzEmotes.cpp
@@ -138,7 +138,7 @@ void FfzEmotes::loadEmotes()
     QString url("https://api.frankerfacez.com/v1/set/global");
 
     NetworkRequest(url)
-    
+
         .timeout(30000)
         .onSuccess([this](auto result) -> Outcome {
             auto emotes = this->emotes();
@@ -151,13 +151,13 @@ void FfzEmotes::loadEmotes()
         .execute();
 }
 
-void FfzEmotes::loadChannel(const QString &channelName,
+void FfzEmotes::loadChannel(const QString &channelId,
                             std::function<void(EmoteMap &&)> callback)
 {
-    log("[FFZEmotes] Reload FFZ Channel Emotes for channel {}\n", channelName);
+    log("[FFZEmotes] Reload FFZ Channel Emotes for channel {}\n", channelId);
 
-    NetworkRequest("https://api.frankerfacez.com/v1/room/" + channelName)
-    
+    NetworkRequest("https://api.frankerfacez.com/v1/room/id/" + channelId)
+
         .timeout(20000)
         .onSuccess([callback = std::move(callback)](auto result) -> Outcome {
             auto pair = parseChannelEmotes(result.parseJson());
@@ -165,7 +165,7 @@ void FfzEmotes::loadChannel(const QString &channelName,
                 callback(std::move(pair.second));
             return pair.first;
         })
-        .onError([channelName](int result) {
+        .onError([channelId](int result) {
             if (result == 203)
             {
                 // User does not have any FFZ emotes
@@ -176,12 +176,12 @@ void FfzEmotes::loadChannel(const QString &channelName,
             {
                 // TODO: Auto retry in case of a timeout, with a delay
                 log("Fetching FFZ emotes for channel {} failed due to timeout",
-                    channelName);
+                    channelId);
                 return true;
             }
 
-            log("Error fetching FFZ emotes for channel {}, error {}",
-                channelName, result);
+            log("Error fetching FFZ emotes for channel {}, error {}", channelId,
+                result);
 
             return true;
         })

--- a/src/providers/ffz/FfzEmotes.hpp
+++ b/src/providers/ffz/FfzEmotes.hpp
@@ -22,7 +22,7 @@ public:
     std::shared_ptr<const EmoteMap> emotes() const;
     boost::optional<EmotePtr> emote(const EmoteName &name) const;
     void loadEmotes();
-    static void loadChannel(const QString &channelName,
+    static void loadChannel(const QString &channelId,
                             std::function<void(EmoteMap &&)> callback);
 
 private:

--- a/src/providers/twitch/ChatroomChannel.cpp
+++ b/src/providers/twitch/ChatroomChannel.cpp
@@ -22,7 +22,7 @@ ChatroomChannel::ChatroomChannel(const QString &channelName,
     }
 }
 
-void ChatroomChannel::refreshChannelEmotes()
+void ChatroomChannel::refreshBTTVChannelEmotes()
 {
     if (this->chatroomOwnerId.isEmpty())
     {
@@ -36,16 +36,21 @@ void ChatroomChannel::refreshChannelEmotes()
                     this->bttvEmotes_.set(
                         std::make_shared<EmoteMap>(std::move(emoteMap)));
             });
-            FfzEmotes::loadChannel(username, [this, weak](auto &&emoteMap) {
-                if (auto shared = weak.lock())
-                    this->ffzEmotes_.set(
-                        std::make_shared<EmoteMap>(std::move(emoteMap)));
-            });
             if (auto shared = weak.lock())
             {
                 this->chatroomOwnerName = username;
             }
         });
+}
+void ChatroomChannel::refreshFFZChannelEmotes()
+{
+    if (this->chatroomOwnerId.isEmpty())
+    {
+        return;
+    }
+    FfzEmotes::loadChannel(this->chatroomOwnerId, [this](auto &&emoteMap) {
+        this->ffzEmotes_.set(std::make_shared<EmoteMap>(std::move(emoteMap)));
+    });
 }
 
 const QString &ChatroomChannel::getDisplayName() const

--- a/src/providers/twitch/ChatroomChannel.hpp
+++ b/src/providers/twitch/ChatroomChannel.hpp
@@ -13,7 +13,8 @@ protected:
     explicit ChatroomChannel(const QString &channelName,
                              TwitchBadges &globalTwitchBadges,
                              BttvEmotes &globalBttv, FfzEmotes &globalFfz);
-    virtual void refreshChannelEmotes() override;
+    virtual void refreshBTTVChannelEmotes() override;
+    virtual void refreshFFZChannelEmotes() override;
     virtual const QString &getDisplayName() const override;
 
     QString chatroomOwnerId;

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -113,6 +113,7 @@ TwitchChannel::TwitchChannel(const QString &name,
         this->refreshLiveStatus();
         this->refreshBadges();
         this->refreshCheerEmotes();
+        this->refreshFFZChannelEmotes();
     });
 
     // timers
@@ -135,7 +136,7 @@ TwitchChannel::TwitchChannel(const QString &name,
 void TwitchChannel::initialize()
 {
     this->refreshChatters();
-    this->refreshChannelEmotes();
+    this->refreshBTTVChannelEmotes();
     this->refreshBadges();
     this->ffzCustomModBadge_.loadCustomModBadge();
 }
@@ -150,7 +151,7 @@ bool TwitchChannel::canSendMessage() const
     return !this->isEmpty();
 }
 
-void TwitchChannel::refreshChannelEmotes()
+void TwitchChannel::refreshBTTVChannelEmotes()
 {
     BttvEmotes::loadChannel(
         this->getName(), [this, weak = weakOf<Channel>(this)](auto &&emoteMap) {
@@ -158,8 +159,12 @@ void TwitchChannel::refreshChannelEmotes()
                 this->bttvEmotes_.set(
                     std::make_shared<EmoteMap>(std::move(emoteMap)));
         });
+}
+
+void TwitchChannel::refreshFFZChannelEmotes()
+{
     FfzEmotes::loadChannel(
-        this->getName(), [this, weak = weakOf<Channel>(this)](auto &&emoteMap) {
+        this->roomId(), [this, weak = weakOf<Channel>(this)](auto &&emoteMap) {
             if (auto shared = weak.lock())
                 this->ffzEmotes_.set(
                     std::make_shared<EmoteMap>(std::move(emoteMap)));

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -85,7 +85,8 @@ public:
     std::shared_ptr<const EmoteMap> bttvEmotes() const;
     std::shared_ptr<const EmoteMap> ffzEmotes() const;
 
-    virtual void refreshChannelEmotes();
+    virtual void refreshBTTVChannelEmotes();
+    virtual void refreshFFZChannelEmotes();
 
     // Badges
     boost::optional<EmotePtr> ffzCustomModBadge() const;

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -663,7 +663,10 @@ void Split::reloadChannelAndSubscriberEmotes()
     auto channel = this->getChannel();
 
     if (auto twitchChannel = dynamic_cast<TwitchChannel *>(channel.get()))
-        twitchChannel->refreshChannelEmotes();
+    {
+        twitchChannel->refreshBTTVChannelEmotes();
+        twitchChannel->refreshFFZChannelEmotes();
+    }
 }
 
 template <typename Iter, typename RandomGenerator>

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -713,7 +713,10 @@ void SplitHeader::reloadChannelEmotes()
     auto channel = this->split_->getChannel();
 
     if (auto twitchChannel = dynamic_cast<TwitchChannel *>(channel.get()))
-        twitchChannel->refreshChannelEmotes();
+    {
+        twitchChannel->refreshFFZChannelEmotes();
+        twitchChannel->refreshBTTVChannelEmotes();
+    }
 }
 
 void SplitHeader::reloadSubscriberEmotes()


### PR DESCRIPTION
Since the ffz api now requires id we need to fetch the id first before we can fetch the emotes. That's why bttv and ffz emotes won't load at the same time.
Closes #1253 