### PR TITLE
Fix open in browser button for whisper split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Minor: Removed "Online Logs" functionality as services are shut down (#1640)
 - Minor: CTRL+F now selects the Find text input field in the Settings Dialog (#1806 #1811)
 - Minor: CTRL+F now selects the search text input field in the Search Popup (#1812)
+- Bugfix: Fix the incorrect `Open stream in browser` labelling in the whisper split (#1860)
 - Bugfix: Fix preview on hover not working when Animated emotes options was disabled (#1546)
 - Bugfix: FFZ custom mod badges no longer scale with the emote scale options (#1602)
 - Bugfix: MacOS updater looked for non-existing fields, causing it to always fail the update check (#1642)

--- a/src/widgets/helper/CommonTexts.hpp
+++ b/src/widgets/helper/CommonTexts.hpp
@@ -4,3 +4,4 @@
 #define OPEN_PLAYER_IN_BROWSER "Open player in browser"
 #define OPEN_IN_STREAMLINK "Open in streamlink"
 #define DONT_OPEN "Don't open"
+#define OPEN_WHISPERS_IN_BROWSER "Open whispers in browser"

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -319,7 +319,7 @@ std::unique_ptr<QMenu> SplitHeader::createMainMenu()
 
     if (this->split_->getChannel()->getType() == Channel::Type::TwitchWhispers)
     {
-        menu->addAction(OPEN_IN_BROWSER, this->split_,
+        menu->addAction(OPEN_WHISPERS_IN_BROWSER, this->split_,
                         &Split::openWhispersInBrowser);
         menu->addSeparator();
     }


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Fixed the issue causing the whisper split to show "Open stream in browser" instead of "Open in browser"/"Open whispers in browser" - https://github.com/Chatterino/chatterino2/commit/8661c833123d06e2b8229fa3609487996a57911d
