### PR TITLE
Fix Channel::isTwitchChannel (issue #2527 )

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@
 - Bugfix: Fixed hidden tooltips when always on top is active (#2384)
 - Bugfix: Fix CLI arguments (`--help`, `--version`, `--channels`) not being respected (#2368, #2190)
 - Bugfix: Fix Twitch cheer emotes not displaying tooltips when hovered (#2434)
+- Bugfix: Fix a crash bug that occurred when user tries make a clip when "/mentions" selected. (#2527)
 - Dev: Updated minimum required Qt framework version to 5.12. (#2210)
 - Dev: Migrated `Kraken::getUser` to Helix (#2260)
 - Dev: Migrated `TwitchAccount::(un)followUser` from Kraken to Helix and moved it to `Helix::(un)followUser`. (#2306)

--- a/src/common/Channel.cpp
+++ b/src/common/Channel.cpp
@@ -56,7 +56,7 @@ const QString &Channel::getLocalizedName() const
 
 bool Channel::isTwitchChannel() const
 {
-    return this->type_ >= Type::Twitch && this->type_ < Type::TwitchEnd;
+    return this->type_ == Type::Twitch;
 }
 
 bool Channel::isEmpty() const


### PR DESCRIPTION
Pull request checklist:

- [+] `CHANGELOG.md` was updated, if applicable

# Description
Fixes #2527 issue and other possible crash bugs.

The ability to cast a Channel to a TwitchChannel is tested through the 'Channel::isTwitchChannel' method.
This method calculated the cast possibility incorrectly.

(Steps to reproduce bug described in #2527 )
