### PR TITLE
Handle middle mouse button on links differently

### DIFF
--- a/src/messages/Link.cpp
+++ b/src/messages/Link.cpp
@@ -19,4 +19,9 @@ bool Link::isValid() const
     return this->type != None;
 }
 
+bool Link::isUrl() const
+{
+    return this->type == Url;
+}
+
 }  // namespace chatterino

--- a/src/messages/Link.hpp
+++ b/src/messages/Link.hpp
@@ -28,6 +28,7 @@ public:
     QString value;
 
     bool isValid() const;
+    bool isUrl() const;
 };
 
 }  // namespace chatterino

--- a/src/widgets/helper/Button.cpp
+++ b/src/widgets/helper/Button.cpp
@@ -212,7 +212,7 @@ void Button::mousePressEvent(QMouseEvent *event)
         return;
     }
 
-    if (event->button() != Qt::LeftButton && event->button() != Qt::MiddleButton)
+    if (event->button() != Qt::LeftButton)
     {
         return;
     }

--- a/src/widgets/helper/Button.cpp
+++ b/src/widgets/helper/Button.cpp
@@ -212,7 +212,7 @@ void Button::mousePressEvent(QMouseEvent *event)
         return;
     }
 
-    if (event->button() != Qt::LeftButton)
+    if (event->button() != Qt::LeftButton && event->button() != Qt::MiddleButton)
     {
         return;
     }

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1384,7 +1384,8 @@ void ChannelView::mousePressEvent(QMouseEvent *event)
                 {
                     break;
                 }
-            } else
+            }
+            else
             {
                 if (this->isScrolling_)
                     this->disableScrolling();

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1408,7 +1408,8 @@ void ChannelView::mouseReleaseEvent(QMouseEvent *event)
     QPoint relativePos;
     int messageIndex;
 
-    bool foundMessage = tryGetMessageAt(event->pos(), layout, relativePos, messageIndex);
+    bool foundMessage =
+        tryGetMessageAt(event->pos(), layout, relativePos, messageIndex);
 
     // check if mouse was pressed
     if (event->button() == Qt::LeftButton)

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1470,7 +1470,7 @@ void ChannelView::mouseReleaseEvent(QMouseEvent *event)
 
             return;
         }
-        else
+        else if (foundMessage)
         {
             const MessageLayoutElement *hoverLayoutElement =
                 layout->getElementAt(relativePos);

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1377,12 +1377,14 @@ void ChannelView::mousePressEvent(QMouseEvent *event)
             const MessageLayoutElement *hoverLayoutElement =
                 layout->getElementAt(relativePos);
 
-            if (hoverLayoutElement != nullptr) {
+            if (hoverLayoutElement != nullptr)
+            {
                 auto &link = hoverLayoutElement->getLink();
                 if (link.isValid()) {
                     break;
                 }
-            } else {
+            } else
+            {
                 if (this->isScrolling_)
                     this->disableScrolling();
                 else

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1377,13 +1377,10 @@ void ChannelView::mousePressEvent(QMouseEvent *event)
             const MessageLayoutElement *hoverLayoutElement =
                 layout->getElementAt(relativePos);
 
-            if (hoverLayoutElement != nullptr)
+            if (hoverLayoutElement != nullptr &&
+                hoverLayoutElement->getLink().isValid())
             {
-                auto &link = hoverLayoutElement->getLink();
-                if (link.isValid())
-                {
-                    break;
-                }
+                break;
             }
             else
             {

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1374,10 +1374,20 @@ void ChannelView::mousePressEvent(QMouseEvent *event)
         break;
 
         case Qt::MiddleButton: {
-            if (this->isScrolling_)
-                this->disableScrolling();
-            else
-                this->enableScrolling(event->screenPos());
+            const MessageLayoutElement *hoverLayoutElement =
+                layout->getElementAt(relativePos);
+
+            if (hoverLayoutElement != nullptr) {
+                auto &link = hoverLayoutElement->getLink();
+                if (link.isValid()) {
+                    break;
+                }
+            } else {
+                if (this->isScrolling_)
+                    this->disableScrolling();
+                else
+                    this->enableScrolling(event->screenPos());
+            }
         }
         break;
 
@@ -1545,6 +1555,14 @@ void ChannelView::handleMouseClick(QMouseEvent *event,
             else
             {
                 this->addContextMenuItems(hoveredElement, layout);
+            }
+        }
+        break;
+        case Qt::MiddleButton: {
+            auto &link = hoveredElement->getLink();
+            if (!getSettings()->linksDoubleClickOnly)
+            {
+                this->handleLinkClick(event, link, layout);
             }
         }
         break;
@@ -1730,7 +1748,7 @@ void ChannelView::showUserInfoPopup(const QString &userName)
 void ChannelView::handleLinkClick(QMouseEvent *event, const Link &link,
                                   MessageLayout *layout)
 {
-    if (event->button() != Qt::LeftButton)
+    if (event->button() != Qt::LeftButton && event->button() != Qt::MiddleButton)
     {
         return;
     }

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1380,7 +1380,8 @@ void ChannelView::mousePressEvent(QMouseEvent *event)
             if (hoverLayoutElement != nullptr)
             {
                 auto &link = hoverLayoutElement->getLink();
-                if (link.isValid()) {
+                if (link.isValid())
+                {
                     break;
                 }
             } else
@@ -1750,7 +1751,8 @@ void ChannelView::showUserInfoPopup(const QString &userName)
 void ChannelView::handleLinkClick(QMouseEvent *event, const Link &link,
                                   MessageLayout *layout)
 {
-    if (event->button() != Qt::LeftButton && event->button() != Qt::MiddleButton)
+    if (event->button() != Qt::LeftButton &&
+        event->button() != Qt::MiddleButton)
     {
         return;
     }


### PR DESCRIPTION
Fixes #1506

Now links can be opened with middle mouse button, the scroll cursor won't activate on links anymore.
