### PR TITLE
update recent messages env documentation

### DIFF
--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -3,7 +3,7 @@ Below I have tried to list all environment variables that can be used to modify 
 
 ### CHATTERINO2_RECENT_MESSAGES_URL
 Used to change the URL that Chatterino2 uses when trying to load historic Twitch chat messages (if the setting is enabled).  
-Default value: `https://recent-messages.robotty.de/api/v2/recent-messages/%1` (an [open-source service](https://github.com/robotty/recent-messages) written and currently run by [@RAnders00](https://github.com/RAnders00))  
+Default value: `https://recent-messages.robotty.de/api/v2/recent-messages/%1` (an [open-source service](https://github.com/robotty/recent-messages2) written and currently run by [@RAnders00](https://github.com/RAnders00) - [visit the homepage for more details about the service](https://recent-messages.robotty.de/))  
 Arguments:  
  - `%1` = Name of the Twitch channel
 


### PR DESCRIPTION
# Description
recent-messages was recently switched to a rewritten "version 2" of the original service, which also meant that it finally got a proper website, which we can now link to. The website bundles information that was previously spread out over a ton of different places.

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
