### PR TITLE
move tooltip when no space is left on the screen to opposite side of cusor

### DIFF
--- a/src/widgets/BaseWindow.cpp
+++ b/src/widgets/BaseWindow.cpp
@@ -571,6 +571,9 @@ void BaseWindow::moveIntoDesktopRect(QWidget *parent)
     QRect s = desktop->availableGeometry(parent);
     QPoint p = this->pos();
 
+    bool stickRight = false;
+    bool stickBottom = false;
+
     if (p.x() < s.left())
     {
         p.setX(s.left());
@@ -581,11 +584,18 @@ void BaseWindow::moveIntoDesktopRect(QWidget *parent)
     }
     if (p.x() + this->width() > s.right())
     {
-        p.setX(globalCursorPos.x() - this->width());
+        stickRight = true;
+        p.setX(s.right() - this->width());
     }
     if (p.y() + this->height() > s.bottom())
     {
-        p.setY(globalCursorPos.y() - this->height());
+        stickBottom = true;
+        p.setY(s.bottom() - this->height());
+    }
+
+    if (stickRight && stickBottom)
+    {
+        p.setY(globalCursorPos.y() - this->height() - 16);
     }
 
     if (p != this->pos())

--- a/src/widgets/BaseWindow.cpp
+++ b/src/widgets/BaseWindow.cpp
@@ -566,6 +566,7 @@ void BaseWindow::moveIntoDesktopRect(QWidget *parent)
 
     // move the widget into the screen geometry if it's not already in there
     QDesktopWidget *desktop = QApplication::desktop();
+    QPoint globalCursorPos = QCursor::pos();
 
     QRect s = desktop->availableGeometry(parent);
     QPoint p = this->pos();
@@ -580,11 +581,11 @@ void BaseWindow::moveIntoDesktopRect(QWidget *parent)
     }
     if (p.x() + this->width() > s.right())
     {
-        p.setX(s.right() - this->width());
+        p.setX(globalCursorPos.x() - this->width());
     }
     if (p.y() + this->height() > s.bottom())
     {
-        p.setY(s.bottom() - this->height());
+        p.setY(globalCursorPos.y() - this->height());
     }
 
     if (p != this->pos())


### PR DESCRIPTION
Moves the tooltip so it can no longer land under the mouse.
fixes #1683 

And it looks something like this:
![toolip2](https://user-images.githubusercontent.com/9765622/81729236-f03b3b00-948b-11ea-9b86-e0e06a4a9472.gif)


