### PR TITLE
feat: add a `finally` callback to NetworkRequests

### DIFF
--- a/src/common/NetworkCommon.hpp
+++ b/src/common/NetworkCommon.hpp
@@ -12,6 +12,7 @@ class NetworkResult;
 using NetworkSuccessCallback = std::function<Outcome(NetworkResult)>;
 using NetworkErrorCallback = std::function<void(NetworkResult)>;
 using NetworkReplyCreatedCallback = std::function<void(QNetworkReply *)>;
+using NetworkFinallyCallback = std::function<void()>;
 
 enum class NetworkRequestType {
     Get,

--- a/src/common/NetworkPrivate.cpp
+++ b/src/common/NetworkPrivate.cpp
@@ -132,11 +132,19 @@ void loadUncached(const std::shared_ptr<NetworkData> &data)
                 data->timer_, &QTimer::timeout, worker, [reply, data]() {
                     qCDebug(chatterinoCommon) << "Aborted!";
                     reply->abort();
+
                     if (data->onError_)
                     {
                         postToThread([data] {
                             data->onError_(NetworkResult(
                                 {}, NetworkResult::timedoutStatus));
+                        });
+                    }
+
+                    if (data->finally_)
+                    {
+                        postToThread([data] {
+                            data->finally_();
                         });
                     }
                 });
@@ -159,15 +167,24 @@ void loadUncached(const std::shared_ptr<NetworkData> &data)
                 if (reply->error() ==
                     QNetworkReply::NetworkError::OperationCanceledError)
                 {
-                    //operation cancelled, most likely timed out
+                    // Operation cancelled, most likely timed out
                     return;
                 }
+
                 if (data->onError_)
                 {
                     auto status = reply->attribute(
                         QNetworkRequest::HttpStatusCodeAttribute);
+                    // TODO: Should this always be run on the GUI thread?
                     postToThread([data, code = status.toInt()] {
                         data->onError_(NetworkResult({}, code));
+                    });
+                }
+
+                if (data->finally_)
+                {
+                    postToThread([data] {
+                        data->finally_();
                     });
                 }
                 return;
@@ -196,6 +213,16 @@ void loadUncached(const std::shared_ptr<NetworkData> &data)
             // log("finished {}", data->request_.url().toString());
 
             reply->deleteLater();
+
+            if (data->finally_)
+            {
+                if (data->executeConcurrently_)
+                    QtConcurrent::run([finally = std::move(data->finally_)] {
+                        finally();
+                    });
+                else
+                    data->finally_();
+            }
         };
 
         if (data->timer_ != nullptr)
@@ -268,6 +295,30 @@ void loadCached(const std::shared_ptr<NetworkData> &data)
                     }
 
                     data->onSuccess_(result);
+                });
+            }
+        }
+
+        if (data->finally_)
+        {
+            if (data->executeConcurrently_ || isGuiThread())
+            {
+                if (data->hasCaller_ && !data->caller_.get())
+                {
+                    return;
+                }
+
+                data->finally_();
+            }
+            else
+            {
+                postToThread([data]() {
+                    if (data->hasCaller_ && !data->caller_.get())
+                    {
+                        return;
+                    }
+
+                    data->finally_();
                 });
             }
         }

--- a/src/common/NetworkPrivate.hpp
+++ b/src/common/NetworkPrivate.hpp
@@ -44,6 +44,7 @@ struct NetworkData {
     NetworkReplyCreatedCallback onReplyCreated_;
     NetworkErrorCallback onError_;
     NetworkSuccessCallback onSuccess_;
+    NetworkFinallyCallback finally_;
 
     NetworkRequestType requestType_ = NetworkRequestType::Get;
 

--- a/src/common/NetworkRequest.cpp
+++ b/src/common/NetworkRequest.cpp
@@ -79,6 +79,12 @@ NetworkRequest NetworkRequest::onSuccess(NetworkSuccessCallback cb) &&
     return std::move(*this);
 }
 
+NetworkRequest NetworkRequest::finally(NetworkFinallyCallback cb) &&
+{
+    this->data->finally_ = cb;
+    return std::move(*this);
+}
+
 NetworkRequest NetworkRequest::header(const char *headerName,
                                       const char *value) &&
 {

--- a/src/common/NetworkRequest.hpp
+++ b/src/common/NetworkRequest.hpp
@@ -42,6 +42,7 @@ public:
     NetworkRequest onReplyCreated(NetworkReplyCreatedCallback cb) &&;
     NetworkRequest onError(NetworkErrorCallback cb) &&;
     NetworkRequest onSuccess(NetworkSuccessCallback cb) &&;
+    NetworkRequest finally(NetworkFinallyCallback cb) &&;
 
     NetworkRequest payload(const QByteArray &payload) &&;
     NetworkRequest cache() &&;


### PR DESCRIPTION
Pull request checklist:

- [x] ~`CHANGELOG.md` was updated, if applicable~ (n/a)

# Description

This patch adds an additional callback to `NetworkRequest` instances. This callback will execute regardless of whether the request failed or succeeded and it will always be executed after the `onSuccess` and `onError` callbacks.

This allows for code de-duplication in some cases (e.g. when unlocking a mutex or updating a timestamp) and can thus reduce the potential of human programming errors. For example, the timestamping logic of #2271 could be simplified with this feature.