### PR TITLE
Fixed some stuff regarding usercard

### DIFF
--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -23,7 +23,6 @@
 
 #include <QCheckBox>
 #include <QDesktopServices>
-#include <QLabel>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 
@@ -164,10 +163,8 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically)
                 .assign(&this->ui_.followerCountLabel);
             vbox.emplace<Label>(TEXT_CREATED.arg(""))
                 .assign(&this->ui_.createdDateLabel);
-            vbox.emplace<Line>(true);
-            vbox.emplace<Label>("")
-                .assign(&this->ui_.followageSubageLabel)
-                ->setMinimumSize(this->minimumSizeHint());
+            vbox.emplace<Label>("").assign(&this->ui_.followageLabel);
+            vbox.emplace<Label>("").assign(&this->ui_.subageLabel);
         }
     }
 
@@ -667,34 +664,33 @@ void UserInfoPopup::updateUserData()
                     return;
                 }
 
-                QString labelText;
-
                 if (!subageInfo.followingSince.isEmpty())
                 {
                     QDateTime followedAt = QDateTime::fromString(
                         subageInfo.followingSince, Qt::ISODate);
                     QString followingSince = followedAt.toString("yyyy-MM-dd");
-                    labelText = "Following since " + followingSince;
+                    this->ui_.followageLabel->setText("❤ Following since " +
+                                                      followingSince);
                 }
 
                 if (subageInfo.isSubHidden)
                 {
-                    labelText += "\nSubscribtion status hidden";
+                    this->ui_.subageLabel->setText(
+                        "Subscription status hidden");
                 }
-                if (subageInfo.isSubbed)
+                else if (subageInfo.isSubbed)
                 {
-                    labelText += QString("\nTier %1 - Subscribed for %2 months")
-                                     .arg(subageInfo.subTier)
-                                     .arg(subageInfo.totalSubMonths);
+                    this->ui_.subageLabel->setText(
+                        QString("★ Tier %1 - Subscribed for %2 months")
+                            .arg(subageInfo.subTier)
+                            .arg(subageInfo.totalSubMonths));
                 }
                 else if (subageInfo.totalSubMonths)
                 {
-                    labelText +=
-                        QString("\nPreviously subscribed for %1 months")
-                            .arg(subageInfo.totalSubMonths);
+                    this->ui_.subageLabel->setText(
+                        QString("★ Previously subscribed for %1 months")
+                            .arg(subageInfo.totalSubMonths));
                 }
-
-                this->ui_.followageSubageLabel->setText(labelText);
             },
             [] {});
     };

--- a/src/widgets/dialogs/UserInfoPopup.hpp
+++ b/src/widgets/dialogs/UserInfoPopup.hpp
@@ -55,7 +55,8 @@ private:
         Label *followerCountLabel = nullptr;
         Label *createdDateLabel = nullptr;
         Label *userIDLabel = nullptr;
-        Label *followageSubageLabel = nullptr;
+        Label *followageLabel = nullptr;
+        Label *subageLabel = nullptr;
 
         QCheckBox *follow = nullptr;
         QCheckBox *ignore = nullptr;


### PR DESCRIPTION
Pull request checklist:

- ~~`CHANGELOG.md` was updated, if applicable~~
not applicable, bug was introduced before stable release

# Description
- Split everything into 2 separate labels, so we won't have any issues with dank dpi (like pajlada had) and no resizing to minimum size is required (which was apparently broken on Windows xd)
- Decided to remove line between follow / sub age and other elements, which was rather not visible / very small and couldn't be seen anyway
- Added nice unicode characters for follow and sub label just to reflect webchat even more and look nicer
- Removed unnecessary QLabel include (which I believe was also introduced by me by an accident)

Previews:

<details>
<summary>Debian 10 with i3</summary>
<img src="https://cdn.zneix.eu/oLAk0Rg.png" alt="https://cdn.zneix.eu/oLAk0Rg.png">
</details>

<details>
<summary>Windows 10</summary>
<img src="https://cdn.zneix.eu/GIxLs6k.png" alt="https://cdn.zneix.eu/GIxLs6k.png">
</details>

Closes #2033, sorry for introducing that "bug" in the first place