### PR TITLE
Make RTL languages render the correct way

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unversioned
+- Bugfix: Rudimentary support for right-to-left-languages (#1970)
 
 ## 2.3.0
 

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -145,6 +145,8 @@ void MessageLayoutContainer::_addElement(MessageLayoutElement *element,
     {
         for (const auto &prevElement : this->elements_)
         {
+            // TODO(leon): Does this behave correctly for non-text elements
+            //             (e.g. emotes)?
             if (!prevElement->getText().isRightToLeft())
                 continue;
 
@@ -167,7 +169,11 @@ void MessageLayoutContainer::_addElement(MessageLayoutElement *element,
 
     if (element->hasTrailingSpace())
     {
-        if (!isRtl)
+        // When we add spacing between individual words, we need to make sure to
+        // add it on the correct side.
+        if (isRtl)
+            this->currentX_ -= this->spaceWidth_;
+        else
             this->currentX_ += this->spaceWidth_;
     }
 }


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Implement a very naive fix for #720. It is the easiest way I could come up with. It would be great if an Arabic- or Hebrew-speaking user could test this to verify that the rendering works as expected.

This is what the example from https://github.com/Chatterino/chatterino2/issues/720#issuecomment-423440590 looks like in web chat and this implementation. (Which is the only reference point I have, really.)
### Chatterino:
![chatterino](https://user-images.githubusercontent.com/35232120/93369855-42cc9f80-f850-11ea-94bc-289f820c540d.png)
### Web Chat:
![web_chat](https://user-images.githubusercontent.com/35232120/93369861-46602680-f850-11ea-9a85-5ff96cb00f44.png)


**Please replace this code with anything more reasonable if you get the chance. I would also be fine with not merging this.** I'm not sure I would want this code in my own code base either. I wanted to offer the "fix" nonetheless. :smile: 