### PR TITLE
Fixed emote pasting bug with multiple spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@
 - Bugfix: /usercard command will now respect the "Automatically close user popup" setting (#1918)
 - Bugfix: Handle symlinks properly when saving commands & settings (#1856, #1908)
 - Bugfix: Starting Chatterino in a minimized state after an update will no longer cause a crash
-- Bugfix: Modify the emote parsing to handle some edge-cases with dots and stuff (#1704, #1714)
+- Bugfix: Modify the emote parsing to handle some edge-cases with dots and stuff. (#1704, #1714, #2490)
 - Bugfix: Fixed timestamps being incorrect on some messages loaded from the recent-messages service on startup (#1286, #2020)
 - Bugfix: Fixed timestamps missing on channel point redemption messages (#1943)
 - Bugfix: Fixed tooltip didn't show in `EmotePopup` depending on the `Link preview` setting enabled or no (#2008)

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -366,6 +366,12 @@ void TwitchMessageBuilder::addWords(
 
     for (auto word : words)
     {
+        if (word.isEmpty())
+        {
+            cursor++;
+            continue;
+        }
+
         while (doesWordContainATwitchEmote(cursor, word, twitchEmotes,
                                            currentTwitchEmoteIt))
         {


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

This should fix the bug described in #2479  
![lole](https://cdn.zneix.eu/mCN0Cjk.png)

Closes #2479
