### PR TITLE
More image uploader services and json logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,15 @@
 # Changelog
 
 ## Unversioned
-- Major: We now support image thumbnails coming from the link resolver. This feature is off by default and can be enabled in the settings with the "Show link thumbnail" setting. This feature also requires the "Show link info when hovering" setting to be enabled (#1664)
-- Major: Added image upload functionality to i.nuuls.com. This works by dragging and dropping an image into a split, or pasting an image into the text edit field. (#1332)
-- Minor: You can now open the Twitch User Card by middle-mouse clicking a username. (#1669)
-- Minor: Emotes in the emote popup are now sorted in the same order as the tab completion (#1549)
-- Minor: Removed "Online Logs" functionality as services are shut down (#1640)
-- Bugfix: Fix preview on hover not working when Animated emotes options was disabled (#1546)
-- Bugfix: FFZ custom mod badges no longer scale with the emote scale options (#1602)
-- Bugfix: MacOS updater looked for non-existing fields, causing it to always fail the update check (#1642)
+- Major: We now support image thumbnails coming from the link resolver. This feature is off by default and can be enabled in the settings with the "Show link thumbnail" setting. This feature also requires the "Show link info when hovering" setting to be enabled ([#1664](https://github.com/Chatterino/chatterino2/pull/1664))
+- Major: Added image upload functionality to i.nuuls.com with an ability to change upload destination. This works by dragging and dropping an image into a split, or pasting an image into the text edit field. ([#1332](https://github.com/Chatterino/chatterino2/pull/1332), [#1741](https://github.com/Chatterino/chatterino2/pull/1741))
+- Minor: You can now open the Twitch User Card by middle-mouse clicking a username. ([#1669](https://github.com/Chatterino/chatterino2/pull/1669))
+- Minor: User Popup now also includes recent user messages ([#1729](https://github.com/Chatterino/chatterino2/pull/1729))
+- Minor: BetterTTV / FrankerFaceZ emote tooltips now also have emote authors' name ([#1721](https://github.com/Chatterino/chatterino2/pull/1721))
+- Minor: Emotes in the emote popup are now sorted in the same order as the tab completion ([#1549](https://github.com/Chatterino/chatterino2/issues/1549))
+- Minor: Removed "Online Logs" functionality as services are shut down ([#1640](https://github.com/Chatterino/chatterino2/issues/1640))
+- Bugfix: Fix preview on hover not working when Animated emotes options was disabled ([#1546](https://github.com/Chatterino/chatterino2/issues/1546))
+- Bugfix: FFZ custom mod badges no longer scale with the emote scale options ([#1602](https://github.com/Chatterino/chatterino2/pull/1602))
+- Bugfix: MacOS updater looked for non-existing fields, causing it to always fail the update check ([#1642](https://github.com/Chatterino/chatterino2/pull/1642))
 - Settings open faster
 - Dev: Fully remove Twitch Chatroom support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,15 @@
 # Changelog
 
 ## Unversioned
-- Major: We now support image thumbnails coming from the link resolver. This feature is off by default and can be enabled in the settings with the "Show link thumbnail" setting. This feature also requires the "Show link info when hovering" setting to be enabled ([#1664](https://github.com/Chatterino/chatterino2/pull/1664))
-- Major: Added image upload functionality to i.nuuls.com with an ability to change upload destination. This works by dragging and dropping an image into a split, or pasting an image into the text edit field. ([#1332](https://github.com/Chatterino/chatterino2/pull/1332), [#1741](https://github.com/Chatterino/chatterino2/pull/1741))
-- Minor: You can now open the Twitch User Card by middle-mouse clicking a username. ([#1669](https://github.com/Chatterino/chatterino2/pull/1669))
-- Minor: User Popup now also includes recent user messages ([#1729](https://github.com/Chatterino/chatterino2/pull/1729))
-- Minor: BetterTTV / FrankerFaceZ emote tooltips now also have emote authors' name ([#1721](https://github.com/Chatterino/chatterino2/pull/1721))
-- Minor: Emotes in the emote popup are now sorted in the same order as the tab completion ([#1549](https://github.com/Chatterino/chatterino2/issues/1549))
-- Minor: Removed "Online Logs" functionality as services are shut down ([#1640](https://github.com/Chatterino/chatterino2/issues/1640))
-- Bugfix: Fix preview on hover not working when Animated emotes options was disabled ([#1546](https://github.com/Chatterino/chatterino2/issues/1546))
-- Bugfix: FFZ custom mod badges no longer scale with the emote scale options ([#1602](https://github.com/Chatterino/chatterino2/pull/1602))
-- Bugfix: MacOS updater looked for non-existing fields, causing it to always fail the update check ([#1642](https://github.com/Chatterino/chatterino2/pull/1642))
+- Major: We now support image thumbnails coming from the link resolver. This feature is off by default and can be enabled in the settings with the "Show link thumbnail" setting. This feature also requires the "Show link info when hovering" setting to be enabled (#1664)
+- Major: Added image upload functionality to i.nuuls.com with an ability to change upload destination. This works by dragging and dropping an image into a split, or pasting an image into the text edit field. (#1332, #1741)
+- Minor: You can now open the Twitch User Card by middle-mouse clicking a username. (#1669)
+- Minor: User Popup now also includes recent user messages (#1729)
+- Minor: BetterTTV / FrankerFaceZ emote tooltips now also have emote authors' name (#1721)
+- Minor: Emotes in the emote popup are now sorted in the same order as the tab completion (#1549)
+- Minor: Removed "Online Logs" functionality as services are shut down (#1640)
+- Bugfix: Fix preview on hover not working when Animated emotes options was disabled (#1546)
+- Bugfix: FFZ custom mod badges no longer scale with the emote scale options (#1602)
+- Bugfix: MacOS updater looked for non-existing fields, causing it to always fail the update check (#1642)
 - Settings open faster
 - Dev: Fully remove Twitch Chatroom support

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -19,21 +19,6 @@ Default value: `https://braize.pajlada.com/chatterino/twitchemotes/set/%1/`
 Arguments:  
  - `%1` = Emote set ID
 
-### CHATTERINO2_IMAGE_UPLOADER_URL
-Used to change the URL that Chatterino2 uses when trying to paste an image into chat. This can be used for hosting the uploaded images yourself.  
-Default value: `https://i.nuuls.com/upload`
-
-Arguments:
- - None
-
-Notes:
- - If you want to host the images yourself. You need [Nuuls' filehost software](https://github.com/nuuls/filehost)
- - Other image hosting software is currently not supported.
-
-### CHATTERINO2_IMAGE_UPLOADER_FORM_BODY
-Used to change the name of an image form field in a request to the URL that Chatterino2 uses when trying to paste an image into chat. This can be used when your image uploading software accepts a different form field than default value.  
-Default value: `attachment`
-
 ### CHATTERINO2_TWITCH_SERVER_HOST
 String value used to change what Twitch chat server host to connect to.  
 Default value: `irc.chat.twitch.tv`

--- a/docs/IMAGEUPLOADER.md
+++ b/docs/IMAGEUPLOADER.md
@@ -1,0 +1,47 @@
+## Image Uploader
+You can drag and drop images to Chatterino or paste them from clipboard to upload them to an external service.
+
+By default, images are uploaded to [i.nuuls.com](https://i.nuuls.com).  
+You can change that in `Chatterino Settings -> External Tools -> Image Uploader`.  
+
+Note to advanced users: This module sends multipart-form requests via POST method, so uploading via SFTP/FTP won't work.  
+However, popular hosts like [imgur.com](https://imgur.com) are [s-ul.eu](https://s-ul.eu) supported. Scroll down to see example cofiguration.
+
+### General settings explanation:
+
+|Row|Description|
+|-|-|
+|Request URL|Link to an API endpoint, which is requested by chatterino. Any needed URL parameters should be included here.|
+|Form field|Name of a field, which contains image data.|
+|Extra headers|Extra headers, that will be included in the request. Header name and value must be separated by colon (`:`). Multiple headers need to be separated with semicolons (`;`).<br>Example: `Authorization: supaKey ; NextHeader: value` .|
+|Image link|Schema that tells where is the link in service's response. Leave empty if server's response is just the link itself. Refer to json properties by `{property}`. Supports dot-notation, example: `{property.anotherProperty}` .|
+|Deletion link|Same as above.|
+
+<br>
+
+## Examples
+
+### i.nuuls.com
+
+Simply clear all the fields.
+
+### imgur.com
+
+|Row|Description|
+|-|-|
+|Request URL|`https://api.imgur.com/3/image`|
+|Form field|`image`|
+|Extra headers|`Authorization: Client-ID c898c0bb848ca39`|
+|Image link|`{data.link}`|
+|Deletion link|`https://imgur.com/delete/{data.deletehash}`|
+
+### s-ul.eu
+
+Replace `XXXXXXXXXXXXXXX` with your API key from s-ul.eu. It can be found on [your account's configuration page](https://s-ul.eu/account/configurations).
+|Row|Description|
+|-|-|
+|Request URL|`https://s-ul.eu/api/v1/upload?wizard=true&key=XXXXXXXXXXXXXXX`|
+|Form field|`file`|
+|Extra headers||
+|Image link|`{url}`|
+|Deletion link|`https://s-ul.eu/delete.php?file={filename}&key=XXXXXXXXXXXXXXX`|

--- a/src/common/Env.cpp
+++ b/src/common/Env.cpp
@@ -57,10 +57,6 @@ Env::Env()
     , twitchEmoteSetResolverUrl(readStringEnv(
           "CHATTERINO2_TWITCH_EMOTE_SET_RESOLVER_URL",
           "https://braize.pajlada.com/chatterino/twitchemotes/set/%1/"))
-    , imageUploaderUrl(readStringEnv("CHATTERINO2_IMAGE_UPLOADER_URL",
-                                     "https://i.nuuls.com/upload"))
-    , imageUploaderFormBody(
-          readStringEnv("CHATTERINO2_IMAGE_UPLOADER_FORM_BODY", "attachment"))
     , twitchServerHost(
           readStringEnv("CHATTERINO2_TWITCH_SERVER_HOST", "irc.chat.twitch.tv"))
     , twitchServerPort(readPortEnv("CHATTERINO2_TWITCH_SERVER_PORT", 443))

--- a/src/common/Env.hpp
+++ b/src/common/Env.hpp
@@ -14,8 +14,6 @@ public:
     const QString recentMessagesApiUrl;
     const QString linkResolverUrl;
     const QString twitchEmoteSetResolverUrl;
-    const QString imageUploaderUrl;
-    const QString imageUploaderFormBody;
     const QString twitchServerHost;
     const uint16_t twitchServerPort;
     const bool twitchServerSecure;

--- a/src/common/NetworkRequest.cpp
+++ b/src/common/NetworkRequest.cpp
@@ -99,6 +99,20 @@ NetworkRequest NetworkRequest::header(const char *headerName,
     return std::move(*this);
 }
 
+NetworkRequest NetworkRequest::headerList(const QStringList &headers) &&
+{
+    for (const QString &header : headers)
+    {
+        const QStringList thisHeader = header.trimmed().split(":");
+        if (thisHeader.size() == 2)
+        {
+            this->data->request_.setRawHeader(thisHeader[0].trimmed().toUtf8(),
+                                              thisHeader[1].trimmed().toUtf8());
+        }
+    }
+    return std::move(*this);
+}
+
 NetworkRequest NetworkRequest::timeout(int ms) &&
 {
     this->data->hasTimeout_ = true;

--- a/src/common/NetworkRequest.hpp
+++ b/src/common/NetworkRequest.hpp
@@ -3,6 +3,7 @@
 #include "common/NetworkCommon.hpp"
 #include "common/NetworkResult.hpp"
 
+#include <QHttpMultiPart>
 #include <memory>
 
 namespace chatterino {
@@ -52,6 +53,7 @@ public:
     NetworkRequest header(const char *headerName, const char *value) &&;
     NetworkRequest header(const char *headerName, const QByteArray &value) &&;
     NetworkRequest header(const char *headerName, const QString &value) &&;
+    NetworkRequest headerList(const QStringList &headers) &&;
     NetworkRequest timeout(int ms) &&;
     NetworkRequest concurrent() &&;
     NetworkRequest authorizeTwitchV5(const QString &clientID,

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -273,6 +273,17 @@ public:
     // Custom URI Scheme
     QStringSetting customURIScheme = {"/external/urischeme"};
 
+    // Image Uploader
+    QStringSetting imageUploaderUrl = {"/external/imageUploader/url",
+                                       "https://i.nuuls.com/upload"};
+    QStringSetting imageUploaderFormField = {
+        "/external/imageUploader/formField", "attachment"};
+    QStringSetting imageUploaderHeaders = {"/external/imageUploader/headers",
+                                           ""};
+    QStringSetting imageUploaderLink = {"/external/imageUploader/link", ""};
+    QStringSetting imageUploaderDeletionLink = {
+        "/external/imageUploader/deletionLink", ""};
+
     /// Misc
     BoolSetting betaUpdates = {"/misc/beta", false};
 #ifdef Q_OS_LINUX

--- a/src/util/NuulsUploader.cpp
+++ b/src/util/NuulsUploader.cpp
@@ -55,7 +55,7 @@ void logToFile(const QString originalFilePath, QString imageLink,
     //reading existing logs
     QFile logReadFile(logFileName);
     bool isLogFileOkay =
-        logReadFile.open(QIODevice::ReadOnly | QIODevice::Text);
+        logReadFile.open(QIODevice::ReadWrite | QIODevice::Text);
     if (!isLogFileOkay)
     {
         channel->addMessage(makeSystemMessage(

--- a/src/util/NuulsUploader.cpp
+++ b/src/util/NuulsUploader.cpp
@@ -18,6 +18,7 @@
 // Delay between uploads in milliseconds
 
 namespace {
+
 boost::optional<QByteArray> convertToPng(QImage image)
 {
     QByteArray imageData;
@@ -49,6 +50,7 @@ void logToFile(const QString originalFilePath, QString imageLink,
                                      : getSettings()->logPath) +
                                 "/ImageUploader.json";
 
+    //reading existing logs
     QFile logReadFile(logFileName);
     bool isLogFileOkay =
         logReadFile.open(QIODevice::ReadOnly | QIODevice::Text);
@@ -59,30 +61,31 @@ void logToFile(const QString originalFilePath, QString imageLink,
         return;
     }
     auto logs = logReadFile.readAll();
-    logReadFile.close();  // already useless xd
-
     if (logs.isEmpty())
     {
         logs = QJsonDocument(QJsonArray()).toJson();
     }
-    QJsonObject jsonObject;
-    jsonObject["channelName"] = channel->getName();
-    jsonObject["deletionLink"] =
+    logReadFile.close();
+
+    //writing new data to logs
+    QJsonObject newLogEntry;
+    newLogEntry["channelName"] = channel->getName();
+    newLogEntry["deletionLink"] =
         deletionLink.isEmpty() ? QJsonValue(QJsonValue::Null) : deletionLink;
-    jsonObject["imageLink"] = imageLink;
-    jsonObject["localPath"] = originalFilePath.isEmpty()
-                                  ? QJsonValue(QJsonValue::Null)
-                                  : originalFilePath;
-    jsonObject["timestamp"] = QDateTime::currentSecsSinceEpoch();
+    newLogEntry["imageLink"] = imageLink;
+    newLogEntry["localPath"] = originalFilePath.isEmpty()
+                                   ? QJsonValue(QJsonValue::Null)
+                                   : originalFilePath;
+    newLogEntry["timestamp"] = QDateTime::currentSecsSinceEpoch();
     // channel name
     // deletion link (can be empty)
     // image link
-    // image path (can be empty)
+    // local path to an image (can be empty)
     // timestamp
     QSaveFile logSaveFile(logFileName);
     logSaveFile.open(QIODevice::WriteOnly | QIODevice::Text);
     QJsonArray entries = QJsonDocument::fromJson(logs).array();
-    entries.push_back(jsonObject);
+    entries.push_back(newLogEntry);
     logSaveFile.write(QJsonDocument(entries).toJson());
     logSaveFile.commit();
 }

--- a/src/util/NuulsUploader.cpp
+++ b/src/util/NuulsUploader.cpp
@@ -5,6 +5,7 @@
 #include "providers/twitch/TwitchMessageBuilder.hpp"
 #include "singletons/Paths.hpp"
 #include "singletons/Settings.hpp"
+#include "util/CombinePath.hpp"
 
 #include <QBuffer>
 #include <QHttpMultiPart>
@@ -45,10 +46,11 @@ static std::queue<RawImageData> uploadQueue;
 void logToFile(const QString originalFilePath, QString imageLink,
                QString deletionLink, ChannelPtr channel)
 {
-    const QString logFileName = (getSettings()->logPath.getValue().isEmpty()
-                                     ? getPaths()->messageLogDirectory
-                                     : getSettings()->logPath) +
-                                "/ImageUploader.json";
+    const QString logFileName =
+        combinePath((getSettings()->logPath.getValue().isEmpty()
+                         ? getPaths()->messageLogDirectory
+                         : getSettings()->logPath),
+                    "ImageUploader.json");
 
     //reading existing logs
     QFile logReadFile(logFileName);

--- a/src/util/NuulsUploader.cpp
+++ b/src/util/NuulsUploader.cpp
@@ -38,9 +38,9 @@ namespace chatterino {
 static auto uploadMutex = QMutex();
 static std::queue<RawImageData> uploadQueue;
 
-//logging information on successful uploads to a csv file
-void logToCsv(const QString originalFilePath, const QString link,
-              ChannelPtr channel)
+// logging information on successful uploads to a csv file
+void logToCsv(const QString originalFilePath, QString link,
+              QString deletionLink, ChannelPtr channel)
 {
     const QString csvFileName = (getSettings()->logPath.getValue().isEmpty()
                                      ? getPaths()->messageLogDirectory
@@ -56,19 +56,41 @@ void logToCsv(const QString originalFilePath, const QString link,
         return;
     }
     QTextStream out(&csvFile);
-    qDebug() << csvExisted;
     if (!csvExisted)
     {
         out << "localPath,imageLink,timestamp,channelName\n";
     }
-    out << originalFilePath + QString(",") << link + QString(",")
+    out << QString("%1,%2,").arg(originalFilePath).arg(link)
         << QDateTime::currentSecsSinceEpoch()
-        << QString(",%1\n").arg(channel->getName());
+        << QString(",%1,%2\n").arg(channel->getName()).arg(deletionLink);
     // image path (can be empty)
     // image link
     // timestamp
     // channel name
+    // deletion link (can be empty)
     csvFile.close();
+}
+
+// extracting link to either image or its deletion from response body
+QString getJSONValue(QJsonValue responseJson, QString jsonPattern)
+{
+    for (const QString &key : jsonPattern.split("."))
+    {
+        responseJson = responseJson[key];
+    }
+    return responseJson.toString();
+}
+
+QString getLinkFromResponse(NetworkResult response, QString pattern)
+{
+    QRegExp regExp("\\{(.+)\\}");
+    regExp.setMinimal(true);
+    while (regExp.indexIn(pattern) != -1)
+    {
+        pattern.replace(regExp.cap(0),
+                        getJSONValue(response.parseJson(), regExp.cap(1)));
+    }
+    return pattern;
 }
 
 void uploadImageToNuuls(RawImageData imageData, ChannelPtr channel,
@@ -77,8 +99,15 @@ void uploadImageToNuuls(RawImageData imageData, ChannelPtr channel,
     const static char *const boundary = "thisistheboudaryasd";
     const static QString contentType =
         QString("multipart/form-data; boundary=%1").arg(boundary);
-    static QUrl url(Env::get().imageUploaderUrl);
-    static QString formBody(Env::get().imageUploaderFormBody);
+    QUrl url(getSettings()->imageUploaderUrl.getValue().isEmpty()
+                 ? getSettings()->imageUploaderUrl.getDefaultValue()
+                 : getSettings()->imageUploaderUrl);
+    QString formField(
+        getSettings()->imageUploaderFormField.getValue().isEmpty()
+            ? getSettings()->imageUploaderFormField.getDefaultValue()
+            : getSettings()->imageUploaderFormField);
+    QStringList extraHeaders(
+        getSettings()->imageUploaderHeaders.getValue().split(";"));
     QString originalFilePath = imageData.filePath;
 
     QHttpMultiPart *payload = new QHttpMultiPart(QHttpMultiPart::FormDataType);
@@ -90,32 +119,50 @@ void uploadImageToNuuls(RawImageData imageData, ChannelPtr channel,
                    QVariant(imageData.data.length()));
     part.setHeader(QNetworkRequest::ContentDispositionHeader,
                    QString("form-data; name=\"%1\"; filename=\"control_v.%2\"")
-                       .arg(formBody)
+                       .arg(formField)
                        .arg(imageData.format));
     payload->setBoundary(boundary);
     payload->append(part);
+
     NetworkRequest(url, NetworkRequestType::Post)
         .header("Content-Type", contentType)
-
+        .headerList(extraHeaders)
         .multiPart(payload)
         .onSuccess([&textEdit, channel,
                     originalFilePath](NetworkResult result) -> Outcome {
-            textEdit.insertPlainText(result.getData() + QString(" "));
+            QString link = getSettings()->imageUploaderLink.getValue().isEmpty()
+                               ? result.getData()
+                               : getLinkFromResponse(
+                                     result, getSettings()->imageUploaderLink);
+            QString deletionLink =
+                getSettings()->imageUploaderDeletionLink.getValue().isEmpty()
+                    ? ""
+                    : getLinkFromResponse(
+                          result, getSettings()->imageUploaderDeletionLink);
+            qDebug() << link << deletionLink;
+            textEdit.insertPlainText(link + " ");
             if (uploadQueue.empty())
             {
                 channel->addMessage(makeSystemMessage(
-                    QString("Your image has been uploaded to ") +
-                    result.getData()));
+                    QString("Your image has been uploaded to %1 %2.")
+                        .arg(link)
+                        .arg(deletionLink.isEmpty()
+                                 ? ""
+                                 : QString("(Deletion link: %1 )")
+                                       .arg(deletionLink))));
                 uploadMutex.unlock();
             }
             else
             {
                 channel->addMessage(makeSystemMessage(
-                    QString(
-                        "Your image has been uploaded to %1 . %2 left. Please "
-                        "wait until all of them are uploaded. About %3 "
-                        "seconds left.")
-                        .arg(result.getData() + QString(""))
+                    QString("Your image has been uploaded to %1 %2. %3 left. "
+                            "Please wait until all of them are uploaded. "
+                            "About %4 seconds left.")
+                        .arg(link)
+                        .arg(deletionLink.isEmpty()
+                                 ? ""
+                                 : QString("(Deletion link: %1 )")
+                                       .arg(deletionLink))
                         .arg(uploadQueue.size())
                         .arg(uploadQueue.size() * (UPLOAD_DELAY / 1000 + 1))));
                 // 2 seconds for the timer that's there not to spam the remote server
@@ -127,7 +174,7 @@ void uploadImageToNuuls(RawImageData imageData, ChannelPtr channel,
                 });
             }
 
-            logToCsv(originalFilePath, result.getData(), channel);
+            logToCsv(originalFilePath, link, deletionLink, channel);
 
             return Success;
         })
@@ -161,7 +208,6 @@ void upload(const QMimeData *source, ChannelPtr channel,
         {
             QString localPath = path.toLocalFile();
             QMimeType mime = mimeDb.mimeTypeForUrl(path);
-            qDebug() << mime.name();
             if (mime.name().startsWith("image") && !mime.inherits("image/gif"))
             {
                 channel->addMessage(makeSystemMessage(

--- a/src/widgets/settingspages/ExternalToolsPage.cpp
+++ b/src/widgets/settingspages/ExternalToolsPage.cpp
@@ -8,7 +8,6 @@
 #include <QFormLayout>
 #include <QGroupBox>
 #include <QLabel>
-#include <QPushButton>
 
 #define STREAMLINK_QUALITY \
     "Choose", "Source", "High", "Medium", "Low", "Audio only"
@@ -46,7 +45,7 @@ ExternalToolsPage::ExternalToolsPage()
         links->setTextFormat(Qt::RichText);
         links->setTextInteractionFlags(Qt::TextBrowserInteraction |
                                        Qt::LinksAccessibleByKeyboard |
-                                       Qt::LinksAccessibleByKeyboard);
+                                       Qt::LinksAccessibleByMouse);
         links->setOpenExternalLinks(true);
 
         groupLayout->setWidget(0, QFormLayout::SpanningRole, description);
@@ -110,7 +109,7 @@ ExternalToolsPage::ExternalToolsPage()
         description->setTextFormat(Qt::RichText);
         description->setTextInteractionFlags(Qt::TextBrowserInteraction |
                                              Qt::LinksAccessibleByKeyboard |
-                                             Qt::LinksAccessibleByKeyboard);
+                                             Qt::LinksAccessibleByMouse);
         description->setOpenExternalLinks(true);
 
         groupLayout->setWidget(0, QFormLayout::SpanningRole, description);

--- a/src/widgets/settingspages/ExternalToolsPage.cpp
+++ b/src/widgets/settingspages/ExternalToolsPage.cpp
@@ -98,13 +98,13 @@ ExternalToolsPage::ExternalToolsPage()
         auto group = layout.emplace<QGroupBox>("Image Uploader");
         auto groupLayout = group.setLayoutType<QFormLayout>();
 
-        const auto description = new QLabel(
-            "You can set custom host for uploading images, like "
-            "imgur.com or s-ul.eu.<br>Check " +
-            formatRichNamedLink(
-                "https://github.com/chatterino/chatterino2/wiki/ImageUploader",
-                "this guide") +
-            " for help.");
+        const auto description =
+            new QLabel("You can set custom host for uploading images, like "
+                       "imgur.com or s-ul.eu.<br>Check " +
+                       formatRichNamedLink("https://gist.github.com/zneix/"
+                                           "14d828c145f755394e5ab0301c314c2a",
+                                           "this guide") +
+                       " for help.");
         description->setWordWrap(true);
         description->setStyleSheet("color: #bbb");
         description->setTextFormat(Qt::RichText);

--- a/src/widgets/settingspages/ExternalToolsPage.cpp
+++ b/src/widgets/settingspages/ExternalToolsPage.cpp
@@ -3,8 +3,12 @@
 #include "Application.hpp"
 #include "util/Helpers.hpp"
 #include "util/LayoutCreator.hpp"
+#include "util/RemoveScrollAreaBackground.hpp"
 
+#include <QFormLayout>
 #include <QGroupBox>
+#include <QLabel>
+#include <QPushButton>
 
 #define STREAMLINK_QUALITY \
     "Choose", "Source", "High", "Medium", "Low", "Audio only"
@@ -14,7 +18,12 @@ namespace chatterino {
 ExternalToolsPage::ExternalToolsPage()
 {
     LayoutCreator<ExternalToolsPage> layoutCreator(this);
-    auto layout = layoutCreator.setLayoutType<QVBoxLayout>();
+
+    auto scroll = layoutCreator.emplace<QScrollArea>();
+    auto widget = scroll.emplaceScrollAreaWidget();
+    removeScrollAreaBackground(scroll.getElement(), widget.getElement());
+
+    auto layout = widget.setLayoutType<QVBoxLayout>();
 
     {
         auto group = layout.emplace<QGroupBox>("Streamlink");
@@ -83,6 +92,44 @@ ExternalToolsPage::ExternalToolsPage()
 
         groupLayout->addRow("URI Scheme:", this->createLineEdit(
                                                getSettings()->customURIScheme));
+    }
+
+    {
+        auto group = layout.emplace<QGroupBox>("Image Uploader");
+        auto groupLayout = group.setLayoutType<QFormLayout>();
+
+        const auto description = new QLabel(
+            "You can set custom host for uploading images, like "
+            "imgur.com or s-ul.eu.<br>Check " +
+            formatRichNamedLink(
+                "https://github.com/chatterino/chatterino2/wiki/ImageUploader",
+                "this guide") +
+            " for help.");
+        description->setWordWrap(true);
+        description->setStyleSheet("color: #bbb");
+        description->setTextFormat(Qt::RichText);
+        description->setTextInteractionFlags(Qt::TextBrowserInteraction |
+                                             Qt::LinksAccessibleByKeyboard |
+                                             Qt::LinksAccessibleByKeyboard);
+        description->setOpenExternalLinks(true);
+
+        groupLayout->setWidget(0, QFormLayout::SpanningRole, description);
+
+        groupLayout->addRow(
+            "Request URL: ",
+            this->createLineEdit(getSettings()->imageUploaderUrl));
+        groupLayout->addRow(
+            "Form field: ",
+            this->createLineEdit(getSettings()->imageUploaderFormField));
+        groupLayout->addRow(
+            "Extra Headers: ",
+            this->createLineEdit(getSettings()->imageUploaderHeaders));
+        groupLayout->addRow(
+            "Image link: ",
+            this->createLineEdit(getSettings()->imageUploaderLink));
+        groupLayout->addRow(
+            "Deletion link: ",
+            this->createLineEdit(getSettings()->imageUploaderDeletionLink));
     }
 
     layout->addStretch(1);

--- a/src/widgets/settingspages/ExternalToolsPage.cpp
+++ b/src/widgets/settingspages/ExternalToolsPage.cpp
@@ -97,13 +97,13 @@ ExternalToolsPage::ExternalToolsPage()
         auto group = layout.emplace<QGroupBox>("Image Uploader");
         auto groupLayout = group.setLayoutType<QFormLayout>();
 
-        const auto description =
-            new QLabel("You can set custom host for uploading images, like "
-                       "imgur.com or s-ul.eu.<br>Check " +
-                       formatRichNamedLink("https://gist.github.com/zneix/"
-                                           "14d828c145f755394e5ab0301c314c2a",
-                                           "this guide") +
-                       " for help.");
+        const auto description = new QLabel(
+            "You can set custom host for uploading images, like "
+            "imgur.com or s-ul.eu.<br>Check " +
+            formatRichNamedLink("https://github.com/Chatterino/chatterino2/"
+                                "blob/master/docs/IMAGEUPLOADER.md",
+                                "this guide") +
+            " for help.");
         description->setWordWrap(true);
         description->setStyleSheet("color: #bbb");
         description->setTextFormat(Qt::RichText);

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -207,33 +207,34 @@ Split::Split(QWidget *parent)
         [this] { this->focused.invoke(); });
     this->input_->ui_.textEdit->focusLost.connect(
         [this] { this->focusLost.invoke(); });
-    this->input_->ui_.textEdit->imagePasted.connect([this](const QMimeData
-                                                               *source) {
-        if (getSettings()->askOnImageUpload.getValue())
-        {
-            QMessageBox msgBox;
-            msgBox.setText("Image upload");
-            msgBox.setInformativeText(
-                "You are uploading an image to i.nuuls.com. You won't be able "
-                "to remove the image from the site. Are you okay with this?");
-            msgBox.addButton(QMessageBox::Cancel);
-            msgBox.addButton(QMessageBox::Yes);
-            msgBox.addButton("Yes, don't ask again", QMessageBox::YesRole);
-
-            msgBox.setDefaultButton(QMessageBox::Yes);
-
-            auto picked = msgBox.exec();
-            if (picked == QMessageBox::Cancel)
+    this->input_->ui_.textEdit->imagePasted.connect(
+        [this](const QMimeData *source) {
+            if (getSettings()->askOnImageUpload.getValue())
             {
-                return;
+                QMessageBox msgBox;
+                msgBox.setText("Image upload");
+                msgBox.setInformativeText(
+                    "You are uploading an image to an external server. You may "
+                    "not be able to remove the image from the site. Are you "
+                    "okay with this?");
+                msgBox.addButton(QMessageBox::Cancel);
+                msgBox.addButton(QMessageBox::Yes);
+                msgBox.addButton("Yes, don't ask again", QMessageBox::YesRole);
+
+                msgBox.setDefaultButton(QMessageBox::Yes);
+
+                auto picked = msgBox.exec();
+                if (picked == QMessageBox::Cancel)
+                {
+                    return;
+                }
+                else if (picked == 0)  // don't ask again button
+                {
+                    getSettings()->askOnImageUpload.setValue(false);
+                }
             }
-            else if (picked == 0)  // don't ask again button
-            {
-                getSettings()->askOnImageUpload.setValue(false);
-            }
-        }
-        upload(source, this->getChannel(), *this->input_->ui_.textEdit);
-    });
+            upload(source, this->getChannel(), *this->input_->ui_.textEdit);
+        });
     setAcceptDrops(true);
 }
 


### PR DESCRIPTION
I wanted to extend #1709 and #1712 by adding more config options for image uploader and changing CSV logs to JSON.

1. Aside from changing form field, I added an option to add extra header(s) defined by user, so it is possible to use hosts like imgur / s-ul, which need an authentication header.  
I decided that it will be the best to parse headers as a string. I know this may look wrong, but usually it is only one auth header and redesigning Settings page for handling names and values separetly is not worth it imo - it would also look too complicated.

2. I added handling JSON responses from those servers, so it is possible to tell chatterino where image link is in the JSON object.

3. Some services, especially imgur, support "deletion links", so I also added an option to specify those in settings.

To achieve all of above, I removed enviroment variables responsible for changing uploader server's URL and form field name (#1709) and added 5 options to `Settings -> External Tools -> Image Uploader` section. I am not sure if that's a good place for those settings, but I took under consideration that Chatterino uses here an external host for uploading images, thus that is a 3rd-party. That is how it looks now:

![](https://cdn.zneix.eu/0VftNa3.png)

There is a link to a guide, which is temporarily [this gist](https://gist.github.com/zneix/14d828c145f755394e5ab0301c314c2a) with help and configuration examples for less advanced users. I first wanted to ask a Developer to add it as a wiki page, but I think that once #1722 is done, I can commit it as a markdown file to docs in this repo.

Note: For testing purposes, I created a new imgur application to obtain Client-ID, which is used in calls to imgur API. It is only for anonymous uploads. Devs can create a new anonymous app [here](https://api.imgur.com/oauth2/addclient) if they wish to do so.

![](https://cdn.zneix.eu/ILEus0J.png)

---

That change is mainly focused on having an ability to delete uploaded content, so you will not "permaleak" a photo of your face or any other sensitive data by an accident after dragging it onto Chatterino by a mistake.

---

I also changed the logging method from CSV (added in #1712) to JSON (as fourtf and pajlada suggested) - it's now one array with objects that contain information about successful uploads.  
Fourtf suggested that I should use [QSaveFile](https://doc.qt.io/qt-5/qsavefile.html), but since it only only supports WriteOnly mode, I had to use [QFile](https://doc.qt.io/qt-5/qfile.html) to read existing data. If that's not efficient, I can use QFile for both.