### PR TITLE
Thumbnails for stream inside of the splitheader tooltip

### DIFF
--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -162,6 +162,7 @@ public:
     BoolSetting linksDoubleClickOnly = {"/links/doubleClickToOpen", false};
     BoolSetting linkInfoTooltip = {"/links/linkInfoTooltip", false};
     IntSetting thumbnailSize = {"/appearance/thumbnailSize", 0};
+    IntSetting thumbnailSizeStream = {"/appearance/thumbnailSizeStream", 2};
     BoolSetting unshortLinks = {"/links/unshortLinks", false};
     BoolSetting lowercaseDomains = {"/links/linkLowercase", true};
 

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -293,6 +293,7 @@ public:
     BoolSetting hideViewerCountAndDuration = {
         "/misc/hideViewerCountAndDuration", false};
     BoolSetting askOnImageUpload = {"/misc/askOnImageUpload", true};
+    BoolSetting showThumbnail = {"/misc/thumbnail", true};
 
     /// Debug
     BoolSetting showUnhandledIrcMessages = {"/debug/showUnhandledIrcMessages",

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -293,7 +293,6 @@ public:
     BoolSetting hideViewerCountAndDuration = {
         "/misc/hideViewerCountAndDuration", false};
     BoolSetting askOnImageUpload = {"/misc/askOnImageUpload", true};
-    BoolSetting showThumbnail = {"/misc/thumbnail", true};
 
     /// Debug
     BoolSetting showUnhandledIrcMessages = {"/debug/showUnhandledIrcMessages",

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -546,6 +546,31 @@ void GeneralPage::initLayout(SettingsLayout &layout)
 
             return fuzzyToInt(args.value, 0);
         });
+    layout.addDropdown<int>(
+        "Show stream thumbnail", {"Off", "Small", "Medium", "Large"},
+        s.thumbnailSizeStream,
+        [](auto val) {
+            if (val == 0)
+                return QString("Off");
+            else if (val == 1)
+                return QString("Small");
+            else if (val == 2)
+                return QString("Medium");
+            else if (val == 3)
+                return QString("Large");
+            else
+                return QString::number(val);
+        },
+        [](auto args) {
+            if (args.value == "Small")
+                return 1;
+            else if (args.value == "Medium")
+                return 2;
+            else if (args.value == "Large")
+                return 3;
+
+            return fuzzyToInt(args.value, 0);
+        });
     layout.addCheckbox("Double click to open links and other elements in chat",
                        s.linksDoubleClickOnly);
     layout.addCheckbox("Unshorten links", s.unshortLinks);

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -90,9 +90,12 @@ namespace {
             <p class=\"center\">%1%2%3%4%5%6 for %7 with %8 viewers</p>")
             .arg(s.title.toHtmlEscaped())
             .arg(s.title.isEmpty() ? QString() : "<br><br>")
-            .arg(thumbnail.isEmpty() ? "Couldn't fetch thumbnail"
-                                     : "<img src=\"data:image/jpg;base64, " +
-                                           thumbnail + "\"/><br>")
+            .arg(getSettings()->thumbnailSizeStream.getValue() > 0
+                     ? (thumbnail.isEmpty()
+                            ? "Couldn't fetch thumbnail"
+                            : "<img src=\"data:image/jpg;base64, " + thumbnail +
+                                  "\"/><br>")
+                     : QString())
             .arg(s.game.toHtmlEscaped())
             .arg(s.game.isEmpty() ? QString() : "<br>")
             .arg(s.rerun ? "Vod-casting" : "Live")

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -20,11 +20,9 @@
 #include "widgets/splits/Split.hpp"
 #include "widgets/splits/SplitContainer.hpp"
 
-#include <QByteArray>
 #include <QDesktopWidget>
 #include <QDrag>
 #include <QHBoxLayout>
-#include <QImage>
 #include <QInputDialog>
 #include <QMenu>
 #include <QMimeData>
