### PR TITLE
Use BTTV V3 API for channel emotes

### DIFF
--- a/src/providers/bttv/BttvEmotes.hpp
+++ b/src/providers/bttv/BttvEmotes.hpp
@@ -16,7 +16,7 @@ class BttvEmotes final
     static constexpr const char *globalEmoteApiUrl =
         "https://api.betterttv.net/2/emotes";
     static constexpr const char *bttvChannelEmoteApiUrl =
-        "https://api.betterttv.net/2/channels/";
+        "https://api.betterttv.net/3/cached/users/twitch/";
 
 public:
     BttvEmotes();
@@ -24,7 +24,7 @@ public:
     std::shared_ptr<const EmoteMap> emotes() const;
     boost::optional<EmotePtr> emote(const EmoteName &name) const;
     void loadEmotes();
-    static void loadChannel(const QString &channelName,
+    static void loadChannel(const QString &channelId,
                             std::function<void(EmoteMap &&)> callback);
 
 private:

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -114,6 +114,7 @@ TwitchChannel::TwitchChannel(const QString &name,
         this->refreshBadges();
         this->refreshCheerEmotes();
         this->refreshFFZChannelEmotes();
+        this->refreshBTTVChannelEmotes();
     });
 
     // timers
@@ -136,7 +137,6 @@ TwitchChannel::TwitchChannel(const QString &name,
 void TwitchChannel::initialize()
 {
     this->refreshChatters();
-    this->refreshBTTVChannelEmotes();
     this->refreshBadges();
     this->ffzCustomModBadge_.loadCustomModBadge();
 }
@@ -154,7 +154,7 @@ bool TwitchChannel::canSendMessage() const
 void TwitchChannel::refreshBTTVChannelEmotes()
 {
     BttvEmotes::loadChannel(
-        this->getName(), [this, weak = weakOf<Channel>(this)](auto &&emoteMap) {
+        this->roomId(), [this, weak = weakOf<Channel>(this)](auto &&emoteMap) {
             if (auto shared = weak.lock())
                 this->bttvEmotes_.set(
                     std::make_shared<EmoteMap>(std::move(emoteMap)));


### PR DESCRIPTION
I didn't find the global emotes API so that still uses BTTV V2 API.

Fixes #1275