### PR TITLE
Copy message flags to preserve highlights

### DIFF
--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -594,7 +594,8 @@ void ChannelView::setChannel(ChannelPtr underlyingChannel)
                     }
                     else
                     {
-                        overridingFlags = MessageFlags(MessageFlag::DoNotLog);
+                        overridingFlags = message->flags;
+                        overridingFlags.get().set(MessageFlag::DoNotLog);
                     }
 
                     this->channel_->addMessage(message, overridingFlags);


### PR DESCRIPTION
Pull request checklist:

~~`CHANGELOG.md` was updated, if applicable~~
(fixes bug from #1748)

# Description
This PR makes sure that messages retain their proper flags when being added to a `ChannelView` by copying the message flags before applying the `DoNotLog` flag. 

Fixes #2086 