### PR TITLE
Disable timestamps by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Minor: Show channels live now enabled by default
 - Minor: Bold usernames enabled by default
 - Minor: Improve UX of the "Login expired!" message (#2029)
+- Minor: Timestamps disabled by default
 - Bugfix: Fix bug preventing users from setting the highlight color of the second entry in the "User" highlights tab (#1898)
 - Bugfix: Fix bug where the "check user follow state" event could trigger a network request requesting the user to follow or unfollow a user. By itself its quite harmless as it just repeats to Twitch the same follow state we had, so no follows should have been lost by this but it meant there was a rogue network request that was fired that could cause a crash (#1906)
 - Bugfix: /usercard command will now respect the "Automatically close user popup" setting (#1918)

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -58,7 +58,7 @@ public:
     static Settings &instance();
 
     /// Appearance
-    BoolSetting showTimestamps = {"/appearance/messages/showTimestamps", true};
+    BoolSetting showTimestamps = {"/appearance/messages/showTimestamps", false};
     BoolSetting animationsWhenFocused = {
         "/appearance/enableAnimationsWhenFocused", false};
     QStringSetting timestampFormat = {"/appearance/messages/timestampFormat",


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Timetamps are less useful in faster chats, almost all online chats basically. I think giving Chatterino a cleaner look by default that's closer to Webchat is better.

- Any advanced users will know how to enable timestamps
- Broadcasters who are too lazy to change the setting now enjoy more space for messages
- Chat looks friendlier for newcomers (closer to webchat)