### PR TITLE
[Fix] Make SearchPopup a BasePopup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 - Minor: Improve UX of the "Login expired!" message (#2029)
 - Minor: PageUp and PageDown now scroll in the selected split (#2070, #2081)
 - Minor: Allow highlights to be excluded from `/mentions`. Excluded highlights will not trigger tab highlights either. (#1793, #2036)
-- Minor: Flag all popup dialogs as actual dialogs so they get the relevant window manager hints (#1843)
+- Minor: Flag all popup dialogs as actual dialogs so they get the relevant window manager hints (#1843, #2182)
 - Minor: Don't show update button for nightly builds on macOS and Linux, this was already the case for Windows (#2163, #2164)
 - Bugfix: Fix crash occurring when pressing Escape in the Color Picker Dialog (#1843)
 - Bugfix: Fix bug preventing users from setting the highlight color of the second entry in the "User" highlights tab (#1898)

--- a/src/widgets/helper/SearchPopup.cpp
+++ b/src/widgets/helper/SearchPopup.cpp
@@ -52,7 +52,8 @@ ChannelPtr SearchPopup::filter(const QString &text, const QString &channelName,
     return channel;
 }
 
-SearchPopup::SearchPopup()
+SearchPopup::SearchPopup(QWidget *parent)
+    : BasePopup({}, parent)
 {
     this->initLayout();
     this->resize(400, 600);

--- a/src/widgets/helper/SearchPopup.hpp
+++ b/src/widgets/helper/SearchPopup.hpp
@@ -15,7 +15,7 @@ namespace chatterino {
 class SearchPopup : public BasePopup
 {
 public:
-    SearchPopup();
+    SearchPopup(QWidget *parent);
 
     virtual void setChannel(const ChannelPtr &channel);
     virtual void setChannelFilters(FilterSetPtr filters);

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -828,7 +828,7 @@ const QList<QUuid> Split::getFilters() const
 
 void Split::showSearch()
 {
-    SearchPopup *popup = new SearchPopup();
+    SearchPopup *popup = new SearchPopup(this);
 
     popup->setChannelFilters(this->view_->getFilterSet());
     popup->setAttribute(Qt::WA_DeleteOnClose);


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Fixes #2154. This is a follow-up to #1843 where we missed to also adjust the `SearchPopup`.

I have only tested this change on sway and while it is unlikely for other OS/WM to break existing behavior with this, we should probably test them regardless.
