### PR TITLE
Fix crash when receiving whisper

### DIFF
--- a/src/common/ChannelChatters.cpp
+++ b/src/common/ChannelChatters.cpp
@@ -72,7 +72,7 @@ void ChannelChatters::setChatters(UsernameSet &&set)
 
 const QColor ChannelChatters::getUserColor(const QString &user)
 {
-    const auto chatterColors = this->chatterColors_.access();
+    const auto chatterColors = this->chatterColors_.accessConst();
 
     const auto search = chatterColors->find(user.toLower());
     if (search == chatterColors->end())

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -600,7 +600,10 @@ void TwitchMessageBuilder::parseUsername()
     //    }
 
     this->message().loginName = this->userName;
-    this->twitchChannel->setUserColor(this->userName, this->usernameColor_);
+    if (this->twitchChannel != nullptr)
+    {
+        this->twitchChannel->setUserColor(this->userName, this->usernameColor_);
+    }
 
     // Update current user color if this is our message
     auto currentUser = getApp()->accounts->twitch.getCurrent();


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

The color mentions PR #2284 introduced a crash when receiving whispers.

We save user colors in the relevant twitch channels, but whispers don't have one, so we crash because `this->twitchChannel` is a `nullptr`.

Fix: don't save the color for whispers. Another possible fix would be to save colors globally instead of per-channel.
