### PR TITLE
Added /streamlink command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,8 +50,7 @@
 - Minor: Update the listing of top-level domains. (#2345)
 - Minor: Properly respect RECONNECT messages from Twitch (#2347)
 - Minor: Added human-readable formatting to remaining timeout duration. (#2398)
-- Minor: Added `/streamlink` command. Usage: `/streamlink <channel>`. You can also use the command without arguments in any twitch channel to open it in streamlink
-. (#2443)
+- Minor: Added `/streamlink` command. Usage: `/streamlink <channel>`. You can also use the command without arguments in any twitch channel to open it in streamlink. (#2443)
 - Bugfix: Fix crash occurring when pressing Escape in the Color Picker Dialog (#1843)
 - Bugfix: Fix bug where the "check user follow state" event could trigger a network request requesting the user to follow or unfollow a user. By itself its quite harmless as it just repeats to Twitch the same follow state we had, so no follows should have been lost by this but it meant there was a rogue network request that was fired that could cause a crash (#1906)
 - Bugfix: /usercard command will now respect the "Automatically close user popup" setting (#1918)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,8 @@
 - Minor: Update the listing of top-level domains. (#2345)
 - Minor: Properly respect RECONNECT messages from Twitch (#2347)
 - Minor: Added human-readable formatting to remaining timeout duration. (#2398)
-- Minor: Added `/streamlink` command. Usage: /streamlink [channel], use "channel" literally to open current channel in streamlink. (#2443)
+- Minor: Added `/streamlink` command. Usage: `/streamlink <channel>`. You can also use the command without arguments in any twitch channel to open it in streamlink
+. (#2443)
 - Bugfix: Fix crash occurring when pressing Escape in the Color Picker Dialog (#1843)
 - Bugfix: Fix bug where the "check user follow state" event could trigger a network request requesting the user to follow or unfollow a user. By itself its quite harmless as it just repeats to Twitch the same follow state we had, so no follows should have been lost by this but it meant there was a rogue network request that was fired that could cause a crash (#1906)
 - Bugfix: /usercard command will now respect the "Automatically close user popup" setting (#1918)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@
 - Minor: Update the listing of top-level domains. (#2345)
 - Minor: Properly respect RECONNECT messages from Twitch (#2347)
 - Minor: Added human-readable formatting to remaining timeout duration. (#2398)
-- Minor: Added `/streamlink` command. (#2443)
+- Minor: Added `/streamlink` command. Usage: /streamlink [channel], use "channel" literally to open current channel in streamlink. (#2443)
 - Bugfix: Fix crash occurring when pressing Escape in the Color Picker Dialog (#1843)
 - Bugfix: Fix bug where the "check user follow state" event could trigger a network request requesting the user to follow or unfollow a user. By itself its quite harmless as it just repeats to Twitch the same follow state we had, so no follows should have been lost by this but it meant there was a rogue network request that was fired that could cause a crash (#1906)
 - Bugfix: /usercard command will now respect the "Automatically close user popup" setting (#1918)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 - Minor: Update the listing of top-level domains. (#2345)
 - Minor: Properly respect RECONNECT messages from Twitch (#2347)
 - Minor: Added human-readable formatting to remaining timeout duration. (#2398)
+- Minor: Added `/streamlink` command. (#2443)
 - Bugfix: Fix crash occurring when pressing Escape in the Color Picker Dialog (#1843)
 - Bugfix: Fix bug where the "check user follow state" event could trigger a network request requesting the user to follow or unfollow a user. By itself its quite harmless as it just repeats to Twitch the same follow state we had, so no follows should have been lost by this but it meant there was a rogue network request that was fired that could cause a crash (#1906)
 - Bugfix: /usercard command will now respect the "Automatically close user popup" setting (#1918)

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -17,6 +17,7 @@
 #include "singletons/WindowManager.hpp"
 #include "util/CombinePath.hpp"
 #include "util/FormatTime.hpp"
+#include "util/StreamLink.hpp"
 #include "util/Twitch.hpp"
 #include "widgets/Window.hpp"
 #include "widgets/dialogs/UserInfoPopup.hpp"
@@ -535,6 +536,32 @@ void CommandController::initialize(Settings &, Paths &paths)
 
                 channel->addMessage(makeSystemMessage(errorMessage));
             });
+
+        return "";
+    });
+
+    this->registerCommand("/streamlink", [](const QStringList &words,
+                                            ChannelPtr channel) {
+        if (words.size() < 2)
+        {
+            channel->addMessage(makeSystemMessage(
+                "Usage: /streamlink [channel], use \"channel\" to open current "
+                "channel in streamlink."));
+            return "";
+        }
+
+        if (!channel->isTwitchChannel())
+        {
+            return "";
+        }
+
+        QString channelName =
+            (words[1] == "channel") ? channel->getName() : words[1];
+        qDebug() << channelName;
+
+        channel->addMessage(makeSystemMessage(
+            QString("Opening %1 in streamlink...").arg(channelName)));
+        openStreamlinkForChannel(channelName);
 
         return "";
     });

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -540,31 +540,30 @@ void CommandController::initialize(Settings &, Paths &paths)
         return "";
     });
 
-    this->registerCommand("/streamlink", [](const QStringList &words,
-                                            ChannelPtr channel) {
-        if (words.size() < 2)
-        {
+    this->registerCommand(
+        "/streamlink", [](const QStringList &words, ChannelPtr channel) {
+            if (words.size() < 2)
+            {
+                channel->addMessage(makeSystemMessage(
+                    "Usage: /streamlink <channel>, use \"channel\" literally "
+                    "to open current channel in streamlink."));
+                return "";
+            }
+
+            if (!channel->isTwitchChannel())
+            {
+                return "";
+            }
+
+            QString channelName =
+                (words[1] == "channel") ? channel->getName() : words[1];
+
             channel->addMessage(makeSystemMessage(
-                "Usage: /streamlink [channel], use \"channel\" to open current "
-                "channel in streamlink."));
+                QString("Opening %1 in streamlink...").arg(channelName)));
+            openStreamlinkForChannel(channelName);
+
             return "";
-        }
-
-        if (!channel->isTwitchChannel())
-        {
-            return "";
-        }
-
-        QString channelName =
-            (words[1] == "channel") ? channel->getName() : words[1];
-        qDebug() << channelName;
-
-        channel->addMessage(makeSystemMessage(
-            QString("Opening %1 in streamlink...").arg(channelName)));
-        openStreamlinkForChannel(channelName);
-
-        return "";
-    });
+        });
 }
 
 void CommandController::save()

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -544,23 +544,26 @@ void CommandController::initialize(Settings &, Paths &paths)
         "/streamlink", [](const QStringList &words, ChannelPtr channel) {
             if (words.size() < 2)
             {
-                channel->addMessage(makeSystemMessage(
-                    "Usage: /streamlink <channel>, use \"channel\" literally "
-                    "to open current channel in streamlink."));
+                if (!channel->isTwitchChannel() || channel->isEmpty())
+                {
+                    channel->addMessage(makeSystemMessage(
+                        "Usage: /streamlink <channel>. You can also use the "
+                        "command without arguments in any twitch channel to "
+                        "open it in streamlink."));
+                }
+                else
+                {
+                    channel->addMessage(
+                        makeSystemMessage(QString("Opening %1 in streamlink...")
+                                              .arg(channel->getName())));
+                    openStreamlinkForChannel(channel->getName());
+                }
                 return "";
             }
-
-            if (!channel->isTwitchChannel())
-            {
-                return "";
-            }
-
-            QString channelName =
-                (words[1] == "channel") ? channel->getName() : words[1];
 
             channel->addMessage(makeSystemMessage(
-                QString("Opening %1 in streamlink...").arg(channelName)));
-            openStreamlinkForChannel(channelName);
+                QString("Opening %1 in streamlink...").arg(words[1])));
+            openStreamlinkForChannel(words[1]);
 
             return "";
         });

--- a/src/util/StreamLink.cpp
+++ b/src/util/StreamLink.cpp
@@ -187,8 +187,7 @@ void openStreamlink(const QString &channelURL, const QString &quality,
         arguments << quality;
     }
 
-    bool res = QProcess::startDetached(getStreamlinkProgram() + " " +
-                                       QString(arguments.join(' ')));
+    bool res = QProcess::startDetached(getStreamlinkProgram(), arguments);
 
     if (!res)
     {


### PR DESCRIPTION

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Usage: /streamlink [channel], use "channel" literally to open current channel in streamlink.

I am not so sure about using 'channel' for opening the current channel in streamlink, it's just a concept and I may change it to just `/streamlink` opening the current channel.
