### PR TITLE
Ensure SwitchSplitItem container can never be null

### DIFF
--- a/src/widgets/dialogs/switcher/QuickSwitcherPopup.cpp
+++ b/src/widgets/dialogs/switcher/QuickSwitcherPopup.cpp
@@ -94,7 +94,7 @@ void QuickSwitcherPopup::updateSuggestions(const QString &text)
             if (split->getChannel()->getName().contains(text,
                                                         Qt::CaseInsensitive))
             {
-                auto item = std::make_unique<SwitchSplitItem>(split);
+                auto item = std::make_unique<SwitchSplitItem>(sc, split);
                 this->switcherModel_.addItem(std::move(item));
 
                 // We want to continue the outer loop so we need a goto

--- a/src/widgets/dialogs/switcher/SwitchSplitItem.cpp
+++ b/src/widgets/dialogs/switcher/SwitchSplitItem.cpp
@@ -7,16 +7,12 @@
 
 namespace chatterino {
 
-SwitchSplitItem::SwitchSplitItem(Split *split)
-    : AbstractSwitcherItem(QIcon(":switcher/switch.svg"))
-    , split_(split)
-{
-}
-
-SwitchSplitItem::SwitchSplitItem(SplitContainer *container)
+SwitchSplitItem::SwitchSplitItem(SplitContainer *container, Split *split)
     : AbstractSwitcherItem(QIcon(":switcher/switch.svg"))
     , container_(container)
+    , split_(split)
 {
+    assert(this->container_ != nullptr);
 }
 
 void SwitchSplitItem::action()

--- a/src/widgets/dialogs/switcher/SwitchSplitItem.hpp
+++ b/src/widgets/dialogs/switcher/SwitchSplitItem.hpp
@@ -13,8 +13,7 @@ namespace chatterino {
 class SwitchSplitItem : public AbstractSwitcherItem
 {
 public:
-    SwitchSplitItem(Split *split);
-    SwitchSplitItem(SplitContainer *container);
+    SwitchSplitItem(SplitContainer *container, Split *split = nullptr);
 
     virtual void action() override;
 
@@ -22,8 +21,8 @@ public:
     virtual QSize sizeHint(const QRect &rect) const override;
 
 private:
-    Split *split_{};
     SplitContainer *container_{};
+    Split *split_{};
 };
 
 }  // namespace chatterino


### PR DESCRIPTION
There were two ways to create a SwitchSplitItem:
a) A Container only: This would let the user switch to a Tab only, but not change which split in the focus was focused
b) A split only: This would programmatically fill in the container (by querying the split) and let the user switch to the Tab and change focus to the split

Since split had no way to programmatically get its container, we can
instead require that the container is always filled in. Where this class
is used (QuickSwitcherPopup.cpp:97 and QuickSwitcherPopup:108) we do
have the container pointer already, so the logic for creating a
SwitchSplitItem has now changed to:
a) A container but no split
b) A container and a split

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
