### PR TITLE
Fix workflow builds on ubuntu

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,6 +101,7 @@ jobs:
             sudo apt-get -y install \
                 libssl-dev \
                 libboost-dev \
+                libxcb-randr0-dev \
                 libboost-system-dev \
                 libboost-filesystem-dev \
                 libpulse-dev \


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Added newly required `libxcb-randr0-dev` to packages we need to install. Hopefully this fixes builds on Ubuntu :)
