### PR TITLE
Recent messages timestamp fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Bugfix: Handle symlinks properly when saving commands & settings (#1856, #1908)
 - Bugfix: Starting Chatterino in a minimized state after an update will no longer cause a crash
 - Bugfix: Modify the emote parsing to handle some edge-cases with dots and stuff (#1704, #1714)
+- Bugfix: Fix recent messages timestamp (#1286)
 
 ## 2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Bugfix: Handle symlinks properly when saving commands & settings (#1856, #1908)
 - Bugfix: Starting Chatterino in a minimized state after an update will no longer cause a crash
 - Bugfix: Modify the emote parsing to handle some edge-cases with dots and stuff (#1704, #1714)
-- Bugfix: Fix recent messages timestamp (#1286)
+- Bugfix: Fixed timestamps being incorrect on some messages loaded from the recent-messages service on startup (#1286, #2020)
 
 ## 2.2.0
 

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -127,7 +127,8 @@ MessageBuilder::MessageBuilder(SystemMessageTag, const QString &text,
 }
 
 MessageBuilder::MessageBuilder(TimeoutMessageTag,
-                               const QString &systemMessageText, int times)
+                               const QString &systemMessageText, int times,
+                               const QTime &time)
     : MessageBuilder()
 {
     QString username = systemMessageText.split(" ").at(0);
@@ -135,7 +136,7 @@ MessageBuilder::MessageBuilder(TimeoutMessageTag,
 
     QString text;
 
-    this->emplace<TimestampElement>();
+    this->emplace<TimestampElement>(time);
     this->emplaceSystemTextAndUpdate(username, text)
         ->setLink({Link::UserInfo, username});
     this->emplaceSystemTextAndUpdate(
@@ -147,13 +148,14 @@ MessageBuilder::MessageBuilder(TimeoutMessageTag,
 
 MessageBuilder::MessageBuilder(TimeoutMessageTag, const QString &username,
                                const QString &durationInSeconds,
-                               const QString &reason, bool multipleTimes)
+                               const QString &reason, bool multipleTimes,
+                               const QTime &time)
     : MessageBuilder()
 {
     QString fullText;
     QString text;
 
-    this->emplace<TimestampElement>();
+    this->emplace<TimestampElement>(time);
     this->emplaceSystemTextAndUpdate(username, fullText)
         ->setLink({Link::UserInfo, username});
 

--- a/src/messages/MessageBuilder.hpp
+++ b/src/messages/MessageBuilder.hpp
@@ -42,10 +42,11 @@ public:
     MessageBuilder(SystemMessageTag, const QString &text,
                    const QTime &time = QTime::currentTime());
     MessageBuilder(TimeoutMessageTag, const QString &systemMessageText,
-                   int times);
+                   int times, const QTime &time = QTime::currentTime());
     MessageBuilder(TimeoutMessageTag, const QString &username,
                    const QString &durationInSeconds, const QString &reason,
-                   bool multipleTimes);
+                   bool multipleTimes,
+                   const QTime &time = QTime::currentTime());
     MessageBuilder(const BanAction &action, uint32_t count = 1);
     MessageBuilder(const UnbanAction &action);
     MessageBuilder(const AutomodUserAction &action);

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -71,11 +71,15 @@ namespace {
 
         // rebuild the raw irc message so we can convert it back to an ircmessage again!
         // this could probably be done in a smarter way
+
         auto s = QString(":tmi.twitch.tv NOTICE %1 :%2")
                      .arg(channelName)
                      .arg(noticeMessage);
 
-        return Communi::IrcMessage::fromData(s.toUtf8(), nullptr);
+        auto newMessage = Communi::IrcMessage::fromData(s.toUtf8(), nullptr);
+        newMessage->setTags(message->tags());
+
+        return newMessage;
     }
 
     // parseRecentMessages takes a json object and returns a vector of

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -220,24 +220,8 @@ MessagePtr TwitchMessageBuilder::build()
     }
 
     // timestamp
-    if (this->historicalMessage_)
-    {
-        // This may be architecture dependent(datatype)
-        bool customReceived = false;
-        qint64 ts =
-            this->tags.value("rm-received-ts").toLongLong(&customReceived);
-        if (!customReceived)
-        {
-            ts = this->tags.value("tmi-sent-ts").toLongLong();
-        }
-
-        QDateTime dateTime = QDateTime::fromMSecsSinceEpoch(ts);
-        this->emplace<TimestampElement>(dateTime.time());
-    }
-    else
-    {
-        this->emplace<TimestampElement>();
-    }
+    this->emplace<TimestampElement>(
+        calculateMessageTimestamp(this->ircMessage));
 
     bool addModerationElement = true;
     if (this->senderIsBroadcaster)

--- a/src/util/IrcHelpers.hpp
+++ b/src/util/IrcHelpers.hpp
@@ -58,4 +58,25 @@ inline QString parseTagString(const QString &input)
     return output;
 }
 
+inline QTime calculateMessageTimestamp(const Communi::IrcMessage *message)
+{
+    // Check if message is from recent-messages API
+    if (message->tags().contains("historical"))
+    {
+        bool customReceived = false;
+        qint64 ts =
+            message->tags().value("rm-received-ts").toLongLong(&customReceived);
+        if (!customReceived)
+        {
+            ts = message->tags().value("tmi-sent-ts").toLongLong();
+        }
+
+        return QDateTime::fromMSecsSinceEpoch(ts).time();
+    }
+    else
+    {
+        return QTime::currentTime();
+    }
+}
+
 }  // namespace chatterino


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Fixes inconsistent timestamps on messages received through the recent-messages API. 

Closes #1286 