### PR TITLE
Fix FFZ emote assertion crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - Bugfix: Fix bug preventing moderator actions when viewing a user card from the search window (#1089)
 - Bugfix: Fix `:` emote completion menu ignoring emote capitalization (#1962)
 - Bugfix: Fix a bug that caused `Ignore page` to fall into an infinity loop with an empty pattern and regex enabled (#2125)
+- Bugfix: Fix a crash casued by FrankerFaceZ responding with invalid emote links (#2191)
 
 ## 2.2.0
 

--- a/src/providers/ffz/FfzEmotes.cpp
+++ b/src/providers/ffz/FfzEmotes.cpp
@@ -14,7 +14,7 @@ namespace {
     Url getEmoteLink(const QJsonObject &urls, const QString &emoteScale)
     {
         auto emote = urls.value(emoteScale);
-        if (emote.isUndefined())
+        if (emote.isUndefined() || emote.type() == QJsonValue::Null)
         {
             return {""};
         }

--- a/src/providers/ffz/FfzEmotes.cpp
+++ b/src/providers/ffz/FfzEmotes.cpp
@@ -14,7 +14,7 @@ namespace {
     Url getEmoteLink(const QJsonObject &urls, const QString &emoteScale)
     {
         auto emote = urls.value(emoteScale);
-        if (emote.isUndefined() || emote.type() == QJsonValue::Null)
+        if (emote.isUndefined() || emote.isNull())
         {
             return {""};
         }


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Apparently, the FFZ API can return `null` values for emote URLs. This PR treats `null` values the same as if they were missing from the JSON response.

See https://github.com/Chatterino/chatterino2/issues/2191#issuecomment-728278070 for more info

Fixes #2191 