### PR TITLE
Made the current channels emotes appear at the top of the emote picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unversioned
 
+- Minor: Made the current channels emotes appear at the top of the emote picker popup.
 - Minor: Added viewer list button to twitch channel header. (#1978)
 - Minor: Added followage and subage information to usercard. (#2023)
 - Minor: Added an option to only open channels specified in command line with `-c` parameter. You can also use `--help` to display short help message (#1940)

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -61,9 +61,7 @@ namespace {
     }
     void addEmoteSets(
         std::vector<std::shared_ptr<TwitchAccount::EmoteSet>> sets,
-        Channel &globalChannel,
-        Channel &subChannel,
-        QString currentChannelName)
+        Channel &globalChannel, Channel &subChannel, QString currentChannelName)
     {
         QMap<QString, QPair<bool, std::vector<MessagePtr>>> mapOfSets;
 

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -61,7 +61,9 @@ namespace {
     }
     void addEmoteSets(
         std::vector<std::shared_ptr<TwitchAccount::EmoteSet>> sets,
-        Channel &globalChannel, Channel &subChannel)
+        Channel &globalChannel,
+        Channel &subChannel,
+        QString currentChannelName)
     {
         QMap<QString, QPair<bool, std::vector<MessagePtr>>> mapOfSets;
 
@@ -100,6 +102,14 @@ namespace {
 
         // Output to channel all created messages,
         // That contain title or emotes.
+        // Put current channel emotes at the top
+        auto currentChannelPair = mapOfSets[currentChannelName];
+        for (auto message : currentChannelPair.second)
+        {
+            subChannel.addMessage(message);
+        }
+        mapOfSets.remove(currentChannelName);
+
         foreach (auto pair, mapOfSets)
         {
             auto &channel = pair.first ? globalChannel : subChannel;
@@ -174,7 +184,7 @@ void EmotePopup::loadChannel(ChannelPtr _channel)
     // twitch
     addEmoteSets(
         getApp()->accounts->twitch.getCurrent()->accessEmotes()->emoteSets,
-        *globalChannel, *subChannel);
+        *globalChannel, *subChannel, _channel->getName());
 
     // global
     addEmotes(*globalChannel, *twitchChannel->globalBttv().emotes(),


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

 Made the current channels emotes appear at the top of the emote picker popup. This makes them easier to find and the user no longer has to scroll down the picker to get them. The remaining are ordered as nornal.

![image](https://user-images.githubusercontent.com/5025171/95668691-6d570300-0b45-11eb-92f7-28301a32c164.png)
