### PR TITLE
Try to improve Twitch IRC network stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - Minor: Tab and split titles now use display/localized channel names (#2189)
 - Minor: Add a setting to limit the amount of historical messages loaded from the Recent Messages API (#2250, #2252)
 - Minor: Made username autocompletion truecase (#1199, #1883)
+- Minor: Properly respect RECONNECT messages from Twitch (#2347)
 - Bugfix: Fix crash occurring when pressing Escape in the Color Picker Dialog (#1843)
 - Bugfix: Fix bug where the "check user follow state" event could trigger a network request requesting the user to follow or unfollow a user. By itself its quite harmless as it just repeats to Twitch the same follow state we had, so no follows should have been lost by this but it meant there was a rogue network request that was fired that could cause a crash (#1906)
 - Bugfix: /usercard command will now respect the "Automatically close user popup" setting (#1918)

--- a/src/providers/irc/AbstractIrcServer.cpp
+++ b/src/providers/irc/AbstractIrcServer.cpp
@@ -135,6 +135,25 @@ void AbstractIrcServer::open(ConnectionType type)
     }
 }
 
+void AbstractIrcServer::addGlobalSystemMessage(QString messageText)
+{
+    std::lock_guard<std::mutex> lock(this->channelMutex);
+
+    MessageBuilder b(systemMessage, messageText);
+    auto message = b.release();
+
+    for (std::weak_ptr<Channel> &weak : this->channels.values())
+    {
+        std::shared_ptr<Channel> chan = weak.lock();
+        if (!chan)
+        {
+            continue;
+        }
+
+        chan->addMessage(message);
+    }
+}
+
 void AbstractIrcServer::disconnect()
 {
     std::lock_guard<std::mutex> locker(this->connectionMutex_);

--- a/src/providers/irc/AbstractIrcServer.cpp
+++ b/src/providers/irc/AbstractIrcServer.cpp
@@ -62,6 +62,8 @@ AbstractIrcServer::AbstractIrcServer()
 
     // listen to reconnect request
     this->readConnection_->reconnectRequested.connect([this] {
+        this->addGlobalSystemMessage(
+            "Server connection timed out, reconnecting");
         this->connect();
     });
     //    this->writeConnection->reconnectRequested.connect([this] {

--- a/src/providers/irc/AbstractIrcServer.hpp
+++ b/src/providers/irc/AbstractIrcServer.hpp
@@ -78,6 +78,8 @@ protected:
 
     void open(ConnectionType type);
 
+    void addGlobalSystemMessage(QString messageText);
+
     QMap<QString, std::weak_ptr<Channel>> channels;
     std::mutex channelMutex;
 

--- a/src/providers/irc/IrcConnection2.cpp
+++ b/src/providers/irc/IrcConnection2.cpp
@@ -57,15 +57,20 @@ IrcConnection::IrcConnection(QObject *parent)
                          }
                      });
 
-    QObject::connect(this, &Communi::IrcConnection::messageReceived,
-                     [this](Communi::IrcMessage *) {
-                         this->recentlyReceivedMessage_ = true;
+    QObject::connect(
+        this, &Communi::IrcConnection::messageReceived,
+        [this](Communi::IrcMessage *message) {
+            this->recentlyReceivedMessage_ = true;
 
-                         if (this->reconnectTimer_.isActive())
-                         {
-                             this->reconnectTimer_.stop();
-                         }
-                     });
+            if (this->reconnectTimer_.isActive())
+            {
+                this->reconnectTimer_.stop();
+
+                // The reconnect timer had started, that means we were waiting for a pong.
+                // Since we received a message, this means that any pong response is meaningless, so we can just stop waiting for the pong and send another ping soon:tm:
+                this->waitingForPong_ = false;
+            }
+        });
 }
 
 }  // namespace chatterino

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -165,6 +165,12 @@ void TwitchIrcServer::readConnectionMessageReceived(
     {
         handler.handleWhisperMessage(message);
     }
+    else if (command == "RECONNECT")
+    {
+        this->addGlobalSystemMessage(
+            "Twitch Servers requested us to reconnect, reconnecting");
+        this->connect();
+    }
 }
 
 void TwitchIrcServer::writeConnectionMessageReceived(
@@ -206,6 +212,12 @@ void TwitchIrcServer::writeConnectionMessageReceived(
 
         handler.handleNoticeMessage(
             static_cast<Communi::IrcNoticeMessage *>(message));
+    }
+    else if (command == "RECONNECT")
+    {
+        this->addGlobalSystemMessage(
+            "Twitch Servers requested us to reconnect, reconnecting");
+        this->connect();
     }
 }
 


### PR DESCRIPTION

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

- Add helper function do add a global system message to all channels of an IRC server
- Reconnect both read and write connections when receiving a RECONNECT message on either connection
