### PR TITLE
Fixed deprecated method QFlags::Zero

### DIFF
--- a/src/controllers/highlights/HighlightModel.cpp
+++ b/src/controllers/highlights/HighlightModel.cpp
@@ -65,8 +65,8 @@ void HighlightModel::afterInit()
     setBoolItem(usernameRow[Column::PlaySound],
                 getSettings()->enableSelfHighlightSound.getValue(), true,
                 false);
-    usernameRow[Column::UseRegex]->setFlags(0);
-    usernameRow[Column::CaseSensitive]->setFlags(0);
+    usernameRow[Column::UseRegex]->setFlags({});
+    usernameRow[Column::CaseSensitive]->setFlags({});
 
     QUrl selfSound = QUrl(getSettings()->selfHighlightSoundUrl.getValue());
     setFilePathItem(usernameRow[Column::SoundPath], selfSound, false);
@@ -74,22 +74,22 @@ void HighlightModel::afterInit()
     auto selfColor = ColorProvider::instance().color(ColorType::SelfHighlight);
     setColorItem(usernameRow[Column::Color], *selfColor, false);
 
-    this->insertCustomRow(usernameRow, 0);
+    this->insertCustomRow(usernameRow, {});
 
     // Highlight settings for whispers
     std::vector<QStandardItem *> whisperRow = this->createRow();
     setBoolItem(whisperRow[Column::Pattern],
                 getSettings()->enableWhisperHighlight.getValue(), true, false);
     whisperRow[Column::Pattern]->setData("Whispers", Qt::DisplayRole);
-    whisperRow[Column::ShowInMentions]->setFlags(0);  // We have /whispers
+    whisperRow[Column::ShowInMentions]->setFlags({});  // We have /whispers
     setBoolItem(whisperRow[Column::FlashTaskbar],
                 getSettings()->enableWhisperHighlightTaskbar.getValue(), true,
                 false);
     setBoolItem(whisperRow[Column::PlaySound],
                 getSettings()->enableWhisperHighlightSound.getValue(), true,
                 false);
-    whisperRow[Column::UseRegex]->setFlags(0);
-    whisperRow[Column::CaseSensitive]->setFlags(0);
+    whisperRow[Column::UseRegex]->setFlags({});
+    whisperRow[Column::CaseSensitive]->setFlags({});
 
     QUrl whisperSound =
         QUrl(getSettings()->whisperHighlightSoundUrl.getValue());
@@ -106,14 +106,14 @@ void HighlightModel::afterInit()
     setBoolItem(subRow[Column::Pattern],
                 getSettings()->enableSubHighlight.getValue(), true, false);
     subRow[Column::Pattern]->setData("Subscriptions", Qt::DisplayRole);
-    subRow[Column::ShowInMentions]->setFlags(0);
+    subRow[Column::ShowInMentions]->setFlags({});
     setBoolItem(subRow[Column::FlashTaskbar],
                 getSettings()->enableSubHighlightTaskbar.getValue(), true,
                 false);
     setBoolItem(subRow[Column::PlaySound],
                 getSettings()->enableSubHighlightSound.getValue(), true, false);
-    subRow[Column::UseRegex]->setFlags(0);
-    subRow[Column::CaseSensitive]->setFlags(0);
+    subRow[Column::UseRegex]->setFlags({});
+    subRow[Column::CaseSensitive]->setFlags({});
 
     QUrl subSound = QUrl(getSettings()->subHighlightSoundUrl.getValue());
     setFilePathItem(subRow[Column::SoundPath], subSound, false);
@@ -129,17 +129,17 @@ void HighlightModel::afterInit()
                 getSettings()->enableRedeemedHighlight.getValue(), true, false);
     redeemedRow[Column::Pattern]->setData(
         "Highlights redeemed with Channel Points", Qt::DisplayRole);
-    redeemedRow[Column::ShowInMentions]->setFlags(0);
+    redeemedRow[Column::ShowInMentions]->setFlags({});
     //    setBoolItem(redeemedRow[Column::FlashTaskbar],
     //                getSettings()->enableRedeemedHighlightTaskbar.getValue(), true,
     //                false);
     //    setBoolItem(redeemedRow[Column::PlaySound],
     //                getSettings()->enableRedeemedHighlightSound.getValue(), true,
     //                false);
-    redeemedRow[Column::FlashTaskbar]->setFlags(0);
-    redeemedRow[Column::PlaySound]->setFlags(0);
-    redeemedRow[Column::UseRegex]->setFlags(0);
-    redeemedRow[Column::CaseSensitive]->setFlags(0);
+    redeemedRow[Column::FlashTaskbar]->setFlags({});
+    redeemedRow[Column::PlaySound]->setFlags({});
+    redeemedRow[Column::UseRegex]->setFlags({});
+    redeemedRow[Column::CaseSensitive]->setFlags({});
 
     QUrl RedeemedSound =
         QUrl(getSettings()->redeemedHighlightSoundUrl.getValue());

--- a/src/widgets/helper/NotebookButton.cpp
+++ b/src/widgets/helper/NotebookButton.cpp
@@ -160,7 +160,7 @@ void NotebookButton::dragEnterEvent(QDragEnterEvent *event)
 
     auto e = new QMouseEvent(QMouseEvent::MouseButtonPress,
                              QPointF(this->width() / 2, this->height() / 2),
-                             Qt::LeftButton, Qt::LeftButton, 0);
+                             Qt::LeftButton, Qt::LeftButton, {});
     Button::mousePressEvent(e);
     delete e;
 }
@@ -172,7 +172,7 @@ void NotebookButton::dragLeaveEvent(QDragLeaveEvent *)
 
     auto e = new QMouseEvent(QMouseEvent::MouseButtonRelease,
                              QPointF(this->width() / 2, this->height() / 2),
-                             Qt::LeftButton, Qt::LeftButton, 0);
+                             Qt::LeftButton, Qt::LeftButton, {});
     Button::mouseReleaseEvent(e);
     delete e;
 }

--- a/src/widgets/helper/SignalLabel.hpp
+++ b/src/widgets/helper/SignalLabel.hpp
@@ -12,7 +12,7 @@ class SignalLabel : public QLabel
     Q_OBJECT
 
 public:
-    explicit SignalLabel(QWidget *parent = nullptr, Qt::WindowFlags f = 0);
+    explicit SignalLabel(QWidget *parent = nullptr, Qt::WindowFlags f = {});
     virtual ~SignalLabel() override = default;
 
 signals:


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
no changelog entry needed

# Description

Reference: https://doc.qt.io/qt-5/qflags-obsolete.html#QFlags-3
