### PR TITLE
[SettingDialog] CTRL+F now selects the Find input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Minor: BetterTTV / FrankerFaceZ emote tooltips now also have emote authors' name (#1721)
 - Minor: Emotes in the emote popup are now sorted in the same order as the tab completion (#1549)
 - Minor: Removed "Online Logs" functionality as services are shut down (#1640)
+- Minor: CTRL+F now selects the Find text input field in the Settings Dialog (#1806 #1811)
 - Bugfix: Fix preview on hover not working when Animated emotes options was disabled (#1546)
 - Bugfix: FFZ custom mod badges no longer scale with the emote scale options (#1602)
 - Bugfix: MacOS updater looked for non-existing fields, causing it to always fail the update check (#1642)

--- a/src/widgets/dialogs/SettingsDialog.cpp
+++ b/src/widgets/dialogs/SettingsDialog.cpp
@@ -3,6 +3,7 @@
 #include "Application.hpp"
 #include "singletons/Resources.hpp"
 #include "util/LayoutCreator.hpp"
+#include "util/Shortcut.hpp"
 #include "widgets/helper/Button.hpp"
 #include "widgets/settingspages/AboutPage.hpp"
 #include "widgets/settingspages/AccountsPage.hpp"
@@ -32,6 +33,11 @@ SettingsDialog::SettingsDialog()
     this->addTabs();
     this->overrideBackgroundColor_ = QColor("#111111");
     this->scaleChangedEvent(this->scale());  // execute twice to width of item
+
+    createWindowShortcut(this, "CTRL+F", [this] {
+        this->ui_.search->setFocus();
+        this->ui_.search->selectAll();
+    });
 }
 
 void SettingsDialog::initUi()

--- a/src/widgets/dialogs/SettingsDialog.hpp
+++ b/src/widgets/dialogs/SettingsDialog.hpp
@@ -31,9 +31,9 @@ enum class SettingsDialogPreference {
 
 class SettingsDialog : public BaseWindow
 {
-public:
     SettingsDialog();
 
+public:
     static void showDialog(SettingsDialogPreference preferredTab =
                                SettingsDialogPreference::NoPreference);
 


### PR DESCRIPTION
# Description

CTRL+F now selects the Find text input in the Setting Dialog (and selects all text if there is any)
<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->

Fixes #1806 