### PR TITLE
Split settings into "Basic" and "Advanced" sections

### DIFF
--- a/chatterino.pro
+++ b/chatterino.pro
@@ -256,6 +256,7 @@ SOURCES += \
     src/widgets/helper/DebugPopup.cpp \
     src/widgets/helper/EditableModelView.cpp \
     src/widgets/helper/EffectLabel.cpp \
+    src/widgets/helper/ExpandableLayout.cpp \
     src/widgets/helper/NotebookButton.cpp \
     src/widgets/helper/NotebookTab.cpp \
     src/widgets/helper/QColorPicker.cpp \
@@ -498,6 +499,7 @@ HEADERS += \
     src/widgets/helper/DebugPopup.hpp \
     src/widgets/helper/EditableModelView.hpp \
     src/widgets/helper/EffectLabel.hpp \
+    src/widgets/helper/ExpandableLayout.hpp \
     src/widgets/helper/Line.hpp \
     src/widgets/helper/NotebookButton.hpp \
     src/widgets/helper/NotebookTab.hpp \

--- a/chatterino.pro
+++ b/chatterino.pro
@@ -177,9 +177,9 @@ SOURCES += \
     src/providers/irc/IrcServer.cpp \
     src/providers/IvrApi.cpp \
     src/providers/LinkResolver.cpp \
-    src/providers/twitch/ChannelPointReward.cpp \
     src/providers/twitch/api/Helix.cpp \
     src/providers/twitch/api/Kraken.cpp \
+    src/providers/twitch/ChannelPointReward.cpp \
     src/providers/twitch/IrcMessageHandler.cpp \
     src/providers/twitch/PubsubActions.cpp \
     src/providers/twitch/PubsubClient.cpp \
@@ -241,8 +241,8 @@ SOURCES += \
     src/widgets/dialogs/QualityPopup.cpp \
     src/widgets/dialogs/SelectChannelDialog.cpp \
     src/widgets/dialogs/SettingsDialog.cpp \
-    src/widgets/listview/GenericItemDelegate.cpp \
     src/widgets/dialogs/switcher/NewTabItem.cpp \
+    src/widgets/dialogs/switcher/QuickSwitcherModel.cpp \
     src/widgets/dialogs/switcher/QuickSwitcherPopup.cpp \
     src/widgets/dialogs/switcher/SwitchSplitItem.cpp \
     src/widgets/dialogs/TextInputDialog.cpp \
@@ -266,11 +266,12 @@ SOURCES += \
     src/widgets/helper/SignalLabel.cpp \
     src/widgets/helper/TitlebarButton.cpp \
     src/widgets/Label.cpp \
-    src/widgets/Notebook.cpp \
-    src/widgets/Scrollbar.cpp \
+    src/widgets/listview/GenericItemDelegate.cpp \
     src/widgets/listview/GenericListItem.cpp \
     src/widgets/listview/GenericListModel.cpp \
     src/widgets/listview/GenericListView.cpp \
+    src/widgets/Notebook.cpp \
+    src/widgets/Scrollbar.cpp \
     src/widgets/settingspages/AboutPage.cpp \
     src/widgets/settingspages/AccountsPage.cpp \
     src/widgets/settingspages/CommandPage.cpp \
@@ -330,6 +331,7 @@ HEADERS += \
     src/common/UniqueAccess.hpp \
     src/common/UsernameSet.hpp \
     src/common/Version.hpp \
+    src/common/WindowDescriptors.hpp \
     src/controllers/accounts/Account.hpp \
     src/controllers/accounts/AccountController.hpp \
     src/controllers/accounts/AccountModel.hpp \
@@ -392,9 +394,9 @@ HEADERS += \
     src/providers/irc/IrcServer.hpp \
     src/providers/IvrApi.hpp \
     src/providers/LinkResolver.hpp \
-    src/providers/twitch/ChannelPointReward.hpp \
     src/providers/twitch/api/Helix.hpp \
     src/providers/twitch/api/Kraken.hpp \
+    src/providers/twitch/ChannelPointReward.hpp \
     src/providers/twitch/EmoteValue.hpp \
     src/providers/twitch/IrcMessageHandler.hpp \
     src/providers/twitch/PubsubActions.hpp \
@@ -480,7 +482,6 @@ HEADERS += \
     src/widgets/dialogs/SelectChannelDialog.hpp \
     src/widgets/dialogs/SettingsDialog.hpp \
     src/widgets/dialogs/switcher/AbstractSwitcherItem.hpp \
-    src/widgets/listview/GenericItemDelegate.hpp \
     src/widgets/dialogs/switcher/NewTabItem.hpp \
     src/widgets/dialogs/switcher/QuickSwitcherModel.hpp \
     src/widgets/dialogs/switcher/QuickSwitcherPopup.hpp \
@@ -508,11 +509,12 @@ HEADERS += \
     src/widgets/helper/SignalLabel.hpp \
     src/widgets/helper/TitlebarButton.hpp \
     src/widgets/Label.hpp \
-    src/widgets/Notebook.hpp \
-    src/widgets/Scrollbar.hpp \
+    src/widgets/listview/GenericItemDelegate.hpp \
     src/widgets/listview/GenericListItem.hpp \
     src/widgets/listview/GenericListModel.hpp \
     src/widgets/listview/GenericListView.hpp \
+    src/widgets/Notebook.hpp \
+    src/widgets/Scrollbar.hpp \
     src/widgets/settingspages/AboutPage.hpp \
     src/widgets/settingspages/AccountsPage.hpp \
     src/widgets/settingspages/CommandPage.hpp \

