### PR TITLE
Fix: ColorButtons in settings don't respect search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,6 @@
 - Bugfix: Fixed timestamps being incorrect on some messages loaded from the recent-messages service on startup (#1286, #2020)
 - Bugfix: Fixed timestamps missing on channel point redemption messages (#1943)
 - Bugfix: Fixed tooltip didn't show in `EmotePopup` depending on the `Link preview` setting enabled or no (#2008)
-- Bugfix: Fixed "Last message line color" button not respecting search queries (#2073)
 
 ## 2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Bugfix: Fixed timestamps being incorrect on some messages loaded from the recent-messages service on startup (#1286, #2020)
 - Bugfix: Fixed timestamps missing on channel point redemption messages (#1943)
 - Bugfix: Fixed tooltip didn't show in `EmotePopup` depending on the `Link preview` setting enabled or no (#2008)
+- Bugfix: Fixed "Last message line color" button not respecting search queries (#2073)
 
 ## 2.2.0
 

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -189,6 +189,9 @@ ColorButton *SettingsLayout::addColorButton(
             });
         });
 
+    this->groups_.back().widgets.push_back({label, {text}});
+    this->groups_.back().widgets.push_back({colorButton, {text}});
+
     return colorButton;
 }
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Prior to this commit, adding a `ColorButton` to a `SettingsLayout` via `SettingsLayout::addColorButton` lead to the button not respecting search queries. This is because they are not added to the layout in a `Group`.

This commit fixes the behavior, causing color buttons to behave like every other settings widget.

