### PR TITLE
Add i.alazymeme.com to imageuploader examples

### DIFF
--- a/docs/IMAGEUPLOADER.md
+++ b/docs/IMAGEUPLOADER.md
@@ -46,12 +46,12 @@ Replace `XXXXXXXXXXXXXXX` with your API key from s-ul.eu. It can be found on [yo
 |Image link|`{url}`|
 |Deletion link|`https://s-ul.eu/delete.php?file={filename}&key=XXXXXXXXXXXXXXX`|
 
-## i.alazymeme.com
+### i.alazymeme.com
 
 |Row|Description|
 |-|-|
 |Request URL|`https://i.alazymeme.com/upload`|
 |Form field|`file`|
-|Extra headers||
+|Extra headers|`Authorization: Basic amVzc2U6cGVuaXMxMjM=`|
 |Image link||
 |Deletion link||

--- a/docs/IMAGEUPLOADER.md
+++ b/docs/IMAGEUPLOADER.md
@@ -45,3 +45,13 @@ Replace `XXXXXXXXXXXXXXX` with your API key from s-ul.eu. It can be found on [yo
 |Extra headers||
 |Image link|`{url}`|
 |Deletion link|`https://s-ul.eu/delete.php?file={filename}&key=XXXXXXXXXXXXXXX`|
+
+## i.alazymeme.com
+
+|Row|Description|
+|-|-|
+|Request URL|`https://i.alazymeme.com/upload`|
+|Form field|`file`|
+|Extra headers||
+|Image link||
+|Deletion link||


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

I was having some latency problems with nuuls' uploader, so I've opened mine to anyone who wants to use it. Based on fourtf's image uploader: https://github.com/fourtf/i

Files will automatically delete after 1 year (as per the default code). There's no deletion link, however it's open source, if someone wants to integrate it; go ahead: https://github.com/alazymeme/i