### PR TITLE
Channel point rewards

### DIFF
--- a/chatterino.pro
+++ b/chatterino.pro
@@ -175,6 +175,7 @@ SOURCES += \
     src/providers/irc/IrcMessageBuilder.cpp \
     src/providers/irc/IrcServer.cpp \
     src/providers/LinkResolver.cpp \
+    src/providers/twitch/ChannelPointReward.cpp \
     src/providers/twitch/api/Helix.cpp \
     src/providers/twitch/api/Kraken.cpp \
     src/providers/twitch/IrcMessageHandler.cpp \
@@ -379,6 +380,7 @@ HEADERS += \
     src/providers/irc/IrcMessageBuilder.hpp \
     src/providers/irc/IrcServer.hpp \
     src/providers/LinkResolver.hpp \
+    src/providers/twitch/ChannelPointReward.hpp \
     src/providers/twitch/api/Helix.hpp \
     src/providers/twitch/api/Kraken.hpp \
     src/providers/twitch/EmoteValue.hpp \

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -285,21 +285,20 @@ void Application::initPubsub()
             chan->deleteMessage(msg->id);
         });
 
-    this->twitch.pubsub->signals_.pointReward.redeemed.connect(
-        [&](const auto &data) {
-            QString channelId;
-            if (rj::getSafe(data, "channel_id", channelId))
-            {
-                const auto &chan =
-                    this->twitch.server->getChannelOrEmptyByID(channelId);
-                auto channel = dynamic_cast<TwitchChannel *>(chan.get());
-                channel->addChannelPointReward(ChannelPointReward(data));
-            }
-            else
-            {
-                qDebug() << "Couldn't find channel id of point reward";
-            }
-        });
+    this->twitch.pubsub->signals_.pointReward.redeemed.connect([&](auto &data) {
+        QString channelId;
+        if (rj::getSafe(data, "channel_id", channelId))
+        {
+            const auto &chan =
+                this->twitch.server->getChannelOrEmptyByID(channelId);
+            auto channel = dynamic_cast<TwitchChannel *>(chan.get());
+            channel->addChannelPointReward(ChannelPointReward(data));
+        }
+        else
+        {
+            qDebug() << "Couldn't find channel id of point reward";
+        }
+    });
 
     this->twitch.pubsub->start();
 

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -284,6 +284,15 @@ void Application::initPubsub()
             chan->deleteMessage(msg->id);
         });
 
+    this->twitch.pubsub->signals_.pointReward.redeemed.connect(
+        [&](const auto &data) {
+            const auto &channel = this->twitch.server->getChannelOrEmptyByID(
+                data["redemption"]["channel_id"].GetString());
+            qDebug() << "redeemed" << data["timestamp"].GetString()
+                     << data["redemption"]["user"]["display_name"].GetString()
+                     << channel->getName();
+        });
+
     this->twitch.pubsub->start();
 
     auto RequestModerationActions = [=]() {

--- a/src/messages/Message.hpp
+++ b/src/messages/Message.hpp
@@ -35,6 +35,7 @@ enum class MessageFlag : uint32_t {
     Debug = (1 << 18),
     Similar = (1 << 19),
     RedeemedHighlight = (1 << 20),
+    RedeemedChannelPointReward = (1 << 21),
 };
 using MessageFlags = FlagsEnum<MessageFlag>;
 

--- a/src/messages/MessageBuilder.hpp
+++ b/src/messages/MessageBuilder.hpp
@@ -31,7 +31,7 @@ struct MessageParseArgs {
     bool isSentWhisper = false;
     bool trimSubscriberUsername = false;
     bool isStaffOrBroadcaster = false;
-    bool isChannelPointReward = false;
+    QString channelPointRewardId = "";
 };
 
 class MessageBuilder

--- a/src/messages/MessageBuilder.hpp
+++ b/src/messages/MessageBuilder.hpp
@@ -31,6 +31,7 @@ struct MessageParseArgs {
     bool isSentWhisper = false;
     bool trimSubscriberUsername = false;
     bool isStaffOrBroadcaster = false;
+    bool isChannelPointReward = false;
 };
 
 class MessageBuilder

--- a/src/messages/MessageElement.cpp
+++ b/src/messages/MessageElement.cpp
@@ -695,4 +695,29 @@ LinebreakElement &LinebreakElement::instance()
     return instance;
 }
 
+ScalingImageElement::ScalingImageElement(ImageSet images,
+                                         MessageElementFlags flags)
+    : MessageElement(flags)
+    , images_(images)
+{
+}
+
+void ScalingImageElement::addToContainer(MessageLayoutContainer &container,
+                                         MessageElementFlags flags)
+{
+    if (flags.hasAny(this->getFlags()))
+    {
+        const auto &image =
+            this->images_.getImageOrLoaded(container.getScale());
+        if (image->isEmpty())
+            return;
+
+        auto size = QSize(image->width() * container.getScale(),
+                          image->height() * container.getScale());
+
+        container.addElement((new ImageLayoutElement(*this, image, size))
+                                 ->setLink(this->getLink()));
+    }
+}
+
 }  // namespace chatterino

--- a/src/messages/MessageElement.cpp
+++ b/src/messages/MessageElement.cpp
@@ -678,4 +678,21 @@ void IrcTextElement::addToContainer(MessageLayoutContainer &container,
     }
 }
 
+LinebreakElement::LinebreakElement()
+    : MessageElement(MessageElementFlag::Linebreak)
+{
+}
+
+void LinebreakElement::addToContainer(MessageLayoutContainer &container,
+                                      MessageElementFlags flags)
+{
+    container.breakLine();
+}
+
+LinebreakElement &LinebreakElement::instance()
+{
+    static LinebreakElement instance;
+    return instance;
+}
+
 }  // namespace chatterino

--- a/src/messages/MessageElement.cpp
+++ b/src/messages/MessageElement.cpp
@@ -679,7 +679,7 @@ void IrcTextElement::addToContainer(MessageLayoutContainer &container,
 }
 
 LinebreakElement::LinebreakElement()
-    : MessageElement(MessageElementFlag::Linebreak)
+    : MessageElement(MessageElementFlag::Misc)
 {
 }
 

--- a/src/messages/MessageElement.cpp
+++ b/src/messages/MessageElement.cpp
@@ -678,21 +678,18 @@ void IrcTextElement::addToContainer(MessageLayoutContainer &container,
     }
 }
 
-LinebreakElement::LinebreakElement()
-    : MessageElement(MessageElementFlag::Misc)
+LinebreakElement::LinebreakElement(MessageElementFlags flags)
+    : MessageElement(flags)
 {
 }
 
 void LinebreakElement::addToContainer(MessageLayoutContainer &container,
                                       MessageElementFlags flags)
 {
-    container.breakLine();
-}
-
-LinebreakElement &LinebreakElement::instance()
-{
-    static LinebreakElement instance;
-    return instance;
+    if (flags.hasAny(this->getFlags()))
+    {
+        container.breakLine();
+    }
 }
 
 ScalingImageElement::ScalingImageElement(ImageSet images,

--- a/src/messages/MessageElement.hpp
+++ b/src/messages/MessageElement.hpp
@@ -4,6 +4,7 @@
 #include "messages/Link.hpp"
 #include "messages/MessageColor.hpp"
 #include "singletons/Fonts.hpp"
+#include "src/messages/ImageSet.hpp"
 
 #include <QRect>
 #include <QString>
@@ -323,6 +324,7 @@ private:
     std::vector<Word> words_;
 };
 
+// Forces a linebreak
 class LinebreakElement : public MessageElement
 {
 public:
@@ -334,4 +336,16 @@ public:
     static LinebreakElement &instance();
 };
 
+// Image element which will pick the quality of the image based on ui scale
+class ScalingImageElement : public MessageElement
+{
+public:
+    ScalingImageElement(ImageSet images, MessageElementFlags flags);
+
+    void addToContainer(MessageLayoutContainer &container,
+                        MessageElementFlags flags) override;
+
+private:
+    ImageSet images_;
+};
 }  // namespace chatterino

