### PR TITLE
Clarified that Redeemed Highlights are from Channel Points, not Bits

### DIFF
--- a/src/controllers/highlights/HighlightModel.cpp
+++ b/src/controllers/highlights/HighlightModel.cpp
@@ -121,7 +121,7 @@ void HighlightModel::afterInit()
     setBoolItem(redeemedRow[Column::Pattern],
                 getSettings()->enableRedeemedHighlight.getValue(), true, false);
     redeemedRow[Column::Pattern]->setData(
-        "Highlights redeemed with Twitch Bits", Qt::DisplayRole);
+        "Highlights redeemed with Channel Points", Qt::DisplayRole);
     //    setBoolItem(redeemedRow[Column::FlashTaskbar],
     //                getSettings()->enableRedeemedHighlightTaskbar.getValue(), true,
     //                false);

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -359,7 +359,7 @@ void GeneralPage::initLayout(SettingsLayout &layout)
     // layout.addCheckbox("Mark last message you read");
     // layout.addDropdown("Last read message style", {"Default"});
     layout.addCheckbox("Show deleted messages", s.hideModerated, true);
-    layout.addCheckbox("Highlight messages redeemed with Twitch Bits",
+    layout.addCheckbox("Highlight messages redeemed with Channel Points",
                        s.enableRedeemedHighlight);
     layout.addDropdown<QString>(
         "Timestamps",


### PR DESCRIPTION
# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
Previously the highlight setting said that the Redeemed highlights were bought with Bits
![image](https://user-images.githubusercontent.com/962989/79633183-35599f00-8164-11ea-8aaf-9f2b0dd78748.png)
However, they're actually redeemed by Channel Points, so I updated the text.
![image](https://user-images.githubusercontent.com/962989/79633197-4bfff600-8164-11ea-9050-31aa4aa032fb.png)
