### PR TITLE
Fix emote popup remember last position 

### DIFF
--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -114,6 +114,7 @@ namespace {
 EmotePopup::EmotePopup(QWidget *parent)
     : BasePopup(BaseWindow::EnableCustomFrame, parent)
 {
+    this->setStayInScreenRect(true);
     this->moveTo(this, getApp()->windows->emotePopupPos(), false);
 
     auto layout = new QVBoxLayout(this);

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -155,7 +155,6 @@ void SplitInput::openEmotePopup()
     if (!this->emotePopup_)
     {
         this->emotePopup_ = new EmotePopup(this);
-        this->emotePopup_->setStayInScreenRect(true);
         this->emotePopup_->setAttribute(Qt::WA_DeleteOnClose);
 
         this->emotePopup_->linkClicked.connect([this](const Link &link) {


### PR DESCRIPTION
Moved `setStayInScreenRect` into `EmotePopup` constructor to avoid `moveIntoDesktopRect` early return.
