### PR TITLE
[Fix] Use copy instead of reference for overriding message flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Minor: Added placeholder text for message text input box. (#2143, #2149)
 - Minor: Added support for FrankerFaceZ badges. (#2101, part of #1658)
 - Minor: Added a navigation list to the settings and reordered them.
-- Major: Added "Channel Filters". See https://wiki.chatterino.com/Filters/ for how they work or how to configure them. (#1748, #2083)
+- Major: Added "Channel Filters". See https://wiki.chatterino.com/Filters/ for how they work or how to configure them. (#1748, #2083, #2090, #2200)
 - Major: Added Streamer Mode configuration (under `Settings -> General`), where you can select which features of Chatterino should behave differently when you are in Streamer Mode. (#2001)
 - Minor: Improved viewer list window.
 - Minor: Added emote completion with `:` to the whispers channel (#2075)

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -605,7 +605,7 @@ void ChannelView::setChannel(ChannelPtr underlyingChannel)
                     }
                     else
                     {
-                        overridingFlags = message->flags;
+                        overridingFlags = MessageFlags(message->flags);
                         overridingFlags.get().set(MessageFlag::DoNotLog);
                     }
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

(**Note**: I also included the initial attempt at fixing this issue (#2090) in order to make the development process more trackable.)

# Description

Fixes #2195, fixes #2196.
This PR can be seen as a follow-up to https://github.com/Chatterino/chatterino2/pull/2090.

Apparently, `boost::optional` did not make a proper copy of the message flags when just using the assignment operator. This commit is explicit about copying, and preserves the message flags.