### PR TITLE
Ensure Twitch username in UserCard uses display name from API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 ## Unversioned
 
-- Major: Added "Channel Filters". See https://wiki.chatterino.com/Filters/ for how they work or how to configure them. (#1748, #2083)
-- Major: Added Streamer Mode configuration (under `Settings -> General`), where you can select which features of Chatterino should behave differently when you are in Streamer Mode. (#2001)
 - Minor: Made usercard update user's display name (#2160)
 - Minor: Added placeholder text for message text input box. (#2143, #2149)
 - Minor: Added support for FrankerFaceZ badges. (#2101, part of #1658)
 - Minor: Added a navigation list to the settings and reordered them.
+- Major: Added "Channel Filters". See https://wiki.chatterino.com/Filters/ for how they work or how to configure them. (#1748, #2083)
+- Major: Added Streamer Mode configuration (under `Settings -> General`), where you can select which features of Chatterino should behave differently when you are in Streamer Mode. (#2001)
 - Minor: Improved viewer list window.
 - Minor: Added emote completion with `:` to the whispers channel (#2075)
 - Minor: Made the current channels emotes appear at the top of the emote picker popup. (#2057)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ## Unversioned
 
+- Major: Added "Channel Filters". See https://wiki.chatterino.com/Filters/ for how they work or how to configure them. (#1748, #2083)
+- Major: Added Streamer Mode configuration (under `Settings -> General`), where you can select which features of Chatterino should behave differently when you are in Streamer Mode. (#2001)
+- Minor: Made usercard update user's display name (#2160)
 - Minor: Added placeholder text for message text input box. (#2143, #2149)
 - Minor: Added support for FrankerFaceZ badges. (#2101, part of #1658)
 - Minor: Added a navigation list to the settings and reordered them.
-- Major: Added "Channel Filters". See https://wiki.chatterino.com/Filters/ for how they work or how to configure them. (#1748, #2083)
-- Major: Added Streamer Mode configuration (under `Settings -> General`), where you can select which features of Chatterino should behave differently when you are in Streamer Mode. (#2001)
 - Minor: Improved viewer list window.
 - Minor: Added emote completion with `:` to the whispers channel (#2075)
 - Minor: Made the current channels emotes appear at the top of the emote picker popup. (#2057)

--- a/src/providers/twitch/api/Kraken.hpp
+++ b/src/providers/twitch/api/Kraken.hpp
@@ -25,9 +25,11 @@ struct KrakenChannel {
 
 struct KrakenUser {
     const QString createdAt;
+    const QString displayName;
 
     KrakenUser(QJsonObject jsonObject)
         : createdAt(jsonObject.value("created_at").toString())
+        , displayName(jsonObject.value("display_name").toString())
     {
     }
 };

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -587,6 +587,7 @@ void UserInfoPopup::updateUserData()
                     return;
                 }
                 this->ui_.nameLabel->setText(user.displayName);
+                this->setWindowTitle(TEXT_TITLE.arg(user.displayName));
                 this->ui_.createdDateLabel->setText(
                     TEXT_CREATED.arg(user.createdAt.section("T", 0, 0)));
             },

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -586,6 +586,7 @@ void UserInfoPopup::updateUserData()
                 {
                     return;
                 }
+                this->ui_.nameLabel->setText(user.displayName);
                 this->ui_.createdDateLabel->setText(
                     TEXT_CREATED.arg(user.createdAt.section("T", 0, 0)));
             },


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Added a simple fix that also updates `nameLabel` in usercard to a proper display name if user is resolved correctly. It's a nice thing making usercard a little bit more useful :)
