### PR TITLE
Vertical tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Major: We now support image thumbnails coming from the link resolver. This feature is off by default and can be enabled in the settings with the "Show link thumbnail" setting. This feature also requires the "Show link info when hovering" setting to be enabled (#1664)
 - Major: Added image upload functionality to i.nuuls.com with an ability to change upload destination. This works by dragging and dropping an image into a split, or pasting an image into the text edit field. (#1332, #1741)
+- Major: Added option to display tabs vertically. (#1815)
 - Minor: Clicking on @mentions will open the User Popup. (#1674)
 - Minor: You can now open the Twitch User Card by middle-mouse clicking a username. (#1669)
 - Minor: User Popup now also includes recent user messages (#1729)

--- a/src/BaseTheme.cpp
+++ b/src/BaseTheme.cpp
@@ -148,7 +148,8 @@ void AB_THEME_CLASS::actuallyUpdate(double hue, double multiplier)
         //            this->tabs.highlighted = {fg, {QColor("#777"),
         //            QColor("#777"), QColor("#666")}};
 
-        this->tabs.dividerLine = this->tabs.selected.backgrounds.regular.color();
+        this->tabs.dividerLine =
+            this->tabs.selected.backgrounds.regular.color();
     }
 
     // Message

--- a/src/BaseTheme.cpp
+++ b/src/BaseTheme.cpp
@@ -148,7 +148,7 @@ void AB_THEME_CLASS::actuallyUpdate(double hue, double multiplier)
         //            this->tabs.highlighted = {fg, {QColor("#777"),
         //            QColor("#777"), QColor("#666")}};
 
-        this->tabs.bottomLine = this->tabs.selected.backgrounds.regular.color();
+        this->tabs.dividerLine = this->tabs.selected.backgrounds.regular.color();
     }
 
     // Message

--- a/src/BaseTheme.hpp
+++ b/src/BaseTheme.hpp
@@ -49,7 +49,7 @@ public:
         TabColors highlighted;
         TabColors selected;
         QColor border;
-        QColor bottomLine;
+        QColor dividerLine;
     } tabs;
 
     /// MESSAGES

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -9,6 +9,7 @@
 #include "controllers/highlights/HighlightPhrase.hpp"
 #include "controllers/moderationactions/ModerationAction.hpp"
 #include "singletons/Toasts.hpp"
+#include "widgets/Notebook.hpp"
 
 namespace chatterino {
 
@@ -78,8 +79,8 @@ public:
     BoolSetting colorizeNicknames = {"/appearance/messages/colorizeNicknames",
                                      false};
 
-    // true = horizontal tabs, false = vertical tabs
-    BoolSetting tabDirection = {"/appearance/tabDirection", true};
+    IntSetting tabDirection = {"/appearance/tabDirection",
+                               NotebookTabDirection::Horizontal};
 
     //    BoolSetting collapseLongMessages =
     //    {"/appearance/messages/collapseLongMessages", false};

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -78,6 +78,9 @@ public:
     BoolSetting colorizeNicknames = {"/appearance/messages/colorizeNicknames",
                                      false};
 
+    // true = horizontal tabs, false = vertical tabs
+    BoolSetting tabDirection = {"/appearance/tabDirection", true};
+
     //    BoolSetting collapseLongMessages =
     //    {"/appearance/messages/collapseLongMessages", false};
     IntSetting collpseMessagesMinLines = {

--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -466,9 +466,10 @@ void Notebook::performLayout(bool animated)
             x += tabHeight;
         }
 
-        int buttonWidth = x;
+        if (this->customButtons_.size() > 0)
+            y = tabHeight;
 
-        y += tabHeight;
+        int buttonWidth = x;
         int top = y;
         x = left;
 
@@ -566,8 +567,13 @@ void Notebook::paintEvent(QPaintEvent *event)
     }
     else
     {
-        painter.fillRect(0, int(NOTEBOOK_TAB_HEIGHT * scale), this->lineOffset_,
-                         int(2 * scale), this->theme->tabs.dividerLine);
+        if (this->customButtons_.size() > 0)
+        {
+            painter.fillRect(0, int(NOTEBOOK_TAB_HEIGHT * scale),
+                             this->lineOffset_, int(2 * scale),
+                             this->theme->tabs.dividerLine);
+        }
+
         /// vertical line
         painter.fillRect(this->lineOffset_, 0, int(2 * scale), this->height(),
                          this->theme->tabs.dividerLine);

--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -357,7 +357,7 @@ void Notebook::performLayout(bool animated)
     const auto tabHeight = int(NOTEBOOK_TAB_HEIGHT * scale);
     const auto addButtonWidth = this->showAddButton_ ? tabHeight : 0;
 
-    if (this->horizontalTabs_)
+    if (this->tabDirection_ == NotebookTabDirection::Horizontal)
     {
         auto x = left;
         auto y = 0;
@@ -543,11 +543,11 @@ void Notebook::performLayout(bool animated)
     }
 }
 
-void Notebook::setHorizontalTabs(bool horizontal)
+void Notebook::setTabDirection(NotebookTabDirection direction)
 {
-    if (horizontal != this->horizontalTabs_)
+    if (direction != this->tabDirection_)
     {
-        this->horizontalTabs_ = horizontal;
+        this->tabDirection_ = direction;
         this->performLayout();
     }
 }
@@ -558,7 +558,7 @@ void Notebook::paintEvent(QPaintEvent *event)
     auto scale = this->scale();
 
     QPainter painter(this);
-    if (this->horizontalTabs_)
+    if (this->tabDirection_ == NotebookTabDirection::Horizontal)
     {
         /// horizontal line
         painter.fillRect(0, this->lineOffset_, this->width(), int(2 * scale),

--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -492,6 +492,15 @@ void Notebook::performLayout(bool animated)
                     this->items_.at(i).tab->normalTabWidth(), largestWidth);
             }
 
+            if (col == columnCount - 1 && this->showAddButton_ &&
+                largestWidth == 0)
+            {
+                largestWidth = this->addButton_->width();
+            }
+
+            if (largestWidth + x < buttonWidth && col == columnCount - 1)
+                largestWidth = buttonWidth - x;
+
             for (int i = colStart; i < colEnd; i++)
             {
                 auto item = this->items_.at(i);
@@ -505,10 +514,6 @@ void Notebook::performLayout(bool animated)
             if (col == columnCount - 1 && this->showAddButton_)
             {
                 this->addButton_->move(x, y);
-                if (largestWidth == 0)
-                {
-                    largestWidth = this->addButton_->width();
-                }
             }
 
             x += largestWidth + lineThickness;

--- a/src/widgets/Notebook.hpp
+++ b/src/widgets/Notebook.hpp
@@ -16,6 +16,8 @@ class NotebookButton;
 class NotebookTab;
 class SplitContainer;
 
+enum NotebookTabDirection { Horizontal = 0, Vertical = 1 };
+
 class Notebook : public BaseWidget
 {
     Q_OBJECT
@@ -52,7 +54,7 @@ public:
 
     void performLayout(bool animate = false);
 
-    void setHorizontalTabs(bool horizontal);
+    void setTabDirection(NotebookTabDirection direction);
 
 protected:
     virtual void scaleChangedEvent(float scale_) override;
@@ -84,7 +86,7 @@ private:
     bool allowUserTabManagement_ = false;
     bool showAddButton_ = false;
     int lineOffset_ = 20;
-    bool horizontalTabs_ = true;
+    NotebookTabDirection tabDirection_ = NotebookTabDirection::Horizontal;
 };
 
 class SplitNotebook : public Notebook, pajlada::Signals::SignalHolder

--- a/src/widgets/Notebook.hpp
+++ b/src/widgets/Notebook.hpp
@@ -52,6 +52,8 @@ public:
 
     void performLayout(bool animate = false);
 
+    void setHorizontalTabs(bool horizontal);
+
 protected:
     virtual void scaleChangedEvent(float scale_) override;
     virtual void resizeEvent(QResizeEvent *) override;
@@ -81,7 +83,8 @@ private:
 
     bool allowUserTabManagement_ = false;
     bool showAddButton_ = false;
-    int lineY_ = 20;
+    int lineOffset_ = 20;
+    bool horizontalTabs_ = true;
 };
 
 class SplitNotebook : public Notebook, pajlada::Signals::SignalHolder

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -62,8 +62,9 @@ Window::Window(WindowType type)
     if (type == WindowType::Main)
     {
         this->resize(int(600 * this->scale()), int(500 * this->scale()));
-        getSettings()->tabDirection.connect(
-            [this](bool val) { this->notebook_->setHorizontalTabs(val); });
+        getSettings()->tabDirection.connect([this](int val) {
+            this->notebook_->setTabDirection(NotebookTabDirection(val));
+        });
     }
     else
     {
@@ -173,7 +174,6 @@ void Window::addLayout()
 
     this->notebook_->setAllowUserTabManagement(true);
     this->notebook_->setShowAddButton(true);
-    this->notebook_->setHorizontalTabs(false);
 }
 
 void Window::addCustomTitlebarButtons()

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -62,6 +62,8 @@ Window::Window(WindowType type)
     if (type == WindowType::Main)
     {
         this->resize(int(600 * this->scale()), int(500 * this->scale()));
+        getSettings()->tabDirection.connect(
+            [this](bool val) { this->notebook_->setHorizontalTabs(val); });
     }
     else
     {
@@ -171,6 +173,7 @@ void Window::addLayout()
 
     this->notebook_->setAllowUserTabManagement(true);
     this->notebook_->setShowAddButton(true);
+    this->notebook_->setHorizontalTabs(false);
 }
 
 void Window::addCustomTitlebarButtons()

--- a/src/widgets/helper/NotebookTab.cpp
+++ b/src/widgets/helper/NotebookTab.cpp
@@ -89,7 +89,20 @@ void NotebookTab::themeChangedEvent()
     this->setMouseEffectColor(this->theme->tabs.regular.text);
 }
 
-void NotebookTab::updateSize()
+void NotebookTab::growWidth(int width)
+{
+    if (this->growWidth_ != width)
+    {
+        this->growWidth_ = width;
+        this->updateSize();
+    }
+    else
+    {
+        this->growWidth_ = width;
+    }
+}
+
+int NotebookTab::normalTabWidth()
 {
     float scale = this->scale();
     int width;
@@ -114,7 +127,20 @@ void NotebookTab::updateSize()
     {
         width = clamp(width, this->height(), int(150 * scale));
     }
+
+    return width;
+}
+
+void NotebookTab::updateSize()
+{
+    float scale = this->scale();
+    int width = this->normalTabWidth();
     auto height = int(NOTEBOOK_TAB_HEIGHT * scale);
+
+    if (width < this->growWidth_)
+    {
+        width = this->growWidth_;
+    }
 
     if (this->width() != width || this->height() != height)
     {
@@ -175,7 +201,7 @@ void NotebookTab::titleUpdated()
 {
     // Queue up save because: Tab title changed
     getApp()->windows->queueSave();
-
+    this->notebook_->performLayout();
     this->updateSize();
     this->update();
 }

--- a/src/widgets/helper/NotebookTab.hpp
+++ b/src/widgets/helper/NotebookTab.hpp
@@ -51,6 +51,9 @@ public:
     QRect getDesiredRect() const;
     void hideTabXChanged();
 
+    void growWidth(int width);
+    int normalTabWidth();
+
 protected:
     virtual void themeChangedEvent() override;
 
@@ -97,6 +100,8 @@ private:
     QAction *highlightNewMessagesAction_;
 
     bool isLive_{};
+
+    int growWidth_ = 0;
 
     QMenu menu_;
 

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -299,6 +299,16 @@ void GeneralPage::initLayout(SettingsLayout &layout)
                 return QString::number(val) + "x";
         },
         [](auto args) { return fuzzyToFloat(args.value, 1.f); });
+    layout.addDropdown<bool>(
+        "Tab direction", {"Horizontal", "Vertical"}, s.tabDirection,
+        [](auto val) {
+            if (val)
+                return "Horizontal";
+            else
+                return "Vertical";
+        },
+        [](auto args) { return args.value == "Horizontal"; });
+
     layout.addCheckbox("Show tab close button", s.showTabCloseButton);
     layout.addCheckbox("Always on top", s.windowTopMost);
 #ifdef USEWINSDK

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -299,15 +299,30 @@ void GeneralPage::initLayout(SettingsLayout &layout)
                 return QString::number(val) + "x";
         },
         [](auto args) { return fuzzyToFloat(args.value, 1.f); });
