### PR TITLE
Adds support for \x0f formatting character in IRC.

### DIFF
--- a/src/messages/MessageElement.cpp
+++ b/src/messages/MessageElement.cpp
@@ -15,7 +15,7 @@ namespace chatterino {
 namespace {
 
     QRegularExpression IRC_COLOR_PARSE_REGEX(
-        "\u0003(\\d{1,2})?(,(\\d{1,2}))?",
+        "(\u0003(\\d{1,2})?(,(\\d{1,2}))?|\u000f)",
         QRegularExpression::UseUnicodePropertiesOption);
 
 }  // namespace
@@ -475,18 +475,23 @@ IrcTextElement::IrcTextElement(const QString &fullText,
                 segments.emplace_back(seg);
                 lastPos = match.capturedStart() + match.capturedLength();
             }
-
             if (!match.captured(1).isEmpty())
             {
-                fg = match.captured(1).toInt(nullptr);
+                fg = -1;
+                bg = -1;
+            }
+
+            if (!match.captured(2).isEmpty())
+            {
+                fg = match.captured(2).toInt(nullptr);
             }
             else
             {
                 fg = -1;
             }
-            if (!match.captured(3).isEmpty())
+            if (!match.captured(4).isEmpty())
             {
-                bg = match.captured(3).toInt(nullptr);
+                bg = match.captured(4).toInt(nullptr);
             }
             else if (fg == -1)
             {


### PR DESCRIPTION
# Description
The \x0f character unsets the current foreground and background colors
as well as other formatting which is currently not interpreted by Chatterino

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->

![alienplscolor2020-07-07_21-52](https://user-images.githubusercontent.com/25011746/86835743-0fb9a300-c08c-11ea-8931-95860b45e088.png)
