### PR TITLE
Show the title when offline

### DIFF
--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -89,7 +89,7 @@ TwitchChannel::TwitchChannel(const QString &name,
     , bttvEmotes_(std::make_shared<EmoteMap>())
     , ffzEmotes_(std::make_shared<EmoteMap>())
     , mod_(false)
-    , titleRefreshedTime_(QTime::currentTime().addSecs(-10))
+    , titleRefreshedTime_(QTime::currentTime().addSecs(-titleRefreshPeriod_))
 {
     log("[TwitchChannel:{}] Opened", name);
 
@@ -447,11 +447,11 @@ void TwitchChannel::refreshTitle()
         return;
     }
 
-    if (this->titleRefreshedTime_.elapsed() < 10 * 1000)
+    if (this->titleRefreshedTime_.elapsed() < this->titleRefreshPeriod_ * 1000)
     {
         return;
     }
-    this->titleRefreshedTime_.start();
+    this->titleRefreshedTime_ = QTime::currentTime();
 
     QString url("https://api.twitch.tv/kraken/channels/" + roomID);
     NetworkRequest::twitchRequest(url)

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -463,14 +463,19 @@ void TwitchChannel::refreshTitle()
 
                 const auto document = result.parseRapidJson();
 
-                if (!document.HasMember("status"))
+                auto statusIt = document.FindMember("status");
+
+                if (statusIt == document.MemberEnd())
                 {
                     return Failure;
                 }
 
                 {
                     auto status = this->streamStatus_.access();
-                    status->title = document["status"].GetString();
+                    if (!rj::getSafe(statusIt->value, status->title))
+                    {
+                        return Failure;
+                    }
                 }
 
                 this->liveStatusChanged.invoke();

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -443,8 +443,6 @@ void TwitchChannel::refreshTitle(){
         return;
     }
 
-    this->streamStatus_.access()->title = "hello";
-
     QString url("https://api.twitch.tv/kraken/channels/"+roomID);
     NetworkRequest::twitchRequest(url)
         .onSuccess(

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -439,20 +439,21 @@ void TwitchChannel::setLive(bool newLiveStatus)
     }
 }
 
