### PR TITLE
Remove Debug Output In Many Different Places

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -145,14 +145,6 @@ void Application::initNm(Paths &paths)
 
 void Application::initPubsub()
 {
-    this->twitch.pubsub->signals_.whisper.sent.connect([](const auto &msg) {
-        qDebug() << "WHISPER SENT LOL";  //
-    });
-
-    this->twitch.pubsub->signals_.whisper.received.connect([](const auto &msg) {
-        qDebug() << "WHISPER RECEIVED LOL";  //
-    });
-
     this->twitch.pubsub->signals_.moderation.chatCleared.connect(
         [this](const auto &action) {
             auto chan =

--- a/src/RunGui.cpp
+++ b/src/RunGui.cpp
@@ -154,11 +154,6 @@ namespace {
                 toBeRemoved << info.absoluteFilePath();
             }
         }
-
-        for (auto &&path : toBeRemoved)
-        {
-            qDebug() << path << QFile(path).remove();
-        }
     }
 }  // namespace
 

--- a/src/messages/Image.cpp
+++ b/src/messages/Image.cpp
@@ -226,10 +226,6 @@ ImagePtr Image::fromUrl(const Url &url, qreal scale)
     {
         cache[url] = shared = ImagePtr(new Image(url, scale));
     }
-    else
-    {
-        // qDebug() << "same image created multiple times:" << url.string;
-    }
 
     return shared;
 }

--- a/src/messages/LimitedQueue.hpp
+++ b/src/messages/LimitedQueue.hpp
@@ -125,8 +125,6 @@ public:
             newChunks->at(0) = newFirstChunk;
 
             this->chunks_ = newChunks;
-            // qDebug() << acceptedItems.size();
-            // qDebug() << this->chunks->at(0)->size();
 
             if (this->chunks_->size() == 1)
             {

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -451,7 +451,6 @@ void IrcMessageHandler::handleUserStateMessage(Communi::IrcMessage *message)
 void IrcMessageHandler::handleWhisperMessage(Communi::IrcMessage *message)
 {
     auto app = getApp();
-    qDebug() << "Received whisper!";
     MessageParseArgs args;
 
     args.isReceivedWhisper = true;

--- a/src/providers/twitch/PubsubClient.cpp
+++ b/src/providers/twitch/PubsubClient.cpp
@@ -826,7 +826,6 @@ void PubSub::listen(rapidjson::Document &&msg)
 
 bool PubSub::tryListen(rapidjson::Document &msg)
 {
-    qDebug() << "tryListen with" << this->clients.size() << "clients";
     for (const auto &p : this->clients)
     {
         const auto &client = p.second;

--- a/src/providers/twitch/PubsubClient.cpp
+++ b/src/providers/twitch/PubsubClient.cpp
@@ -820,7 +820,6 @@ void PubSub::listen(rapidjson::Document &&msg)
 
     this->addClient();
 
-    qDebug() << "Added to the back of the queue";
     this->requests.emplace_back(
         std::make_unique<rapidjson::Document>(std::move(msg)));
 }

--- a/src/providers/twitch/TwitchAccount.cpp
+++ b/src/providers/twitch/TwitchAccount.cpp
@@ -386,7 +386,6 @@ void TwitchAccount::autoModAllow(const QString msgID)
     QString url("https://api.twitch.tv/kraken/chat/twitchbot/approve");
 
     auto qba = (QString("{\"msg_id\":\"") + msgID + "\"}").toUtf8();
-    qDebug() << qba;
 
     NetworkRequest(url, NetworkRequestType::Post)
         .header("Content-Type", "application/json")
@@ -406,7 +405,6 @@ void TwitchAccount::autoModDeny(const QString msgID)
     QString url("https://api.twitch.tv/kraken/chat/twitchbot/deny");
 
     auto qba = (QString("{\"msg_id\":\"") + msgID + "\"}").toUtf8();
-    qDebug() << qba;
 
     NetworkRequest(url, NetworkRequestType::Post)
         .header("Content-Type", "application/json")

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -1063,8 +1063,6 @@ void TwitchMessageBuilder::parseHighlights()
         {
             continue;
         }
-        qDebug() << "Highlight because user" << this->ircMessage->nick()
-                 << "sent a message";
 
         this->message().flags.set(MessageFlag::Highlighted);
         this->message().highlightColor = userHighlight.getColor();
@@ -1127,9 +1125,6 @@ void TwitchMessageBuilder::parseHighlights()
         {
             continue;
         }
-
-        qDebug() << "Highlight because" << this->originalMessage_ << "matches"
-                 << highlight.getPattern();
 
         this->message().flags.set(MessageFlag::Highlighted);
         this->message().highlightColor = highlight.getColor();

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -174,8 +174,6 @@ bool TwitchMessageBuilder::isIgnored() const
     {
         if (phrase.isBlock() && phrase.isMatch(this->originalMessage_))
         {
-            qDebug() << "Blocking message because it contains ignored phrase"
-                     << phrase.getPattern();
             return true;
         }
     }
@@ -205,8 +203,7 @@ bool TwitchMessageBuilder::isIgnored() const
                     case ShowIgnoredUsersMessages::Never:
                         break;
                 }
-                qDebug() << "Blocking message because it's from blocked user"
-                         << user.name;
+
                 return true;
             }
         }

