### PR TITLE
Commands are now saved upon pressing Ok in the settings window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,5 +73,8 @@ rapidjson/*
 
 Thumbs.db
 
-#I HATE MAC
-.DS_Store
+# I HATE MAC
+.DS_Storei
+
+# Other editors/IDEs
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -74,7 +74,7 @@ rapidjson/*
 Thumbs.db
 
 # I HATE MAC
-.DS_Storei
+.DS_Store
 
 # Other editors/IDEs
 .vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Minor: Changed the English in two rate-limited system messages (#1878)
 - Minor: Added image for streamer mode in the user popup icon.
 - Minor: Added vip and unvip buttons.
+- Minor: Commands are now saved upon pressing Ok in the settings window
 - Bugfix: Fix bug preventing users from setting the highlight color of the second entry in the "User" highlights tab (#1898)
 - Bugfix: Fix bug where the "check user follow state" event could trigger a network request requesting the user to follow or unfollow a user. By itself its quite harmless as it just repeats to Twitch the same follow state we had, so no follows should have been lost by this but it meant there was a rogue network request that was fired that could cause a crash (#1906)
 - Bugfix: /usercard command will now respect the "Automatically close user popup" setting (#1918)

--- a/src/widgets/dialogs/SettingsDialog.cpp
+++ b/src/widgets/dialogs/SettingsDialog.cpp
@@ -16,6 +16,7 @@
 #include "widgets/settingspages/KeyboardSettingsPage.hpp"
 #include "widgets/settingspages/ModerationPage.hpp"
 #include "widgets/settingspages/NotificationPage.hpp"
+#include "controllers/commands/CommandController.hpp"
 
 #include <QDialogButtonBox>
 #include <QLineEdit>
@@ -318,6 +319,7 @@ void SettingsDialog::onOkClicked()
 {
     if (!getArgs().dontSaveSettings)
     {
+        getApp()->commands->save();
         pajlada::Settings::SettingManager::gSave();
     }
     this->close();

--- a/src/widgets/dialogs/SettingsDialog.cpp
+++ b/src/widgets/dialogs/SettingsDialog.cpp
@@ -2,6 +2,7 @@
 
 #include "Application.hpp"
 #include "common/Args.hpp"
+#include "controllers/commands/CommandController.hpp"
 #include "singletons/Resources.hpp"
 #include "util/LayoutCreator.hpp"
 #include "util/Shortcut.hpp"
@@ -16,7 +17,6 @@
 #include "widgets/settingspages/KeyboardSettingsPage.hpp"
 #include "widgets/settingspages/ModerationPage.hpp"
 #include "widgets/settingspages/NotificationPage.hpp"
-#include "controllers/commands/CommandController.hpp"
 
 #include <QDialogButtonBox>
 #include <QLineEdit>


### PR DESCRIPTION
Currently commands are only saved on exiting chatterino. I shutdown my computer without closing chatterino beforehand and always lose my new commands because of that.

With this PR commands are saved once you press the Ok Button in the Settings, similar to the rest of the settings.