### PR TITLE
Made emote tooltips use author's displayName consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Major: Added "Channel Filters". See https://wiki.chatterino.com/Filters/ for how they work or how to configure them. (#1748, #2083, #2090, #2200)
 - Major: Added Streamer Mode configuration (under `Settings -> General`), where you can select which features of Chatterino should behave differently when you are in Streamer Mode. (#2001)
+- Minor: Made BetterTTV emote tooltips use authors' display name. (#2267)
 - Minor: Made "#channel" in `/mentions` tab a clickable link which takes you to the channel that you were mentioned in. (#2220)
 - Minor: Added a keyboard shortcut (Ctrl+F5) for "Reconnect" (#2215)
 - Minor: Made `Try to find usernames without @ prefix` option still resolve usernames when special characters (commas, dots, (semi)colons, exclamation mark, question mark) are appended to them. (#2212)

--- a/src/providers/bttv/BttvEmotes.cpp
+++ b/src/providers/bttv/BttvEmotes.cpp
@@ -56,7 +56,7 @@ namespace {
                 ImageSet{Image::fromUrl(getEmoteLinkV3(id, "1x"), 1),
                          Image::fromUrl(getEmoteLinkV3(id, "2x"), 0.5),
                          Image::fromUrl(getEmoteLinkV3(id, "3x"), 0.25)},
-                Tooltip{name.string + "<br />Global BetterTTV Emote"},
+                Tooltip{name.string + "<br>Global BetterTTV Emote"},
                 Url{emoteLinkFormat.arg(id.string)},
             });
 
@@ -66,12 +66,13 @@ namespace {
 
         return {Success, std::move(emotes)};
     }
-    std::pair<Outcome, EmoteMap> parseChannelEmotes(const QJsonObject &jsonRoot,
-                                                    const QString &userName)
+    std::pair<Outcome, EmoteMap> parseChannelEmotes(
+        const QJsonObject &jsonRoot, const QString &channelDisplayName)
     {
         auto emotes = EmoteMap();
 
-        auto innerParse = [&jsonRoot, &emotes, &userName](const char *key) {
+        auto innerParse = [&jsonRoot, &emotes,
+                           &channelDisplayName](const char *key) {
             auto jsonEmotes = jsonRoot.value(key).toArray();
             for (auto jsonEmote_ : jsonEmotes)
             {
@@ -81,9 +82,8 @@ namespace {
                 auto name = EmoteName{jsonEmote.value("code").toString()};
                 auto author = EmoteAuthor{jsonEmote.value("user")
                                               .toObject()
-                                              .value("name")
+                                              .value("displayName")
                                               .toString()};
-                // emoteObject.value("imageType").toString();
 
                 auto emote = Emote({
                     name,
@@ -92,10 +92,13 @@ namespace {
                         Image::fromUrl(getEmoteLinkV3(id, "2x"), 0.5),
                         Image::fromUrl(getEmoteLinkV3(id, "3x"), 0.25),
                     },
-                    Tooltip{name.string + "<br>Channel BetterTTV Emote" +
-                            ((author.string.isEmpty())
-                                 ? "<br>By: " + userName.toUtf8()
-                                 : "<br>By: " + author.string)},
+                    Tooltip{
+                        QString("%1<br>%2 BetterTTV Emote<br>By: %3")
+                            .arg(name.string)
+                            // when author is empty, it is a channel emote created by the broadcaster
+                            .arg(author.string.isEmpty() ? "Channel" : "Shared")
+                            .arg(author.string.isEmpty() ? channelDisplayName
+                                                         : author.string)},
                     Url{emoteLinkFormat.arg(id.string)},
                 });
 
@@ -149,15 +152,18 @@ void BttvEmotes::loadEmotes()
 }
 
 void BttvEmotes::loadChannel(std::weak_ptr<Channel> channel,
-                             const QString &channelId, const QString &userName,
+                             const QString &channelId,
+                             const QString &channelDisplayName,
                              std::function<void(EmoteMap &&)> callback,
                              bool manualRefresh)
 {
     NetworkRequest(QString(bttvChannelEmoteApiUrl) + channelId)
         .timeout(3000)
-        .onSuccess([callback = std::move(callback), channel, &userName,
+        .onSuccess([callback = std::move(callback), channel,
+                    &channelDisplayName,
                     manualRefresh](auto result) -> Outcome {
-            auto pair = parseChannelEmotes(result.parseJson(), userName);
+            auto pair =
+                parseChannelEmotes(result.parseJson(), channelDisplayName);
             if (pair.first)
                 callback(std::move(pair.second));
             if (auto shared = channel.lock(); manualRefresh)

--- a/src/providers/bttv/BttvEmotes.hpp
+++ b/src/providers/bttv/BttvEmotes.hpp
@@ -26,7 +26,8 @@ public:
     boost::optional<EmotePtr> emote(const EmoteName &name) const;
     void loadEmotes();
     static void loadChannel(std::weak_ptr<Channel> channel,
-                            const QString &channelId, const QString &userName,
+                            const QString &channelId,
+                            const QString &channelDisplayName,
                             std::function<void(EmoteMap &&)> callback,
                             bool manualRefresh);
 

--- a/src/providers/ffz/FfzEmotes.cpp
+++ b/src/providers/ffz/FfzEmotes.cpp
@@ -68,7 +68,7 @@ namespace {
 
                 auto emote = Emote();
                 fillInEmoteData(urls, name,
-                                name.string + "<br/>Global FFZ Emote", emote);
+                                name.string + "<br>Global FFZ Emote", emote);
                 emote.homePage =
                     Url{QString("https://www.frankerfacez.com/emoticon/%1-%2")
                             .arg(id.string)
@@ -137,8 +137,9 @@ namespace {
 
                 Emote emote;
                 fillInEmoteData(urls, name,
-                                name.string + "<br/>Channel FFZ Emote" +
-                                    "<br />By: " + author.string,
+                                QString("%1<br>Channel FFZ Emote<br>By: %2")
+                                    .arg(name.string)
+                                    .arg(author.string),
                                 emote);
                 emote.homePage =
                     Url{QString("https://www.frankerfacez.com/emoticon/%1-%2")

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -241,7 +241,7 @@ void TwitchChannel::setLocalizedName(const QString &name)
 void TwitchChannel::refreshBTTVChannelEmotes(bool manualRefresh)
 {
     BttvEmotes::loadChannel(
-        weakOf<Channel>(this), this->roomId(), this->getDisplayName(),
+        weakOf<Channel>(this), this->roomId(), this->getLocalizedName(),
         [this, weak = weakOf<Channel>(this)](auto &&emoteMap) {
             if (auto shared = weak.lock())
                 this->bttvEmotes_.set(

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -241,7 +241,7 @@ void TwitchChannel::setLocalizedName(const QString &name)
 void TwitchChannel::refreshBTTVChannelEmotes(bool manualRefresh)
 {
     BttvEmotes::loadChannel(
-        weakOf<Channel>(this), this->roomId(), this->getName(),
+        weakOf<Channel>(this), this->roomId(), this->getDisplayName(),
         [this, weak = weakOf<Channel>(this)](auto &&emoteMap) {
             if (auto shared = weak.lock())
                 this->bttvEmotes_.set(


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Before, only tooltips for FrankerFaceZ emotes used displayName. After having displayName methods for current channel implemented in #2189, I decided to make use of those and made BetterTTV emote tooltips consistent with FrankerFaceZ ones.
Also made a split between channel emotes (created by broadcaster) and actual shared emotes (that were created by others).

Related: #1765, Feature originally implemented in #1721