### PR TITLE
Fixed settings dialog size

### DIFF
--- a/src/widgets/dialogs/SettingsDialog.cpp
+++ b/src/widgets/dialogs/SettingsDialog.cpp
@@ -30,7 +30,7 @@ SettingsDialog::SettingsDialog(QWidget *parent)
           parent)
 {
     this->setWindowTitle("Chatterino Settings");
-    this->resize(815, 600);
+    this->resize(915, 600);
     this->themeChangedEvent();
     this->scaleChangedEvent(this->scale());
 


### PR DESCRIPTION
Pull request checklist:

- ~~[ ] `CHANGELOG.md` was updated, if applicable~~
Fixed a bug introduced after last stable release

# Description
Since there was a navigation section added to `Settings -> General` there was an annoying horizontal scrollbar because the window wasn't wide enough and since it was bothering me so much I decided to make a quick fix for that.

Before:

https://cdn.zneix.eu/cuIZ3Os.png
![if you read this](https://cdn.zneix.eu/cuIZ3Os.png)

After:

https://cdn.zneix.eu/mOgd1re.png
![vi von zulul](https://cdn.zneix.eu/mOgd1re.png)
