### PR TITLE
fix buffer overflow in parseEmoji

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@
 - Bugfix: Fix directory not opening when clicking "Open AppData Directory" setting button on macOS (#2531, #2537)
 - Bugfix: Fix quickswitcher not respecting order of tabs when filtering (#2519, #2561)
 - Bugfix: Fix GNOME not associating Chatterino's window with its desktop entry (#1863, #2587)
+- Bugfix: Fix buffer overflow in emoji parsing
 - Dev: Updated minimum required Qt framework version to 5.12. (#2210)
 - Dev: Migrated `Kraken::getUser` to Helix (#2260)
 - Dev: Migrated `TwitchAccount::(un)followUser` from Kraken to Helix and moved it to `Helix::(un)followUser`. (#2306)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,7 @@
 - Bugfix: Fix directory not opening when clicking "Open AppData Directory" setting button on macOS (#2531, #2537)
 - Bugfix: Fix quickswitcher not respecting order of tabs when filtering (#2519, #2561)
 - Bugfix: Fix GNOME not associating Chatterino's window with its desktop entry (#1863, #2587)
-- Bugfix: Fix buffer overflow in emoji parsing
+- Bugfix: Fix buffer overflow in emoji parsing. (#2602)
 - Dev: Updated minimum required Qt framework version to 5.12. (#2210)
 - Dev: Migrated `Kraken::getUser` to Helix (#2260)
 - Dev: Migrated `TwitchAccount::(un)followUser` from Kraken to Helix and moved it to `Helix::(un)followUser`. (#2306)

--- a/src/providers/emoji/Emojis.cpp
+++ b/src/providers/emoji/Emojis.cpp
@@ -24,7 +24,7 @@ namespace {
                     const rapidjson::Value &unparsedEmoji,
                     QString shortCode = QString())
     {
-        static uint unicodeBytes[4];
+        std::array<uint32_t, 7> unicodeBytes;
 
         struct {
             bool apple;
@@ -91,11 +91,12 @@ namespace {
 
         for (const QString &unicodeCharacter : unicodeCharacters)
         {
-            unicodeBytes[numUnicodeBytes++] =
+            unicodeBytes.at(numUnicodeBytes++) =
                 QString(unicodeCharacter).toUInt(nullptr, 16);
         }
 
-        emojiData->value = QString::fromUcs4(unicodeBytes, numUnicodeBytes);
+        emojiData->value =
+            QString::fromUcs4(unicodeBytes.data(), numUnicodeBytes);
     }
 
     // getToneNames takes a tones and returns their names in the same order


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

Copied from commit:
Some unified emoji codes are up to 7 bytes. This patch raises the unicodeBytes array size to 7 in addition to using .at() to catch possible future overflows early. May be worthwhile looking into why some unified codes are 7 bytes in the first place.

=================================================================
==4158928==ERROR: AddressSanitizer: global-buffer-overflow on address 0x562ebb5cd1f0 at pc 0x562eba0f5e72 bp 0x7ffc2705e830 sp 0x7ffc2705e820
WRITE of size 4 at 0x562ebb5cd1f0 thread T0
    #0 0x562eba0f5e71 in parseEmoji /home/yoitsu/Git/chatterino2/src/providers/emoji/Emojis.cpp:94
    #1 0x562eba0f71ae in chatterino::Emojis::loadEmojis() /home/yoitsu/Git/chatterino2/src/providers/emoji/Emojis.cpp:158
    #2 0x562eba0f6a71 in chatterino::Emojis::load() /home/yoitsu/Git/chatterino2/src/providers/emoji/Emojis.cpp:130
    #3 0x562eba4b87c8 in chatterino::Emotes::initialize(chatterino::Settings&, chatterino::Paths&) /home/yoitsu/Git/chatterino2/src/singletons/Emotes.cpp:18
    #4 0x562eb9e05466 in chatterino::Application::initialize(chatterino::Settings&, chatterino::Paths&) /home/yoitsu/Git/chatterino2/src/Application.cpp:102
    #5 0x562eb9e770b1 in chatterino::runGui(QApplication&, chatterino::Paths&, chatterino::Settings&) /home/yoitsu/Git/chatterino2/src/RunGui.cpp:217
    #6 0x562eb9dfdf7a in main /home/yoitsu/Git/chatterino2/src/main.cpp:90
    #7 0x7fa324a83b24 in __libc_start_main (/usr/lib/libc.so.6+0x27b24)
    #8 0x562eb9de889d in _start (/home/yoitsu/Git/chatterino2/build/bin/chatterino+0x5ef89d)

0x562ebb5cd1f0 is located 0 bytes to the right of global variable 'unicodeBytes' defined in '/home/yoitsu/Git/chatterino2/src/providers/emoji/Emojis.cpp:27:21' (0x562ebb5cd1e0) of size 16
0x562ebb5cd1f0 is located 48 bytes to the left of global variable 'emojiSets' defined in '/home/yoitsu/Git/chatterino2/src/providers/emoji/Emojis.cpp:224:47' (0x562ebb5cd220) of size 48
SUMMARY: AddressSanitizer: global-buffer-overflow /home/yoitsu/Git/chatterino2/src/providers/emoji/Emojis.cpp:94 in parseEmoji
Shadow bytes around the buggy address:
  0x0ac6576b19e0: 00 00 00 00 00 00 f9 f9 f9 f9 f9 f9 00 f9 f9 f9
  0x0ac6576b19f0: f9 f9 f9 f9 01 f9 f9 f9 f9 f9 f9 f9 01 f9 f9 f9
  0x0ac6576b1a00: f9 f9 f9 f9 01 f9 f9 f9 f9 f9 f9 f9 00 00 00 00
  0x0ac6576b1a10: 00 00 f9 f9 f9 f9 f9 f9 00 f9 f9 f9 f9 f9 f9 f9
  0x0ac6576b1a20: 00 f9 f9 f9 f9 f9 f9 f9 00 f9 f9 f9 f9 f9 f9 f9
=>0x0ac6576b1a30: 00 00 00 00 00 00 f9 f9 f9 f9 f9 f9 00 00[f9]f9
  0x0ac6576b1a40: f9 f9 f9 f9 00 00 00 00 00 00 f9 f9 f9 f9 f9 f9
  0x0ac6576b1a50: 00 f9 f9 f9 f9 f9 f9 f9 01 f9 f9 f9 f9 f9 f9 f9
  0x0ac6576b1a60: 01 f9 f9 f9 f9 f9 f9 f9 01 f9 f9 f9 f9 f9 f9 f9
  0x0ac6576b1a70: 00 00 00 00 00 00 f9 f9 f9 f9 f9 f9 00 f9 f9 f9
  0x0ac6576b1a80: f9 f9 f9 f9 00 f9 f9 f9 f9 f9 f9 f9 00 f9 f9 f9
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==4158928==ABORTING