### PR TITLE
Added Ctrl+1/2/3/... shortcuts to Emote Popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Major: Added "Channel Filters". See https://wiki.chatterino.com/Filters/ for how they work or how to configure them. (#1748, #2083, #2090, #2200)
 - Major: Added Streamer Mode configuration (under `Settings -> General`), where you can select which features of Chatterino should behave differently when you are in Streamer Mode. (#2001)
+- Minor: Added Ctrl + 1/2/3/... and Ctrl+9 shortcuts to Emote Popup (activated with Ctrl+E). They work exactly the same as shortcuts in main window. (#2263)
 - Minor: Made "#channel" in `/mentions` tab a clickable link which takes you to the channel that you were mentioned in. (#2220)
 - Minor: Added a keyboard shortcut (Ctrl+F5) for "Reconnect" (#2215)
 - Minor: Made `Try to find usernames without @ prefix` option still resolve usernames when special characters (commas, dots, (semi)colons, exclamation mark, question mark) are appended to them. (#2212)

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -305,12 +305,10 @@ void Window::addShortcuts()
     // CTRL + 1-8 to open corresponding tab.
     for (auto i = 0; i < 8; i++)
     {
-        char hotkey[7];
-        std::sprintf(hotkey, "CTRL+%d", i + 1);
         const auto openTab = [this, i] {
             this->notebook_->selectIndex(i);
         };
-        createWindowShortcut(this, hotkey, openTab);
+        createWindowShortcut(this, QString("CTRL+%1").arg(i + 1), openTab);
     }
 
     createWindowShortcut(this, "CTRL+9", [this] {

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -308,7 +308,8 @@ void Window::addShortcuts()
         const auto openTab = [this, i] {
             this->notebook_->selectIndex(i);
         };
-        createWindowShortcut(this, QString("CTRL+%1").arg(i + 1), openTab);
+        createWindowShortcut(this, QString("CTRL+%1").arg(i + 1).toUtf8(),
+                             openTab);
     }
 
     createWindowShortcut(this, "CTRL+9", [this] {

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -156,6 +156,23 @@ EmotePopup::EmotePopup(QWidget *parent)
 
     this->loadEmojis();
 
+    // CTRL + 1-8 to open corresponding tab
+    for (auto i = 0; i < 8; i++)
+    {
+        char hotkey[7];
+        std::sprintf(hotkey, "CTRL+%d", i + 1);
+        const auto openTab = [this, i, notebook] {
+            notebook->selectIndex(i);
+        };
+        createWindowShortcut(this, hotkey, openTab);
+    }
+
+    // Open last tab (first one from right)
+    createWindowShortcut(this, "CTRL+9", [=] {
+        notebook->selectLastTab();
+    });
+
+    // Cycle through tabs
     createWindowShortcut(this, "CTRL+Tab", [=] {
         notebook->selectNextTab();
     });

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -162,7 +162,8 @@ EmotePopup::EmotePopup(QWidget *parent)
         const auto openTab = [this, i, notebook] {
             notebook->selectIndex(i);
         };
-        createWindowShortcut(this, QString("CTRL+%1").arg(i + 1), openTab);
+        createWindowShortcut(this, QString("CTRL+%1").arg(i + 1).toUtf8(),
+                             openTab);
     }
 
     // Open last tab (first one from right)

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -159,12 +159,10 @@ EmotePopup::EmotePopup(QWidget *parent)
     // CTRL + 1-8 to open corresponding tab
     for (auto i = 0; i < 8; i++)
     {
-        char hotkey[7];
-        std::sprintf(hotkey, "CTRL+%d", i + 1);
         const auto openTab = [this, i, notebook] {
             notebook->selectIndex(i);
         };
-        createWindowShortcut(this, hotkey, openTab);
+        createWindowShortcut(this, QString("CTRL+%1").arg(i + 1), openTab);
     }
 
     // Open last tab (first one from right)


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Added Ctrl + 1/2/3/... shortcuts to Emote Popup window. To keep consistency with shortcuts from main window, I decided to add Ctrl + 9 (selecting rightmost tab) as well. I thought it could be a nice enchancement which won't break anything, but will make some crazy keyboard shortcut nerds like me happy.