-    layout.addDropdown<bool>(
+    layout.addDropdown<int>(
         "Tab direction", {"Horizontal", "Vertical"}, s.tabDirection,
         [](auto val) {
-            if (val)
-                return "Horizontal";
-            else
-                return "Vertical";
+            switch (val)
+            {
+                case NotebookTabDirection::Horizontal:
+                    return "Horizontal";
+                case NotebookTabDirection::Vertical:
+                    return "Vertical";
+            }
+
+            return "";
         },
-        [](auto args) { return args.value == "Horizontal"; });
+        [](auto args) {
+            if (args.value == "Vertical")
+            {
+                return NotebookTabDirection::Vertical;
+            }
+            else
+            {
+                // default to horizontal
+                return NotebookTabDirection::Horizontal;
+            }
+        });
 
     layout.addCheckbox("Show tab close button", s.showTabCloseButton);
     layout.addCheckbox("Always on top", s.windowTopMost);


### PR DESCRIPTION
# Description
Adds the option to use vertical tabs on the left side of the screen. Tabs fill from top to bottom and wrap into another column if necessary. 

Closes #388

<details>
<summary>Screenshots</summary>
<img width="893" alt="Screen Shot 2020-07-19 at 1 44 39 PM" src="https://user-images.githubusercontent.com/24928223/87881497-95f8b200-c9c7-11ea-8f9c-2b2d312d7c9f.png">
<img width="893" alt="Screen Shot 2020-07-19 at 1 44 49 PM" src="https://user-images.githubusercontent.com/24928223/87881499-97c27580-c9c7-11ea-953b-77aa648aece2.png">
</details>