### PR TITLE
Fix Bug Regarding Mentions with Comma

### DIFF
--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1506,7 +1506,8 @@ void ChannelView::handleMouseClick(QMouseEvent *event,
             auto &link = hoveredElement->getLink();
             if (link.type == Link::UserInfo)
             {
-                insertText("@" + link.value + ", ");
+                const bool commaMention = getSettings()->mentionUsersWithComma;
+                insertText("@" + link.value + (commaMention ? ", " : " "));
             }
             else if (link.type == Link::UserWhisper)
             {


### PR DESCRIPTION
While tab-completing user names already respected the setting for mentions with commas, right-clicking user names did not.

This PR adds the missing check in `ChannelView::handleMouseClick`.

Fixes #1352.