--- a/src/widgets/helper/ExpandableLayout.cpp
+++ b/src/widgets/helper/ExpandableLayout.cpp
@@ -1,0 +1,61 @@
+#include "widgets/helper/ExpandableLayout.hpp"
+
+#include "widgets/Label.hpp"
+
+namespace chatterino {
+
+ExpandableLayout::ExpandableLayout(const QString &title, QWidget *parent)
+    : BaseWidget(parent)
+{
+    auto layout = new QVBoxLayout(this);
+    layout->setContentsMargins(0, 0, 0, 0);
+
+    this->toggleButton_ = new QToolButton(this);
+    this->content_ = new QWidget(this);
+
+    this->toggleButton_->setCheckable(true);
+    this->toggleButton_->setText(title);
+    this->toggleButton_->setArrowType(Qt::ArrowType::DownArrow);
+    this->toggleButton_->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
+    this->toggleButton_->setStyleSheet("QToolButton {border: none;}");
+
+    QObject::connect(this->toggleButton_, &QToolButton::toggled, this,
+                     &ExpandableLayout::toggle);
+    // Forward QToolButton::toggled signal
+    QObject::connect(this->toggleButton_, &QToolButton::toggled,
+                     [this](bool toggled) { emit buttonToggled(toggled); });
+
+    layout->addWidget(this->toggleButton_);
+    layout->setAlignment(this->toggleButton_, Qt::AlignHCenter);
+
+    layout->addWidget(this->content_);
+
+    this->setLayout(layout);
+
+    // Collapsed per default
+    this->toggle(false);
+}
+
+void ExpandableLayout::toggle(bool expand)
+{
+    this->toggleButton_->setArrowType(expand ? Qt::ArrowType::UpArrow
+                                             : Qt::ArrowType::DownArrow);
+    this->content_->setVisible(expand);
+}
+
+void ExpandableLayout::setContent(QLayout *layout)
+{
+    if (auto *prevLayout = this->content_->layout(); prevLayout)
+    {
+        /*
+         * An existing layout on a QWidget must be deleted before a new one can
+         * be assigned (cf. https://doc.qt.io/qt-5/layout.html). QLayout does
+         * not inherit from QObject so we cannot use QObject::deleteLater.
+         */
+        delete prevLayout;
+    }
+
+    this->content_->setLayout(layout);
+}
+
+}  // namespace chatterino

--- a/src/widgets/helper/ExpandableLayout.hpp
+++ b/src/widgets/helper/ExpandableLayout.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "widgets/BaseWidget.hpp"
+
+#include <QLayout>
+#include <QToolButton>
+
+namespace chatterino {
+
+/**
+ * This class provides a way to make any kind of QLayout collapsible. Users can
+ * click a button to toggle visibility of the underlying layout.
+ */
+class ExpandableLayout : public BaseWidget
+{
+    Q_OBJECT
+
+public:
+    explicit ExpandableLayout(const QString &title, QWidget *parent = nullptr);
+
+    /**
+     * Attach a layout to be collapsed.
+     *
+     * If set, any previous layout will be deleted by this method. This widget
+     * will take ownership of the passed layout.
+     */
+    void setContent(QLayout *layout);
+
+public slots:
+    /**
+     * Toggle visibility of the attached layout.
+     *
+     * Set to `true` to expand the widget and `false` to hide it.
+     */
+    void toggle(bool expand);
+
+signals:
+    void buttonToggled(bool expanded);
+
+private:
+    // We use QToolButton because it has built-in support for nice arrows
+    QToolButton *toggleButton_{};
+    QWidget *content_{};
+};
+
+}  // namespace chatterino

--- a/src/widgets/settingspages/ExternalToolsPage.cpp
+++ b/src/widgets/settingspages/ExternalToolsPage.cpp
@@ -121,6 +121,9 @@ ExternalToolsPage::ExternalToolsPage()
 
         groupLayout->addRow(this->createCheckBox(
             "Enable image uploader", getSettings()->imageUploaderEnabled));
+        groupLayout->addRow(
+            this->createCheckBox("Ask for confirmation when uploading an image",
+                                 getSettings()->askOnImageUpload));
 
         groupLayout->addRow(
             "Request URL: ",

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -543,16 +543,6 @@ void GeneralPage::initLayout(SettingsLayout &layout)
                         "Apple", "Google", "Messenger"},
                        s.emojiSet);
 
-    layout.addTitle("Visible Badges");
-    layout.addCheckbox("Authority (staff, admin)",
-                       getSettings()->showBadgesGlobalAuthority);
-    layout.addCheckbox("Channel (broadcaster, moderator)",
-                       getSettings()->showBadgesChannelAuthority);
-    layout.addCheckbox("Subscriber ", getSettings()->showBadgesSubscription);
-    layout.addCheckbox("Vanity (prime, bits, subgifter)",
-                       getSettings()->showBadgesVanity);
-    layout.addCheckbox("Chatterino", getSettings()->showBadgesChatterino);
-
     layout.addTitle("Chat title");
     layout.addDescription("In live channels show:");
     layout.addCheckbox("Uptime", s.headerUptime);
@@ -787,6 +777,19 @@ QLayout *GeneralPage::buildAdvancedSettingsLayout()
             s.hideSimilarMaxMessagesToCheck,
             [](auto val) { return QString::number(val); },
             [](auto args) { return fuzzyToInt(args.value, 3); });
