### PR TITLE
Show visual feedback when BTTV and FFZ emotes are loaded

### DIFF
--- a/src/providers/bttv/BttvEmotes.cpp
+++ b/src/providers/bttv/BttvEmotes.cpp
@@ -144,13 +144,14 @@ void BttvEmotes::loadChannel(TwitchChannel &channel, const QString &channelId,
 {
     NetworkRequest(QString(bttvChannelEmoteApiUrl) + channelId)
         .timeout(3000)
-        .onSuccess([callback = std::move(callback), &channel](auto result) -> Outcome {
-            auto pair = parseChannelEmotes(result.parseJson());
-            if (pair.first)
-                callback(std::move(pair.second));
-            channel.addMessage(makeSystemMessage("BTTV: emotes reloaded."));
-            return pair.first;
-        })
+        .onSuccess(
+            [callback = std::move(callback), &channel](auto result) -> Outcome {
+                auto pair = parseChannelEmotes(result.parseJson());
+                if (pair.first)
+                    callback(std::move(pair.second));
+                channel.addMessage(makeSystemMessage("BTTV: emotes reloaded."));
+                return pair.first;
+            })
         .onError([channelId, &channel](auto result) {
             if (result.status() == 203)
             {

--- a/src/providers/bttv/BttvEmotes.cpp
+++ b/src/providers/bttv/BttvEmotes.cpp
@@ -151,7 +151,7 @@ void BttvEmotes::loadChannel(std::weak_ptr<Channel> channel,
             if (pair.first)
                 callback(std::move(pair.second));
             if (auto shared = channel.lock())
-                shared->addMessage(makeSystemMessage("BTTV: emotes reloaded."));
+                shared->addMessage(makeSystemMessage("BetterTTV channel emotes reloaded."));
             return pair.first;
         })
         .onError([channelId, channel](auto result) {
@@ -162,7 +162,7 @@ void BttvEmotes::loadChannel(std::weak_ptr<Channel> channel,
             {
                 // User does not have any BTTV emotes
                 shared->addMessage(
-                    makeSystemMessage("BTTV: this channel has no emotes."));
+                    makeSystemMessage("This channel has no BetterTTV channel emotes."));
             }
             else if (result.status() == NetworkResult::timedoutStatus)
             {
@@ -170,14 +170,14 @@ void BttvEmotes::loadChannel(std::weak_ptr<Channel> channel,
                 qDebug() << "Fetching BTTV emotes for channel" << channelId
                          << "failed due to timeout";
                 shared->addMessage(makeSystemMessage(
-                    "BTTV: failed to fetch emotes. (timed out)"));
+                    "Failed to fetch BetterTTV channel emotes. (timed out)"));
             }
             else
             {
                 qDebug() << "Error fetching BTTV emotes for channel"
                          << channelId << ", error" << result.status();
                 shared->addMessage(makeSystemMessage(
-                    "BTTV: failed to fetch emotes. (unknown error)"));
+                    "Failed to fetch BetterTTV channel emotes. (unknown error)"));
             }
         })
         .execute();

--- a/src/providers/bttv/BttvEmotes.hpp
+++ b/src/providers/bttv/BttvEmotes.hpp
@@ -25,8 +25,10 @@ public:
     std::shared_ptr<const EmoteMap> emotes() const;
     boost::optional<EmotePtr> emote(const EmoteName &name) const;
     void loadEmotes();
-    static void loadChannel(std::weak_ptr<Channel> channel, const QString &channelId,
-                            std::function<void(EmoteMap &&)> callback);
+    static void loadChannel(std::weak_ptr<Channel> channel,
+                            const QString &channelId,
+                            std::function<void(EmoteMap &&)> callback,
+                            bool manualRefresh);
 
 private:
     Atomic<std::shared_ptr<const EmoteMap>> global_;

--- a/src/providers/bttv/BttvEmotes.hpp
+++ b/src/providers/bttv/BttvEmotes.hpp
@@ -4,6 +4,7 @@
 #include "boost/optional.hpp"
 #include "common/Aliases.hpp"
 #include "common/Atomic.hpp"
+#include "providers/twitch/TwitchChannel.hpp"
 
 namespace chatterino {
 
@@ -24,7 +25,7 @@ public:
     std::shared_ptr<const EmoteMap> emotes() const;
     boost::optional<EmotePtr> emote(const EmoteName &name) const;
     void loadEmotes();
-    static void loadChannel(const QString &channelId,
+    static void loadChannel(TwitchChannel &channel, const QString &channelId,
                             std::function<void(EmoteMap &&)> callback);
 
 private:

--- a/src/providers/bttv/BttvEmotes.hpp
+++ b/src/providers/bttv/BttvEmotes.hpp
@@ -25,7 +25,7 @@ public:
     std::shared_ptr<const EmoteMap> emotes() const;
     boost::optional<EmotePtr> emote(const EmoteName &name) const;
     void loadEmotes();
-    static void loadChannel(TwitchChannel &channel, const QString &channelId,
+    static void loadChannel(std::weak_ptr<Channel> channel, const QString &channelId,
                             std::function<void(EmoteMap &&)> callback);
 
 private:

--- a/src/providers/ffz/FfzEmotes.cpp
+++ b/src/providers/ffz/FfzEmotes.cpp
@@ -204,7 +204,7 @@ void FfzEmotes::loadChannel(
             emoteCallback(std::move(emoteMap));
             modBadgeCallback(std::move(modBadge));
             if (auto shared = channel.lock())
-                shared->addMessage(makeSystemMessage("FFZ: emotes reloaded."));
+                shared->addMessage(makeSystemMessage("FrankerFaceZ channel emotes reloaded."));
 
             return Success;
         })
@@ -216,7 +216,7 @@ void FfzEmotes::loadChannel(
             {
                 // User does not have any FFZ emotes
                 shared->addMessage(
-                    makeSystemMessage("FFZ: this channel has no emotes."));
+                    makeSystemMessage("This channel has no FrankerFaceZ channel emotes."));
             }
             else if (result.status() == NetworkResult::timedoutStatus)
             {
@@ -224,14 +224,14 @@ void FfzEmotes::loadChannel(
                 qDebug() << "Fetching FFZ emotes for channel" << channelId
                          << "failed due to timeout";
                 shared->addMessage(makeSystemMessage(
-                    "FFZ: failed to fetch emotes. (timed out)"));
+                    "Failed to fetch FrankerFaceZ channel emotes. (timed out)"));
             }
             else
             {
                 qDebug() << "Error fetching FFZ emotes for channel" << channelId
                          << ", error" << result.status();
                 shared->addMessage(makeSystemMessage(
-                    "FFZ: failed to fetch emotes. (unknown error)"));
+                    "Failed to fetch FrankerFaceZ channel emotes. (unknown error)"));
             }
         })
         .execute();

