### PR TITLE
Add missing tab completion for commands

### DIFF
--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -29,7 +29,7 @@
             "/unban", "/timeout", "/untimeout", "/slow", "/slowoff",    \
             "/r9kbeta", "/r9kbetaoff", "/emoteonly", "/emoteonlyoff",   \
             "/clear", "/subscribers", "/subscribersoff", "/followers",  \
-            "/followersoff", "/user"                                    \
+            "/followersoff", "/user", "/usercard"                       \
     }
 
 namespace {

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -23,13 +23,14 @@
 #include <QFile>
 #include <QRegularExpression>
 
-#define TWITCH_DEFAULT_COMMANDS                                         \
-    {                                                                   \
-        "/help", "/w", "/me", "/disconnect", "/mods", "/color", "/ban", \
-            "/unban", "/timeout", "/untimeout", "/slow", "/slowoff",    \
-            "/r9kbeta", "/r9kbetaoff", "/emoteonly", "/emoteonlyoff",   \
-            "/clear", "/subscribers", "/subscribersoff", "/followers",  \
-            "/followersoff", "/user", "/usercard"                       \
+#define TWITCH_DEFAULT_COMMANDS                                            \
+    {                                                                      \
+        "/help", "/w", "/me", "/disconnect", "/mods", "/color", "/ban",    \
+            "/unban", "/timeout", "/untimeout", "/slow", "/slowoff",       \
+            "/r9kbeta", "/r9kbetaoff", "/emoteonly", "/emoteonlyoff",      \
+            "/clear", "/subscribers", "/subscribersoff", "/followers",     \
+            "/followersoff", "/user", "/usercard", "/follow", "/unfollow", \
+            "/ignore", "/unignore"                                         \
     }
 
 namespace {


### PR DESCRIPTION
# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
adds completion for `/usercard`, `/follow`, `/unfollow`, `/ignore`, `/unignore`