### PR TITLE
Clean up debug output

### DIFF
--- a/src/widgets/settingspages/GeneralPageView.hpp
+++ b/src/widgets/settingspages/GeneralPageView.hpp
@@ -4,7 +4,6 @@
 #include <boost/variant.hpp>
 #include "Application.hpp"
 #include "common/ChatterinoSetting.hpp"
-#include "common/QLogging.hpp"
 #include "singletons/WindowManager.hpp"
 #include "widgets/helper/SignalLabel.hpp"
 

--- a/src/widgets/settingspages/GeneralPageView.hpp
+++ b/src/widgets/settingspages/GeneralPageView.hpp
@@ -193,7 +193,6 @@ public:
 protected:
     void resizeEvent(QResizeEvent *ev) override
     {
-        qCDebug(chatterinoWidget) << ev->size();
     }
 
 private:


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

This has been introduced in 0ecea8ad838de7039b3f74e3982d5d1ed9316f3b, I made [a comment](https://github.com/Chatterino/chatterino2/commit/0ecea8ad838de7039b3f74e3982d5d1ed9316f3b#r43544815) about it but I think nobody saw it. I believe it was an overlooked mistake and more of a debug artifact. It logs a shitton of `QSize`'s upon resizing settings page, ultra annoying.
