### PR TITLE
Enforce changelog entry via CI

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -1,0 +1,19 @@
+name: Changelog Check
+
+on:
+  pull_request:
+    branches: [ master ]
+    types: [ opened, synchronize, reopened, ready_for_review, labeled, unlabeled ]
+
+jobs:
+  check-changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      # Gives an error if there's no change in the changelog (except using label)
+      - name: Changelog check
+        uses: dangoslen/changelog-enforcer@v1.5.1
+        with:
+          changeLogPath: 'CHANGELOG.md'
+          skipLabel: 'no changelog entry needed'


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

This GitHub Actions workflow checks whether a PR includes a change to the `CHANGELOG.md` file. The changelog check can be disabled via a label: `no changelog entry needed` (needs to be creates separately by a repository admin)

I recommend that the admin also set the changelog check as "Required" in the branch protection settings to prevent PRs from being merged without either having a changelog entry or that have been marked as "no changelog entry needed".

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
