### PR TITLE
Usercard command fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Minor: Disable checking for updates on unsupported platforms (#1874)
 - Bugfix: Fix bug preventing users from setting the highlight color of the second entry in the "User" highlights tab (#1898)
+- Bugfix: /usercard command will now respect the "Automatically close user popup" setting (#1918)
 
 ## 2.2.0
 

--- a/resources/contributors.txt
+++ b/resources/contributors.txt
@@ -31,6 +31,7 @@ YungLPR | https://github.com/leon-richardt | | Contributor
 Mm2PL | https://github.com/mm2pl | | Contributor
 gempir | https://github.com/gempir | | Contributor
 mfmarlow | https://github.com/mfmarlow | | Contributor
+dnsge | https://github.com/dnsge | | Contributor
 # If you are a contributor add yourself above this line
 
 Defman21 | https://github.com/Defman21 |  | Documentation

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -451,7 +451,9 @@ QString CommandController::execCommand(const QString &textNoEmoji,
                     makeSystemMessage("Usage /usercard [user]"));
                 return "";
             }
-            auto *userPopup = new UserInfoPopup(false);
+
+            auto *userPopup =
+                new UserInfoPopup(getSettings()->autoCloseUserPopup);
             userPopup->setData(words[1], channel);
             userPopup->move(QCursor::pos());
             userPopup->show();


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

__I'm not sure if changes like this really deserve a changelog entry. Thoughts?__

# Description
Minor bugfix:
Opening a usercard via the `/usercard someone` command will now respect the "Automatically close user popup" setting.
