### PR TITLE
Fix app data dir not opening on macOS when "Open AppData" button pressed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@
 - Bugfix: Fixed hidden tooltips when always on top is active (#2384)
 - Bugfix: Fix CLI arguments (`--help`, `--version`, `--channels`) not being respected (#2368, #2190)
 - Bugfix: Fix Twitch cheer emotes not displaying tooltips when hovered (#2434)
+- Bugfix: Fix a crash on macOS when clicking "Open AppData Directory" in settings (#2531)
 - Dev: Updated minimum required Qt framework version to 5.12. (#2210)
 - Dev: Migrated `Kraken::getUser` to Helix (#2260)
 - Dev: Migrated `TwitchAccount::(un)followUser` from Kraken to Helix and moved it to `Helix::(un)followUser`. (#2306)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@
 - Bugfix: Fixed hidden tooltips when always on top is active (#2384)
 - Bugfix: Fix CLI arguments (`--help`, `--version`, `--channels`) not being respected (#2368, #2190)
 - Bugfix: Fix Twitch cheer emotes not displaying tooltips when hovered (#2434)
-- Bugfix: Fix a crash on macOS when clicking "Open AppData Directory" in settings (#2531)
+- Bugfix: Fix directory not opening when clicking "Open AppData Directory" setting button on macOS (#2531)
 - Dev: Updated minimum required Qt framework version to 5.12. (#2210)
 - Dev: Migrated `Kraken::getUser` to Helix (#2260)
 - Dev: Migrated `TwitchAccount::(un)followUser` from Kraken to Helix and moved it to `Helix::(un)followUser`. (#2306)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@
 - Bugfix: Fixed hidden tooltips when always on top is active (#2384)
 - Bugfix: Fix CLI arguments (`--help`, `--version`, `--channels`) not being respected (#2368, #2190)
 - Bugfix: Fix Twitch cheer emotes not displaying tooltips when hovered (#2434)
-- Bugfix: Fix directory not opening when clicking "Open AppData Directory" setting button on macOS (#2531)
+- Bugfix: Fix directory not opening when clicking "Open AppData Directory" setting button on macOS (#2531, #2537)
 - Dev: Updated minimum required Qt framework version to 5.12. (#2210)
 - Dev: Migrated `Kraken::getUser` to Helix (#2260)
 - Dev: Migrated `TwitchAccount::(un)followUser` from Kraken to Helix and moved it to `Helix::(un)followUser`. (#2306)

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -455,7 +455,11 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     layout.addDescription("All local files like settings and cache files are "
                           "store in this directory.");
     layout.addButton("Open AppData directory", [] {
+#ifdef Q_OS_DARWIN
+        QDesktopServices::openUrl("file://" + getPaths()->rootAppDataDirectory);
+#else
         QDesktopServices::openUrl(getPaths()->rootAppDataDirectory);
+#endif
     });
 
     layout.addSubtitle("Temporary files (Cache)");


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

This PR aims to fix chatterino's app data directory not opening on macOS when pressing the "Open AppData..." button. When pressing the button on Windows/Linux the relevant directory is opened in the file explorer. When attempting to do this on macOS Finder does not open up the expected directory of `$HOME/Library/Application Support/chatterino`. 

This is caused by macOS requiring `file://` prior to the path in order for it to be opened in finder.

Fixes #2531 