### PR TITLE
Added ability to open stream in external video player via URI scheme.

### DIFF
--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -257,6 +257,9 @@ public:
                                        "Choose"};
     QStringSetting streamlinkOpts = {"/external/streamlink/options", ""};
 
+    // Custom URI Scheme
+    QStringSetting customURIScheme = {"/external/urischeme"};
+
     /// Misc
     BoolSetting betaUpdates = {"/misc/beta", false};
 #ifdef Q_OS_LINUX

--- a/src/widgets/settingspages/ExternalToolsPage.cpp
+++ b/src/widgets/settingspages/ExternalToolsPage.cpp
@@ -68,6 +68,23 @@ ExternalToolsPage::ExternalToolsPage()
             this->managedConnections_);
     }
 
+    {
+        auto group = layout.emplace<QGroupBox>("Custom URI Scheme");
+        auto groupLayout = group.setLayoutType<QFormLayout>();
+
+        const auto description = new QLabel(
+            "You can open video streams directly in any video player that "
+            "has built-in Twitch support and has own URI Scheme.\nE.g.: "
+            "IINA for macOS and Potplayer (with extension) for Windows.");
+        description->setWordWrap(true);
+        description->setStyleSheet("color: #bbb");
+
+        groupLayout->setWidget(0, QFormLayout::SpanningRole, description);
+
+        groupLayout->addRow("URI Scheme:", this->createLineEdit(
+                                               getSettings()->customURIScheme));
+    }
+
     layout->addStretch(1);
 }
 

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -534,6 +534,23 @@ void Split::openInStreamlink()
     }
 }
 
+void Split::openWithCustomScheme()
+{
+    const auto scheme = getSettings()->customURIScheme.getValue();
+    if (scheme.isEmpty())
+    {
+        return;
+    }
+    const auto channel = this->getChannel().get();
+
+    if (const auto twitchChannel = dynamic_cast<TwitchChannel *>(channel))
+    {
+        QDesktopServices::openUrl(QString("%1https://twitch.tv/%2")
+                                      .arg(scheme)
+                                      .arg(twitchChannel->getName()));
+    }
+}
+
 void Split::showViewerList()
 {
     auto viewerDock = new QDockWidget("Viewer List", this);

--- a/src/widgets/splits/Split.hpp
+++ b/src/widgets/splits/Split.hpp
@@ -126,6 +126,7 @@ public slots:
     void openInBrowser();
     void openBrowserPlayer();
     void openInStreamlink();
+    void openWithCustomScheme();
     void copyToClipboard();
     void showSearch();
     void showViewerList();

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -245,6 +245,13 @@ void SplitHeader::initializeLayout()
                              }
                          });
 
+    getSettings()->customURIScheme.connect([this] {
+        if (const auto drop = this->dropdownButton_)
+        {
+            drop->setMenu(this->createMainMenu());
+        }
+    });
+
     layout->setMargin(0);
     layout->setSpacing(0);
     this->setLayout(layout);
@@ -289,6 +296,12 @@ std::unique_ptr<QMenu> SplitHeader::createMainMenu()
 #endif
         menu->addAction(OPEN_IN_STREAMLINK, this->split_,
                         &Split::openInStreamlink);
+
+        if (!getSettings()->customURIScheme.getValue().isEmpty())
+        {
+            menu->addAction("Open with URI Scheme", this->split_,
+                            &Split::openWithCustomScheme);
+        }
         menu->addSeparator();
     }
 


### PR DESCRIPTION
This PR adds a new simple external tool for opening streams directly in any video player that has built-in Twitch support and has own URI Scheme.

Sample use case:
- Install mpv+youtube-dl.
- Add a custom protocol for mpv to the system (`my-super-protocol://`).
- Add it to the chatterino settings.
- Open and watch any stream without streamlink.

<details>

![image](https://user-images.githubusercontent.com/4051126/78499143-aefe8f80-7757-11ea-953d-69f3c96f3026.png)

</details>