### PR TITLE
Fix freeze in Ignore & Replace if replacement followed by emote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - Bugfix: Fix `:` emote completion menu ignoring emote capitalization (#1962)
 - Bugfix: Fix a bug that caused `Ignore page` to fall into an infinity loop with an empty pattern and regex enabled (#2125)
 - Bugfix: Fix a crash casued by FrankerFaceZ responding with invalid emote links (#2191)
+- Bugfix: Fix a freeze caused by ignored & replaced phrases followed by Twitch Emotes (#2231)
 - Dev: Updated minimum required Qt framework version to 5.12. (#2210)
 
 ## 2.2.0

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -738,6 +738,7 @@ void TwitchMessageBuilder::runIgnoreReplaces(
             if (index >= pos)
             {
                 index += by;
+                item.end += by;
             }
         }
     };


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

This fixes an issue that could happen when using the "Ignore & Replace" functionality of Ignore.
If a Twitch emote followed a replaced phrase and the replaced phrase differed in length from the replacement phrase, the Twitch emote position data was not fully updating, causing the Twitch emote searching code to get stuck in an endless loop.

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
