### PR TITLE
Quick Switch: Add support for light themes

### DIFF
--- a/src/widgets/dialogs/switcher/QuickSwitcherPopup.cpp
+++ b/src/widgets/dialogs/switcher/QuickSwitcherPopup.cpp
@@ -1,6 +1,7 @@
 #include "widgets/dialogs/switcher/QuickSwitcherPopup.hpp"
 
 #include "Application.hpp"
+#include "singletons/Theme.hpp"
 #include "singletons/WindowManager.hpp"
 #include "util/LayoutCreator.hpp"
 #include "widgets/Notebook.hpp"
@@ -48,6 +49,8 @@ QuickSwitcherPopup::QuickSwitcherPopup(QWidget *parent)
     // This places the popup in the middle of the parent widget
     this->setGeometry(QStyle::alignedRect(Qt::LeftToRight, Qt::AlignCenter,
                                           this->size(), geom));
+
+    this->themeChangedEvent();
 }
 
 QuickSwitcherPopup::~QuickSwitcherPopup()
@@ -195,6 +198,29 @@ bool QuickSwitcherPopup::eventFilter(QObject *watched, QEvent *event)
     }
 
     return false;
+}
+
+void QuickSwitcherPopup::themeChangedEvent()
+{
+    BasePopup::themeChangedEvent();
+
+    const QString textCol = this->theme->window.text.name();
+    const QString bgCol = this->theme->window.background.name();
+
+    const QString selCol =
+        (this->theme->isLightTheme()
+             ? "#68B1FF"  // Copied from Theme::splits.input.styleSheet
+             : this->theme->tabs.selected.backgrounds.regular.color().name());
+
+    const QString listStyle =
+        QString(
+            "color: %1; background-color: %2; selection-background-color: %3")
+            .arg(textCol)
+            .arg(bgCol)
+            .arg(selCol);
+
+    this->ui_.searchEdit->setStyleSheet(this->theme->splits.input.styleSheet);
+    this->ui_.list->setStyleSheet(listStyle);
 }
 
 }  // namespace chatterino

--- a/src/widgets/dialogs/switcher/QuickSwitcherPopup.hpp
+++ b/src/widgets/dialogs/switcher/QuickSwitcherPopup.hpp
@@ -26,6 +26,7 @@ public:
 
 protected:
     virtual bool eventFilter(QObject *watched, QEvent *event) override;
+    virtual void themeChangedEvent() override;
 
 public slots:
     void updateSuggestions(const QString &text);


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable (not applicable)

# Description

Fixes #1854.
Adds basic support for light themes in the Quick Switcher popup.

Don't think it's worth adding an own category in the `Theme` singleton for it. Correct me if you think otherwise.
