### PR TITLE
Fix crash when moving splits across windows and closing parent tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@
 - Bugfix: Fix a bug that caused `Ignore page` to fall into an infinity loop with an empty pattern and regex enabled (#2125)
 - Bugfix: Fix a crash caused by FrankerFaceZ responding with invalid emote links (#2191)
 - Bugfix: Fix a freeze caused by ignored & replaced phrases followed by Twitch Emotes (#2231)
-- Bugfix: Fix a crash bug that occurred when moving splits across windows and closing the "parent tab"
+- Bugfix: Fix a crash bug that occurred when moving splits across windows and closing the "parent tab" (#2249, #2259)
 - Dev: Updated minimum required Qt framework version to 5.12. (#2210)
 
 ## 2.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - Bugfix: Fix a bug that caused `Ignore page` to fall into an infinity loop with an empty pattern and regex enabled (#2125)
 - Bugfix: Fix a crash caused by FrankerFaceZ responding with invalid emote links (#2191)
 - Bugfix: Fix a freeze caused by ignored & replaced phrases followed by Twitch Emotes (#2231)
+- Bugfix: Fix a crash bug that occurred when moving splits across windows and closing the "parent tab"
 - Dev: Updated minimum required Qt framework version to 5.12. (#2210)
 
 ## 2.2.2

--- a/src/widgets/splits/SplitContainer.cpp
+++ b/src/widgets/splits/SplitContainer.cpp
@@ -211,19 +211,19 @@ void SplitContainer::addSplit(Split *split)
 
     this->refreshTab();
 
-    split->getChannelView().tabHighlightRequested.connect(
-        [this](HighlightState state) {
-            if (this->tab_ != nullptr)
-            {
-                this->tab_->setHighlightState(state);
-            }
-        });
+    this->managedConnect(split->getChannelView().tabHighlightRequested,
+                         [this](HighlightState state) {
+                             if (this->tab_ != nullptr)
+                             {
+                                 this->tab_->setHighlightState(state);
+                             }
+                         });
 
-    split->getChannelView().liveStatusChanged.connect([this]() {
+    this->managedConnect(split->getChannelView().liveStatusChanged, [this]() {
         this->refreshTabLiveStatus();
     });
 
-    split->focused.connect([this, split] {
+    this->managedConnect(split->focused, [this, split] {
         this->setSelected(split);
     });
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

- Use ManagedConnect instead of barebones connect
- Add changelog entry

Fixes #2249 

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
