### PR TITLE
Open Multiple Splits from SelectChannelDialog

### DIFF
--- a/src/widgets/dialogs/SelectChannelDialog.hpp
+++ b/src/widgets/dialogs/SelectChannelDialog.hpp
@@ -19,9 +19,9 @@ class SelectChannelDialog final : public BaseWindow
 public:
     SelectChannelDialog(QWidget *parent = nullptr);
 
-    void setSelectedChannel(IndirectChannel selectedChannel_);
-    IndirectChannel getSelectedChannel() const;
-    bool hasSeletedChannel() const;
+    void setSelectedChannel(IndirectChannel _channel);
+    std::vector<IndirectChannel> getSelectedChannels() const;
+    bool hasSelectedChannels() const;
 
     pajlada::Signals::NoArgSignal closed;
 
@@ -42,11 +42,11 @@ private:
     struct {
         Notebook *notebook;
         struct {
-            QRadioButton *channel;
-            QLineEdit *channelName;
-            QRadioButton *whispers;
-            QRadioButton *mentions;
-            QRadioButton *watching;
+            QCheckBox *channels;
+            QLineEdit *channelNames;
+            QCheckBox *whispers;
+            QCheckBox *mentions;
+            QCheckBox *watching;
         } twitch;
         struct {
             QLineEdit *channel;
@@ -54,10 +54,10 @@ private:
         } irc;
     } ui_;
 
-    EventFilter tabFilter_;
+    EventFilter keyboardFilter_;
 
-    ChannelPtr selectedChannel_;
-    bool hasSelectedChannel_ = false;
+    std::vector<IndirectChannel> selectedChannels_;
+    bool hasSelectedChannels_ = false;
 
     void ok();
     friend class EventFilter;

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -318,16 +318,35 @@ void Split::showChangeChannelPopup(const char *dialogTitle, bool empty,
     dialog->setAttribute(Qt::WA_DeleteOnClose);
     dialog->show();
     dialog->closed.connect([=] {
-        if (dialog->hasSeletedChannel())
+        if (dialog->hasSelectedChannels())
         {
-            this->setChannel(dialog->getSelectedChannel());
+            auto channels = dialog->getSelectedChannels();
+            for (auto it = channels.begin(); it != channels.end(); ++it)
+            {
+                if (!it->get())
+                    continue;
+
+                // The first channel will be placed in the current split.
+                // New splits will be appended for all other channels.
+                if (it == channels.begin())
+                {
+                    this->setChannel(*it);
+                }
+                else
+                {
+                    Split *split = new Split(this->container_);
+                    split->setChannel(*it);
+                    this->container_->appendSplit(split);
+                }
+            }
+
             if (this->isInContainer())
             {
                 this->container_->refreshTab();
             }
         }
 
-        callback(dialog->hasSeletedChannel());
+        callback(dialog->hasSelectedChannels());
         this->selectChannelDialog_ = nullptr;
     });
     this->selectChannelDialog_ = dialog;


### PR DESCRIPTION
### Description

This PR allows users to open multiple splits at once from the SelectChannelDialog. The text entered in the line edit is split by spaces and a new channel split is opened for each element. When the "Whispers"/"Mentions"/"Watching" check boxes are checked, a split for these is opened as well.

There is support for tabbing through the check boxes and enabling them with "Enter" but I couldn't figure out how to highlight the currently selected check box. If anyone knows, please comment or send a PR.

Feel free to squash commits.

### Screenshots

Kind of hard to show this in screenshots but it should be pretty self-explanatory.

![New dialog for opening splits](https://user-images.githubusercontent.com/35232120/65831445-b54c1480-e2b9-11e9-8eee-b423533bb4b6.png)

![After the splits have been opened](https://user-images.githubusercontent.com/35232120/65831449-c09f4000-e2b9-11e9-9e1e-89872d23b2f4.png)

