### PR TITLE
Fix Subscription Messages Triggering Split Highlights

### DIFF
--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -648,7 +648,8 @@ void ChannelView::messageAppended(MessagePtr &message,
 
     if (!messageFlags->has(MessageFlag::DoNotTriggerNotification))
     {
-        if (messageFlags->has(MessageFlag::Highlighted))
+        if (messageFlags->has(MessageFlag::Highlighted) &&
+            !messageFlags->has(MessageFlag::Subscription))
         {
             this->tabHighlightRequested.invoke(HighlightState::Highlighted);
         }


### PR DESCRIPTION
Since #1320, subscription messages are treated as highlights in order to allow customization. This caused subscription messages to highlight the split(s) the message was received in. This is not intended behavior.

This commit fixes the issue by additionally checking if the `Subscription` flag is set on a highlighted message.