### PR TITLE
Document FreeBSD build instructions

### DIFF
--- a/BUILDING_ON_FREEBSD.md
+++ b/BUILDING_ON_FREEBSD.md
@@ -1,0 +1,17 @@
+# FreeBSD
+
+Note on Qt version compatibility: If you are installing Qt from a package manager, please ensure the version you are installing is at least **Qt 5.10 or newer**.
+
+## FreeBSD 12.1-RELEASE
+
+Note: This is known to work on FreeBSD 12.1-RELEASE amd64. Chances are
+high that this also works on older FreeBSD releases, architectures and
+FreeBSD 13.0-CURRENT.
+
+1. Install build dependencies from package sources (or build from the
+   ports tree): `# pkg install qt5-core qt5-multimedia qt5-svg
+   qt5-qmake qt5-buildtools gstreamer-plugins-good boost-libs
+   rapidjson`
+1. go into project directory
+1. create build folder `$ mkdir build && cd build`
+1. `$ qmake .. && make`

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Current releases are available at [https://chatterino.com](https://chatterino.co
 ## Nightly build
 You can download the latest Chatterino 2 build over [here](https://github.com/Chatterino/chatterino2/releases/tag/nightly-build)
 
-You might also need to install the [VC++ 2017 Redistributable](https://aka.ms/vs/15/release/vc_redist.x64.exe) from Microsoft if you do not have it installed already.  
+You might also need to install the [VC++ 2017 Redistributable](https://aka.ms/vs/15/release/vc_redist.x64.exe) from Microsoft if you do not have it installed already.
 If you still receive an error about `MSVCR120.dll missing`, then you should install the [VC++ 2013 Restributable](https://download.microsoft.com/download/2/E/6/2E61CFA4-993B-4DD4-91DA-3737CD5CD6E3/vcredist_x64.exe
 ).
 
@@ -31,6 +31,8 @@ git submodule update --init --recursive
 [Building on Linux](../master/BUILDING_ON_LINUX.md)
 
 [Building on Mac](../master/BUILDING_ON_MAC.md)
+
+[Building on FreeBSD](../master/BUILDING_ON_FREEBSD.md)
 
 ## Code style
 The code is formatted using clang format in Qt Creator. [.clang-format](src/.clang-format) contains the style file for clang format.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Current releases are available at [https://chatterino.com](https://chatterino.co
 ## Nightly build
 You can download the latest Chatterino 2 build over [here](https://github.com/Chatterino/chatterino2/releases/tag/nightly-build)
 
-You might also need to install the [VC++ 2017 Redistributable](https://aka.ms/vs/15/release/vc_redist.x64.exe) from Microsoft if you do not have it installed already.
+You might also need to install the [VC++ 2017 Redistributable](https://aka.ms/vs/15/release/vc_redist.x64.exe) from Microsoft if you do not have it installed already.  
 If you still receive an error about `MSVCR120.dll missing`, then you should install the [VC++ 2013 Restributable](https://download.microsoft.com/download/2/E/6/2E61CFA4-993B-4DD4-91DA-3737CD5CD6E3/vcredist_x64.exe
 ).
 


### PR DESCRIPTION
Build succeeded and worked on FreeBSD 12.1 (see underneath). I felt like documenting the dependencies from the ports collection.

This has been tested under the following conditions:

```
$ uname -apKU
FreeBSD triton 12.1-RELEASE FreeBSD 12.1-RELEASE r354233 GENERIC  amd64 amd64 1201000 1201000
```

It may also work on older versions and (should definitely) on FreeBSD 13.0-CURRENT. Other processor architectures might support chatterino as well depending on the tier (and thus ports availability). See [https://www.freebsd.org/platforms/](https://www.freebsd.org/platforms/)
