### PR TITLE
Fix emote popup position

### DIFF
--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -114,7 +114,7 @@ namespace {
 EmotePopup::EmotePopup(QWidget *parent)
     : BasePopup(BaseWindow::EnableCustomFrame, parent)
 {
-    this->moveTo(this, getApp()->windows->emotePopupPos());
+    this->moveTo(this, getApp()->windows->emotePopupPos(), false);
 
     auto layout = new QVBoxLayout(this);
     this->getLayoutContainer()->setLayout(layout);


### PR DESCRIPTION
Currently, repeated launch of emote popup causes it to "drift". Use `offset=false` for `moveTo` so that emote popup does not shift positions on every launch.