--- a/src/messages/MessageElement.hpp
+++ b/src/messages/MessageElement.hpp
@@ -108,8 +108,6 @@ enum class MessageElementFlag {
     // e.g. BTTV's SoSnowy during christmas season
     ZeroWidthEmote = (1 << 31),
 
-    Linebreak = (1 << 32),
-
     Default = Timestamp | Badges | Username | BitsStatic | FfzEmoteImage |
               BttvEmoteImage | TwitchEmoteImage | BitsAmount | Text |
               AlwaysShow,

--- a/src/messages/MessageElement.hpp
+++ b/src/messages/MessageElement.hpp
@@ -40,6 +40,9 @@ enum class MessageElementFlag {
     BttvEmoteImage = (1 << 6),
     BttvEmoteText = (1 << 7),
     BttvEmote = BttvEmoteImage | BttvEmoteText,
+
+    ChannelPointReward = (1 << 8),
+
     FfzEmoteImage = (1 << 10),
     FfzEmoteText = (1 << 11),
     FfzEmote = FfzEmoteImage | FfzEmoteText,
@@ -326,12 +329,10 @@ private:
 class LinebreakElement : public MessageElement
 {
 public:
-    LinebreakElement();
+    LinebreakElement(MessageElementFlags flags);
 
     void addToContainer(MessageLayoutContainer &container,
                         MessageElementFlags flags) override;
-
-    static LinebreakElement &instance();
 };
 
 // Image element which will pick the quality of the image based on ui scale

--- a/src/messages/MessageElement.hpp
+++ b/src/messages/MessageElement.hpp
@@ -107,6 +107,8 @@ enum class MessageElementFlag {
     // e.g. BTTV's SoSnowy during christmas season
     ZeroWidthEmote = (1 << 31),
 
+    Linebreak = (1 << 32),
+
     Default = Timestamp | Badges | Username | BitsStatic | FfzEmoteImage |
               BttvEmoteImage | TwitchEmoteImage | BitsAmount | Text |
               AlwaysShow,
@@ -319,6 +321,17 @@ private:
     };
 
     std::vector<Word> words_;
+};
+
+class LinebreakElement : public MessageElement
+{
+public:
+    LinebreakElement();
+
+    void addToContainer(MessageLayoutContainer &container,
+                        MessageElementFlags flags) override;
+
+    static LinebreakElement &instance();
 };
 
 }  // namespace chatterino

--- a/src/messages/layouts/MessageLayout.cpp
+++ b/src/messages/layouts/MessageLayout.cpp
@@ -169,7 +169,7 @@ void MessageLayout::actuallyLayout(int width, MessageElementFlags flags)
 // Painting
 void MessageLayout::paint(QPainter &painter, int width, int y, int messageIndex,
                           Selection &selection, bool isLastReadMessage,
-                          bool isWindowFocused)
+                          bool isWindowFocused, bool isMentions)
 {
     auto app = getApp();
     QPixmap *pixmap = this->buffer_.get();
@@ -220,7 +220,8 @@ void MessageLayout::paint(QPainter &painter, int width, int y, int messageIndex,
                          app->themes->messages.disabled);
     }
 
