### PR TITLE
Fixed deprecated method QTime::elapsed

### DIFF
--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -36,7 +36,7 @@
 namespace chatterino {
 namespace {
     constexpr char MAGIC_MESSAGE_SUFFIX[] = u8" \U000E0000";
-    constexpr int TITLE_REFRESH_PERIOD = 10;
+    constexpr int TITLE_REFRESH_PERIOD = 10000;
     constexpr int CLIP_CREATION_COOLDOWN = 5000;
     const QString CLIPS_LINK("https://clips.twitch.tv/%1");
     const QString CLIPS_FAILURE_CLIPS_DISABLED_TEXT(
@@ -159,7 +159,6 @@ TwitchChannel::TwitchChannel(const QString &name,
     , bttvEmotes_(std::make_shared<EmoteMap>())
     , ffzEmotes_(std::make_shared<EmoteMap>())
     , mod_(false)
-    , titleRefreshedTime_(QTime::currentTime().addSecs(-TITLE_REFRESH_PERIOD))
 {
     qCDebug(chatterinoTwitch) << "[TwitchChannel" << name << "] Opened";
 
@@ -587,20 +586,20 @@ void TwitchChannel::setLive(bool newLiveStatus)
 
 void TwitchChannel::refreshTitle()
 {
-    auto roomID = this->roomId();
-    if (roomID.isEmpty())
+    // timer has never started, proceed and start it
+    if (!this->titleRefreshedTimer_.isValid())
+    {
+        this->titleRefreshedTimer_.start();
+    }
+    else if (this->roomId().isEmpty() ||
+             this->titleRefreshedTimer_.elapsed() < TITLE_REFRESH_PERIOD)
     {
         return;
     }
-
-    if (this->titleRefreshedTime_.elapsed() < TITLE_REFRESH_PERIOD * 1000)
-    {
-        return;
-    }
-    this->titleRefreshedTime_ = QTime::currentTime();
+    this->titleRefreshedTimer_.restart();
 
     getHelix()->getChannel(
-        roomID,
+        this->roomId(),
         [this, weak = weakOf<Channel>(this)](HelixChannel channel) {
             ChannelPtr shared = weak.lock();
 
@@ -953,8 +952,13 @@ void TwitchChannel::createClip()
         return;
     }
 
-    if (QTime().currentTime() < this->timeNextClipCreationAllowed_ ||
-        this->isClipCreationInProgress)
+    // timer has never started, proceed and start it
+    if (!this->clipCreationTimer_.isValid())
+    {
+        this->clipCreationTimer_.start();
+    }
+    else if (this->clipCreationTimer_.elapsed() < CLIP_CREATION_COOLDOWN ||
+             this->isClipCreationInProgress)
     {
         return;
     }
@@ -1034,8 +1038,7 @@ void TwitchChannel::createClip()
         },
         // finallyCallback - this will always execute, so clip creation won't ever be stuck
         [this] {
-            this->timeNextClipCreationAllowed_ =
-                QTime().currentTime().addMSecs(CLIP_CREATION_COOLDOWN);
+            this->clipCreationTimer_.restart();
             this->isClipCreationInProgress = false;
         });
 }

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -13,6 +13,7 @@
 
 #include <IrcConnection>
 #include <QColor>
+#include <QElapsedTimer>
 #include <QRegularExpression>
 #include <boost/optional.hpp>
 #include <pajlada/signals/signalholder.hpp>
@@ -188,8 +189,8 @@ private:
     QObject lifetimeGuard_;
     QTimer liveStatusTimer_;
     QTimer chattersListTimer_;
-    QTime titleRefreshedTime_;
-    QTime timeNextClipCreationAllowed_{QTime().currentTime()};
+    QElapsedTimer titleRefreshedTimer_;
+    QElapsedTimer clipCreationTimer_;
     bool isClipCreationInProgress{false};
 
     friend class TwitchIrcServer;


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
no changelog entry needed LOOOOOOOOOOOOL

# Description

After I checked out to `cmake-build` branch, I saw many deprecation warnings and most of them\* can be fixed, so I went ahead and did just that.

\* We can't replace `QString::SkipEmptyParts` with newer `Qt::SkipEmptyParts` since the second method was added just in Qt 5.14, so it would not work on our minimal supported version (Qt 5.12). I also left a couple warnings that I didn't understand how to fix, perhaps I could fix them later on.  
I believe there should be no conflicts with both qmake builds and cmake ones, since migration to cmake builds doesn't touch code at all 😎

# Update

Edit: @pajlada wanted me to split changes from this pull request to multiple PRs (#2508, #2509, #2510, #2511, #2512)

This pull request specifically fixes deprecated [`QTime::elapsed`](https://doc.qt.io/qt-5/qtime-obsolete.html#elapsed), which is replaced with [`QTimerElapsed::elapsed`](https://doc.qt.io/qt-5/qtime-obsolete.html#elapsed) method. To keep better consistency, I updated other `QTime` timer in this file to use `QElapsedTimer` class as well