### PR TITLE
Fixed usercard on linux

### DIFF
--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -452,7 +452,6 @@ QString CommandController::execCommand(const QString &textNoEmoji,
             }
             auto *userPopup = new UserInfoPopup;
             userPopup->setData(words[1], channel);
-            userPopup->setActionOnFocusLoss(BaseWindow::Delete);
             userPopup->move(QCursor::pos());
             userPopup->show();
             return "";

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -92,9 +92,6 @@ UserInfoPopup::UserInfoPopup()
 {
     this->setWindowTitle("Usercard");
     this->setStayInScreenRect(true);
-#ifdef Q_OS_LINUX
-    this->setWindowFlag(Qt::Dialog);
-#endif
 
     // Close the popup when Escape is pressed
     createWindowShortcut(this, "Escape", [this] { this->deleteLater(); });


### PR DESCRIPTION
Closes #1750 
- /usercard command doesn't close the popup imidiatelly
- removed "Dialog" window flag. It seems to be unnecessary and causes issues - on left-clicking user name it sometimes didn't render unless I clicked 2-3 times. With that window flag removed there were no issues with left-clicking user names at all.