### PR TITLE
macOS update checker fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,5 +4,6 @@
 - Minor: Emotes in the emote popup are now sorted in the same order as the tab completion (#1549)
 - Bugfix: Fix preview on hover not working when Animated emotes options was disabled (#1546)
 - Bugfix: FFZ custom mod badges no longer scale with the emote scale options (#1602)
+- Bugfix: MacOS updater looked for non-existing fields, causing it to always fail the update check (#1642)
 - Settings open faster
 - Dev: Fully remove Twitch Chatroom support

--- a/src/singletons/Updates.cpp
+++ b/src/singletons/Updates.cpp
@@ -259,7 +259,7 @@ void Updates::checkForUpdates()
             }
 
 #if defined Q_OS_WIN || defined Q_OS_MACOS
-            /// Windows downloads an installer for the new version
+            /// Downloads an installer for the new version
             QJsonValue updateExe_val = object.value("updateexe");
             if (!updateExe_val.isString())
             {
@@ -268,7 +268,8 @@ void Updates::checkForUpdates()
                 return Failure;
             }
             this->updateExe_ = updateExe_val.toString();
-
+#endif
+#ifdef Q_OS_WIN
             /// Windows portable
             QJsonValue portable_val = object.value("portable_download");
             if (!portable_val.isString())
@@ -278,14 +279,15 @@ void Updates::checkForUpdates()
                 return Failure;
             }
             this->updatePortable_ = portable_val.toString();
-
-#elif defined Q_OS_LINUX
+#endif
+#ifdef Q_OS_LINUX
             QJsonValue updateGuide_val = object.value("updateguide");
             if (updateGuide_val.isString())
             {
                 this->updateGuideLink_ = updateGuide_val.toString();
             }
-#else
+#endif
+#if !defined(Q_OS_WIN) && !defined(Q_OS_MAC) && !defined(Q_OS_LINUX)
             return Failure;
 #endif
 

--- a/src/util/InitUpdateButton.cpp
+++ b/src/util/InitUpdateButton.cpp
@@ -16,7 +16,7 @@ void initUpdateButton(Button &button,
         dialog->setActionOnFocusLoss(BaseWindow::Delete);
 
         auto globalPoint = button.mapToGlobal(
-                    QPoint(int(-100 * button.scale()), button.height()));
+            QPoint(int(-100 * button.scale()), button.height()));
 
         // Make sure that update dialog will not go off left edge of screen
         if (globalPoint.x() < 0)

--- a/src/util/InitUpdateButton.cpp
+++ b/src/util/InitUpdateButton.cpp
@@ -14,8 +14,16 @@ void initUpdateButton(Button &button,
     QObject::connect(&button, &Button::leftClicked, [&button] {
         auto dialog = new UpdateDialog();
         dialog->setActionOnFocusLoss(BaseWindow::Delete);
-        dialog->move(button.mapToGlobal(
-            QPoint(int(-100 * button.scale()), button.height())));
+
+        auto globalPoint = button.mapToGlobal(
+                    QPoint(int(-100 * button.scale()), button.height()));
+
+        // Make sure that update dialog will not go off left edge of screen
+        if (globalPoint.x() < 0) {
+            globalPoint.setX(0);
+        }
+
+        dialog->move(globalPoint);
         dialog->show();
         dialog->raise();
 

--- a/src/util/InitUpdateButton.cpp
+++ b/src/util/InitUpdateButton.cpp
@@ -19,7 +19,8 @@ void initUpdateButton(Button &button,
                     QPoint(int(-100 * button.scale()), button.height()));
 
         // Make sure that update dialog will not go off left edge of screen
-        if (globalPoint.x() < 0) {
+        if (globalPoint.x() < 0)
+        {
             globalPoint.setX(0);
         }
 


### PR DESCRIPTION
# Description
On macOS, checking the web API for an update would always result in the "Failed to load version information" message. Also, the update message dialog could sometimes be off-screen to the left making the message unreadable.

Chatterino expected a JSON field "portable_download" for both Windows and macOS, but the web API only provides that field for the `/win/` endpoint. This results in macOS Chatterino always complaining that it couldn't check for an update.

Screenshot before:
<img width="634" alt="before" src="https://user-images.githubusercontent.com/24928223/79927641-678e2980-840e-11ea-9696-d0e2bc5fe042.png">

Screenshot after: (I locally bumped version to test)
<img width="754" alt="after" src="https://user-images.githubusercontent.com/24928223/79927649-6bba4700-840e-11ea-9a93-829c771750f8.png">
