### PR TITLE
Connect to Twitch IRC server using port 443 instead of 6697

### DIFF
--- a/src/common/Env.cpp
+++ b/src/common/Env.cpp
@@ -59,7 +59,7 @@ Env::Env()
           "https://braize.pajlada.com/chatterino/twitchemotes/set/%1/"))
     , twitchServerHost(
           readStringEnv("CHATTERINO2_TWITCH_SERVER_HOST", "irc.chat.twitch.tv"))
-    , twitchServerPort(readPortEnv("CHATTERINO2_TWITCH_SERVER_PORT", 6697))
+    , twitchServerPort(readPortEnv("CHATTERINO2_TWITCH_SERVER_PORT", 443))
     , twitchServerSecure(readBoolEnv("CHATTERINO2_TWITCH_SERVER_SECURE", true))
 {
 }


### PR DESCRIPTION
I experience connection issues similar to these described in #1493 (no messages and users displayed) when running Chatterino in a firewalled environment (outgoing TCP connections to port 6697 blocked). It seems that a breaking change was introduced in PR #1449 (builds before this change worked well on the same machine/environment).

It seems that default Twitch IRC connection port was [accidentally(?) set from 443 to 6697](https://github.com/Chatterino/chatterino2/pull/1449/files#diff-cf97ac2da2381327578c41c94df81a77R62), as opposed to [defaults described in docs](https://github.com/Chatterino/chatterino2/pull/1449/files#diff-17a44c0332fd031df859f133db848ac1R30). Proposed change actually sets the default of `CHATTERINO2_TWITCH_SERVER_PORT` environment value to `443` and hopefully resolves issue #1493.