### PR TITLE
Updated required packages for arch

### DIFF
--- a/BUILDING_ON_LINUX.md
+++ b/BUILDING_ON_LINUX.md
@@ -12,7 +12,7 @@ install [chatterino2-git](https://aur.archlinux.org/packages/chatterino2-git/) f
 1. `sudo pacman -S qt5-base qt5-multimedia qt5-svg gst-plugins-ugly gst-plugins-good boost rapidjson pkgconf openssl`
 1. go into project directory
 1. create build folder `mkdir build && cd build`
-1. `qmake .. && make -j$(nproc)`
+1. `qmake .. && make`
 
 ## Fedora 28 and above
 *most likely works the same for other Red Hat-like distros. Substitue `dnf` with `yum`.*

--- a/BUILDING_ON_LINUX.md
+++ b/BUILDING_ON_LINUX.md
@@ -9,10 +9,10 @@ Note on Qt version compatibility: If you are installing Qt from a package manage
 
 ## Arch Linux
 install [chatterino2-git](https://aur.archlinux.org/packages/chatterino2-git/) from the aur or build manually as follows:
-1. `sudo pacman -S qt5-base qt5-multimedia qt5-svg gst-plugins-ugly gst-plugins-good boost rapidjson`
+1. `sudo pacman -S qt5-base qt5-multimedia qt5-svg gst-plugins-ugly gst-plugins-good boost rapidjson pkgconf openssl`
 1. go into project directory
 1. create build folder `mkdir build && cd build`
-1. `qmake .. && make`
+1. `qmake .. && make -j$(nproc)`
 
 ## Fedora 28 and above
 *most likely works the same for other Red Hat-like distros. Substitue `dnf` with `yum`.*


### PR DESCRIPTION
Pull request checklist:

- ~~`CHANGELOG.md` was updated, if applicable~~
not applicable

# Description

I tried compiling chatterino on completely clean arch linux today and I got some openssl error while running `qmake ..`. Turns out `pkg-config` was failing, because there was no such command.
Also added thread number to make since some users might not know about `-j` argument.
