### PR TITLE
Bring back seconds in timestamps

### DIFF
--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -360,7 +360,9 @@ void GeneralPage::initLayout(SettingsLayout &layout)
     // layout.addDropdown("Last read message style", {"Default"});
     layout.addCheckbox("Show deleted messages", s.hideModerated, true);
     layout.addDropdown<QString>(
-        "Timestamps", {"Disable", "h:mm", "hh:mm", "h:mm a", "hh:mm a"},
+        "Timestamps",
+        {"Disable", "h:mm", "hh:mm", "h:mm a", "hh:mm a", "h:mm:ss", "hh:mm:ss",
+         "h:mm:ss a", "hh:mm:ss a"},
         s.timestampFormat,
         [](auto val) {
             return getSettings()->showTimestamps.getValue()


### PR DESCRIPTION
# Description
Fixes #1605. Adds new timestamp options:
  - 24 hours with seconds, can change width (`h:mm:ss`)
  - 24 hours with seconds, cannot change width (`hh:mm:ss`)
  - 12 hours with seconds, can change width (`h:mm:ss a`)
  - 12 hours with seconds, cannot change width (`hh:mm:ss a`)