### PR TITLE
Added higher tier information to sub badge tooltip

### DIFF
--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -1325,6 +1325,9 @@ void TwitchMessageBuilder::appendTwitchBadges()
             auto badgeInfoIt = badgeInfos.find(badge.key_);
             if (badgeInfoIt != badgeInfos.end())
             {
+                // badge.value_ is 4 chars long if user is subbed on higher tier
+                // (tier + amount of months with leading zero if less than 100)
+                // e.g. 3054 - tier 3 4,5-year sub. 2108 - tier 2 9-year sub
                 const auto &subTier =
                     badge.value_.length() > 3 ? badge.value_.front() : '1';
                 const auto &subMonths = badgeInfoIt->second;

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -1325,8 +1325,14 @@ void TwitchMessageBuilder::appendTwitchBadges()
             auto badgeInfoIt = badgeInfos.find(badge.key_);
             if (badgeInfoIt != badgeInfos.end())
             {
+                const auto &subTier =
+                    badge.value_.length() > 3 ? badge.value_.front() : '1';
                 const auto &subMonths = badgeInfoIt->second;
-                tooltip += QString(" (%0 months)").arg(subMonths);
+                tooltip +=
+                    QString(" (%1%2 months)")
+                        .arg(subTier != '1' ? QString("Tier %1, ").arg(subTier)
+                                            : "")
+                        .arg(subMonths);
             }
         }
 


### PR DESCRIPTION
With recent Twitch's changes for higher tier subs the sub badge tooltip was also updated in webchat and I though it would be a nice idea to have that behaviour in chatterino:

Webchat https://cdn.zneix.eu/XmR2hR6.png
![webchat](https://cdn.zneix.eu/XmR2hR6.png)

Chatterino https://cdn.zneix.eu/6z3X5yX.png
![chatterino](https://cdn.zneix.eu/6z3X5yX.png)