### PR TITLE
feat: /clearmessages command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Major: Added Streamer Mode configuration (under `Settings -> General`), where you can select which features of Chatterino should behave differently when you are in Streamer Mode. (#2001, #2316, #2342, #2376)
 - Major: Color mentions to match the mentioned users. You can disable this by unchecking "Color @usernames" under `Settings -> General -> Advanced (misc.)`. (#1963, #2284)
 - Major: Commands `/ignore` and `/unignore` have been renamed to `/block` and `/unblock` in order to keep consistency with Twitch's terms. (#2370)
+- Minor: Added `/clearmessages` command - does what "Burger menu -> More -> Clear messages" does. (#2485)
 - Minor: Added `/marker` command - similar to webchat, it creates a stream marker. (#2360)
 - Minor: Added `/chatters` command showing chatter count. (#2344)
 - Minor: Added a button to the split context menu to open the moderation view for a channel when the account selected has moderator permissions. (#2321)

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -21,6 +21,7 @@
 #include "util/Twitch.hpp"
 #include "widgets/Window.hpp"
 #include "widgets/dialogs/UserInfoPopup.hpp"
+#include "widgets/splits/Split.hpp"
 
 #include <QApplication>
 #include <QFile>
@@ -632,6 +633,16 @@ void CommandController::initialize(Settings &, Paths &paths)
 
             return "";
         });
+
+    this->registerCommand("/clearmessages", [](const auto & /*words*/,
+                                               ChannelPtr channel) {
+        auto *currentPage = dynamic_cast<SplitContainer *>(
+            getApp()->windows->getMainWindow().getNotebook().getSelectedPage());
+
+        currentPage->getSelectedSplit()->getChannelView().clearMessages();
+
+        return "";
+    });
 }
 
 void CommandController::save()


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

There was a request for clearing messages through a command.
Syntax `/clearmessages`, it has no arguments.

Thank you @zneix for the code. (Which also means you can blame him for it ![image](https://user-images.githubusercontent.com/13697809/109489611-69416880-7a87-11eb-8379-54032ae39399.png))