### PR TITLE
[Bug fix] Highlights in /mentions

### DIFF
--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -582,6 +582,11 @@ void ChannelView::setChannel(ChannelPtr channel)
         this->lastMessageHasAlternateBackground_ =
             !this->lastMessageHasAlternateBackground_;
 
+        if (channel->shouldIgnoreHighlights())
+        {
+                    messageLayout->flags.set(MessageLayoutFlag::IgnoreHighlights);
+        }
+
         this->messages_.pushBack(MessageLayoutPtr(messageLayout), deleted);
         this->scrollBar_->addHighlight(snapshot[i]->getScrollBarHighlight());
     }

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -584,7 +584,7 @@ void ChannelView::setChannel(ChannelPtr channel)
 
         if (channel->shouldIgnoreHighlights())
         {
-                    messageLayout->flags.set(MessageLayoutFlag::IgnoreHighlights);
+            messageLayout->flags.set(MessageLayoutFlag::IgnoreHighlights);
         }
 
         this->messages_.pushBack(MessageLayoutPtr(messageLayout), deleted);


### PR DESCRIPTION
### Description
When opening channel "/mentions", after being pinged, old messages would be highlighted.

### Screenshot
**Before**
![image](https://user-images.githubusercontent.com/17132081/65378911-05c2e100-dcc0-11e9-8821-5b74dc1e9e41.png)
