### PR TITLE
Fixing bits

### DIFF
--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -758,6 +758,7 @@ void TwitchChannel::refreshCheerEmotes()
 
                     cheerEmote.color = QColor(tier.color);
                     cheerEmote.minBits = tier.minBits;
+                    cheerEmote.regex = cheerEmoteSet.regex;
 
                     // TODO(pajlada): We currently hardcode dark here :|
                     // We will continue to do so for now since we haven't had to

--- a/src/providers/twitch/TwitchEmotes.hpp
+++ b/src/providers/twitch/TwitchEmotes.hpp
@@ -18,6 +18,7 @@ using EmotePtr = std::shared_ptr<const Emote>;
 struct CheerEmote {
     QColor color;
     int minBits;
+    QRegularExpression regex;
 
     EmotePtr animatedEmote;
     EmotePtr staticEmote;

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -1264,15 +1264,22 @@ void TwitchMessageBuilder::appendChatterinoBadges()
 
 Outcome TwitchMessageBuilder::tryParseCheermote(const QString &string)
 {
+    if (this->bitsLeft == 0)
+    {
+        return Failure;
+    }
+
     auto cheerOpt = this->twitchChannel->cheerEmote(string);
+
     if (!cheerOpt)
     {
         return Failure;
     }
+
     auto &cheerEmote = *cheerOpt;
     auto match = cheerEmote.regex.match(string);
 
-    if (!match.hasMatch() || this->bitsLeft == 0)
+    if (!match.hasMatch())
     {
         return Failure;
     }
@@ -1286,17 +1293,7 @@ Outcome TwitchMessageBuilder::tryParseCheermote(const QString &string)
     else
     {
         QString newString = string;
-
-        // Calculate digits in the cheernumber
-        int x = cheerValue;
-        int length = 1;
-        while (x /= 10)
-        {
-            length++;
-        }
-
-        // Remove old number and add the new
-        newString.chop(length);
+        newString.chop(QString::number(cheerValue).length());
         newString += QString::number(cheerValue - this->bitsLeft);
 
         return tryParseCheermote(newString);

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -1269,6 +1269,13 @@ Outcome TwitchMessageBuilder::tryParseCheermote(const QString &string)
         return Failure;
     }
     auto &cheerEmote = *cheerOpt;
+    auto match = cheerEmote.regex.match(string);
+
+    if (!match.hasMatch() || !(match.captured(1) <= this->bits))
+    {
+        return Failure;
+    }
+
     if (cheerEmote.staticEmote)
     {
         this->emplace<EmoteElement>(cheerEmote.staticEmote,
@@ -1281,9 +1288,11 @@ Outcome TwitchMessageBuilder::tryParseCheermote(const QString &string)
     }
     if (cheerEmote.color != QColor())
     {
-        this->emplace<TextElement>(this->bits, MessageElementFlag::BitsAmount,
+        this->emplace<TextElement>(match.captured(1),
+                                   MessageElementFlag::BitsAmount,
                                    cheerEmote.color);
     }
+
     return Success;
 }
 

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -1277,17 +1277,18 @@ Outcome TwitchMessageBuilder::tryParseCheermote(const QString &string)
         return Failure;
     }
 
-    if (this->bitsLeft >= match.captured(1).toInt())
+    int cheerValue = match.captured(1).toInt();
+
+    if (this->bitsLeft >= cheerValue)
     {
-        this->bitsLeft -= match.captured(1).toInt();
+        this->bitsLeft -= cheerValue;
     }
     else
     {
         QString newString = string;
-        int stringCheer = match.captured(1).toInt();
 
         // Calculate digits in the cheernumber
-        int x = stringCheer;
+        int x = cheerValue;
         int length = 1;
         while (x /= 10)
         {
@@ -1296,8 +1297,7 @@ Outcome TwitchMessageBuilder::tryParseCheermote(const QString &string)
 
         // Remove old number and add the new
         newString.chop(length);
-        newString +=
-            QString::number(match.captured(1).toInt() - this->bitsLeft);
+        newString += QString::number(cheerValue - this->bitsLeft);
 
         return tryParseCheermote(newString);
     }

--- a/src/providers/twitch/TwitchMessageBuilder.hpp
+++ b/src/providers/twitch/TwitchMessageBuilder.hpp
@@ -81,6 +81,7 @@ private:
     QString roomID_;
     bool hasBits_ = false;
     QString bits;
+    int bitsLeft;
     bool historicalMessage_ = false;
 
     QString userId_;


### PR DESCRIPTION
Fixes #1402 
This pr fixes some issues with the current bits being displayed.


1. Someone types something similiar to what Tetyys types (he's cheered one bit here):
New:
![](https://i.nuuls.com/dBq1C.png)
Old:
![](https://i.nuuls.com/LfcaD.png)


2. Bits should now display different numbers instead of all being the same
New:
![](https://i.nuuls.com/eU_j5.png)
Old:
![](https://i.nuuls.com/WC_Tf.png)

3. Bits now get calculated how many are left (one bit cheered here)
New:
![](https://i.nuuls.com/DHdsL.png)
Old:
![](https://i.nuuls.com/Bcpcd.png)

4. If the amount that is left is less than the next cheer string it will make it accordingly smaller
E.g: 1500 bits cheered and with the message (total written 1599):
```Cheer1000 Cheer100 Cheer100 Cheer100 Cheer100 Cheer99 Cheer100```
New:
![](https://i.nuuls.com/Mbpy6.png)
Old:
![](https://i.nuuls.com/smlrI.png)