### PR TITLE
Fixed "raw mentions" not being clickable with special characters appended to them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unversioned
 
+- Minor: Made `Try to find usernames without @ prefix` option still resolve usernames when special characters (commas, dots, (semi)colons, exclamation mark, question mark) are appended to them. (#2212)
 - Minor: Made usercard update user's display name (#2160)
 - Minor: Added placeholder text for message text input box. (#2143, #2149)
 - Minor: Added support for FrankerFaceZ badges. (#2101, part of #1658)

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -29,11 +29,13 @@
 
 namespace {
 
+const QString regexHelpString("(\\w+)[.,!?;:]*?$");
+
 // matches a mention with punctuation at the end, like "@username," or "@username!!!" where capture group would return "username"
-const QRegularExpression mentionRegex("^@(\\w+)[.,!?;:]*?$");
+const QRegularExpression mentionRegex("^@" + regexHelpString);
 
 // if findAllUsernames setting is enabled, matches strings like in the examples above, but without @ symbol at the beginning
-const QRegularExpression allUsernamesMentionRegex("^(\\w+)[.,!?;:]*?$");
+const QRegularExpression allUsernamesMentionRegex("^" + regexHelpString);
 
 const QSet<QString> zeroWidthEmotes{
     "SoSnowy",  "IceCold",   "SantaHat", "TopHat",

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -30,10 +30,10 @@
 namespace {
 
 // matches a mention with punctuation at the end, like "@username," or "@username!!!" where capture group would return "username"
-const QRegularExpression mentionRegex("^@(\\w+)[.,!?;]*?$");
+const QRegularExpression mentionRegex("^@(\\w+)[.,!?;:]*?$");
 
 // if findAllUsernames setting is enabled, matches strings like in the examples above, but without @ symbol at the beginning
-const QRegularExpression allUsernamesMentionRegex("^(\\w+)[.,!?;]*?$");
+const QRegularExpression allUsernamesMentionRegex("^(\\w+)[.,!?;:]*?$");
 
 const QSet<QString> zeroWidthEmotes{
     "SoSnowy",  "IceCold",   "SantaHat", "TopHat",


### PR DESCRIPTION

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Made "raw-mentions" consistent with @mentions in setting bold usernames and being able display usercard by clicking. To achieve that, I added a second, simple regex; similar to `mentionRegex`.

https://cdn.zneix.eu/2LdNrGt.png
![https://cdn.zneix.eu/q8Hh5mh.png](https://cdn.zneix.eu/2LdNrGt.png)

I also decided to add colon to special characters that will not have influence on not resolving usercard, because many chatters often use "Copy full message" from message context menu and paste that in chat, which has format similar to `13:37 zneix: message xd` and it is pretty convenient to have it resolve to mention as well.
