### PR TITLE
Now also shows months subscribed in tooltip

### DIFF
--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -1251,6 +1251,34 @@ void TwitchMessageBuilder::appendTwitchBadges()
                 break;
             }
         }
+        else if (badge.startsWith("founder/"))
+        {
+            if (auto badgeEmote =
+                    this->twitchChannel->globalTwitchBadges().badge("founder",
+                                                                    "0"))
+            {
+                auto badgeInfo = this->tags.find("badge-info");
+                if (badgeInfo != this->tags.end() &&
+                    badgeInfo.value().toString().split(',')[0].startsWith(
+                        "founder/"))
+                {
+                    auto subMonths =
+                        badgeInfo.value().toString().split(',')[0].mid(8);
+                    this->emplace<BadgeElement>(
+                            badgeEmote.get(),
+                            MessageElementFlag::BadgeSubscription)
+                        ->setTooltip(QString((*badgeEmote)->tooltip.string) +
+                                     " (" + subMonths + " months)");
+                }
+                else
+                {
+                    this->emplace<BadgeElement>(
+                            badgeEmote.get(),
+                            MessageElementFlag::BadgeSubscription)
+                        ->setTooltip((*badgeEmote)->tooltip.string);
+                }
+            }
+        }
         else if (badge.startsWith("subscriber/"))
         {
             if (auto badgeEmote = this->twitchChannel->twitchBadge(
@@ -1309,7 +1337,7 @@ void TwitchMessageBuilder::appendTwitchBadges()
             }
         }
     }
-}
+}  // namespace chatterino
 
 void TwitchMessageBuilder::appendChatterinoBadges()
 {

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -1256,9 +1256,26 @@ void TwitchMessageBuilder::appendTwitchBadges()
             if (auto badgeEmote = this->twitchChannel->twitchBadge(
                     "subscriber", badge.mid(11)))
             {
-                this->emplace<BadgeElement>(
-                        badgeEmote.get(), MessageElementFlag::BadgeSubscription)
-                    ->setTooltip((*badgeEmote)->tooltip.string);
+                auto badgeInfo = this->tags.find("badge-info");
+                if (badgeInfo != this->tags.end() &&
+                    badgeInfo.value().toString().split(',')[0].startsWith(
+                        "subscriber/"))
+                {
+                    auto subMonths =
+                        badgeInfo.value().toString().split(',')[0].mid(11);
+                    this->emplace<BadgeElement>(
+                            badgeEmote.get(),
+                            MessageElementFlag::BadgeSubscription)
+                        ->setTooltip(QString((*badgeEmote)->tooltip.string) +
+                                     " (" + subMonths + " months)");
+                }
+                else
+                {
+                    this->emplace<BadgeElement>(
+                            badgeEmote.get(),
+                            MessageElementFlag::BadgeSubscription)
+                        ->setTooltip((*badgeEmote)->tooltip.string);
+                }
                 continue;
             }
 


### PR DESCRIPTION
Now shows months in tooltip when hovering over the subscriber badge.
Since ```@badge-info``` only gives ```subscriber/{months}``` according to https://dev.twitch.tv/docs/irc/tags#globaluserstate-twitch-tags we use first index on the tag.

Closes #1418 