### PR TITLE
Expect a PONG response to our PINGs.

### DIFF
--- a/src/providers/irc/IrcConnection2.hpp
+++ b/src/providers/irc/IrcConnection2.hpp
@@ -18,6 +18,9 @@ private:
     QTimer pingTimer_;
     QTimer reconnectTimer_;
     std::atomic<bool> recentlyReceivedMessage_{true};
+
+    // waitingForPong_ is set to true when we send a PING message, and back to false when we receive the matching PONG response
+    std::atomic<bool> waitingForPong_{false};
 };
 
 }  // namespace chatterino


### PR DESCRIPTION
If no PONG was received, force a reconnection.

Fixes #1164

How does this work?
Keep track of sent PINGs and PONGs.
Expect each PING to have a matching PONG.
If a PING does not receive a PONG by the time it's time for us to send another PING message (after 5+ seconds), we stop refreshing the reconnection timer and let it run out on its own (usually after another ~5 seconds).

This way of doing it is a little bit iffy because we have two connections. In the scenario where the entire connection actually dies, both the read and the write connection will die, probably around the same time, and both fire reconnect requests. this will disconnect and reconnect both the read and write connections. But this is not a worse solution than what we already have, it's just not perfect.