### PR TITLE
Fix clang-format Only Reformatting .cpp Files

### DIFF
--- a/tools/clang-format-all.sh
+++ b/tools/clang-format-all.sh
@@ -3,5 +3,5 @@
 read -p "Are you sure you want to run clang-format on all files in src/? (y/n) " -n 1 -r
 echo
 if [[ $REPLY =~ ^[Yy]$ ]]; then
-    find src/ -iname "*.hpp" -o -iname "*.cpp" -exec clang-format -i {} \;
+    find src/ \( -iname "*.hpp" -o -iname "*.cpp" \) -exec clang-format -i {} \;
 fi


### PR DESCRIPTION
I hope that this isn't depended on the `find` version (similar to how #1309 used to be) but when I run the `clang-format-all.sh` script, only `.cpp` files are operated on. Please check on your own systems.

I confirmed this when replacing the `-exec` part with a `-print`: It does not find any header files.
In this PR, I changed the expression to a regex that matches `.cpp` and `.hpp` files.