### PR TITLE
Removed refresh label from usercard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 - Minor: Added an option to only open channels specified in command line with `-c` parameter. You can also use `--help` to display short help message (#1940, #2368)
 - Minor: Added customizable timeout buttons to the user info popup
 - Minor: Deprecate loading of "v1" window layouts. If you haven't updated Chatterino in more than 2 years, there's a chance you will lose your window layout.
-- Minor: User popup will now automatically display messages as they are received
+- Minor: User popup will now automatically display messages as they are received. (#1982, #2514)
 - Minor: Changed the English in two rate-limited system messages (#1878)
 - Minor: Added a setting to disable messages sent to /mentions split from making the tab highlight with the red marker (#1994)
 - Minor: Added image for streamer mode in the user popup icon.

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -211,10 +211,9 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically, QWidget *parent)
         user->addStretch(1);
 
         QObject::connect(usercard.getElement(), &Button::leftClicked, [this] {
-            QDesktopServices::openUrl(
-                QString("https://www.twitch.tv/popout/%1/viewercard/%2")
-                    .arg(this->channel_->getName())
-                    .arg(this->userName_));
+            QDesktopServices::openUrl("https://www.twitch.tv/popout/" +
+                                      this->channel_->getName() +
+                                      "/viewercard/" + this->userName_);
         });
 
         QObject::connect(mod.getElement(), &Button::leftClicked, [this] {
@@ -530,9 +529,45 @@ void UserInfoPopup::setData(const QString &name, const ChannelPtr &channel)
 
     this->userStateChanged_.invoke();
 
+    this->updateLatestMessages();
     QTimer::singleShot(1, this, [this] {
         this->setStayInScreenRect(true);
     });
+}
+
+void UserInfoPopup::updateLatestMessages()
+{
+    auto filteredChannel = filterMessages(this->userName_, this->channel_);
+    this->ui_.latestMessages->setChannel(filteredChannel);
+    this->ui_.latestMessages->setSourceChannel(this->channel_);
+
+    const bool hasMessages = filteredChannel->hasMessages();
+    this->ui_.latestMessages->setVisible(hasMessages);
+    this->ui_.noMessagesLabel->setVisible(!hasMessages);
+
+    // shrink dialog in case ChannelView goes from visible to hidden
+    this->adjustSize();
+
+    this->refreshConnection_
+        .disconnect();  // remove once https://github.com/pajlada/signals/pull/10 gets merged
+
+    this->refreshConnection_ = this->channel_->messageAppended.connect(
+        [this, hasMessages](auto message, auto) {
+            if (!checkMessageUserName(this->userName_, message))
+                return;
+
+            if (hasMessages)
+            {
+                // display message in ChannelView
+                this->ui_.latestMessages->channel()->addMessage(message);
+            }
+            else
+            {
+                // The ChannelView is currently hidden, so manually refresh
+                // and display the latest messages
+                this->updateLatestMessages();
+            }
+        });
 }
 
 void UserInfoPopup::updateUserData()

--- a/src/widgets/dialogs/UserInfoPopup.hpp
+++ b/src/widgets/dialogs/UserInfoPopup.hpp
@@ -30,6 +30,7 @@ protected:
 private:
     void installEvents();
     void updateUserData();
+    void updateLatestMessages();
 
     void loadAvatar(const QUrl &url);
     bool isMod_;

--- a/src/widgets/dialogs/UserInfoPopup.hpp
+++ b/src/widgets/dialogs/UserInfoPopup.hpp
@@ -30,7 +30,6 @@ protected:
 private:
     void installEvents();
     void updateUserData();
-    void updateLatestMessages();
 
     void loadAvatar(const QUrl &url);
     bool isMod_;


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
no changelog entry needed

# Description

Ever since #1982 we refresh messages on the usercard automatically, without any need to click the button anymore, so I decided to remove it and it seems that nothing broke.
