### PR TITLE
Better Highlights: Fix Wrong Color for Migrated Phrases

### DIFF
--- a/src/BaseTheme.cpp
+++ b/src/BaseTheme.cpp
@@ -159,9 +159,6 @@ void AB_THEME_CLASS::actuallyUpdate(double hue, double multiplier)
     this->messages.backgrounds.regular = getColor(0, sat, 1);
     this->messages.backgrounds.alternate = getColor(0, sat, 0.96);
 
-    this->messages.backgrounds.subscription =
-        blendColors(QColor("#C466FF"), this->messages.backgrounds.regular, 0.7);
-
     // this->messages.backgrounds.resub
     // this->messages.backgrounds.whisper
     this->messages.disabled = getColor(0, sat, 1, 0.6);

--- a/src/BaseTheme.cpp
+++ b/src/BaseTheme.cpp
@@ -159,18 +159,6 @@ void AB_THEME_CLASS::actuallyUpdate(double hue, double multiplier)
     this->messages.backgrounds.regular = getColor(0, sat, 1);
     this->messages.backgrounds.alternate = getColor(0, sat, 0.96);
 
-    if (isLight_)
-    {
-        this->messages.backgrounds.highlighted =
-            blendColors(themeColor, this->messages.backgrounds.regular, 0.8);
-    }
-    else
-    {
-        // REMOVED
-        // this->messages.backgrounds.highlighted =
-        //    QColor(getSettings()->highlightColor);
-    }
-
     this->messages.backgrounds.subscription =
         blendColors(QColor("#C466FF"), this->messages.backgrounds.regular, 0.7);
 

--- a/src/BaseTheme.hpp
+++ b/src/BaseTheme.hpp
@@ -64,7 +64,6 @@ public:
         struct {
             QColor regular;
             QColor alternate;
-            QColor subscription;
             // QColor whisper;
         } backgrounds;
 

--- a/src/BaseTheme.hpp
+++ b/src/BaseTheme.hpp
@@ -64,7 +64,6 @@ public:
         struct {
             QColor regular;
             QColor alternate;
-            QColor highlighted;
             QColor subscription;
             // QColor whisper;
         } backgrounds;

