### PR TITLE
Changed text to moderator

### DIFF
--- a/src/providers/ffz/FfzEmotes.cpp
+++ b/src/providers/ffz/FfzEmotes.cpp
@@ -102,7 +102,7 @@ namespace {
             modBadge = std::make_shared<Emote>(Emote{
                 {""},
                 modBadgeImageSet,
-                Tooltip{"Twitch Channel Moderator"},
+                Tooltip{"Moderator"},
                 modBadge1x,
             });
         }


### PR DESCRIPTION
Fixes #1585

ffz currently adds no data in their json for the name of the badge, so it's fine to keep it hardcoded.
e.g https://api.frankerfacez.com/v1/room/id/43309508