### PR TITLE
Fix ping payload not breaking portable mode

### DIFF
--- a/src/providers/irc/IrcConnection2.cpp
+++ b/src/providers/irc/IrcConnection2.cpp
@@ -6,8 +6,7 @@ namespace chatterino {
 
 namespace {
 
-    const auto payload =
-        QString("chatterino/%1").arg(Version::instance().version());
+    const auto payload = QString("chatterino/" CHATTERINO_VERSION);
 
 }  // namespace
 


### PR DESCRIPTION
This payload was initialized before main was called, so before the
QApplication was initialized. This broke our portable checker

Fixes #1481