### PR TITLE
Fixed closing tab with middle button when tab management is not allowed.

### DIFF
--- a/src/widgets/helper/NotebookTab.cpp
+++ b/src/widgets/helper/NotebookTab.cpp
@@ -466,7 +466,8 @@ void NotebookTab::mouseReleaseEvent(QMouseEvent *event)
         }
     };
 
-    if (event->button() == Qt::MiddleButton)
+    if (event->button() == Qt::MiddleButton &&
+        this->notebook_->getAllowUserTabManagement())
     {
         if (this->rect().contains(event->pos()))
         {


### PR DESCRIPTION
This PR fixes the possibility to close the tabs in the "Emotes" popup using the middle mouse button.