### PR TITLE
fix: showInMentions attribute is now serialized correctly

### DIFF
--- a/src/controllers/highlights/HighlightModel.cpp
+++ b/src/controllers/highlights/HighlightModel.cpp
@@ -25,7 +25,7 @@ HighlightPhrase HighlightModel::getItemFromRow(
 
     return HighlightPhrase{
         row[Column::Pattern]->data(Qt::DisplayRole).toString(),
-        row[Column::ShowInMentions]->data(Qt::DisplayRole).toBool(),
+        row[Column::ShowInMentions]->data(Qt::CheckStateRole).toBool(),
         row[Column::FlashTaskbar]->data(Qt::CheckStateRole).toBool(),
         row[Column::PlaySound]->data(Qt::CheckStateRole).toBool(),
         row[Column::UseRegex]->data(Qt::CheckStateRole).toBool(),


### PR DESCRIPTION
Pull request checklist:

- [x] ~`CHANGELOG.md` was updated, if applicable~ (n/a, #2036 is unversioned)

# Description

Fixes #2134.

This was an error introduced in ec94869 / #2036. Instead of the `Qt::CheckStateRole`, which stores the state represented in the table view, the `Qt::DisplayRole` was used. As per the [documentation], this always returns `false` in our use case.

[documentation]: https://doc.qt.io/qt-5/qvariant.html#toBool