### PR TITLE
fix/docs: update download link for nightly builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Current releases are available at [https://chatterino.com](https://chatterino.co
 Windows users can also install Chatterino [from Chocolatey](https://chocolatey.org/packages/chatterino).
 
 ## Nightly build
-You can download the latest Chatterino 2 build over [here](https://github.com/Chatterino/chatterino2/releases/tag/nightly-build)
+You can download the latest Chatterino 2 build over [here](https://github.com/Chatterino/chatterino2/releases/tag/github-actions-nightly)
 
 You might also need to install the [VC++ 2017 Redistributable](https://aka.ms/vs/15/release/vc_redist.x64.exe) from Microsoft if you do not have it installed already.  
 If you still receive an error about `MSVCR120.dll missing`, then you should install the [VC++ 2013 Restributable](https://download.microsoft.com/download/2/E/6/2E61CFA4-993B-4DD4-91DA-3737CD5CD6E3/vcredist_x64.exe


### PR DESCRIPTION
Pull request checklist:

- [x] ~~`CHANGELOG.md` was updated, if applicable~~ (n/a)

# Description

The previous link pointed to the old nightly releases. The download link on chatterino.com should probably be updated as well.

Credit to @sando for bringing this up on the Discord.
