### PR TITLE
move pause-icon to the left and increase size and visibility

### DIFF
--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -856,10 +856,10 @@ void ChannelView::paintEvent(QPaintEvent * /*event*/)
     // draw paused sign
     if (this->paused())
     {
-        auto a = this->scale() * 16;
-        auto brush = QBrush(QColor(127, 127, 127, 63));
-        painter.fillRect(QRectF(this->width() - a, a / 4, a / 4, a), brush);
-        painter.fillRect(QRectF(this->width() - a / 2, a / 4, a / 4, a), brush);
+        auto a = this->scale() * 20;
+        auto brush = QBrush(QColor(127, 127, 127, 255));
+        painter.fillRect(QRectF(5, a / 4, a / 4, a), brush);
+        painter.fillRect(QRectF(15, a / 4, a / 4, a), brush);
     }
 }
 


### PR DESCRIPTION
# Description

fixes #1656

Looks like this now
![uMeR-](https://user-images.githubusercontent.com/9765622/80864930-45a26b80-8c86-11ea-8685-714afba6d487.gif)


