### PR TITLE
Color mentions to match the mentioned users color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@
 - Minor: Don't show update button for nightly builds on macOS and Linux, this was already the case for Windows (#2163, #2164)
 - Minor: Tab and split titles now use display/localized channel names (#2189)
 - Minor: Add a setting to limit the amount of historical messages loaded from the Recent Messages API (#2250, #2252)
-- Minor: Color mentions to match the mentioned users (#1963, #2121)
+- Minor: Color mentions to match the mentioned users (#1963, #2121, #2284)
 - Bugfix: Fix crash occurring when pressing Escape in the Color Picker Dialog (#1843)
 - Bugfix: Fix bug where the "check user follow state" event could trigger a network request requesting the user to follow or unfollow a user. By itself its quite harmless as it just repeats to Twitch the same follow state we had, so no follows should have been lost by this but it meant there was a rogue network request that was fired that could cause a crash (#1906)
 - Bugfix: /usercard command will now respect the "Automatically close user popup" setting (#1918)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Major: Added "Channel Filters". See https://wiki.chatterino.com/Filters/ for how they work or how to configure them. (#1748, #2083, #2090, #2200)
 - Major: Added Streamer Mode configuration (under `Settings -> General`), where you can select which features of Chatterino should behave differently when you are in Streamer Mode. (#2001)
-- Major: Color mentions to match the mentioned users. You can disable this by unchecking "Color usernames" under `Settings -> General -> Advanced (misc.)`. (#1963, #2284)
+- Major: Color mentions to match the mentioned users. You can disable this by unchecking "Color @usernames" under `Settings -> General -> Advanced (misc.)`. (#1963, #2284)
 - Minor: Made BetterTTV emote tooltips use authors' display name. (#2267)
 - Minor: Added Ctrl + 1/2/3/... and Ctrl+9 shortcuts to Emote Popup (activated with Ctrl+E). They work exactly the same as shortcuts in main window. (#2263)
 - Minor: Added reconnect link to the "You are banned" message. (#2266)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Minor: Don't show update button for nightly builds on macOS and Linux, this was already the case for Windows (#2163, #2164)
 - Minor: Tab and split titles now use display/localized channel names (#2189)
 - Minor: Add a setting to limit the amount of historical messages loaded from the Recent Messages API (#2250, #2252)
+- Minor: Color mentions to match the mentioned users (#1963, #2121)
 - Bugfix: Fix crash occurring when pressing Escape in the Color Picker Dialog (#1843)
 - Bugfix: Fix bug where the "check user follow state" event could trigger a network request requesting the user to follow or unfollow a user. By itself its quite harmless as it just repeats to Twitch the same follow state we had, so no follows should have been lost by this but it meant there was a rogue network request that was fired that could cause a crash (#1906)
 - Bugfix: /usercard command will now respect the "Automatically close user popup" setting (#1918)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Major: Added "Channel Filters". See https://wiki.chatterino.com/Filters/ for how they work or how to configure them. (#1748, #2083, #2090, #2200)
 - Major: Added Streamer Mode configuration (under `Settings -> General`), where you can select which features of Chatterino should behave differently when you are in Streamer Mode. (#2001)
+- Major: Color mentions to match the mentioned users. You can disable this by unchecking "Color usernames" under `Settings -> General -> Advanced (misc.)`. (#1963, #2121, #2284)
 - Minor: Made BetterTTV emote tooltips use authors' display name. (#2267)
 - Minor: Added Ctrl + 1/2/3/... and Ctrl+9 shortcuts to Emote Popup (activated with Ctrl+E). They work exactly the same as shortcuts in main window. (#2263)
 - Minor: Added reconnect link to the "You are banned" message. (#2266)
@@ -40,7 +41,6 @@
 - Minor: Don't show update button for nightly builds on macOS and Linux, this was already the case for Windows (#2163, #2164)
 - Minor: Tab and split titles now use display/localized channel names (#2189)
 - Minor: Add a setting to limit the amount of historical messages loaded from the Recent Messages API (#2250, #2252)
-- Minor: Color mentions to match the mentioned users (#1963, #2121, #2284)
 - Bugfix: Fix crash occurring when pressing Escape in the Color Picker Dialog (#1843)
 - Bugfix: Fix bug where the "check user follow state" event could trigger a network request requesting the user to follow or unfollow a user. By itself its quite harmless as it just repeats to Twitch the same follow state we had, so no follows should have been lost by this but it meant there was a rogue network request that was fired that could cause a crash (#1906)
 - Bugfix: /usercard command will now respect the "Automatically close user popup" setting (#1918)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Major: Added "Channel Filters". See https://wiki.chatterino.com/Filters/ for how they work or how to configure them. (#1748, #2083, #2090, #2200)
 - Major: Added Streamer Mode configuration (under `Settings -> General`), where you can select which features of Chatterino should behave differently when you are in Streamer Mode. (#2001)
-- Major: Color mentions to match the mentioned users. You can disable this by unchecking "Color usernames" under `Settings -> General -> Advanced (misc.)`. (#1963, #2121, #2284)
+- Major: Color mentions to match the mentioned users. You can disable this by unchecking "Color usernames" under `Settings -> General -> Advanced (misc.)`. (#1963, #2284)
 - Minor: Made BetterTTV emote tooltips use authors' display name. (#2267)
 - Minor: Added Ctrl + 1/2/3/... and Ctrl+9 shortcuts to Emote Popup (activated with Ctrl+E). They work exactly the same as shortcuts in main window. (#2263)
 - Minor: Added reconnect link to the "You are banned" message. (#2266)

--- a/src/common/ChannelChatters.cpp
+++ b/src/common/ChannelChatters.cpp
@@ -65,6 +65,11 @@ void ChannelChatters::addPartedUser(const QString &user)
     }
 }
 
+void ChannelChatters::setChatters(UsernameSet &&set)
+{
+    *this->chatters_.access() = set;
+}
+
 const QColor ChannelChatters::getUserColor(const QString &user)
 {
     const auto chatterColors = this->chatterColors_.access();
@@ -78,11 +83,6 @@ const QColor ChannelChatters::getUserColor(const QString &user)
     {
         return search->second;
     }
-}
-
-void ChannelChatters::setChatters(UsernameSet &&set)
-{
-    *this->chatters_.access() = set;
 }
 
 void ChannelChatters::setUserColor(const QString &user, const QColor &color)

--- a/src/common/ChannelChatters.cpp
+++ b/src/common/ChannelChatters.cpp
@@ -77,7 +77,8 @@ const QColor ChannelChatters::getUserColor(const QString &user)
     const auto search = chatterColors->find(user.toLower());
     if (search == chatterColors->end())
     {
-        return QColor(MessageColor::Text);
+        // Returns an invalid color so we can decide not to override `textColor`
+        return QColor();
     }
     else
     {

--- a/src/common/ChannelChatters.cpp
+++ b/src/common/ChannelChatters.cpp
@@ -67,9 +67,9 @@ void ChannelChatters::addPartedUser(const QString &user)
 
 const QColor ChannelChatters::getUserColor(const QString &user)
 {
-    auto chatterColors = this->chatterColors_.access();
+    const auto chatterColors = this->chatterColors_.access();
 
-    auto search = chatterColors->find(user.toLower());
+    const auto search = chatterColors->find(user.toLower());
     if (search == chatterColors->end())
     {
         return QColor(MessageColor::Text);
@@ -85,10 +85,10 @@ void ChannelChatters::setChatters(UsernameSet &&set)
     *this->chatters_.access() = set;
 }
 
-void ChannelChatters::setUserColor(const QString &user, const QColor color)
+void ChannelChatters::setUserColor(const QString &user, const QColor &color)
 {
-    auto chatterColors = this->chatterColors_.access();
-    chatterColors->emplace(user.toLower(), color);
+    const auto chatterColors = this->chatterColors_.access();
+    chatterColors->insert_or_assign(user.toLower(), color);
 }
 
 }  // namespace chatterino

--- a/src/common/ChannelChatters.cpp
+++ b/src/common/ChannelChatters.cpp
@@ -64,9 +64,31 @@ void ChannelChatters::addPartedUser(const QString &user)
         });
     }
 }
+
+const QColor ChannelChatters::getUserColor(const QString &user)
+{
+    auto chatterColors = this->chatterColors_.access();
+
+    auto search = chatterColors->find(user.toLower());
+    if (search == chatterColors->end())
+    {
+        return QColor(MessageColor::Text);
+    }
+    else
+    {
+        return search->second;
+    }
+}
+
 void ChannelChatters::setChatters(UsernameSet &&set)
 {
     *this->chatters_.access() = set;
+}
+
+void ChannelChatters::setUserColor(const QString &user, const QColor color)
+{
+    auto chatterColors = this->chatterColors_.access();
+    chatterColors->emplace(user.toLower(), color);
 }
 
 }  // namespace chatterino

--- a/src/common/ChannelChatters.cpp
+++ b/src/common/ChannelChatters.cpp
@@ -80,10 +80,8 @@ const QColor ChannelChatters::getUserColor(const QString &user)
         // Returns an invalid color so we can decide not to override `textColor`
         return QColor();
     }
-    else
-    {
-        return search->second;
-    }
+
+    return search->second;
 }
 
 void ChannelChatters::setUserColor(const QString &user, const QColor &color)

--- a/src/common/ChannelChatters.hpp
+++ b/src/common/ChannelChatters.hpp
@@ -17,8 +17,8 @@ public:
     void addRecentChatter(const QString &user);
     void addJoinedUser(const QString &user);
     void addPartedUser(const QString &user);
-    const QColor getUserColor(const QString &user);
     void setChatters(UsernameSet &&set);
+    const QColor getUserColor(const QString &user);
     void setUserColor(const QString &user, const QColor &color);
 
 private:

--- a/src/common/ChannelChatters.hpp
+++ b/src/common/ChannelChatters.hpp
@@ -19,7 +19,7 @@ public:
     void addPartedUser(const QString &user);
     const QColor getUserColor(const QString &user);
     void setChatters(UsernameSet &&set);
-    void setUserColor(const QString &user, const QColor color);
+    void setUserColor(const QString &user, const QColor &color);
 
 private:
     Channel &channel_;

--- a/src/common/ChannelChatters.hpp
+++ b/src/common/ChannelChatters.hpp
@@ -17,13 +17,16 @@ public:
     void addRecentChatter(const QString &user);
     void addJoinedUser(const QString &user);
     void addPartedUser(const QString &user);
+    const QColor getUserColor(const QString &user);
     void setChatters(UsernameSet &&set);
+    void setUserColor(const QString &user, const QColor color);
 
 private:
     Channel &channel_;
 
     // maps 2 char prefix to set of names
     UniqueAccess<UsernameSet> chatters_;
+    UniqueAccess<std::map<QString, QColor>> chatterColors_;
 
     // combines multiple joins/parts into one message
     UniqueAccess<QStringList> joinedUsers_;

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -482,7 +482,12 @@ void TwitchMessageBuilder::addTextOrEmoji(const QString &string_)
 
             if (getSettings()->colorUsernames)
             {
-                textColor = this->twitchChannel->getUserColor(username);
+                if (auto userColor =
+                        this->twitchChannel->getUserColor(username);
+                    userColor.isValid())
+                {
+                    textColor = userColor;
+                }
             }
 
             this->emplace<TextElement>(string, MessageElementFlag::BoldUsername,
@@ -506,7 +511,12 @@ void TwitchMessageBuilder::addTextOrEmoji(const QString &string_)
         {
             if (getSettings()->colorUsernames)
             {
-                textColor = this->twitchChannel->getUserColor(username);
+                if (auto userColor =
+                        this->twitchChannel->getUserColor(username);
+                    userColor.isValid())
+                {
+                    textColor = userColor;
+                }
             }
 
             this->emplace<TextElement>(string, MessageElementFlag::BoldUsername,

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -479,14 +479,18 @@ void TwitchMessageBuilder::addTextOrEmoji(const QString &string_)
         if (match.hasMatch())
         {
             QString username = match.captured(1);
-            auto userColor = this->twitchChannel->getUserColor(username);
+
+            if (getSettings()->colorUsernames)
+            {
+                textColor = this->twitchChannel->getUserColor(username);
+            }
 
             this->emplace<TextElement>(string, MessageElementFlag::BoldUsername,
-                                       userColor, FontStyle::ChatMediumBold)
+                                       textColor, FontStyle::ChatMediumBold)
                 ->setLink({Link::UserInfo, username});
 
             this->emplace<TextElement>(
-                    string, MessageElementFlag::NonBoldUsername, userColor)
+                    string, MessageElementFlag::NonBoldUsername, textColor)
                 ->setLink({Link::UserInfo, username});
             return;
         }
@@ -500,14 +504,17 @@ void TwitchMessageBuilder::addTextOrEmoji(const QString &string_)
 
         if (match.hasMatch() && chatters->contains(username))
         {
-            auto userColor = this->twitchChannel->getUserColor(username);
+            if (getSettings()->colorUsernames)
+            {
+                textColor = this->twitchChannel->getUserColor(username);
+            }
 
             this->emplace<TextElement>(string, MessageElementFlag::BoldUsername,
-                                       userColor, FontStyle::ChatMediumBold)
+                                       textColor, FontStyle::ChatMediumBold)
                 ->setLink({Link::UserInfo, username});
 
             this->emplace<TextElement>(
-                    string, MessageElementFlag::NonBoldUsername, userColor)
+                    string, MessageElementFlag::NonBoldUsername, textColor)
                 ->setLink({Link::UserInfo, username});
             return;
         }

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -479,13 +479,14 @@ void TwitchMessageBuilder::addTextOrEmoji(const QString &string_)
         if (match.hasMatch())
         {
             QString username = match.captured(1);
+            auto userColor = this->twitchChannel->getUserColor(username);
 
             this->emplace<TextElement>(string, MessageElementFlag::BoldUsername,
-                                       textColor, FontStyle::ChatMediumBold)
+                                       userColor, FontStyle::ChatMediumBold)
                 ->setLink({Link::UserInfo, username});
 
             this->emplace<TextElement>(
-                    string, MessageElementFlag::NonBoldUsername, textColor)
+                    string, MessageElementFlag::NonBoldUsername, userColor)
                 ->setLink({Link::UserInfo, username});
             return;
         }
@@ -499,12 +500,14 @@ void TwitchMessageBuilder::addTextOrEmoji(const QString &string_)
 
         if (match.hasMatch() && chatters->contains(username))
         {
+            auto userColor = this->twitchChannel->getUserColor(username);
+
             this->emplace<TextElement>(string, MessageElementFlag::BoldUsername,
-                                       textColor, FontStyle::ChatMediumBold)
+                                       userColor, FontStyle::ChatMediumBold)
                 ->setLink({Link::UserInfo, username});
 
             this->emplace<TextElement>(
-                    string, MessageElementFlag::NonBoldUsername, textColor)
+                    string, MessageElementFlag::NonBoldUsername, userColor)
                 ->setLink({Link::UserInfo, username});
             return;
         }
@@ -580,6 +583,7 @@ void TwitchMessageBuilder::parseUsername()
     //    }
 
     this->message().loginName = this->userName;
+    this->twitchChannel->setUserColor(this->userName, this->usernameColor_);
 
     // Update current user color if this is our message
     auto currentUser = getApp()->accounts->twitch.getCurrent();

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -104,6 +104,7 @@ public:
     BoolSetting enableSmoothScrollingNewMessages = {
         "/appearance/smoothScrollingNewMessages", false};
     BoolSetting boldUsernames = {"/appearance/messages/boldUsernames", true};
+    BoolSetting colorUsernames = {"/appearance/messages/colorUsernames", true};
     BoolSetting findAllUsernames = {"/appearance/messages/findAllUsernames",
                                     false};
     // BoolSetting customizable splitheader

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -572,6 +572,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
                        s.autoCloseUserPopup);
     layout.addCheckbox("Lowercase domains (anti-phishing)", s.lowercaseDomains);
     layout.addCheckbox("Bold @usernames", s.boldUsernames);
+    layout.addCheckbox("Color @usernames", s.colorUsernames);
     layout.addCheckbox("Try to find usernames without @ prefix",
                        s.findAllUsernames);
     layout.addDropdown<float>(


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

![2020-12-15-223048_656x354_scrot](https://user-images.githubusercontent.com/1957540/102275807-3ecf1d00-3f26-11eb-9a1d-2848875dce4e.png)

Fixes #1963
Fixes #2121 