### PR TITLE
Made --version argument output consistent with AboutPage

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,7 +38,13 @@ int main(int argc, char **argv)
     }
     else if (getArgs().printVersion)
     {
-        qInfo().noquote() << Version::instance().fullVersion();
+        auto version = Version::instance();
+        qInfo().noquote() << QString("%1 (commit %2%3)")
+                                 .arg(version.fullVersion())
+                                 .arg(version.commitHash())
+                                 .arg(Modes::instance().isNightly
+                                          ? ", " + version.dateOfBuild()
+                                          : "");
     }
     else
     {


### PR DESCRIPTION
When using `chatterino --version` it now also outputs commit (and date of build if on nightly), just like in Settings -> About:

![](https://cdn.zneix.eu/GnPIMtQ.png)

I think it's a useful addition, especially when you work with nightly builds and want to quickly identify version without having to launch the app and going to settings.