### PR TITLE
Fixed deprecated method QFontMetrics::width

### DIFF
--- a/src/messages/MessageElement.cpp
+++ b/src/messages/MessageElement.cpp
@@ -320,7 +320,7 @@ void TextElement::addToContainer(MessageLayoutContainer &container,
 
             // fourtf: add again
             //            if (word.width == -1) {
-            word.width = metrics.width(word.text);
+            word.width = metrics.horizontalAdvance(word.text);
             //            }
 
             // see if the text fits in the current line
@@ -357,8 +357,9 @@ void TextElement::addToContainer(MessageLayoutContainer &container,
                 auto isSurrogate = text.size() > i + 1 &&
                                    QChar::isHighSurrogate(text[i].unicode());
 
-                auto charWidth = isSurrogate ? metrics.width(text.mid(i, 2))
-                                             : metrics.width(text[i]);
+                auto charWidth = isSurrogate
+                                     ? metrics.horizontalAdvance(text.mid(i, 2))
+                                     : metrics.horizontalAdvance(text[i]);
 
                 if (!container.fitsInLine(width + charWidth))
                 {
@@ -585,7 +586,7 @@ void IrcTextElement::addToContainer(MessageLayoutContainer &container,
 
             // fourtf: add again
             //            if (word.width == -1) {
-            word.width = metrics.width(word.text);
+            word.width = metrics.horizontalAdvance(word.text);
             //            }
 
             // see if the text fits in the current line
@@ -632,8 +633,9 @@ void IrcTextElement::addToContainer(MessageLayoutContainer &container,
                 auto isSurrogate = text.size() > i + 1 &&
                                    QChar::isHighSurrogate(text[i].unicode());
 
-                auto charWidth = isSurrogate ? metrics.width(text.mid(i, 2))
-                                             : metrics.width(text[i]);
+                auto charWidth = isSurrogate
+                                     ? metrics.horizontalAdvance(text.mid(i, 2))
+                                     : metrics.horizontalAdvance(text[i]);
 
                 if (!container.fitsInLine(width + charWidth))
                 {

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -43,8 +43,8 @@ void MessageLayoutContainer::begin(int width, float scale, MessageFlags flags)
     auto mediumFontMetrics =
         getApp()->fonts->getFontMetrics(FontStyle::ChatMedium, scale);
     this->textLineHeight_ = mediumFontMetrics.height();
-    this->spaceWidth_ = mediumFontMetrics.width(' ');
-    this->dotdotdotWidth_ = mediumFontMetrics.width("...");
+    this->spaceWidth_ = mediumFontMetrics.horizontalAdvance(' ');
+    this->dotdotdotWidth_ = mediumFontMetrics.horizontalAdvance("...");
     this->canAddMessages_ = true;
     this->isCollapsed_ = false;
 }

--- a/src/messages/layouts/MessageLayoutElement.cpp
+++ b/src/messages/layouts/MessageLayoutElement.cpp
@@ -309,7 +309,7 @@ int TextLayoutElement::getXFromIndex(int index)
         int x = 0;
         for (int i = 0; i < index; i++)
         {
-            x += metrics.width(this->getText()[i]);
+            x += metrics.horizontalAdvance(this->getText()[i]);
         }
         return x + this->getRect().left();
     }
@@ -429,7 +429,7 @@ void MultiColorTextLayoutElement::paint(QPainter &painter)
                                 this->getRect().y(), 10000, 10000),
                          segment.text,
                          QTextOption(Qt::AlignLeft | Qt::AlignTop));
-        xOffset += metrics.width(segment.text);
+        xOffset += metrics.horizontalAdvance(segment.text);
     }
 }
 

--- a/src/messages/layouts/MessageLayoutElement.cpp
+++ b/src/messages/layouts/MessageLayoutElement.cpp
@@ -270,7 +270,7 @@ int TextLayoutElement::getMouseOverIndex(const QPoint &abs) const
     for (auto i = 0; i < this->getText().size(); i++)
     {
         auto &&text = this->getText();
-        auto width = metrics.width(this->getText()[i]);
+        auto width = metrics.horizontalAdvance(this->getText()[i]);
 
         if (x + width > abs.x())
         {

--- a/src/widgets/Label.cpp
+++ b/src/widgets/Label.cpp
@@ -106,7 +106,7 @@ void Label::paintEvent(QPaintEvent *)
     // draw text
     QRect textRect(offset, 0, this->width() - offset - offset, this->height());
 
-    int width = metrics.width(this->text_);
+    int width = metrics.horizontalAdvance(this->text_);
     Qt::Alignment alignment = !this->centered_ || width > textRect.width()
                                   ? Qt::AlignLeft | Qt::AlignVCenter
                                   : Qt::AlignCenter;
@@ -128,7 +128,8 @@ void Label::updateSize()
     QFontMetrics metrics =
         getFonts()->getFontMetrics(this->fontStyle_, this->scale());
 
-    int width = metrics.width(this->text_) + (2 * this->getOffset());
+    int width =
+        metrics.horizontalAdvance(this->text_) + (2 * this->getOffset());
     int height = metrics.height();
     this->preferedSize_ = QSize(width, height);
 

--- a/src/widgets/helper/NotebookTab.cpp
+++ b/src/widgets/helper/NotebookTab.cpp
@@ -119,11 +119,11 @@ int NotebookTab::normalTabWidth()
 
     if (this->hasXButton())
     {
-        width = (metrics.width(this->getTitle()) + int(32 * scale));
+        width = (metrics.horizontalAdvance(this->getTitle()) + int(32 * scale));
     }
     else
     {
-        width = (metrics.width(this->getTitle()) + int(16 * scale));
+        width = (metrics.horizontalAdvance(this->getTitle()) + int(16 * scale));
     }
 
     if (this->height() > 150 * scale)
@@ -390,7 +390,7 @@ void NotebookTab::paintEvent(QPaintEvent *)
         textRect.setRight(textRect.right() - this->height() / 2);
     }
 
-    int width = metrics.width(this->getTitle());
+    int width = metrics.horizontalAdvance(this->getTitle());
     Qt::Alignment alignment = width > textRect.width()
                                   ? Qt::AlignLeft | Qt::AlignVCenter
                                   : Qt::AlignHCenter | Qt::AlignVCenter;


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
no changelog entry needed

# Description

Reference: https://doc.qt.io/qt-5/qfontmetrics-obsolete.html#width
Replaced with [`QFontMetrics::horizontalAdvance`](https://doc.qt.io/qt-5/qfontmetrics.html#horizontalAdvance)