--- a/src/providers/ffz/FfzEmotes.hpp
+++ b/src/providers/ffz/FfzEmotes.hpp
@@ -24,7 +24,7 @@ public:
     boost::optional<EmotePtr> emote(const EmoteName &name) const;
     void loadEmotes();
     static void loadChannel(
-        TwitchChannel &channel, const QString &channelId,
+        std::weak_ptr<Channel> channel, const QString &channelId,
         std::function<void(EmoteMap &&)> emoteCallback,
         std::function<void(boost::optional<EmotePtr>)> modBadgeCallback);
 

--- a/src/providers/ffz/FfzEmotes.hpp
+++ b/src/providers/ffz/FfzEmotes.hpp
@@ -4,6 +4,7 @@
 #include "boost/optional.hpp"
 #include "common/Aliases.hpp"
 #include "common/Atomic.hpp"
+#include "providers/twitch/TwitchChannel.hpp"
 
 namespace chatterino {
 
@@ -23,7 +24,7 @@ public:
     boost::optional<EmotePtr> emote(const EmoteName &name) const;
     void loadEmotes();
     static void loadChannel(
-        const QString &channelId,
+        TwitchChannel &channel, const QString &channelId,
         std::function<void(EmoteMap &&)> emoteCallback,
         std::function<void(boost::optional<EmotePtr>)> modBadgeCallback);
 

--- a/src/providers/ffz/FfzEmotes.hpp
+++ b/src/providers/ffz/FfzEmotes.hpp
@@ -26,7 +26,8 @@ public:
     static void loadChannel(
         std::weak_ptr<Channel> channel, const QString &channelId,
         std::function<void(EmoteMap &&)> emoteCallback,
-        std::function<void(boost::optional<EmotePtr>)> modBadgeCallback);
+        std::function<void(boost::optional<EmotePtr>)> modBadgeCallback,
+        bool manualRefresh);
 
 private:
     Atomic<std::shared_ptr<const EmoteMap>> global_;

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -158,7 +158,7 @@ bool TwitchChannel::canSendMessage() const
 void TwitchChannel::refreshBTTVChannelEmotes()
 {
     BttvEmotes::loadChannel(
-        *this, this->roomId(),
+        weakOf<Channel>(this), this->roomId(),
         [this, weak = weakOf<Channel>(this)](auto &&emoteMap) {
             if (auto shared = weak.lock())
                 this->bttvEmotes_.set(
@@ -169,7 +169,7 @@ void TwitchChannel::refreshBTTVChannelEmotes()
 void TwitchChannel::refreshFFZChannelEmotes()
 {
     FfzEmotes::loadChannel(
-        *this, this->roomId(),
+        weakOf<Channel>(this), this->roomId(),
         [this, weak = weakOf<Channel>(this)](auto &&emoteMap) {
             if (auto shared = weak.lock())
                 this->ffzEmotes_.set(

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -158,7 +158,8 @@ bool TwitchChannel::canSendMessage() const
 void TwitchChannel::refreshBTTVChannelEmotes()
 {
     BttvEmotes::loadChannel(
-        this->roomId(), [this, weak = weakOf<Channel>(this)](auto &&emoteMap) {
+        *this, this->roomId(),
+        [this, weak = weakOf<Channel>(this)](auto &&emoteMap) {
             if (auto shared = weak.lock())
                 this->bttvEmotes_.set(
                     std::make_shared<EmoteMap>(std::move(emoteMap)));
@@ -168,7 +169,7 @@ void TwitchChannel::refreshBTTVChannelEmotes()
 void TwitchChannel::refreshFFZChannelEmotes()
 {
     FfzEmotes::loadChannel(
-        this->roomId(),
+        *this, this->roomId(),
         [this, weak = weakOf<Channel>(this)](auto &&emoteMap) {
             if (auto shared = weak.lock())
                 this->ffzEmotes_.set(

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -118,8 +118,8 @@ TwitchChannel::TwitchChannel(const QString &name,
         this->refreshLiveStatus();
         this->refreshBadges();
         this->refreshCheerEmotes();
-        this->refreshFFZChannelEmotes();
-        this->refreshBTTVChannelEmotes();
+        this->refreshFFZChannelEmotes(false);
+        this->refreshBTTVChannelEmotes(false);
     });
 
     // timers
@@ -155,7 +155,7 @@ bool TwitchChannel::canSendMessage() const
     return !this->isEmpty();
 }
 
-void TwitchChannel::refreshBTTVChannelEmotes()
+void TwitchChannel::refreshBTTVChannelEmotes(bool manualRefresh)
 {
     BttvEmotes::loadChannel(
         weakOf<Channel>(this), this->roomId(),
@@ -163,10 +163,11 @@ void TwitchChannel::refreshBTTVChannelEmotes()
             if (auto shared = weak.lock())
                 this->bttvEmotes_.set(
                     std::make_shared<EmoteMap>(std::move(emoteMap)));
-        });
+        },
+        manualRefresh);
 }
 
-void TwitchChannel::refreshFFZChannelEmotes()
+void TwitchChannel::refreshFFZChannelEmotes(bool manualRefresh)
 {
     FfzEmotes::loadChannel(
         weakOf<Channel>(this), this->roomId(),
@@ -180,7 +181,8 @@ void TwitchChannel::refreshFFZChannelEmotes()
             {
                 this->ffzCustomModBadge_.set(std::move(modBadge));
             }
-        });
+        },
+        manualRefresh);
 }
 
 void TwitchChannel::sendMessage(const QString &message)

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -91,8 +91,8 @@ public:
     std::shared_ptr<const EmoteMap> bttvEmotes() const;
     std::shared_ptr<const EmoteMap> ffzEmotes() const;
 
-    virtual void refreshBTTVChannelEmotes();
-    virtual void refreshFFZChannelEmotes();
+    virtual void refreshBTTVChannelEmotes(bool manualRefresh);
+    virtual void refreshFFZChannelEmotes(bool manualRefresh);
 
     // Badges
     boost::optional<EmotePtr> ffzCustomModBadge() const;

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -695,8 +695,8 @@ void Split::reloadChannelAndSubscriberEmotes()
 
     if (auto twitchChannel = dynamic_cast<TwitchChannel *>(channel.get()))
     {
-        twitchChannel->refreshBTTVChannelEmotes();
-        twitchChannel->refreshFFZChannelEmotes();
+        twitchChannel->refreshBTTVChannelEmotes(true);
+        twitchChannel->refreshFFZChannelEmotes(true);
     }
 }
 

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -765,8 +765,8 @@ void SplitHeader::reloadChannelEmotes()
 
     if (auto twitchChannel = dynamic_cast<TwitchChannel *>(channel.get()))
     {
-        twitchChannel->refreshFFZChannelEmotes();
-        twitchChannel->refreshBTTVChannelEmotes();
+        twitchChannel->refreshFFZChannelEmotes(true);
+        twitchChannel->refreshBTTVChannelEmotes(true);
     }
 }
 


### PR DESCRIPTION
Upon joining a channel or pressing F5, BTTV and FFZ emotes are
(re)loaded. This change adds visual feedback of the network requests and
their outcome, in the form of a system message in the associated
channel's chat window. These are the 8 possible system messages that can
be shown:

BTTV: emotes reloaded.
BTTV: this channel has no emotes.
BTTV: failed to fetch emotes. (timed out)
BTTV: failed to fetch emotes. (unknown error)
FFZ: emotes reloaded.
FFZ: this channel has no emotes.
FFZ: failed to fetch emotes. (timed out)
FFZ: failed to fetch emotes. (unknown error)