### PR TITLE
fix: no longer crash on clip creation in "special" channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unversioned
 
-- Major: Added clip creation support. You can create clips with `/clip` command, `Alt+X` keybind or `Create a clip` option in split header's context menu. This requires a new authentication scope so re-authentication will be required to use it. (#2271, #2377)
+- Major: Added clip creation support. You can create clips with `/clip` command, `Alt+X` keybind or `Create a clip` option in split header's context menu. This requires a new authentication scope so re-authentication will be required to use it. (#2271, #2377, #2528)
 - Major: Added "Channel Filters". See https://wiki.chatterino.com/Filters/ for how they work or how to configure them. (#1748, #2083, #2090, #2200, #2225)
 - Major: Added Streamer Mode configuration (under `Settings -> General`), where you can select which features of Chatterino should behave differently when you are in Streamer Mode. (#2001, #2316, #2342, #2376)
 - Major: Color mentions to match the mentioned users. You can disable this by unchecking "Color @usernames" under `Settings -> General -> Advanced (misc.)`. (#1963, #2284)

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -523,7 +523,9 @@ void CommandController::initialize(Settings &, Paths &paths)
         });
 
     this->registerCommand("/clip", [](const auto & /*words*/, auto channel) {
-        if (!channel->isTwitchChannel())
+        if (const auto type = channel->getType();
+            type != Channel::Type::Twitch &&
+            type != Channel::Type::TwitchWatching)
         {
             return "";
         }

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -123,7 +123,9 @@ Split::Split(QWidget *parent)
 
     // Alt+X: create clip LUL
     createShortcut(this, "Alt+X", [this] {
-        if (!this->getChannel()->isTwitchChannel())
+        if (const auto type = this->getChannel()->getType();
+            type != Channel::Type::Twitch &&
+            type != Channel::Type::TwitchWatching)
         {
             return;
         }


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Fixes #2527.

Clip creation via the `Alt+X` shortcut failed for the `/mentions` and `/whispers` channel. This happened because `Channel::isTwitchChannel` returns `true` for these channels. (Internally, the types are `Channel::Type::TwitchMentions` and `Channel::Type::TwitchWhispers` in anticipation of supporting more platforms in the future.)
This lead to a false assumption in the clip creation logic: Not all channels that display "Twitch content" are able to create clips.

The employed fix checks the channel type in more detail. Clip creation is only allowed if the channel is `Channel::Type::Twitch` or `Channel::Type::TwitchWatching`. This makes sure that there always is an associated channel to generate a clip from.

Additional note: Clip creation did not crash when initiated via the `/clip` command. This is due to the fact that `CommandController::execCommand` makes additional checks regarding the channel context before executing the command.
