### PR TITLE
Synchronize Clipboard with Primary Selection on Linux when copying

### DIFF
--- a/chatterino.pro
+++ b/chatterino.pro
@@ -210,6 +210,7 @@ SOURCES += \
     src/singletons/TooltipPreviewImage.cpp \
     src/singletons/Updates.cpp \
     src/singletons/WindowManager.cpp \
+    src/util/Clipboard.cpp \
     src/util/DebugCount.cpp \
     src/util/FormatTime.cpp \
     src/util/FunctionEventFilter.cpp \
@@ -412,6 +413,7 @@ HEADERS += \
     src/singletons/Updates.hpp \
     src/singletons/WindowManager.hpp \
     src/util/Clamp.hpp \
+    src/util/Clipboard.hpp \
     src/util/CombinePath.hpp \
     src/util/ConcurrentMap.hpp \
     src/util/DebugCount.hpp \

--- a/src/util/Clipboard.cpp
+++ b/src/util/Clipboard.cpp
@@ -1,10 +1,11 @@
 #include "util/Clipboard.hpp"
-#include <QClipboard>
+#include <QApplication>
 
 namespace chatterino {
 
-void crossPlatformCopy(QClipboard *clipboard, const QString &text)
+void crossPlatformCopy(const QString &text)
 {
+    auto clipboard = QApplication::clipboard();
     clipboard->setText(text);
     if (clipboard->supportsSelection())
     {

--- a/src/util/Clipboard.cpp
+++ b/src/util/Clipboard.cpp
@@ -1,0 +1,14 @@
+#include <QClipboard>
+#include "util/Clipboard.hpp"
+
+namespace chatterino {
+
+void crossPlatformCopy(QClipboard *clipboard, const QString &text)
+{
+    clipboard->setText(text);
+    if (clipboard->supportsSelection()) {
+        clipboard->setText(text, QClipboard::Selection);
+    }
+}
+
+}  // namespace chatterino

--- a/src/util/Clipboard.cpp
+++ b/src/util/Clipboard.cpp
@@ -1,12 +1,13 @@
-#include <QClipboard>
 #include "util/Clipboard.hpp"
+#include <QClipboard>
 
 namespace chatterino {
 
 void crossPlatformCopy(QClipboard *clipboard, const QString &text)
 {
     clipboard->setText(text);
-    if (clipboard->supportsSelection()) {
+    if (clipboard->supportsSelection())
+    {
         clipboard->setText(text, QClipboard::Selection);
     }
 }

--- a/src/util/Clipboard.hpp
+++ b/src/util/Clipboard.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+class QClipboard;
+
+namespace chatterino {
+
+void crossPlatformCopy(QClipboard *clipboard, const QString &text);
+
+}  // namespace chatterino

--- a/src/util/Clipboard.hpp
+++ b/src/util/Clipboard.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-class QClipboard;
+#include <QString>
 
 namespace chatterino {
 
-void crossPlatformCopy(QClipboard *clipboard, const QString &text);
+void crossPlatformCopy(const QString &text);
 
 }  // namespace chatterino

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -66,7 +66,8 @@ namespace {
             {
                 copyMenu->addAction(
                     QString(scale) + "x link", [url = image->url()] {
-                        crossPlatformCopy(QApplication::clipboard(), url.string);
+                        crossPlatformCopy(QApplication::clipboard(),
+                                          url.string);
                     });
                 openMenu->addAction(
                     QString(scale) + "x link", [url = image->url()] {
@@ -126,7 +127,8 @@ ChannelView::ChannelView(BaseWidget *parent)
 
     auto shortcut = new QShortcut(QKeySequence("Ctrl+C"), this);
     QObject::connect(shortcut, &QShortcut::activated, [this] {
-        crossPlatformCopy(QGuiApplication::clipboard(), this->getSelectedText());
+        crossPlatformCopy(QGuiApplication::clipboard(),
+                          this->getSelectedText());
     });
 
     this->clickTimer_ = new QTimer(this);
@@ -1326,7 +1328,8 @@ void ChannelView::mousePressEvent(QMouseEvent *event)
     // check if message is collapsed
     switch (event->button())
     {
-        case Qt::LeftButton: {
+        case Qt::LeftButton:
+        {
             this->lastPressPosition_ = event->screenPos();
             this->isMouseDown_ = true;
 
@@ -1344,7 +1347,8 @@ void ChannelView::mousePressEvent(QMouseEvent *event)
         }
         break;
 
-        case Qt::RightButton: {
+        case Qt::RightButton:
+        {
             this->lastRightPressPosition_ = event->screenPos();
             this->isRightMouseDown_ = true;
         }
@@ -1462,7 +1466,8 @@ void ChannelView::handleMouseClick(QMouseEvent *event,
 {
     switch (event->button())
     {
-        case Qt::LeftButton: {
+        case Qt::LeftButton:
+        {
             if (this->selecting_)
             {
                 // this->pausedBySelection = false;
@@ -1486,7 +1491,8 @@ void ChannelView::handleMouseClick(QMouseEvent *event,
             }
         }
         break;
-        case Qt::RightButton: {
+        case Qt::RightButton:
+        {
             auto insertText = [=](QString text) {
                 if (auto split = dynamic_cast<Split *>(this->parentWidget()))
                 {
@@ -1553,8 +1559,9 @@ void ChannelView::addContextMenuItems(
             menu->addAction("Open link incognito",
                             [url] { openLinkIncognito(url); });
         }
-        menu->addAction("Copy link",
-                        [url] { crossPlatformCopy(QApplication::clipboard(), url); });
+        menu->addAction("Copy link", [url] {
+            crossPlatformCopy(QApplication::clipboard(), url);
+        });
 
         menu->addSeparator();
     }
@@ -1563,7 +1570,8 @@ void ChannelView::addContextMenuItems(
     if (!this->selection_.isEmpty())
     {
         menu->addAction("Copy selection", [this] {
-            crossPlatformCopy(QGuiApplication::clipboard(), this->getSelectedText());
+            crossPlatformCopy(QGuiApplication::clipboard(),
+                              this->getSelectedText());
         });
     }
 
@@ -1702,14 +1710,16 @@ void ChannelView::handleLinkClick(QMouseEvent *event, const Link &link,
     switch (link.type)
     {
         case Link::UserWhisper:
-        case Link::UserInfo: {
+        case Link::UserInfo:
+        {
             auto user = link.value;
             this->showUserInfoPopup(user);
             qDebug() << "Clicked " << user << "s message";
         }
         break;
 
-        case Link::Url: {
+        case Link::Url:
+        {
             if (getSettings()->openLinksIncognito && supportsIncognitoLinks())
                 openLinkIncognito(link.value);
             else
@@ -1717,7 +1727,8 @@ void ChannelView::handleLinkClick(QMouseEvent *event, const Link &link,
         }
         break;
 
-        case Link::UserAction: {
+        case Link::UserAction:
+        {
             QString value = link.value;
 
             value.replace("{user}", layout->getMessage()->loginName)
@@ -1729,12 +1740,14 @@ void ChannelView::handleLinkClick(QMouseEvent *event, const Link &link,
         }
         break;
 
-        case Link::AutoModAllow: {
+        case Link::AutoModAllow:
+        {
             getApp()->accounts->twitch.getCurrent()->autoModAllow(link.value);
         }
         break;
 
-        case Link::AutoModDeny: {
+        case Link::AutoModDeny:
+        {
             getApp()->accounts->twitch.getCurrent()->autoModDeny(link.value);
         }
 

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1328,8 +1328,7 @@ void ChannelView::mousePressEvent(QMouseEvent *event)
     // check if message is collapsed
     switch (event->button())
     {
-        case Qt::LeftButton:
-        {
+        case Qt::LeftButton: {
             this->lastPressPosition_ = event->screenPos();
             this->isMouseDown_ = true;
 
@@ -1347,8 +1346,7 @@ void ChannelView::mousePressEvent(QMouseEvent *event)
         }
         break;
 
-        case Qt::RightButton:
-        {
+        case Qt::RightButton: {
             this->lastRightPressPosition_ = event->screenPos();
             this->isRightMouseDown_ = true;
         }
@@ -1466,8 +1464,7 @@ void ChannelView::handleMouseClick(QMouseEvent *event,
 {
     switch (event->button())
     {
-        case Qt::LeftButton:
-        {
+        case Qt::LeftButton: {
             if (this->selecting_)
             {
                 // this->pausedBySelection = false;
@@ -1491,8 +1488,7 @@ void ChannelView::handleMouseClick(QMouseEvent *event,
             }
         }
         break;
-        case Qt::RightButton:
-        {
+        case Qt::RightButton: {
             auto insertText = [=](QString text) {
                 if (auto split = dynamic_cast<Split *>(this->parentWidget()))
                 {
@@ -1710,16 +1706,14 @@ void ChannelView::handleLinkClick(QMouseEvent *event, const Link &link,
     switch (link.type)
     {
         case Link::UserWhisper:
-        case Link::UserInfo:
-        {
+        case Link::UserInfo: {
             auto user = link.value;
             this->showUserInfoPopup(user);
             qDebug() << "Clicked " << user << "s message";
         }
         break;
 
-        case Link::Url:
-        {
+        case Link::Url: {
             if (getSettings()->openLinksIncognito && supportsIncognitoLinks())
                 openLinkIncognito(link.value);
             else
@@ -1727,8 +1721,7 @@ void ChannelView::handleLinkClick(QMouseEvent *event, const Link &link,
         }
         break;
 
-        case Link::UserAction:
-        {
+        case Link::UserAction: {
             QString value = link.value;
 
             value.replace("{user}", layout->getMessage()->loginName)
@@ -1740,14 +1733,12 @@ void ChannelView::handleLinkClick(QMouseEvent *event, const Link &link,
         }
         break;
 
-        case Link::AutoModAllow:
-        {
+        case Link::AutoModAllow: {
             getApp()->accounts->twitch.getCurrent()->autoModAllow(link.value);
         }
         break;
 
-        case Link::AutoModDeny:
-        {
+        case Link::AutoModDeny: {
             getApp()->accounts->twitch.getCurrent()->autoModDeny(link.value);
         }
 

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -66,8 +66,7 @@ namespace {
             {
                 copyMenu->addAction(
                     QString(scale) + "x link", [url = image->url()] {
-                        crossPlatformCopy(QApplication::clipboard(),
-                                          url.string);
+                        crossPlatformCopy(url.string);
                     });
                 openMenu->addAction(
                     QString(scale) + "x link", [url = image->url()] {
@@ -87,7 +86,7 @@ namespace {
 
             copyMenu->addAction(
                 "Copy " + name + " emote link", [url = emote.homePage] {
-                    crossPlatformCopy(QApplication::clipboard(), url.string);
+                    crossPlatformCopy(url.string);
                 });
             openMenu->addAction(
                 "Open " + name + " emote link", [url = emote.homePage] {
@@ -127,8 +126,7 @@ ChannelView::ChannelView(BaseWidget *parent)
 
     auto shortcut = new QShortcut(QKeySequence("Ctrl+C"), this);
     QObject::connect(shortcut, &QShortcut::activated, [this] {
-        crossPlatformCopy(QGuiApplication::clipboard(),
-                          this->getSelectedText());
+        crossPlatformCopy(this->getSelectedText());
     });
 
     this->clickTimer_ = new QTimer(this);
@@ -1556,7 +1554,7 @@ void ChannelView::addContextMenuItems(
                             [url] { openLinkIncognito(url); });
         }
         menu->addAction("Copy link", [url] {
-            crossPlatformCopy(QApplication::clipboard(), url);
+            crossPlatformCopy(url);
         });
 
         menu->addSeparator();
@@ -1566,8 +1564,7 @@ void ChannelView::addContextMenuItems(
     if (!this->selection_.isEmpty())
     {
         menu->addAction("Copy selection", [this] {
-            crossPlatformCopy(QGuiApplication::clipboard(),
-                              this->getSelectedText());
+            crossPlatformCopy(this->getSelectedText());
         });
     }
 
@@ -1576,14 +1573,14 @@ void ChannelView::addContextMenuItems(
         layout->addSelectionText(copyString, 0, INT_MAX,
                                  CopyMode::OnlyTextAndEmotes);
 
-        crossPlatformCopy(QGuiApplication::clipboard(), copyString);
+        crossPlatformCopy(copyString);
     });
 
     menu->addAction("Copy full message", [layout] {
         QString copyString;
         layout->addSelectionText(copyString);
 
-        crossPlatformCopy(QGuiApplication::clipboard(), copyString);
+        crossPlatformCopy(copyString);
     });
 
     // Open in new split.

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -28,6 +28,7 @@
 #include "singletons/Theme.hpp"
 #include "singletons/TooltipPreviewImage.hpp"
 #include "singletons/WindowManager.hpp"
+#include "util/Clipboard.hpp"
 #include "util/DistanceBetweenPoints.hpp"
 #include "util/IncognitoBrowser.hpp"
 #include "widgets/Scrollbar.hpp"
@@ -65,7 +66,7 @@ namespace {
             {
                 copyMenu->addAction(
                     QString(scale) + "x link", [url = image->url()] {
-                        QApplication::clipboard()->setText(url.string);
+                        crossPlatformCopy(QApplication::clipboard(), url.string);
                     });
                 openMenu->addAction(
                     QString(scale) + "x link", [url = image->url()] {
@@ -85,7 +86,7 @@ namespace {
 
             copyMenu->addAction(
                 "Copy " + name + " emote link", [url = emote.homePage] {
-                    QApplication::clipboard()->setText(url.string);  //
+                    crossPlatformCopy(QApplication::clipboard(), url.string);
                 });
             openMenu->addAction(
                 "Open " + name + " emote link", [url = emote.homePage] {
@@ -125,7 +126,7 @@ ChannelView::ChannelView(BaseWidget *parent)
 
     auto shortcut = new QShortcut(QKeySequence("Ctrl+C"), this);
     QObject::connect(shortcut, &QShortcut::activated, [this] {
-        QGuiApplication::clipboard()->setText(this->getSelectedText());
+        crossPlatformCopy(QGuiApplication::clipboard(), this->getSelectedText());
     });
 
     this->clickTimer_ = new QTimer(this);
@@ -1553,7 +1554,7 @@ void ChannelView::addContextMenuItems(
                             [url] { openLinkIncognito(url); });
         }
         menu->addAction("Copy link",
-                        [url] { QApplication::clipboard()->setText(url); });
+                        [url] { crossPlatformCopy(QApplication::clipboard(), url); });
 
         menu->addSeparator();
     }
@@ -1562,7 +1563,7 @@ void ChannelView::addContextMenuItems(
     if (!this->selection_.isEmpty())
     {
         menu->addAction("Copy selection", [this] {
-            QGuiApplication::clipboard()->setText(this->getSelectedText());
+            crossPlatformCopy(QGuiApplication::clipboard(), this->getSelectedText());
         });
     }
 
@@ -1571,14 +1572,14 @@ void ChannelView::addContextMenuItems(
         layout->addSelectionText(copyString, 0, INT_MAX,
                                  CopyMode::OnlyTextAndEmotes);
 
-        QGuiApplication::clipboard()->setText(copyString);
+        crossPlatformCopy(QGuiApplication::clipboard(), copyString);
     });
 
     menu->addAction("Copy full message", [layout] {
         QString copyString;
         layout->addSelectionText(copyString);
 
-        QGuiApplication::clipboard()->setText(copyString);
+        crossPlatformCopy(QGuiApplication::clipboard(), copyString);
     });
 
     // Open in new split.

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -65,9 +65,8 @@ namespace {
             if (!image->isEmpty())
             {
                 copyMenu->addAction(
-                    QString(scale) + "x link", [url = image->url()] {
-                        crossPlatformCopy(url.string);
-                    });
+                    QString(scale) + "x link",
+                    [url = image->url()] { crossPlatformCopy(url.string); });
                 openMenu->addAction(
                     QString(scale) + "x link", [url = image->url()] {
                         QDesktopServices::openUrl(QUrl(url.string));
@@ -85,9 +84,8 @@ namespace {
             openMenu->addSeparator();
 
             copyMenu->addAction(
-                "Copy " + name + " emote link", [url = emote.homePage] {
-                    crossPlatformCopy(url.string);
-                });
+                "Copy " + name + " emote link",
+                [url = emote.homePage] { crossPlatformCopy(url.string); });
             openMenu->addAction(
                 "Open " + name + " emote link", [url = emote.homePage] {
                     QDesktopServices::openUrl(QUrl(url.string));  //
@@ -125,9 +123,8 @@ ChannelView::ChannelView(BaseWidget *parent)
     });
 
     auto shortcut = new QShortcut(QKeySequence("Ctrl+C"), this);
-    QObject::connect(shortcut, &QShortcut::activated, [this] {
-        crossPlatformCopy(this->getSelectedText());
-    });
+    QObject::connect(shortcut, &QShortcut::activated,
+                     [this] { crossPlatformCopy(this->getSelectedText()); });
 
     this->clickTimer_ = new QTimer(this);
     this->clickTimer_->setSingleShot(true);
@@ -1553,9 +1550,7 @@ void ChannelView::addContextMenuItems(
             menu->addAction("Open link incognito",
                             [url] { openLinkIncognito(url); });
         }
-        menu->addAction("Copy link", [url] {
-            crossPlatformCopy(url);
-        });
+        menu->addAction("Copy link", [url] { crossPlatformCopy(url); });
 
         menu->addSeparator();
     }
@@ -1563,9 +1558,8 @@ void ChannelView::addContextMenuItems(
     // Copy actions
     if (!this->selection_.isEmpty())
     {
-        menu->addAction("Copy selection", [this] {
-            crossPlatformCopy(this->getSelectedText());
-        });
+        menu->addAction("Copy selection",
+                        [this] { crossPlatformCopy(this->getSelectedText()); });
     }
 
     menu->addAction("Copy message", [layout] {

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -660,7 +660,8 @@ void Split::openSubPage()
 
 void Split::copyToClipboard()
 {
-    crossPlatformCopy(QApplication::clipboard(), this->view_->getSelectedText());
+    crossPlatformCopy(QApplication::clipboard(),
+                      this->view_->getSelectedText());
 }
 
 void Split::showSearch()

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -10,6 +10,7 @@
 #include "singletons/Settings.hpp"
 #include "singletons/Theme.hpp"
 #include "singletons/WindowManager.hpp"
+#include "util/Clipboard.hpp"
 #include "util/Shortcut.hpp"
 #include "util/StreamLink.hpp"
 #include "widgets/Notebook.hpp"
@@ -659,7 +660,7 @@ void Split::openSubPage()
 
 void Split::copyToClipboard()
 {
-    QApplication::clipboard()->setText(this->view_->getSelectedText());
+    crossPlatformCopy(QApplication::clipboard(), this->view_->getSelectedText());
 }
 
 void Split::showSearch()

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -660,8 +660,7 @@ void Split::openSubPage()
 
 void Split::copyToClipboard()
 {
-    crossPlatformCopy(QApplication::clipboard(),
-                      this->view_->getSelectedText());
+    crossPlatformCopy(this->view_->getSelectedText());
 }
 
 void Split::showSearch()


### PR DESCRIPTION
Hello!

I'm a pretty heavy user of Middle Mouse click and Shift+Insert on Linux (those shortcuts pull data from the primary selection rather than the clipboard, the difference between them is summarize really well here: https://unix.stackexchange.com/a/139193). And the fact that Chatterino is the only app on my setup that does not sync with the selection makes it really inconvenient for me. So I went ahead and tried to fix it. Maybe the fix will be useful for other Linux users.

Please, let me know what you think.