### PR TITLE
fix: make LoginWidget child of AccountsPage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@
 - Minor: Improve UX of the "Login expired!" message (#2029)
 - Minor: PageUp and PageDown now scroll in the selected split (#2070, #2081)
 - Minor: Allow highlights to be excluded from `/mentions`. Excluded highlights will not trigger tab highlights either. (#1793, #2036)
-- Minor: Flag all popup dialogs as actual dialogs so they get the relevant window manager hints (#1843, #2182, #2185, #2232)
+- Minor: Flag all popup dialogs as actual dialogs so they get the relevant window manager hints (#1843, #2182, #2185, #2232, #2234)
 - Minor: Don't show update button for nightly builds on macOS and Linux, this was already the case for Windows (#2163, #2164)
 - Bugfix: Fix crash occurring when pressing Escape in the Color Picker Dialog (#1843)
 - Bugfix: Fix bug preventing users from setting the highlight color of the second entry in the "User" highlights tab (#1898)

--- a/src/widgets/dialogs/LoginDialog.cpp
+++ b/src/widgets/dialogs/LoginDialog.cpp
@@ -245,7 +245,8 @@ void AdvancedLoginWidget::refreshButtons()
     }
 }
 
-LoginWidget::LoginWidget()
+LoginWidget::LoginWidget(QWidget *parent)
+    : QDialog(parent)
 {
 #ifdef USEWINSDK
     ::SetWindowPos(HWND(this->winId()), HWND_TOPMOST, 0, 0, 0, 0,

--- a/src/widgets/dialogs/LoginDialog.hpp
+++ b/src/widgets/dialogs/LoginDialog.hpp
@@ -64,7 +64,7 @@ public:
 class LoginWidget : public QDialog
 {
 public:
-    LoginWidget();
+    LoginWidget(QWidget *parent);
 
 private:
     struct {

--- a/src/widgets/settingspages/AccountsPage.cpp
+++ b/src/widgets/settingspages/AccountsPage.cpp
@@ -32,8 +32,8 @@ AccountsPage::AccountsPage()
     view->getTableView()->horizontalHeader()->setVisible(false);
     view->getTableView()->horizontalHeader()->setStretchLastSection(true);
 
-    view->addButtonPressed.connect([] {
-        static auto loginWidget = new LoginWidget();
+    view->addButtonPressed.connect([this] {
+        static auto loginWidget = new LoginWidget(this);
 
         loginWidget->show();
         loginWidget->raise();


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Another followup to #1843, this time regarding the `LoginWidget` spawned when adding a new account.
