### PR TITLE
Implement missing cheer emote tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
 - Bugfix: Fix anonymous users being pinged by "username" justinfan64537 (#2156, #2352)
 - Bugfix: Fixed hidden tooltips when always on top is active (#2384)
 - Bugfix: Fix CLI arguments (`--help`, `--version`, `--channels`) not being respected (#2368, #2190)
+- Bugfix: Fix Twitch cheer emotes not displaying tooltips when hovered (#2434)
 - Dev: Updated minimum required Qt framework version to 5.12. (#2210)
 - Dev: Migrated `Kraken::getUser` to Helix (#2260)
 - Dev: Migrated `TwitchAccount::(un)followUser` from Kraken to Helix and moved it to `Helix::(un)followUser`. (#2306)

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -911,7 +911,7 @@ void TwitchChannel::refreshCheerEmotes()
 
                     // Combine the prefix (e.g. BibleThump) with the tier (1, 100 etc.)
                     auto emoteTooltip =
-                        set.prefix + tier.id + "<br/>Twitch Cheer Emote";
+                        set.prefix + tier.id + "<br>Twitch Cheer Emote";
                     cheerEmote.animatedEmote = std::make_shared<Emote>(
                         Emote{EmoteName{"cheer emote"},
                               ImageSet{

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -909,6 +909,7 @@ void TwitchChannel::refreshCheerEmotes()
                     // We will continue to do so for now since we haven't had to
                     // solve that anywhere else
 
+                    // Combine the prefix (e.g. BibleThump) with the tier (1, 100 etc.)
                     auto emoteTooltip = set.prefix + tier.id + "<br/>Twitch Cheer Emote";
                     cheerEmote.animatedEmote = std::make_shared<Emote>(
                         Emote{EmoteName{"cheer emote"},

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -917,7 +917,7 @@ void TwitchChannel::refreshCheerEmotes()
                                   tier.images["dark"]["animated"]["2"],
                                   tier.images["dark"]["animated"]["4"],
                               },
-                              Tooltip{}, Url{}});
+                              Tooltip{emoteTooltip}, Url{}});
                     cheerEmote.staticEmote = std::make_shared<Emote>(
                         Emote{EmoteName{"cheer emote"},
                               ImageSet{
@@ -925,7 +925,7 @@ void TwitchChannel::refreshCheerEmotes()
                                   tier.images["dark"]["static"]["2"],
                                   tier.images["dark"]["static"]["4"],
                               },
-                              Tooltip{}, Url{}});
+                              Tooltip{emoteTooltip}, Url{}});
 
                     cheerEmoteSet.cheerEmotes.emplace_back(cheerEmote);
                 }

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -911,7 +911,7 @@ void TwitchChannel::refreshCheerEmotes()
 
                     // Combine the prefix (e.g. BibleThump) with the tier (1, 100 etc.)
                     auto emoteTooltip =
-                            set.prefix + tier.id + "<br/>Twitch Cheer Emote";
+                        set.prefix + tier.id + "<br/>Twitch Cheer Emote";
                     cheerEmote.animatedEmote = std::make_shared<Emote>(
                         Emote{EmoteName{"cheer emote"},
                               ImageSet{

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -910,7 +910,8 @@ void TwitchChannel::refreshCheerEmotes()
                     // solve that anywhere else
 
                     // Combine the prefix (e.g. BibleThump) with the tier (1, 100 etc.)
-                    auto emoteTooltip = set.prefix + tier.id + "<br/>Twitch Cheer Emote";
+                    auto emoteTooltip =
+                            set.prefix + tier.id + "<br/>Twitch Cheer Emote";
                     cheerEmote.animatedEmote = std::make_shared<Emote>(
                         Emote{EmoteName{"cheer emote"},
                               ImageSet{

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -909,6 +909,7 @@ void TwitchChannel::refreshCheerEmotes()
                     // We will continue to do so for now since we haven't had to
                     // solve that anywhere else
 
+                    auto emoteTooltip = set.prefix + tier.id + "<br/>Twitch Cheer Emote";
                     cheerEmote.animatedEmote = std::make_shared<Emote>(
                         Emote{EmoteName{"cheer emote"},
                               ImageSet{


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

This PR fixes/adds the ability to hover over a cheer emote and display a tooltip. This is because no tooltip is set on the cheer emotes when they are parsed/created - failing a check in [ChannelView.cpp#L1406](https://github.com/Chatterino/chatterino2/blob/master/src/widgets/helper/ChannelView.cpp#L1406) where a tooltip must be present in order to show.

This aims to fix #2434

**Steps to reproduce:**
  1. Find/create a cheer message containing a cheer emote
  2. Hover over the emote

**Expected result:**
Emote tooltip displays with a larger version of the emote as well as the text value of the emote

**Actual result (prior to this PR):**
No tooltip is displayed.

_NOTE: I'm not a proficient C++ dev, nor do I have much experience with QT so if it looks weird just comment on the line with an example of how I can do better._