### PR TITLE
Fix tooltip not showing in `EmotePopup`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Bugfix: Starting Chatterino in a minimized state after an update will no longer cause a crash
 - Bugfix: Modify the emote parsing to handle some edge-cases with dots and stuff (#1704, #1714)
 - Bugfix: Fixed timestamps being incorrect on some messages loaded from the recent-messages service on startup (#1286, #2020)
+- Bugfix: Fixed tooltip didn't show in `EmotePopup` depending on the `Link preview` setting enabled or no (#2008)
 
 ## 2.2.0
 

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1273,12 +1273,11 @@ void ChannelView::mouseMoveEvent(QMouseEvent *event)
 
     const auto &tooltip = hoverLayoutElement->getCreator().getTooltip();
     bool isLinkValid = hoverLayoutElement->getLink().isValid();
+    auto emoteElement =
+        dynamic_cast<const EmoteElement *>(&hoverLayoutElement->getCreator());
 
-    if (tooltip.isEmpty())
-    {
-        tooltipWidget->hide();
-    }
-    else if (isLinkValid && !getSettings()->linkInfoTooltip)
+    if (tooltip.isEmpty() || (isLinkValid && emoteElement == nullptr &&
+                              !getSettings()->linkInfoTooltip))
     {
         tooltipWidget->hide();
     }
@@ -1286,8 +1285,6 @@ void ChannelView::mouseMoveEvent(QMouseEvent *event)
     {
         auto &tooltipPreviewImage = TooltipPreviewImage::instance();
         tooltipPreviewImage.setImageScale(0, 0);
-        auto emoteElement = dynamic_cast<const EmoteElement *>(
-            &hoverLayoutElement->getCreator());
         auto badgeElement = dynamic_cast<const BadgeElement *>(
             &hoverLayoutElement->getCreator());
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description
Fixes #2008.

Basically, different behavior happens because, in chat, emotes don't have a link, but in `EmotePopup` they do. So we need to check if its emote or not.