### PR TITLE
Added chatterino as the application 

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,10 @@ int main(int argc, char **argv)
 {
     QApplication a(argc, argv);
 
+    QCoreApplication::setApplicationName("chatterino");
+    QCoreApplication::setApplicationVersion("2.1.7");
+    QCoreApplication::setOrganizationDomain("https://www.chatterino.com");
+
     // convert char** to QStringList
     auto args = QStringList();
     std::transform(argv + 1, argv + argc, std::back_inserter(args),

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,7 +22,7 @@ int main(int argc, char **argv)
     QApplication a(argc, argv);
 
     QCoreApplication::setApplicationName("chatterino");
-    QCoreApplication::setApplicationVersion("2.1.7");
+    QCoreApplication::setApplicationVersion(CHATTERINO_VERSION);
     QCoreApplication::setOrganizationDomain("https://www.chatterino.com");
 
     // convert char** to QStringList


### PR DESCRIPTION
I've started using dwm and wanted to make a special rule for the chatterino classname to all go to the same tag (Desktop). But chatterino doesn't right now provide a WM_CLASS variable in X11 for those windows. This will add that and a little more info about the application.

# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
