### PR TITLE
Further placeholder text fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Minor: Added a keyboard shortcut (Ctrl+F5) for "Reconnect" (#2215)
 - Minor: Made `Try to find usernames without @ prefix` option still resolve usernames when special characters (commas, dots, (semi)colons, exclamation mark, question mark) are appended to them. (#2212)
 - Minor: Made usercard update user's display name (#2160)
-- Minor: Added placeholder text for message text input box. (#2143, #2149)
+- Minor: Added placeholder text for message text input box. (#2143, #2149, #2264)
 - Minor: Added support for FrankerFaceZ badges. (#2101, part of #1658)
 - Minor: Added a navigation list to the settings and reordered them.
 - Minor: Added a link to twitchemotes.com to context menu when right-clicking Twitch emotes. (#2214)

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -137,11 +137,15 @@ Split::Split(QWidget *parent)
 
     this->input_->ui_.textEdit->installEventFilter(parent);
 
+    // update placeheolder text on Twitch account change and channel change
     this->signalHolder_.managedConnect(
         getApp()->accounts->twitch.currentUserChanged, [this] {
-            this->onAccountSelected();
+            this->updateInputPlaceholder();
         });
-    this->onAccountSelected();
+    this->signalHolder_.managedConnect(channelChanged, [this] {
+        this->updateInputPlaceholder();
+    });
+    this->updateInputPlaceholder();
 
     this->view_->mouseDown.connect([this](QMouseEvent *) {
         this->giveFocus(Qt::MouseFocusReason);
@@ -290,7 +294,7 @@ void Split::setContainer(SplitContainer *container)
     this->container_ = container;
 }
 
-void Split::onAccountSelected()
+void Split::updateInputPlaceholder()
 {
     if (!this->getChannel()->isTwitchChannel())
     {
@@ -312,19 +316,6 @@ void Split::onAccountSelected()
     }
 
     this->input_->ui_.textEdit->setPlaceholderText(placeholderText);
-
-    this->updateTooltipColor();
-    this->signalHolder_.managedConnect(this->theme->updated, [this]() {
-        this->updateTooltipColor();
-    });
-}
-
-void Split::updateTooltipColor()
-{
-    QPalette dankPalette;
-    dankPalette.setColor(QPalette::PlaceholderText,
-                         this->theme->messages.textColors.chatPlaceholder);
-    this->input_->ui_.textEdit->setPalette(dankPalette);
 }
 
 IndirectChannel Split::getIndirectChannel()

--- a/src/widgets/splits/Split.hpp
+++ b/src/widgets/splits/Split.hpp
@@ -96,8 +96,7 @@ protected:
 private:
     void channelNameUpdated(const QString &newChannelName);
     void handleModifiers(Qt::KeyboardModifiers modifiers);
-    void onAccountSelected();
-    void updateTooltipColor();
+    void updateInputPlaceholder();
 
     SplitContainer *container_;
     IndirectChannel channel_;

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -127,13 +127,17 @@ void SplitInput::scaleChangedEvent(float scale)
 
 void SplitInput::themeChangedEvent()
 {
-    QPalette palette;
+    QPalette palette, placeholderPalette;
 
-    palette.setColor(QPalette::Foreground, this->theme->splits.input.text);
+    palette.setColor(QPalette::WindowText, this->theme->splits.input.text);
+    placeholderPalette.setColor(
+        QPalette::PlaceholderText,
+        this->theme->messages.textColors.chatPlaceholder);
 
     this->updateEmoteButton();
     this->ui_.textEditLength->setPalette(palette);
 
+    this->ui_.textEdit->setPalette(placeholderPalette);
     this->ui_.textEdit->setStyleSheet(this->theme->splits.input.styleSheet);
 
     this->ui_.hbox->setMargin(


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

- Added an event listener for `channelChanged` signal to ensure placeholder is preserved when changing channels.
- Moved entire function related to applying placeholder's color to SplitInput.cpp to ensure it will be applied in all cases, preventing random edge cases listed in #2253.
- While I was at it, in `SplitInput.cpp` I also changed `QPalette::Foreground` enum to `QPalette::WindowText` due to [deprecation warning](https://doc.qt.io/qt-5/qpalette.html#ColorRole-enum) since Qt 5.13.

Closes #2253
