### PR TITLE
[Workaround] "Fix" macOS Travis Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,9 @@ matrix:
       script:
         - mkdir build && cd build
         - dateOfBuild="CHATTERINO_NIGHTLY_VERSION_STRING=\"\\\"$(date +%d.%m.%Y)\\\"\""
-        - /usr/local/opt/qt/bin/qmake .. DEFINES+=$dateOfBuild && make -j8
+        - /usr/local/opt/qt/bin/qmake .. DEFINES+=$dateOfBuild
+        - sed -i 's/-framework\\\ /-framework /g' Makefile
+        - make -j8
         - /usr/local/opt/qt/bin/macdeployqt chatterino.app -dmg
         - mkdir app
         - hdiutil attach chatterino.dmg

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ matrix:
         - mkdir build && cd build
         - dateOfBuild="CHATTERINO_NIGHTLY_VERSION_STRING=\"\\\"$(date +%d.%m.%Y)\\\"\""
         - /usr/local/opt/qt/bin/qmake .. DEFINES+=$dateOfBuild
-        - sed -i 's/-framework\\\ /-framework /g' Makefile
+        - sed -ie 's/-framework\\\ /-framework /g' Makefile
         - make -j8
         - /usr/local/opt/qt/bin/macdeployqt chatterino.app -dmg
         - mkdir app


### PR DESCRIPTION
Workaround for #1327.

This PR just adds a `sed` command to convert the wrong `-framework\` flags to the correct `-framework` flags. I think we should merge this until we can figure out what's actually wrong.