### PR TITLE
Fix quick switcher not ordering based on tab order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@
 - Bugfix: Fix Twitch cheer emotes not displaying tooltips when hovered (#2434, #2503)
 - Bugfix: Fix BTTV/FFZ channel emotes saying unknown error when no emotes found (#2542)
 - Bugfix: Fix directory not opening when clicking "Open AppData Directory" setting button on macOS (#2531, #2537)
+- Bugfix: Fix quickswitcher not respecting order of tabs when filtering (#2519, #TODO)
 - Dev: Updated minimum required Qt framework version to 5.12. (#2210)
 - Dev: Migrated `Kraken::getUser` to Helix (#2260)
 - Dev: Migrated `TwitchAccount::(un)followUser` from Kraken to Helix and moved it to `Helix::(un)followUser`. (#2306)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,7 @@
 - Bugfix: Fix Twitch cheer emotes not displaying tooltips when hovered (#2434, #2503)
 - Bugfix: Fix BTTV/FFZ channel emotes saying unknown error when no emotes found (#2542)
 - Bugfix: Fix directory not opening when clicking "Open AppData Directory" setting button on macOS (#2531, #2537)
-- Bugfix: Fix quickswitcher not respecting order of tabs when filtering (#2519, #TODO)
+- Bugfix: Fix quickswitcher not respecting order of tabs when filtering (#2519, #2561)
 - Dev: Updated minimum required Qt framework version to 5.12. (#2210)
 - Dev: Migrated `Kraken::getUser` to Helix (#2260)
 - Dev: Migrated `TwitchAccount::(un)followUser` from Kraken to Helix and moved it to `Helix::(un)followUser`. (#2306)

--- a/src/widgets/dialogs/switcher/QuickSwitcherPopup.cpp
+++ b/src/widgets/dialogs/switcher/QuickSwitcherPopup.cpp
@@ -14,14 +14,14 @@
 namespace chatterino {
 
 namespace {
-    QSet<SplitContainer *> openPages()
+    QList<SplitContainer *> openPages()
     {
-        QSet<SplitContainer *> pages;
+        QList<SplitContainer *> pages;
 
         auto &nb = getApp()->windows->getMainWindow().getNotebook();
         for (int i = 0; i < nb.getPageCount(); ++i)
         {
-            pages.insert(static_cast<SplitContainer *>(nb.getPageAt(i)));
+            pages.append(static_cast<SplitContainer *>(nb.getPageAt(i)));
         }
 
         return pages;


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

The quick switcher was using a `QSet` instead of a order-respecting collection type when fetching the user's tabs. By replacing `QSet` with `QList` we keep the order of tabs.

See #2519 for more details and test setup.

# Screenshots

![Chatterino2_QuickSwitcher_Fixed](https://user-images.githubusercontent.com/4962764/112267203-0188d280-8c6d-11eb-85f7-8209bfd73eba.png)