### PR TITLE
Make "moderation mode" setting persist

### DIFF
--- a/src/common/WindowDescriptors.cpp
+++ b/src/common/WindowDescriptors.cpp
@@ -76,6 +76,7 @@ void SplitDescriptor::loadFromJSON(SplitDescriptor &descriptor,
 {
     descriptor.type_ = data.value("type").toString();
     descriptor.server_ = data.value("server").toInt(-1);
+    descriptor.moderationMode_ = root.value("moderationMode").toBool();
     if (data.contains("channel"))
     {
         descriptor.channelName_ = data.value("channel").toString();


### PR DESCRIPTION
Pull request checklist:

~~`CHANGELOG.md` was updated, if applicable~~
(fixes bug in unversioned change)

# Description
Fixes a small bug introduced in #1964. "Moderation mode" would be written to the settings file but wouldn't be loaded. 

Closes #2032