+    }
+
+    // "Visible Badges" section
+    {
+        layout->addTitle("Visible Badges");
+        layout->addCheckbox("Authority (staff, admin)",
+                            s.showBadgesGlobalAuthority);
+        layout->addCheckbox("Channel (broadcaster, moderator)",
+                            s.showBadgesChannelAuthority);
+        layout->addCheckbox("Subscriber ", s.showBadgesSubscription);
+        layout->addCheckbox("Vanity (prime, bits, subgifter)",
+                            s.showBadgesVanity);
+        layout->addCheckbox("Chatterino", s.showBadgesChatterino);
     }
 
     return layout;

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -401,8 +401,6 @@ void GeneralPage::initLayout(SettingsLayout &layout)
     layout.addCheckbox("Smooth scrolling", s.enableSmoothScrolling);
     layout.addCheckbox("Smooth scrolling on new messages",
                        s.enableSmoothScrollingNewMessages);
-    layout.addCheckbox("Allow sending duplicate messages",
-                       s.allowDuplicateMessages);
 
     layout.addTitle("Messages");
     layout.addCheckbox("Separate with lines", s.separateMessages);
@@ -778,6 +776,8 @@ QLayout *GeneralPage::buildAdvancedSettingsLayout()
         layout->addCheckbox("Show input when it's empty", s.showEmptyInput);
         layout->addCheckbox("Show message length while typing",
                             s.showMessageLength);
+        layout->addCheckbox("Allow sending duplicate messages",
+                            s.allowDuplicateMessages);
     }
 
     return layout;

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -364,8 +364,6 @@ void GeneralPage::initLayout(SettingsLayout &layout)
 #endif
     if (!BaseWindow::supportsCustomWindowFrame())
     {
-        layout.addCheckbox("Show preferences button (Ctrl+P to show)",
-                           s.hidePreferencesButton, true);
         layout.addCheckbox("Show user button", s.hideUserButton, true);
     }
     layout.addCheckbox("Show which channels are live in tabs", s.showTabLive);
@@ -769,6 +767,12 @@ QLayout *GeneralPage::buildAdvancedSettingsLayout()
     {
         layout->addTitle("Interface");
         layout->addCheckbox("Show tab close button", s.showTabCloseButton);
+
+        if (!BaseWindow::supportsCustomWindowFrame())
+        {
+            layout->addCheckbox("Show preferences button (Ctrl+P to show)",
+                                s.hidePreferencesButton, true);
+        }
     }
 
     return layout;

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -523,8 +523,6 @@ void GeneralPage::initLayout(SettingsLayout &layout)
     layout.addCheckbox("Animate", s.animateEmotes);
     layout.addCheckbox("Animate only when Chatterino is focused",
                        s.animationsWhenFocused);
-    layout.addCheckbox("Enable emote auto-completion by typing :",
-                       s.emoteCompletionWithColon);
     layout.addDropdown<float>(
         "Size", {"0.5x", "0.75x", "Default", "1.25x", "1.5x", "2x"},
         s.emoteScale,
@@ -778,6 +776,13 @@ QLayout *GeneralPage::buildAdvancedSettingsLayout()
                             s.showMessageLength);
         layout->addCheckbox("Allow sending duplicate messages",
                             s.allowDuplicateMessages);
+    }
+
+    // "Emotes" section
+    {
+        layout->addTitle("Emotes");
+        layout->addCheckbox("Enable emote auto-completion by typing :",
+                            s.emoteCompletionWithColon);
     }
 
     return layout;

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -543,13 +543,6 @@ void GeneralPage::initLayout(SettingsLayout &layout)
                         "Apple", "Google", "Messenger"},
                        s.emojiSet);
 
-    layout.addTitle("Chat Title");
-    layout.addDescription("In live channels show:");
-    layout.addCheckbox("Uptime", s.headerUptime);
-    layout.addCheckbox("Viewer count", s.headerViewerCount);
-    layout.addCheckbox("Category", s.headerGame);
-    layout.addCheckbox("Title", s.headerStreamTitle);
-
     layout.addTitle("Beta");
     if (Version::instance().isSupportedOS())
     {
@@ -790,6 +783,16 @@ QLayout *GeneralPage::buildAdvancedSettingsLayout()
         layout->addCheckbox("Vanity (prime, bits, subgifter)",
                             s.showBadgesVanity);
         layout->addCheckbox("Chatterino", s.showBadgesChatterino);
+    }
+
+    // "Chat Title" section
+    {
+        layout->addTitle("Chat Title");
+        layout->addDescription("In live channels show:");
+        layout->addCheckbox("Uptime", s.headerUptime);
+        layout->addCheckbox("Viewer count", s.headerViewerCount);
+        layout->addCheckbox("Category", s.headerGame);
+        layout->addCheckbox("Title", s.headerStreamTitle);
     }
 
     return layout;

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -589,15 +589,6 @@ void GeneralPage::initLayout(SettingsLayout &layout)
     layout.addCheckbox("Mention users with a comma (User,)",
                        s.mentionUsersWithComma);
     layout.addCheckbox("Lowercase domains (anti-phishing)", s.lowercaseDomains);
-    layout.addDropdown<float>(
-        "Username font weight", {"50", "Default", "75", "100"}, s.boldScale,
-        [](auto val) {
-            if (val == 63)
-                return QString("Default");
-            else
-                return QString::number(val);
-        },
-        [](auto args) { return fuzzyToFloat(args.value, 63.f); });
     layout.addCheckbox("Double click to open links and other elements in chat",
                        s.linksDoubleClickOnly);
     layout.addCheckbox("Unshorten links", s.unshortLinks);
@@ -809,6 +800,15 @@ QLayout *GeneralPage::buildAdvancedSettingsLayout()
         layout->addCheckbox("Bold @usernames", s.boldUsernames);
         layout->addCheckbox("Try to find usernames without @ prefix",
                             s.findAllUsernames);