-    if (this->message_->flags.has(MessageFlag::RedeemedChannelPointReward))
+    if (!isMentions &&
+        this->message_->flags.has(MessageFlag::RedeemedChannelPointReward))
     {
         painter.fillRect(
             0, y, this->scale_ * 4, pixmap->height(),

--- a/src/messages/layouts/MessageLayout.cpp
+++ b/src/messages/layouts/MessageLayout.cpp
@@ -220,6 +220,13 @@ void MessageLayout::paint(QPainter &painter, int width, int y, int messageIndex,
                          app->themes->messages.disabled);
     }
 
+    if (this->message_->flags.has(MessageFlag::RedeemedChannelPointReward))
+    {
+        painter.fillRect(
+            0, y, this->scale_ * 4, pixmap->height(),
+            *ColorProvider::instance().color(ColorType::Subscription));
+    }
+
     // draw selection
     if (!selection.isEmpty())
     {

--- a/src/messages/layouts/MessageLayout.hpp
+++ b/src/messages/layouts/MessageLayout.hpp
@@ -47,7 +47,7 @@ public:
     // Painting
     void paint(QPainter &painter, int width, int y, int messageIndex,
                Selection &selection, bool isLastReadMessage,
-               bool isWindowFocused);
+               bool isWindowFocused, bool isMentions);
     void invalidateBuffer();
     void deleteBuffer();
     void deleteCache();

--- a/src/providers/twitch/ChannelPointReward.cpp
+++ b/src/providers/twitch/ChannelPointReward.cpp
@@ -3,29 +3,58 @@
 
 namespace chatterino {
 
-QString parseImage(const rapidjson::Value &obj, const char *key)
+QString parseImage(const rapidjson::Value &obj, const char *key, bool &result)
 {
     QString url;
-    assert(rj::getSafe(obj, key, url));
+    if (!(result = rj::getSafe(obj, key, url)))
+    {
+        qDebug() << "No url value found for key in reward image object:" << key;
+        return "";
+    }
 
     return url;
 }
 
 ChannelPointReward::ChannelPointReward(rapidjson::Value &reward)
 {
-    assert(rj::getSafe(reward, "id", this->id));
-    assert(rj::getSafe(reward, "channel_id", this->channelId));
-    assert(rj::getSafe(reward, "title", this->title));
-    assert(rj::getSafe(reward, "cost", this->cost));
+    if (!(this->hasParsedSuccessfully = rj::getSafe(reward, "id", this->id)))
+    {
+        qDebug() << "No id found for reward";
+        return;
+    }
+
+    if (!(this->hasParsedSuccessfully =
+              rj::getSafe(reward, "channel_id", this->channelId)))
+    {
+        qDebug() << "No channel_id found for reward";
+        return;
+    }
+
+    if (!(this->hasParsedSuccessfully =
+              rj::getSafe(reward, "title", this->title)))
+    {
+        qDebug() << "No title found for reward";
+        return;
+    }
+
+    if (!(this->hasParsedSuccessfully =
+              rj::getSafe(reward, "cost", this->cost)))
+    {
+        qDebug() << "No cost found for reward";
+        return;
+    }
 
     rapidjson::Value obj;
     if (rj::getSafeObject(reward, "image", obj) && !obj.IsNull() &&
         obj.IsObject())
     {
         this->image = ImageSet{
-            Image::fromUrl({parseImage(obj, "url_1x")}, 1),
-            Image::fromUrl({parseImage(obj, "url_2x")}, 0.5),
-            Image::fromUrl({parseImage(obj, "url_4x")}, 0.25),
+            Image::fromUrl(
+                {parseImage(obj, "url_1x", this->hasParsedSuccessfully)}, 1),
+            Image::fromUrl(
+                {parseImage(obj, "url_2x", this->hasParsedSuccessfully)}, 0.5),
+            Image::fromUrl(
+                {parseImage(obj, "url_4x", this->hasParsedSuccessfully)}, 0.25),
         };
     }
     else

--- a/src/providers/twitch/ChannelPointReward.cpp
+++ b/src/providers/twitch/ChannelPointReward.cpp
@@ -3,28 +3,29 @@
 
 namespace chatterino {
 
-QString parseImage(const rapidjson::Value &image, const char *key)
+QString parseImage(const rapidjson::Value &obj, const char *key)
 {
     QString url;
-    assert(rj::getSafe(image, key, url));
+    assert(rj::getSafe(obj, key, url));
 
     return url;
 }
 
-ChannelPointReward::ChannelPointReward(const rapidjson::Value &reward)
+ChannelPointReward::ChannelPointReward(rapidjson::Value &reward)
 {
     assert(rj::getSafe(reward, "id", this->id));
     assert(rj::getSafe(reward, "channel_id", this->channelId));
     assert(rj::getSafe(reward, "title", this->title));
     assert(rj::getSafe(reward, "cost", this->cost));
 
-    rapidjson::Value image;
-    if (rj::getSafe(reward, "image", image))
+    rapidjson::Value obj;
+    if (rj::getSafeObject(reward, "image", obj) && !obj.IsNull() &&
+        obj.IsObject())
     {
         this->image = ImageSet{
-            Image::fromUrl({parseImage(image, "url_1x")}, 1),
-            Image::fromUrl({parseImage(image, "url_2x")}, 0.5),
-            Image::fromUrl({parseImage(image, "url_4x")}, 0.25),
+            Image::fromUrl({parseImage(obj, "url_1x")}, 1),
+            Image::fromUrl({parseImage(obj, "url_2x")}, 0.5),
+            Image::fromUrl({parseImage(obj, "url_4x")}, 0.25),
         };
     }
     else

--- a/src/providers/twitch/ChannelPointReward.cpp
+++ b/src/providers/twitch/ChannelPointReward.cpp
@@ -1,0 +1,66 @@
+#include "ChannelPointReward.hpp"
+#include "util/RapidjsonHelpers.hpp"
+
+namespace chatterino {
+
+ChannelPointReward::ChannelPointReward(const rapidjson::Value &reward)
+{
+    assert(rj::getSafe(reward, "id", this->rewardId));
+    assert(rj::getSafe(reward, "channel_id", this->channelId));
+    assert(rj::getSafe(reward, "title", this->rewardTitle));
+    assert(rj::getSafe(reward, "cost", this->rewardCost));
+
+    rapidjson::Value image;
+    if (rj::getSafe(reward, "image", image))
+    {
+        this->rewardImage = ImageSet{
+            Image::fromUrl({parseImage(image, "url_1x")}, 1),
+            Image::fromUrl({parseImage(image, "url_2x")}, 0.5),
+            Image::fromUrl({parseImage(image, "url_4x")}, 0.25),
+        };
+    }
+    else
+    {
+        static const ImageSet defaultImage{
+            Image::fromUrl({TWITCH_CHANNEL_POINT_REWARD_URL(1)}, 1),
+            Image::fromUrl({TWITCH_CHANNEL_POINT_REWARD_URL(2)}, 0.5),
+            Image::fromUrl({TWITCH_CHANNEL_POINT_REWARD_URL(4)}, 0.25)};
+        this->rewardImage = defaultImage;
+    }
+}
+
+QString ChannelPointReward::getRewardId() const
+{
+    return rewardId;
+}
+
+QString ChannelPointReward::getChannelId() const
+{
+    return channelId;
+}
+
+QString ChannelPointReward::getRewardTitle() const
+{
+    return rewardTitle;
+}
+
+int ChannelPointReward::getRewardCost() const
+{
+    return rewardCost;
+}
+
+ImageSet ChannelPointReward::getRewardImage() const
+{
+    return rewardImage;
+}
+
+QString ChannelPointReward::parseImage(const rapidjson::Value &image,
+                                       const char *key)
+{
+    QString url;
+    assert(rj::getSafe(image, key, url));
+
+    return url;
+}
+
+}  // namespace chatterino

--- a/src/providers/twitch/ChannelPointReward.cpp
+++ b/src/providers/twitch/ChannelPointReward.cpp
@@ -3,7 +3,8 @@
 
 namespace chatterino {
 
-QString parseImage(const rapidjson::Value &obj, const char *key, bool &result)
+QString parseRewardImage(const rapidjson::Value &obj, const char *key,
+                         bool &result)
 {
     QString url;
     if (!(result = rj::getSafe(obj, key, url)))
@@ -15,8 +16,24 @@ QString parseImage(const rapidjson::Value &obj, const char *key, bool &result)
     return url;
 }
 
-ChannelPointReward::ChannelPointReward(rapidjson::Value &reward)
+ChannelPointReward::ChannelPointReward(rapidjson::Value &redemption)
 {
+    rapidjson::Value user;
+    if (!(this->hasParsedSuccessfully =
+              rj::getSafeObject(redemption, "user", user)))
+    {
+        qDebug() << "No user info found for redemption";
+        return;
+    }
+
+    rapidjson::Value reward;
+    if (!(this->hasParsedSuccessfully =
+              rj::getSafeObject(redemption, "reward", reward)))
+    {
+        qDebug() << "No reward info found for redemption";
+        return;
+    }
+
     if (!(this->hasParsedSuccessfully = rj::getSafe(reward, "id", this->id)))
     {
         qDebug() << "No id found for reward";
@@ -44,17 +61,34 @@ ChannelPointReward::ChannelPointReward(rapidjson::Value &reward)
         return;
     }
 
+    if (!(this->hasParsedSuccessfully = rj::getSafe(
+              reward, "is_user_input_required", this->isUserInputRequired)))
+    {
+        qDebug() << "No information if user input is required found for reward";
+        return;
+    }
+
+    // We don't need to store user information for rewards with user input
+    // because we will get the user info from a corresponding IRC message
+    if (!this->isUserInputRequired)
+    {
+        this->parseUser(user);
+    }
+
     rapidjson::Value obj;
     if (rj::getSafeObject(reward, "image", obj) && !obj.IsNull() &&
         obj.IsObject())
     {
         this->image = ImageSet{
             Image::fromUrl(
-                {parseImage(obj, "url_1x", this->hasParsedSuccessfully)}, 1),
+                {parseRewardImage(obj, "url_1x", this->hasParsedSuccessfully)},
+                1),
             Image::fromUrl(
-                {parseImage(obj, "url_2x", this->hasParsedSuccessfully)}, 0.5),
+                {parseRewardImage(obj, "url_2x", this->hasParsedSuccessfully)},
+                0.5),
             Image::fromUrl(
-                {parseImage(obj, "url_4x", this->hasParsedSuccessfully)}, 0.25),
+                {parseRewardImage(obj, "url_4x", this->hasParsedSuccessfully)},
+                0.25),
         };
     }
     else
@@ -64,6 +98,29 @@ ChannelPointReward::ChannelPointReward(rapidjson::Value &reward)
             Image::fromUrl({TWITCH_CHANNEL_POINT_REWARD_URL("2.png")}, 0.5),
             Image::fromUrl({TWITCH_CHANNEL_POINT_REWARD_URL("4.png")}, 0.25)};
         this->image = defaultImage;
+    }
+}
+
+void ChannelPointReward::parseUser(rapidjson::Value &user)
+{
+    if (!(this->hasParsedSuccessfully = rj::getSafe(user, "id", this->user.id)))
+    {
+        qDebug() << "No id found for user in reward";
+        return;
+    }
+
+    if (!(this->hasParsedSuccessfully =
+              rj::getSafe(user, "login", this->user.login)))
+    {
+        qDebug() << "No login name found for user in reward";
+        return;
+    }
+
+    if (!(this->hasParsedSuccessfully =
+              rj::getSafe(user, "display_name", this->user.displayName)))
+    {
+        qDebug() << "No display name found for user in reward";
+        return;
     }
 }
 

--- a/src/providers/twitch/ChannelPointReward.cpp
+++ b/src/providers/twitch/ChannelPointReward.cpp
@@ -3,17 +3,25 @@
 
 namespace chatterino {
 
+QString parseImage(const rapidjson::Value &image, const char *key)
+{
+    QString url;
+    assert(rj::getSafe(image, key, url));
+
+    return url;
+}
+
 ChannelPointReward::ChannelPointReward(const rapidjson::Value &reward)
 {
-    assert(rj::getSafe(reward, "id", this->rewardId));
+    assert(rj::getSafe(reward, "id", this->id));
     assert(rj::getSafe(reward, "channel_id", this->channelId));
-    assert(rj::getSafe(reward, "title", this->rewardTitle));
-    assert(rj::getSafe(reward, "cost", this->rewardCost));
+    assert(rj::getSafe(reward, "title", this->title));
+    assert(rj::getSafe(reward, "cost", this->cost));
 
     rapidjson::Value image;
     if (rj::getSafe(reward, "image", image))
     {
-        this->rewardImage = ImageSet{
+        this->image = ImageSet{
             Image::fromUrl({parseImage(image, "url_1x")}, 1),
             Image::fromUrl({parseImage(image, "url_2x")}, 0.5),
             Image::fromUrl({parseImage(image, "url_4x")}, 0.25),
@@ -25,42 +33,8 @@ ChannelPointReward::ChannelPointReward(const rapidjson::Value &reward)
             Image::fromUrl({TWITCH_CHANNEL_POINT_REWARD_URL(1)}, 1),
             Image::fromUrl({TWITCH_CHANNEL_POINT_REWARD_URL(2)}, 0.5),
             Image::fromUrl({TWITCH_CHANNEL_POINT_REWARD_URL(4)}, 0.25)};
-        this->rewardImage = defaultImage;
+        this->image = defaultImage;
     }
-}
-
-QString ChannelPointReward::getRewardId() const
-{
-    return rewardId;
-}
-
-QString ChannelPointReward::getChannelId() const
-{
-    return channelId;
-}
-
-QString ChannelPointReward::getRewardTitle() const
-{
-    return rewardTitle;
-}
-
-int ChannelPointReward::getRewardCost() const
-{
-    return rewardCost;
-}
-
-ImageSet ChannelPointReward::getRewardImage() const
-{
-    return rewardImage;
-}
-
-QString ChannelPointReward::parseImage(const rapidjson::Value &image,
-                                       const char *key)
-{
-    QString url;
-    assert(rj::getSafe(image, key, url));
-
-    return url;
 }
 
 }  // namespace chatterino

--- a/src/providers/twitch/ChannelPointReward.cpp
+++ b/src/providers/twitch/ChannelPointReward.cpp
@@ -30,9 +30,9 @@ ChannelPointReward::ChannelPointReward(const rapidjson::Value &reward)
     else
     {
         static const ImageSet defaultImage{
-            Image::fromUrl({TWITCH_CHANNEL_POINT_REWARD_URL(1)}, 1),
-            Image::fromUrl({TWITCH_CHANNEL_POINT_REWARD_URL(2)}, 0.5),
-            Image::fromUrl({TWITCH_CHANNEL_POINT_REWARD_URL(4)}, 0.25)};
+            Image::fromUrl({TWITCH_CHANNEL_POINT_REWARD_URL("1.png")}, 1),
+            Image::fromUrl({TWITCH_CHANNEL_POINT_REWARD_URL("2.png")}, 0.5),
+            Image::fromUrl({TWITCH_CHANNEL_POINT_REWARD_URL("4.png")}, 0.25)};
         this->image = defaultImage;
     }
 }

