### PR TITLE
Fix windows build not compiling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,6 +86,12 @@ jobs:
             7z a chatterino-windows-x86-64.zip Chatterino2/
         shell: cmd
 
+      - name: Ensure build succeeded (Windows)
+        if: startsWith(matrix.os, 'windows')
+        run: |
+            cd build
+            ls release/chatterino.exe
+
       - name: Upload artifact (Windows)
         if: startsWith(matrix.os, 'windows')
         uses: actions/upload-artifact@v2.2.2

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -177,17 +177,16 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically, QWidget *parent)
                         auto menu = new QMenu;
                         previousMenu = menu;
 
-                        // add context menu actions
-                        menu->addAction(
-                            "Open avatar in browser",
-                            [avatarUrl = this->avatarUrl_] {
-                                QDesktopServices::openUrl(QUrl(avatarUrl));
-                            });
+                        auto avatarUrl = this->avatarUrl_;
 
-                        menu->addAction("Copy avatar link",
-                                        [avatarUrl = this->avatarUrl_] {
-                                            crossPlatformCopy(avatarUrl);
-                                        });
+                        // add context menu actions
+                        menu->addAction("Open avatar in browser", [avatarUrl] {
+                            QDesktopServices::openUrl(QUrl(avatarUrl));
+                        });
+
+                        menu->addAction("Copy avatar link", [avatarUrl] {
+                            crossPlatformCopy(avatarUrl);
+                        });
 
                         menu->popup(QCursor::pos());
                         menu->raise();


### PR DESCRIPTION
What we also ended up doing was ensuring that the chatterino2.exe file is actually present before continuing with uploading the artifact.

unfortunately, using `cmd` means we don't get any actual error codes, so this is the check we'll have to do.

If we were able to use powershell for the build command that'd be neater, but there's no clean way I know of to load the vcvars file from powershell

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
