### PR TITLE
Fixed compilation warning on tests

### DIFF
--- a/src/common/NetworkPrivate.cpp
+++ b/src/common/NetworkPrivate.cpp
@@ -39,7 +39,7 @@ QString NetworkData::getHash()
     {
         QByteArray bytes;
 
-        bytes.append(this->request_.url().toString());
+        bytes.append(this->request_.url().toString().toUtf8());
 
         for (const auto &header : this->request_.rawHeaderList())
         {


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
No changelog entry needed

# Description

Fixes deprecation warning on compiling tests, example of this warning: https://github.com/Chatterino/chatterino2/pull/2316/checks?check_run_id=1613724673#step:8:50
