### PR TITLE
Make emote popup remember last position

### DIFF
--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -274,6 +274,16 @@ Window *WindowManager::windowAt(int index)
     return this->windows_.at(index);
 }
 
+QPoint WindowManager::emotePopupPos()
+{
+    return this->emotePopupPos_;
+}
+
+void WindowManager::setEmotePopupPos(QPoint pos)
+{
+    this->emotePopupPos_ = pos;
+}
+
 void WindowManager::initialize(Settings &settings, Paths &paths)
 {
     assertInGuiThread();
@@ -401,6 +411,10 @@ void WindowManager::initialize(Settings &settings, Paths &paths)
         }
         window.show();
 
+        QJsonObject emote_popup_obj = window_obj.value("emotePopup").toObject();
+        this->emotePopupPos_ = QPoint(emote_popup_obj.value("x").toInt(),
+                                      emote_popup_obj.value("y").toInt());
+
         if (window_obj.value("state") == "minimized")
         {
             window.setWindowState(Qt::WindowMinimized);
@@ -477,6 +491,11 @@ void WindowManager::save()
         window_obj.insert("y", rect.y());
         window_obj.insert("width", rect.width());
         window_obj.insert("height", rect.height());
+
+        QJsonObject emote_popup_obj;
+        emote_popup_obj.insert("x", this->emotePopupPos_.x());
+        emote_popup_obj.insert("y", this->emotePopupPos_.y());
+        window_obj.insert("emotePopup", emote_popup_obj);
 
         // window tabs
         QJsonArray tabs_arr;

--- a/src/singletons/WindowManager.hpp
+++ b/src/singletons/WindowManager.hpp
@@ -51,6 +51,9 @@ public:
     int windowCount();
     Window *windowAt(int index);
 
+    QPoint emotePopupPos();
+    void setEmotePopupPos(QPoint pos);
+
     virtual void initialize(Settings &settings, Paths &paths) override;
     virtual void save() override;
     void closeAll();
@@ -88,6 +91,8 @@ private:
     void encodeNodeRecusively(SplitContainer::Node *node, QJsonObject &obj);
 
     bool initialized_ = false;
+
+    QPoint emotePopupPos_;
 
     std::atomic<int> generation_{0};
 

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -8,6 +8,7 @@
 #include "messages/MessageBuilder.hpp"
 #include "providers/twitch/TwitchChannel.hpp"
 #include "singletons/Emotes.hpp"
+#include "singletons/WindowManager.hpp"
 #include "util/Shortcut.hpp"
 #include "widgets/Notebook.hpp"
 #include "widgets/helper/ChannelView.hpp"
@@ -113,6 +114,8 @@ namespace {
 EmotePopup::EmotePopup(QWidget *parent)
     : BasePopup(BaseWindow::EnableCustomFrame, parent)
 {
+    this->move(getApp()->windows->emotePopupPos());
+
     auto layout = new QVBoxLayout(this);
     this->getLayoutContainer()->setLayout(layout);
 
@@ -220,4 +223,9 @@ void EmotePopup::loadEmojis()
     this->viewEmojis_->setChannel(emojiChannel);
 }
 
+void EmotePopup::closeEvent(QCloseEvent *event)
+{
+    getApp()->windows->setEmotePopupPos(this->pos());
+    QWidget::closeEvent(event);
+}
 }  // namespace chatterino

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -114,7 +114,7 @@ namespace {
 EmotePopup::EmotePopup(QWidget *parent)
     : BasePopup(BaseWindow::EnableCustomFrame, parent)
 {
-    this->move(getApp()->windows->emotePopupPos());
+    this->moveTo(this, getApp()->windows->emotePopupPos());
 
     auto layout = new QVBoxLayout(this);
     this->getLayoutContainer()->setLayout(layout);

--- a/src/widgets/dialogs/EmotePopup.hpp
+++ b/src/widgets/dialogs/EmotePopup.hpp
@@ -19,6 +19,8 @@ public:
     void loadChannel(ChannelPtr channel);
     void loadEmojis();
 
+    virtual void closeEvent(QCloseEvent *event) override;
+
     pajlada::Signals::Signal<Link> linkClicked;
 
 private:


### PR DESCRIPTION
This attempts to fix https://github.com/Chatterino/chatterino2/issues/662

Emote popup position is stored in "window-layout.json". `closeEvent` is reimplemented in `EmotePopup` so that the popup position is saved through `WindowManager`.