--- a/src/providers/twitch/ChannelPointReward.hpp
+++ b/src/providers/twitch/ChannelPointReward.hpp
@@ -18,6 +18,16 @@ struct ChannelPointReward {
     int cost;
     ImageSet image;
     bool hasParsedSuccessfully = false;
+    bool isUserInputRequired = false;
+
+    struct {
+        QString id;
+        QString login;
+        QString displayName;
+    } user;
+
+private:
+    void parseUser(rapidjson::Value &user);
 };
 
 }  // namespace chatterino

--- a/src/providers/twitch/ChannelPointReward.hpp
+++ b/src/providers/twitch/ChannelPointReward.hpp
@@ -17,6 +17,7 @@ struct ChannelPointReward {
     QString title;
     int cost;
     ImageSet image;
+    bool hasParsedSuccessfully = false;
 };
 
 }  // namespace chatterino

--- a/src/providers/twitch/ChannelPointReward.hpp
+++ b/src/providers/twitch/ChannelPointReward.hpp
@@ -9,26 +9,14 @@
         .arg(x)
 
 namespace chatterino {
-class ChannelPointReward
-{
-public:
+struct ChannelPointReward {
     ChannelPointReward(const rapidjson::Value &reward);
     ChannelPointReward() = delete;
-
-    QString getRewardId() const;
-    QString getChannelId() const;
-    QString getRewardTitle() const;
-    int getRewardCost() const;
-    ImageSet getRewardImage() const;
-
-private:
-    QString rewardId;
+    QString id;
     QString channelId;
-    QString rewardTitle;
-    int rewardCost;
-    ImageSet rewardImage;
-
-    QString parseImage(const rapidjson::Value &image, const char *key);
+    QString title;
+    int cost;
+    ImageSet image;
 };
 
 }  // namespace chatterino

--- a/src/providers/twitch/ChannelPointReward.hpp
+++ b/src/providers/twitch/ChannelPointReward.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "common/Aliases.hpp"
+#include "messages/Image.hpp"
+#include "messages/ImageSet.hpp"
+
+#define TWITCH_CHANNEL_POINT_REWARD_URL(x)                                  \
+    QString("https://static-cdn.jtvnw.net/custom-reward-images/default-%1") \
+        .arg(x)
+
+namespace chatterino {
+class ChannelPointReward
+{
+public:
+    ChannelPointReward(const rapidjson::Value &reward);
+    ChannelPointReward() = delete;
+
+    QString getRewardId() const;
+    QString getChannelId() const;
+    QString getRewardTitle() const;
+    int getRewardCost() const;
+    ImageSet getRewardImage() const;
+
+private:
+    QString rewardId;
+    QString channelId;
+    QString rewardTitle;
+    int rewardCost;
+    ImageSet rewardImage;
+
+    QString parseImage(const rapidjson::Value &image, const char *key);
+};
+
+}  // namespace chatterino

--- a/src/providers/twitch/ChannelPointReward.hpp
+++ b/src/providers/twitch/ChannelPointReward.hpp
@@ -10,7 +10,7 @@
 
 namespace chatterino {
 struct ChannelPointReward {
-    ChannelPointReward(const rapidjson::Value &reward);
+    ChannelPointReward(rapidjson::Value &reward);
     ChannelPointReward() = delete;
     QString id;
     QString channelId;

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -225,7 +225,7 @@ void IrcMessageHandler::addMessage(Communi::IrcMessage *_message,
         {
             // Need to wait for pubsub reward notification
             channel->channelPointRewardAdded.connect(
-                [=, &server, &_message](ChannelPointReward reward) {
+                [=, &server](ChannelPointReward reward) {
                     if (reward.id == rewardId)
                     {
                         this->addMessage(_message, target, content, server,

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -225,7 +225,7 @@ void IrcMessageHandler::addMessage(Communi::IrcMessage *_message,
         {
             // Need to wait for pubsub reward notification
             channel->channelPointRewardAdded.connect(
-                [=, &server](ChannelPointReward reward) {
+                [=, &server, &_message](ChannelPointReward reward) {
                     if (reward.id == rewardId)
                     {
                         this->addMessage(_message, target, content, server,

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -224,12 +224,14 @@ void IrcMessageHandler::addMessage(Communi::IrcMessage *_message,
         if (!channel->isChannelPointRewardKnown(rewardId))
         {
             // Need to wait for pubsub reward notification
+            auto clone = _message->clone();
             channel->channelPointRewardAdded.connect(
                 [=, &server](ChannelPointReward reward) {
                     if (reward.id == rewardId)
                     {
-                        this->addMessage(_message, target, content, server,
-                                         isSub, isAction);
+                        this->addMessage(clone, target, content, server, isSub,
+                                         isAction);
+                        clone->deleteLater();
                         return true;
                     }
                     return false;

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -227,7 +227,7 @@ void IrcMessageHandler::addMessage(Communi::IrcMessage *_message,
             // Need to wait for pubsub reward notification
             channel->channelPointRewardAdded.connect(
                 [=, &server](ChannelPointReward reward) {
-                    if (reward.getRewardId() == rewardId)
+                    if (reward.id == rewardId)
                     {
                         this->addMessage(_message, target, content, server,
                                          isSub, isAction);

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -220,7 +220,6 @@ void IrcMessageHandler::addMessage(Communi::IrcMessage *_message,
     const auto &tags = _message->tags();
     if (const auto &it = tags.find("custom-reward-id"); it != tags.end())
     {
-        args.isChannelPointReward = true;
         const auto rewardId = it.value().toString();
         if (!channel->isChannelPointRewardKnown(rewardId))
         {
@@ -237,6 +236,7 @@ void IrcMessageHandler::addMessage(Communi::IrcMessage *_message,
                 });
             return;
         }
+        args.channelPointRewardId = rewardId;
     }
 
     TwitchMessageBuilder builder(chan.get(), _message, args, content, isAction);

--- a/src/providers/twitch/PubsubClient.cpp
+++ b/src/providers/twitch/PubsubClient.cpp
@@ -1116,7 +1116,6 @@ void PubSub::handleMessageResponse(const rapidjson::Value &outerData)
     else if (topic.startsWith("community-points-channel-v1."))
     {
         std::string pointEventType;
-
         if (!rj::getSafe(msg, "type", pointEventType))
         {
             qDebug() << "Bad channel point event data";
@@ -1125,17 +1124,17 @@ void PubSub::handleMessageResponse(const rapidjson::Value &outerData)
 
         if (pointEventType == "reward-redeemed")
         {
-            if (!rj::getSafe(msg, "data", msg))
+            if (!rj::getSafeObject(msg, "data", msg))
             {
                 qDebug() << "No data found for redeemed reward";
                 return;
             }
-            if (!rj::getSafe(msg, "redemption", msg))
+            if (!rj::getSafeObject(msg, "redemption", msg))
             {
                 qDebug() << "No redemption info found for redeemed reward";
                 return;
             }
-            if (!rj::getSafe(msg, "reward", msg))
+            if (!rj::getSafeObject(msg, "reward", msg))
             {
                 qDebug() << "No reward info found for redeemed reward";
                 return;

--- a/src/providers/twitch/PubsubClient.cpp
+++ b/src/providers/twitch/PubsubClient.cpp
@@ -1134,11 +1134,6 @@ void PubSub::handleMessageResponse(const rapidjson::Value &outerData)
                 qDebug() << "No redemption info found for redeemed reward";
                 return;
             }
-            if (!rj::getSafeObject(msg, "reward", msg))
-            {
-                qDebug() << "No reward info found for redeemed reward";
-                return;
-            }
             this->signals_.pointReward.redeemed.invoke(msg);
         }
         else

--- a/src/providers/twitch/PubsubClient.cpp
+++ b/src/providers/twitch/PubsubClient.cpp
@@ -1125,8 +1125,31 @@ void PubSub::handleMessageResponse(const rapidjson::Value &outerData)
 
         if (pointEventType == "reward-redeemed")
         {
-            const auto &data = msg["data"];
-            this->signals_.pointReward.redeemed.invoke(data);
+            if (!rj::getSafe(msg, "data", msg))
+            {
+                if (!rj::getSafe(msg, "redemption", msg))
+                {
+                    if (!rj::getSafe(msg, "reward", msg))
+                    {
+                        this->signals_.pointReward.redeemed.invoke(msg);
+                    }
+                    else
+                    {
+                        qDebug() << "No reward info found for redeemed reward";
+                        return;
+                    }
+                }
+                else
+                {
+                    qDebug() << "No redemption info found for redeemed reward";
+                    return;
+                }
+            }
+            else
+            {
+                qDebug() << "No data found for redeemed reward";
+                return;
+            }
         }
         else
         {

--- a/src/providers/twitch/PubsubClient.cpp
+++ b/src/providers/twitch/PubsubClient.cpp
@@ -1127,29 +1127,20 @@ void PubSub::handleMessageResponse(const rapidjson::Value &outerData)
         {
             if (!rj::getSafe(msg, "data", msg))
             {
-                if (!rj::getSafe(msg, "redemption", msg))
-                {
-                    if (!rj::getSafe(msg, "reward", msg))
-                    {
-                        this->signals_.pointReward.redeemed.invoke(msg);
-                    }
-                    else
-                    {
-                        qDebug() << "No reward info found for redeemed reward";
-                        return;
-                    }
-                }
-                else
-                {
-                    qDebug() << "No redemption info found for redeemed reward";
-                    return;
-                }
-            }
-            else
-            {
                 qDebug() << "No data found for redeemed reward";
                 return;
             }
+            if (!rj::getSafe(msg, "redemption", msg))
+            {
+                qDebug() << "No redemption info found for redeemed reward";
+                return;
+            }
+            if (!rj::getSafe(msg, "reward", msg))
+            {
+                qDebug() << "No reward info found for redeemed reward";
+                return;
+            }
+            this->signals_.pointReward.redeemed.invoke(msg);
         }
         else
         {

--- a/src/providers/twitch/PubsubClient.hpp
+++ b/src/providers/twitch/PubsubClient.hpp
@@ -122,6 +122,10 @@ public:
             Signal<const rapidjson::Value &> received;
             Signal<const rapidjson::Value &> sent;
         } whisper;
+
+        struct {
+            Signal<const rapidjson::Value &> redeemed;
+        } pointReward;
     } signals_;
 
     void listenToWhispers(std::shared_ptr<TwitchAccount> account);
@@ -130,6 +134,9 @@ public:
 
     void listenToChannelModerationActions(
         const QString &channelID, std::shared_ptr<TwitchAccount> account);
+
+    void listenToChannelPointRewards(const QString &channelID,
+                                     std::shared_ptr<TwitchAccount> account);
 
     std::vector<std::unique_ptr<rapidjson::Document>> requests;
 

--- a/src/providers/twitch/PubsubClient.hpp
+++ b/src/providers/twitch/PubsubClient.hpp
@@ -124,7 +124,7 @@ public:
         } whisper;
 
         struct {
-            Signal<const rapidjson::Value &> redeemed;
+            Signal<rapidjson::Value &> redeemed;
         } pointReward;
     } signals_;
 

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -186,6 +186,27 @@ void TwitchChannel::refreshFFZChannelEmotes(bool manualRefresh)
         manualRefresh);
 }
 
+void TwitchChannel::addChannelPointReward(const ChannelPointReward &reward)
+{
+    bool result;
+    {
+        auto channelPointRewards = this->channelPointRewards_.access();
+        result = channelPointRewards->try_emplace(reward.getRewardId(), reward)
+                     .second;
+    }
+    if (result)
+    {
+        this->channelPointRewardAdded.invoke(reward);
+    }
+}
+
+bool TwitchChannel::isChannelPointRewardKnown(QString rewardId)
+{
+    const auto &pointRewards = this->channelPointRewards_.accessConst();
+    const auto &it = pointRewards->find(rewardId);
+    return it != pointRewards->end();
+}
+
 void TwitchChannel::sendMessage(const QString &message)
 {
     auto app = getApp();

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -611,6 +611,7 @@ void TwitchChannel::refreshPubsub()
     auto account = getApp()->accounts->twitch.getCurrent();
     getApp()->twitch2->pubsub->listenToChannelModerationActions(roomId,
                                                                 account);
+    getApp()->twitch2->pubsub->listenToChannelPointRewards(roomId, account);
 }
 
 void TwitchChannel::refreshChatters()

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -191,8 +191,7 @@ void TwitchChannel::addChannelPointReward(const ChannelPointReward &reward)
     bool result;
     {
         auto channelPointRewards = this->channelPointRewards_.access();
-        result = channelPointRewards->try_emplace(reward.getRewardId(), reward)
-                     .second;
+        result = channelPointRewards->try_emplace(reward.id, reward).second;
     }
     if (result)
     {

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -199,11 +199,22 @@ void TwitchChannel::addChannelPointReward(const ChannelPointReward &reward)
     }
 }
 
-bool TwitchChannel::isChannelPointRewardKnown(QString rewardId)
+bool TwitchChannel::isChannelPointRewardKnown(const QString &rewardId)
 {
     const auto &pointRewards = this->channelPointRewards_.accessConst();
     const auto &it = pointRewards->find(rewardId);
     return it != pointRewards->end();
+}
+
+boost::optional<ChannelPointReward> TwitchChannel::channelPointReward(
+    const QString &rewardId) const
+{
+    auto rewards = this->channelPointRewards_.accessConst();
+    auto it = rewards->find(rewardId);
+
+    if (it == rewards->end())
+        return boost::none;
+    return it->second;
 }
 
 void TwitchChannel::sendMessage(const QString &message)

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -193,6 +193,14 @@ void TwitchChannel::addChannelPointReward(const ChannelPointReward &reward)
         return;
     }
 
+    if (!reward.isUserInputRequired)
+    {
+        MessageBuilder builder;
+        TwitchMessageBuilder::appendChannelPointRewardMessage(reward, &builder);
+        this->addMessage(builder.release());
+        return;
+    }
+
     bool result;
     {
         auto channelPointRewards = this->channelPointRewards_.access();

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -188,6 +188,11 @@ void TwitchChannel::refreshFFZChannelEmotes(bool manualRefresh)
 
 void TwitchChannel::addChannelPointReward(const ChannelPointReward &reward)
 {
+    if (!reward.hasParsedSuccessfully)
+    {
+        return;
+    }
+
     bool result;
     {
         auto channelPointRewards = this->channelPointRewards_.access();

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -113,7 +113,9 @@ public:
     pajlada::Signals::SelfDisconnectingSignal<ChannelPointReward>
         channelPointRewardAdded;
     void addChannelPointReward(const ChannelPointReward &reward);
-    bool isChannelPointRewardKnown(QString rewardId);
+    bool isChannelPointRewardKnown(const QString &rewardId);
+    boost::optional<ChannelPointReward> channelPointReward(
+        const QString &rewardId) const;
 
 private:
     struct NameOptions {

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -7,6 +7,7 @@
 #include "common/Outcome.hpp"
 #include "common/UniqueAccess.hpp"
 #include "common/UsernameSet.hpp"
+#include "providers/twitch/ChannelPointReward.hpp"
 #include "providers/twitch/TwitchEmotes.hpp"
 #include "providers/twitch/api/Helix.hpp"
 
@@ -108,6 +109,12 @@ public:
     pajlada::Signals::NoArgSignal liveStatusChanged;
     pajlada::Signals::NoArgSignal roomModesChanged;
 
+    // Channel point rewards
+    pajlada::Signals::SelfDisconnectingSignal<ChannelPointReward>
+        channelPointRewardAdded;
+    void addChannelPointReward(const ChannelPointReward &reward);
+    bool isChannelPointRewardKnown(QString rewardId);
+
 private:
     struct NameOptions {
         QString displayName;
@@ -158,6 +165,7 @@ private:
     UniqueAccess<std::map<QString, std::map<QString, EmotePtr>>>
         badgeSets_;  // "subscribers": { "0": ... "3": ... "6": ...
     UniqueAccess<std::vector<CheerEmoteSet>> cheerEmoteSets_;
+    UniqueAccess<std::map<QString, ChannelPointReward>> channelPointRewards_;
 
     bool mod_ = false;
     bool vip_ = false;

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -189,12 +189,13 @@ MessagePtr TwitchMessageBuilder::build()
 
     this->parseRoomID();
 
-    this->appendChannelName();
-
-    if (this->args.isChannelPointReward)
+    if (this->args.channelPointRewardId != "")
     {
         this->message().flags.set(MessageFlag::RedeemedChannelPointReward);
+        this->appendChannelPointRewardMessage();
     }
+
+    this->appendChannelName();
 
     if (this->tags.contains("rm-deleted"))
     {
@@ -1109,6 +1110,27 @@ Outcome TwitchMessageBuilder::tryParseCheermote(const QString &string)
     }
 
     return Success;
+}
+
+void TwitchMessageBuilder::appendChannelPointRewardMessage()
+{
+    const auto &reward = this->twitchChannel->channelPointReward(
+        this->args.channelPointRewardId);
+    if (reward.has_value())
+    {
+        this->emplace<TextElement>(QString("Redeemed"),
+                                   MessageElementFlag::Text);
+        this->emplace<TextElement>(reward->title, MessageElementFlag::Text,
+                                   MessageColor::Text,
+                                   FontStyle::ChatMediumBold);
+        this->emplace<ImageElement>(
+            reward->image.getImageOrLoaded(getSettings()->emoteScale),
+            MessageElementFlag::EmoteImages);
+        this->emplace<TextElement>(QString::number(reward->cost),
+                                   MessageElementFlag::Text, MessageColor::Text,
+                                   FontStyle::ChatMediumBold);
+        this->emplace<LinebreakElement>();
+    }
 }
 
 }  // namespace chatterino

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -191,6 +191,11 @@ MessagePtr TwitchMessageBuilder::build()
 
     this->appendChannelName();
 
+    if (this->args.isChannelPointReward)
+    {
+        this->message().flags.set(MessageFlag::RedeemedChannelPointReward);
+    }
+
     if (this->tags.contains("rm-deleted"))
     {
         this->message().flags.set(MessageFlag::Disabled);

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -1116,7 +1116,7 @@ void TwitchMessageBuilder::appendChannelPointRewardMessage()
 {
     const auto &reward = this->twitchChannel->channelPointReward(
         this->args.channelPointRewardId);
-    if (reward.has_value())
+    if (reward)
     {
         this->emplace<TextElement>(QString("Redeemed"),
                                    MessageElementFlag::Text);

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -1123,9 +1123,8 @@ void TwitchMessageBuilder::appendChannelPointRewardMessage()
         this->emplace<TextElement>(reward->title, MessageElementFlag::Text,
                                    MessageColor::Text,
                                    FontStyle::ChatMediumBold);
-        this->emplace<ImageElement>(
-            reward->image.getImageOrLoaded(getSettings()->emoteScale),
-            MessageElementFlag::EmoteImages);
+        this->emplace<ScalingImageElement>(reward->image,
+                                           MessageElementFlag::EmoteImages);
         this->emplace<TextElement>(QString::number(reward->cost),
                                    MessageElementFlag::Text, MessageColor::Text,
                                    FontStyle::ChatMediumBold);

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -196,7 +196,6 @@ MessagePtr TwitchMessageBuilder::build()
             this->args.channelPointRewardId);
         if (reward)
         {
-            this->message().flags.set(MessageFlag::RedeemedChannelPointReward);
             this->appendChannelPointRewardMessage(reward.get(), this);
         }
     }
@@ -1144,6 +1143,8 @@ void TwitchMessageBuilder::appendChannelPointRewardMessage(
         builder->emplace<LinebreakElement>(
             MessageElementFlag::ChannelPointReward);
     }
+
+    builder->message().flags.set(MessageFlag::RedeemedChannelPointReward);
 }
 
 }  // namespace chatterino

--- a/src/providers/twitch/TwitchMessageBuilder.hpp
+++ b/src/providers/twitch/TwitchMessageBuilder.hpp
@@ -1,8 +1,9 @@
-#pragma once
+﻿#pragma once
 
 #include "common/Aliases.hpp"
 #include "common/Outcome.hpp"
 #include "messages/SharedMessageBuilder.hpp"
+#include "providers/twitch/ChannelPointReward.hpp"
 #include "providers/twitch/TwitchBadge.hpp"
 
 #include <IrcMessage>

--- a/src/providers/twitch/TwitchMessageBuilder.hpp
+++ b/src/providers/twitch/TwitchMessageBuilder.hpp
@@ -43,6 +43,9 @@ public:
     void triggerHighlights() override;
     MessagePtr build() override;
 
+    static void appendChannelPointRewardMessage(
+        const ChannelPointReward &reward, MessageBuilder *builder);
+
 private:
     void parseUsernameColor() override;
     void parseUsername() override;
@@ -68,8 +71,6 @@ private:
     void appendTwitchBadges();
     void appendChatterinoBadges();
     Outcome tryParseCheermote(const QString &string);
-
-    void appendChannelPointRewardMessage();
 
     QString roomID_;
     bool hasBits_ = false;

--- a/src/providers/twitch/TwitchMessageBuilder.hpp
+++ b/src/providers/twitch/TwitchMessageBuilder.hpp
@@ -69,6 +69,8 @@ private:
     void appendChatterinoBadges();
     Outcome tryParseCheermote(const QString &string);
 
+    void appendChannelPointRewardMessage();
+
     QString roomID_;
     bool hasBits_ = false;
     QString bits;

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -171,6 +171,7 @@ void WindowManager::updateWordTypeMask()
                                       : MEF::NonBoldUsername);
     flags.set(settings->lowercaseDomains ? MEF::LowercaseLink
                                          : MEF::OriginalLink);
+    flags.set(MEF::ChannelPointReward);
 
     // update flags
     MessageElementFlags newFlags = static_cast<MessageElementFlags>(flags);

--- a/src/util/RapidjsonHelpers.cpp
+++ b/src/util/RapidjsonHelpers.cpp
@@ -28,5 +28,22 @@ namespace rj {
         return std::string(buffer.GetString());
     }
 
+    bool getSafeObject(rapidjson::Value &obj, const char *key,
+                       rapidjson::Value &out)
+    {
+        if (!checkJsonValue(obj, key))
+        {
+            return false;
+        }
+
+        out = obj[key].Move();
+        return true;
+    }
+
+    bool checkJsonValue(const rapidjson::Value &obj, const char *key)
+    {
+        return obj.IsObject() && !obj.IsNull() && obj.HasMember(key);
+    }
+
 }  // namespace rj
 }  // namespace chatterino

--- a/src/util/RapidjsonHelpers.hpp
+++ b/src/util/RapidjsonHelpers.hpp
@@ -67,20 +67,12 @@ namespace rj {
         arr.PushBack(pajlada::Serialize<Type>::get(value, a), a);
     }
 
+    bool checkJsonValue(const rapidjson::Value &obj, const char *key);
+
     template <typename Type>
     bool getSafe(const rapidjson::Value &obj, const char *key, Type &out)
     {
-        if (!obj.IsObject())
-        {
-            return false;
-        }
-
-        if (!obj.HasMember(key))
-        {
-            return false;
-        }
-
-        if (obj.IsNull())
+        if (!checkJsonValue(obj, key))
         {
             return false;
         }
@@ -99,6 +91,9 @@ namespace rj {
 
         return !error;
     }
+
+    bool getSafeObject(rapidjson::Value &obj, const char *key,
+                       rapidjson::Value &out);
 
     std::string stringify(const rapidjson::Value &value);
 

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -244,6 +244,8 @@ void Window::addDebugStuff()
 
     // channel point reward test
     const char* channelRewardMessage = "{ \"type\": \"MESSAGE\", \"data\": { \"topic\": \"community-points-channel-v1.11148817\", \"message\": { \"type\": \"reward-redeemed\", \"data\": { \"timestamp\": \"2020-07-13T20:19:31.430785354Z\", \"redemption\": { \"id\": \"b9628798-1b4e-4122-b2a6-031658df6755\", \"user\": { \"id\": \"91800084\", \"login\": \"cranken1337\", \"display_name\": \"cranken1337\" }, \"channel_id\": \"11148817\", \"redeemed_at\": \"2020-07-13T20:19:31.345237005Z\", \"reward\": { \"id\": \"313969fe-cc9f-4a0a-83c6-172acbd96957\", \"channel_id\": \"11148817\", \"title\": \"annoying reward pogchamp\", \"prompt\": \"\", \"cost\": 3000, \"is_user_input_required\": false, \"is_sub_only\": false, \"image\": null, \"default_image\": { \"url_1x\": \"https://static-cdn.jtvnw.net/custom-reward-images/default-1.png\", \"url_2x\": \"https://static-cdn.jtvnw.net/custom-reward-images/default-2.png\", \"url_4x\": \"https://static-cdn.jtvnw.net/custom-reward-images/default-4.png\" }, \"background_color\": \"#52ACEC\", \"is_enabled\": true, \"is_paused\": false, \"is_in_stock\": true, \"max_per_stream\": { \"is_enabled\": false, \"max_per_stream\": 0 }, \"should_redemptions_skip_request_queue\": false, \"template_id\": null, \"updated_for_indicator_at\": \"2020-01-20T04:33:33.624956679Z\" }, \"status\": \"UNFULFILLED\", \"cursor\": \"Yjk2Mjg3OTgtMWI0ZS00MTIyLWIyYTYtMDMxNjU4ZGY2NzU1X18yMDIwLTA3LTEzVDIwOjE5OjMxLjM0NTIzNzAwNVo=\" } } } } }";
+    const char * channelRewardIRCMessage(R"(@badge-info=subscriber/43;badges=subscriber/42;color=#1E90FF;custom-reward-id=313969fe-cc9f-4a0a-83c6-172acbd96957;display-name=Cranken1337;emotes=;flags=;id=3cee3f27-a1d0-44d1-a606-722cebdad08b;mod=0;room-id=11148817;subscriber=1;tmi-sent-ts=1594756484132;turbo=0;user-id=91800084;user-type= :cranken1337!cranken1337@cranken1337.tmi.twitch.tv PRIVMSG #pajlada :wow, amazing reward)");
+
     // clang-format on
 
     createWindowShortcut(this, "F6", [=] {
@@ -270,17 +272,12 @@ void Window::addDebugStuff()
     });
 
     createWindowShortcut(this, "F9", [=] {
-        auto *dialog = new WelcomeDialog();
-        dialog->setAttribute(Qt::WA_DeleteOnClose);
-        dialog->show();
-    });
-
-    createWindowShortcut(this, "F4", [=] {
         rapidjson::Document doc;
         doc.Parse(channelRewardMessage);
         auto app = getApp();
+        app->twitch.server->addFakeMessage(channelRewardIRCMessage);
         app->twitch.pubsub->signals_.pointReward.redeemed.invoke(
-            doc["data"]["message"]["data"]);
+            doc["data"]["message"]["data"]["redemption"]["reward"]);
     });
 
 #endif

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -25,6 +25,8 @@
 #include "widgets/splits/SplitContainer.hpp"
 
 #ifdef C_DEBUG
+#    include <rapidjson/document.h>
+#    include "providers/twitch/PubsubClient.hpp"
 #    include "util/SampleCheerMessages.hpp"
 #    include "util/SampleLinks.hpp"
 #endif
@@ -239,6 +241,9 @@ void Window::addDebugStuff()
     linkMessages.emplace_back(R"(@badge-info=subscriber/48;badges=broadcaster/1,subscriber/36,partner/1;color=#CC44FF;display-name=pajlada;emotes=;flags=;id=3c23cf3c-0864-4699-a76b-089350141147;mod=0;room-id=11148817;subscriber=1;tmi-sent-ts=1577628844607;turbo=0;user-id=11148817;user-type= :pajlada!pajlada@pajlada.tmi.twitch.tv PRIVMSG #pajlada : Links that should pass: )" + getValidLinks().join(' '));
     linkMessages.emplace_back(R"(@badge-info=subscriber/48;badges=broadcaster/1,subscriber/36,partner/1;color=#CC44FF;display-name=pajlada;emotes=;flags=;id=3c23cf3c-0864-4699-a76b-089350141147;mod=0;room-id=11148817;subscriber=1;tmi-sent-ts=1577628844607;turbo=0;user-id=11148817;user-type= :pajlada!pajlada@pajlada.tmi.twitch.tv PRIVMSG #pajlada : Links that should NOT pass: )" + getInvalidLinks().join(' '));
     linkMessages.emplace_back(R"(@badge-info=subscriber/48;badges=broadcaster/1,subscriber/36,partner/1;color=#CC44FF;display-name=pajlada;emotes=;flags=;id=3c23cf3c-0864-4699-a76b-089350141147;mod=0;room-id=11148817;subscriber=1;tmi-sent-ts=1577628844607;turbo=0;user-id=11148817;user-type= :pajlada!pajlada@pajlada.tmi.twitch.tv PRIVMSG #pajlada : Links that should technically pass but we choose not to parse them: )" + getValidButIgnoredLinks().join(' '));
+
+    // channel point reward test
+    const char* channelRewardMessage = "{ \"type\": \"MESSAGE\", \"data\": { \"topic\": \"community-points-channel-v1.11148817\", \"message\": { \"type\": \"reward-redeemed\", \"data\": { \"timestamp\": \"2020-07-13T20:19:31.430785354Z\", \"redemption\": { \"id\": \"b9628798-1b4e-4122-b2a6-031658df6755\", \"user\": { \"id\": \"91800084\", \"login\": \"cranken1337\", \"display_name\": \"cranken1337\" }, \"channel_id\": \"11148817\", \"redeemed_at\": \"2020-07-13T20:19:31.345237005Z\", \"reward\": { \"id\": \"313969fe-cc9f-4a0a-83c6-172acbd96957\", \"channel_id\": \"11148817\", \"title\": \"annoying reward pogchamp\", \"prompt\": \"\", \"cost\": 3000, \"is_user_input_required\": false, \"is_sub_only\": false, \"image\": null, \"default_image\": { \"url_1x\": \"https://static-cdn.jtvnw.net/custom-reward-images/default-1.png\", \"url_2x\": \"https://static-cdn.jtvnw.net/custom-reward-images/default-2.png\", \"url_4x\": \"https://static-cdn.jtvnw.net/custom-reward-images/default-4.png\" }, \"background_color\": \"#52ACEC\", \"is_enabled\": true, \"is_paused\": false, \"is_in_stock\": true, \"max_per_stream\": { \"is_enabled\": false, \"max_per_stream\": 0 }, \"should_redemptions_skip_request_queue\": false, \"template_id\": null, \"updated_for_indicator_at\": \"2020-01-20T04:33:33.624956679Z\" }, \"status\": \"UNFULFILLED\", \"cursor\": \"Yjk2Mjg3OTgtMWI0ZS00MTIyLWIyYTYtMDMxNjU4ZGY2NzU1X18yMDIwLTA3LTEzVDIwOjE5OjMxLjM0NTIzNzAwNVo=\" } } } } }";
     // clang-format on
 
     createWindowShortcut(this, "F6", [=] {
@@ -270,8 +275,16 @@ void Window::addDebugStuff()
         dialog->show();
     });
 
+    createWindowShortcut(this, "F4", [=] {
+        rapidjson::Document doc;
+        doc.Parse(channelRewardMessage);
+        auto app = getApp();
+        app->twitch.pubsub->signals_.pointReward.redeemed.invoke(
+            doc["data"]["message"]["data"]);
+    });
+
 #endif
-}
+}  // namespace chatterino
 
 void Window::addShortcuts()
 {

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -243,8 +243,9 @@ void Window::addDebugStuff()
     linkMessages.emplace_back(R"(@badge-info=subscriber/48;badges=broadcaster/1,subscriber/36,partner/1;color=#CC44FF;display-name=pajlada;emotes=;flags=;id=3c23cf3c-0864-4699-a76b-089350141147;mod=0;room-id=11148817;subscriber=1;tmi-sent-ts=1577628844607;turbo=0;user-id=11148817;user-type= :pajlada!pajlada@pajlada.tmi.twitch.tv PRIVMSG #pajlada : Links that should technically pass but we choose not to parse them: )" + getValidButIgnoredLinks().join(' '));
 
     // channel point reward test
-    const char* channelRewardMessage = "{ \"type\": \"MESSAGE\", \"data\": { \"topic\": \"community-points-channel-v1.11148817\", \"message\": { \"type\": \"reward-redeemed\", \"data\": { \"timestamp\": \"2020-07-13T20:19:31.430785354Z\", \"redemption\": { \"id\": \"b9628798-1b4e-4122-b2a6-031658df6755\", \"user\": { \"id\": \"91800084\", \"login\": \"cranken1337\", \"display_name\": \"cranken1337\" }, \"channel_id\": \"11148817\", \"redeemed_at\": \"2020-07-13T20:19:31.345237005Z\", \"reward\": { \"id\": \"313969fe-cc9f-4a0a-83c6-172acbd96957\", \"channel_id\": \"11148817\", \"title\": \"annoying reward pogchamp\", \"prompt\": \"\", \"cost\": 3000, \"is_user_input_required\": false, \"is_sub_only\": false, \"image\": null, \"default_image\": { \"url_1x\": \"https://static-cdn.jtvnw.net/custom-reward-images/default-1.png\", \"url_2x\": \"https://static-cdn.jtvnw.net/custom-reward-images/default-2.png\", \"url_4x\": \"https://static-cdn.jtvnw.net/custom-reward-images/default-4.png\" }, \"background_color\": \"#52ACEC\", \"is_enabled\": true, \"is_paused\": false, \"is_in_stock\": true, \"max_per_stream\": { \"is_enabled\": false, \"max_per_stream\": 0 }, \"should_redemptions_skip_request_queue\": false, \"template_id\": null, \"updated_for_indicator_at\": \"2020-01-20T04:33:33.624956679Z\" }, \"status\": \"UNFULFILLED\", \"cursor\": \"Yjk2Mjg3OTgtMWI0ZS00MTIyLWIyYTYtMDMxNjU4ZGY2NzU1X18yMDIwLTA3LTEzVDIwOjE5OjMxLjM0NTIzNzAwNVo=\" } } } } }";
-    const char * channelRewardIRCMessage(R"(@badge-info=subscriber/43;badges=subscriber/42;color=#1E90FF;custom-reward-id=313969fe-cc9f-4a0a-83c6-172acbd96957;display-name=Cranken1337;emotes=;flags=;id=3cee3f27-a1d0-44d1-a606-722cebdad08b;mod=0;room-id=11148817;subscriber=1;tmi-sent-ts=1594756484132;turbo=0;user-id=91800084;user-type= :cranken1337!cranken1337@cranken1337.tmi.twitch.tv PRIVMSG #pajlada :wow, amazing reward)");
+    const char *channelRewardMessage = "{ \"type\": \"MESSAGE\", \"data\": { \"topic\": \"community-points-channel-v1.11148817\", \"message\": { \"type\": \"reward-redeemed\", \"data\": { \"timestamp\": \"2020-07-13T20:19:31.430785354Z\", \"redemption\": { \"id\": \"b9628798-1b4e-4122-b2a6-031658df6755\", \"user\": { \"id\": \"91800084\", \"login\": \"cranken1337\", \"display_name\": \"cranken1337\" }, \"channel_id\": \"11148817\", \"redeemed_at\": \"2020-07-13T20:19:31.345237005Z\", \"reward\": { \"id\": \"313969fe-cc9f-4a0a-83c6-172acbd96957\", \"channel_id\": \"11148817\", \"title\": \"annoying reward pogchamp\", \"prompt\": \"\", \"cost\": 3000, \"is_user_input_required\": true, \"is_sub_only\": false, \"image\": null, \"default_image\": { \"url_1x\": \"https://static-cdn.jtvnw.net/custom-reward-images/default-1.png\", \"url_2x\": \"https://static-cdn.jtvnw.net/custom-reward-images/default-2.png\", \"url_4x\": \"https://static-cdn.jtvnw.net/custom-reward-images/default-4.png\" }, \"background_color\": \"#52ACEC\", \"is_enabled\": true, \"is_paused\": false, \"is_in_stock\": true, \"max_per_stream\": { \"is_enabled\": false, \"max_per_stream\": 0 }, \"should_redemptions_skip_request_queue\": false, \"template_id\": null, \"updated_for_indicator_at\": \"2020-01-20T04:33:33.624956679Z\" }, \"user_input\": \"wow, amazing reward\", \"status\": \"UNFULFILLED\", \"cursor\": \"Yjk2Mjg3OTgtMWI0ZS00MTIyLWIyYTYtMDMxNjU4ZGY2NzU1X18yMDIwLTA3LTEzVDIwOjE5OjMxLjM0NTIzNzAwNVo=\" } } } } }";
+    const char *channelRewardMessage2 = "{ \"type\": \"MESSAGE\", \"data\": { \"topic\": \"community-points-channel-v1.11148817\", \"message\": { \"type\": \"reward-redeemed\", \"data\": { \"timestamp\": \"2020-07-13T20:19:31.430785354Z\", \"redemption\": { \"id\": \"b9628798-1b4e-4122-b2a6-031658df6755\", \"user\": { \"id\": \"91800084\", \"login\": \"cranken1337\", \"display_name\": \"cranken1337\" }, \"channel_id\": \"11148817\", \"redeemed_at\": \"2020-07-13T20:19:31.345237005Z\", \"reward\": { \"id\": \"313969fe-cc9f-4a0a-83c6-172acbd96957\", \"channel_id\": \"11148817\", \"title\": \"annoying reward pogchamp\", \"prompt\": \"\", \"cost\": 3000, \"is_user_input_required\": false, \"is_sub_only\": false, \"image\": null, \"default_image\": { \"url_1x\": \"https://static-cdn.jtvnw.net/custom-reward-images/default-1.png\", \"url_2x\": \"https://static-cdn.jtvnw.net/custom-reward-images/default-2.png\", \"url_4x\": \"https://static-cdn.jtvnw.net/custom-reward-images/default-4.png\" }, \"background_color\": \"#52ACEC\", \"is_enabled\": true, \"is_paused\": false, \"is_in_stock\": true, \"max_per_stream\": { \"is_enabled\": false, \"max_per_stream\": 0 }, \"should_redemptions_skip_request_queue\": false, \"template_id\": null, \"updated_for_indicator_at\": \"2020-01-20T04:33:33.624956679Z\" }, \"status\": \"UNFULFILLED\", \"cursor\": \"Yjk2Mjg3OTgtMWI0ZS00MTIyLWIyYTYtMDMxNjU4ZGY2NzU1X18yMDIwLTA3LTEzVDIwOjE5OjMxLjM0NTIzNzAwNVo=\" } } } } }";
+    const char *channelRewardIRCMessage(R"(@badge-info=subscriber/43;badges=subscriber/42;color=#1E90FF;custom-reward-id=313969fe-cc9f-4a0a-83c6-172acbd96957;display-name=Cranken1337;emotes=;flags=;id=3cee3f27-a1d0-44d1-a606-722cebdad08b;mod=0;room-id=11148817;subscriber=1;tmi-sent-ts=1594756484132;turbo=0;user-id=91800084;user-type= :cranken1337!cranken1337@cranken1337.tmi.twitch.tv PRIVMSG #pajlada :wow, amazing reward)");
 
     // clang-format on
 
@@ -273,11 +274,23 @@ void Window::addDebugStuff()
 
     createWindowShortcut(this, "F9", [=] {
         rapidjson::Document doc;
-        doc.Parse(channelRewardMessage);
         auto app = getApp();
-        app->twitch.server->addFakeMessage(channelRewardIRCMessage);
-        app->twitch.pubsub->signals_.pointReward.redeemed.invoke(
-            doc["data"]["message"]["data"]["redemption"]["reward"]);
+        static bool alt = true;
+        if (alt)
+        {
+            doc.Parse(channelRewardMessage);
+            app->twitch.server->addFakeMessage(channelRewardIRCMessage);
+            app->twitch.pubsub->signals_.pointReward.redeemed.invoke(
+                doc["data"]["message"]["data"]["redemption"]);
+            alt = !alt;
+        }
+        else
+        {
+            doc.Parse(channelRewardMessage2);
+            app->twitch.pubsub->signals_.pointReward.redeemed.invoke(
+                doc["data"]["message"]["data"]["redemption"]);
+            alt = !alt;
+        }
     });
 
 #endif

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -853,6 +853,7 @@ MessageElementFlags ChannelView::getFlags() const
         if (this->channel_ == app->twitch.server->mentionsChannel)
         {
             flags.set(MessageElementFlag::ChannelName);
+            flags.unset(MessageElementFlag::ChannelPointReward);
         }
     }
 
@@ -899,6 +900,9 @@ void ChannelView::drawMessages(QPainter &painter)
     MessageLayout *end = nullptr;
     bool windowFocused = this->window() == QApplication::activeWindow();
 
+    auto app = getApp();
+    bool isMentions = this->channel_ == app->twitch.server->mentionsChannel;
+
     for (size_t i = start; i < messagesSnapshot.size(); ++i)
     {
         MessageLayout *layout = messagesSnapshot[i].get();
@@ -910,7 +914,7 @@ void ChannelView::drawMessages(QPainter &painter)
         }
 
         layout->paint(painter, DRAW_WIDTH, y, i, this->selection_,
-                      isLastMessage, windowFocused);
+                      isLastMessage, windowFocused, isMentions);
 
         y += layout->getHeight();
 


### PR DESCRIPTION
Adds parsing and showing of channel point rewards in channels.

Currently there is still one unfixable drawback: We can't get the channel point icon. Twitch uses their gql endpoint for the image and we can't/shouldn't access that.

- [X] Show purple highlight next to reward messages
- [x] Requires an addition to pajladas signal library: https://github.com/pajlada/signals/pull/7
- [x] Show title(type,cost,image) for reward
- [x] Show rewards without user message
- [x] `F9` to print a debug message