### PR TITLE
remove normalizing of splits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,7 @@
 - Bugfix: Fix CLI arguments (`--help`, `--version`, `--channels`) not being respected (#2368, #2190)
 - Bugfix: Fix Twitch cheer emotes not displaying tooltips when hovered (#2434)
 - Bugfix: Fix directory not opening when clicking "Open AppData Directory" setting button on macOS (#2531, #2537)
-- Bugfix: Fix splits beeing not accurately sized as they were when the application was previously open
+- Bugfix: Fix splits being not accurately sized as they were when the application was previously open (#2362, #2548)
 - Dev: Updated minimum required Qt framework version to 5.12. (#2210)
 - Dev: Migrated `Kraken::getUser` to Helix (#2260)
 - Dev: Migrated `TwitchAccount::(un)followUser` from Kraken to Helix and moved it to `Helix::(un)followUser`. (#2306)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@
 - Bugfix: Fix CLI arguments (`--help`, `--version`, `--channels`) not being respected (#2368, #2190)
 - Bugfix: Fix Twitch cheer emotes not displaying tooltips when hovered (#2434)
 - Bugfix: Fix directory not opening when clicking "Open AppData Directory" setting button on macOS (#2531, #2537)
+- Bugfix: Fix splits beeing not accurately sized as they were when the application was previously open
 - Dev: Updated minimum required Qt framework version to 5.12. (#2210)
 - Dev: Migrated `Kraken::getUser` to Helix (#2260)
 - Dev: Migrated `TwitchAccount::(un)followUser` from Kraken to Helix and moved it to `Helix::(un)followUser`. (#2306)

--- a/src/widgets/splits/SplitContainer.cpp
+++ b/src/widgets/splits/SplitContainer.cpp
@@ -1258,20 +1258,6 @@ void SplitContainer::Node::layout(bool addSpacing, float _scale,
                     resizeRects.push_back(
                         ResizeRect(r.toRect(), child.get(), isVertical));
                 }
-
-                // normalize flex
-                if (isVertical)
-                {
-                    child->flexV_ =
-                        child->flexV_ / totalFlex * this->children_.size();
-                    child->flexH_ = 1;
-                }
-                else
-                {
-                    child->flexH_ =
-                        child->flexH_ / totalFlex * this->children_.size();
-                    child->flexV_ = 1;
-                }
             }
         }
         break;


### PR DESCRIPTION
Could not find any benefit of normalization, but splits got resized to bigger than they should. 

Fixes #2362

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

I'm testing this on my machine for now, but I can't see any regressions with this and I have a pretty big split setup with like 3 columns and each having 3-4 rows