@@ -575,8 +573,8 @@ void SplitHeader::updateChannelText()
         {
             this->isLive_ = true;
             if (getSettings()->showThumbnail &&
-                (this->lastThumbnail_.isNull() ||
-                 this->lastThumbnail_.addSecs(60) < QTime::currentTime()))
+                (!this->lastThumbnail_.isValid() ||
+                 this->lastThumbnail_.elapsed() > 60 * 1000))
             {
                 QString url = "https://static-cdn.jtvnw.net/"
                               "previews-ttv/live_user_" +
@@ -586,7 +584,7 @@ void SplitHeader::updateChannelText()
                         this->thumbnail_ =
                             QString::fromLatin1(result.getData().toBase64());
                         updateChannelText();
-                        this->lastThumbnail_ = QTime::currentTime();
+                        this->lastThumbnail_.start();
                         return Success;
                     })
                     .execute();

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -90,12 +90,9 @@ namespace {
             <p class=\"center\">%1%2%3%4%5%6 for %7 with %8 viewers</p>")
             .arg(s.title.toHtmlEscaped())
             .arg(s.title.isEmpty() ? QString() : "<br><br>")
-            .arg(s.title.isEmpty()
-                     ? QString()
-                     : (thumbnail.isEmpty()
-                            ? "Couldn't fetch thumbnail"
-                            : "<img src=\"data:image/jpg;base64, " + thumbnail +
-                                  "\"/><br>"))
+            .arg(thumbnail.isEmpty() ? "Couldn't fetch thumbnail"
+                                     : "<img src=\"data:image/jpg;base64, " +
+                                           thumbnail + "\"/><br>")
             .arg(s.game.toHtmlEscaped())
             .arg(s.game.isEmpty() ? QString() : "<br>")
             .arg(s.rerun ? "Vod-casting" : "Live")
