### PR TITLE
Add Version Information to "About" Page

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,7 +20,7 @@ assignees: ''
 <!-- If applicable, add screenshots to help explain your problem. Use the integrated uploader of the issue form to upload images, or copy an image to the clipboard and paste it in the input box -->
 
 **Chatterino version**
-<!-- Please enter the version info from the program's title bar, e.g. `2.0.4 (15.08.2019 c1afbd5-1)` -->
+<!-- Please copy the version information from the "About" page in the Settings, e.g. `Chatterino 2.1.4 (commit 35c7853c4, 16.09.2019)` -->
 
 **Additional context**
 <!-- Add any other context about the problem here. -->

--- a/chatterino.pro
+++ b/chatterino.pro
@@ -88,6 +88,7 @@ SOURCES += \
     src/common/NetworkRequest.cpp \
     src/common/NetworkResult.cpp \
     src/common/UsernameSet.cpp \
+    src/common/Version.cpp \
     src/controllers/accounts/Account.cpp \
     src/controllers/accounts/AccountController.cpp \
     src/controllers/accounts/AccountModel.cpp \

--- a/src/common/Version.cpp
+++ b/src/common/Version.cpp
@@ -1,0 +1,67 @@
+#include "common/Version.hpp"
+
+#include "common/Modes.hpp"
+
+#define UGLYMACROHACK1(s) #s
+#define FROM_EXTERNAL_DEFINE(s) UGLYMACROHACK1(s)
+
+namespace chatterino {
+
+Version::Version()
+{
+    // Version
+    this->version_ = CHATTERINO_VERSION;
+
+    // Commit hash
+    this->commitHash_ =
+        QString(FROM_EXTERNAL_DEFINE(CHATTERINO_GIT_HASH)).remove('"');
+
+    // Date of build
+#ifdef CHATTERINO_NIGHTLY_VERSION_STRING
+    this->dateOfBuild_ =
+        QString(FROM_EXTERNAL_DEFINE(CHATTERINO_NIGHTLY_VERSION_STRING))
+            .remove('"');
+#endif
+
+    // "Full" version string, as displayed in window title
+    this->fullVersion_ = "Chatterino ";
+    if (Modes::getInstance().isNightly)
+    {
+        this->fullVersion_ += "Nightly ";
+    }
+
+    this->fullVersion_ += this->version_;
+
+    if (Modes::getInstance().isNightly)
+    {
+        this->fullVersion_ += this->dateOfBuild_;
+    }
+}
+
+const Version &Version::getInstance()
+{
+    static Version instance;
+    return instance;
+}
+
+const QString &Version::getVersion() const
+{
+    return this->version_;
+}
+
+const QString &Version::getFullVersion() const
+{
+    return this->fullVersion_;
+}
+
+const QString &Version::getCommitHash() const
+{
+    return this->commitHash_;
+}
+
+const QString &Version::getDateOfBuild() const
+{
+    return this->dateOfBuild_;
+}
+
+}  // namespace chatterino

--- a/src/common/Version.hpp
+++ b/src/common/Version.hpp
@@ -13,3 +13,26 @@
 #else
 #    define CHATTERINO_OS "unknown"
 #endif
+
+namespace chatterino {
+
+class Version
+{
+public:
+    static const Version &getInstance();
+
+    const QString &getVersion() const;
+    const QString &getCommitHash() const;
+    const QString &getDateOfBuild() const;
+    const QString &getFullVersion() const;
+
+private:
+    Version();
+
+    QString version_;
+    QString commitHash_;
+    QString dateOfBuild_;
+    QString fullVersion_;
+};
+
+};

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -363,30 +363,12 @@ void Window::addMenuBar()
             [=] { this->notebook_->selectPreviousTab(); });
 }
 
-#define UGLYMACROHACK1(s) #s
-#define UGLYMACROHACK(s) UGLYMACROHACK1(s)
-
 void Window::onAccountSelected()
 {
     auto user = getApp()->accounts->twitch.getCurrent();
 
     // update title
-    QString title = "Chatterino ";
-    if (Modes::getInstance().isNightly)
-    {
-        title += "Nightly ";
-    }
-    title += CHATTERINO_VERSION;
-
-    if (Modes::getInstance().isNightly)
-    {
-#ifdef CHATTERINO_NIGHTLY_VERSION_STRING
-        title +=
-            QString(" (" UGLYMACROHACK(CHATTERINO_NIGHTLY_VERSION_STRING) ")");
-#endif
-    }
-
-    this->setWindowTitle(title);
+    this->setWindowTitle(Version::getInstance().getFullVersion());
 
     // update user
     if (user->isAnon())

--- a/src/widgets/settingspages/AboutPage.cpp
+++ b/src/widgets/settingspages/AboutPage.cpp
@@ -1,5 +1,7 @@
 #include "AboutPage.hpp"
 
+#include "common/Modes.hpp"
+#include "common/Version.hpp"
 #include "debug/Log.hpp"
 #include "util/LayoutCreator.hpp"
 #include "util/RemoveScrollAreaBackground.hpp"
@@ -70,6 +72,24 @@ AboutPage::AboutPage()
             //                //        github->setPalette(palette);
             //            }
         }*/
+
+        auto versionInfo = layout.emplace<QGroupBox>("Version");
+        {
+            auto version = Version::getInstance();
+            QString text = QString("%1 (commit %2%3)")
+                               .arg(version.getFullVersion())
+                               .arg("<a "
+                                    "href=\"https://github.com/Chatterino/"
+                                    "chatterino2/commit/" +
+                                    version.getCommitHash() + "\">" +
+                                    version.getCommitHash() + "</a>")
+                               .arg(Modes::getInstance().isNightly ? ", " + version.getDateOfBuild() : "");
+
+            auto versionLabel = versionInfo.emplace<QLabel>(text);
+            versionLabel->setOpenExternalLinks(true);
+            versionLabel->setTextInteractionFlags(Qt::TextSelectableByMouse |
+                                                  Qt::LinksAccessibleByMouse);
+        }
 
         auto licenses =
             layout.emplace<QGroupBox>("Open source software used...");


### PR DESCRIPTION
### Description

This PR adds information about the program version to the "About" page.

As the program's version is also displayed in the window title (and to avoid code duplication), I put the "information parsing logic" in its own class at `common/Version.cpp`. Not sure whether this is the best solution.

The text in the version information box is copyable so that users can easily paste it when filing bug reports.

Also kind of related to #874.

### Screenshot

![Version information in the "About" page](https://user-images.githubusercontent.com/35232120/64977030-e1779680-d8b2-11e9-8428-26e38ee2826e.png)