### PR TITLE
Fix `runIgnoreReplaces` fall into infinity loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - Bugfix: Fix Tab key not working in the Ctrl+K Quick Switcher (#2065)
 - Bugfix: Fix bug preventing moderator actions when viewing a user card from the search window (#1089)
 - Bugfix: Fix `:` emote completion menu ignoring emote capitalization (#1962)
+- Bugfix: Fix a bug that caused `Ignore page` to fall into an infinity loop with an empty pattern and regex enabled (#2125)
 
 ## 2.2.0
 

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -763,6 +763,11 @@ void TwitchMessageBuilder::runIgnoreReplaces(
         {
             continue;
         }
+        const auto &pattern = phrase.getPattern();
+        if (pattern.isEmpty())
+        {
+            continue;
+        }
         if (phrase.isRegex())
         {
             const auto &regex = phrase.getRegex();
@@ -835,11 +840,6 @@ void TwitchMessageBuilder::runIgnoreReplaces(
         }
         else
         {
-            const auto &pattern = phrase.getPattern();
-            if (pattern.isEmpty())
-            {
-                continue;
-            }
             int from = 0;
             while ((from = this->originalMessage_.indexOf(
                         pattern, from, phrase.caseSensitivity())) != -1)


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description
Fixes #2125 
Because an empty pattern always has a match, it'll endlessly populate `originalMessage_` with `replace` string, so simply move the `isEmpty` check.
