### PR TITLE
check path is not empty

### DIFF
--- a/src/singletons/Paths.cpp
+++ b/src/singletons/Paths.cpp
@@ -44,7 +44,7 @@ QString Paths::cacheDirectory()
         QStringSetting cachePathSetting("/cache/path");
 
         cachePathSetting.connect([](const auto &newPath, auto) {
-            if (newPath.length() > 0)
+            if (!newPath.isEmpty())
             {
                 QDir().mkpath(newPath);
             }

--- a/src/singletons/Paths.cpp
+++ b/src/singletons/Paths.cpp
@@ -44,7 +44,8 @@ QString Paths::cacheDirectory()
         QStringSetting cachePathSetting("/cache/path");
 
         cachePathSetting.connect([](const auto &newPath, auto) {
-            if (newPath.length() > 0) {
+            if (newPath.length() > 0)
+            {
                 QDir().mkpath(newPath);
             }
         });

--- a/src/singletons/Paths.cpp
+++ b/src/singletons/Paths.cpp
@@ -44,7 +44,9 @@ QString Paths::cacheDirectory()
         QStringSetting cachePathSetting("/cache/path");
 
         cachePathSetting.connect([](const auto &newPath, auto) {
-            QDir().mkpath(newPath);
+            if (newPath.length() > 0) {
+                QDir().mkpath(newPath);
+            }
         });
 
         return cachePathSetting;


### PR DESCRIPTION
Fixes a `QDir::mkpath: Empty or null file path` error on startup.