### PR TITLE
fix size of splits not loading properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Major: Added custom FrankerFaceZ VIP Badges. (#2628)
 - Minor: Added `in:<channels>` search filter to find messages sent in specific channels. (#2299, #2634)
 - Minor: Allow for built-in Chatterino commands to be used in custom commands. (#2632)
+- Bugfix: Size of splits not saved properly (#2362, #2548)
 - Bugfix: Fix crash that could occur when the user changed the "Custom stream player URI Scheme" setting if the user had closed down and splits in the application runtime. (#2592)
 
 ## 2.3.0

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -502,9 +502,6 @@ void WindowManager::encodeNodeRecursively(SplitNode *node, QJsonObject &obj)
             QJsonArray filters;
             encodeFilters(node->getSplit(), filters);
             obj.insert("filters", filters);
-
-            obj.insert("flexh", node->getHorizontalFlex());
-            obj.insert("flexv", node->getVerticalFlex());
         }
         break;
         case SplitNode::HorizontalContainer:
@@ -524,6 +521,9 @@ void WindowManager::encodeNodeRecursively(SplitNode *node, QJsonObject &obj)
         }
         break;
     }
+
+    obj.insert("flexh", node->getHorizontalFlex());
+    obj.insert("flexv", node->getVerticalFlex());
 }
 
 void WindowManager::encodeChannel(IndirectChannel channel, QJsonObject &obj)

--- a/src/widgets/splits/SplitContainer.cpp
+++ b/src/widgets/splits/SplitContainer.cpp
@@ -412,6 +412,11 @@ Split *SplitContainer::getTopRightSplit(Node &node)
 
 void SplitContainer::layout()
 {
+    if (this->disableLayouting_)
+    {
+        return;
+    }
+
     // update top right split
     auto topRight = this->getTopRightSplit(this->baseNode_);
     if (this->topRight_)
@@ -702,7 +707,10 @@ void SplitContainer::applyFromDescriptor(const NodeDescriptor &rootNode)
 {
     assert(this->baseNode_.type_ == Node::EmptyRoot);
 
+    this->disableLayouting_ = true;
     this->applyFromDescriptorRecursively(rootNode, &this->baseNode_);
+    this->disableLayouting_ = false;
+    this->layout();
 }
 
 void SplitContainer::applyFromDescriptorRecursively(

--- a/src/widgets/splits/SplitContainer.cpp
+++ b/src/widgets/splits/SplitContainer.cpp
@@ -777,6 +777,13 @@ void SplitContainer::applyFromDescriptorRecursively(
             {
                 Node *_node = new Node();
                 _node->parent_ = node;
+
+                if (auto *n = std::get_if<ContainerNodeDescriptor>(&item))
+                {
+                    _node->flexH_ = n->flexH_;
+                    _node->flexV_ = n->flexV_;
+                }
+
                 node->children_.emplace_back(_node);
                 this->applyFromDescriptorRecursively(item, _node);
             }

--- a/src/widgets/splits/SplitContainer.hpp
+++ b/src/widgets/splits/SplitContainer.hpp
@@ -250,6 +250,7 @@ private:
     Node baseNode_;
     Split *selected_{};
     Split *topRight_{};
+    bool disableLayouting_{};
 
     NotebookTab *tab_;
     std::vector<Split *> splits_;


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Temporarily disables layouting while splits are being loaded. Also brings loading splits from O(N²) to O(N) I guess.