### PR TITLE
Add StartupWMClass property to desktop file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@
 - Bugfix: Fix BTTV/FFZ channel emotes saying unknown error when no emotes found (#2542)
 - Bugfix: Fix directory not opening when clicking "Open AppData Directory" setting button on macOS (#2531, #2537)
 - Bugfix: Fix quickswitcher not respecting order of tabs when filtering (#2519, #2561)
-- Bugfix: Fix GNOME not associating Chatterino's window with its desktop entry (#1863)
+- Bugfix: Fix GNOME not associating Chatterino's window with its desktop entry (#1863, #2587)
 - Dev: Updated minimum required Qt framework version to 5.12. (#2210)
 - Dev: Migrated `Kraken::getUser` to Helix (#2260)
 - Dev: Migrated `TwitchAccount::(un)followUser` from Kraken to Helix and moved it to `Helix::(un)followUser`. (#2306)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@
 - Bugfix: Fix BTTV/FFZ channel emotes saying unknown error when no emotes found (#2542)
 - Bugfix: Fix directory not opening when clicking "Open AppData Directory" setting button on macOS (#2531, #2537)
 - Bugfix: Fix quickswitcher not respecting order of tabs when filtering (#2519, #2561)
+- Bugfix: Fix GNOME not associating Chatterino's window with its desktop entry (#1863)
 - Dev: Updated minimum required Qt framework version to 5.12. (#2210)
 - Dev: Migrated `Kraken::getUser` to Helix (#2260)
 - Dev: Migrated `TwitchAccount::(un)followUser` from Kraken to Helix and moved it to `Helix::(un)followUser`. (#2306)

--- a/resources/com.chatterino.chatterino.desktop
+++ b/resources/com.chatterino.chatterino.desktop
@@ -7,3 +7,4 @@ Exec=chatterino
 Icon=chatterino
 Terminal=false
 Categories=Network;InstantMessaging;
+StartupWMClass=chatterino


### PR DESCRIPTION
Pull request checklist:

- [ x ] `CHANGELOG.md` was updated, if applicable

# Description

This adds the StartupWMClass property to the desktop file, which window managers can use to determine when chatterino has opened and which window belongs to it.

GNOME uses this property, so this will fix #1863. You can test this by applying this patch to the desktop file of an existing install.
