### PR TITLE
Fix next tab completion breaking after tabbing an @-mention with a single letter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@
 - Bugfix: Fix anonymous users being pinged by "username" justinfan64537 (#2156, #2352)
 - Bugfix: Fixed hidden tooltips when always on top is active (#2384)
 - Bugfix: Fix CLI arguments (`--help`, `--version`, `--channels`) not being respected (#2368, #2190)
+- Bugfix: Fix next tab completion breaking after tabbing an @-mention with a single letter (#2451)
 - Dev: Updated minimum required Qt framework version to 5.12. (#2210)
 - Dev: Migrated `Kraken::getUser` to Helix (#2260)
 - Dev: Migrated `TwitchAccount::(un)followUser` from Kraken to Helix and moved it to `Helix::(un)followUser`. (#2306)

--- a/src/common/CompletionModel.cpp
+++ b/src/common/CompletionModel.cpp
@@ -91,9 +91,6 @@ void CompletionModel::refresh(const QString &prefix, bool isFirstWord)
     std::lock_guard<std::mutex> guard(this->itemsMutex_);
     this->items_.clear();
 
-    if (prefix.length() < 2)
-        return;
-
     if (auto channel = dynamic_cast<TwitchChannel *>(&this->channel_))
     {
         // account emotes

--- a/src/widgets/helper/ResizingTextEdit.cpp
+++ b/src/widgets/helper/ResizingTextEdit.cpp
@@ -120,7 +120,9 @@ void ResizingTextEdit::keyPressEvent(QKeyEvent *event)
         }();
 
         // check if there is something to complete
-        if (currentCompletionPrefix.size() <= 1)
+        if (currentCompletionPrefix.size() <= 1 ||
+            (currentCompletionPrefix.startsWith("@") &&
+             currentCompletionPrefix.size() <= 2))
         {
             return;
         }


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Fixes the bug described in #1107 that still occurred after tabbing an @ mention with a single letter:
![failed tabcomplete after one letter @ mention](https://user-images.githubusercontent.com/19888861/107851055-32245380-6e07-11eb-8000-3fecc220f118.gif)
