### PR TITLE
Added emote completion with `:` to the whispers channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unversioned
 
 - Major: Added Streamer Mode configuration (under `Settings -> General`), where you can select which features of Chatterino should behave differently when you are in Streamer Mode. (#2001)
+- Minor: Added emote completion with `:` to the whispers channel (#2075)
 - Minor: Made the current channels emotes appear at the top of the emote picker popup. (#2057)
 - Minor: Added viewer list button to twitch channel header. (#1978)
 - Minor: Added followage and subage information to usercard. (#2023)

--- a/src/widgets/splits/EmoteInputPopup.cpp
+++ b/src/widgets/splits/EmoteInputPopup.cpp
@@ -82,7 +82,7 @@ void EmoteInputPopup::updateEmotes(const QString &text, ChannelPtr channel)
             addEmotes(emotes, twitch->emotes, text, "Twitch Emote");
         }
 
-        if(tc)
+        if (tc)
         {
             // TODO extract "Channel BetterTTV" text into a #define.
             if (auto bttv = tc->bttvEmotes())

--- a/src/widgets/splits/EmoteInputPopup.cpp
+++ b/src/widgets/splits/EmoteInputPopup.cpp
@@ -72,8 +72,9 @@ void EmoteInputPopup::initLayout()
 void EmoteInputPopup::updateEmotes(const QString &text, ChannelPtr channel)
 {
     std::vector<_Emote> emotes;
-
-    if (auto tc = dynamic_cast<TwitchChannel *>(channel.get()))
+    auto tc = dynamic_cast<TwitchChannel *>(channel.get());
+    auto wc = channel.get()->getType() == Channel::Type::TwitchWhispers;
+    if (tc || wc)
     {
         if (auto user = getApp()->accounts->twitch.getCurrent())
         {
@@ -81,16 +82,19 @@ void EmoteInputPopup::updateEmotes(const QString &text, ChannelPtr channel)
             addEmotes(emotes, twitch->emotes, text, "Twitch Emote");
         }
 
-        // TODO extract "Channel BetterTTV" text into a #define.
-        if (auto bttv = tc->bttvEmotes())
-            addEmotes(emotes, *bttv, text, "Channel BetterTTV");
-        if (auto ffz = tc->ffzEmotes())
-            addEmotes(emotes, *ffz, text, "Channel FrankerFaceZ");
+        if(tc)
+        {
+            // TODO extract "Channel BetterTTV" text into a #define.
+            if (auto bttv = tc->bttvEmotes())
+                addEmotes(emotes, *bttv, text, "Channel BetterTTV");
+            if (auto ffz = tc->ffzEmotes())
+                addEmotes(emotes, *ffz, text, "Channel FrankerFaceZ");
 
-        if (auto bttvG = tc->globalBttv().emotes())
-            addEmotes(emotes, *bttvG, text, "Global BetterTTV");
-        if (auto ffzG = tc->globalFfz().emotes())
-            addEmotes(emotes, *ffzG, text, "Global FrankerFaceZ");
+            if (auto bttvG = tc->globalBttv().emotes())
+                addEmotes(emotes, *bttvG, text, "Global BetterTTV");
+            if (auto ffzG = tc->globalFfz().emotes())
+                addEmotes(emotes, *ffzG, text, "Global FrankerFaceZ");
+        }
 
         addEmojis(emotes, getApp()->emotes->emojis.emojis, text);
     }

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -462,8 +462,8 @@ void SplitInput::updateColonMenu()
 {
     auto channel = this->split_->getChannel().get();
     if (!getSettings()->emoteCompletionWithColon ||
-        (!dynamic_cast<TwitchChannel *>(channel)
-        && !(channel->getType() == Channel::Type::TwitchWhispers)))
+        (!dynamic_cast<TwitchChannel *>(channel) &&
+         !(channel->getType() == Channel::Type::TwitchWhispers)))
     {
         this->hideColonMenu();
         return;

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -460,8 +460,10 @@ void SplitInput::onCursorPositionChanged()
 
 void SplitInput::updateColonMenu()
 {
+    auto channel = this->split_->getChannel().get();
     if (!getSettings()->emoteCompletionWithColon ||
-        !dynamic_cast<TwitchChannel *>(this->split_->getChannel().get()))
+        (!dynamic_cast<TwitchChannel *>(channel)
+        && !(channel->getType() == Channel::Type::TwitchWhispers)))
     {
         this->hideColonMenu();
         return;


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Added emote completion with `:` to the whispers channel. It is limited to Twitch emotes and emojis. Global bttv and ffz emotes would be feasible, but require much more refactoring.

Closes (#2075)