### PR TITLE
Added support for chat relocation when using Chatterino extension

### DIFF
--- a/src/singletons/NativeMessaging.cpp
+++ b/src/singletons/NativeMessaging.cpp
@@ -198,11 +198,12 @@ void NativeMessagingServer::ReceiverThread::handleMessage(
         AttachedWindow::GetArgs args;
         args.winId = root.value("winId").toString();
         args.yOffset = root.value("yOffset").toInt(-1);
+        args.x = root.value("size").toObject().value("x").toInt(-1);
         args.width = root.value("size").toObject().value("width").toInt(-1);
         args.height = root.value("size").toObject().value("height").toInt(-1);
         args.fullscreen = attachFullscreen;
 
-        qDebug() << args.width << args.height << args.winId;
+        qDebug() << args.x << args.width << args.height << args.winId;
 
         if (_type.isNull() || args.winId.isNull())
         {

--- a/src/widgets/AttachedWindow.cpp
+++ b/src/widgets/AttachedWindow.cpp
@@ -91,6 +91,8 @@ AttachedWindow *AttachedWindow::get(void *target, const GetArgs &args)
 
     window->fullscreen_ = args.fullscreen;
 
+    window->x_ = args.x;
+
     if (args.height != -1)
     {
         if (args.height == 0)
@@ -269,10 +271,21 @@ void AttachedWindow::updateWindowRect(void *_attachedPtr)
         // offset
         int o = this->fullscreen_ ? 0 : 8;
 
-        ::MoveWindow(hwnd, int(rect.right - this->width_ * scale - o),
-                     int(rect.bottom - this->height_ * scale - o),
-                     int(this->width_ * scale), int(this->height_ * scale),
-                     true);
+        if (this->x_ != -1)
+        {
+            ::MoveWindow(hwnd, int(rect.left + this->x_ * scale + o),
+                         int(rect.bottom - this->height_ * scale - o),
+                         int(this->width_ * scale), int(this->height_ * scale),
+                         true);
+        }
+        //support for old extension version 1.2
+        else
+        {
+            ::MoveWindow(hwnd, int(rect.right - this->width_ * scale - o),
+                         int(rect.bottom - this->height_ * scale - o),
+                         int(this->width_ * scale), int(this->height_ * scale),
+                         true);
+        }
     }
 
 //    if (this->fullscreen_)

--- a/src/widgets/AttachedWindow.hpp
+++ b/src/widgets/AttachedWindow.hpp
@@ -17,6 +17,7 @@ public:
     struct GetArgs {
         QString winId;
         int yOffset = -1;
+        int x = -1;
         int width = -1;
         int height = -1;
         bool fullscreen = false;
@@ -53,6 +54,7 @@ private:
     void *target_;
     int yOffset_;
     int currentYOffset_;
+    int x_ = -1;
     int width_ = 360;
     int height_ = -1;
     bool fullscreen_ = false;


### PR DESCRIPTION
# Description
I added support for moving the chat when using the Chatterino Native Host extension.

Extensions like BTTV allow you to swap sidebars, moving the chat div to the left side of the screen. Currently, Chatterino doesn't support this feature as it uses a static determination for where to put the chat (right side of window - chat width). 

Together with Chatterino/chatterino-browser-ext#19 , this solves that problem. Without the changes in the extension, the behavior defaults to the current behavior.

Current behavior:
![image](https://user-images.githubusercontent.com/44077383/88468026-ae1e7480-ce92-11ea-84f3-f3b1d9633891.png)

With these changes:
![image](https://user-images.githubusercontent.com/44077383/88468028-b2e32880-ce92-11ea-900d-073235380121.png)
