### PR TITLE
Make ModBadgeElement a descendant of BadgeElement instead of EmoteElement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,5 +3,6 @@
 ## Unversioned
 - Minor: Emotes in the emote popup are now sorted in the same order as the tab completion (#1549)
 - Bugfix: Fix preview on hover not working when Animated emotes options was disabled (#1546)
+- Bugfix: FFZ custom mod badges no longer scale with the emote scale options (#1602)
 - Settings open faster
 - Dev: Fully remove Twitch Chatroom support

--- a/src/messages/MessageElement.cpp
+++ b/src/messages/MessageElement.cpp
@@ -164,21 +164,6 @@ MessageLayoutElement *EmoteElement::makeImageLayoutElement(
     return new ImageLayoutElement(*this, image, size);
 }
 
-// MOD BADGE
-ModBadgeElement::ModBadgeElement(const EmotePtr &data,
-                                 MessageElementFlags flags_)
-    : EmoteElement(data, flags_)
-{
-}
-
-MessageLayoutElement *ModBadgeElement::makeImageLayoutElement(
-    const ImagePtr &image, const QSize &size)
-{
-    static const QColor modBadgeBackgroundColor("#34AE0A");
-    return new ImageWithBackgroundLayoutElement(*this, image, size,
-                                                modBadgeBackgroundColor);
-}
-
 // BADGE
 BadgeElement::BadgeElement(const EmotePtr &emote, MessageElementFlags flags)
     : MessageElement(flags)
@@ -200,14 +185,41 @@ void BadgeElement::addToContainer(MessageLayoutContainer &container,
         auto size = QSize(int(container.getScale() * image->width()),
                           int(container.getScale() * image->height()));
 
-        container.addElement((new ImageLayoutElement(*this, image, size))
-                                 ->setLink(this->getLink()));
+        container.addElement(this->makeImageLayoutElement(image, size));
     }
 }
 
 EmotePtr BadgeElement::getEmote() const
 {
     return this->emote_;
+}
+
+MessageLayoutElement *BadgeElement::makeImageLayoutElement(
+    const ImagePtr &image, const QSize &size)
+{
+    auto element =
+        (new ImageLayoutElement(*this, image, size))->setLink(this->getLink());
+
+    return element;
+}
+
+// MOD BADGE
+ModBadgeElement::ModBadgeElement(const EmotePtr &data,
+                                 MessageElementFlags flags_)
+    : BadgeElement(data, flags_)
+{
+}
+
+MessageLayoutElement *ModBadgeElement::makeImageLayoutElement(
+    const ImagePtr &image, const QSize &size)
+{
+    static const QColor modBadgeBackgroundColor("#34AE0A");
+
+    auto element = (new ImageWithBackgroundLayoutElement(
+                        *this, image, size, modBadgeBackgroundColor))
+                       ->setLink(this->getLink());
+
+    return element;
 }
 
 // TEXT

--- a/src/messages/MessageElement.hpp
+++ b/src/messages/MessageElement.hpp
@@ -223,17 +223,6 @@ private:
     EmotePtr emote_;
 };
 
-// Behaves like an emote element, except it creates a different image layout element that draws the mod badge background
-class ModBadgeElement : public EmoteElement
-{
-public:
-    ModBadgeElement(const EmotePtr &data, MessageElementFlags flags_);
-
-protected:
-    MessageLayoutElement *makeImageLayoutElement(const ImagePtr &image,
-                                                 const QSize &size) override;
-};
-
 class BadgeElement : public MessageElement
 {
 public:
@@ -244,8 +233,22 @@ public:
 
     EmotePtr getEmote() const;
 
+protected:
+    virtual MessageLayoutElement *makeImageLayoutElement(const ImagePtr &image,
+                                                         const QSize &size);
+
 private:
     EmotePtr emote_;
+};
+
+class ModBadgeElement : public BadgeElement
+{
+public:
+    ModBadgeElement(const EmotePtr &data, MessageElementFlags flags_);
+
+protected:
+    MessageLayoutElement *makeImageLayoutElement(const ImagePtr &image,
+                                                 const QSize &size) override;
 };
 
 // contains a text, formated depending on the preferences


### PR DESCRIPTION
this causes it to behave as it should, and not be scaled when emotes are
scaled. :)

Fixes #1491 