### PR TITLE
Added setting to auto close user popup

### DIFF
--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -126,7 +126,7 @@ public:
     BoolSetting showParts = {"/behaviour/showParts", false};
     FloatSetting mouseScrollMultiplier = {"/behaviour/mouseScrollMultiplier",
                                           1.0};
-    BoolSetting autoCloseUserPopup = {"/behaviour/autoCloseUserPopup", false};
+    BoolSetting autoCloseUserPopup = {"/behaviour/autoCloseUserPopup", true};
     // BoolSetting twitchSeperateWriteConnection =
     // {"/behaviour/twitchSeperateWriteConnection", false};
 

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -126,6 +126,7 @@ public:
     BoolSetting showParts = {"/behaviour/showParts", false};
     FloatSetting mouseScrollMultiplier = {"/behaviour/mouseScrollMultiplier",
                                           1.0};
+    BoolSetting autoCloseUserPopup = {"/behaviour/autoCloseUserPopup", false};
     // BoolSetting twitchSeperateWriteConnection =
     // {"/behaviour/twitchSeperateWriteConnection", false};
 

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1817,6 +1817,10 @@ void ChannelView::hideEvent(QHideEvent *)
 void ChannelView::showUserInfoPopup(const QString &userName)
 {
     auto *userPopup = new UserInfoPopup;
+    if (getSettings()->autoCloseUserPopup)
+    {
+        userPopup->setActionOnFocusLoss(BaseWindow::Delete);
+    }
     userPopup->setData(userName, this->hasSourceChannel() ? this->sourceChannel_
                                                           : this->channel_);
     QPoint offset(int(150 * this->scale()), int(70 * this->scale()));

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -509,6 +509,8 @@ void GeneralPage::initLayout(SettingsLayout &layout)
                        s.mentionUsersWithComma);
     layout.addCheckbox("Show joined users (< 1000 chatters)", s.showJoins);
     layout.addCheckbox("Show parted users (< 1000 chatters)", s.showParts);
+    layout.addCheckbox("Automatically close user popup when it loses focus",
+                       s.autoCloseUserPopup);
     layout.addCheckbox("Lowercase domains (anti-phishing)", s.lowercaseDomains);
     layout.addCheckbox("Bold @usernames", s.boldUsernames);
     layout.addCheckbox("Try to find usernames without @ prefix",


### PR DESCRIPTION
This attempts for fix https://github.com/Chatterino/chatterino2/issues/1820.

Apply `userPopup->setActionOnFocusLoss(BaseWindow::Delete);` only when the user has enabled the setting to "automatically close user popup when it loses focus". This will not close user popups created before toggling the option.