### PR TITLE
clang-tidy: use std::move and const& where possible

### DIFF
--- a/src/BaseSettings.cpp
+++ b/src/BaseSettings.cpp
@@ -13,7 +13,7 @@ AB_SETTINGS_CLASS *AB_SETTINGS_CLASS::instance = nullptr;
 void _actuallyRegisterSetting(
     std::weak_ptr<pajlada::Settings::SettingData> setting)
 {
-    _settings.push_back(setting);
+    _settings.push_back(std::move(setting));
 }
 
 AB_SETTINGS_CLASS::AB_SETTINGS_CLASS(const QString &settingsDirectory)

--- a/src/common/Args.cpp
+++ b/src/common/Args.cpp
@@ -106,7 +106,7 @@ void Args::applyCustomChannelLayout(const QString &argValue)
         return QRect(-1, -1, -1, -1);
     }();
 
-    window.geometry_ = std::move(configMainLayout);
+    window.geometry_ = configMainLayout;
 
     QStringList channelArgList = argValue.split(";");
     for (const QString &channelArg : channelArgList)

--- a/src/common/Channel.cpp
+++ b/src/common/Channel.cpp
@@ -237,7 +237,7 @@ void Channel::replaceMessage(size_t index, MessagePtr replacement)
     }
 }
 
-void Channel::deleteMessage(QString messageID)
+void Channel::deleteMessage(const QString &messageID)
 {
     LimitedQueueSnapshot<MessagePtr> snapshot = this->getMessageSnapshot();
     int snapshotLength = snapshot.size();
@@ -320,7 +320,7 @@ void Channel::onConnected()
 // Indirect channel
 //
 IndirectChannel::Data::Data(ChannelPtr _channel, Channel::Type _type)
-    : channel(_channel)
+    : channel(std::move(_channel))
     , type(_type)
 {
 }
@@ -339,7 +339,7 @@ void IndirectChannel::reset(ChannelPtr channel)
 {
     assert(this->data_->type != Channel::Type::Direct);
 
-    this->data_->channel = channel;
+    this->data_->channel = std::move(channel);
     this->data_->changed.invoke();
 }
 

--- a/src/common/Channel.hpp
+++ b/src/common/Channel.hpp
@@ -75,7 +75,7 @@ public:
     void disableAllMessages();
     void replaceMessage(MessagePtr message, MessagePtr replacement);
     void replaceMessage(size_t index, MessagePtr replacement);
-    void deleteMessage(QString messageID);
+    void deleteMessage(const QString &messageID);
 
     bool hasMessages() const;
 

--- a/src/common/ChatterinoSetting.cpp
+++ b/src/common/ChatterinoSetting.cpp
@@ -6,7 +6,7 @@ namespace chatterino {
 
 void _registerSetting(std::weak_ptr<pajlada::Settings::SettingData> setting)
 {
-    _actuallyRegisterSetting(setting);
+    _actuallyRegisterSetting(std::move(setting));
 }
 
 }  // namespace chatterino

--- a/src/common/DownloadManager.cpp
+++ b/src/common/DownloadManager.cpp
@@ -18,7 +18,8 @@ DownloadManager::~DownloadManager()
     manager->deleteLater();
 }
 