--- a/src/controllers/highlights/HighlightPhrase.cpp
+++ b/src/controllers/highlights/HighlightPhrase.cpp
@@ -2,7 +2,7 @@
 
 namespace chatterino {
 
-QColor HighlightPhrase::FALLBACK_COLOR = QColor(127, 63, 73, 127);
+QColor HighlightPhrase::FALLBACK_HIGHLIGHT_COLOR = QColor(127, 63, 73, 127);
 
 bool HighlightPhrase::operator==(const HighlightPhrase &other) const
 {

--- a/src/controllers/highlights/HighlightPhrase.cpp
+++ b/src/controllers/highlights/HighlightPhrase.cpp
@@ -3,6 +3,7 @@
 namespace chatterino {
 
 QColor HighlightPhrase::FALLBACK_HIGHLIGHT_COLOR = QColor(127, 63, 73, 127);
+QColor HighlightPhrase::FALLBACK_SUB_COLOR = QColor(196, 102, 255, 100);
 
 bool HighlightPhrase::operator==(const HighlightPhrase &other) const
 {

--- a/src/controllers/highlights/HighlightPhrase.cpp
+++ b/src/controllers/highlights/HighlightPhrase.cpp
@@ -2,6 +2,8 @@
 
 namespace chatterino {
 
+QColor HighlightPhrase::FALLBACK_COLOR = QColor(127, 63, 73, 127);
+
 bool HighlightPhrase::operator==(const HighlightPhrase &other) const
 {
     return std::tie(this->pattern_, this->hasSound_, this->hasAlert_,

--- a/src/controllers/highlights/HighlightPhrase.hpp
+++ b/src/controllers/highlights/HighlightPhrase.hpp
@@ -70,6 +70,8 @@ public:
     const QUrl &getSoundUrl() const;
     const std::shared_ptr<QColor> getColor() const;
 
+    static constexpr QColor FALLBACK_COLOR = QColor(127, 63, 73, 127);
+
 private:
     QString pattern_;
     bool hasAlert_;
@@ -133,14 +135,7 @@ struct Deserialize<chatterino::HighlightPhrase> {
 
         auto _color = QColor(encodedColor);
         if (!_color.isValid())
-        {
-            /*
-             * As a fallback, use the default self-highlight color. We can't use
-             * getApp()->themes here because the Application instance is not
-             * initialized when this function is called.
-             */
-            _color = QColor(127, 63, 73, 127);
-        }
+            _color = chatterino::HighlightPhrase::FALLBACK_COLOR;
 
         return chatterino::HighlightPhrase(_pattern, _hasAlert, _hasSound,
                                            _isRegex, _isCaseSensitive,

--- a/src/controllers/highlights/HighlightPhrase.hpp
+++ b/src/controllers/highlights/HighlightPhrase.hpp
@@ -74,7 +74,7 @@ public:
      * XXX: Use the constexpr constructor here once we are building with
      * Qt>=5.13.
      */
-    static QColor FALLBACK_COLOR;
+    static QColor FALLBACK_HIGHLIGHT_COLOR;
 
 private:
     QString pattern_;
@@ -139,7 +139,7 @@ struct Deserialize<chatterino::HighlightPhrase> {
 
         auto _color = QColor(encodedColor);
         if (!_color.isValid())
-            _color = chatterino::HighlightPhrase::FALLBACK_COLOR;
+            _color = chatterino::HighlightPhrase::FALLBACK_HIGHLIGHT_COLOR;
 
         return chatterino::HighlightPhrase(_pattern, _hasAlert, _hasSound,
                                            _isRegex, _isCaseSensitive,

--- a/src/controllers/highlights/HighlightPhrase.hpp
+++ b/src/controllers/highlights/HighlightPhrase.hpp
@@ -132,6 +132,15 @@ struct Deserialize<chatterino::HighlightPhrase> {
         chatterino::rj::getSafe(value, "color", encodedColor);
 
         auto _color = QColor(encodedColor);
+        if (!_color.isValid())
+        {
+            /*
+             * As a fallback, use the default self-highlight color. We can't use
+             * getApp()->themes here because the Application instance is not
+             * initialized when this function is called.
+             */
+            _color = QColor(140, 84, 89, 127);
+        }
 
         return chatterino::HighlightPhrase(_pattern, _hasAlert, _hasSound,
                                            _isRegex, _isCaseSensitive,

--- a/src/controllers/highlights/HighlightPhrase.hpp
+++ b/src/controllers/highlights/HighlightPhrase.hpp
@@ -75,6 +75,7 @@ public:
      * Qt>=5.13.
      */
     static QColor FALLBACK_HIGHLIGHT_COLOR;
+    static QColor FALLBACK_SUB_COLOR;
 
 private:
     QString pattern_;

--- a/src/controllers/highlights/HighlightPhrase.hpp
+++ b/src/controllers/highlights/HighlightPhrase.hpp
@@ -139,7 +139,7 @@ struct Deserialize<chatterino::HighlightPhrase> {
              * getApp()->themes here because the Application instance is not
              * initialized when this function is called.
              */
-            _color = QColor(140, 84, 89, 127);
+            _color = QColor(127, 63, 73, 127);
         }
 
         return chatterino::HighlightPhrase(_pattern, _hasAlert, _hasSound,

--- a/src/controllers/highlights/HighlightPhrase.hpp
+++ b/src/controllers/highlights/HighlightPhrase.hpp
@@ -70,7 +70,7 @@ public:
     const QUrl &getSoundUrl() const;
     const std::shared_ptr<QColor> getColor() const;
 
-    static constexpr QColor FALLBACK_COLOR = QColor(127, 63, 73, 127);
+    static QColor FALLBACK_COLOR = QColor(127, 63, 73, 127);
 
 private:
     QString pattern_;

--- a/src/controllers/highlights/HighlightPhrase.hpp
+++ b/src/controllers/highlights/HighlightPhrase.hpp
@@ -70,7 +70,11 @@ public:
     const QUrl &getSoundUrl() const;
     const std::shared_ptr<QColor> getColor() const;
 
-    static QColor FALLBACK_COLOR = QColor(127, 63, 73, 127);
+    /*
+     * XXX: Use the constexpr constructor here once we are building with
+     * Qt>=5.13.
+     */
+    static QColor FALLBACK_COLOR;
 
 private:
     QString pattern_;

--- a/src/providers/colors/ColorProvider.cpp
+++ b/src/providers/colors/ColorProvider.cpp
@@ -89,8 +89,7 @@ void ColorProvider::initTypeColorMap()
     {
         this->typeColorMap_.insert(
             {ColorType::Subscription,
-             std::make_shared<QColor>(
-                 HighlightPhrase::FALLBACK_HIGHLIGHT_COLOR)});
+             std::make_shared<QColor>(HighlightPhrase::FALLBACK_SUB_COLOR)});
     }
 
     customColor = getSettings()->whisperHighlightColor;

--- a/src/providers/colors/ColorProvider.cpp
+++ b/src/providers/colors/ColorProvider.cpp
@@ -75,7 +75,8 @@ void ColorProvider::initTypeColorMap()
     {
         this->typeColorMap_.insert(
             {ColorType::SelfHighlight,
-             std::make_shared<QColor>(HighlightPhrase::FALLBACK_COLOR)});
+             std::make_shared<QColor>(
+                 HighlightPhrase::FALLBACK_HIGHLIGHT_COLOR)});
     }
 
     customColor = getSettings()->subHighlightColor;
@@ -88,7 +89,8 @@ void ColorProvider::initTypeColorMap()
     {
         this->typeColorMap_.insert(
             {ColorType::Subscription,
-             std::make_shared<QColor>(HighlightPhrase::FALLBACK_COLOR)});
+             std::make_shared<QColor>(
+                 HighlightPhrase::FALLBACK_HIGHLIGHT_COLOR)});
     }
 
     customColor = getSettings()->whisperHighlightColor;
@@ -101,7 +103,8 @@ void ColorProvider::initTypeColorMap()
     {
         this->typeColorMap_.insert(
             {ColorType::Whisper,
-             std::make_shared<QColor>(HighlightPhrase::FALLBACK_COLOR)});
+             std::make_shared<QColor>(
+                 HighlightPhrase::FALLBACK_HIGHLIGHT_COLOR)});
     }
 }
 
@@ -115,7 +118,7 @@ void ColorProvider::initDefaultColors()
     this->defaultColors_.emplace_back(28, 141, 117, 127);  // Cyan-ish
 
     auto backgrounds = getApp()->themes->messages.backgrounds;
-    this->defaultColors_.push_back(HighlightPhrase::FALLBACK_COLOR);
+    this->defaultColors_.push_back(HighlightPhrase::FALLBACK_HIGHLIGHT_COLOR);
     this->defaultColors_.push_back(backgrounds.subscription);
 }
 

--- a/src/providers/colors/ColorProvider.cpp
+++ b/src/providers/colors/ColorProvider.cpp
@@ -117,9 +117,8 @@ void ColorProvider::initDefaultColors()
     this->defaultColors_.emplace_back(143, 48, 24, 127);   // Red-ish
     this->defaultColors_.emplace_back(28, 141, 117, 127);  // Cyan-ish
 
-    auto backgrounds = getApp()->themes->messages.backgrounds;
     this->defaultColors_.push_back(HighlightPhrase::FALLBACK_HIGHLIGHT_COLOR);
-    this->defaultColors_.push_back(backgrounds.subscription);
+    this->defaultColors_.push_back(HighlightPhrase::FALLBACK_SUB_COLOR);
 }
 
 }  // namespace chatterino

--- a/src/providers/colors/ColorProvider.cpp
+++ b/src/providers/colors/ColorProvider.cpp
@@ -64,7 +64,6 @@ void ColorProvider::initTypeColorMap()
 {
     // Read settings for custom highlight colors and save them in map.
     // If no custom values can be found, set up default values instead.
-    auto backgrounds = getApp()->themes->messages.backgrounds;
 
     QString customColor = getSettings()->selfHighlightColor;
     if (QColor(customColor).isValid())
@@ -76,7 +75,7 @@ void ColorProvider::initTypeColorMap()
     {
         this->typeColorMap_.insert(
             {ColorType::SelfHighlight,
-             std::make_shared<QColor>(backgrounds.highlighted)});
+             std::make_shared<QColor>(HighlightPhrase::FALLBACK_COLOR)});
     }
 
     customColor = getSettings()->subHighlightColor;
@@ -89,7 +88,7 @@ void ColorProvider::initTypeColorMap()
     {
         this->typeColorMap_.insert(
             {ColorType::Subscription,
-             std::make_shared<QColor>(backgrounds.subscription)});
+             std::make_shared<QColor>(HighlightPhrase::FALLBACK_COLOR)});
     }
 
     customColor = getSettings()->whisperHighlightColor;
