### PR TITLE
Reset the lastMessageHasAlternateBackground{Reverse} values when clearing all messages in a ChannelView.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unversioned
+
 - Major: We now support image thumbnails coming from the link resolver. This feature is off by default and can be enabled in the settings with the "Show link thumbnail" setting. This feature also requires the "Show link info when hovering" setting to be enabled (#1664)
 - Major: Added image upload functionality to i.nuuls.com with an ability to change upload destination. This works by dragging and dropping an image into a split, or pasting an image into the text edit field. (#1332, #1741)
 - Minor: You can now open the Twitch User Card by middle-mouse clicking a username. (#1669)
@@ -12,6 +13,7 @@
 - Bugfix: FFZ custom mod badges no longer scale with the emote scale options (#1602)
 - Bugfix: MacOS updater looked for non-existing fields, causing it to always fail the update check (#1642)
 - Bugfix: Fixed message menu crashing if the message you right-clicked goes out of scope before you select an action (#1783) (#1787)
+- Bugfix: Fixed alternate messages flickering in UserInfoPopup when clicking Refresh if there was an odd number of messages in there (#1789 #1810)
 - Settings open faster
 - Dev: Fully remove Twitch Chatroom support
 - Dev: Handle conversion of historical CLEARCHAT messages to NOTICE messages in Chatterino instead of relying on the Recent Messages API to handle it for us. (#1804)

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -467,6 +467,9 @@ void ChannelView::clearMessages()
     this->messages_.clear();
     this->scrollBar_->clearHighlights();
     this->queueLayout();
+
+    this->lastMessageHasAlternateBackground_ = false;
+    this->lastMessageHasAlternateBackgroundReverse_ = true;
 }
 
 Scrollbar &ChannelView::getScrollBar()


### PR DESCRIPTION
# Description

This makes it so that we consistently start with the same values after
having cleared a ChannelView.
Example place where this happens: UserInfoPopup when user messages are
loaded and refreshed

Fixes #1789 