+        layout->addDropdown<float>(
+            "Username font weight", {"50", "Default", "75", "100"}, s.boldScale,
+            [](auto val) {
+                if (val == 63)
+                    return QString("Default");
+                else
+                    return QString::number(val);
+            },
+            [](auto args) { return fuzzyToFloat(args.value, 63.f); });
     }
 
     return layout;

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -605,9 +605,6 @@ void GeneralPage::initLayout(SettingsLayout &layout)
     layout.addCheckbox("Load message history on connect",
                        s.loadTwitchMessageHistoryOnConnect);
 
-    layout.addCheckbox("Ask for confirmation when uploading an image",
-                       s.askOnImageUpload);
-
     // Advanced Settings setup
     {
         auto *const advancedSettings =

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -543,32 +543,6 @@ void GeneralPage::initLayout(SettingsLayout &layout)
                         "Apple", "Google", "Messenger"},
                        s.emojiSet);
 
-    layout.addTitle("R9K");
-    layout.addDescription(
-        "Hide similar messages by the same user. Toggle hidden "
-        "messages by pressing Ctrl+H.");
-    layout.addCheckbox("Hide similar messages", s.similarityEnabled);
-    //layout.addCheckbox("Gray out matches", s.colorSimilarDisabled);
-    layout.addCheckbox("Hide my own messages", s.hideSimilarMyself);
-    layout.addCheckbox("Receive notification sounds from hidden messages",
-                       s.shownSimilarTriggerHighlights);
-    s.hideSimilar.connect(
-        []() { getApp()->windows->forceLayoutChannelViews(); }, false);
-    layout.addDropdown<float>(
-        "Similarity threshold", {"0.5", "0.75", "0.9"}, s.similarityPercentage,
-        [](auto val) { return QString::number(val); },
-        [](auto args) { return fuzzyToFloat(args.value, 0.9f); });
-    layout.addDropdown<int>(
-        "Maximum delay between messages",
-        {"5s", "10s", "15s", "30s", "60s", "120s"}, s.hideSimilarMaxDelay,
-        [](auto val) { return QString::number(val) + "s"; },
-        [](auto args) { return fuzzyToInt(args.value, 5); });
-    layout.addDropdown<int>(
-        "Amount of previous messages to check", {"1", "2", "3", "4", "5"},
-        s.hideSimilarMaxMessagesToCheck,
-        [](auto val) { return QString::number(val); },
-        [](auto args) { return fuzzyToInt(args.value, 3); });
-
     layout.addTitle("Visible badges");
     layout.addCheckbox("Authority (staff, admin)",
                        getSettings()->showBadgesGlobalAuthority);
@@ -783,6 +757,36 @@ QLayout *GeneralPage::buildAdvancedSettingsLayout()
         layout->addTitle("Emotes");
         layout->addCheckbox("Enable emote auto-completion by typing :",
                             s.emoteCompletionWithColon);
+    }
+
+    // "R9K" section
+    {
+        layout->addTitle("R9K");
+        layout->addDescription(
+            "Hide similar messages by the same user. Toggle hidden "
+            "messages by pressing Ctrl+H.");
+        layout->addCheckbox("Hide similar messages", s.similarityEnabled);
+        //layout->addCheckbox("Gray out matches", s.colorSimilarDisabled);
+        layout->addCheckbox("Hide my own messages", s.hideSimilarMyself);
+        layout->addCheckbox("Receive notification sounds from hidden messages",
+                            s.shownSimilarTriggerHighlights);
+        s.hideSimilar.connect(
+            []() { getApp()->windows->forceLayoutChannelViews(); }, false);
+        layout->addDropdown<float>(
+            "Similarity threshold", {"0.5", "0.75", "0.9"},
+            s.similarityPercentage,
+            [](auto val) { return QString::number(val); },
+            [](auto args) { return fuzzyToFloat(args.value, 0.9f); });
+        layout->addDropdown<int>(
+            "Maximum delay between messages",
+            {"5s", "10s", "15s", "30s", "60s", "120s"}, s.hideSimilarMaxDelay,
+            [](auto val) { return QString::number(val) + "s"; },
+            [](auto args) { return fuzzyToInt(args.value, 5); });
+        layout->addDropdown<int>(
+            "Amount of previous messages to check", {"1", "2", "3", "4", "5"},
+            s.hideSimilarMaxMessagesToCheck,
+            [](auto val) { return QString::number(val); },
+            [](auto args) { return fuzzyToInt(args.value, 3); });
     }
 
     return layout;

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -586,8 +586,6 @@ void GeneralPage::initLayout(SettingsLayout &layout)
 
     layout.addCheckbox("Restart on crash", s.restartOnCrash);
 
-    layout.addCheckbox("Colorize users without color set (gray names)",
-                       s.colorizeNicknames);
     layout.addCheckbox("Mention users with a comma (User,)",
                        s.mentionUsersWithComma);
     layout.addCheckbox("Show joined users (< 1000 chatters)", s.showJoins);
@@ -808,6 +806,8 @@ QLayout *GeneralPage::buildAdvancedSettingsLayout()
 
         layout->addCheckbox("Show moderation messages", s.hideModerationActions,
                             true);
+        layout->addCheckbox("Colorize users without color set (gray names)",
+                            s.colorizeNicknames);
     }
 
     return layout;

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -358,7 +358,6 @@ void GeneralPage::initLayout(SettingsLayout &layout)
             }
         });
 
-    layout.addCheckbox("Show tab close button", s.showTabCloseButton);
     layout.addCheckbox("Always on top", s.windowTopMost);
 #ifdef USEWINSDK
     layout.addCheckbox("Start with Windows", s.autorun);
