### PR TITLE
Fixes URL Regular Expression

### DIFF
--- a/src/common/LinkParser.cpp
+++ b/src/common/LinkParser.cpp
@@ -18,7 +18,7 @@ LinkParser::LinkParser(const QString &unparsedString)
      *              @[-;:&=\\+\\$,\\w]+    <-- If a username is present, match an optional "@passsword"
      *          )?
      *      )?
-     *      (?:[\\w-]+\\.){1,}    <-- Infinite domain capture group "a." (eg: a.b.c. is valid)
+     *      (?:[\\w-]+\\.){1,256}    <-- Infinite domain capture group "a." (eg: a.b.c. is valid)
      *      [\\w-]+        <-- Matches the TLD (.com, .net, etc.). The `.` before the TLD is present from the match above.
      *      (?::\\d+)? <-- Port (optional)
      *      (?:\\/[^\\/]*) <-- Infinite path matching (/a/b/c), no traling slash

--- a/src/common/LinkParser.cpp
+++ b/src/common/LinkParser.cpp
@@ -9,9 +9,27 @@ namespace chatterino {
 
 LinkParser::LinkParser(const QString &unparsedString)
 {
+    /**
+     *  (
+     *      https?:\\/\\/ <-- Must be http(s)
+     *      (?:
+     *          [-;:&=\\+\\$,\\w]+      <-- Username (optional)
+     *          (?:
+     *              @[-;:&=\\+\\$,\\w]+    <-- If a username is present, match an optional "@passsword"
+     *          )?
+     *      )?
+     *      (?:[\\w-]+\\.){1,}    <-- Infinite domain capture group "a." (eg: a.b.c. is valid)
+     *      [\\w-]+        <-- Matches the TLD (.com, .net, etc.). The `.` before the TLD is present from the match above.
+     *      (?::\\d+)? <-- Port (optional)
+     *      (?:\\/[^\\/]*) <-- Infinite path matching (/a/b/c), no traling slash
+     *      *\\/? <-- Optional trailing slash
+     *  )
+     */
+
     static QRegularExpression linkRegex(
-        "^(?:http(s)?:\\/\\/)?[\\w.-]+(?:\\.[\\w\\.-]+)+[\\w\\-\\._~:/"
-        "?#[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$",
+        "(https?:\\/\\/"
+        "(?:[-;:&=\\+\\$,\\w]+(?:@[-;:&=\\+\\$,\\w]+)?)?(?:[\\w-]+\\.){1,}[\\w-"
+        "]+(?::\\d+)?(?:\\/[^\\/]*)*\\/?)",
         QRegularExpression::CaseInsensitiveOption);
 
     this->match_ = linkRegex.match(unparsedString);

--- a/src/common/LinkParser.cpp
+++ b/src/common/LinkParser.cpp
@@ -27,9 +27,12 @@ LinkParser::LinkParser(const QString &unparsedString)
      */
 
     static QRegularExpression linkRegex(
-        "(https?:\\/\\/"
-        "(?:[-;:&=\\+\\$,\\w]+(?:@[-;:&=\\+\\$,\\w]+)?)?(?:[\\w-]+\\.){1,}[\\w-"
-        "]+(?::\\d+)?(?:\\/[^\\/]*)*\\/?)",
+        "(^(https?:\\/\\/(([-;:&=\\+\\$,\\w]+)(@"
+        "([-;:&=\\+\\$,\\w]+))?)?([\\w-]*\\.){1,}"
+        "[\\w-]+(:\\d+)?(\\/[^\\/\\n?]*)*\\/?(\\?"
+        "(([^=\\n&]+)(?:=([^&\\n]*))?&"
+        ")*([^=\\n&]+)(?:=([^&\\n]*))?)?"
+        "(\\#[^\\n]+)?)$)",
         QRegularExpression::CaseInsensitiveOption);
 
     this->match_ = linkRegex.match(unparsedString);


### PR DESCRIPTION
With support for:

- HTTP Authentication (Username:Password?)?
- ~Infinite~ 256 domain capture groups
- Ports
- Path Matching
- Querystring
- Anchors

Currently passes on the following test cases:
```
# Standard
http://host.tld/
https://host.tld/

# Username
http://username@host.tld/
https://username@host.tld/

# Password
http://username:password@host.tld/
https://username:password@host.tld/

# Subdomain
http://sub.host.tld
https://sub.host.tld

http://sub.host.tld/
https://sub.host.tld/

# Path
http://host.tld/some/random/path
https://host.tld/some/random/path

# Querystring
http://host.tld?query=value
https://host.tld?query=value

http://host.tld?query=value&abc=123
https://host.tld?query=value&abc=123

# With Trailing TLD Slash
http://host.tld/?query=value&abc=123&yhf=abc_def

# No Equals
http://host.tld/?query=value&abc=123&yhf

# Null QS Values
http://host.tld?query=value&abc=
http://host.tld?query=value&abc=

# Anchor
http://host.tld/#block
https://host.tld/#anchor

http://host.tld/path/?qs=true#block
https://host.tld/path/?qs=true#anchor
```
and not to forget the infamous `test...` which fails.

Currently working on getting [the following PCRE Regex](https://regex101.com/r/Cf906l/latest/) to compile which is a bit stricter.

^ This needs some more revisions for edge cases. ![WAYTOODANK](https://robinlemon.is-inside.me/yhpFnZ56.png)