### PR TITLE
Added links to twitchemotes.com to Twitch emotes' context menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Minor: Added a navigation list to the settings and reordered them.
 - Major: Added "Channel Filters". See https://wiki.chatterino.com/Filters/ for how they work or how to configure them. (#1748, #2083, #2090, #2200)
 - Major: Added Streamer Mode configuration (under `Settings -> General`), where you can select which features of Chatterino should behave differently when you are in Streamer Mode. (#2001)
+- Minor: Added a link to twitchemotes.com to conext menu when right-clicking Twitch emotes. (#2214)
 - Minor: Improved viewer list window.
 - Minor: Added emote completion with `:` to the whispers channel (#2075)
 - Minor: Made the current channels emotes appear at the top of the emote picker popup. (#2057)

--- a/src/providers/twitch/TwitchEmotes.cpp
+++ b/src/providers/twitch/TwitchEmotes.cpp
@@ -74,14 +74,15 @@ EmotePtr TwitchEmotes::getOrCreateEmote(const EmoteId &id,
 
     if (!shared)
     {
-        (*cache)[id] = shared = std::make_shared<Emote>(
-            Emote{EmoteName{name},
-                  ImageSet{
-                      Image::fromUrl(getEmoteLink(id, "1.0"), 1),
-                      Image::fromUrl(getEmoteLink(id, "2.0"), 0.5),
-                      Image::fromUrl(getEmoteLink(id, "3.0"), 0.25),
-                  },
-                  Tooltip{name + "<br>Twitch Emote"}, Url{}});
+        (*cache)[id] = shared = std::make_shared<Emote>(Emote{
+            EmoteName{name},
+            ImageSet{
+                Image::fromUrl(getEmoteLink(id, "1.0"), 1),
+                Image::fromUrl(getEmoteLink(id, "2.0"), 0.5),
+                Image::fromUrl(getEmoteLink(id, "3.0"), 0.25),
+            },
+            Tooltip{name + "<br>Twitch Emote"},
+            Url{QString("https://twitchemotes.com/emotes/%1").arg(id.string)}});
     }
 
     return shared;

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -103,7 +103,11 @@ namespace {
                                 });
         };
 
-        if (creatorFlags.has(MessageElementFlag::BttvEmote))
+        if (creatorFlags.has(MessageElementFlag::TwitchEmote))
+        {
+            addPageLink("TwitchEmotes");
+        }
+        else if (creatorFlags.has(MessageElementFlag::BttvEmote))
         {
             addPageLink("BTTV");
         }


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

As discussed on pajlada's stream earlier today, I added a link to context menus pointing to `twitchemotes.com/emotes/%1`. I am aware that links might sometimes not work in some weird edge-cases (e.g. event emotes from qa_tw_partner), but I don't think we have any other alternative than twitchemotes.com for Twitch emote links and I think it's decent in general and I was missing similar functionality to quickly get emote link with some more imformation than just a .jpg file from regular sizes links.
