### PR TITLE
Only listen to new pubsub "moderator added" syntax

### DIFF
--- a/src/providers/twitch/PubsubHelpers.cpp
+++ b/src/providers/twitch/PubsubHelpers.cpp
@@ -46,6 +46,11 @@ bool getTargetUser(const rapidjson::Value &data, ActionUser &user)
     return rj::getSafe(data, "target_user_id", user.id);
 }
 
+bool getTargetUserName(const rapidjson::Value &data, ActionUser &user)
+{
+    return rj::getSafe(data, "target_user_login", user.name);
+}
+
 rapidjson::Document createListenMessage(const std::vector<QString> &topicsVec,
                                         std::shared_ptr<TwitchAccount> account)
 {

--- a/src/providers/twitch/PubsubHelpers.hpp
+++ b/src/providers/twitch/PubsubHelpers.hpp
@@ -16,6 +16,7 @@ const rapidjson::Value &getMsgID(const rapidjson::Value &data);
 bool getCreatedByUser(const rapidjson::Value &data, ActionUser &user);
 
 bool getTargetUser(const rapidjson::Value &data, ActionUser &user);
+bool getTargetUserName(const rapidjson::Value &data, ActionUser &user);
 
 rapidjson::Document createListenMessage(const std::vector<QString> &topicsVec,
                                         std::shared_ptr<TwitchAccount> account);


### PR DESCRIPTION
# Description

A new moderator added pubsub event was added, which fires from web chat and from chatterino.
The old moderator added pubsub event was still there, slightly old syntax, but only fired from chatterino. We now only listen to the new moderator added pubsub event

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
