### PR TITLE
Update tlds.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - Minor: Tab and split titles now use display/localized channel names (#2189)
 - Minor: Add a setting to limit the amount of historical messages loaded from the Recent Messages API (#2250, #2252)
 - Minor: Made username autocompletion truecase (#1199, #1883)
+- Minor: Update the listing of top-level domains.
 - Bugfix: Fix crash occurring when pressing Escape in the Color Picker Dialog (#1843)
 - Bugfix: Fix bug where the "check user follow state" event could trigger a network request requesting the user to follow or unfollow a user. By itself its quite harmless as it just repeats to Twitch the same follow state we had, so no follows should have been lost by this but it meant there was a rogue network request that was fired that could cause a crash (#1906)
 - Bugfix: /usercard command will now respect the "Automatically close user popup" setting (#1918)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@
 - Minor: Tab and split titles now use display/localized channel names (#2189)
 - Minor: Add a setting to limit the amount of historical messages loaded from the Recent Messages API (#2250, #2252)
 - Minor: Made username autocompletion truecase (#1199, #1883)
-- Minor: Update the listing of top-level domains.
+- Minor: Update the listing of top-level domains. (#2345)
 - Bugfix: Fix crash occurring when pressing Escape in the Color Picker Dialog (#1843)
 - Bugfix: Fix bug where the "check user follow state" event could trigger a network request requesting the user to follow or unfollow a user. By itself its quite harmless as it just repeats to Twitch the same follow state we had, so no follows should have been lost by this but it meant there was a rogue network request that was fired that could cause a crash (#1906)
 - Bugfix: /usercard command will now respect the "Automatically close user popup" setting (#1918)

--- a/resources/contributors.txt
+++ b/resources/contributors.txt
@@ -14,7 +14,7 @@ pajlada | https://pajlada.se | :/avatars/pajlada.png | Collaborator, co-develope
 
 Cranken | https://github.com/Cranken | | Contributor
 hemirt | https://github.com/hemirt | | Contributor
-LajamerrMittisdine | https://github.com/LajamerrMittisdine | | Contributor
+LajamerrMittesdine | https://github.com/LajamerrMittesdine | | Contributor
 coral | https://github.com/coral |  | Contributor, design
 apa420 | https://github.com/apa420 |  | Contributor
 DatGuy1 | https://github.com/DatGuy1 |  | Contributor

--- a/resources/tlds.txt
+++ b/resources/tlds.txt
@@ -14,7 +14,6 @@ accenture
 accountant
 accountants
 aco
-active
 actor
 ad
 adac
@@ -33,7 +32,6 @@ agakhan
 agency
 ai
 aig
-aigo
 airbus
 airforce
 airtel
@@ -48,6 +46,7 @@ ally
 alsace
 alstom
 am
+amazon
 americanexpress
 americanfamily
 amex
@@ -144,7 +143,6 @@ biz
 bj
 black
 blackfriday
-blanco
 blockbuster
 blog
 bloomberg
@@ -153,7 +151,6 @@ bm
 bms
 bmw
 bn
-bnl
 bnpparibas
 bo
 boats
@@ -212,7 +209,6 @@ care
 career
 careers
 cars
-cartier
 casa
 case
 caseih
@@ -227,7 +223,6 @@ cbre
 cbs
 cc
 cd
-ceb
 center
 ceo
 cern
@@ -245,7 +240,6 @@ cheap
 chintai
 christmas
 chrome
-chrysler
 church
 ci
 cipriani
@@ -297,6 +291,7 @@ country
 coupon
 coupons
 courses
+cpa
 cr
 credit
 creditcard
@@ -358,9 +353,7 @@ dnp
 do
 docs
 doctor
-dodge
 dog
-doha
 domains
 dot
 download
@@ -369,7 +362,6 @@ dtv
 dubai
 duck
 dunlop
-duns
 dupont
 durban
 dvag
@@ -390,7 +382,6 @@ energy
 engineer
 engineering
 enterprises
-epost
 epson
 equipment
 er
@@ -399,14 +390,12 @@ erni
 es
 esq
 estate
-esurance
 et
 etisalat
 eu
 eurovision
 eus
 events
-everbank
 exchange
 expert
 exposed
@@ -522,7 +511,6 @@ gold
 goldpoint
 golf
 goo
-goodhands
 goodyear
 goog
 google
@@ -580,7 +568,6 @@ homegoods
 homes
 homesense
 honda
-honeywell
 horse
 hospital
 host
@@ -614,6 +601,7 @@ imdb
 immo
 immobilien
 in
+inc
 industries
 infiniti
 info
@@ -623,7 +611,6 @@ institute
 insurance
 insure
 int
-intel
 international
 intuit
 investments
@@ -633,7 +620,6 @@ iq
 ir
 irish
 is
-iselect
 ismaili
 ist
 istanbul
@@ -641,17 +627,14 @@ it
 itau
 itv
 iveco
-iwc
 jaguar
 java
 jcb
-jcp
 je
 jeep
 jetzt
 jewelry
 jio
-jlc
 jll
 jm
 jmp
@@ -700,12 +683,10 @@ kyoto
 kz
 la
 lacaixa
-ladbrokes
 lamborghini
 lamer
 lancaster
 lancia
-lancome
 land
 landrover
 lanxess
@@ -726,7 +707,6 @@ lego
 lexus
 lgbt
 li
-liaison
 lidl
 life
 lifeinsurance
@@ -745,6 +725,7 @@ living
 lixil
 lk
 llc
+llp
 loan
 loans
 locker
@@ -764,7 +745,6 @@ ltd
 ltda
 lu
 lundbeck
-lupin
 luxe
 luxury
 lv
@@ -800,7 +780,6 @@ memorial
 men
 menu
 merckmsd
-metlife
 mg
 mh
 miami
@@ -820,7 +799,6 @@ mn
 mo
 mobi
 mobile
-mobily
 moda
 moe
 moi
@@ -828,7 +806,6 @@ mom
 monash
 money
 monster
-mopar
 mormon
 mortgage
 moscow
@@ -836,7 +813,6 @@ moto
 motorcycles
 mov
 movie
-movistar
 mp
 mq
 mr
@@ -855,7 +831,6 @@ my
 mz
 na
 nab
-nadex
 nagoya
 name
 nationwide
@@ -934,7 +909,6 @@ ovh
 pa
 page
 panasonic
-panerai
 paris
 pars
 partners
@@ -957,7 +931,6 @@ photo
 photography
 photos
 physio
-piaget
 pics
 pictet
 pictures
@@ -1040,7 +1013,6 @@ rexroth
 rich
 richardli
 ricoh
-rightathome
 ril
 rio
 rip
@@ -1091,7 +1063,6 @@ schule
 schwarz
 science
 scjohnson
-scor
 scot
 sd
 se
@@ -1123,7 +1094,6 @@ shopping
 shouji
 show
 showtime
-shriram
 si
 silk
 sina
@@ -1153,22 +1123,20 @@ solutions
 song
 sony
 soy
+spa
 space
-spiegel
 sport
 spot
 spreadbetting
 sr
 srl
-srt
+ss
 st
 stada
 staples
 star
-starhub
 statebank
 statefarm
-statoil
 stc
 stcgroup
 stockholm
@@ -1193,7 +1161,6 @@ swiss
 sx
 sy
 sydney
-symantec
 systems
 sz
 tab
@@ -1214,8 +1181,6 @@ team
 tech
 technology
 tel
-telecity
-telefonica
 temasek
 tennis
 teva
@@ -1275,7 +1240,6 @@ tz
 ua
 ubank
 ubs
-uconnect
 ug
 uk
 unicom
@@ -1309,8 +1273,6 @@ vip
 virgin
 visa
 vision
-vista
-vistaprint
 viva
 vivo
 vlaanderen
@@ -1329,7 +1291,6 @@ walmart
 walter
 wang
 wanggou
-warman
 watch
 watches
 weather
@@ -1405,6 +1366,7 @@ xn--bck1b9a5dre4c
 xn--c1avg
 xn--c2br7g
 xn--cck2b3b
+xn--cckwcxetd
 xn--cg4bki
 xn--clchc0ea0b2g2a9gcd
 xn--czr694b
@@ -1415,7 +1377,6 @@ xn--d1alf
 xn--e1a4c
 xn--eckvdtc9d
 xn--efvy88h
-xn--estv75g
 xn--fct429k
 xn--fhbei
 xn--fiq228c5hs
@@ -1441,12 +1402,12 @@ xn--io0a7i
 xn--j1aef
 xn--j1amh
 xn--j6w193g
+xn--jlq480n2rg
 xn--jlq61u9w7b
 xn--jvr189m
 xn--kcrx77d1x4a
 xn--kprw13d
 xn--kpry57d
-xn--kpu716f
 xn--kput3i
 xn--l1acc
 xn--lgbbat1ad8j
@@ -1457,13 +1418,14 @@ xn--mgba7c0bbn0a
 xn--mgbaakc7dvf
 xn--mgbaam7a8h
 xn--mgbab2bd
+xn--mgbah1a3hjkrd
 xn--mgbai9azgqp6j
 xn--mgbayh7gpa
-xn--mgbb9fbpob
 xn--mgbbh1a
 xn--mgbbh1a71e
 xn--mgbc0a9azcg
 xn--mgbca7dzdo
+xn--mgbcpq6gpa1a
 xn--mgberp4a5d4ar
 xn--mgbgu82a
 xn--mgbi4ecexp
@@ -1486,11 +1448,12 @@ xn--ogbpf8fl
 xn--otu796d
 xn--p1acf
 xn--p1ai
-xn--pbt977c
 xn--pgbs0dh
 xn--pssy2u
+xn--q7ce6a
 xn--q9jyb4c
 xn--qcka1pmc
+xn--qxa6a
 xn--qxam
 xn--rhqv96g
 xn--rovu88b
@@ -1516,7 +1479,6 @@ xn--y9a3aq
 xn--yfro4i67o
 xn--ygbi2ammx
 xn--zfr164b
-xperia
 xxx
 xyz
 yachts
@@ -1536,7 +1498,6 @@ zappos
 zara
 zero
 zip
-zippo
 zm
 zone
 zuerich
@@ -1581,6 +1542,7 @@ zw
 орг
 नेट
 ストア
+アマゾン
 삼성
 சிங்கப்பூர்
 商标
@@ -1591,7 +1553,6 @@ zw
 ею
 ポイント
 新闻
-工行
 家電
 كوم
 中文网
@@ -1617,12 +1578,12 @@ zw
 ком
 укр
 香港
+亚马逊
 诺基亚
 食品
 飞利浦
 台湾
 台灣
-手表
 手机
 мон
 الجزائر
@@ -1633,13 +1594,14 @@ zw
 اتصالات
 امارات
 بازار
+موريتانيا
 پاکستان
 الاردن
-موبايلي
 بارت
 بھارت
 المغرب
 ابوظبي
+البحرين
 السعودية
 ڀارت
 كاثوليك
@@ -1662,11 +1624,12 @@ zw
 招聘
 рус
 рф
-珠宝
 تونس
 大拿
+ລາວ
 みんな
 グーグル
+ευ
 ελ
 世界
 書籍


### PR DESCRIPTION
This update adds and removes top level domains to reflect the current ICANN listing as of # Version 2021010800, Last Updated Fri Jan  8 07:07:02 2021 UTC

Adds:
+amazon
+cpa
+inc
+llp
+spa
+ss
+xn--cckwcxetd
+xn--jlq480n2rg
+xn--mgbah1a3hjkrd
+xn--mgbcpq6gpa1a
+xn--q7ce6a
+xn--qxa6a
+アマゾン
+亚马逊
+موريتانيا
+البحرين
+ລາວ
+ευ

Removed:
-active
-aigo
-blanco
-bnl
-cartier
-ceb
-chrysler
-dodge
-doha
-duns
-epost
-esurance
-everbank
-goodhands
-honeywell
-intel
-iselect
-iwc
-jcp
-jlc
-ladbrokes
-lancome
-liaison
-lupin
-metlife
-mobily
-mopar
-movistar
-nadex
-panerai
-piaget
-rightathome
-scor
-shriram
-spiegel
-srt
-starhub
-statoil
-symantec
-telecity
-telefonica
-uconnect
-vista
-vistaprint
-warman
-xn--estv75g
-xn--kpu716f
-xn--mgbb9fbpob
-xn--pbt977c
-xperia
-zippo
-工行
-手表
-موبايلي
-珠宝

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
