### PR TITLE
Use Qt's dialog where applicable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Minor: Improve UX of the "Login expired!" message (#2029)
 - Minor: PageUp and PageDown now scroll in the selected split (#2070, #2081)
 - Minor: Allow highlights to be excluded from `/mentions`. Excluded highlights will not trigger tab highlights either. (#1793, #2036)
+- Minor: Flag all popup dialogs as actual dialogs so they get the relevant window manager hints (#1843)
 - Bugfix: Fix bug preventing users from setting the highlight color of the second entry in the "User" highlights tab (#1898)
 - Bugfix: Fix bug where the "check user follow state" event could trigger a network request requesting the user to follow or unfollow a user. By itself its quite harmless as it just repeats to Twitch the same follow state we had, so no follows should have been lost by this but it meant there was a rogue network request that was fired that could cause a crash (#1906)
 - Bugfix: /usercard command will now respect the "Automatically close user popup" setting (#1918)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Minor: PageUp and PageDown now scroll in the selected split (#2070, #2081)
 - Minor: Allow highlights to be excluded from `/mentions`. Excluded highlights will not trigger tab highlights either. (#1793, #2036)
 - Minor: Flag all popup dialogs as actual dialogs so they get the relevant window manager hints (#1843)
+- Bugfix: Fix crash occurring when pressing Escape in the Color Picker Dialog (#1843)
 - Bugfix: Fix bug preventing users from setting the highlight color of the second entry in the "User" highlights tab (#1898)
 - Bugfix: Fix bug where the "check user follow state" event could trigger a network request requesting the user to follow or unfollow a user. By itself its quite harmless as it just repeats to Twitch the same follow state we had, so no follows should have been lost by this but it meant there was a rogue network request that was fired that could cause a crash (#1906)
 - Bugfix: /usercard command will now respect the "Automatically close user popup" setting (#1918)

--- a/src/common/FlagsEnum.hpp
+++ b/src/common/FlagsEnum.hpp
@@ -59,6 +59,15 @@ public:
         return static_cast<Q>(this->value_) & static_cast<Q>(flag);
     }
 
+    FlagsEnum operator|(T flag)
+    {
+        FlagsEnum xd;
+        xd.value_ = this->value_;
+        xd.set(flag, true);
+
+        return xd;
+    }
+
     bool hasAny(FlagsEnum flags) const
     {
         return static_cast<Q>(this->value_) & static_cast<Q>(flags.value_);

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -18,7 +18,6 @@
 #include "util/CombinePath.hpp"
 #include "util/Twitch.hpp"
 #include "widgets/Window.hpp"
-#include "widgets/dialogs/QualityPopup.hpp"
 #include "widgets/dialogs/UserInfoPopup.hpp"
 
 #include <QApplication>
@@ -455,11 +454,6 @@ QString CommandController::execCommand(const QString &textNoEmoji,
                 sendWhisperMessage(text);
             }
 
-            return "";
-        }
-        else if (commandName == "/xd")
-        {
-            QualityPopup::showDialog("pajlada", {"a", "b"});
             return "";
         }
     }

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -14,8 +14,10 @@
 #include "singletons/Paths.hpp"
 #include "singletons/Settings.hpp"
 #include "singletons/Theme.hpp"
+#include "singletons/WindowManager.hpp"
 #include "util/CombinePath.hpp"
 #include "util/Twitch.hpp"
+#include "widgets/Window.hpp"
 #include "widgets/dialogs/QualityPopup.hpp"
 #include "widgets/dialogs/UserInfoPopup.hpp"
 
@@ -406,7 +408,9 @@ void CommandController::initialize(Settings &, Paths &paths)
             return "";
         }
 
-        auto *userPopup = new UserInfoPopup(getSettings()->autoCloseUserPopup);
+        auto *userPopup = new UserInfoPopup(
+            getSettings()->autoCloseUserPopup,
+            static_cast<QWidget *>(&(getApp()->windows->getMainWindow())));
         userPopup->setData(words[1], channel);
         userPopup->move(QCursor::pos());
         userPopup->show();

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -16,6 +16,7 @@
 #include "singletons/Theme.hpp"
 #include "util/CombinePath.hpp"
 #include "util/Twitch.hpp"
+#include "widgets/dialogs/QualityPopup.hpp"
 #include "widgets/dialogs/UserInfoPopup.hpp"
 
 #include <QApplication>
@@ -450,6 +451,11 @@ QString CommandController::execCommand(const QString &textNoEmoji,
                 sendWhisperMessage(text);
             }
 
+            return "";
+        }
+        else if (commandName == "/xd")
+        {
+            QualityPopup::showDialog("pajlada", {"a", "b"});
             return "";
         }
     }

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -49,10 +49,12 @@ namespace {
 using SplitNode = SplitContainer::Node;
 using SplitDirection = SplitContainer::Direction;
 
-void WindowManager::showSettingsDialog(SettingsDialogPreference preference)
+void WindowManager::showSettingsDialog(QWidget *parent,
+                                       SettingsDialogPreference preference)
 {
-    QTimer::singleShot(
-        80, [preference] { SettingsDialog::showDialog(preference); });
+    QTimer::singleShot(80, [parent, preference] {
+        SettingsDialog::showDialog(parent, preference);
+    });
 }
 
 void WindowManager::showAccountSelectPopup(QPoint point)

--- a/src/singletons/WindowManager.hpp
+++ b/src/singletons/WindowManager.hpp
@@ -30,6 +30,7 @@ public:
     static IndirectChannel decodeChannel(const SplitDescriptor &descriptor);
 
     void showSettingsDialog(
+        QWidget *parent,
         SettingsDialogPreference preference = SettingsDialogPreference());
 
     // Show the account selector widget at point

--- a/src/widgets/AccountSwitchPopup.cpp
+++ b/src/widgets/AccountSwitchPopup.cpp
@@ -30,8 +30,9 @@ AccountSwitchPopup::AccountSwitchPopup(QWidget *parent)
     hbox->addWidget(manageAccountsButton);
     vbox->addLayout(hbox);
 
-    connect(manageAccountsButton, &QPushButton::clicked, []() {
-        SettingsDialog::showDialog(SettingsDialogPreference::Accounts);  //
+    connect(manageAccountsButton, &QPushButton::clicked, [this]() {
+        SettingsDialog::showDialog(this,
+                                   SettingsDialogPreference::Accounts);  //
     });
 
     this->getLayoutContainer()->setLayout(vbox);

--- a/src/widgets/BasePopup.cpp
+++ b/src/widgets/BasePopup.cpp
@@ -3,7 +3,7 @@
 namespace chatterino {
 
 BasePopup::BasePopup(FlagsEnum<Flags> _flags, QWidget *parent)
-    : BaseWindow(std::move(_flags), parent)
+    : BaseWindow(_flags | Dialog, parent)
 {
 }
 

--- a/src/widgets/BaseWindow.cpp
+++ b/src/widgets/BaseWindow.cpp
@@ -45,9 +45,9 @@
 namespace chatterino {
 
 BaseWindow::BaseWindow(FlagsEnum<Flags> _flags, QWidget *parent)
-    : BaseWidget(parent,
-                 Qt::Window | (_flags.has(TopMost) ? Qt::WindowStaysOnTopHint
-                                                   : Qt::WindowFlags()))
+    : BaseWidget(parent, (_flags.has(Dialog) ? Qt::Dialog : Qt::Window) |
+                             (_flags.has(TopMost) ? Qt::WindowStaysOnTopHint
+                                                  : Qt::WindowFlags()))
     , enableCustomFrame_(_flags.has(EnableCustomFrame))
     , frameless_(_flags.has(Frameless))
     , flags_(_flags)

--- a/src/widgets/BaseWindow.hpp
+++ b/src/widgets/BaseWindow.hpp
@@ -30,6 +30,7 @@ public:
         DisableCustomScaling = 8,
         FramelessDraggable = 16,
         DontFocus = 32,
+        Dialog = 64,
     };
 
     enum ActionOnFocusLoss { Nothing, Delete, Close, Hide };

--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -652,7 +652,7 @@ void SplitNotebook::addCustomButtons()
     settingsBtn->setIcon(NotebookButton::Settings);
 
     QObject::connect(settingsBtn, &NotebookButton::leftClicked,
-                     [] { getApp()->windows->showSettingsDialog(); });
+                     [this] { getApp()->windows->showSettingsDialog(this); });
 
     // account
     auto userBtn = this->addCustomButton();

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -158,8 +158,9 @@ void Window::addCustomTitlebarButtons()
         return;
 
     // settings
-    this->addTitleBarButton(TitleBarButtonStyle::Settings,
-                            [] { getApp()->windows->showSettingsDialog(); });
+    this->addTitleBarButton(TitleBarButtonStyle::Settings, [this] {
+        getApp()->windows->showSettingsDialog(this);  //
+    });
 
     // updates
     auto update = this->addTitleBarButton(TitleBarButtonStyle::None, [] {});
@@ -291,7 +292,9 @@ void Window::addShortcuts()
 {
     /// Initialize program-wide hotkeys
     // Open settings
-    createWindowShortcut(this, "CTRL+P", [] { SettingsDialog::showDialog(); });
+    createWindowShortcut(this, "CTRL+P", [this] {
+        SettingsDialog::showDialog(this);  //
+    });
 
     // Switch tab
     createWindowShortcut(this, "CTRL+T", [this] {
@@ -398,8 +401,9 @@ void Window::addMenuBar()
     QMenu *menu = mainMenu->addMenu(QString());
     QAction *prefs = menu->addAction(QString());
     prefs->setMenuRole(QAction::PreferencesRole);
-    connect(prefs, &QAction::triggered, this,
-            [] { SettingsDialog::showDialog(); });
+    connect(prefs, &QAction::triggered, this, [this] {
+        SettingsDialog::showDialog(this);  //
+    });
 
     // Window menu.
     QMenu *windowMenu = mainMenu->addMenu(QString("Window"));

--- a/src/widgets/dialogs/ColorPickerDialog.cpp
+++ b/src/widgets/dialogs/ColorPickerDialog.cpp
@@ -123,7 +123,7 @@ QColor ColorPickerDialog::selectedColor() const
 
 void ColorPickerDialog::closeEvent(QCloseEvent *)
 {
-    this->closed.invoke();
+    this->closed.invoke(this->selectedColor());
 }
 
 void ColorPickerDialog::themeChangedEvent()

--- a/src/widgets/dialogs/ColorPickerDialog.hpp
+++ b/src/widgets/dialogs/ColorPickerDialog.hpp
@@ -42,7 +42,7 @@ public:
      */
     QColor selectedColor() const;
 
-    pajlada::Signals::NoArgSignal closed;
+    pajlada::Signals::Signal<QColor> closed;
 
 protected:
     void closeEvent(QCloseEvent *);

--- a/src/widgets/dialogs/ColorPickerDialog.hpp
+++ b/src/widgets/dialogs/ColorPickerDialog.hpp
@@ -27,7 +27,7 @@ public:
      * You can connect to the ::closed signal of this instance to get notified
      * when the dialog is closed.
      */
-    ColorPickerDialog(const QColor &initial, QWidget *parent = nullptr);
+    ColorPickerDialog(const QColor &initial, QWidget *parent);
 
     ~ColorPickerDialog();
 

--- a/src/widgets/dialogs/QualityPopup.cpp
+++ b/src/widgets/dialogs/QualityPopup.cpp
@@ -1,10 +1,14 @@
 #include "QualityPopup.hpp"
+#include "Application.hpp"
+#include "singletons/WindowManager.hpp"
 #include "util/StreamLink.hpp"
+#include "widgets/Window.hpp"
 
 namespace chatterino {
 
 QualityPopup::QualityPopup(const QString &_channelName, QStringList options)
-    : BaseWindow(BaseWindow::Flags::Dialog, nullptr)
+    : BasePopup({},
+                static_cast<QWidget *>(&(getApp()->windows->getMainWindow())))
     , channelName_(_channelName)
 {
     this->ui_.okButton.setText("OK");

--- a/src/widgets/dialogs/QualityPopup.cpp
+++ b/src/widgets/dialogs/QualityPopup.cpp
@@ -4,7 +4,8 @@
 namespace chatterino {
 
 QualityPopup::QualityPopup(const QString &_channelName, QStringList options)
-    : channelName_(_channelName)
+    : BaseWindow(BaseWindow::Flags::Dialog, nullptr)
+    , channelName_(_channelName)
 {
     this->ui_.okButton.setText("OK");
     this->ui_.cancelButton.setText("Cancel");

--- a/src/widgets/dialogs/QualityPopup.hpp
+++ b/src/widgets/dialogs/QualityPopup.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "widgets/BaseWindow.hpp"
+#include "widgets/BasePopup.hpp"
 
 #include <QComboBox>
 #include <QDialogButtonBox>
@@ -9,7 +9,7 @@
 
 namespace chatterino {
 
-class QualityPopup : public BaseWindow
+class QualityPopup : public BasePopup
 {
 public:
     QualityPopup(const QString &_channelName, QStringList options);

--- a/src/widgets/dialogs/SelectChannelDialog.cpp
+++ b/src/widgets/dialogs/SelectChannelDialog.cpp
@@ -26,7 +26,9 @@
 namespace chatterino {
 
 SelectChannelDialog::SelectChannelDialog(QWidget *parent)
-    : BaseWindow(BaseWindow::EnableCustomFrame, parent)
+    : BaseWindow(
+          {BaseWindow::Flags::EnableCustomFrame, BaseWindow::Flags::Dialog},
+          parent)
     , selectedChannel_(Channel::getEmpty())
 {
     this->setWindowTitle("Select a channel to join");

--- a/src/widgets/dialogs/SettingsDialog.cpp
+++ b/src/widgets/dialogs/SettingsDialog.cpp
@@ -25,7 +25,8 @@
 namespace chatterino {
 
 SettingsDialog::SettingsDialog()
-    : BaseWindow(BaseWindow::DisableCustomScaling)
+    : BaseWindow(
+          {BaseWindow::Flags::DisableCustomScaling, BaseWindow::Flags::Dialog})
 {
     this->setWindowTitle("Chatterino Settings");
     this->resize(815, 600);

--- a/src/widgets/dialogs/SettingsDialog.cpp
+++ b/src/widgets/dialogs/SettingsDialog.cpp
@@ -43,6 +43,10 @@ SettingsDialog::SettingsDialog(QWidget *parent)
         this->ui_.search->setFocus();
         this->ui_.search->selectAll();
     });
+
+    // Disable the ? button in the titlebar until we decide to use it
+    this->setWindowFlags(this->windowFlags() &
+                         ~Qt::WindowContextHelpButtonHint);
 }
 
 void SettingsDialog::initUi()

--- a/src/widgets/dialogs/SettingsDialog.cpp
+++ b/src/widgets/dialogs/SettingsDialog.cpp
@@ -24,9 +24,10 @@
 
 namespace chatterino {
 
-SettingsDialog::SettingsDialog()
+SettingsDialog::SettingsDialog(QWidget *parent)
     : BaseWindow(
-          {BaseWindow::Flags::DisableCustomScaling, BaseWindow::Flags::Dialog})
+          {BaseWindow::Flags::DisableCustomScaling, BaseWindow::Flags::Dialog},
+          parent)
 {
     this->setWindowTitle("Chatterino Settings");
     this->resize(815, 600);
@@ -239,9 +240,10 @@ SettingsDialogTab *SettingsDialog::tab(SettingsTabId id)
     return nullptr;
 }
 
-void SettingsDialog::showDialog(SettingsDialogPreference preferredTab)
+void SettingsDialog::showDialog(QWidget *parent,
+                                SettingsDialogPreference preferredTab)
 {
-    static SettingsDialog *instance = new SettingsDialog();
+    static SettingsDialog *instance = new SettingsDialog(parent);
     static bool hasShownBefore = false;
     if (hasShownBefore)
         instance->refresh();

--- a/src/widgets/dialogs/SettingsDialog.hpp
+++ b/src/widgets/dialogs/SettingsDialog.hpp
@@ -31,10 +31,11 @@ enum class SettingsDialogPreference {
 
 class SettingsDialog : public BaseWindow
 {
-    SettingsDialog();
+    SettingsDialog(QWidget *parent);
 
 public:
-    static void showDialog(SettingsDialogPreference preferredTab =
+    static void showDialog(QWidget *parent,
+                           SettingsDialogPreference preferredTab =
                                SettingsDialogPreference::NoPreference);
 
 protected:

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -108,7 +108,7 @@ namespace {
 FlagsEnum<BaseWindow::Flags> userInfoPopupFlags{BaseWindow::Dialog,
                                                 BaseWindow::EnableCustomFrame};
 FlagsEnum<BaseWindow::Flags> userInfoPopupFlagsCloseAutomatically{
-    userInfoPopupFlags};
+    BaseWindow::EnableCustomFrame};
 #else
 FlagsEnum<BaseWindow::Flags> userInfoPopupFlags{BaseWindow::EnableCustomFrame};
 FlagsEnum<BaseWindow::Flags> userInfoPopupFlagsCloseAutomatically{

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -104,13 +104,21 @@ namespace {
 
 }  // namespace
 
+#ifdef Q_OS_LINUX
+FlagsEnum<BaseWindow::Flags> userInfoPopupFlags{BaseWindow::Dialog,
+                                                BaseWindow::EnableCustomFrame};
+FlagsEnum<BaseWindow::Flags> userInfoPopupFlagsCloseAutomatically{
+    userInfoPopupFlags};
+#else
+FlagsEnum<BaseWindow::Flags> userInfoPopupFlags{BaseWindow::EnableCustomFrame};
+FlagsEnum<BaseWindow::Flags> userInfoPopupFlagsCloseAutomatically{
+    BaseWindow::EnableCustomFrame, BaseWindow::Frameless,
+    BaseWindow::FramelessDraggable};
+#endif
+
 UserInfoPopup::UserInfoPopup(bool closeAutomatically)
-    : BaseWindow(
-          closeAutomatically
-              ? FlagsEnum<BaseWindow::Flags>{BaseWindow::EnableCustomFrame,
-                                             BaseWindow::Frameless,
-                                             BaseWindow::FramelessDraggable}
-              : BaseWindow::EnableCustomFrame)
+    : BaseWindow(closeAutomatically ? userInfoPopupFlagsCloseAutomatically
+                                    : userInfoPopupFlags)
     , hack_(new bool)
 {
     this->setWindowTitle("Usercard");

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -116,9 +116,10 @@ FlagsEnum<BaseWindow::Flags> userInfoPopupFlagsCloseAutomatically{
     BaseWindow::FramelessDraggable};
 #endif
 
-UserInfoPopup::UserInfoPopup(bool closeAutomatically)
+UserInfoPopup::UserInfoPopup(bool closeAutomatically, QWidget *parent)
     : BaseWindow(closeAutomatically ? userInfoPopupFlagsCloseAutomatically
-                                    : userInfoPopupFlags)
+                                    : userInfoPopupFlags,
+                 parent)
     , hack_(new bool)
 {
     this->setWindowTitle("Usercard");

--- a/src/widgets/dialogs/UserInfoPopup.hpp
+++ b/src/widgets/dialogs/UserInfoPopup.hpp
@@ -18,7 +18,7 @@ class UserInfoPopup final : public BaseWindow
     Q_OBJECT
 
 public:
-    UserInfoPopup(bool closeAutomatically);
+    UserInfoPopup(bool closeAutomatically, QWidget *parent);
     ~UserInfoPopup();
 
     void setData(const QString &name, const ChannelPtr &channel);

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1997,7 +1997,8 @@ void ChannelView::handleLinkClick(QMouseEvent *event, const Link &link,
         break;
 
         case Link::OpenAccountsPage: {
-            SettingsDialog::showDialog(SettingsDialogPreference::Accounts);
+            SettingsDialog::showDialog(this,
+                                       SettingsDialogPreference::Accounts);
         }
         break;
 

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1937,7 +1937,8 @@ void ChannelView::hideEvent(QHideEvent *)
 
 void ChannelView::showUserInfoPopup(const QString &userName)
 {
-    auto *userPopup = new UserInfoPopup(getSettings()->autoCloseUserPopup);
+    auto *userPopup =
+        new UserInfoPopup(getSettings()->autoCloseUserPopup, this);
     userPopup->setData(userName, this->hasSourceChannel()
                                      ? this->sourceChannel_
                                      : this->underlyingChannel_);

--- a/src/widgets/helper/DebugPopup.hpp
+++ b/src/widgets/helper/DebugPopup.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <QWidget>
+#include "widgets/BasePopup.hpp"
 
 namespace chatterino {
 
-class DebugPopup : public QWidget
+class DebugPopup : public BasePopup
 {
 public:
     DebugPopup();

--- a/src/widgets/settingspages/AboutPage.cpp
+++ b/src/widgets/settingspages/AboutPage.cpp
@@ -4,6 +4,7 @@
 #include "common/Version.hpp"
 #include "util/LayoutCreator.hpp"
 #include "util/RemoveScrollAreaBackground.hpp"
+#include "widgets/BasePopup.hpp"
 #include "widgets/helper/SignalLabel.hpp"
 
 #include <QFormLayout>
@@ -230,17 +231,25 @@ void AboutPage::addLicense(QFormLayout *form, const QString &name,
     auto *a = new QLabel("<a href=\"" + website + "\">" + name + "</a>");
     a->setOpenExternalLinks(true);
     auto *b = new QLabel("<a href=\"" + licenseLink + "\">show license</a>");
-    QObject::connect(b, &QLabel::linkActivated, [licenseLink, name] {
-        auto *edit = new QTextEdit;
+    QObject::connect(
+        b, &QLabel::linkActivated, [parent = this, name, licenseLink] {
+            auto window =
+                new BasePopup(BaseWindow::Flags::EnableCustomFrame, parent);
+            window->setWindowTitle("Chatterino - License for " + name);
+            window->setAttribute(Qt::WA_DeleteOnClose);
+            auto layout = new QVBoxLayout();
+            auto *edit = new QTextEdit;
 
-        edit->setWindowTitle(
-            QString("Chatterino - showing %1's license").arg(name));
-        QFile file(licenseLink);
-        file.open(QIODevice::ReadOnly);
-        edit->setText(file.readAll());
-        edit->setReadOnly(true);
-        edit->show();
-    });
+            QFile file(licenseLink);
+            file.open(QIODevice::ReadOnly);
+            edit->setText(file.readAll());
+            edit->setReadOnly(true);
+
+            layout->addWidget(edit);
+
+            window->getLayoutContainer()->setLayout(layout);
+            window->show();
+        });
 
     form->addRow(a, b);
 }

--- a/src/widgets/settingspages/GeneralPageView.cpp
+++ b/src/widgets/settingspages/GeneralPageView.cpp
@@ -169,9 +169,7 @@ ColorButton *GeneralPageView::addColorButton(
             auto dialog = new ColorPickerDialog(QColor(setting), this);
             dialog->setAttribute(Qt::WA_DeleteOnClose);
             dialog->show();
-            dialog->closed.connect([&setting, colorButton, &dialog] {
-                QColor selected = dialog->selectedColor();
-
+            dialog->closed.connect([&setting, colorButton](QColor selected) {
                 if (selected.isValid())
                 {
                     setting = selected.name(QColor::HexArgb);

--- a/src/widgets/settingspages/GeneralPageView.cpp
+++ b/src/widgets/settingspages/GeneralPageView.cpp
@@ -165,8 +165,8 @@ ColorButton *GeneralPageView::addColorButton(
     layout->addWidget(colorButton);
     this->addLayout(layout);
     QObject::connect(
-        colorButton, &ColorButton::clicked, [&setting, colorButton]() {
-            auto dialog = new ColorPickerDialog(QColor(setting));
+        colorButton, &ColorButton::clicked, [this, &setting, colorButton]() {
+            auto dialog = new ColorPickerDialog(QColor(setting), this);
             dialog->setAttribute(Qt::WA_DeleteOnClose);
             dialog->show();
             dialog->closed.connect([&setting, colorButton, &dialog] {

--- a/src/widgets/settingspages/HighlightingPage.cpp
+++ b/src/widgets/settingspages/HighlightingPage.cpp
@@ -244,9 +244,7 @@ void HighlightingPage::tableCellClicked(const QModelIndex &clicked,
         auto dialog = new ColorPickerDialog(initial, this);
         dialog->setAttribute(Qt::WA_DeleteOnClose);
         dialog->show();
-        dialog->closed.connect([=] {
-            QColor selected = dialog->selectedColor();
-
+        dialog->closed.connect([=](QColor selected) {
             if (selected.isValid())
             {
                 view->getModel()->setData(clicked, selected,

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -57,7 +57,7 @@ namespace {
                            const QString &title, const QString &description)
     {
         auto window =
-            new BaseWindow(BaseWindow::Flags::EnableCustomFrame, parent);
+            new BasePopup(BaseWindow::Flags::EnableCustomFrame, parent);
         window->setWindowTitle("Chatterino - " + title);
         window->setAttribute(Qt::WA_DeleteOnClose);
         auto layout = new QVBoxLayout();

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -240,8 +240,8 @@ void SplitHeader::initializeLayout()
                             if (getSettings()->moderationActions.empty())
                             {
                                 getApp()->windows->showSettingsDialog(
-                                    SettingsDialogPreference::
-                                        ModerationActions);
+                                    this, SettingsDialogPreference::
+                                              ModerationActions);
                                 this->split_->setModerationMode(true);
                             }
                             else
@@ -258,6 +258,7 @@ void SplitHeader::initializeLayout()
                         case Qt::RightButton:
                         case Qt::MiddleButton:
                             getApp()->windows->showSettingsDialog(
+                                this,
                                 SettingsDialogPreference::ModerationActions);
                             break;
                     }


### PR DESCRIPTION
# Description

This should hopefully fix a lot of issues people run into using tiling window managers.
There are a few more places that should start using BaseWindow with the Dialog flag or BasePopup instead, but that can come later. For now, this is in a testable phase.
The windows that should work better now are:
 * Streamlink quality popup (Can temporarily be accessed by typing /xd in a split)
 * Emote input popup (The one that pops up if you type `:fors` and that suggests `forsenE`)
 * Emote menu (Cccessed by pressing the smiley face in the bottom right of a split or pressing CTRL+E)
 * Channel changer dialog (Accessed by pressing CTRL+R or pressing the slim hamburger menu and clicking "Change Channel")
 * Settings dialog (Accessed by pressing CTRL+P or pressing the cogwheel button)
 * Tutorial videos (Accessed by pressing the slim hamburger menu and clicking either of the options under the "How to..." submenu)
 * License dialog (Accessed by pressing CTRL+P, going to the About side-tab, pressing "show license" on some of the licenses)
 * Color picker dialog (Accessed by pressing CTRL+P, going to the Highlights side-tab, selecting a custom color for one of your highlights)
 * User Info Popup (Accessed by typing `/usercard pajlada` or pressing a username in a split)
 * Debug Popup (Accessed by pressing F10)

Test checklist:
 - [x] Linux w/ i3
 - [x] Linux w/ dwm
 - [x] Linux w/ Sway
 - [x] Linux w/ non-tiling WM (KDE or Gnome)
 - [x] Windows
 - [x] MacOS

Template for testing:
```
Popup                    | master (3ee08b9ff) | PR build | Notes
------------------------ | :----------------: | :------: | ----------
Streamlink quality popup | ❌                 | ✔️
Emote input popup        | ✔️                 | ✔️
Emote menu               | ❌                 | ✔️
Channel changer dialog   | ❌                 | ✔️
Settings dialog          | ❌                 | ✔️
Tutorial videos          | ❌                 | ✔️
License dialog           | ❌                 | ✔️
Color picker dialog      | ❌                 | ✔️
User Info Popup          | ❌                 | ✔️
Debug Popup              | ❌                 | ✔️
```