### PR TITLE
Added logging for uploaded images

### DIFF
--- a/src/util/NuulsUploader.cpp
+++ b/src/util/NuulsUploader.cpp
@@ -95,8 +95,8 @@ void uploadImageToNuuls(RawImageData imageData, ChannelPtr channel,
             if (uploadQueue.empty())
             {
                 channel->addMessage(makeSystemMessage(
-                    QString("Your image has been uploaded to ")
-                        + result.getData() + QString(" .")));
+                    QString("Your image has been uploaded to ") +
+                    result.getData() + QString(" .")));
                 uploadMutex.unlock();
             }
             else

--- a/src/util/NuulsUploader.cpp
+++ b/src/util/NuulsUploader.cpp
@@ -105,7 +105,7 @@ void uploadImageToNuuls(RawImageData imageData, ChannelPtr channel,
             {
                 channel->addMessage(makeSystemMessage(
                     QString("Your image has been uploaded to ") +
-                    result.getData() + QString(" .")));
+                    result.getData()));
                 uploadMutex.unlock();
             }
             else
@@ -184,7 +184,7 @@ void upload(const QMimeData *source, ChannelPtr channel,
                 else
                 {
                     channel->addMessage(makeSystemMessage(
-                        QString("Cannot upload file: %1, Couldn't convert "
+                        QString("Cannot upload file: %1. Couldn't convert "
                                 "image to png.")
                             .arg(localPath)));
                     uploadMutex.unlock();
@@ -212,7 +212,7 @@ void upload(const QMimeData *source, ChannelPtr channel,
             else
             {
                 channel->addMessage(makeSystemMessage(
-                    QString("Cannot upload file: %1, not an image")
+                    QString("Cannot upload file: %1. Not an image.")
                         .arg(localPath)));
                 uploadMutex.unlock();
                 return;

--- a/src/util/NuulsUploader.hpp
+++ b/src/util/NuulsUploader.hpp
@@ -8,6 +8,7 @@ namespace chatterino {
 struct RawImageData {
     QByteArray data;
     QString format;
+    QString filePath;
 };
 
 void upload(QByteArray imageData, ChannelPtr channel,


### PR DESCRIPTION
Closes #1678  
Added logging upload information to a file located in `{messageLogDirectory}/ImageUploader.csv`

I am not sure if the path I chose is okay, since `messageLogDirectory` contains logged messages in general, but there was no better existing path for that.  
Maybe creating another directory for misc logs can be an alternative, but I don't think this is necessary (as for now).

Logged stuff is comma-separated and in following format.
Tell me if the order and types of logged information are okay

1. Path to original file (may be empty on clipboard uploads)
2. Link to uploaded image
3. Current timestamp
4. Current channel's name

I also added uploader's responses to system messages that are being generated and send in current channel upon successful file upload - makes it possible to automatically preview images and I think it's a neat addition.