### PR TITLE
Improve the "You are banned" message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Major: Added "Channel Filters". See https://wiki.chatterino.com/Filters/ for how they work or how to configure them. (#1748, #2083, #2090, #2200)
 - Major: Added Streamer Mode configuration (under `Settings -> General`), where you can select which features of Chatterino should behave differently when you are in Streamer Mode. (#2001)
+- Minor: Added reconnect link to the "You are banned" message.
 - Minor: Made "#channel" in `/mentions` tab a clickable link which takes you to the channel that you were mentioned in. (#2220)
 - Minor: Added a keyboard shortcut (Ctrl+F5) for "Reconnect" (#2215)
 - Minor: Made `Try to find usernames without @ prefix` option still resolve usernames when special characters (commas, dots, (semi)colons, exclamation mark, question mark) are appended to them. (#2212)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Major: Added "Channel Filters". See https://wiki.chatterino.com/Filters/ for how they work or how to configure them. (#1748, #2083, #2090, #2200)
 - Major: Added Streamer Mode configuration (under `Settings -> General`), where you can select which features of Chatterino should behave differently when you are in Streamer Mode. (#2001)
-- Minor: Added reconnect link to the "You are banned" message.
+- Minor: Added reconnect link to the "You are banned" message. (#2266)
 - Minor: Made "#channel" in `/mentions` tab a clickable link which takes you to the channel that you were mentioned in. (#2220)
 - Minor: Added a keyboard shortcut (Ctrl+F5) for "Reconnect" (#2215)
 - Minor: Made `Try to find usernames without @ prefix` option still resolve usernames when special characters (commas, dots, (semi)colons, exclamation mark, question mark) are appended to them. (#2212)

--- a/src/messages/Link.hpp
+++ b/src/messages/Link.hpp
@@ -21,6 +21,7 @@ public:
         AutoModDeny,
         OpenAccountsPage,
         JumpToChannel,
+        Reconnect
     };
 
     Link();

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -700,7 +700,7 @@ std::vector<MessagePtr> IrcMessageHandler::parseNoticeMessage(
                                         .arg(curUser->getUserName());
         const auto loginPromptText = QString(" Try adding your account again.");
 
-        MessageBuilder builder;
+        auto builder = MessageBuilder();
         builder.message().flags.set(MessageFlag::System);
 
         builder.emplace<TimestampElement>();

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -25,7 +25,6 @@ MessagePtr generateBannedMessage(bool confirmedBan)
 {
     const auto linkColor = MessageColor(MessageColor::Link);
     const auto accountsLink = Link(Link::Reconnect, QString());
-    const auto curUser = getApp()->accounts->twitch.getCurrent();
     const auto bannedText =
         confirmedBan
             ? QString("You were banned from this channel!")

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -38,7 +38,7 @@ MessagePtr generateBannedMessage(bool confirmedBan)
                   "If you believe you have been unbanned, try reconnecting.")
             : QString("Try reconnecting.");
 
-    auto builder = MessageBuilder();
+    MessageBuilder builder;
     builder.message().flags.set(MessageFlag::System);
 
     builder.emplace<TimestampElement>();

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -26,9 +26,11 @@ MessagePtr generateBannedMessage(bool confirmedBan)
     const auto linkColor = MessageColor(MessageColor::Link);
     const auto accountsLink = Link(Link::Reconnect, QString());
     const auto curUser = getApp()->accounts->twitch.getCurrent();
-    const auto bannedText = confirmedBan
-                                ? QString("You were banned from this channel!")
-                                : QString("You were forced off this channel.");
+    const auto bannedText =
+        confirmedBan
+            ? QString("You were banned from this channel!")
+            : QString(
+                  "Your connection to this channel was unexpectedly dropped.");
 
     const auto reconnectPromptText =
         confirmedBan
@@ -698,7 +700,7 @@ std::vector<MessagePtr> IrcMessageHandler::parseNoticeMessage(
                                         .arg(curUser->getUserName());
         const auto loginPromptText = QString(" Try adding your account again.");
 
-        auto builder = MessageBuilder();
+        MessageBuilder builder;
         builder.message().flags.set(MessageFlag::System);
 
         builder.emplace<TimestampElement>();

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -2080,6 +2080,10 @@ void ChannelView::handleLinkClick(QMouseEvent *event, const Link &link,
             }
         }
         break;
+        case Link::Reconnect: {
+            this->underlyingChannel_.get()->reconnect();
+        }
+        break;
 
         default:;
     }


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->

Closes #2110 
## Adds:
  - *You were forced off the channel, try reconnecting* message
  - *You have been banned* message
  - `Link::Reconnect`
## Removes:
  - nothing
## Changes
  - How the *You are banned message* is handled.

## Notes
An unexpected `PART` doesn't exactly mean being banned. If you get banned you get a Pubsub message saying that you were  after the `PART`.

## Screenshots
![2020-12-08_16-46](https://user-images.githubusercontent.com/25011746/101505699-8d037f80-396c-11eb-9af0-57ac4599efa9.png)