--- a/src/singletons/NativeMessaging.cpp
+++ b/src/singletons/NativeMessaging.cpp
@@ -187,8 +187,6 @@ void NativeMessagingServer::ReceiverThread::handleMessage(
         return;
     }
 
-    qDebug() << root;
-
     if (action == "select")
     {
         QString _type = root.value("type").toString();

--- a/src/util/IncognitoBrowser.cpp
+++ b/src/util/IncognitoBrowser.cpp
@@ -61,8 +61,6 @@ namespace {
         if (command.isNull())
             return QString();
 
-        qDebug() << command;
-
         // inject switch to enable private browsing
         command = injectPrivateSwitch(command);
         if (command.isNull())

--- a/src/widgets/AttachedWindow.cpp
+++ b/src/widgets/AttachedWindow.cpp
@@ -29,8 +29,6 @@ BOOL CALLBACK enumWindows(HWND hwnd, LPARAM)
     auto className = std::make_unique<WCHAR[]>(length);
     GetClassName(hwnd, className.get(), length);
 
-    // qDebug() << QString::fromWCharArray(className.get(), length);
-
     if (lstrcmp(className.get(), L"Shell_TrayWnd") == 0 ||
         lstrcmp(className.get(), L"Shell_Secondary") == 0)
     {

--- a/src/widgets/BaseWindow.cpp
+++ b/src/widgets/BaseWindow.cpp
@@ -384,7 +384,6 @@ void BaseWindow::mousePressEvent(QMouseEvent *event)
 
             if (!recursiveCheckMouseTracking(widget))
             {
-                qDebug() << "Start moving";
                 this->moving = true;
             }
         }
@@ -401,7 +400,6 @@ void BaseWindow::mouseReleaseEvent(QMouseEvent *event)
     {
         if (this->moving)
         {
-            qDebug() << "Stop moving";
             this->moving = false;
         }
     }

--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -149,7 +149,6 @@ void Notebook::select(QWidget *page)
         {
             if (containsChild(page, item.selectedWidget))
             {
-                qDebug() << item.selectedWidget;
                 item.selectedWidget->setFocus(Qt::MouseFocusReason);
             }
             else

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -158,8 +158,6 @@ UserInfoPopup::UserInfoPopup()
 
             if (twitchChannel)
             {
-                qDebug() << this->userName_;
-
                 bool isMyself =
                     QString::compare(
                         getApp()->accounts->twitch.getCurrent()->getUserName(),

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1701,7 +1701,6 @@ void ChannelView::handleLinkClick(QMouseEvent *event, const Link &link,
         case Link::UserInfo: {
             auto user = link.value;
             this->showUserInfoPopup(user);
-            qDebug() << "Clicked " << user << "s message";
         }
         break;
 

--- a/src/widgets/splits/SplitOverlay.cpp
+++ b/src/widgets/splits/SplitOverlay.cpp
@@ -158,8 +158,6 @@ void SplitOverlay::mouseMoveEvent(QMouseEvent *event)
 {
     BaseWidget::mouseMoveEvent(event);
 
-    //    qDebug() << QGuiApplication::queryKeyboardModifiers();
-
     //    if ((QGuiApplication::queryKeyboardModifiers() & Qt::AltModifier) ==
     //    Qt::AltModifier) {
     //        this->hide();


### PR DESCRIPTION
# Description

As mentioned in #1601, many uses of `qDebug()` are artifacts of previous development and no longer serve any real purpose. I tried to gather the uncontroversial ones in this PR.

Removal is split into multiple commits in order to be easier to review (and revert, if needed) but should be squashed on merge.