-void DownloadManager::setFile(QString fileURL, const QString &channelName)
+void DownloadManager::setFile(const QString &fileURL,
+                              const QString &channelName)
 {
     QString saveFilePath;
     saveFilePath =

--- a/src/common/DownloadManager.hpp
+++ b/src/common/DownloadManager.hpp
@@ -17,7 +17,7 @@ class DownloadManager : public QObject
 public:
     explicit DownloadManager(QObject *parent = nullptr);
     virtual ~DownloadManager();
-    void setFile(QString fileURL, const QString &channelName);
+    void setFile(const QString &fileURL, const QString &channelName);
 
 private:
     QNetworkAccessManager *manager;

--- a/src/common/NetworkRequest.cpp
+++ b/src/common/NetworkRequest.cpp
@@ -28,7 +28,7 @@ NetworkRequest::NetworkRequest(const std::string &url,
     this->initializeDefaultValues();
 }
 
-NetworkRequest::NetworkRequest(QUrl url, NetworkRequestType requestType)
+NetworkRequest::NetworkRequest(const QUrl &url, NetworkRequestType requestType)
     : data(new NetworkData)
 {
     this->data->request_.setUrl(url);

--- a/src/common/NetworkRequest.hpp
+++ b/src/common/NetworkRequest.hpp
@@ -24,8 +24,8 @@ public:
     explicit NetworkRequest(
         const std::string &url,
         NetworkRequestType requestType = NetworkRequestType::Get);
-    explicit NetworkRequest(
-        QUrl url, NetworkRequestType requestType = NetworkRequestType::Get);
+    explicit NetworkRequest(const QUrl &url, NetworkRequestType requestType =
+                                                 NetworkRequestType::Get);
 
     // Enable move
     NetworkRequest(NetworkRequest &&other) = default;

--- a/src/controllers/highlights/HighlightPhrase.cpp
+++ b/src/controllers/highlights/HighlightPhrase.cpp
@@ -57,7 +57,7 @@ HighlightPhrase::HighlightPhrase(const QString &pattern, bool showInMentions,
     , isRegex_(isRegex)
     , isCaseSensitive_(isCaseSensitive)
     , soundUrl_(soundUrl)
-    , color_(color)
+    , color_(std::move(color))
     , regex_(isRegex_
                  ? pattern
                  : REGEX_START_BOUNDARY + QRegularExpression::escape(pattern) +

--- a/src/controllers/notifications/NotificationController.cpp
+++ b/src/controllers/notifications/NotificationController.cpp
@@ -197,7 +197,7 @@ void NotificationController::getFakeTwitchChannelLiveStatus(
         });
 }
 
-void NotificationController::removeFakeChannel(const QString channelName)
+void NotificationController::removeFakeChannel(const QString &channelName)
 {
     auto i = std::find(fakeTwitchChannels.begin(), fakeTwitchChannels.end(),
                        channelName);

--- a/src/controllers/notifications/NotificationController.hpp
+++ b/src/controllers/notifications/NotificationController.hpp
@@ -40,7 +40,7 @@ private:
     bool initialized_ = false;
 
     void fetchFakeChannels();
-    void removeFakeChannel(const QString channelName);
+    void removeFakeChannel(const QString &channelName);
     void getFakeTwitchChannelLiveStatus(const QString &channelName);
 
     // fakeTwitchChannels is a list of streams who are live that we have already sent out a notification for

--- a/src/messages/layouts/MessageLayout.cpp
+++ b/src/messages/layouts/MessageLayout.cpp
@@ -39,7 +39,7 @@ namespace {
 }  // namespace
 
 MessageLayout::MessageLayout(MessagePtr message)
-    : message_(message)
+    : message_(std::move(message))
     , container_(std::make_shared<MessageLayoutContainer>())
 {
     DebugCount::increase("message layout");

--- a/src/messages/layouts/MessageLayoutElement.cpp
+++ b/src/messages/layouts/MessageLayoutElement.cpp
@@ -88,7 +88,7 @@ FlagsEnum<MessageElementFlag> MessageLayoutElement::getFlags() const
 ImageLayoutElement::ImageLayoutElement(MessageElement &creator, ImagePtr image,
                                        const QSize &size)
     : MessageLayoutElement(creator, size)
-    , image_(image)
+    , image_(std::move(image))
 {
     this->trailingSpace = creator.hasTrailingSpace();
 }

--- a/src/providers/IvrApi.cpp
+++ b/src/providers/IvrApi.cpp
@@ -59,7 +59,8 @@ void IvrApi::getBulkEmoteSets(QString emoteSetList,
         .execute();
 }
 
-NetworkRequest IvrApi::makeRequest(QString url, QUrlQuery urlQuery)
+NetworkRequest IvrApi::makeRequest(const QString &url,
+                                   const QUrlQuery &urlQuery)
 {
     assert(!url.startsWith("/"));
 

--- a/src/providers/IvrApi.hpp
+++ b/src/providers/IvrApi.hpp
@@ -81,7 +81,7 @@ public:
     static void initialize();
 
 private:
-    NetworkRequest makeRequest(QString url, QUrlQuery urlQuery);
+    NetworkRequest makeRequest(const QString &url, const QUrlQuery &urlQuery);
 };
 
 IvrApi *getIvr();

--- a/src/providers/LinkResolver.cpp
+++ b/src/providers/LinkResolver.cpp
@@ -26,32 +26,32 @@ void LinkResolver::getLinkInfo(
                        QUrl::toPercentEncoding(url, "", "/:"))))
         .caller(caller)
         .timeout(30000)
-        .onSuccess(
-            [successCallback, url](NetworkResult result) mutable -> Outcome {
-                auto root = result.parseJson();
-                auto statusCode = root.value("status").toInt();
-                QString response = QString();
-                QString linkString = url;
-                ImagePtr thumbnail = nullptr;
-                if (statusCode == 200)
+        .onSuccess([successCallback,
+                    url](const NetworkResult &result) mutable -> Outcome {
+            auto root = result.parseJson();
+            auto statusCode = root.value("status").toInt();
+            QString response = QString();
+            QString linkString = url;
+            ImagePtr thumbnail = nullptr;
+            if (statusCode == 200)
+            {
+                response = root.value("tooltip").toString();
+                thumbnail =
+                    Image::fromUrl({root.value("thumbnail").toString()});
+                if (getSettings()->unshortLinks)
                 {
-                    response = root.value("tooltip").toString();
-                    thumbnail =
-                        Image::fromUrl({root.value("thumbnail").toString()});
-                    if (getSettings()->unshortLinks)
-                    {
-                        linkString = root.value("link").toString();
-                    }
+                    linkString = root.value("link").toString();
                 }
-                else
-                {
-                    response = root.value("message").toString();
-                }
-                successCallback(QUrl::fromPercentEncoding(response.toUtf8()),
-                                Link(Link::Url, linkString), thumbnail);
+            }
+            else
+            {
+                response = root.value("message").toString();
+            }
+            successCallback(QUrl::fromPercentEncoding(response.toUtf8()),
+                            Link(Link::Url, linkString), thumbnail);
 
-                return Success;
-            })
+            return Success;
+        })
         .onError([successCallback, url](auto /*result*/) {
             successCallback("No link info found", Link(Link::Url, url),
                             nullptr);

--- a/src/providers/colors/ColorProvider.cpp
+++ b/src/providers/colors/ColorProvider.cpp
@@ -26,7 +26,7 @@ const std::shared_ptr<QColor> ColorProvider::color(ColorType type) const
 void ColorProvider::updateColor(ColorType type, QColor color)
 {
     auto colorPtr = this->typeColorMap_.at(type);
-    *colorPtr = color;
+    *colorPtr = std::move(color);
 }
 
 QSet<QColor> ColorProvider::recentColors() const
@@ -37,12 +37,12 @@ QSet<QColor> ColorProvider::recentColors() const
      * Currently, only colors used in highlight phrases are considered. This
      * may change at any point in the future.
      */
-    for (auto phrase : getSettings()->highlightedMessages)
+    for (const auto &phrase : getSettings()->highlightedMessages)
     {
         retVal.insert(*phrase.getColor());
     }
 
-    for (auto userHl : getSettings()->highlightedUsers)
+    for (const auto &userHl : getSettings()->highlightedUsers)
     {
         retVal.insert(*userHl.getColor());
     }

--- a/src/providers/emoji/Emojis.cpp
+++ b/src/providers/emoji/Emojis.cpp
@@ -22,7 +22,7 @@ namespace {
 
     void parseEmoji(const std::shared_ptr<EmojiData> &emojiData,
                     const rapidjson::Value &unparsedEmoji,
-                    QString shortCode = QString())
+                    const QString &shortCode = QString())
     {
         static uint unicodeBytes[4];
 

--- a/src/providers/irc/AbstractIrcServer.cpp
+++ b/src/providers/irc/AbstractIrcServer.cpp
@@ -417,7 +417,8 @@ void AbstractIrcServer::readConnectionMessageReceived(
 {
 }
 
-void AbstractIrcServer::forEachChannel(std::function<void(ChannelPtr)> func)
+void AbstractIrcServer::forEachChannel(
+    const std::function<void(ChannelPtr)> &func)
 {
     std::lock_guard<std::mutex> lock(this->channelMutex);
 

--- a/src/providers/irc/AbstractIrcServer.hpp
+++ b/src/providers/irc/AbstractIrcServer.hpp
@@ -46,7 +46,7 @@ public:
     void addGlobalSystemMessage(const QString &messageText);
 
     // iteration
-    void forEachChannel(std::function<void(ChannelPtr)> func);
+    void forEachChannel(const std::function<void(ChannelPtr)> &func);
 
 protected:
     AbstractIrcServer();

--- a/src/providers/irc/Irc2.cpp
+++ b/src/providers/irc/Irc2.cpp
@@ -95,7 +95,7 @@ Irc::Irc()
             auto server = std::make_unique<IrcServer>(args.item, ab->second);
 
             // set server of abandoned channels
-            for (auto weak : ab->second)
+            for (const auto &weak : ab->second)
                 if (auto shared = weak.lock())
                     if (auto ircChannel =
                             dynamic_cast<IrcChannel *>(shared.get()))
@@ -121,7 +121,7 @@ Irc::Irc()
             auto abandoned = server->second->getChannels();
 
             // set server of abandoned servers to nullptr
-            for (auto weak : abandoned)
+            for (const auto &weak : abandoned)
                 if (auto shared = weak.lock())
                     if (auto ircChannel =
                             dynamic_cast<IrcChannel *>(shared.get()))

--- a/src/providers/irc/IrcCommands.cpp
+++ b/src/providers/irc/IrcCommands.cpp
@@ -37,7 +37,7 @@ Outcome invokeIrcCommand(const QString &commandName, const QString &allParams,
         return params.mid(i + 1).join(' ');
     };
 
-    auto sendRaw = [&](QString str) {
+    auto sendRaw = [&](const QString &str) {
         channel.server()->sendRawMessage(str);
     };
 

--- a/src/providers/irc/IrcMessageBuilder.cpp
+++ b/src/providers/irc/IrcMessageBuilder.cpp
@@ -28,7 +28,8 @@ IrcMessageBuilder::IrcMessageBuilder(Channel *_channel,
                                      const Communi::IrcMessage *_ircMessage,
                                      const MessageParseArgs &_args,
                                      QString content, bool isAction)
-    : SharedMessageBuilder(_channel, _ircMessage, _args, content, isAction)
+    : SharedMessageBuilder(_channel, _ircMessage, _args, std::move(content),
+                           isAction)
 {
     assert(false);
     this->usernameColor_ = getApp()->themes->messages.textColors.system;

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -149,11 +149,11 @@ void IrcMessageHandler::setSimilarityFlags(MessagePtr msg, ChannelPtr chan)
     }
 }
 
-static QMap<QString, QString> parseBadges(QString badgesString)
+static QMap<QString, QString> parseBadges(const QString &badgesString)
 {
     QMap<QString, QString> badges;
 
-    for (auto badgeData : badgesString.split(','))
+    for (const auto &badgeData : badgesString.split(','))
     {
         auto parts = badgeData.split('/');
         if (parts.length() != 2)
@@ -261,7 +261,7 @@ void IrcMessageHandler::addMessage(Communi::IrcMessage *_message,
             // Need to wait for pubsub reward notification
             auto clone = _message->clone();
             channel->channelPointRewardAdded.connect(
-                [=, &server](ChannelPointReward reward) {
+                [=, &server](const ChannelPointReward &reward) {
                     if (reward.id == rewardId)
                     {
                         this->addMessage(clone, target, content, server, isSub,

--- a/src/providers/twitch/TwitchAccount.hpp
+++ b/src/providers/twitch/TwitchAccount.hpp
@@ -38,7 +38,7 @@ struct TwitchEmoteSetResolverResponse {
     //      "custom": false
     //    }
 
-    TwitchEmoteSetResolverResponse(QJsonObject jsonObject)
+    TwitchEmoteSetResolverResponse(const QJsonObject &jsonObject)
         : channelName(jsonObject.value("channel_name").toString())
         , channelId(jsonObject.value("channel_id").toString())
         , type(jsonObject.value("type").toString())
@@ -98,23 +98,23 @@ public:
     bool isAnon() const;
 
     void loadBlocks();
-    void blockUser(QString userId, std::function<void()> onSuccess,
+    void blockUser(const QString &userId, std::function<void()> onSuccess,
                    std::function<void()> onFailure);
-    void unblockUser(QString userId, std::function<void()> onSuccess,
+    void unblockUser(const QString &userId, std::function<void()> onSuccess,
                      std::function<void()> onFailure);
 
-    void checkFollow(const QString targetUserID,
+    void checkFollow(const QString &targetUserID,
                      std::function<void(FollowResult)> onFinished);
 
     std::set<TwitchUser> getBlocks() const;
 
     void loadEmotes();
-    void loadUserstateEmotes(QStringList emoteSetKeys);
+    void loadUserstateEmotes(const QStringList &emoteSetKeys);
     AccessGuard<const TwitchAccountEmoteData> accessEmotes() const;
 
     // Automod actions
-    void autoModAllow(const QString msgID);
-    void autoModDeny(const QString msgID);
+    void autoModAllow(const QString &msgID);
+    void autoModDeny(const QString &msgID);
 
 private:
     void loadEmoteSetData(std::shared_ptr<EmoteSet> emoteSet);

--- a/src/providers/twitch/TwitchAccountManager.cpp
+++ b/src/providers/twitch/TwitchAccountManager.cpp
@@ -178,7 +178,7 @@ bool TwitchAccountManager::removeUser(TwitchAccount *account)
 {
     static const QString accountFormat("/accounts/uid%1");
 
-    auto userID(account->getUserId());
+    const auto &userID(account->getUserId());
     if (!userID.isEmpty())
     {
         pajlada::Settings::SettingManager::removeSetting(

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -58,7 +58,7 @@ void Helix::getUserByName(QString userName,
                           HelixFailureCallback failureCallback)
 {
     QStringList userIds;
-    QStringList userLogins{userName};
+    QStringList userLogins{std::move(userName)};
 
     this->fetchUsers(
         userIds, userLogins,
@@ -136,7 +136,8 @@ void Helix::getUserFollowers(
     QString userId, ResultCallback<HelixUsersFollowsResponse> successCallback,
     HelixFailureCallback failureCallback)
 {
-    this->fetchUsersFollows("", userId, successCallback, failureCallback);
+    this->fetchUsersFollows("", std::move(userId), std::move(successCallback),
+                            std::move(failureCallback));
 }
 
 void Helix::getUserFollow(
@@ -145,7 +146,7 @@ void Helix::getUserFollow(
     HelixFailureCallback failureCallback)
 {
     this->fetchUsersFollows(
-        userId, targetId,
+        std::move(userId), std::move(targetId),
         [successCallback](const auto &response) {
             if (response.data.empty())
             {
@@ -155,7 +156,7 @@ void Helix::getUserFollow(
 
             successCallback(true, response.data[0]);
         },
-        failureCallback);
+        std::move(failureCallback));
 }
 
 void Helix::fetchStreams(
@@ -209,7 +210,7 @@ void Helix::getStreamById(QString userId,
                           ResultCallback<bool, HelixStream> successCallback,
                           HelixFailureCallback failureCallback)
 {
-    QStringList userIds{userId};
+    QStringList userIds{std::move(userId)};
     QStringList userLogins;
 
     this->fetchStreams(
@@ -230,7 +231,7 @@ void Helix::getStreamByName(QString userName,
                             HelixFailureCallback failureCallback)
 {
     QStringList userIds;
-    QStringList userLogins{userName};
+    QStringList userLogins{std::move(userName)};
 
     this->fetchStreams(
         userIds, userLogins,
@@ -299,7 +300,7 @@ void Helix::getGameById(QString gameId,
                         ResultCallback<HelixGame> successCallback,
                         HelixFailureCallback failureCallback)
 {
-    QStringList gameIds{gameId};
+    QStringList gameIds{std::move(gameId)};
     QStringList gameNames;
 
     this->fetchGames(
@@ -409,7 +410,7 @@ void Helix::createClip(QString channelId,
                 break;
             }
         })
-        .finally(finallyCallback)
+        .finally(std::move(finallyCallback))
         .execute();
 }
 
@@ -620,7 +621,7 @@ void Helix::updateChannel(QString broadcasterId, QString gameId,
         })
         .execute();
 }
-NetworkRequest Helix::makeRequest(QString url, QUrlQuery urlQuery)
+NetworkRequest Helix::makeRequest(const QString &url, const QUrlQuery &urlQuery)
 {
     assert(!url.startsWith("/"));
 
@@ -653,8 +654,8 @@ NetworkRequest Helix::makeRequest(QString url, QUrlQuery urlQuery)
 
 void Helix::update(QString clientId, QString oauthToken)
 {
-    this->clientId = clientId;
-    this->oauthToken = oauthToken;
+    this->clientId = std::move(clientId);
+    this->oauthToken = std::move(oauthToken);
 }
 
 void Helix::initialize()

--- a/src/providers/twitch/api/Helix.hpp
+++ b/src/providers/twitch/api/Helix.hpp
@@ -28,7 +28,7 @@ struct HelixUser {
     QString profileImageUrl;
     int viewCount;
 
-    explicit HelixUser(QJsonObject jsonObject)
+    explicit HelixUser(const QJsonObject &jsonObject)
         : id(jsonObject.value("id").toString())
         , login(jsonObject.value("login").toString())
         , displayName(jsonObject.value("display_name").toString())
@@ -56,7 +56,7 @@ struct HelixUsersFollowsRecord {
     {
     }
 
-    explicit HelixUsersFollowsRecord(QJsonObject jsonObject)
+    explicit HelixUsersFollowsRecord(const QJsonObject &jsonObject)
         : fromId(jsonObject.value("from_id").toString())
         , fromName(jsonObject.value("from_name").toString())
         , toId(jsonObject.value("to_id").toString())
@@ -69,7 +69,7 @@ struct HelixUsersFollowsRecord {
 struct HelixUsersFollowsResponse {
     int total;
     std::vector<HelixUsersFollowsRecord> data;
-    explicit HelixUsersFollowsResponse(QJsonObject jsonObject)
+    explicit HelixUsersFollowsResponse(const QJsonObject &jsonObject)
         : total(jsonObject.value("total").toInt())
     {
         const auto &jsonData = jsonObject.value("data").toArray();
@@ -107,7 +107,7 @@ struct HelixStream {
     {
     }
 
-    explicit HelixStream(QJsonObject jsonObject)
+    explicit HelixStream(const QJsonObject &jsonObject)
         : id(jsonObject.value("id").toString())
         , userId(jsonObject.value("user_id").toString())
         , userName(jsonObject.value("user_name").toString())
@@ -127,7 +127,7 @@ struct HelixGame {
     QString name;
     QString boxArtUrl;
 
-    explicit HelixGame(QJsonObject jsonObject)
+    explicit HelixGame(const QJsonObject &jsonObject)
         : id(jsonObject.value("id").toString())
         , name(jsonObject.value("name").toString())
         , boxArtUrl(jsonObject.value("box_art_url").toString())
@@ -139,7 +139,7 @@ struct HelixClip {
     QString id;  // clip slug
     QString editUrl;
 
-    explicit HelixClip(QJsonObject jsonObject)
+    explicit HelixClip(const QJsonObject &jsonObject)
         : id(jsonObject.value("id").toString())
         , editUrl(jsonObject.value("edit_url").toString())
     {
@@ -154,7 +154,7 @@ struct HelixChannel {
     QString gameName;
     QString title;
 
-    explicit HelixChannel(QJsonObject jsonObject)
+    explicit HelixChannel(const QJsonObject &jsonObject)
         : userId(jsonObject.value("broadcaster_id").toString())
         , name(jsonObject.value("broadcaster_name").toString())
         , language(jsonObject.value("broadcaster_language").toString())
@@ -171,7 +171,7 @@ struct HelixStreamMarker {
     QString id;
     int positionSeconds;
 
-    explicit HelixStreamMarker(QJsonObject jsonObject)
+    explicit HelixStreamMarker(const QJsonObject &jsonObject)
         : createdAt(jsonObject.value("created_at").toString())
         , description(jsonObject.value("description").toString())
         , id(jsonObject.value("id").toString())
@@ -185,7 +185,7 @@ struct HelixBlock {
     QString userName;
     QString displayName;
 
-    explicit HelixBlock(QJsonObject jsonObject)
+    explicit HelixBlock(const QJsonObject &jsonObject)
         : userId(jsonObject.value("user_id").toString())
         , userName(jsonObject.value("user_login").toString())
         , displayName(jsonObject.value("display_name").toString())
@@ -307,7 +307,7 @@ public:
     static void initialize();
 
 private:
-    NetworkRequest makeRequest(QString url, QUrlQuery urlQuery);
+    NetworkRequest makeRequest(const QString &url, const QUrlQuery &urlQuery);
 
     QString clientId;
     QString oauthToken;

--- a/src/providers/twitch/api/Kraken.cpp
+++ b/src/providers/twitch/api/Kraken.cpp
@@ -30,7 +30,8 @@ void Kraken::getUserEmotes(TwitchAccount *account,
         .execute();
 }
 
-NetworkRequest Kraken::makeRequest(QString url, QUrlQuery urlQuery)
+NetworkRequest Kraken::makeRequest(const QString &url,
+                                   const QUrlQuery &urlQuery)
 {
     assert(!url.startsWith("/"));
 
@@ -63,8 +64,8 @@ NetworkRequest Kraken::makeRequest(QString url, QUrlQuery urlQuery)
 
 void Kraken::update(QString clientId, QString oauthToken)
 {
-    this->clientId = clientId;
-    this->oauthToken = oauthToken;
+    this->clientId = std::move(clientId);
+    this->oauthToken = std::move(oauthToken);
 }
 
 void Kraken::initialize()

--- a/src/providers/twitch/api/Kraken.hpp
+++ b/src/providers/twitch/api/Kraken.hpp
@@ -18,7 +18,7 @@ using ResultCallback = std::function<void(T...)>;
 struct KrakenEmoteSets {
     const QJsonObject emoteSets;
 
-    KrakenEmoteSets(QJsonObject jsonObject)
+    KrakenEmoteSets(const QJsonObject &jsonObject)
         : emoteSets(jsonObject.value("emoticon_sets").toObject())
     {
     }
@@ -28,7 +28,7 @@ struct KrakenEmote {
     const QString code;
     const QString id;
 
-    KrakenEmote(QJsonObject jsonObject)
+    KrakenEmote(const QJsonObject &jsonObject)
         : code(jsonObject.value("code").toString())
         , id(QString::number(jsonObject.value("id").toInt()))
     {
@@ -48,7 +48,7 @@ public:
     static void initialize();
 
 private:
-    NetworkRequest makeRequest(QString url, QUrlQuery urlQuery);
+    NetworkRequest makeRequest(const QString &url, const QUrlQuery &urlQuery);
 
     QString clientId;
     QString oauthToken;

--- a/src/singletons/Logging.cpp
+++ b/src/singletons/Logging.cpp
@@ -28,7 +28,7 @@ void Logging::addMessage(const QString &channelName, MessagePtr message)
         auto channel = new LoggingChannel(channelName);
         channel->addMessage(message);
         this->loggingChannels_.emplace(
-            channelName, std::unique_ptr<LoggingChannel>(std::move(channel)));
+            channelName, std::unique_ptr<LoggingChannel>(channel));
     }
     else
     {

--- a/src/singletons/TooltipPreviewImage.cpp
+++ b/src/singletons/TooltipPreviewImage.cpp
@@ -33,7 +33,7 @@ TooltipPreviewImage::TooltipPreviewImage()
 
 void TooltipPreviewImage::setImage(ImagePtr image)
 {
-    this->image_ = image;
+    this->image_ = std::move(image);
 
     this->refreshTooltipWidgetPixmap();
 }

--- a/src/util/FormatTime.cpp
+++ b/src/util/FormatTime.cpp
@@ -50,7 +50,7 @@ QString formatTime(int totalSeconds)
     return res;
 }
 
-QString formatTime(QString totalSecondsString)
+QString formatTime(const QString &totalSecondsString)
 {
     bool ok = true;
     int totalSeconds(totalSecondsString.toInt(&ok));

--- a/src/util/FormatTime.hpp
+++ b/src/util/FormatTime.hpp
@@ -6,6 +6,6 @@ namespace chatterino {
 
 // format: 1h 23m 42s
 QString formatTime(int totalSeconds);
-QString formatTime(QString totalSecondsString);
+QString formatTime(const QString &totalSecondsString);
 
 }  // namespace chatterino

--- a/src/util/NuulsUploader.cpp
+++ b/src/util/NuulsUploader.cpp
@@ -21,7 +21,7 @@
 
 namespace {
 
-boost::optional<QByteArray> convertToPng(QImage image)
+boost::optional<QByteArray> convertToPng(const QImage &image)
 {
     QByteArray imageData;
     QBuffer buf(&imageData);
@@ -44,8 +44,8 @@ static auto uploadMutex = QMutex();
 static std::queue<RawImageData> uploadQueue;
 
 // logging information on successful uploads to a json file
-void logToFile(const QString originalFilePath, QString imageLink,
-               QString deletionLink, ChannelPtr channel)
+void logToFile(const QString &originalFilePath, const QString &imageLink,
+               const QString &deletionLink, ChannelPtr channel)
 {
     const QString logFileName =
         combinePath((getSettings()->logPath.getValue().isEmpty()
@@ -94,7 +94,7 @@ void logToFile(const QString originalFilePath, QString imageLink,
 }
 
 // extracting link to either image or its deletion from response body
-QString getJSONValue(QJsonValue responseJson, QString jsonPattern)
+QString getJSONValue(QJsonValue responseJson, const QString &jsonPattern)
 {
     for (const QString &key : jsonPattern.split("."))
     {
@@ -103,7 +103,7 @@ QString getJSONValue(QJsonValue responseJson, QString jsonPattern)
     return responseJson.toString();
 }
 
-QString getLinkFromResponse(NetworkResult response, QString pattern)
+QString getLinkFromResponse(const NetworkResult &response, QString pattern)
 {
     QRegExp regExp("\\{(.+)\\}");
     regExp.setMinimal(true);
@@ -115,7 +115,7 @@ QString getLinkFromResponse(NetworkResult response, QString pattern)
     return pattern;
 }
 
-void uploadImageToNuuls(RawImageData imageData, ChannelPtr channel,
+void uploadImageToNuuls(const RawImageData &imageData, ChannelPtr channel,
                         ResizingTextEdit &textEdit)
 {
     const static char *const boundary = "thisistheboudaryasd";
@@ -151,7 +151,7 @@ void uploadImageToNuuls(RawImageData imageData, ChannelPtr channel,
         .headerList(extraHeaders)
         .multiPart(payload)
         .onSuccess([&textEdit, channel,
-                    originalFilePath](NetworkResult result) -> Outcome {
+                    originalFilePath](const NetworkResult &result) -> Outcome {
             QString link = getSettings()->imageUploaderLink.getValue().isEmpty()
                                ? result.getData()
                                : getLinkFromResponse(
@@ -200,7 +200,7 @@ void uploadImageToNuuls(RawImageData imageData, ChannelPtr channel,
 
             return Success;
         })
-        .onError([channel](NetworkResult result) -> bool {
+        .onError([channel](const NetworkResult &result) -> bool {
             channel->addMessage(makeSystemMessage(
                 QString("An error happened while uploading your image: %1")
                     .arg(result.status())));

--- a/src/util/PostToThread.hpp
+++ b/src/util/PostToThread.hpp
@@ -17,7 +17,7 @@ class LambdaRunnable : public QRunnable
 public:
     LambdaRunnable(std::function<void()> action)
     {
-        this->action_ = action;
+        this->action_ = std::move(action);
     }
 
     void run()

--- a/src/util/StreamLink.cpp
+++ b/src/util/StreamLink.cpp
@@ -200,7 +200,7 @@ void openStreamlinkForChannel(const QString &channel)
     if (preferredQuality == "choose")
     {
         getStreamQualities(channelURL, [=](QStringList qualityOptions) {
-            QualityPopup::showDialog(channel, qualityOptions);
+            QualityPopup::showDialog(channel, std::move(qualityOptions));
         });
 
         return;

--- a/src/widgets/AttachedWindow.cpp
+++ b/src/widgets/AttachedWindow.cpp
@@ -143,7 +143,7 @@ void AttachedWindow::detach(const QString &winId)
 
 void AttachedWindow::setChannel(ChannelPtr channel)
 {
-    this->ui_.split->setChannel(channel);
+    this->ui_.split->setChannel(std::move(channel));
 }
 
 void AttachedWindow::showEvent(QShowEvent *)

--- a/src/widgets/Label.cpp
+++ b/src/widgets/Label.cpp
@@ -5,13 +5,13 @@
 namespace chatterino {
 
 Label::Label(QString text, FontStyle style)
-    : Label(nullptr, text, style)
+    : Label(nullptr, std::move(text), style)
 {
 }
 
 Label::Label(BaseWidget *parent, QString text, FontStyle style)
     : BaseWidget(parent)
-    , text_(text)
+    , text_(std::move(text))
     , fontStyle_(style)
 {
     this->connections_.managedConnect(getFonts()->fontChanged, [this] {

--- a/src/widgets/Scrollbar.cpp
+++ b/src/widgets/Scrollbar.cpp
@@ -30,7 +30,7 @@ Scrollbar::Scrollbar(ChannelView *parent)
     setMouseTracking(true);
 }
 
-void Scrollbar::addHighlight(ScrollbarHighlight highlight)
+void Scrollbar::addHighlight(const ScrollbarHighlight &highlight)
 {
     ScrollbarHighlight deleted;
     this->highlights_.pushBack(highlight, deleted);
@@ -42,7 +42,8 @@ void Scrollbar::addHighlightsAtStart(
     this->highlights_.pushFront(_highlights);
 }
 
-void Scrollbar::replaceHighlight(size_t index, ScrollbarHighlight replacement)
+void Scrollbar::replaceHighlight(size_t index,
+                                 const ScrollbarHighlight &replacement)
 {
     this->highlights_.replaceItem(index, replacement);
 }

--- a/src/widgets/Scrollbar.hpp
+++ b/src/widgets/Scrollbar.hpp
@@ -20,10 +20,10 @@ class Scrollbar : public BaseWidget
 public:
     Scrollbar(ChannelView *parent = nullptr);
 
-    void addHighlight(ScrollbarHighlight highlight);
+    void addHighlight(const ScrollbarHighlight &highlight);
     void addHighlightsAtStart(
         const std::vector<ScrollbarHighlight> &highlights_);
-    void replaceHighlight(size_t index, ScrollbarHighlight replacement);
+    void replaceHighlight(size_t index, const ScrollbarHighlight &replacement);
 
     void pauseHighlights();
     void unpauseHighlights();

--- a/src/widgets/StreamView.cpp
+++ b/src/widgets/StreamView.cpp
@@ -26,7 +26,7 @@ StreamView::StreamView(ChannelPtr channel, const QUrl &url)
 
     auto chat = layoutCreator.emplace<ChannelView>();
     chat->setFixedWidth(300);
-    chat->setChannel(channel);
+    chat->setChannel(std::move(channel));
 
     this->layout()->setSpacing(0);
     this->layout()->setMargin(0);

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -61,7 +61,8 @@ namespace {
     }
     void addEmoteSets(
         std::vector<std::shared_ptr<TwitchAccount::EmoteSet>> sets,
-        Channel &globalChannel, Channel &subChannel, QString currentChannelName)
+        Channel &globalChannel, Channel &subChannel,
+        const QString &currentChannelName)
     {
         QMap<QString, QPair<bool, std::vector<MessagePtr>>> mapOfSets;
 
@@ -102,7 +103,7 @@ namespace {
         // That contain title or emotes.
         // Put current channel emotes at the top
         auto currentChannelPair = mapOfSets[currentChannelName];
-        for (auto message : currentChannelPair.second)
+        for (const auto &message : currentChannelPair.second)
         {
             subChannel.addMessage(message);
         }
@@ -111,7 +112,7 @@ namespace {
         foreach (auto pair, mapOfSets)
         {
             auto &channel = pair.first ? globalChannel : subChannel;
-            for (auto message : pair.second)
+            for (const auto &message : pair.second)
             {
                 channel.addMessage(message);
             }
@@ -136,7 +137,7 @@ EmotePopup::EmotePopup(QWidget *parent)
         this->linkClicked.invoke(link);
     };
 
-    auto makeView = [&](QString tabTitle) {
+    auto makeView = [&](const QString &tabTitle) {
         auto view = new ChannelView();
 
         view->setOverrideFlags(MessageElementFlags{

--- a/src/widgets/dialogs/NotificationPopup.cpp
+++ b/src/widgets/dialogs/NotificationPopup.cpp
@@ -45,7 +45,7 @@ void NotificationPopup::updatePosition()
 
 void NotificationPopup::addMessage(MessagePtr msg)
 {
-    this->channel_->addMessage(msg);
+    this->channel_->addMessage(std::move(msg));
 
     //    QTimer::singleShot(5000, this, [this, msg] { this->channel->remove });
 }

--- a/src/widgets/dialogs/QualityPopup.cpp
+++ b/src/widgets/dialogs/QualityPopup.cpp
@@ -7,7 +7,8 @@
 
 namespace chatterino {
 
-QualityPopup::QualityPopup(const QString &_channelName, QStringList options)
+QualityPopup::QualityPopup(const QString &_channelName,
+                           const QStringList &options)
     : BasePopup({},
                 static_cast<QWidget *>(&(getApp()->windows->getMainWindow())))
     , channelName_(_channelName)
@@ -33,7 +34,8 @@ QualityPopup::QualityPopup(const QString &_channelName, QStringList options)
     this->setLayout(&this->ui_.vbox);
 }
 
-void QualityPopup::showDialog(const QString &channelName, QStringList options)
+void QualityPopup::showDialog(const QString &channelName,
+                              const QStringList &options)
 {
     QualityPopup *instance = new QualityPopup(channelName, options);
 

--- a/src/widgets/dialogs/QualityPopup.hpp
+++ b/src/widgets/dialogs/QualityPopup.hpp
@@ -12,8 +12,9 @@ namespace chatterino {
 class QualityPopup : public BasePopup
 {
 public:
-    QualityPopup(const QString &_channelName, QStringList options);
-    static void showDialog(const QString &_channelName, QStringList options);
+    QualityPopup(const QString &_channelName, const QStringList &options);
+    static void showDialog(const QString &_channelName,
+                           const QStringList &options);
 
 private:
     void okButtonClicked();

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -97,7 +97,7 @@ namespace {
 
     const auto borderColor = QColor(255, 255, 255, 80);
 
-    int calculateTimeoutDuration(TimeoutButton timeout)
+    int calculateTimeoutDuration(const TimeoutButton &timeout)
     {
         static const QMap<QString, int> durations{
             {"s", 1}, {"m", 60}, {"h", 3600}, {"d", 86400}, {"w", 604800},

--- a/src/widgets/helper/Button.cpp
+++ b/src/widgets/helper/Button.cpp
@@ -12,7 +12,7 @@ namespace chatterino {
 namespace {
 
     // returns a new resized image or the old one if the size didn't change
-    auto resizePixmap(const QPixmap &current, const QPixmap resized,
+    auto resizePixmap(const QPixmap &current, const QPixmap &resized,
                       const QSize &size) -> QPixmap
     {
         if (resized.size() == size)
@@ -38,7 +38,7 @@ Button::Button(BaseWidget *parent)
 
 void Button::setMouseEffectColor(boost::optional<QColor> color)
 {
-    this->mouseEffectColor_ = color;
+    this->mouseEffectColor_ = std::move(color);
 }
 
 void Button::setPixmap(const QPixmap &_pixmap)

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -550,7 +550,7 @@ bool ChannelView::getEnableScrollingToBottom() const
 
 void ChannelView::setOverrideFlags(boost::optional<MessageElementFlags> value)
 {
-    this->overrideFlags_ = value;
+    this->overrideFlags_ = std::move(value);
 }
 
 const boost::optional<MessageElementFlags> &ChannelView::getOverrideFlags()
@@ -647,7 +647,7 @@ void ChannelView::setChannel(ChannelPtr underlyingChannel)
     this->channelConnections_.push_back(this->channel_->messageAppended.connect(
         [this](MessagePtr &message,
                boost::optional<MessageFlags> overridingFlags) {
-            this->messageAppended(message, overridingFlags);
+            this->messageAppended(message, std::move(overridingFlags));
         }));
 
     this->channelConnections_.push_back(
@@ -753,7 +753,7 @@ ChannelPtr ChannelView::sourceChannel() const
 
 void ChannelView::setSourceChannel(ChannelPtr sourceChannel)
 {
-    this->sourceChannel_ = sourceChannel;
+    this->sourceChannel_ = std::move(sourceChannel);
 }
 
 bool ChannelView::hasSourceChannel() const
@@ -1444,8 +1444,8 @@ void ChannelView::mouseMoveEvent(QMouseEvent *event)
                 std::weak_ptr<MessageLayout> weakLayout = layout;
                 LinkResolver::getLinkInfo(
                     element->getLink().value, nullptr,
-                    [weakLayout, element](QString tooltipText,
-                                          Link originalLink,
+                    [weakLayout, element](const QString &tooltipText,
+                                          const Link &originalLink,
                                           ImagePtr thumbnail) {
                         auto shared = weakLayout.lock();
                         if (!shared)
@@ -1764,7 +1764,7 @@ void ChannelView::handleMouseClick(QMouseEvent *event,
         }
         break;
         case Qt::RightButton: {
-            auto insertText = [=](QString text) {
+            auto insertText = [=](const QString &text) {
                 if (auto split = dynamic_cast<Split *>(this->parentWidget()))
                 {
                     split->insertTextToInput(text);

--- a/src/widgets/helper/SearchPopup.cpp
+++ b/src/widgets/helper/SearchPopup.cpp
@@ -66,7 +66,7 @@ SearchPopup::SearchPopup(QWidget *parent)
 
 void SearchPopup::setChannelFilters(FilterSetPtr filters)
 {
-    this->channelFilters_ = filters;
+    this->channelFilters_ = std::move(filters);
 }
 
 void SearchPopup::setChannel(const ChannelPtr &channel)

--- a/src/widgets/helper/SettingsDialogTab.cpp
+++ b/src/widgets/helper/SettingsDialogTab.cpp
@@ -9,7 +9,8 @@ namespace chatterino {
 
 SettingsDialogTab::SettingsDialogTab(SettingsDialog *_dialog,
                                      std::function<SettingsPage *()> _lazyPage,
-                                     const QString &name, QString imageFileName,
+                                     const QString &name,
+                                     const QString &imageFileName,
                                      SettingsTabId id)
     : BaseWidget(_dialog)
     , dialog_(_dialog)

--- a/src/widgets/helper/SettingsDialogTab.hpp
+++ b/src/widgets/helper/SettingsDialogTab.hpp
@@ -25,7 +25,7 @@ class SettingsDialogTab : public BaseWidget
 public:
     SettingsDialogTab(SettingsDialog *dialog_,
                       std::function<SettingsPage *()> page_,
-                      const QString &name, QString imageFileName,
+                      const QString &name, const QString &imageFileName,
                       SettingsTabId id);
 
     void setSelected(bool selected_);

--- a/src/widgets/settingspages/CommandPage.cpp
+++ b/src/widgets/settingspages/CommandPage.cpp
@@ -59,9 +59,9 @@ CommandPage::CommandPage()
         QObject::connect(button, &QPushButton::clicked, this, [] {
             QFile c1settings = c1settingsPath();
             c1settings.open(QIODevice::ReadOnly);
-            for (auto line : QString(c1settings.readAll())
-                                 .split(QRegularExpression("[\r\n]"),
-                                        QString::SkipEmptyParts))
+            for (const auto &line : QString(c1settings.readAll())
+                                        .split(QRegularExpression("[\r\n]"),
+                                               QString::SkipEmptyParts))
             {
                 if (int index = line.indexOf(' '); index != -1)
                 {

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -57,7 +57,7 @@ namespace {
                         return 0;
                 }
             },
-            [](DropdownArgs args) {
+            [](const DropdownArgs &args) {
                 switch (args.index)
                 {
                     case 1:
@@ -272,7 +272,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
                     return 1;
             }
         },
-        [](DropdownArgs args) {
+        [](const DropdownArgs &args) {
             switch (args.index)
             {
                 case 0:
@@ -340,7 +340,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
             [](int value) {
                 return value;
             },
-            [](DropdownArgs args) {
+            [](const DropdownArgs &args) {
                 return static_cast<StreamerModeSetting>(args.index);
             },
             false);

--- a/src/widgets/settingspages/HighlightingPage.cpp
+++ b/src/widgets/settingspages/HighlightingPage.cpp
@@ -246,7 +246,7 @@ void HighlightingPage::tableCellClicked(const QModelIndex &clicked,
         auto dialog = new ColorPickerDialog(initial, this);
         dialog->setAttribute(Qt::WA_DeleteOnClose);
         dialog->show();
-        dialog->closed.connect([=](QColor selected) {
+        dialog->closed.connect([=](const QColor &selected) {
             if (selected.isValid())
             {
                 view->getModel()->setData(clicked, selected,

--- a/src/widgets/settingspages/ModerationPage.cpp
+++ b/src/widgets/settingspages/ModerationPage.cpp
@@ -24,13 +24,13 @@
 
 namespace chatterino {
 
-qint64 dirSize(QString dirPath)
+qint64 dirSize(const QString &dirPath)
 {
     qint64 size = 0;
     QDir dir(dirPath);
     // calculate total size of current directories' files
     QDir::Filters fileFilters = QDir::Files | QDir::System | QDir::Hidden;
-    for (QString filePath : dir.entryList(fileFilters))
+    for (const QString &filePath : dir.entryList(fileFilters))
     {
         QFileInfo fi(dir, filePath);
         size += fi.size();
@@ -38,7 +38,7 @@ qint64 dirSize(QString dirPath)
     // add size of child directories recursively
     QDir::Filters dirFilters =
         QDir::Dirs | QDir::NoDotAndDotDot | QDir::System | QDir::Hidden;
-    for (QString childDirPath : dir.entryList(dirFilters))
+    for (const QString &childDirPath : dir.entryList(dirFilters))
         size += dirSize(dirPath + QDir::separator() + childDirPath);
     return size;
 }
@@ -261,7 +261,7 @@ void ModerationPage::addModerationButtonSettings(
 
     // build one line for each customizable button
     auto i = 0;
-    for (const auto tButton : getSettings()->timeoutButtons.getValue())
+    for (const auto &tButton : getSettings()->timeoutButtons.getValue())
     {
         const auto buttonNumber = QString::number(i);
         auto timeout = timeoutLayout.emplace<QHBoxLayout>().withoutMargin();

--- a/src/widgets/splits/EmoteInputItem.cpp
+++ b/src/widgets/splits/EmoteInputItem.cpp
@@ -3,7 +3,7 @@
 namespace chatterino {
 
 EmoteInputItem::EmoteInputItem(const EmotePtr &emote, const QString &text,
-                               ActionCallback action)
+                               const ActionCallback &action)
     : emote_(emote)
     , text_(text)
     , action_(action)

--- a/src/widgets/splits/EmoteInputItem.hpp
+++ b/src/widgets/splits/EmoteInputItem.hpp
@@ -12,7 +12,7 @@ class EmoteInputItem : public GenericListItem
 
 public:
     EmoteInputItem(const EmotePtr &emote, const QString &text,
-                   ActionCallback action);
+                   const ActionCallback &action);
 
     // GenericListItem interface
 public:

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -415,7 +415,7 @@ void Split::insertTextToInput(const QString &text)
 }
 
 void Split::showChangeChannelPopup(const char *dialogTitle, bool empty,
-                                   std::function<void(bool)> callback)
+                                   const std::function<void(bool)> &callback)
 {
     if (this->selectChannelDialog_.hasElement())
     {
@@ -707,7 +707,7 @@ void Split::showViewerList()
     auto chattersList = new QListWidget();
     auto resultList = new QListWidget();
 
-    auto formatListItemText = [](QString text) {
+    auto formatListItemText = [](const QString &text) {
         auto item = new QListWidgetItem();
         item->setText(text);
         item->setFont(getApp()->fonts->getFont(FontStyle::ChatMedium, 1.0));
@@ -786,7 +786,7 @@ void Split::showViewerList()
         viewerDock->setMinimumWidth(300);
     });
 
-    auto listDoubleClick = [=](QString userName) {
+    auto listDoubleClick = [=](const QString &userName) {
         if (!labels.contains(userName) && !userName.isEmpty())
         {
             this->view_->showUserInfoPopup(userName);
@@ -841,7 +841,7 @@ void Split::setFiltersDialog()
     }
 }
 
-void Split::setFilters(const QList<QUuid> ids)
+void Split::setFilters(const QList<QUuid> &ids)
 {
     this->view_->setFilters(ids);
     this->header_->updateChannelText();

--- a/src/widgets/splits/Split.hpp
+++ b/src/widgets/splits/Split.hpp
@@ -54,7 +54,7 @@ public:
     ChannelPtr getChannel();
     void setChannel(IndirectChannel newChannel);
 
-    void setFilters(const QList<QUuid> ids);
+    void setFilters(const QList<QUuid> &ids);
     const QList<QUuid> getFilters() const;
 
     void setModerationMode(bool value);
@@ -63,7 +63,7 @@ public:
     void insertTextToInput(const QString &text);
 
     void showChangeChannelPopup(const char *dialogTitle, bool empty,
-                                std::function<void(bool)> callback);
+                                const std::function<void(bool)> &callback);
     void giveFocus(Qt::FocusReason reason);
     bool hasFocus() const;
     void updateGifEmotes();


### PR DESCRIPTION
Copied from commit:
*All* changes have been done from suggestions by clang-tidy. However these edits aren't just braindeadly following suggestion by the linter, but I have kept these details in mind when going through the suggestions:
- Smart pointer have been exempt from const& edits. Although it's perfectly valid to pass shared (and weak) pointers by reference (see https://stackoverflow.com/a/8741626), it's fairly counterintuitive, especially to new coders. However, std::move is used where applicable.
- Functions with callbacks have been exempt from const& edits. I do not know the chatterino codebase (and C++ callback semantics in general) well enough if these callbacks are always resolved before the parent function goes out of scope.

Other notes:
- I also have removed a few occurrences of std::move where the object was trivially copyable, in which case std::move does nothing (or possibly even degrades perfomance).
- I may have missed some cases which could use std::move and const&, as clangd was throwing errors on some of the UI code which may have masked linter warnings.
- This commit has been successfully built and tested. *In theory* the only issues this commit could cause are from const& and callback contexts where the callback outlives the parent, and since I intentionally skipped those this commit *should* be free performance gains for little effort.

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable