### PR TITLE
📦 Switch to packages from conan-center && updated packages 

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,12 +1,12 @@
 [requires]
-OpenSSL/1.1.1b@conan/stable
-boost/1.69.0@conan/stable
+openssl/1.1.1d
+boost/1.71.0
 
 [generators]
 qmake
 
 [options]
-OpenSSL:shared=True
+openssl:shared=True
 
 [imports]
 bin, *.dll -> ./Chatterino2 @ keep_path=False


### PR DESCRIPTION
Changes
* Conan now uses the packages from the official [conan-center](https://center.conan.io) 
* Updated openssl to `1.1.1d`
* Updated boost to `1.71.0`

I've tested this PR on windows, everything seems to work without any problems