### PR TITLE
chore: remove a redundant `using namespace` declaration

### DIFF
--- a/src/widgets/dialogs/switcher/QuickSwitcherPopup.cpp
+++ b/src/widgets/dialogs/switcher/QuickSwitcherPopup.cpp
@@ -14,8 +14,6 @@
 namespace chatterino {
 
 namespace {
-    using namespace chatterino;
-
     QSet<SplitContainer *> openPages()
     {
         QSet<SplitContainer *> pages;


### PR DESCRIPTION
Pull request checklist:

- [x] ~`CHANGELOG.md` was updated, if applicable~ (not applicable)

# Description

This patch removes a redundant `using namespace` declaration that was introduced by an earlier PR of mine (#1588) .
