### PR TITLE
Removed annoying help tooltip for splits

### DIFF
--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -653,16 +653,14 @@ void SplitHeader::mousePressEvent(QMouseEvent *event)
 {
     switch (event->button())
     {
-        case Qt::LeftButton:
-        {
+        case Qt::LeftButton: {
             this->dragging_ = true;
 
             this->dragStart_ = event->pos();
         }
         break;
 
-        case Qt::RightButton:
-        {
+        case Qt::RightButton: {
             auto menu = this->createMainMenu().release();
             menu->setAttribute(Qt::WA_DeleteOnClose);
             menu->popup(this->mapToGlobal(event->pos() + QPoint(0, 4)));

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -673,41 +673,6 @@ void SplitHeader::mousePressEvent(QMouseEvent *event)
 
 void SplitHeader::mouseReleaseEvent(QMouseEvent *event)
 {
-    if (this->dragging_ && event->button() == Qt::LeftButton)
-    {
-        auto pos = event->globalPos();
-
-        if (!showingHelpTooltip_)
-        {
-            this->showingHelpTooltip_ = true;
-
-            QTimer::singleShot(400, this, [this, pos] {
-                if (this->doubleClicked_)
-                {
-                    this->doubleClicked_ = false;
-                    this->showingHelpTooltip_ = false;
-                    return;
-                }
-
-                auto tooltip = new TooltipWidget();
-
-                tooltip->setText("Double click or press <Ctrl+R> to change the "
-                                 "channel.\nClick and "
-                                 "drag to move the split.");
-                tooltip->setFixedSize(tooltip->sizeHint());
-                tooltip->setAttribute(Qt::WA_DeleteOnClose);
-                tooltip->move(pos);
-                tooltip->show();
-                tooltip->raise();
-
-                QTimer::singleShot(3000, tooltip, [this, tooltip] {
-                    tooltip->close();
-                    this->showingHelpTooltip_ = false;
-                });
-            });
-        }
-    }
-
     this->dragging_ = false;
 }
 

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -653,14 +653,16 @@ void SplitHeader::mousePressEvent(QMouseEvent *event)
 {
     switch (event->button())
     {
-        case Qt::LeftButton: {
+        case Qt::LeftButton:
+        {
             this->dragging_ = true;
 
             this->dragStart_ = event->pos();
         }
         break;
 
-        case Qt::RightButton: {
+        case Qt::RightButton:
+        {
             auto menu = this->createMainMenu().release();
             menu->setAttribute(Qt::WA_DeleteOnClose);
             menu->popup(this->mapToGlobal(event->pos() + QPoint(0, 4)));
@@ -694,6 +696,7 @@ void SplitHeader::mouseReleaseEvent(QMouseEvent *event)
                 tooltip->setText("Double click or press <Ctrl+R> to change the "
                                  "channel.\nClick and "
                                  "drag to move the split.");
+                tooltip->setFixedSize(tooltip->sizeHint());
                 tooltip->setAttribute(Qt::WA_DeleteOnClose);
                 tooltip->move(pos);
                 tooltip->show();

--- a/src/widgets/splits/SplitHeader.hpp
+++ b/src/widgets/splits/SplitHeader.hpp
@@ -66,7 +66,6 @@ private:
     QPoint dragStart_{};
     bool dragging_{false};
     bool doubleClicked_{false};
-    bool showingHelpTooltip_{false};
     bool menuVisible_{false};
 
     // signals


### PR DESCRIPTION
It was unnecessarily taking too much space.

Before https://cdn.zneix.eu/EF8zEL8.png
![](https://cdn.zneix.eu/EF8zEL8.png)

I eventually removed it entirely after fourtf's comment.
~~After https://cdn.zneix.eu/6eRX2ze.png~~
~~![](https://cdn.zneix.eu/6eRX2ze.png)~~

We were talking about it with supinic on his stream and there was a suggestion to disable / remove this completely. Having an option to "disable help / tooltips" would be nice, but there's not so many of those things currently - maybe something could be added in the future if chatterino will have more help tooltips.