### PR TITLE
Added /chatters command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Major: Added "Channel Filters". See https://wiki.chatterino.com/Filters/ for how they work or how to configure them. (#1748, #2083, #2090, #2200)
 - Major: Added Streamer Mode configuration (under `Settings -> General`), where you can select which features of Chatterino should behave differently when you are in Streamer Mode. (#2001)
 - Major: Color mentions to match the mentioned users. You can disable this by unchecking "Color @usernames" under `Settings -> General -> Advanced (misc.)`. (#1963, #2284)
+- Minor: Added `/chatters` command showing chatter count. (#2344)
 - Minor: Added a button to the split context menu to open the moderation view for a channel when the account selected has moderator permissions. (#2321)
 - Minor: Made BetterTTV emote tooltips use authors' display name. (#2267)
 - Minor: Added Ctrl + 1/2/3/... and Ctrl+9 shortcuts to Emote Popup (activated with Ctrl+E). They work exactly the same as shortcuts in main window. (#2263)

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -439,13 +439,16 @@ void CommandController::initialize(Settings &, Paths &paths)
         "/chatters", [](const auto & /*words*/, auto channel) {
             auto twitchChannel = dynamic_cast<TwitchChannel *>(channel.get());
 
-            auto message =
-                (twitchChannel == nullptr)
-                    ? "The /chatters command only works in Twitch Channels"
-                    : "Chatter count: " +
-                          QString::number(twitchChannel->chatterCount());
+            if (twitchChannel == nullptr)
+            {
+                channel->addMessage(makeSystemMessage(
+                    "The /chatters command only works in Twitch Channels"));
+            }
 
-            channel->addMessage(makeSystemMessage(message));
+            channel->addMessage(makeSystemMessage(
+                QString("Chatter count: %1")
+                    .arg(QString::number(twitchChannel->chatterCount()))));
+
             return "";
         });
 }

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -439,11 +439,13 @@ void CommandController::initialize(Settings &, Paths &paths)
         "/chatters", [](const auto & /*words*/, auto channel) {
             auto twitchChannel = dynamic_cast<TwitchChannel *>(channel.get());
 
-            channel->addMessage(makeSystemMessage(
+            auto message =
                 (twitchChannel == nullptr)
                     ? "The /chatters command only works in Twitch Channels"
                     : "Chatter count: " +
-                          QString::number(twitchChannel->chatterCount())));
+                          QString::number(twitchChannel->chatterCount());
+
+            channel->addMessage(makeSystemMessage(message));
             return "";
         });
 }

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -147,7 +147,7 @@ bool appendWhisperMessageWordsLocally(const QStringList &words)
 bool appendWhisperMessageStringLocally(const QString &textNoEmoji)
 {
     QString text = getApp()->emotes->emojis.replaceShortCodes(textNoEmoji);
-    QStringList words = text.split(' ', Qt::SkipEmptyParts);
+    QStringList words = text.split(' ', QString::SkipEmptyParts);
 
     if (words.length() == 0)
     {
@@ -469,7 +469,7 @@ QString CommandController::execCommand(const QString &textNoEmoji,
                                        ChannelPtr channel, bool dryRun)
 {
     QString text = getApp()->emotes->emojis.replaceShortCodes(textNoEmoji);
-    QStringList words = text.split(' ', Qt::SkipEmptyParts);
+    QStringList words = text.split(' ', QString::SkipEmptyParts);
 
     if (words.length() == 0)
     {

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -147,7 +147,7 @@ bool appendWhisperMessageWordsLocally(const QStringList &words)
 bool appendWhisperMessageStringLocally(const QString &textNoEmoji)
 {
     QString text = getApp()->emotes->emojis.replaceShortCodes(textNoEmoji);
-    QStringList words = text.split(' ', QString::SkipEmptyParts);
+    QStringList words = text.split(' ', Qt::SkipEmptyParts);
 
     if (words.length() == 0)
     {
@@ -434,6 +434,22 @@ void CommandController::initialize(Settings &, Paths &paths)
         userPopup->show();
         return "";
     });
+
+    this->registerCommand(
+        "/chatters", [](const auto & /*words*/, auto channel) {
+            auto twitchChannel = dynamic_cast<TwitchChannel *>(channel.get());
+            if (twitchChannel == nullptr)
+            {
+                channel->addMessage(makeSystemMessage(
+                    "The /chatters command only works in Twitch Channels"));
+                return "";
+            }
+
+            channel->addMessage(makeSystemMessage(
+                "Chatter count: " +
+                QString::number(twitchChannel->chatterCount())));
+            return "";
+        });
 }
 
 void CommandController::save()
@@ -453,7 +469,7 @@ QString CommandController::execCommand(const QString &textNoEmoji,
                                        ChannelPtr channel, bool dryRun)
 {
     QString text = getApp()->emotes->emojis.replaceShortCodes(textNoEmoji);
-    QStringList words = text.split(' ', QString::SkipEmptyParts);
+    QStringList words = text.split(' ', Qt::SkipEmptyParts);
 
     if (words.length() == 0)
     {

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -443,6 +443,7 @@ void CommandController::initialize(Settings &, Paths &paths)
             {
                 channel->addMessage(makeSystemMessage(
                     "The /chatters command only works in Twitch Channels"));
+                return "";
             }
 
             channel->addMessage(makeSystemMessage(

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -438,16 +438,12 @@ void CommandController::initialize(Settings &, Paths &paths)
     this->registerCommand(
         "/chatters", [](const auto & /*words*/, auto channel) {
             auto twitchChannel = dynamic_cast<TwitchChannel *>(channel.get());
-            if (twitchChannel == nullptr)
-            {
-                channel->addMessage(makeSystemMessage(
-                    "The /chatters command only works in Twitch Channels"));
-                return "";
-            }
 
             channel->addMessage(makeSystemMessage(
-                "Chatter count: " +
-                QString::number(twitchChannel->chatterCount())));
+                (twitchChannel == nullptr)
+                    ? "The /chatters command only works in Twitch Channels"
+                    : "Chatter count: " +
+                          QString::number(twitchChannel->chatterCount())));
             return "";
         });
 }
@@ -533,7 +529,7 @@ QString CommandController::execCommand(const QString &textNoEmoji,
 void CommandController::registerCommand(QString commandName,
                                         CommandFunction commandFunction)
 {
-    assert(this->commands_.contains(commandName) == false);
+    assert(!this->commands_.contains(commandName));
 
     this->commands_[commandName] = commandFunction;
 

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -782,7 +782,7 @@ void TwitchChannel::refreshChatters()
                 auto data = result.parseJson();
                 this->chatterCount_ = data.value("chatter_count").toInt();
 
-                auto pair = parseChatters(data);
+                auto pair = parseChatters(std::move(data));
                 if (pair.first)
                 {
                     this->setChatters(std::move(pair.second));

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -528,6 +528,11 @@ const QString &TwitchChannel::popoutPlayerUrl()
     return this->popoutPlayerUrl_;
 }
 
+int &TwitchChannel::chatterCount()
+{
+    return this->chatterCount_;
+}
+
 void TwitchChannel::setLive(bool newLiveStatus)
 {
     bool gotNewLiveStatus = false;
@@ -770,9 +775,14 @@ void TwitchChannel::refreshChatters()
                 // channel still exists?
                 auto shared = weak.lock();
                 if (!shared)
+                {
                     return Failure;
+                }
 
-                auto pair = parseChatters(result.parseJson());
+                auto data = result.parseJson();
+                this->chatterCount_ = data.value("chatter_count").toInt();
+
+                auto pair = parseChatters(data);
                 if (pair.first)
                 {
                     this->setChatters(std::move(pair.second));

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -528,7 +528,7 @@ const QString &TwitchChannel::popoutPlayerUrl()
     return this->popoutPlayerUrl_;
 }
 
-int &TwitchChannel::chatterCount()
+int TwitchChannel::chatterCount()
 {
     return this->chatterCount_;
 }

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -78,7 +78,7 @@ public:
     const QString &subscriptionUrl();
     const QString &channelUrl();
     const QString &popoutPlayerUrl();
-    int &chatterCount();
+    int chatterCount();
     virtual bool isLive() const override;
     QString roomId() const;
     AccessGuard<const RoomModes> accessRoomModes() const;

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -78,6 +78,7 @@ public:
     const QString &subscriptionUrl();
     const QString &channelUrl();
     const QString &popoutPlayerUrl();
+    int &chatterCount();
     virtual bool isLive() const override;
     QString roomId() const;
     AccessGuard<const RoomModes> accessRoomModes() const;
@@ -155,6 +156,7 @@ private:
     const QString subscriptionUrl_;
     const QString channelUrl_;
     const QString popoutPlayerUrl_;
+    int chatterCount_;
     UniqueAccess<StreamStatus> streamStatus_;
     UniqueAccess<RoomModes> roomModes_;
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

As described in #2343, this is meant to replicate BetterTTV extension's behavoir and make use of the `chatter_count` property we're reciving while fetching data from TMI API. If the approach I chose isn't the best, let me know how can I change it.

While I was at it, I replaced deprecated `QString::SkipEmptyLines` with corresponding updated version from `Qt` namespace

Closes #2343
