### PR TITLE
Add parent-window option

### DIFF
--- a/src/common/Args.cpp
+++ b/src/common/Args.cpp
@@ -18,11 +18,16 @@ Args::Args(const QApplication &app)
 
     // Used internally by app to restart after unexpected crashes
     QCommandLineOption crashRecoveryOption("crash-recovery");
-    crashRecoveryOption.setHidden(true);
+    crashRecoveryOption.setFlags(QCommandLineOption::HiddenFromHelp);
+
+    // Added to ignore the parent-window option passed during native messaging
+    QCommandLineOption parentWindowOption("parent-window");
+    parentWindowOption.setFlags(QCommandLineOption::HiddenFromHelp);
 
     parser.addOptions({
         {{"v", "version"}, "Displays version information."},
         crashRecoveryOption,
+        parentWindowOption,
     });
     parser.addOption(QCommandLineOption(
         {"c", "channels"},


### PR DESCRIPTION
Pull request checklist:

~~`CHANGELOG.md` was updated, if applicable~~

# Description

Fixes the "unknown option 'parent-window'" error that Windows users experience when using the browser extension by simply ignoring the command line option.

Fixes Chatterino/chatterino-browser-ext/issues/41