@@ -765,6 +764,12 @@ QLayout *GeneralPage::buildAdvancedSettingsLayout()
     auto &s = *getSettings();
     auto layout = new SettingsLayout;
     layout->setContentsMargins(0, 0, 0, 0);
+
+    // "Interface" section
+    {
+        layout->addTitle("Interface");
+        layout->addCheckbox("Show tab close button", s.showTabCloseButton);
+    }
 
     return layout;
 }

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -605,10 +605,6 @@ void GeneralPage::initLayout(SettingsLayout &layout)
     layout.addCheckbox("Load message history on connect",
                        s.loadTwitchMessageHistoryOnConnect);
 
-    layout.addCheckbox("Enable experimental IRC support (requires restart)",
-                       s.enableExperimentalIrc);
-    layout.addCheckbox("Show unhandled IRC messages",
-                       s.showUnhandledIrcMessages);
     layout.addCheckbox(
         "Hide viewercount and stream length while hovering the split",
         s.hideViewerCountAndDuration);
@@ -773,6 +769,16 @@ QLayout *GeneralPage::buildAdvancedSettingsLayout()
         layout->addButton("Open AppData directory", [] {
             QDesktopServices::openUrl(getPaths()->rootAppDataDirectory);
         });
+    }
+
+    // "IRC" section
+    {
+        layout->addTitle("IRC");
+        layout->addCheckbox(
+            "Enable experimental IRC support (requires restart)",
+            s.enableExperimentalIrc);
+        layout->addCheckbox("Show unhandled IRC messages",
+                            s.showUnhandledIrcMessages);
     }
 
     // "Miscellaneous" section

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -401,7 +401,6 @@ void GeneralPage::initLayout(SettingsLayout &layout)
     layout.addCheckbox("Smooth scrolling", s.enableSmoothScrolling);
     layout.addCheckbox("Smooth scrolling on new messages",
                        s.enableSmoothScrollingNewMessages);
-    layout.addCheckbox("Show message length while typing", s.showMessageLength);
     layout.addCheckbox("Allow sending duplicate messages",
                        s.allowDuplicateMessages);
 
@@ -777,6 +776,8 @@ QLayout *GeneralPage::buildAdvancedSettingsLayout()
     {
         layout->addTitle("Chat");
         layout->addCheckbox("Show input when it's empty", s.showEmptyInput);
+        layout->addCheckbox("Show message length while typing",
+                            s.showMessageLength);
     }
 
     return layout;

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -543,7 +543,7 @@ void GeneralPage::initLayout(SettingsLayout &layout)
                         "Apple", "Google", "Messenger"},
                        s.emojiSet);
 
-    layout.addTitle("Chat title");
+    layout.addTitle("Chat Title");
     layout.addDescription("In live channels show:");
     layout.addCheckbox("Uptime", s.headerUptime);
     layout.addCheckbox("Viewer count", s.headerViewerCount);

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -586,15 +586,6 @@ void GeneralPage::initLayout(SettingsLayout &layout)
 
     layout.addCheckbox("Restart on crash", s.restartOnCrash);
 
-#ifdef Q_OS_LINUX
-    if (!getPaths()->isPortable())
-    {
-        layout.addCheckbox(
-            "Use libsecret/KWallet/Gnome keychain to secure passwords",
-            s.useKeyring);
-    }
-#endif
-
     layout.addCheckbox("Show moderation messages", s.hideModerationActions,
                        true);
     layout.addCheckbox("Colorize users without color set (gray names)",
@@ -802,6 +793,20 @@ QLayout *GeneralPage::buildAdvancedSettingsLayout()
         layout->addButton("Open AppData directory", [] {
             QDesktopServices::openUrl(getPaths()->rootAppDataDirectory);
         });
+    }
+
+    // "Miscellaneous" section
+    {
+        layout->addTitle("Miscellaneous");
+
+#ifdef Q_OS_LINUX
+        if (!getPaths()->isPortable())
+        {
+            layout->addCheckbox(
+                "Use libsecret/KWallet/Gnome keychain to secure passwords",
+                s.useKeyring);
+        }
+#endif
     }
 
     return layout;

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -605,7 +605,6 @@ void GeneralPage::initLayout(SettingsLayout &layout)
     layout.addCheckbox("Load message history on connect",
                        s.loadTwitchMessageHistoryOnConnect);
 
-    layout.addCheckbox("Combine multiple bit tips into one", s.stackBits);
     layout.addCheckbox("Ask for confirmation when uploading an image",
                        s.askOnImageUpload);
 
@@ -815,6 +814,7 @@ QLayout *GeneralPage::buildAdvancedSettingsLayout()
             "Stack timeouts", {"Stack", "Stack until timeout", "Don't stack"},
             s.timeoutStackStyle, [](int index) { return index; },
             [](auto args) { return args.index; }, false);
+        layout->addCheckbox("Combine multiple bit tips into one", s.stackBits);
     }
 
     return layout;

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -543,7 +543,7 @@ void GeneralPage::initLayout(SettingsLayout &layout)
                         "Apple", "Google", "Messenger"},
                        s.emojiSet);
 