@@ -102,7 +101,7 @@ void ColorProvider::initTypeColorMap()
     {
         this->typeColorMap_.insert(
             {ColorType::Whisper,
-             std::make_shared<QColor>(backgrounds.highlighted)});
+             std::make_shared<QColor>(HighlightPhrase::FALLBACK_COLOR)});
     }
 }
 
@@ -116,7 +115,7 @@ void ColorProvider::initDefaultColors()
     this->defaultColors_.emplace_back(28, 141, 117, 127);  // Cyan-ish
 
     auto backgrounds = getApp()->themes->messages.backgrounds;
-    this->defaultColors_.push_back(backgrounds.highlighted);
+    this->defaultColors_.push_back(HighlightPhrase::FALLBACK_COLOR);
     this->defaultColors_.push_back(backgrounds.subscription);
 }
 

--- a/src/singletons/Theme.cpp
+++ b/src/singletons/Theme.cpp
@@ -48,8 +48,6 @@ void Theme::actuallyUpdate(double hue, double multiplier)
         this->splits.resizeHandleBackground = QColor(0, 148, 255, 0x20);
     }
 
-    this->messages.backgrounds.highlighted = QColor(127, 63, 73, 127);
-
     this->splits.header.background = getColor(0, sat, flat ? 1 : 0.9);
     this->splits.header.border = getColor(0, sat, flat ? 1 : 0.85);
     this->splits.header.text = this->messages.textColors.regular;
