### PR TITLE
Improved textEdit placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unversioned
 
-- Minor: Added placeholder text for message text input box. (#2143)
+- Minor: Added placeholder text for message text input box. (#2143, #2149)
 - Minor: Added support for FrankerFaceZ badges. (#2101, part of #1658)
 - Minor: Added a navigation list to the settings and reordered them.
 - Major: Added "Channel Filters". See https://wiki.chatterino.com/Filters/ for how they work or how to configure them. (#1748, #2083)

--- a/src/BaseTheme.cpp
+++ b/src/BaseTheme.cpp
@@ -156,6 +156,8 @@ void AB_THEME_CLASS::actuallyUpdate(double hue, double multiplier)
     this->messages.textColors.link =
         isLight_ ? QColor(66, 134, 244) : QColor(66, 134, 244);
     this->messages.textColors.system = QColor(140, 127, 127);
+    this->messages.textColors.chatPlaceholder =
+        isLight_ ? QColor(175, 159, 159) : QColor(93, 85, 85);
 
     this->messages.backgrounds.regular = getColor(0, sat, 1);
     this->messages.backgrounds.alternate = getColor(0, sat, 0.96);

--- a/src/BaseTheme.hpp
+++ b/src/BaseTheme.hpp
@@ -61,6 +61,7 @@ public:
             QColor caret;
             QColor link;
             QColor system;
+            QColor chatPlaceholder;
         } textColors;
 
         struct {

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -283,6 +283,11 @@ void Split::setContainer(SplitContainer *container)
 
 void Split::onAccountSelected()
 {
+    if (!this->getChannel()->isTwitchChannel())
+    {
+        return;
+    }
+
     auto user = getApp()->accounts->twitch.getCurrent();
     QString placeholderText;
 
@@ -298,6 +303,19 @@ void Split::onAccountSelected()
     }
 
     this->input_->ui_.textEdit->setPlaceholderText(placeholderText);
+
+    this->updateTooltipColor();
+    this->signalHolder_.managedConnect(this->theme->updated, [this]() {
+        this->updateTooltipColor();  //
+    });
+}
+
+void Split::updateTooltipColor()
+{
+    QPalette dankPalette;
+    dankPalette.setColor(QPalette::PlaceholderText,
+                         this->theme->messages.textColors.chatPlaceholder);
+    this->input_->ui_.textEdit->setPalette(dankPalette);
 }
 
 IndirectChannel Split::getIndirectChannel()

--- a/src/widgets/splits/Split.hpp
+++ b/src/widgets/splits/Split.hpp
@@ -97,6 +97,7 @@ private:
     void channelNameUpdated(const QString &newChannelName);
     void handleModifiers(Qt::KeyboardModifiers modifiers);
     void onAccountSelected();
+    void updateTooltipColor();
 
     SplitContainer *container_;
     IndirectChannel channel_;


### PR DESCRIPTION
Pull request checklist:

- ~~[ ] `CHANGELOG.md` was updated, if applicable~~
not applicable

# Description

I applied some suggestions about placeholder text being a bit too 'easily readable' and made it slightly lighter to not mix with color of system messages and message timestamps.
I also read that tooltip might've been causing some issues on non-twitch channels, so I removed it (though, it only makes sense in twitch channels anyway).
