### PR TITLE
Added possibility to change image uploader's form body with Enviroment Variables

### DIFF
--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -20,7 +20,7 @@ Arguments:
  - `%1` = Emote set ID
 
 ### CHATTERINO2_IMAGE_UPLOADER_URL
-Used to change the URL that Chatterino2 uses when trying to paste an image into chat. This can be used for hosting the uploaded images yourself.
+Used to change the URL that Chatterino2 uses when trying to paste an image into chat. This can be used for hosting the uploaded images yourself.  
 Default value: `https://i.nuuls.com/upload`
 
 Arguments:
@@ -29,6 +29,10 @@ Arguments:
 Notes:
  - If you want to host the images yourself. You need [Nuuls' filehost software](https://github.com/nuuls/filehost)
  - Other image hosting software is currently not supported.
+
+### CHATTERINO2_IMAGE_UPLOADER_FORM_BODY
+Used to change the name of an image form field in a request to the URL that Chatterino2 uses when trying to paste an image into chat. This can be used when your image uploading software accepts a different form field than default value.  
+Default value: `attachment`
 
 ### CHATTERINO2_TWITCH_SERVER_HOST
 String value used to change what Twitch chat server host to connect to.  

--- a/src/common/Env.cpp
+++ b/src/common/Env.cpp
@@ -59,7 +59,8 @@ Env::Env()
           "https://braize.pajlada.com/chatterino/twitchemotes/set/%1/"))
     , imageUploaderUrl(readStringEnv("CHATTERINO2_IMAGE_UPLOADER_URL",
                                      "https://i.nuuls.com/upload"))
-    , imageUploaderFormBody(readStringEnv("CHATTERINO2_IMAGE_UPLOADER_FORM_BODY", "attachment"))
+    , imageUploaderFormBody(
+          readStringEnv("CHATTERINO2_IMAGE_UPLOADER_FORM_BODY", "attachment"))
     , twitchServerHost(
           readStringEnv("CHATTERINO2_TWITCH_SERVER_HOST", "irc.chat.twitch.tv"))
     , twitchServerPort(readPortEnv("CHATTERINO2_TWITCH_SERVER_PORT", 443))

--- a/src/common/Env.cpp
+++ b/src/common/Env.cpp
@@ -59,6 +59,7 @@ Env::Env()
           "https://braize.pajlada.com/chatterino/twitchemotes/set/%1/"))
     , imageUploaderUrl(readStringEnv("CHATTERINO2_IMAGE_UPLOADER_URL",
                                      "https://i.nuuls.com/upload"))
+    , imageUploaderFormBody(readStringEnv("CHATTERINO2_IMAGE_UPLOADER_FORM_BODY", "attachment"))
     , twitchServerHost(
           readStringEnv("CHATTERINO2_TWITCH_SERVER_HOST", "irc.chat.twitch.tv"))
     , twitchServerPort(readPortEnv("CHATTERINO2_TWITCH_SERVER_PORT", 443))

--- a/src/common/Env.hpp
+++ b/src/common/Env.hpp
@@ -15,6 +15,7 @@ public:
     const QString linkResolverUrl;
     const QString twitchEmoteSetResolverUrl;
     const QString imageUploaderUrl;
+    const QString imageUploaderFormBody;
     const QString twitchServerHost;
     const uint16_t twitchServerPort;
     const bool twitchServerSecure;

--- a/src/util/NuulsUploader.cpp
+++ b/src/util/NuulsUploader.cpp
@@ -52,11 +52,10 @@ void uploadImageToNuuls(RawImageData imageData, ChannelPtr channel,
                    QString("image/%1").arg(imageData.format));
     part.setHeader(QNetworkRequest::ContentLengthHeader,
                    QVariant(imageData.data.length()));
-    part.setHeader(
-        QNetworkRequest::ContentDispositionHeader,
-        QString("form-data; name=\"%1\"; filename=\"control_v.%2\"")
-                .arg(FormBody)
-                .arg(imageData.format));
+    part.setHeader(QNetworkRequest::ContentDispositionHeader,
+                   QString("form-data; name=\"%1\"; filename=\"control_v.%2\"")
+                       .arg(FormBody)
+                       .arg(imageData.format));
     payload->setBoundary(boundary);
     payload->append(part);
     NetworkRequest(url, NetworkRequestType::Post)

--- a/src/util/NuulsUploader.cpp
+++ b/src/util/NuulsUploader.cpp
@@ -43,6 +43,7 @@ void uploadImageToNuuls(RawImageData imageData, ChannelPtr channel,
     const static QString contentType =
         QString("multipart/form-data; boundary=%1").arg(boundary);
     static QUrl url(Env::get().imageUploaderUrl);
+    static QString FormBody(Env::get().imageUploaderFormBody);
 
     QHttpMultiPart *payload = new QHttpMultiPart(QHttpMultiPart::FormDataType);
     QHttpPart part = QHttpPart();
@@ -53,8 +54,9 @@ void uploadImageToNuuls(RawImageData imageData, ChannelPtr channel,
                    QVariant(imageData.data.length()));
     part.setHeader(
         QNetworkRequest::ContentDispositionHeader,
-        QString("form-data; name=\"attachment\"; filename=\"control_v.%1\"")
-            .arg(imageData.format));
+        QString("form-data; name=\"%1\"; filename=\"control_v.%2\"")
+                .arg(FormBody)
+                .arg(imageData.format));
     payload->setBoundary(boundary);
     payload->append(part);
     NetworkRequest(url, NetworkRequestType::Post)

--- a/src/util/NuulsUploader.cpp
+++ b/src/util/NuulsUploader.cpp
@@ -43,7 +43,7 @@ void uploadImageToNuuls(RawImageData imageData, ChannelPtr channel,
     const static QString contentType =
         QString("multipart/form-data; boundary=%1").arg(boundary);
     static QUrl url(Env::get().imageUploaderUrl);
-    static QString FormBody(Env::get().imageUploaderFormBody);
+    static QString formBody(Env::get().imageUploaderFormBody);
 
     QHttpMultiPart *payload = new QHttpMultiPart(QHttpMultiPart::FormDataType);
     QHttpPart part = QHttpPart();
@@ -54,7 +54,7 @@ void uploadImageToNuuls(RawImageData imageData, ChannelPtr channel,
                    QVariant(imageData.data.length()));
     part.setHeader(QNetworkRequest::ContentDispositionHeader,
                    QString("form-data; name=\"%1\"; filename=\"control_v.%2\"")
-                       .arg(FormBody)
+                       .arg(formBody)
                        .arg(imageData.format));
     payload->setBoundary(boundary);
     payload->append(part);


### PR DESCRIPTION
Nuuls' uploader software accepts `attachment` as a name of an image form field, but some other hosts don't accept that and use other names.  
This PR makes it possible to change that value with enviroment variable and with this change I can upload images to other uploaders that use multipart form data (like my server).

Since the URL of uploader can be changed with EVs, I thought it would be cool to have this small thing changeable as well.  
This PR also adds a missing newline in docs about changeable uploader's URL.