### PR TITLE
Fixed remaining timeout message

### DIFF
--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -719,16 +719,18 @@ std::vector<MessagePtr> IrcMessageHandler::parseNoticeMessage(
     }
     else if (message->tags()["msg-id"] == "msg_timedout")
     {
-        std::vector<MessagePtr> builtMessages;
+        std::vector<MessagePtr> builtMessage;
 
-        QString formattedMessage = "You are timed out for ";
-        formattedMessage.append(
-            formatTime(message->content().split(" ").value(5)));
+        QString remainingTime =
+            formatTime(message->content().split(" ").value(5));
+        QString formattedMessage =
+            QString("You are timed out for %1.")
+                .arg(remainingTime.isEmpty() ? "0s" : remainingTime);
 
-        builtMessages.emplace_back(makeSystemMessage(
-            formattedMessage.append("."), calculateMessageTimestamp(message)));
+        builtMessage.emplace_back(makeSystemMessage(
+            formattedMessage, calculateMessageTimestamp(message)));
 
-        return builtMessages;
+        return builtMessage;
     }
     else
     {


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

This fixes a case, where your timeout is smaller than 1 second and your timeout message would appear as `You are timed out for .`

![hi mm and Leon](https://cdn.zneix.eu/xWRE4xx.png)
