### PR TITLE
Fixed deprecated method QComboBox::currentIndexChanged

### DIFF
--- a/src/widgets/settingspages/GeneralPageView.hpp
+++ b/src/widgets/settingspages/GeneralPageView.hpp
@@ -172,13 +172,11 @@ public:
             this->managedConnections_);
 
         QObject::connect(
-            combo,
-            QOverload<const QString &>::of(&QComboBox::currentIndexChanged),
-            //            &QComboBox::editTextChanged,
+            combo, QOverload<const int>::of(&QComboBox::currentIndexChanged),
             [combo, &setting,
-             setValue = std::move(setValue)](const QString &newValue) {
-                setting = setValue(
-                    DropdownArgs{newValue, combo->currentIndex(), combo});
+             setValue = std::move(setValue)](const int newIndex) {
+                setting = setValue(DropdownArgs{combo->itemText(newIndex),
+                                                combo->currentIndex(), combo});
                 getApp()->windows->forceLayoutChannelViews();
             });
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
no changelog entry needed

# Description

Reference: https://doc.qt.io/qt-5/qcombobox-obsolete.html#currentIndexChanged-1
