### PR TITLE
Better Highlights: Rework Highlight Parsing Order

### DIFF
--- a/src/providers/twitch/TwitchMessageBuilder.hpp
+++ b/src/providers/twitch/TwitchMessageBuilder.hpp
@@ -92,7 +92,6 @@ private:
 
     const bool action_ = false;
 
-    bool highlightVisual_ = false;
     bool highlightAlert_ = false;
     bool highlightSound_ = false;
 


### PR DESCRIPTION
This PR is in response to #1523.

Whispers are now only added to the `/mentions` tab if they also match a user name or phrase highlight. On a related note, the `highlightVisual_` member has been removed as it is no longer necessary.