-    layout.addTitle("Visible badges");
+    layout.addTitle("Visible Badges");
     layout.addCheckbox("Authority (staff, admin)",
                        getSettings()->showBadgesGlobalAuthority);
     layout.addCheckbox("Channel (broadcaster, moderator)",

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -605,10 +605,6 @@ void GeneralPage::initLayout(SettingsLayout &layout)
     layout.addCheckbox("Load message history on connect",
                        s.loadTwitchMessageHistoryOnConnect);
 
-    layout.addDropdown<int>(
-        "Stack timeouts", {"Stack", "Stack until timeout", "Don't stack"},
-        s.timeoutStackStyle, [](int index) { return index; },
-        [](auto args) { return args.index; }, false);
     layout.addCheckbox("Combine multiple bit tips into one", s.stackBits);
     layout.addCheckbox("Ask for confirmation when uploading an image",
                        s.askOnImageUpload);
@@ -815,6 +811,10 @@ QLayout *GeneralPage::buildAdvancedSettingsLayout()
         layout->addCheckbox(
             "Hide viewercount and stream length while hovering the split",
             s.hideViewerCountAndDuration);
+        layout->addDropdown<int>(
+            "Stack timeouts", {"Stack", "Stack until timeout", "Don't stack"},
+            s.timeoutStackStyle, [](int index) { return index; },
+            [](auto args) { return args.index; }, false);
     }
 
     return layout;

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -605,9 +605,6 @@ void GeneralPage::initLayout(SettingsLayout &layout)
     layout.addCheckbox("Load message history on connect",
                        s.loadTwitchMessageHistoryOnConnect);
 
-    layout.addCheckbox(
-        "Hide viewercount and stream length while hovering the split",
-        s.hideViewerCountAndDuration);
     layout.addDropdown<int>(
         "Stack timeouts", {"Stack", "Stack until timeout", "Don't stack"},
         s.timeoutStackStyle, [](int index) { return index; },
@@ -815,6 +812,9 @@ QLayout *GeneralPage::buildAdvancedSettingsLayout()
                     return QString::number(val);
             },
             [](auto args) { return fuzzyToFloat(args.value, 63.f); });
+        layout->addCheckbox(
+            "Hide viewercount and stream length while hovering the split",
+            s.hideViewerCountAndDuration);
     }
 
     return layout;

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -576,13 +576,6 @@ void GeneralPage::initLayout(SettingsLayout &layout)
                        s.attachExtensionToAnyProcess);
 #endif
 
-    layout.addTitle("AppData");
-    layout.addDescription("All local files like settings and cache files are "
-                          "store in this directory.");
-    layout.addButton("Open AppData directory", [] {
-        QDesktopServices::openUrl(getPaths()->rootAppDataDirectory);
-    });
-
     layout.addTitle("Miscellaneous");
 
     if (supportsIncognitoLinks())
@@ -798,6 +791,17 @@ QLayout *GeneralPage::buildAdvancedSettingsLayout()
 
             layout->addLayout(box);
         }
+    }
+
+    // "AppData" section
+    {
+        layout->addTitle("AppData");
+        layout->addDescription(
+            "All local files like settings and cache files are "
+            "store in this directory.");
+        layout->addButton("Open AppData directory", [] {
+            QDesktopServices::openUrl(getPaths()->rootAppDataDirectory);
+        });
     }
 
     return layout;

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -80,7 +80,7 @@ TitleLabel *SettingsLayout::addTitle(const QString &title)
 {
     // space
     if (!this->groups_.empty())
-        this->addWidget(this->groups_.back().space = new Space);
+        this->addSpace();
 
     // title
     auto label = new TitleLabel(title + ":");
@@ -212,6 +212,11 @@ DescriptionLabel *SettingsLayout::addDescription(const QString &text)
 void SettingsLayout::addSeperator()
 {
     this->addWidget(new Line(false));
+}
+
+void SettingsLayout::addSpace()
+{
+    this->addWidget(this->groups_.back().space = new Space);
 }
 
 bool SettingsLayout::filterElements(const QString &query)
@@ -612,6 +617,7 @@ void GeneralPage::initLayout(SettingsLayout &layout)
         auto *const advancedSettingsLayout =
             this->buildAdvancedSettingsLayout();
         advancedSettings->setContent(advancedSettingsLayout);
+        layout.addSpace();
         layout.addWidget(advancedSettings);
     }
 

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -588,8 +588,6 @@ void GeneralPage::initLayout(SettingsLayout &layout)
 
     layout.addCheckbox("Mention users with a comma (User,)",
                        s.mentionUsersWithComma);
-    layout.addCheckbox("Show joined users (< 1000 chatters)", s.showJoins);
-    layout.addCheckbox("Show parted users (< 1000 chatters)", s.showParts);
     layout.addCheckbox("Automatically close user popup when it loses focus",
                        s.autoCloseUserPopup);
     layout.addCheckbox("Lowercase domains (anti-phishing)", s.lowercaseDomains);
@@ -808,6 +806,8 @@ QLayout *GeneralPage::buildAdvancedSettingsLayout()
                             true);
         layout->addCheckbox("Colorize users without color set (gray names)",
                             s.colorizeNicknames);
+        layout->addCheckbox("Show joined users (< 1000 chatters)", s.showJoins);
+        layout->addCheckbox("Show parted users (< 1000 chatters)", s.showParts);
     }
 
     return layout;

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -16,6 +16,7 @@
 #include "widgets/BaseWindow.hpp"
 #include "widgets/dialogs/ColorPickerDialog.hpp"
 #include "widgets/helper/ColorButton.hpp"
+#include "widgets/helper/ExpandableLayout.hpp"
 #include "widgets/helper/Line.hpp"
 
 #define CHROME_EXTENSION_LINK                                           \
@@ -743,10 +744,29 @@ void GeneralPage::initLayout(SettingsLayout &layout)
     layout.addCheckbox("Ask for confirmation when uploading an image",
                        s.askOnImageUpload);
 
+    // Advanced Settings setup
+    {
+        auto *const advancedSettings =
+            new ExpandableLayout("Advanced Settings", this);
+        auto *const advancedSettingsLayout =
+            this->buildAdvancedSettingsLayout();
+        advancedSettings->setContent(advancedSettingsLayout);
+        layout.addWidget(advancedSettings);
+    }
+
     // invisible element for width
     auto inv = new BaseWidget(this);
     inv->setScaleIndependantWidth(500);
     layout.addWidget(inv);
