### PR TITLE
Register "Enter" shortcut to confirm select channel dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 - Minor: Update emojis version to 13 (2020). (#1555)
 - Minor: Remove EmojiOne 2 and 3 due to license restrictions. (#1555)
 - Minor: Added `/streamlink` command. Usage: `/streamlink <channel>`. You can also use the command without arguments in any twitch channel to open it in streamlink. (#2443)
+- Minor: Select channel dialog can now be confirmed using the numpad's enter key (#2464)
 - Bugfix: Fix crash occurring when pressing Escape in the Color Picker Dialog (#1843)
 - Bugfix: Fix bug where the "check user follow state" event could trigger a network request requesting the user to follow or unfollow a user. By itself its quite harmless as it just repeats to Twitch the same follow state we had, so no follows should have been lost by this but it meant there was a rogue network request that was fired that could cause a crash (#1906)
 - Bugfix: /usercard command will now respect the "Automatically close user popup" setting (#1918)

--- a/src/widgets/dialogs/SelectChannelDialog.cpp
+++ b/src/widgets/dialogs/SelectChannelDialog.cpp
@@ -224,6 +224,9 @@ SelectChannelDialog::SelectChannelDialog(QWidget *parent)
     createWindowShortcut(this, "Return", [=] {
         this->ok();
     });
+    createWindowShortcut(this, "Enter", [=] {
+        this->ok();
+    });
     createWindowShortcut(this, "Esc", [=] {
         this->close();
     });


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Registered numpad's enter key as a shortcut to confirm the select channel dialog.
