### PR TITLE
Fixes C1001 compiler error on release builds with MSVC

### DIFF
--- a/src/singletons/Theme.cpp
+++ b/src/singletons/Theme.cpp
@@ -85,7 +85,7 @@ void Theme::actuallyUpdate(double hue, double multiplier)
     if (getSettings()->highlightColor != "")
     {
         this->messages.backgrounds.highlighted =
-            QColor(getSettings()->highlightColor);
+            QColor(getSettings()->highlightColor.getValue());
     }
 }
 

--- a/src/util/StreamLink.cpp
+++ b/src/util/StreamLink.cpp
@@ -199,7 +199,7 @@ void openStreamlinkForChannel(const QString &channel)
 {
     QString channelURL = "twitch.tv/" + channel;
 
-    QString preferredQuality = getSettings()->preferredQuality;
+    QString preferredQuality = getSettings()->preferredQuality.getValue();
     preferredQuality = preferredQuality.toLower();
 
     if (preferredQuality == "choose")


### PR DESCRIPTION
The Microsoft Visual C/C++ compiler crashes when trying to optimize these lines in release mode.

```
"C:\Users\ignaz\git\chatterino2\build\chatterino.vcxproj" (default target) (1) ->
(ClCompile target) ->
  C:\Users\ignaz\git\chatterino2\src\util\StreamLink.cpp(202,63): fatal error C1001: An internal error has occurred in the compiler. [C:\Users\ignaz\git\chatterino2\build\chatterino.vcxproj]
C:\Users\ignaz\git\chatterino2\src\util\StreamLink.cpp(202,63): fatal error C1001: (compiler file 'msc1.cpp', line 1529) [C:\Users\ignaz\git\chatterino2\build\chatterino.vcxproj]
C:\Users\ignaz\git\chatterino2\src\util\StreamLink.cpp(202,63): fatal error C1001:  To work around this problem, try simplifying or changing the program near the locations listed above. [C:\Users\ignaz\git\chatterino2\build\chatterino.vcxproj]
C:\Users\ignaz\git\chatterino2\src\util\StreamLink.cpp(202,63): fatal error C1001: Please choose the Technical Support command on the Visual C++ [C:\Users\ignaz\git\chatterino2\build\chatterino.vcxproj]
C:\Users\ignaz\git\chatterino2\src\util\StreamLink.cpp(202,63): fatal error C1001:  Help menu, or open the Technical Support help file for more information [C:\Users\ignaz\git\chatterino2\build\chatterino.vcxproj]
C:\Users\ignaz\git\chatterino2\src\util\StreamLink.cpp(202,63): fatal error C1001: Internal Compiler Error in C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.23.28105\bin\HostX86\x64\CL.exe.  You will be prompted to send an error report to Microsoft later. [C:\Users\ignaz\git\chatterino2\build\chatterino.vcxproj]
C:\Users\ignaz\git\chatterino2\src\util\StreamLink.cpp(202,63): fatal error C1001: INTERNAL COMPILER ERROR in 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.23.28105\bin\HostX86\x64\CL.exe' [C:\Users\ignaz\git\chatterino2\build\chatterino.vcxproj]
C:\Users\ignaz\git\chatterino2\src\util\StreamLink.cpp(202,63): fatal error C1001:     Please choose the Technical Support command on the Visual C++ [C:\Users\ignaz\git\chatterino2\build\chatterino.vcxproj]
C:\Users\ignaz\git\chatterino2\src\util\StreamLink.cpp(202,63): fatal error C1001:     Help menu, or open the Technical Support help file for more information [C:\Users\ignaz\git\chatterino2\build\chatterino.vcxproj]
```