### PR TITLE
Add Setting for Case-Sensitivity in Highlights

### DIFF
--- a/src/controllers/highlights/HighlightModel.cpp
+++ b/src/controllers/highlights/HighlightModel.cpp
@@ -8,7 +8,7 @@ namespace chatterino {
 
 // commandmodel
 HighlightModel::HighlightModel(QObject *parent)
-    : SignalVectorModel<HighlightPhrase>(4, parent)
+    : SignalVectorModel<HighlightPhrase>(5, parent)
 {
 }
 
@@ -16,12 +16,13 @@ HighlightModel::HighlightModel(QObject *parent)
 HighlightPhrase HighlightModel::getItemFromRow(
     std::vector<QStandardItem *> &row, const HighlightPhrase &original)
 {
-    // key, alert, sound, regex
+    // key, alert, sound, regex, case-sensitivity
 
     return HighlightPhrase{row[0]->data(Qt::DisplayRole).toString(),
                            row[1]->data(Qt::CheckStateRole).toBool(),
                            row[2]->data(Qt::CheckStateRole).toBool(),
-                           row[3]->data(Qt::CheckStateRole).toBool()};
+                           row[3]->data(Qt::CheckStateRole).toBool(),
+                           row[4]->data(Qt::CheckStateRole).toBool()};
 }
 
 // turns a row in the model into a vector item
@@ -32,6 +33,7 @@ void HighlightModel::getRowFromItem(const HighlightPhrase &item,
     setBoolItem(row[1], item.getAlert());
     setBoolItem(row[2], item.getSound());
     setBoolItem(row[3], item.isRegex());
+    setBoolItem(row[4], item.isCaseSensitive());
 }
 
 void HighlightModel::afterInit()

--- a/src/controllers/highlights/UserHighlightModel.cpp
+++ b/src/controllers/highlights/UserHighlightModel.cpp
@@ -8,7 +8,7 @@ namespace chatterino {
 
 // commandmodel
 UserHighlightModel::UserHighlightModel(QObject *parent)
-    : SignalVectorModel<HighlightPhrase>(4, parent)
+    : SignalVectorModel<HighlightPhrase>(5, parent)
 {
 }
 
@@ -21,7 +21,8 @@ HighlightPhrase UserHighlightModel::getItemFromRow(
     return HighlightPhrase{row[0]->data(Qt::DisplayRole).toString(),
                            row[1]->data(Qt::CheckStateRole).toBool(),
                            row[2]->data(Qt::CheckStateRole).toBool(),
-                           row[3]->data(Qt::CheckStateRole).toBool()};
+                           row[3]->data(Qt::CheckStateRole).toBool(),
+                           row[4]->data(Qt::CheckStateRole).toBool()};
 }
 
 // row into vector item
@@ -32,6 +33,7 @@ void UserHighlightModel::getRowFromItem(const HighlightPhrase &item,
     setBoolItem(row[1], item.getAlert());
     setBoolItem(row[2], item.getSound());
     setBoolItem(row[3], item.isRegex());
+    setBoolItem(row[4], item.isCaseSensitive());
 }
 
 }  // namespace chatterino

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -952,7 +952,7 @@ void TwitchMessageBuilder::parseHighlights()
     {
         HighlightPhrase selfHighlight(
             currentUsername, getSettings()->enableSelfHighlightTaskbar,
-            getSettings()->enableSelfHighlightSound, false);
+            getSettings()->enableSelfHighlightSound, false, false);
         activeHighlights.emplace_back(std::move(selfHighlight));
     }
 

--- a/src/widgets/settingspages/HighlightingPage.cpp
+++ b/src/widgets/settingspages/HighlightingPage.cpp
@@ -57,7 +57,7 @@ HighlightingPage::HighlightingPage()
 
                 view->addRegexHelpLink();
                 view->setTitles({"Pattern", "Flash\ntaskbar", "Play\nsound",
-                                 "Enable\nregex"});
+                                 "Enable\nregex", "Case-\nsensitive"});
                 view->getTableView()->horizontalHeader()->setSectionResizeMode(
                     QHeaderView::Fixed);
                 view->getTableView()->horizontalHeader()->setSectionResizeMode(
@@ -71,8 +71,8 @@ HighlightingPage::HighlightingPage()
                 });
 
                 view->addButtonPressed.connect([] {
-                    getApp()->highlights->phrases.appendItem(
-                        HighlightPhrase{"my phrase", true, false, false});
+                    getApp()->highlights->phrases.appendItem(HighlightPhrase{
+                        "my phrase", true, false, false, false});
                 });
             }
 
@@ -87,6 +87,9 @@ HighlightingPage::HighlightingPage()
                         .getElement();
 
                 view->addRegexHelpLink();
+
+                // Case-sensitivity doesn't make sense for user names so it is
+                // set to "false" by default & no checkbox is shown
                 view->setTitles({"Username", "Flash\ntaskbar", "Play\nsound",
                                  "Enable\nregex"});
                 view->getTableView()->horizontalHeader()->setSectionResizeMode(
@@ -103,7 +106,7 @@ HighlightingPage::HighlightingPage()
 
                 view->addButtonPressed.connect([] {
                     getApp()->highlights->highlightedUsers.appendItem(
-                        HighlightPhrase{"highlighted user", true, false,
+                        HighlightPhrase{"highlighted user", true, false, false,
                                         false});
                 });
             }


### PR DESCRIPTION
### Description

This PR adds a setting that allows users to choose whether a highlight phrase should check for case or not. Works for Regex and regular substring patterns.

The default behavior is to match case-insensitively.

Fixes #1289.

### Screenshots
![Screenshot of new settings pages](https://user-images.githubusercontent.com/35232120/64478002-4ee44280-d1a2-11e9-90d3-25328dd04df2.png)
![Example of new options](https://user-images.githubusercontent.com/35232120/64478034-a1bdfa00-d1a2-11e9-976e-831986a2e56f.png)
