### PR TITLE
fix clang check when clang++ is called c++

### DIFF
--- a/lib/warnings.pri
+++ b/lib/warnings.pri
@@ -33,7 +33,7 @@ win32-msvc* {
 
     QMAKE_CXXFLAGS_WARN_ON += -Werror=return-type
 
-    CXX_VERSION = $$system($QMAKE_CXX --version)
+    CXX_VERSION = $$system($$QMAKE_CXX --version)
     contains(CXX_VERSION, "clang") {
         QMAKE_CXXFLAGS_WARN_ON += -Wno-unused-local-typedef
         QMAKE_CXXFLAGS_WARN_ON += -Wno-unused-private-field

--- a/lib/warnings.pri
+++ b/lib/warnings.pri
@@ -33,7 +33,8 @@ win32-msvc* {
 
     QMAKE_CXXFLAGS_WARN_ON += -Werror=return-type
 
-    equals(QMAKE_CXX, "clang++") {
+    CXX_VERSION = $$system($QMAKE_CXX --version)
+    contains(CXX_VERSION, "clang") {
         QMAKE_CXXFLAGS_WARN_ON += -Wno-unused-local-typedef
         QMAKE_CXXFLAGS_WARN_ON += -Wno-unused-private-field
     } else {


### PR DESCRIPTION
The check for clang fails when `clang++` is installed as `c++`. This fixes it for me.