### PR TITLE
fix: Crash on MS Edge browser ext connection

### DIFF
--- a/src/widgets/AttachedWindow.cpp
+++ b/src/widgets/AttachedWindow.cpp
@@ -187,7 +187,9 @@ void AttachedWindow::attachToHwnd(void *_attachedPtr)
                 if (!qfilename.endsWith("chrome.exe") &&
                     !qfilename.endsWith("firefox.exe") &&
                     !qfilename.endsWith("vivaldi.exe") &&
-                    !qfilename.endsWith("opera.exe"))
+                    !qfilename.endsWith("opera.exe") &&
+                    !qfilename.endsWith("msedge.exe"))
+
                 {
                     qDebug() << "NM Illegal caller" << qfilename;
                     this->timer_.stop();


### PR DESCRIPTION
Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable

# Description
Browser extension makes Chatterino crash, when the extension is running on Microsoft Edge. The logic for which browsers are allowed, **are hardcoded.** This fix adds `msedge.exe` to the logic in AttachedWindow..

**The crash itself when it does fail the logic *is not* fixed...** Or rather, I don't think Chatterino should crash when [it fails.](https://github.com/KararTY/chatterino2/blob/f83645382f14e6f4e0747d634056a760cce4a6ee/src/widgets/AttachedWindow.cpp#L187)