### PR TITLE
🐛 Fixed OpenSSL version

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-OpenSSL/1.0.2s@conan/stable
+OpenSSL/1.1.1b@conan/stable
 boost/1.69.0@conan/stable
 
 [generators]


### PR DESCRIPTION
The OpenSSL version needs to be the same as described here: https://wiki.qt.io/Qt_5.13_Tools_and_Versions
Otherwise, chatterino2 fails to connect with the message `this platform does not support OpenSSL`