### PR TITLE
Fix "Always on top" setting for macOS

### DIFF
--- a/src/widgets/BaseWindow.cpp
+++ b/src/widgets/BaseWindow.cpp
@@ -214,9 +214,14 @@ void BaseWindow::init()
         });
     }
 #else
-//    if (getSettings()->windowTopMost.getValue()) {
-//        this->setWindowFlag(Qt::WindowStaysOnTopHint);
-//    }
+    // TopMost flag overrides setting
+    if (!this->flags_.has(TopMost))
+    {
+        getSettings()->windowTopMost.connect([this](bool topMost, auto) {
+            this->setWindowFlag(Qt::WindowStaysOnTopHint, topMost);
+            this->show();
+        });
+    }
 #endif
 }
 


### PR DESCRIPTION
# Description

This fixes the "Always on top" setting on macOS. Previously, it only worked on Windows. It would be great if someone could check if this implementation also works on Linux.

Closes #1166 