### PR TITLE
[Bug Fix] Fix Version String on Windows

### DIFF
--- a/src/common/Version.cpp
+++ b/src/common/Version.cpp
@@ -16,11 +16,11 @@ Version::Version()
     this->commitHash_ =
         QString(FROM_EXTERNAL_DEFINE(CHATTERINO_GIT_HASH)).remove('"');
 
-    // Date of build
+    // Date of build, this is depended on the format not changing
 #ifdef CHATTERINO_NIGHTLY_VERSION_STRING
     this->dateOfBuild_ =
         QString(FROM_EXTERNAL_DEFINE(CHATTERINO_NIGHTLY_VERSION_STRING))
-            .remove('"');
+            .remove('"').split(' ')[0];
 #endif
 
     // "Full" version string, as displayed in window title
@@ -31,11 +31,6 @@ Version::Version()
     }
 
     this->fullVersion_ += this->version_;
-
-    if (Modes::getInstance().isNightly)
-    {
-        this->fullVersion_ += this->dateOfBuild_;
-    }
 }
 
 const Version &Version::getInstance()


### PR DESCRIPTION
### Description

This is a follow-up to #1315.

The `CHATTERINO_NIGHTLY_VERSION_STRING` defines differ on Windows and macOS/Linux for some reason.
(See `appveyor.yml` and `travis.yml`, respectively.)

Therefore, the Windows version string looked really messed up.
I "fixed" this issue by splitting the define on spaces and only considering the first element of the split.

### Screenshots
**Before:**
![Version string is messed up](https://user-images.githubusercontent.com/35232120/65377901-77476300-dcb1-11e9-9ae4-b1254a9bb3ba.png)

**After:**
![Version string is fixed](https://user-images.githubusercontent.com/35232120/65377929-d5744600-dcb1-11e9-9821-6f66169f8d3f.png)

