### PR TITLE
removed linebreak after wrapped TextElements

### DIFF
--- a/src/messages/MessageElement.cpp
+++ b/src/messages/MessageElement.cpp
@@ -361,10 +361,9 @@ void TextElement::addToContainer(MessageLayoutContainer &container,
                 if (isSurrogate)
                     i++;
             }
-
-            container.addElement(getTextLayoutElement(
+            //add the final piece of wrapped text
+            container.addElementNoLineBreak(getTextLayoutElement(
                 text.mid(wordStart), width, this->hasTrailingSpace()));
-            container.breakLine();
         }
     }
 }

--- a/src/messages/MessageElement.cpp
+++ b/src/messages/MessageElement.cpp
@@ -669,10 +669,9 @@ void IrcTextElement::addToContainer(MessageLayoutContainer &container,
             }
 
             // Add last remaining text & segments
-            container.addElement(
+            container.addElementNoLineBreak(
                 getTextLayoutElement(text.mid(wordStart), segments, width,
                                      this->hasTrailingSpace()));
-            container.breakLine();
         }
     }
 }


### PR DESCRIPTION
# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->

Changed text-wrapping behavior. Removed the linebreak after wrapped text elements to improve the readability of messages containing wrapped words. 

Before:
![image](https://user-images.githubusercontent.com/44077383/87861770-28348380-c8fe-11ea-9543-af9ad2604494.png)

After:
![image](https://user-images.githubusercontent.com/44077383/87861773-2e2a6480-c8fe-11ea-890a-114e2534705c.png)

