### PR TITLE
Add 'open in mod view' button to split context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Major: Added "Channel Filters". See https://wiki.chatterino.com/Filters/ for how they work or how to configure them. (#1748, #2083, #2090, #2200)
 - Major: Added Streamer Mode configuration (under `Settings -> General`), where you can select which features of Chatterino should behave differently when you are in Streamer Mode. (#2001)
 - Major: Color mentions to match the mentioned users. You can disable this by unchecking "Color @usernames" under `Settings -> General -> Advanced (misc.)`. (#1963, #2284)
-- Minor: Added a button to the split context menu to open the moderation view for a channel when the account selected has moderator permissions.
+- Minor: Added a button to the split context menu to open the moderation view for a channel when the account selected has moderator permissions. (#2321)
 - Minor: Made BetterTTV emote tooltips use authors' display name. (#2267)
 - Minor: Added Ctrl + 1/2/3/... and Ctrl+9 shortcuts to Emote Popup (activated with Ctrl+E). They work exactly the same as shortcuts in main window. (#2263)
 - Minor: Added reconnect link to the "You are banned" message. (#2266)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Major: Added "Channel Filters". See https://wiki.chatterino.com/Filters/ for how they work or how to configure them. (#1748, #2083, #2090, #2200)
 - Major: Added Streamer Mode configuration (under `Settings -> General`), where you can select which features of Chatterino should behave differently when you are in Streamer Mode. (#2001)
 - Major: Color mentions to match the mentioned users. You can disable this by unchecking "Color @usernames" under `Settings -> General -> Advanced (misc.)`. (#1963, #2284)
+- Minor: Added a button to the split context menu to open the moderation view for a channel when the account selected has moderator permissions.
 - Minor: Made BetterTTV emote tooltips use authors' display name. (#2267)
 - Minor: Added Ctrl + 1/2/3/... and Ctrl+9 shortcuts to Emote Popup (activated with Ctrl+E). They work exactly the same as shortcuts in main window. (#2263)
 - Minor: Added reconnect link to the "You are banned" message. (#2266)

--- a/src/widgets/helper/CommonTexts.hpp
+++ b/src/widgets/helper/CommonTexts.hpp
@@ -2,6 +2,7 @@
 
 #define OPEN_IN_BROWSER "Open stream in browser"
 #define OPEN_PLAYER_IN_BROWSER "Open player in browser"
+#define OPEN_MOD_VIEW_IN_BROWSER "Open mod view in browser"
 #define OPEN_IN_STREAMLINK "Open in streamlink"
 #define DONT_OPEN "Don't open"
 #define OPEN_WHISPERS_IN_BROWSER "Open whispers in browser"

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -630,6 +630,17 @@ void Split::openBrowserPlayer()
     }
 }
 
+void Split::openModViewInBrowser()
+{
+    auto channel = this->getChannel();
+
+    if (auto twitchChannel = dynamic_cast<TwitchChannel *>(channel.get()))
+    {
+        QDesktopServices::openUrl("https://twitch.tv/moderator/" +
+                                  twitchChannel->getName());
+    }
+}
+
 void Split::openInStreamlink()
 {
     try

--- a/src/widgets/splits/Split.hpp
+++ b/src/widgets/splits/Split.hpp
@@ -133,6 +133,7 @@ public slots:
     void popup();
     void clear();
     void openInBrowser();
+    void openModViewInBrowser();
     void openWhispersInBrowser();
     void openBrowserPlayer();
     void openInStreamlink();

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -366,8 +366,11 @@ std::unique_ptr<QMenu> SplitHeader::createMainMenu()
         menu->addAction(OPEN_PLAYER_IN_BROWSER, this->split_,
                         &Split::openBrowserPlayer);
 #endif
-        menu->addAction(OPEN_MOD_VIEW_IN_BROWSER, this->split_,
-                        &Split::openModViewInBrowser);
+        if (this->split_->getChannel()->hasModRights())
+        {
+            menu->addAction(OPEN_MOD_VIEW_IN_BROWSER, this->split_,
+                            &Split::openModViewInBrowser);
+        }
 
         menu->addAction(OPEN_IN_STREAMLINK, this->split_,
                         &Split::openInStreamlink);

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -366,6 +366,9 @@ std::unique_ptr<QMenu> SplitHeader::createMainMenu()
         menu->addAction(OPEN_PLAYER_IN_BROWSER, this->split_,
                         &Split::openBrowserPlayer);
 #endif
+        menu->addAction(OPEN_MOD_VIEW_IN_BROWSER, this->split_,
+                        &Split::openModViewInBrowser);
+
         menu->addAction(OPEN_IN_STREAMLINK, this->split_,
                         &Split::openInStreamlink);
 

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -366,12 +366,6 @@ std::unique_ptr<QMenu> SplitHeader::createMainMenu()
         menu->addAction(OPEN_PLAYER_IN_BROWSER, this->split_,
                         &Split::openBrowserPlayer);
 #endif
-        if (this->split_->getChannel()->hasModRights())
-        {
-            menu->addAction(OPEN_MOD_VIEW_IN_BROWSER, this->split_,
-                            &Split::openModViewInBrowser);
-        }
-
         menu->addAction(OPEN_IN_STREAMLINK, this->split_,
                         &Split::openInStreamlink);
 
@@ -380,6 +374,13 @@ std::unique_ptr<QMenu> SplitHeader::createMainMenu()
             menu->addAction("Open in custom player", this->split_,
                             &Split::openWithCustomScheme);
         }
+
+        if (this->split_->getChannel()->hasModRights())
+        {
+            menu->addAction(OPEN_MOD_VIEW_IN_BROWSER, this->split_,
+                            &Split::openModViewInBrowser);
+        }
+
         menu->addSeparator();
     }
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Adds an extra button to the split context menu to open the moderation view for a channel when the account selected has moderator permissions.

# Preview

Using anonymous mode: ![](https://i.imgur.com/xOSTigQ.png)
Using an account with moderator permissions: ![](https://i.imgur.com/EjF2oKZ.png)