-void TwitchChannel::refreshTitle(){
+void TwitchChannel::refreshTitle()
+{
     auto roomID = this->roomId();
-    if(roomID.isEmpty())
+    if (roomID.isEmpty())
     {
         return;
     }
 
-    if(this->titleRefreshedTime_.elapsed()<10*1000)
+    if (this->titleRefreshedTime_.elapsed() < 10 * 1000)
     {
         return;
     }
     this->titleRefreshedTime_.start();
 
-    QString url("https://api.twitch.tv/kraken/channels/"+roomID);
+    QString url("https://api.twitch.tv/kraken/channels/" + roomID);
     NetworkRequest::twitchRequest(url)
         .onSuccess(
             [this, weak = weakOf<Channel>(this)](auto result) -> Outcome {
@@ -462,7 +463,8 @@ void TwitchChannel::refreshTitle(){
 
                 const auto document = result.parseRapidJson();
 
-                if(!document.HasMember("status")){
+                if (!document.HasMember("status"))
+                {
                     return Failure;
                 }
 

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -110,6 +110,7 @@ TwitchChannel::TwitchChannel(const QString &name,
     // room id loaded -> refresh live status
     this->roomIdChanged.connect([this]() {
         this->refreshPubsub();
+        this->refreshTitle();
         this->refreshLiveStatus();
         this->refreshBadges();
         this->refreshCheerEmotes();

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -472,7 +472,6 @@ void TwitchChannel::refreshTitle(){
                 return Success;
             })
         .execute();
-
 }
 
 void TwitchChannel::refreshLiveStatus()

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -440,12 +440,13 @@ void TwitchChannel::setLive(bool newLiveStatus)
 }
 
 void TwitchChannel::refreshTitle(){
-    auto roomID= this->roomId();
-    if(roomID.isEmpty()){
+    auto roomID = this->roomId();
+    if(roomID.isEmpty())
+    {
         return;
     }
 
-    if(this->titleRefreshedTime_.elapsed()<10000)
+    if(this->titleRefreshedTime_.elapsed()<10*1000)
     {
         return;
     }

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -89,6 +89,7 @@ TwitchChannel::TwitchChannel(const QString &name,
     , bttvEmotes_(std::make_shared<EmoteMap>())
     , ffzEmotes_(std::make_shared<EmoteMap>())
     , mod_(false)
+    , titleRefreshedTime_(QTime::currentTime().addSecs(-10))
 {
     log("[TwitchChannel:{}] Opened", name);
 
@@ -443,6 +444,12 @@ void TwitchChannel::refreshTitle(){
     if(roomID.isEmpty()){
         return;
     }
+
+    if(this->titleRefreshedTime_.elapsed()<10000)
+    {
+        return;
+    }
+    this->titleRefreshedTime_.start();
 
     QString url("https://api.twitch.tv/kraken/channels/"+roomID);
     NetworkRequest::twitchRequest(url)

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -124,6 +124,7 @@ private:
     void refreshChatters();
     void refreshBadges();
     void refreshCheerEmotes();
+    void refreshTitle();
     void loadRecentMessages();
 
     void setLive(bool newLiveStatus);
@@ -166,6 +167,7 @@ private:
     QObject lifetimeGuard_;
     QTimer liveStatusTimer_;
     QTimer chattersListTimer_;
+    QTimer titleChangedTimer_;
 
     friend class TwitchIrcServer;
     friend class TwitchMessageBuilder;

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -167,6 +167,7 @@ private:
     QObject lifetimeGuard_;
     QTimer liveStatusTimer_;
     QTimer chattersListTimer_;
+    QTime titleRefreshedTime_;
 
     friend class TwitchIrcServer;
     friend class TwitchMessageBuilder;

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -169,6 +169,8 @@ private:
     QTimer chattersListTimer_;
     QTime titleRefreshedTime_;
 
+    const int titleRefreshPeriod_ = 10;
+
     friend class TwitchIrcServer;
     friend class TwitchMessageBuilder;
     friend class IrcMessageHandler;

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -167,7 +167,6 @@ private:
     QObject lifetimeGuard_;
     QTimer liveStatusTimer_;
     QTimer chattersListTimer_;
-    QTimer titleChangedTimer_;
 
     friend class TwitchIrcServer;
     friend class TwitchMessageBuilder;

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -69,6 +69,7 @@ public:
     virtual bool hasHighRateLimit() const override;
     virtual bool canReconnect() const override;
     virtual void reconnect() override;
+    void refreshTitle();
 
     // Data
     const QString &subscriptionUrl();
@@ -124,7 +125,6 @@ private:
     void refreshChatters();
     void refreshBadges();
     void refreshCheerEmotes();
-    void refreshTitle();
     void loadRecentMessages();
 
     void setLive(bool newLiveStatus);

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -548,6 +548,7 @@ void SplitHeader::updateChannelText()
 
     if (auto twitchChannel = dynamic_cast<TwitchChannel *>(channel.get()))
     {
+        twitchChannel->refreshTitle();
         const auto streamStatus = twitchChannel->accessStreamStatus();
 
         if (streamStatus->live)

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -680,8 +680,11 @@ void SplitHeader::enterEvent(QEvent *event)
 {
     if (!this->tooltipText_.isEmpty())
     {
-        dynamic_cast<TwitchChannel *>(this->split_->getChannel().get())
-            ->refreshTitle();
+        auto channel = this->split_->getChannel().get();
+        if (channel->getType() == Channel::Type::Twitch)
+        {
+            dynamic_cast<TwitchChannel *>(channel)->refreshTitle();
+        }
 
         TooltipPreviewImage::instance().setImage(nullptr);
 

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -549,6 +549,7 @@ void SplitHeader::updateChannelText()
     if (auto twitchChannel = dynamic_cast<TwitchChannel *>(channel.get()))
     {
         const auto streamStatus = twitchChannel->accessStreamStatus();
+
         if (streamStatus->live)
         {
             this->isLive_ = true;

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -103,7 +103,7 @@ namespace {
     {
         return QString("<style>.center { text-align: center; }</style> \
                        <p class=\"center\">Offline<br>%1</p>")
-                       .arg(s.title.toHtmlEscaped());
+            .arg(s.title.toHtmlEscaped());
     }
     auto formatTitle(const TwitchChannel::StreamStatus &s, Settings &settings)
     {
@@ -548,7 +548,6 @@ void SplitHeader::updateChannelText()
 
     if (auto twitchChannel = dynamic_cast<TwitchChannel *>(channel.get()))
     {
-        twitchChannel->refreshTitle();
         const auto streamStatus = twitchChannel->accessStreamStatus();
 
         if (streamStatus->live)
@@ -559,7 +558,7 @@ void SplitHeader::updateChannelText()
         }
         else
         {
-            this->tooltipText_ =  formatOfflineTooltip(*streamStatus);
+            this->tooltipText_ = formatOfflineTooltip(*streamStatus);
         }
     }
 
@@ -681,6 +680,9 @@ void SplitHeader::enterEvent(QEvent *event)
 {
     if (!this->tooltipText_.isEmpty())
     {
+        dynamic_cast<TwitchChannel *>(this->split_->getChannel().get())
+            ->refreshTitle();
+
         TooltipPreviewImage::instance().setImage(nullptr);
 
         auto tooltip = TooltipWidget::instance();

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -99,6 +99,12 @@ namespace {
             .arg(s.uptime)
             .arg(QString::number(s.viewerCount));
     }
+    auto formatOfflineTooltip(const TwitchChannel::StreamStatus &s)
+    {
+        return QString("<style>.center { text-align: center; }</style> \
+                       <p class=\"center\">Offline<br>%1</p>")
+                       .arg(s.title.toHtmlEscaped());
+    }
     auto formatTitle(const TwitchChannel::StreamStatus &s, Settings &settings)
     {
         auto title = QString();
@@ -543,12 +549,15 @@ void SplitHeader::updateChannelText()
     if (auto twitchChannel = dynamic_cast<TwitchChannel *>(channel.get()))
     {
         const auto streamStatus = twitchChannel->accessStreamStatus();
-
         if (streamStatus->live)
         {
             this->isLive_ = true;
             this->tooltipText_ = formatTooltip(*streamStatus);
             title += formatTitle(*streamStatus, *getSettings());
+        }
+        else
+        {
+            this->tooltipText_ =  formatOfflineTooltip(*streamStatus);
         }
     }
 


### PR DESCRIPTION
**Description**
This PR solves issue #1264 
The format of the offline tooltip text is different so it can be easily distinguished when a stream is live. Timer for title update is currently set to 15 sec, it might be too low.
**Screenshots**
![image](https://user-images.githubusercontent.com/17132081/65994127-ecc1e900-e492-11e9-8621-17d2df1e3a2b.png)
