### PR TITLE
Migrated Kraken's getUser to Helix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 - Bugfix: Fix a freeze caused by ignored & replaced phrases followed by Twitch Emotes (#2231)
 - Bugfix: Fix a crash bug that occurred when moving splits across windows and closing the "parent tab" (#2249, #2259)
 - Dev: Updated minimum required Qt framework version to 5.12. (#2210)
+- Dev: Migrated `Kraken::getUser` to Helix (#2260)
 
 ## 2.2.2
 

--- a/src/providers/twitch/api/Helix.hpp
+++ b/src/providers/twitch/api/Helix.hpp
@@ -20,19 +20,19 @@ using ResultCallback = std::function<void(T...)>;
 
 struct HelixUser {
     QString id;
+    QString login;
     QString createdAt;
     QString displayName;
     QString description;
-    QString login;
     QString profileImageUrl;
     int viewCount;
 
     explicit HelixUser(QJsonObject jsonObject)
         : id(jsonObject.value("id").toString())
+        , login(jsonObject.value("login").toString())
         , createdAt(jsonObject.value("created_at").toString())
         , displayName(jsonObject.value("display_name").toString())
         , description(jsonObject.value("description").toString())
-        , login(jsonObject.value("login").toString())
         , profileImageUrl(jsonObject.value("profile_image_url").toString())
         , viewCount(jsonObject.value("view_count").toInt())
     {

--- a/src/providers/twitch/api/Helix.hpp
+++ b/src/providers/twitch/api/Helix.hpp
@@ -20,17 +20,19 @@ using ResultCallback = std::function<void(T...)>;
 
 struct HelixUser {
     QString id;
-    QString login;
+    QString createdAt;
     QString displayName;
     QString description;
+    QString login;
     QString profileImageUrl;
     int viewCount;
 
     explicit HelixUser(QJsonObject jsonObject)
         : id(jsonObject.value("id").toString())
-        , login(jsonObject.value("login").toString())
+        , createdAt(jsonObject.value("created_at").toString())
         , displayName(jsonObject.value("display_name").toString())
         , description(jsonObject.value("description").toString())
+        , login(jsonObject.value("login").toString())
         , profileImageUrl(jsonObject.value("profile_image_url").toString())
         , viewCount(jsonObject.value("view_count").toInt())
     {

--- a/src/providers/twitch/api/Helix.hpp
+++ b/src/providers/twitch/api/Helix.hpp
@@ -21,8 +21,8 @@ using ResultCallback = std::function<void(T...)>;
 struct HelixUser {
     QString id;
     QString login;
-    QString createdAt;
     QString displayName;
+    QString createdAt;
     QString description;
     QString profileImageUrl;
     int viewCount;
@@ -30,8 +30,8 @@ struct HelixUser {
     explicit HelixUser(QJsonObject jsonObject)
         : id(jsonObject.value("id").toString())
         , login(jsonObject.value("login").toString())
-        , createdAt(jsonObject.value("created_at").toString())
         , displayName(jsonObject.value("display_name").toString())
+        , createdAt(jsonObject.value("created_at").toString())
         , description(jsonObject.value("description").toString())
         , profileImageUrl(jsonObject.value("profile_image_url").toString())
         , viewCount(jsonObject.value("view_count").toInt())

--- a/src/providers/twitch/api/Kraken.cpp
+++ b/src/providers/twitch/api/Kraken.cpp
@@ -29,26 +29,6 @@ void Kraken::getChannel(QString userId,
         .execute();
 }
 
-void Kraken::getUser(QString userId, ResultCallback<KrakenUser> successCallback,
-                     KrakenFailureCallback failureCallback)
-{
-    assert(!userId.isEmpty());
-
-    this->makeRequest("users/" + userId, {})
-        .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
-            auto root = result.parseJson();
-
-            successCallback(root);
-
-            return Success;
-        })
-        .onError([failureCallback](auto result) {
-            // TODO: make better xd
-            failureCallback();
-        })
-        .execute();
-}
-
 NetworkRequest Kraken::makeRequest(QString url, QUrlQuery urlQuery)
 {
     assert(!url.startsWith("/"));

--- a/src/providers/twitch/api/Kraken.hpp
+++ b/src/providers/twitch/api/Kraken.hpp
@@ -23,17 +23,6 @@ struct KrakenChannel {
     }
 };
 
-struct KrakenUser {
-    const QString createdAt;
-    const QString displayName;
-
-    KrakenUser(QJsonObject jsonObject)
-        : createdAt(jsonObject.value("created_at").toString())
-        , displayName(jsonObject.value("display_name").toString())
-    {
-    }
-};
-
 class Kraken final : boost::noncopyable
 {
 public:
@@ -41,10 +30,6 @@ public:
     void getChannel(QString userId,
                     ResultCallback<KrakenChannel> resultCallback,
                     KrakenFailureCallback failureCallback);
-
-    // https://dev.twitch.tv/docs/v5/reference/users#get-user-by-id
-    void getUser(QString userId, ResultCallback<KrakenUser> resultCallback,
-                 KrakenFailureCallback failureCallback);
 
     void update(QString clientId, QString oauthToken);
 

--- a/src/providers/twitch/api/README.md
+++ b/src/providers/twitch/api/README.md
@@ -4,15 +4,6 @@ this folder describes what sort of API requests we do, what permissions are requ
 ## Kraken (V5)
 We use a bunch of Kraken (V5) in Chatterino2.
 
-### Get User
-URL: https://dev.twitch.tv/docs/v5/reference/users#get-user-by-id
-
-Migration path: **Unknown**
-
- * We implement this in `providers/twitch/api/Kraken.cpp getUser`  
-   Used in:
-     * `UserInfoPopup` to get the "created at" date of a user
-
 ### Get Channel
 URL: https://dev.twitch.tv/docs/v5/reference/channels#get-channel
 
@@ -95,7 +86,7 @@ URL: https://dev.twitch.tv/docs/api/reference#get-users
 
  * We implement this in `providers/twitch/api/Helix.cpp fetchUsers`.  
    Used in:
-     * `UserInfoPopup` to get ID and viewcount of username we clicked
+     * `UserInfoPopup` to get ID, viewCount, displayName, createdAt of username we clicked
      * `CommandController` to power any commands that need to get a user ID
      * `Toasts` to get the profile picture of a streamer who just went live
      * `TwitchAccount` ignore and unignore features to translate user name to user ID

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -580,25 +580,14 @@ void UserInfoPopup::updateUserData()
 
         this->userId_ = user.id;
 
+        this->ui_.nameLabel->setText(user.displayName);
+        this->setWindowTitle(TEXT_TITLE.arg(user.displayName));
+        this->ui_.viewCountLabel->setText(TEXT_VIEWS.arg(user.viewCount));
+        this->ui_.createdDateLabel->setText(
+            TEXT_CREATED.arg(user.createdAt.section("T", 0, 0)));
         this->ui_.userIDLabel->setText(TEXT_USER_ID + user.id);
         this->ui_.userIDLabel->setProperty("copy-text", user.id);
 
-        this->ui_.viewCountLabel->setText(TEXT_VIEWS.arg(user.viewCount));
-        getKraken()->getUser(
-            user.id,
-            [this, hack](const auto &user) {
-                if (!hack.lock())
-                {
-                    return;
-                }
-                this->ui_.nameLabel->setText(user.displayName);
-                this->setWindowTitle(TEXT_TITLE.arg(user.displayName));
-                this->ui_.createdDateLabel->setText(
-                    TEXT_CREATED.arg(user.createdAt.section("T", 0, 0)));
-            },
-            [] {
-                // failure
-            });
         if (isInStreamerMode() &&
             getSettings()->streamerModeHideUsercardAvatars)
         {


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Since Helix API now has `created_at` field exposed in API response, I decided to migrate properties from Kraken call to Helix. Since method calling old API wasn't used anywhere else, I straight up purged it.
It's also worth to mention that because of this we now make 1 less API call while opening a usercard, which should speed this process up a little.