### PR TITLE
Localized all relevant numbers visible to end-user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 - Minor: Update emojis version to 13 (2020). (#1555)
 - Minor: Remove EmojiOne 2 and 3 due to license restrictions. (#1555)
 - Minor: Added `/streamlink` command. Usage: `/streamlink <channel>`. You can also use the command without arguments in any twitch channel to open it in streamlink. (#2443)
+- Minor: Humanized all numbers visible to end-users. (#2488)
 - Bugfix: Fix crash occurring when pressing Escape in the Color Picker Dialog (#1843)
 - Bugfix: Fix bug where the "check user follow state" event could trigger a network request requesting the user to follow or unfollow a user. By itself its quite harmless as it just repeats to Twitch the same follow state we had, so no follows should have been lost by this but it meant there was a rogue network request that was fired that could cause a crash (#1906)
 - Bugfix: /usercard command will now respect the "Automatically close user popup" setting (#1918)

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -17,6 +17,7 @@
 #include "singletons/WindowManager.hpp"
 #include "util/CombinePath.hpp"
 #include "util/FormatTime.hpp"
+#include "util/Helpers.hpp"
 #include "util/StreamLink.hpp"
 #include "util/Twitch.hpp"
 #include "widgets/Window.hpp"
@@ -515,7 +516,7 @@ void CommandController::initialize(Settings &, Paths &paths)
 
             channel->addMessage(makeSystemMessage(
                 QString("Chatter count: %1")
-                    .arg(QString::number(twitchChannel->chatterCount()))));
+                    .arg(localizeNumbers(twitchChannel->chatterCount()))));
 
             return "";
         });

--- a/src/util/Helpers.cpp
+++ b/src/util/Helpers.cpp
@@ -1,5 +1,6 @@
 #include "Helpers.hpp"
 
+#include <QLocale>
 #include <QUuid>
 
 namespace chatterino {
@@ -33,6 +34,12 @@ QString shortenString(const QString &str, unsigned maxWidth)
     }
 
     return shortened;
+}
+
+QString localizeNumbers(const int &number)
+{
+    QLocale locale;
+    return locale.toString(number);
 }
 
 }  // namespace chatterino

--- a/src/util/Helpers.hpp
+++ b/src/util/Helpers.hpp
@@ -13,4 +13,6 @@ QString formatRichNamedLink(const QString &url, const QString &name,
 
 QString shortenString(const QString &str, unsigned maxWidth = 50);
 
+QString localizeNumbers(const int &number);
+
 }  // namespace chatterino

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -14,6 +14,7 @@
 #include "singletons/Resources.hpp"
 #include "singletons/Settings.hpp"
 #include "util/Clipboard.hpp"
+#include "util/Helpers.hpp"
 #include "util/LayoutCreator.hpp"
 #include "util/PostToThread.hpp"
 #include "util/Shortcut.hpp"
@@ -611,7 +612,8 @@ void UserInfoPopup::updateUserData()
 
         this->ui_.nameLabel->setText(user.displayName);
         this->setWindowTitle(TEXT_TITLE.arg(user.displayName));
-        this->ui_.viewCountLabel->setText(TEXT_VIEWS.arg(user.viewCount));
+        this->ui_.viewCountLabel->setText(
+            TEXT_VIEWS.arg(localizeNumbers(user.viewCount)));
         this->ui_.createdDateLabel->setText(
             TEXT_CREATED.arg(user.createdAt.section("T", 0, 0)));
         this->ui_.userIDLabel->setText(TEXT_USER_ID + user.id);
@@ -635,7 +637,7 @@ void UserInfoPopup::updateUserData()
                     return;
                 }
                 this->ui_.followerCountLabel->setText(
-                    TEXT_FOLLOWERS.arg(followers.total));
+                    TEXT_FOLLOWERS.arg(localizeNumbers(followers.total)));
             },
             [] {
                 // on failure

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -10,6 +10,7 @@
 #include "singletons/Theme.hpp"
 #include "singletons/TooltipPreviewImage.hpp"
 #include "singletons/WindowManager.hpp"
+#include "util/Helpers.hpp"
 #include "util/LayoutCreator.hpp"
 #include "util/LayoutHelper.hpp"
 #include "util/StreamerMode.hpp"
@@ -47,7 +48,7 @@ namespace {
                 text += "r9k, ";
             if (modes->slowMode)
                 text +=
-                    QString("slow(%1), ").arg(QString::number(modes->slowMode));
+                    QString("slow(%1), ").arg(localizeNumbers(modes->slowMode));
             if (modes->emoteOnly)
                 text += "emote, ";
             if (modes->submode)
@@ -57,7 +58,7 @@ namespace {
                 if (modes->followerOnly != 0)
                 {
                     text += QString("follow(%1m), ")
-                                .arg(QString::number(modes->followerOnly));
+                                .arg(localizeNumbers(modes->followerOnly));
                 }
                 else
                 {
@@ -131,7 +132,7 @@ namespace {
             return QString("%1 for %2 with %3 viewers")
                 .arg(s.rerun ? "Vod-casting" : "Live")
                 .arg(s.uptime)
-                .arg(QString::number(s.viewerCount));
+                .arg(localizeNumbers(s.viewerCount));
         }();
 
         return QString("<p style=\"text-align: center;\">" +  //
@@ -163,7 +164,7 @@ namespace {
         if (settings.headerUptime)
             title += " - " + s.uptime;
         if (settings.headerViewerCount)
-            title += " - " + QString::number(s.viewerCount);
+            title += " - " + localizeNumbers(s.viewerCount);
         if (settings.headerGame && !s.game.isEmpty())
             title += " - " + s.game;
         if (settings.headerStreamTitle && !s.title.isEmpty())


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Added a simple utility function for using Qt's [`QLocale.toString()`](https://doc.qt.io/qt-5/qlocale.html#toString-6) and making all the things like viewerCount, followerCount be separated with commas, dots or spaces, depending on user's system locale settings.  
I tried to add it whereever applicable, but let me know if I forgot about something.
