### PR TITLE
Only show VIP buttons if broadcaster

### DIFF
--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -217,7 +217,8 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically)
         });
 
         // userstate
-        this->userStateChanged_.connect([this, mod, unmod]() mutable {
+        this->userStateChanged_.connect([this, mod, unmod, vip,
+                                         unvip]() mutable {
             TwitchChannel *twitchChannel =
                 dynamic_cast<TwitchChannel *>(this->channel_.get());
 
@@ -235,6 +236,8 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically)
             }
             mod->setVisible(visibilityModButtons);
             unmod->setVisible(visibilityModButtons);
+            vip->setVisible(visibilityModButtons);
+            unvip->setVisible(visibilityModButtons);
         });
     }
 


### PR DESCRIPTION
Pull request checklist:

~~`CHANGELOG.md` was updated, if applicable~~

# Description
VIP/un-VIP buttons that were added in #1996 will now only show if you are the broadcaster (like the mod/un-mod buttons).
