### PR TITLE
Add tray icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unversioned
 
+- Major: Add ability to minimize and close Chatterino to system tray (#2501)
 - Minor: Added `is:first-msg` search option. (#3700)
 - Minor: Added quotation marks in the permitted/blocked Automod messages for clarity. (#3654)
 - Minor: Adjust large stream thumbnail to 16:9 (#3655)

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -58,6 +58,14 @@ enum UsernameDisplayMode : int {
     LocalizedName = 2,             // Localized name
     UsernameAndLocalizedName = 3,  // Username (Localized name)
 };
+
+enum TrayAction : int {
+    AskMe = 0,              // Default
+    MinimizeToTray = 1,     // Minimize to tray icon
+    MinimizeToTaskBar = 2,  // Minimize to task bar
+    CloseChatterino = 3     // Close program
+};
+
 /// Settings which are availlable for reading and writing on the gui thread.
 // These settings are still accessed concurrently in the code but it is bad practice.
 class Settings : public ABSettings, public ConcurrentSettings
@@ -112,6 +120,10 @@ public:
     BoolSetting showTabLive = {"/appearance/showTabLiveButton", true};
     BoolSetting hidePreferencesButton = {"/appearance/hidePreferencesButton",
                                          false};
+    EnumSetting<TrayAction> minizeTrayAction = {
+        "/appearance/minimizeTrayAction", AskMe};
+    EnumSetting<TrayAction> closeTrayAction = {"/appearance/closeTrayAction",
+                                               AskMe};
     BoolSetting hideUserButton = {"/appearance/hideUserButton", false};
     BoolSetting enableSmoothScrolling = {"/appearance/smoothScrolling", true};
     BoolSetting enableSmoothScrollingNewMessages = {

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -642,6 +642,29 @@ void WindowManager::closeAll()
     }
 }
 
+void WindowManager::setVisibilityAll(bool visible)
+{
+    assertInGuiThread();
+    getMainWindow().getTrayIcon()->setVisible(!visible);
+
+    for (Window *window : windows_)
+    {
+        if (!window->getFlags().has(BaseWindow::IgnoreTrayEvent))
+        {
+            if (window->shouldHandleTrayEvent(visible))
+            {
+                window->setVisible(visible);
+                if (visible)
+                {
+                    window->activateWindow();
+                    window->raise();
+                    window->showNormal();
+                }
+            }
+        }
+    }
+}
+
 int WindowManager::getGeneration() const
 {
     return this->generation_;

--- a/src/singletons/WindowManager.hpp
+++ b/src/singletons/WindowManager.hpp
@@ -68,6 +68,7 @@ public:
     virtual void initialize(Settings &settings, Paths &paths) override;
     virtual void save() override;
     void closeAll();
+    void setVisibilityAll(bool visible);
 
     int getGeneration() const;
     void incGeneration();

--- a/src/widgets/BaseWindow.hpp
+++ b/src/widgets/BaseWindow.hpp
@@ -31,6 +31,7 @@ public:
         FramelessDraggable = 16,
         DontFocus = 32,
         Dialog = 64,
+        IgnoreTrayEvent = 128,
     };
 
     enum ActionOnFocusLoss { Nothing, Delete, Close, Hide };
@@ -63,6 +64,10 @@ public:
 
     static bool supportsCustomWindowFrame();
 
+    FlagsEnum<Flags> const &getFlags();
+
+    virtual bool shouldHandleTrayEvent(bool visible);
+
 protected:
     virtual bool nativeEvent(const QByteArray &eventType, void *message,
                              long *result) override;
@@ -81,6 +86,8 @@ protected:
     virtual bool event(QEvent *event) override;
     virtual void wheelEvent(QWheelEvent *event) override;
 
+    virtual bool isMainWindow();
+
     void mousePressEvent(QMouseEvent *event) override;
     void mouseReleaseEvent(QMouseEvent *event) override;
     void mouseMoveEvent(QMouseEvent *event) override;
@@ -89,6 +96,8 @@ protected:
 
     void updateScale();
 
+    void handleMinimizeEvent(QEvent *event);
+    void handleCloseEvent(QEvent *event);
     boost::optional<QColor> overrideBackgroundColor_;
 
 private:

--- a/src/widgets/TooltipWidget.cpp
+++ b/src/widgets/TooltipWidget.cpp
@@ -23,7 +23,9 @@ TooltipWidget *TooltipWidget::instance()
 }
 
 TooltipWidget::TooltipWidget(BaseWidget *parent)
-    : BaseWindow({BaseWindow::TopMost, BaseWindow::DontFocus}, parent)
+    : BaseWindow({BaseWindow::TopMost, BaseWindow::DontFocus,
+                  BaseWindow::IgnoreTrayEvent},
+                 parent)
     , displayImage_(new QLabel())
     , displayText_(new QLabel())
 {

--- a/src/widgets/Window.hpp
+++ b/src/widgets/Window.hpp
@@ -2,6 +2,7 @@
 
 #include "widgets/BaseWindow.hpp"
 
+#include <QSystemTrayIcon>
 #include <boost/signals2.hpp>
 #include <pajlada/settings/setting.hpp>
 #include <pajlada/signals/signal.hpp>
@@ -25,12 +26,14 @@ public:
 
     WindowType getType();
     SplitNotebook &getNotebook();
+    QSystemTrayIcon *getTrayIcon();
 
     pajlada::Signals::NoArgSignal closed;
 
 protected:
     void closeEvent(QCloseEvent *event) override;
     bool event(QEvent *event) override;
+    bool isMainWindow() override;
 
 private:
     void addCustomTitlebarButtons();
@@ -50,6 +53,11 @@ private:
 
     pajlada::Signals::SignalHolder signalHolder_;
     std::vector<boost::signals2::scoped_connection> bSignals_;
+
+    QSystemTrayIcon *trayIcon_ = nullptr;
+    QAction *actionExit_ = nullptr;
+    QAction *actionShow_ = nullptr;
+    QMenu *trayContextMenu_ = nullptr;
 
     friend class Notebook;
 };

--- a/src/widgets/dialogs/SettingsDialog.cpp
+++ b/src/widgets/dialogs/SettingsDialog.cpp
@@ -351,6 +351,22 @@ void SettingsDialog::showEvent(QShowEvent *)
     this->ui_.search->setText("");
 }
 
+bool SettingsDialog::shouldHandleTrayEvent(bool visible)
+{
+    if (visible)
+    {
+        // Only reshow the settings dialog if it was visible before we
+        // hid the window to the tray bar
+        return wasVisible_;
+    }
+    else
+    {
+        wasVisible_ = isVisible();
+    }
+
+    return BaseWindow::shouldHandleTrayEvent(visible);
+}
+
 ///// Widget creation helpers
 void SettingsDialog::onOkClicked()
 {

--- a/src/widgets/dialogs/SettingsDialog.hpp
+++ b/src/widgets/dialogs/SettingsDialog.hpp
@@ -40,6 +40,8 @@ public:
                            SettingsDialogPreference preferredTab =
                                SettingsDialogPreference::NoPreference);
 
+    bool shouldHandleTrayEvent(bool visible) override;
+
 protected:
     virtual void scaleChangedEvent(float newDpi) override;
     virtual void themeChangedEvent() override;
@@ -73,6 +75,7 @@ private:
     std::vector<SettingsDialogTab *> tabs_;
     SettingsDialogTab *selectedTab_{};
     SettingsDialogTab *lastSelectedByUser_{};
+    bool wasVisible_ = false;
 
     friend class SettingsDialogTab;
 };

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -16,6 +16,7 @@
 #include "util/IncognitoBrowser.hpp"
 #include "util/StreamerMode.hpp"
 #include "widgets/BaseWindow.hpp"
