### PR TITLE
Add option for username tab completion only with an @ prefix

### DIFF
--- a/src/common/CompletionModel.cpp
+++ b/src/common/CompletionModel.cpp
@@ -127,7 +127,7 @@ void CompletionModel::refresh(const QString &prefix, bool isFirstWord)
                               TaggedString::Type::Username);
                 }
             }
-            else if (!getSettings()->userOnlyCompletionWithAt)
+            else if (!getSettings()->userCompletionOnlyWithAt)
             {
                 for (const auto &name :
                      usernames->subrange(Prefix(usernamePrefix)))

--- a/src/common/CompletionModel.cpp
+++ b/src/common/CompletionModel.cpp
@@ -127,7 +127,7 @@ void CompletionModel::refresh(const QString &prefix, bool isFirstWord)
                               TaggedString::Type::Username);
                 }
             }
-            else
+            else if (!getSettings()->userOnlyCompletionWithAt)
             {
                 for (const auto &name :
                      usernames->subrange(Prefix(usernamePrefix)))

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -125,6 +125,8 @@ public:
         "/behaviour/autocompletion/smallStreamerLimit", 1000};
     BoolSetting prefixOnlyEmoteCompletion = {
         "/behaviour/autocompletion/prefixOnlyCompletion", true};
+    BoolSetting userOnlyCompletionWithAt = {
+        "/behaviour/autocompletion/userOnlyCompletionWithAt", true};
 
     FloatSetting pauseOnHoverDuration = {"/behaviour/pauseOnHoverDuration", 0};
     EnumSetting<Qt::KeyboardModifier> pauseChatModifier = {

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -125,8 +125,8 @@ public:
         "/behaviour/autocompletion/smallStreamerLimit", 1000};
     BoolSetting prefixOnlyEmoteCompletion = {
         "/behaviour/autocompletion/prefixOnlyCompletion", true};
-    BoolSetting userOnlyCompletionWithAt = {
-        "/behaviour/autocompletion/userOnlyCompletionWithAt", true};
+    BoolSetting userCompletionOnlyWithAt = {
+        "/behaviour/autocompletion/userCompletionOnlyWithAt", true};
 
     FloatSetting pauseOnHoverDuration = {"/behaviour/pauseOnHoverDuration", 0};
     EnumSetting<Qt::KeyboardModifier> pauseChatModifier = {

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -126,7 +126,7 @@ public:
     BoolSetting prefixOnlyEmoteCompletion = {
         "/behaviour/autocompletion/prefixOnlyCompletion", true};
     BoolSetting userCompletionOnlyWithAt = {
-        "/behaviour/autocompletion/userCompletionOnlyWithAt", true};
+        "/behaviour/autocompletion/userCompletionOnlyWithAt", false};
 
     FloatSetting pauseOnHoverDuration = {"/behaviour/pauseOnHoverDuration", 0};
     EnumSetting<Qt::KeyboardModifier> pauseChatModifier = {

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -524,6 +524,8 @@ void GeneralPage::initLayout(SettingsLayout &layout)
     layout.addCheckbox(
         "Only search for emote autocompletion at the start of emote names",
         s.prefixOnlyEmoteCompletion);
+    layout.addCheckbox("Only search for username autocompletion with an @",
+                       s.userOnlyCompletionWithAt);
 
     layout.addCheckbox("Show twitch whispers inline", s.inlineWhispers);
     layout.addCheckbox("Highlight received inline whispers",

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -525,7 +525,7 @@ void GeneralPage::initLayout(SettingsLayout &layout)
         "Only search for emote autocompletion at the start of emote names",
         s.prefixOnlyEmoteCompletion);
     layout.addCheckbox("Only search for username autocompletion with an @",
-                       s.userOnlyCompletionWithAt);
+                       s.userCompletionOnlyWithAt);
 
     layout.addCheckbox("Show twitch whispers inline", s.inlineWhispers);
     layout.addCheckbox("Highlight received inline whispers",


### PR DESCRIPTION
This attempts to fix https://github.com/Chatterino/chatterino2/issues/1552

When the "Only search for username autocompletion with an @" option is enabled, usernames will be omitted from the `CompletionModel` unless there's an "@" prefix