### PR TITLE
Made #channel link in /mentions jump to #channel split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unversioned
 
+- Minor: Made "#channel" in `/mentions` tab a clickable link which takes you to the channel that you were mentioned in. (#2220)
 - Minor: Added a keyboard shortcut (Ctrl+F5) for "Reconnect" (#2215)
 - Minor: Made `Try to find usernames without @ prefix` option still resolve usernames when special characters (commas, dots, (semi)colons, exclamation mark, question mark) are appended to them. (#2212)
 - Minor: Made usercard update user's display name (#2160)

--- a/src/messages/Link.hpp
+++ b/src/messages/Link.hpp
@@ -20,6 +20,7 @@ public:
         AutoModAllow,
         AutoModDeny,
         OpenAccountsPage,
+        JumpToChannel,
     };
 
     Link();

--- a/src/messages/SharedMessageBuilder.cpp
+++ b/src/messages/SharedMessageBuilder.cpp
@@ -356,7 +356,7 @@ void SharedMessageBuilder::addTextOrEmoji(const QString &string_)
 void SharedMessageBuilder::appendChannelName()
 {
     QString channelName("#" + this->channel->getName());
-    Link link(Link::Url, this->channel->getName() + "\n" + this->message().id);
+    Link link(Link::JumpToChannel, this->channel->getName());
 
     this->emplace<TextElement>(channelName, MessageElementFlag::ChannelName,
                                MessageColor::System)

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -2043,6 +2043,41 @@ void ChannelView::handleLinkClick(QMouseEvent *event, const Link &link,
                                        SettingsDialogPreference::Accounts);
         }
         break;
+        case Link::JumpToChannel: {
+            // Get all currently open pages
+            QSet<SplitContainer *> openPages;
+
+            auto &nb = getApp()->windows->getMainWindow().getNotebook();
+            for (int i = 0; i < nb.getPageCount(); ++i)
+            {
+                openPages.insert(
+                    static_cast<SplitContainer *>(nb.getPageAt(i)));
+            }
+
+            for (auto *sc : openPages)
+            {
+                auto splits = sc->getSplits();
+
+                // Find channel with mention in all opened channels
+                // TODO(zneix): Consider opening a channel if it's closed (?)
+                auto it = std::find_if(
+                    splits.begin(), splits.end(), [link](Split *split) {
+                        return split->getChannel()->getName() == link.value;
+                    });
+
+                if (it != splits.end())
+                {
+                    // Select SplitContainer and Split itself where mention message was sent
+                    // TODO(zneix): Try exploring ways of scrolling to a certain message as well
+                    auto &nb = getApp()->windows->getMainWindow().getNotebook();
+                    nb.select(sc);
+
+                    Split *dankSplit = *it;
+                    sc->setSelected(dankSplit);
+                }
+            }
+        }
+        break;
 
         default:;
     }

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -2054,11 +2054,11 @@ void ChannelView::handleLinkClick(QMouseEvent *event, const Link &link,
                     static_cast<SplitContainer *>(nb.getPageAt(i)));
             }
 
-            for (auto *sc : openPages)
+            for (auto *page : openPages)
             {
-                auto splits = sc->getSplits();
+                auto splits = page->getSplits();
 
-                // Find channel with mention in all opened channels
+                // Search for channel matching link in page/split container
                 // TODO(zneix): Consider opening a channel if it's closed (?)
                 auto it = std::find_if(
                     splits.begin(), splits.end(), [link](Split *split) {
@@ -2070,10 +2070,10 @@ void ChannelView::handleLinkClick(QMouseEvent *event, const Link &link,
                     // Select SplitContainer and Split itself where mention message was sent
                     // TODO(zneix): Try exploring ways of scrolling to a certain message as well
                     auto &nb = getApp()->windows->getMainWindow().getNotebook();
-                    nb.select(sc);
+                    nb.select(page);
 
-                    Split *dankSplit = *it;
-                    sc->setSelected(dankSplit);
+                    Split *split = *it;
+                    page->setSelected(split);
                     break;
                 }
             }

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -2069,7 +2069,6 @@ void ChannelView::handleLinkClick(QMouseEvent *event, const Link &link,
                 {
                     // Select SplitContainer and Split itself where mention message was sent
                     // TODO(zneix): Try exploring ways of scrolling to a certain message as well
-                    auto &nb = getApp()->windows->getMainWindow().getNotebook();
                     nb.select(page);
 
                     Split *split = *it;

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -2045,12 +2045,12 @@ void ChannelView::handleLinkClick(QMouseEvent *event, const Link &link,
         break;
         case Link::JumpToChannel: {
             // Get all currently open pages
-            QSet<SplitContainer *> openPages;
+            QList<SplitContainer *> openPages;
 
             auto &nb = getApp()->windows->getMainWindow().getNotebook();
             for (int i = 0; i < nb.getPageCount(); ++i)
             {
-                openPages.insert(
+                openPages.push_back(
                     static_cast<SplitContainer *>(nb.getPageAt(i)));
             }
 
@@ -2074,6 +2074,7 @@ void ChannelView::handleLinkClick(QMouseEvent *event, const Link &link,
 
                     Split *dankSplit = *it;
                     sc->setSelected(dankSplit);
+                    break;
                 }
             }
         }


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

The `#channel` part in `/mentions` tab is a link and as fourtf once said, it was supposed to take you to the channel and message that you were mentioned in - very similar to how it is done on Discord, but it wasn't working properly and even shown those bugged URL links on some environments (See #2087).

I looked at code from channel switcher and in a pretty similar way added it here. And while channel switcher opens up a new channel when the target channel is closed, I assumed that messages in `/mentions` come always from already open channels and there's no real need to make this function open a new channel because I assume that the split with a channel will still be open.

While switching current SplitContainer and the Split itself works flawlessly, I wasn't really able to implement scrolling to certain message - maybe I can look into that further in the future and send another PR with the solution, but for now this is better than nothing and also fixes an open issue.

<details>
<summary>GIF with demonstration</summary>
<img src="https://cdn.zneix.eu/AQORwpk.gif" alt="https://cdn.zneix.eu/q8Hh5mh.png">
</details>

Closes #2087
