### PR TITLE
Now show joined setting doesn't also show parted and parted shows parted

### DIFF
--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -618,7 +618,7 @@ void IrcMessageHandler::handlePartMessage(Communi::IrcMessage *message)
     {
         if (message->nick() !=
                 getApp()->accounts->twitch.getCurrent()->getUserName() &&
-            getSettings()->showJoins.getValue())
+            getSettings()->showParts.getValue())
         {
             twitchChannel->addPartedUser(message->nick());
         }


### PR DESCRIPTION
Before checking show joined users would show parted and joined.
Now it only shows joined.
Parted will not show parted users before it didn't do anything!
Fixes #1367 