### PR TITLE
Remove "needs triage" issue label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Report something not working correctly that should be fixed
 title: ''
-labels: bug, needs triage
+labels: bug
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature-suggestion.md
+++ b/.github/ISSUE_TEMPLATE/feature-suggestion.md
@@ -2,7 +2,7 @@
 name: Feature suggestion
 about: Suggest an idea for this project
 title: ''
-labels: enhancement, needs triage
+labels: enhancement
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/something-completely-different.md
+++ b/.github/ISSUE_TEMPLATE/something-completely-different.md
@@ -2,9 +2,7 @@
 name: Something completely different
 about: If you have something completely different
 title: ''
-labels: needs triage
 assignees: ''
-
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/something-completely-different.md
+++ b/.github/ISSUE_TEMPLATE/something-completely-different.md
@@ -3,6 +3,7 @@ name: Something completely different
 about: If you have something completely different
 title: ''
 assignees: ''
+
 ---
 
 <!--


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Also, delete the label for existing issues here: https://github.com/Chatterino/chatterino2/issues/labels

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
