### PR TITLE
Improve "Login expired!" message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Minor: Colorized nicknames now enabled by default
 - Minor: Show channels live now enabled by default
 - Minor: Bold usernames enabled by default
+- Minor: Improve UX of the "Login expired!" message (#2029)
 - Bugfix: Fix bug preventing users from setting the highlight color of the second entry in the "User" highlights tab (#1898)
 - Bugfix: Fix bug where the "check user follow state" event could trigger a network request requesting the user to follow or unfollow a user. By itself its quite harmless as it just repeats to Twitch the same follow state we had, so no follows should have been lost by this but it meant there was a rogue network request that was fired that could cause a crash (#1906)
 - Bugfix: /usercard command will now respect the "Automatically close user popup" setting (#1918)

--- a/src/messages/Link.hpp
+++ b/src/messages/Link.hpp
@@ -19,6 +19,7 @@ public:
         UserAction,
         AutoModAllow,
         AutoModDeny,
+        OpenAccountsPage,
     };
 
     Link();

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -655,9 +655,25 @@ std::vector<MessagePtr> IrcMessageHandler::parseNoticeMessage(
 {
     if (message->content().startsWith("Login auth", Qt::CaseInsensitive))
     {
-        return {MessageBuilder(systemMessage,
-                               "Login expired! Try logging in again.")
-                    .release()};
+        const auto linkColor = MessageColor(MessageColor::Link);
+        const auto accountsLink = Link(Link::OpenAccountsPage, QString());
+        const auto curUser = getApp()->accounts->twitch.getCurrent();
+        const auto expirationText = QString("Login expired for user \"%1\"!")
+                                        .arg(curUser->getUserName());
+        const auto loginPromptText = QString(" Try adding your account again.");
+
+        auto builder = MessageBuilder();
+        builder.message().flags.set(MessageFlag::System);
+
+        builder.emplace<TimestampElement>();
+        builder.emplace<TextElement>(expirationText, MessageElementFlag::Text,
+                                     MessageColor::System);
+        builder
+            .emplace<TextElement>(loginPromptText, MessageElementFlag::Text,
+                                  linkColor)
+            ->setLink(accountsLink);
+
+        return {builder.release()};
     }
     else
     {

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1885,6 +1885,7 @@ void ChannelView::handleLinkClick(QMouseEvent *event, const Link &link,
         case Link::OpenAccountsPage: {
             SettingsDialog::showDialog(SettingsDialogPreference::Accounts);
         }
+        break;
 
         default:;
     }

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -38,6 +38,7 @@
 #include "util/Twitch.hpp"
 #include "widgets/Scrollbar.hpp"
 #include "widgets/TooltipWidget.hpp"
+#include "widgets/dialogs/SettingsDialog.hpp"
 #include "widgets/dialogs/UserInfoPopup.hpp"
 #include "widgets/helper/EffectLabel.hpp"
 #include "widgets/splits/Split.hpp"
@@ -1878,6 +1879,11 @@ void ChannelView::handleLinkClick(QMouseEvent *event, const Link &link,
 
         case Link::AutoModDeny: {
             getApp()->accounts->twitch.getCurrent()->autoModDeny(link.value);
+        }
+        break;
+
+        case Link::OpenAccountsPage: {
+            SettingsDialog::showDialog(SettingsDialogPreference::Accounts);
         }
 
         default:;


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

The message display when an OAuth token expires repeatedly lead to users asking about what they should do in order to fix it. This PR changes the error message in order to clarify that users need to re-add their account. Additionally, a link to the "Accounts" page is included in the message (see video).

Video: https://i.nuuls.com/v0qWI.mp4
