### PR TITLE
Switch Global badge Tool-tips from Description to Title

### DIFF
--- a/src/providers/twitch/TwitchBadges.cpp
+++ b/src/providers/twitch/TwitchBadges.cpp
@@ -47,7 +47,7 @@ void TwitchBadges::loadTwitchBadges()
                                 {versionObj.value("image_url_4x").toString()},
                                 .25),
                         },
-                        Tooltip{versionObj.value("description").toString()},
+                        Tooltip{versionObj.value("title").toString()},
                         Url{versionObj.value("click_url").toString()}};
                     // "title"
                     // "clickAction"


### PR DESCRIPTION
Currently Chatterino uses the description from the global badge api, which has actively caused "issues" because whomever does this always seems to make a minor or major mistake on the descriptions.

Previously the Bit Leader badges and Direct Relief - Charity 2018 badges were blank because the description fields were blank but they were fixed via a ticket I put in to have them fixed.
![image](https://user-images.githubusercontent.com/41973452/67428412-1232a600-f5ac-11e9-8ab6-a99fa86508dc.png)

![image](https://user-images.githubusercontent.com/41973452/67428487-355d5580-f5ac-11e9-834d-31cd51f65cbf.png)

It would also fix the 1000 Gifted Subs badge, as well the recently added founders badge. 
![image](https://user-images.githubusercontent.com/41973452/67428868-fed40a80-f5ac-11e9-98c9-61fd4aa7db37.png)

![image](https://user-images.githubusercontent.com/41973452/67427934-1dd19d00-f5ab-11e9-955c-bd3a7efbdfb2.png)

Twitch Admin and Staff as well would be cleaned up to be Staff and Admin respectively
![image](https://user-images.githubusercontent.com/41973452/67427534-4a38e980-f5aa-11e9-9ca8-7cc88ffadb19.png)
![image](https://user-images.githubusercontent.com/41973452/67428806-e106a580-f5ac-11e9-9070-c01ae0f4fa7c.png)
