### PR TITLE
Improve search popup window titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Major: Added "Channel Filters". See https://wiki.chatterino.com/Filters/ for how they work or how to configure them. (#1748, #2083, #2090, #2200)
 - Major: Added Streamer Mode configuration (under `Settings -> General`), where you can select which features of Chatterino should behave differently when you are in Streamer Mode. (#2001)
-- Minor: Improve search popup window titles (#2268)
+- Minor: Improved search popup window titles. (#2268)
 - Minor: Made "#channel" in `/mentions` tab a clickable link which takes you to the channel that you were mentioned in. (#2220)
 - Minor: Added a keyboard shortcut (Ctrl+F5) for "Reconnect" (#2215)
 - Minor: Made `Try to find usernames without @ prefix` option still resolve usernames when special characters (commas, dots, (semi)colons, exclamation mark, question mark) are appended to them. (#2212)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Major: Added "Channel Filters". See https://wiki.chatterino.com/Filters/ for how they work or how to configure them. (#1748, #2083, #2090, #2200)
 - Major: Added Streamer Mode configuration (under `Settings -> General`), where you can select which features of Chatterino should behave differently when you are in Streamer Mode. (#2001)
+- Minor: Improve search popup window titles (#2268)
 - Minor: Made "#channel" in `/mentions` tab a clickable link which takes you to the channel that you were mentioned in. (#2220)
 - Minor: Added a keyboard shortcut (Ctrl+F5) for "Reconnect" (#2215)
 - Minor: Made `Try to find usernames without @ prefix` option still resolve usernames when special characters (commas, dots, (semi)colons, exclamation mark, question mark) are appended to them. (#2212)

--- a/src/widgets/helper/SearchPopup.cpp
+++ b/src/widgets/helper/SearchPopup.cpp
@@ -81,7 +81,25 @@ void SearchPopup::setChannel(const ChannelPtr &channel)
 
 void SearchPopup::updateWindowTitle()
 {
-    this->setWindowTitle("Searching in " + this->channelName_ + "s history");
+    QString historyName;
+
+    if (this->channelName_ == "/whispers")
+    {
+        historyName = "whispers";
+    }
+    else if (this->channelName_ == "/mentions")
+    {
+        historyName = "mentions";
+    }
+    else if (this->channelName_.isEmpty())
+    {
+        historyName = "<empty>'s";
+    }
+    else
+    {
+        historyName = QString("%1's").arg(this->channelName_);
+    }
+    this->setWindowTitle("Searching in " + historyName + " history");
 }
 
 void SearchPopup::search()


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
Closes #2166 
Adds special cases for `/whispers`, `/mentions` and empty tabs, and an apostrophe in the titles.