### PR TITLE
🐛 Fixed windows CI not reporting exitcodes correctly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,6 @@ jobs:
           version: ${{ matrix.qt-version }}
 
       # WINDOWS
-
       - name: Cache conan packages
         if: startsWith(matrix.os, 'windows')
         uses: actions/cache@v2.1.4
@@ -71,21 +70,25 @@ jobs:
           key: ${{ runner.os }}-conan-${{ hashFiles('**/conanfile.txt') }}-20210307
           path: C:/.conan/
 
+      - name: Add Conan to path
+        if: startsWith(matrix.os, 'windows')
+        run: echo "C:\Program Files\Conan\conan\" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        
       - name: Install dependencies (Windows)
         if: startsWith(matrix.os, 'windows')
         run: |
             choco install conan -y
-
-            refreshenv
-        shell: cmd
+        
+      - name: Enable Developer Command Prompt
+        if: startsWith(matrix.os, 'windows')
+        uses: ilammy/msvc-dev-cmd@v1.6.0
 
       - name: Build (Windows)
         if: startsWith(matrix.os, 'windows') && matrix.build-system == 'qmake'
         run: |
-            call "%programfiles(x86)%\Microsoft Visual Studio\%vs_version%\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
             mkdir build
             cd build
-            "C:\Program Files\Conan\conan\conan.exe" install ..
+            conan install ..
             qmake ..
             set cl=/MP
             nmake /S /NOLOGO
@@ -93,15 +96,13 @@ jobs:
             cp release/chatterino.exe Chatterino2/
             echo nightly > Chatterino2/modes
             7z a chatterino-windows-x86-64.zip Chatterino2/
-        shell: cmd
-
+            
       - name: Build with CMake (Windows)
         if: startsWith(matrix.os, 'windows') && matrix.build-system == 'cmake'
         run: |
-            call "%programfiles(x86)%\Microsoft Visual Studio\%vs_version%\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
             mkdir build
             cd build
-            "C:\Program Files\Conan\conan\conan.exe" install ..
+            conan install ..
             cmake -G"NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DUSE_CONAN=ON ..
             set cl=/MP
             nmake /S /NOLOGO
@@ -109,13 +110,6 @@ jobs:
             cp bin/chatterino.exe Chatterino2/
             echo nightly > Chatterino2/modes
             7z a chatterino-windows-x86-64.zip Chatterino2/
-        shell: cmd
-
-      - name: Ensure build succeeded (Windows)
-        if: startsWith(matrix.os, 'windows')
-        run: |
-            cd build
-            ls Chatterino2/chatterino.exe
 
       - name: Upload artifact (Windows)
         if: startsWith(matrix.os, 'windows')


### PR DESCRIPTION
This uses https://github.com/ilammy/msvc-dev-cmd to setup the MSVC environment, and https://github.com/AnotherFoxGuy/conan-onefile for the installation of conan



-----------------------------------

Pull request checklist:
- [x] `CHANGELOG.md` was updated, if applicable
