### PR TITLE
Add setting to limit number of historical messages to load on connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Minor: Allow highlights to be excluded from `/mentions`. Excluded highlights will not trigger tab highlights either. (#1793, #2036)
 - Minor: Flag all popup dialogs as actual dialogs so they get the relevant window manager hints (#1843, #2182, #2185, #2232, #2234)
 - Minor: Don't show update button for nightly builds on macOS and Linux, this was already the case for Windows (#2163, #2164)
+- Minor: Add a setting to limit the amount of historical messages loaded from the Recent Messages API (#2250, #2252)
 - Bugfix: Fix crash occurring when pressing Escape in the Color Picker Dialog (#1843)
 - Bugfix: Fix bug where the "check user follow state" event could trigger a network request requesting the user to follow or unfollow a user. By itself its quite harmless as it just repeats to Twitch the same follow state we had, so no follows should have been lost by this but it meant there was a rogue network request that was fired that could cause a crash (#1906)
 - Bugfix: /usercard command will now respect the "Automatically close user popup" setting (#1918)
@@ -54,9 +55,11 @@
 - Dev: Updated minimum required Qt framework version to 5.12. (#2210)
 
 ## 2.2.2
+
 - Bugfix: Fix a potential crash related to channel point rewards (279a80b)
 
 ## 2.2.1
+
 - Minor: Disable checking for updates on unsupported platforms (#1874)
 - Bugfix: Fix bug preventing users from setting the highlight color of the second entry in the "User" highlights tab (#1898)
 

--- a/src/PrecompiledHeader.hpp
+++ b/src/PrecompiledHeader.hpp
@@ -86,6 +86,7 @@
 #    include <QShortcut>
 #    include <QSizePolicy>
 #    include <QSlider>
+#    include <QSpinBox>
 #    include <QStackedLayout>
 #    include <QStandardPaths>
 #    include <QString>

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -675,7 +675,13 @@ void TwitchChannel::loadRecentMessages()
         return;
     }
 
-    NetworkRequest(Env::get().recentMessagesApiUrl.arg(this->getName()))
+    auto baseURL = Env::get().recentMessagesApiUrl.arg(this->getName());
+
+    auto url = QString("%1?limit=%2")
+                   .arg(baseURL)
+                   .arg(getSettings()->twitchMessageHistoryLimit);
+
+    NetworkRequest(url)
         .onSuccess([weak = weakOf<Channel>(this)](auto result) -> Outcome {
             auto shared = weak.lock();
             if (!shared)

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -327,8 +327,14 @@ public:
 
     IntSetting startUpNotification = {"/misc/startUpNotification", 0};
     QStringSetting currentVersion = {"/misc/currentVersion", ""};
+
     BoolSetting loadTwitchMessageHistoryOnConnect = {
         "/misc/twitch/loadMessageHistoryOnConnect", true};
+    IntSetting twitchMessageHistoryLimit = {
+        "/misc/twitch/messageHistoryLimit",
+        800,
+    };
+
     IntSetting emotesTooltipPreview = {"/misc/emotesTooltipPreview", 1};
     BoolSetting openLinksIncognito = {"/misc/openLinksIncognito", 0};
 

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -600,6 +600,9 @@ void GeneralPage::initLayout(GeneralPageView &layout)
                        s.highlightInlineWhispers);
     layout.addCheckbox("Load message history on connect",
                        s.loadTwitchMessageHistoryOnConnect);
+    // TODO: Change phrasing to use better english once we can tag settings, right now it's kept as history instead of historical so that the setting shows up when the user searches for history
+    layout.addIntInput("Max number of history messages to load on connect",
+                       s.twitchMessageHistoryLimit, 10, 800, 10);
 
     layout.addCheckbox("Enable experimental IRC support (requires restart)",
                        s.enableExperimentalIrc);

--- a/src/widgets/settingspages/GeneralPageView.cpp
+++ b/src/widgets/settingspages/GeneralPageView.cpp
@@ -189,6 +189,43 @@ ColorButton *GeneralPageView::addColorButton(
     return colorButton;
 }
 
+QSpinBox *GeneralPageView::addIntInput(const QString &text, IntSetting &setting,
+                                       int min, int max, int step)
+{
+    auto layout = new QHBoxLayout;
+
+    auto label = new QLabel(text + ":");
+
+    auto input = new QSpinBox;
+    input->setMinimum(min);
+    input->setMaximum(max);
+
+    // update when setting changes
+    setting.connect(
+        [input](const int &value, auto) {
+            input->setValue(value);
+        },
+        this->managedConnections_);
+
+    // update setting on value changed
+    QObject::connect(input, QOverload<int>::of(&QSpinBox::valueChanged), this,
+                     [&setting](int newValue) {
+                         setting = newValue;
+                     });
+
+    layout->addWidget(label);
+    layout->addStretch(1);
+    layout->addWidget(input);
+
+    this->addLayout(layout);
+
+    // groups
+    this->groups_.back().widgets.push_back({input, {text}});
+    this->groups_.back().widgets.push_back({label, {text}});
+
+    return input;
+}
+
 void GeneralPageView::addNavigationSpacing()
 {
     this->navigationLayout_->addSpacing(24);

--- a/src/widgets/settingspages/GeneralPageView.hpp
+++ b/src/widgets/settingspages/GeneralPageView.hpp
@@ -101,6 +101,8 @@ public:
                           bool editable = false);
     ColorButton *addColorButton(const QString &text, const QColor &color,
                                 pajlada::Settings::Setting<QString> &setting);
+    QSpinBox *addIntInput(const QString &text, IntSetting &setting, int min,
+                          int max, int step);
     void addNavigationSpacing();
 
     template <typename OnClick>


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

This pull request adds a setting to limit the amount of historical messages to fetch from the Recent Messages API.

Fixes #2250

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
