### PR TITLE
Fix tooltips in chat not showing on ctrl hover.

### DIFF
--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1038,14 +1038,6 @@ void ChannelView::leaveEvent(QEvent *)
 
 void ChannelView::mouseMoveEvent(QMouseEvent *event)
 {
-    if (event->modifiers() & (Qt::AltModifier | Qt::ControlModifier))
-    {
-        this->unsetCursor();
-
-        event->ignore();
-        return;
-    }
-
     /// Pause on hover
     if (float pauseTime = getSettings()->pauseOnHoverDuration;
         pauseTime > 0.001f)


### PR DESCRIPTION
Removes some dead code that prevented tooltips on badges etc. from showing while holding the control/alt modifiers.

Fixes #1292 