@@ -572,22 +569,21 @@ void SplitHeader::updateChannelText()
         if (streamStatus->live)
         {
             this->isLive_ = true;
-            if (getSettings()->showThumbnail &&
-                (!this->lastThumbnail_.isValid() ||
-                 this->lastThumbnail_.elapsed() > 60 * 1000))
+            if (!this->lastThumbnail_.isValid() ||
+                this->lastThumbnail_.elapsed() > 5 * 60 * 1000)
             {
                 QString url = "https://static-cdn.jtvnw.net/"
                               "previews-ttv/live_user_" +
-                              channel->getName().toLower() + "-180x90.jpg";
+                              channel->getName().toLower() + "-160x90.jpg";
                 NetworkRequest(url, NetworkRequestType::Get)
                     .onSuccess([this](auto result) -> Outcome {
                         this->thumbnail_ =
                             QString::fromLatin1(result.getData().toBase64());
                         updateChannelText();
-                        this->lastThumbnail_.start();
                         return Success;
                     })
                     .execute();
+                this->lastThumbnail_.restart();
             }
             this->tooltipText_ = formatTooltip(*streamStatus, this->thumbnail_);
             title += formatTitle(*streamStatus, *getSettings());

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -586,6 +586,7 @@ void SplitHeader::updateChannelText()
                         this->thumbnail_ =
                             QString::fromLatin1(result.getData().toBase64());
                         updateChannelText();
+                        this->lastThumbnail_ = QTime::currentTime();
                         return Success;
                     })
                     .execute();

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -569,12 +569,25 @@ void SplitHeader::updateChannelText()
         if (streamStatus->live)
         {
             this->isLive_ = true;
-            if (!this->lastThumbnail_.isValid() ||
-                this->lastThumbnail_.elapsed() > 5 * 60 * 1000)
+            QString url = "https://static-cdn.jtvnw.net/"
+                          "previews-ttv/live_user_" +
+                          channel->getName().toLower();
+            switch (getSettings()->thumbnailSizeStream.getValue())
             {
-                QString url = "https://static-cdn.jtvnw.net/"
-                              "previews-ttv/live_user_" +
-                              channel->getName().toLower() + "-160x90.jpg";
+                case 1:
+                    url.append("-80x45.jpg");
+                    break;
+                case 2:
+                    url.append("-160x90.jpg");
+                    break;
+                case 3:
+                    url.append("-360x180.jpg");
+                    break;
+            }
+            if (getSettings()->thumbnailSizeStream > 0 &&
+                (!this->lastThumbnail_.isValid() ||
+                 this->lastThumbnail_.elapsed() > 5 * 60 * 1000))
+            {
                 NetworkRequest(url, NetworkRequestType::Get)
                     .onSuccess([this](auto result) -> Outcome {
                         this->thumbnail_ =
@@ -595,7 +608,7 @@ void SplitHeader::updateChannelText()
     }
 
     this->titleLabel_->setText(title.isEmpty() ? "<empty>" : title);
-}
+}  // namespace chatterino
 
 void SplitHeader::updateModerationModeIcon()
 {

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -574,7 +574,9 @@ void SplitHeader::updateChannelText()
         if (streamStatus->live)
         {
             this->isLive_ = true;
-            if (getSettings()->showThumbnail)
+            if (getSettings()->showThumbnail &&
+                (this->lastThumbnail_.isNull() ||
+                 this->lastThumbnail_.addSecs(60) < QTime::currentTime()))
             {
                 QString url = "https://static-cdn.jtvnw.net/"
                               "previews-ttv/live_user_" +
@@ -583,6 +585,7 @@ void SplitHeader::updateChannelText()
                     .onSuccess([this](auto result) -> Outcome {
                         this->thumbnail_ =
                             QString::fromLatin1(result.getData().toBase64());
+                        updateChannelText();
                         return Success;
                     })
                     .execute();

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -586,8 +586,10 @@ void SplitHeader::updateChannelText()
                 case 3:
                     url.append("-360x180.jpg");
                     break;
+                default:
+                    url = "";
             }
-            if (getSettings()->thumbnailSizeStream > 0 &&
+            if (!url.isEmpty() &&
                 (!this->lastThumbnail_.isValid() ||
                  this->lastThumbnail_.elapsed() > 5 * 60 * 1000))
             {
@@ -611,7 +613,7 @@ void SplitHeader::updateChannelText()
     }
 
     this->titleLabel_->setText(title.isEmpty() ? "<empty>" : title);
-}  // namespace chatterino
+}
 
 void SplitHeader::updateModerationModeIcon()
 {

--- a/src/widgets/splits/SplitHeader.hpp
+++ b/src/widgets/splits/SplitHeader.hpp
@@ -53,6 +53,7 @@ private:
     QString tooltipText_{};
     bool isLive_{false};
     QString thumbnail_;
+    QTime lastThumbnail_;
 
     // ui
     Button *dropdownButton_{};

--- a/src/widgets/splits/SplitHeader.hpp
+++ b/src/widgets/splits/SplitHeader.hpp
@@ -52,6 +52,7 @@ private:
     Split *const split_{};
     QString tooltipText_{};
     bool isLive_{false};
+    QString thumbnail_;
 
     // ui
     Button *dropdownButton_{};

--- a/src/widgets/splits/SplitHeader.hpp
+++ b/src/widgets/splits/SplitHeader.hpp
@@ -53,7 +53,7 @@ private:
     QString tooltipText_{};
     bool isLive_{false};
     QString thumbnail_;
-    QTime lastThumbnail_;
+    QElapsedTimer lastThumbnail_;
 
     // ui
     Button *dropdownButton_{};


### PR DESCRIPTION
# Description
Fetches a thumbnail for a stream on twitch and puts it into the splitheader tooltip.
This is the only thing I miss from only running streamlink

Issues right now:
- ~You have to hover over the header twice before it actually displays the thumbnail.~
- ~I think it downloads the thumbnail every time you hover it~
- Setting in general for disabling it because of data usage

How it currently looks:
![](https://i.nuuls.com/mXEVv.png)