### PR TITLE
Bump macOS minimum version to 10.14

### DIFF
--- a/BUILDING_ON_MAC.md
+++ b/BUILDING_ON_MAC.md
@@ -1,5 +1,6 @@
 # Building on macOS
 #### Note - If you want to develop Chatterino 2 you will also need to install Qt Creator (make sure to install **Qt 5.12 or newer**)
+#### Note - Chatterino 2 is only tested on macOS 10.14 and above - anything below that is considered unsupported. It may or may not work on earlier versions
 1. Install Xcode and Xcode Command Line Utilites
 2. Start Xcode, settings -> Locations, activate your Command Line Tools
 3. Install brew https://brew.sh/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@
 - Dev: Migrated `TwitchAccount::(un)followUser` from Kraken to Helix and moved it to `Helix::(un)followUser`. (#2306)
 - Dev: Migrated `Kraken::getChannel` to Helix. (#2381)
 - Dev: Build in CI with multiple Qt versions (#2349)
+- Dev: Updated minimum required macOS version to 10.15 (#2386)
 
 ## 2.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@
 - Dev: Migrated `TwitchAccount::(un)followUser` from Kraken to Helix and moved it to `Helix::(un)followUser`. (#2306)
 - Dev: Migrated `Kraken::getChannel` to Helix. (#2381)
 - Dev: Build in CI with multiple Qt versions (#2349)
-- Dev: Updated minimum required macOS version to 10.15 (#2386)
+- Dev: Updated minimum required macOS version to 10.14 (#2386)
 
 ## 2.2.2
 

--- a/chatterino.pro
+++ b/chatterino.pro
@@ -59,7 +59,7 @@ linux {
 }
 
 macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.15
+    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.14
 
     INCLUDEPATH += /usr/local/include
     INCLUDEPATH += /usr/local/opt/openssl/include

--- a/chatterino.pro
+++ b/chatterino.pro
@@ -59,6 +59,8 @@ linux {
 }
 
 macx {
+    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.15
+
     INCLUDEPATH += /usr/local/include
     INCLUDEPATH += /usr/local/opt/openssl/include
     LIBS += -L/usr/local/opt/openssl/lib


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Right now minimum macOS version is 10.13. For example some external libraries (boost, openssl) have brew formulas only for 10.14 (Mojave). 
Also it would introduce full C++17 (currently used) support for apple clang, which will be useful for example in https://github.com/Chatterino/chatterino2/pull/2368#pullrequestreview-573454781
Maybe it should be bumped to only 10.14 for more compatibility, let me know if you think so.