### PR TITLE
Fix styling of channel point reward message text.

### DIFF
--- a/src/messages/MessageElement.hpp
+++ b/src/messages/MessageElement.hpp
@@ -42,6 +42,7 @@ enum class MessageElementFlag {
     BttvEmote = BttvEmoteImage | BttvEmoteText,
 
     ChannelPointReward = (1 << 8),
+    ChannelPointRewardImage = ChannelPointReward | TwitchEmoteImage,
 
     FfzEmoteImage = (1 << 10),
     FfzEmoteText = (1 << 11),

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -123,9 +123,20 @@ void MessageLayoutContainer::_addElement(MessageLayoutElement *element,
         xOffset -= element->getRect().width() + this->spaceWidth_;
     }
 
+    auto yOffset = 0;
+
+    if (element->getCreator().getFlags().has(
+            MessageElementFlag::ChannelPointReward) &&
+        element->getCreator().getFlags().hasNone(
+            {MessageElementFlag::TwitchEmoteImage}))
+    {
+        yOffset -= (this->margin.top * this->scale_);
+    }
+
     // set move element
-    element->setPosition(QPoint(this->currentX_ + xOffset,
-                                this->currentY_ - element->getRect().height()));
+    element->setPosition(
+        QPoint(this->currentX_ + xOffset,
+               this->currentY_ - element->getRect().height() + yOffset));
 
     // add element
     this->elements_.push_back(std::unique_ptr<MessageLayoutElement>(element));

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -1158,7 +1158,7 @@ void TwitchMessageBuilder::appendChannelPointRewardMessage(
         reward.title, MessageElementFlag::ChannelPointReward,
         MessageColor::Text, FontStyle::ChatMediumBold);
     builder->emplace<ScalingImageElement>(
-        reward.image, MessageElementFlag::ChannelPointReward);
+        reward.image, MessageElementFlag::ChannelPointRewardImage);
     builder->emplace<TextElement>(
         QString::number(reward.cost), MessageElementFlag::ChannelPointReward,
         MessageColor::Text, FontStyle::ChatMediumBold);


### PR DESCRIPTION
# Description

Fixes the styling of the channel point reward message text by removing margin from the top of the reward text.
Example:
![chatterino_2020-08-08_18-06-40](https://user-images.githubusercontent.com/13486663/89714906-26f8f280-d9a2-11ea-9822-23134b7b0c07.png)