+}
+
+QLayout *GeneralPage::buildAdvancedSettingsLayout()
+{
+    auto &s = *getSettings();
+    auto layout = new SettingsLayout;
+    layout->setContentsMargins(0, 0, 0, 0);
+
+    return layout;
 }
 
 void GeneralPage::initExtra()

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -589,8 +589,6 @@ void GeneralPage::initLayout(SettingsLayout &layout)
     layout.addCheckbox("Mention users with a comma (User,)",
                        s.mentionUsersWithComma);
     layout.addCheckbox("Lowercase domains (anti-phishing)", s.lowercaseDomains);
-    layout.addCheckbox("Try to find usernames without @ prefix",
-                       s.findAllUsernames);
     layout.addDropdown<float>(
         "Username font weight", {"50", "Default", "75", "100"}, s.boldScale,
         [](auto val) {
@@ -809,6 +807,8 @@ QLayout *GeneralPage::buildAdvancedSettingsLayout()
             "Automatically close user popup when it loses focus",
             s.autoCloseUserPopup);
         layout->addCheckbox("Bold @usernames", s.boldUsernames);
+        layout->addCheckbox("Try to find usernames without @ prefix",
+                            s.findAllUsernames);
     }
 
     return layout;

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -401,7 +401,6 @@ void GeneralPage::initLayout(SettingsLayout &layout)
     layout.addCheckbox("Smooth scrolling", s.enableSmoothScrolling);
     layout.addCheckbox("Smooth scrolling on new messages",
                        s.enableSmoothScrollingNewMessages);
-    layout.addCheckbox("Show input when it's empty", s.showEmptyInput);
     layout.addCheckbox("Show message length while typing", s.showMessageLength);
     layout.addCheckbox("Allow sending duplicate messages",
                        s.allowDuplicateMessages);
@@ -772,6 +771,12 @@ QLayout *GeneralPage::buildAdvancedSettingsLayout()
 
         layout->addCheckbox("Show which channels are live in tabs",
                             s.showTabLive);
+    }
+
+    // "Chat" section
+    {
+        layout->addTitle("Chat");
+        layout->addCheckbox("Show input when it's empty", s.showEmptyInput);
     }
 
     return layout;

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -588,8 +588,6 @@ void GeneralPage::initLayout(SettingsLayout &layout)
 
     layout.addCheckbox("Mention users with a comma (User,)",
                        s.mentionUsersWithComma);
-    layout.addCheckbox("Automatically close user popup when it loses focus",
-                       s.autoCloseUserPopup);
     layout.addCheckbox("Lowercase domains (anti-phishing)", s.lowercaseDomains);
     layout.addCheckbox("Bold @usernames", s.boldUsernames);
     layout.addCheckbox("Try to find usernames without @ prefix",
@@ -808,6 +806,9 @@ QLayout *GeneralPage::buildAdvancedSettingsLayout()
                             s.colorizeNicknames);
         layout->addCheckbox("Show joined users (< 1000 chatters)", s.showJoins);
         layout->addCheckbox("Show parted users (< 1000 chatters)", s.showParts);
+        layout->addCheckbox(
+            "Automatically close user popup when it loses focus",
+            s.autoCloseUserPopup);
     }
 
     return layout;

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -362,10 +362,6 @@ void GeneralPage::initLayout(SettingsLayout &layout)
 #ifdef USEWINSDK
     layout.addCheckbox("Start with Windows", s.autorun);
 #endif
-    if (!BaseWindow::supportsCustomWindowFrame())
-    {
-        layout.addCheckbox("Show user button", s.hideUserButton, true);
-    }
     layout.addCheckbox("Show which channels are live in tabs", s.showTabLive);
 
     layout.addTitle("Chat");
@@ -772,6 +768,7 @@ QLayout *GeneralPage::buildAdvancedSettingsLayout()
         {
             layout->addCheckbox("Show preferences button (Ctrl+P to show)",
                                 s.hidePreferencesButton, true);
+            layout->addCheckbox("Show user button", s.hideUserButton, true);
         }
     }
 

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -639,6 +639,7 @@ void GeneralPage::initLayout(SettingsLayout &layout)
 
         advancedSettings->setContent(advancedSettingsLayout);
         layout.addSpace();
+        layout.addSeperator();
         layout.addWidget(advancedSettings);
 
         // Scroll down when "Advanced Settings" are expanded

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -576,37 +576,6 @@ void GeneralPage::initLayout(SettingsLayout &layout)
                        s.attachExtensionToAnyProcess);
 #endif
 
-    layout.addTitle("Cache");
-    layout.addDescription(
-        "Files that are used often (such as emotes) are saved to disk to "
-        "reduce bandwidth usage and to speed up loading.");
-
-    auto cachePathLabel = layout.addDescription("placeholder :D");
-    getSettings()->cachePath.connect([cachePathLabel](const auto &,
-                                                      auto) mutable {
-        QString newPath = getPaths()->cacheDirectory();
-
-        QString pathShortened = "Cache saved at <a href=\"file:///" + newPath +
-                                "\"><span style=\"color: white;\">" +
-                                shortenString(newPath, 50) + "</span></a>";
-        cachePathLabel->setText(pathShortened);
-        cachePathLabel->setToolTip(newPath);
-    });
-
-    // Choose and reset buttons
-    {
-        auto box = new QHBoxLayout;
-
-        box->addWidget(layout.makeButton("Choose cache path", [this]() {
-            getSettings()->cachePath = QFileDialog::getExistingDirectory(this);
-        }));
-        box->addWidget(layout.makeButton(
-            "Reset", []() { getSettings()->cachePath = ""; }));
-        box->addStretch(1);
-
-        layout.addLayout(box);
-    }
-
     layout.addTitle("AppData");
     layout.addDescription("All local files like settings and cache files are "
                           "store in this directory.");
