### PR TITLE
Add Ctrl+F5 as a shortcut for reconnect()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unversioned
 
+- Minor: Added a keyboard shortcut (Ctrl+F5) for "Reconnect" (#2215)
 - Minor: Made usercard update user's display name (#2160)
 - Minor: Added placeholder text for message text input box. (#2143, #2149)
 - Minor: Added support for FrankerFaceZ badges. (#2101, part of #1658)

--- a/src/widgets/settingspages/KeyboardSettingsPage.cpp
+++ b/src/widgets/settingspages/KeyboardSettingsPage.cpp
@@ -66,6 +66,7 @@ KeyboardSettingsPage::KeyboardSettingsPage()
     form->addRow(new QLabel("Ctrl + P"), new QLabel("Open Settings menu"));
     form->addRow(new QLabel("F5"),
                  new QLabel("Reload subscriber and channel emotes"));
+    form->addRow(new QLabel("Ctrl + F5"), new QLabel("Reconnect channels"));
 
     form->addItem(new QSpacerItem(16, 16));
     form->addRow(new QLabel("PageUp"), new QLabel("Scroll up"));

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -117,6 +117,9 @@ Split::Split(QWidget *parent)
     // F5: reload emotes
     createShortcut(this, "F5", &Split::reloadChannelAndSubscriberEmotes);
 
+    // CTRL+F5: reconnect
+    createShortcut(this, "CTRL+F5", &Split::reconnect);
+
     // F10
     createShortcut(this, "F10", [] {
         auto *popup = new DebugPopup;
@@ -846,6 +849,11 @@ void Split::reloadChannelAndSubscriberEmotes()
         twitchChannel->refreshBTTVChannelEmotes(true);
         twitchChannel->refreshFFZChannelEmotes(true);
     }
+}
+
+void Split::reconnect()
+{
+    this->getChannel()->reconnect();
 }
 
 void Split::dragEnterEvent(QDragEnterEvent *event)

--- a/src/widgets/splits/Split.hpp
+++ b/src/widgets/splits/Split.hpp
@@ -144,6 +144,7 @@ public slots:
     void showViewerList();
     void openSubPage();
     void reloadChannelAndSubscriberEmotes();
+    void reconnect();
 };
 
 }  // namespace chatterino

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -386,7 +386,10 @@ std::unique_ptr<QMenu> SplitHeader::createMainMenu()
 
     // reload / reconnect
     if (this->split_->getChannel()->canReconnect())
-        menu->addAction("Reconnect", this, SLOT(reconnect()));
+    {
+        menu->addAction("Reconnect", this, SLOT(reconnect()),
+                        QKeySequence("Ctrl+F5"));
+    }
 
     if (dynamic_cast<TwitchChannel *>(this->split_->getChannel().get()))
     {


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description
Added a keyboard shortcut (Ctrl+F5) for "Reconnect"
<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
