### PR TITLE
fix a crash using middle click scroll on chat window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Bugfix: MacOS updater looked for non-existing fields, causing it to always fail the update check (#1642)
 - Bugfix: Fixed message menu crashing if the message you right-clicked goes out of scope before you select an action (#1783) (#1787)
 - Bugfix: Fixed alternate messages flickering in UserInfoPopup when clicking Refresh if there was an odd number of messages in there (#1789 #1810)
+- Bugfix: Fix a crash when using middle click scroll on a chat window. (#1870)
 - Settings open faster
 - Dev: Fully remove Twitch Chatroom support
 - Dev: Handle conversion of historical CLEARCHAT messages to NOTICE messages in Chatterino instead of relying on the Recent Messages API to handle it for us. (#1804)

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1966,8 +1966,7 @@ void ChannelView::disableScrolling()
 
 void ChannelView::scrollUpdateRequested()
 {
-    const qreal dpi =
-        QGuiApplication::screenAt(this->pos())->devicePixelRatio();
+    const qreal dpi = this->devicePixelRatio();
     const qreal delta = dpi * (this->currentMousePosition_.y() -
                                this->lastMiddlePressPosition_.y());
     const int cursorHeight = this->cursors_.neutral.pixmap().height();

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1966,7 +1966,7 @@ void ChannelView::disableScrolling()
 
 void ChannelView::scrollUpdateRequested()
 {
-    const qreal dpi = this->devicePixelRatio();
+    const qreal dpi = this->devicePixelRatioF();
     const qreal delta = dpi * (this->currentMousePosition_.y() -
                                this->lastMiddlePressPosition_.y());
     const int cursorHeight = this->cursors_.neutral.pixmap().height();


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description
Middle click scrolling caused `QGuiApplication::screenAt(this->pos())` to return null and crash on Linux Mint 20, easy fix.
<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