@@ -793,6 +762,42 @@ QLayout *GeneralPage::buildAdvancedSettingsLayout()
         layout->addCheckbox("Viewer count", s.headerViewerCount);
         layout->addCheckbox("Category", s.headerGame);
         layout->addCheckbox("Title", s.headerStreamTitle);
+    }
+
+    // "Cache" section
+    {
+        layout->addTitle("Cache");
+        layout->addDescription(
+            "Files that are used often (such as emotes) are saved to disk to "
+            "reduce bandwidth usage and to speed up loading.");
+
+        auto cachePathLabel = layout->addDescription("placeholder :D");
+        getSettings()->cachePath.connect([cachePathLabel](const auto &,
+                                                          auto) mutable {
+            QString newPath = getPaths()->cacheDirectory();
+
+            QString pathShortened = "Cache saved at <a href=\"file:///" +
+                                    newPath +
+                                    "\"><span style=\"color: white;\">" +
+                                    shortenString(newPath, 50) + "</span></a>";
+            cachePathLabel->setText(pathShortened);
+            cachePathLabel->setToolTip(newPath);
+        });
+
+        // Choose and reset buttons
+        {
+            auto box = new QHBoxLayout;
+
+            box->addWidget(layout->makeButton("Choose cache path", [this]() {
+                getSettings()->cachePath =
+                    QFileDialog::getExistingDirectory(this);
+            }));
+            box->addWidget(layout->makeButton(
+                "Reset", []() { getSettings()->cachePath = ""; }));
+            box->addStretch(1);
+
+            layout->addLayout(box);
+        }
     }
 
     return layout;

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -589,7 +589,6 @@ void GeneralPage::initLayout(SettingsLayout &layout)
     layout.addCheckbox("Mention users with a comma (User,)",
                        s.mentionUsersWithComma);
     layout.addCheckbox("Lowercase domains (anti-phishing)", s.lowercaseDomains);
-    layout.addCheckbox("Bold @usernames", s.boldUsernames);
     layout.addCheckbox("Try to find usernames without @ prefix",
                        s.findAllUsernames);
     layout.addDropdown<float>(
@@ -809,6 +808,7 @@ QLayout *GeneralPage::buildAdvancedSettingsLayout()
         layout->addCheckbox(
             "Automatically close user popup when it loses focus",
             s.autoCloseUserPopup);
+        layout->addCheckbox("Bold @usernames", s.boldUsernames);
     }
 
     return layout;

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -586,8 +586,6 @@ void GeneralPage::initLayout(SettingsLayout &layout)
 
     layout.addCheckbox("Restart on crash", s.restartOnCrash);
 
-    layout.addCheckbox("Show moderation messages", s.hideModerationActions,
-                       true);
     layout.addCheckbox("Colorize users without color set (gray names)",
                        s.colorizeNicknames);
     layout.addCheckbox("Mention users with a comma (User,)",
@@ -807,6 +805,9 @@ QLayout *GeneralPage::buildAdvancedSettingsLayout()
                 s.useKeyring);
         }
 #endif
+
+        layout->addCheckbox("Show moderation messages", s.hideModerationActions,
+                            true);
     }
 
     return layout;

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -362,7 +362,6 @@ void GeneralPage::initLayout(SettingsLayout &layout)
 #ifdef USEWINSDK
     layout.addCheckbox("Start with Windows", s.autorun);
 #endif
-    layout.addCheckbox("Show which channels are live in tabs", s.showTabLive);
 
     layout.addTitle("Chat");
 
@@ -770,6 +769,9 @@ QLayout *GeneralPage::buildAdvancedSettingsLayout()
                                 s.hidePreferencesButton, true);
             layout->addCheckbox("Show user button", s.hideUserButton, true);
         }
+
+        layout->addCheckbox("Show which channels are live in tabs",
+                            s.showTabLive);
     }
 
     return layout;

--- a/src/widgets/settingspages/GeneralPage.hpp
+++ b/src/widgets/settingspages/GeneralPage.hpp
@@ -75,6 +75,7 @@ public:
                           bool editable = false);
     ColorButton *addColorButton(const QString &text, const QColor &color,
                                 pajlada::Settings::Setting<QString> &setting);
+    void addSpace();
 
     template <typename OnClick>
     QPushButton *makeButton(const QString &text, OnClick onClick)

--- a/src/widgets/settingspages/GeneralPage.hpp
+++ b/src/widgets/settingspages/GeneralPage.hpp
@@ -189,6 +189,7 @@ public:
 
 private:
     void initLayout(SettingsLayout &layout);
+    QLayout *buildAdvancedSettingsLayout();
     void initExtra();
 
     QString getFont(const DropdownArgs &args) const;


### PR DESCRIPTION
Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable

# Description
Progress towards https://github.com/Chatterino/chatterino2/issues/1956, refer to the linked issue for more information.

**TODO**:
- [x] Devise a way to hide "Advanced" section (see `ExpandableLayout` class)
- [x] Decide which settings should go into the "Basic" and "Advanced" section
- [ ] Consistent search behavior
- [ ] Decide on a strategy for "Advanced Settings" button UX
- [ ] Explore other strategies: Advanced Settting on different page, Advanced Settings in different tab
- [ ] Document which settings have been moved