### PR TITLE
Add cache limit to `chattersColors`

### DIFF
--- a/src/common/ChannelChatters.cpp
+++ b/src/common/ChannelChatters.cpp
@@ -72,10 +72,10 @@ void ChannelChatters::setChatters(UsernameSet &&set)
 
 const QColor ChannelChatters::getUserColor(const QString &user)
 {
-    const auto chatterColors = this->chatterColors_.accessConst();
+    const auto chattersColors = this->chattersColors_.accessConst();
 
-    const auto search = chatterColors->find(user.toLower());
-    if (search == chatterColors->end())
+    const auto search = chattersColors->find(user.toLower());
+    if (search == chattersColors->end())
     {
         // Returns an invalid color so we can decide not to override `textColor`
         return QColor();
@@ -86,8 +86,14 @@ const QColor ChannelChatters::getUserColor(const QString &user)
 
 void ChannelChatters::setUserColor(const QString &user, const QColor &color)
 {
-    const auto chatterColors = this->chatterColors_.access();
-    chatterColors->insert_or_assign(user.toLower(), color);
+    const auto chattersColors = this->chattersColors_.access();
+    chattersColors->insert_or_assign(user, color);
+}
+
+void ChannelChatters::removeUserColor(const QString &user)
+{
+    const auto chattersColors = this->chattersColors_.access();
+    chattersColors->erase(user);
 }
 
 }  // namespace chatterino

--- a/src/common/ChannelChatters.hpp
+++ b/src/common/ChannelChatters.hpp
@@ -20,13 +20,14 @@ public:
     void setChatters(UsernameSet &&set);
     const QColor getUserColor(const QString &user);
     void setUserColor(const QString &user, const QColor &color);
+    void removeUserColor(const QString &user);
 
 private:
     Channel &channel_;
 
     // maps 2 char prefix to set of names
     UniqueAccess<UsernameSet> chatters_;
-    UniqueAccess<std::map<QString, QColor>> chatterColors_;
+    UniqueAccess<std::unordered_map<QString, QColor>> chattersColors_;
 
     // combines multiple joins/parts into one message
     UniqueAccess<QStringList> joinedUsers_;

--- a/src/messages/layouts/MessageLayout.cpp
+++ b/src/messages/layouts/MessageLayout.cpp
@@ -47,6 +47,7 @@ MessageLayout::MessageLayout(MessagePtr message)
 
 MessageLayout::~MessageLayout()
 {
+    this->destroyed.invoke();
     DebugCount::decrease("message layout");
 }
 

--- a/src/messages/layouts/MessageLayout.hpp
+++ b/src/messages/layouts/MessageLayout.hpp
@@ -63,6 +63,8 @@ public:
     // Misc
     bool isDisabled() const;
 
+    pajlada::Signals::NoArgSignal destroyed;
+
 private:
     // variables
     MessagePtr message_;

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -785,6 +785,16 @@ void ChannelView::messageAppended(MessagePtr &message,
     this->lastMessageHasAlternateBackground_ =
         !this->lastMessageHasAlternateBackground_;
 
+    if (auto tc = dynamic_cast<TwitchChannel *>(this->underlyingChannel_.get()))
+    {
+        this->channelConnections_.push_back(messageRef->destroyed.connect(
+            [tc, userName = messageRef->getMessage()->loginName] {
+                if (userName == "")
+                    return;
+                tc->removeUserColor(userName);
+            }));
+    }
+
     if (this->messages_.pushBack(MessageLayoutPtr(messageRef), deleted))
     {
         if (this->paused())


### PR DESCRIPTION
Pull request checklist:

- [x] ~~`CHANGELOG.md` was updated, if applicable~~

# Description

I was late to #2284 merge and raised some concerns about how colors cache never gets cleared. I'm not sure that it's the best solution, feel free to discuss.
Additionally, i've added some changes:
* Changed `chatterColor` -> `chattersColors` for consistency (nitpick, but mistyped myself a lot then searching)
* Changed `chattersColor` type form `std::map` to `std::unordered_map` (not entirely sure why its map in the first place)
* Remove `toLower()` in `setUserColor` (passed `user` is already in lowercase, so its leads to unnecessary string copy)