### PR TITLE
Get better timeout messages for self

### DIFF
--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -600,9 +600,6 @@ void TwitchChannel::loadRecentMessages()
 
 void TwitchChannel::refreshPubsub()
 {
-    // listen to moderation actions
-    if (!this->hasModRights())
-        return;
     auto roomId = this->roomId();
     if (roomId.isEmpty())
         return;


### PR DESCRIPTION
# Description
In web chat you get better timeout messages when you're the target. You also get to know the reason you were banned or timed out.
This makes it so you always subscribe to the pubsub topic providing this data, regardless of moderator status.

Fixes #962 

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