+#include "widgets/Window.hpp"
 #include "widgets/helper/Line.hpp"
 #include "widgets/settingspages/GeneralPageView.hpp"
 
@@ -185,6 +186,62 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         layout.addCheckbox("Show user button", s.hideUserButton, true);
     }
     layout.addCheckbox("Show which channels are live in tabs", s.showTabLive);
+
+    minimizeTrayAction =
+        layout.addDropdown<std::underlying_type<TrayAction>::type>(
+            "Behavior when you press the minimize button",
+            {"Ask me", "Minimize to task bar", "Minimize to tray"},
+            s.minizeTrayAction,
+            [](auto val) {
+                switch (val)
+                {
+                    default:
+                    case TrayAction::MinimizeToTaskBar:
+                        return QString("Minimize to task bar");
+                    case TrayAction::AskMe:
+                        return QString("Ask me");
+                    case TrayAction::MinimizeToTray:
+                        return QString("Minimize to tray");
+                }
+            },
+            [](auto args) {
+                if (args.value == "Minimize to tray")
+                    return TrayAction::MinimizeToTray;
+                if (args.value == "Ask me")
+                    return TrayAction::AskMe;
+                return TrayAction::MinimizeToTaskBar;
+            },
+            false);
+    closeTrayAction =
+        layout.addDropdown<std::underlying_type<TrayAction>::type>(
+            "Behavior when you press the close button",
+            {"Ask me", "Close Chatterino", "Minimize to tray"},
+            s.closeTrayAction,
+            [](auto val) {
+                switch (val)
+                {
+                    default:
+                    case TrayAction::CloseChatterino:
+                        return QString("Close Chatterino");
+                    case TrayAction::AskMe:
+                        return QString("Ask me");
+                    case TrayAction::MinimizeToTray:
+                        return QString("Minimize to tray");
+                }
+            },
+            [](auto args) {
+                if (args.value == "Minimize to tray")
+                    return TrayAction::MinimizeToTray;
+                if (args.value == "Ask me")
+                    return TrayAction::AskMe;
+                return TrayAction::CloseChatterino;
+            },
+            false);
+
+    minimizeTrayAction->setMinimumWidth(
+        closeTrayAction->minimumSizeHint().width() + 35);
+    closeTrayAction->setMinimumWidth(
+        closeTrayAction->minimumSizeHint().width() + 35);
 
     layout.addTitle("Chat");
 

--- a/src/widgets/settingspages/GeneralPage.hpp
+++ b/src/widgets/settingspages/GeneralPage.hpp
@@ -29,6 +29,10 @@ private:
 
     DescriptionLabel *cachePath_{};
     GeneralPageView *view_{};
+
+    QCheckBox *enableTrayIcon{};
+    QComboBox *minimizeTrayAction{};
+    QComboBox *closeTrayAction{};
 };
 
 }  // namespace chatterino


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description
Added an optional tray icon. The tray icon can be used when the main window is minimized, closed or both. Clicking the tray icon will toggle the visibility of all windows. Right clicking it will open a context menu to show or close the application so users have an option to exit if they set Chatterino to hide when closing the main window.
![image](https://user-images.githubusercontent.com/8353672/110246020-27706080-7f66-11eb-98d4-ef7596ef0abb.png)

I only tested this on linux with KDE, so it would have to be tested on other platforms as well, but I assume Qt takes care of the tray icon fairly well. I hope I put everything in the right place, I didn't really know where to put the enum for the tray icon setting, so if there's some issues I'd be happy to correct them.

Closes #1358