### PR TITLE
Changelog crash fix (macOS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Bugfix: Fix bug preventing users from setting the highlight color of the second entry in the "User" highlights tab (#1898)
 - Bugfix: /usercard command will now respect the "Automatically close user popup" setting (#1918)
 - Bugfix: Handle symlinks properly when saving commands & settings (#1856, #1908)
+- Bugfix: Starting Chatterino in a minimized state after an update will no longer cause a crash
 
 ## 2.2.0
 

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -3,6 +3,7 @@
 #include <atomic>
 
 #include "common/Args.hpp"
+#include "common/Version.hpp"
 #include "controllers/accounts/AccountController.hpp"
 #include "controllers/commands/CommandController.hpp"
 #include "controllers/ignores/IgnoreController.hpp"
@@ -69,6 +70,23 @@ void Application::initialize(Settings &settings, Paths &paths)
 {
     assert(isAppInitialized == false);
     isAppInitialized = true;
+
+    // Show changelog
+    if (getSettings()->currentVersion.getValue() != "" &&
+        getSettings()->currentVersion.getValue() != CHATTERINO_VERSION)
+    {
+        auto box = new QMessageBox(QMessageBox::Information, "Chatterino 2",
+                                   "Show changelog?",
+                                   QMessageBox::Yes | QMessageBox::No);
+        box->setAttribute(Qt::WA_DeleteOnClose);
+        if (box->exec() == QMessageBox::Yes)
+        {
+            QDesktopServices::openUrl(
+                QUrl("https://www.chatterino.com/changelog"));
+        }
+    }
+
+    getSettings()->currentVersion.setValue(CHATTERINO_VERSION);
 
     if (getSettings()->enableExperimentalIrc)
     {

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -119,35 +119,6 @@ bool Window::event(QEvent *event)
     return BaseWindow::event(event);
 }
 
-void Window::showEvent(QShowEvent *event)
-{
-    // Startup notification
-    /*if (getSettings()->startUpNotification.getValue() < 1)
-    {
-        getSettings()->startUpNotification = 1;
-    }*/
-
-    // Show changelog
-    if (getSettings()->currentVersion.getValue() != "" &&
-        getSettings()->currentVersion.getValue() != CHATTERINO_VERSION)
-    {
-        auto box = new QMessageBox(QMessageBox::Information, "Chatterino 2",
-                                   "Show changelog?",
-                                   QMessageBox::Yes | QMessageBox::No);
-        box->setAttribute(Qt::WA_DeleteOnClose);
-        if (box->exec() == QMessageBox::Yes)
-        {
-            QDesktopServices::openUrl(
-                QUrl("https://www.chatterino.com/changelog"));
-        }
-    }
-
-    getSettings()->currentVersion.setValue(CHATTERINO_VERSION);
-
-    // --
-    BaseWindow::showEvent(event);
-}
-
 void Window::closeEvent(QCloseEvent *)
 {
     if (this->type_ == WindowType::Main)

--- a/src/widgets/Window.hpp
+++ b/src/widgets/Window.hpp
@@ -28,7 +28,6 @@ public:
     pajlada::Signals::NoArgSignal closed;
 
 protected:
-    void showEvent(QShowEvent *) override;
     void closeEvent(QCloseEvent *event) override;
     bool event(QEvent *event) override;
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

On macOS, trying to display a dialog before showing the main window (like when starting minimized) leads to a crash. The dialog will now show before the main window is opened, preventing this issue.

As far as I know, this issue only existed on macOS.