@@ -74,15 +72,6 @@ void Theme::actuallyUpdate(double hue, double multiplier)
     this->splits.background = getColor(0, sat, 1);
     this->splits.dropPreview = QColor(0, 148, 255, 0x30);
     this->splits.dropPreviewBorder = QColor(0, 148, 255, 0xff);
-
-    // Highlighted Messages
-    // hidden setting from PR #744 - if set it will overwrite theme color
-    // TODO: implement full theme support
-    if (getSettings()->highlightColor != "")
-    {
-        this->messages.backgrounds.highlighted =
-            QColor(getSettings()->highlightColor.getValue());
-    }
 }
 
 void Theme::normalizeColor(QColor &color)

--- a/src/singletons/Theme.cpp
+++ b/src/singletons/Theme.cpp
@@ -48,7 +48,7 @@ void Theme::actuallyUpdate(double hue, double multiplier)
         this->splits.resizeHandleBackground = QColor(0, 148, 255, 0x20);
     }
 
-    this->messages.backgrounds.highlighted = QColor(140, 84, 89, 127);
+    this->messages.backgrounds.highlighted = QColor(127, 63, 73, 127);
 
     this->splits.header.background = getColor(0, sat, flat ? 1 : 0.9);
     this->splits.header.border = getColor(0, sat, flat ? 1 : 0.85);


### PR DESCRIPTION
Prior to this commit, no default color was set when an "old" highlight phrase (one added prior to #1320 / 5957551) was deserialized. This commit makes highlight phrases uses the default self-highlight color for these situations. This approach is reasonably sensible since that color is also similar to the old highlight color.

Fixes #1565.