### PR TITLE
clang-tidy: use std::move where applicable

### DIFF
--- a/src/BaseSettings.cpp
+++ b/src/BaseSettings.cpp
@@ -13,7 +13,7 @@ AB_SETTINGS_CLASS *AB_SETTINGS_CLASS::instance = nullptr;
 void _actuallyRegisterSetting(
     std::weak_ptr<pajlada::Settings::SettingData> setting)
 {
-    _settings.push_back(setting);
+    _settings.push_back(std::move(setting));
 }
 
 AB_SETTINGS_CLASS::AB_SETTINGS_CLASS(const QString &settingsDirectory)

--- a/src/common/Args.cpp
+++ b/src/common/Args.cpp
@@ -106,7 +106,7 @@ void Args::applyCustomChannelLayout(const QString &argValue)
         return QRect(-1, -1, -1, -1);
     }();
 
-    window.geometry_ = std::move(configMainLayout);
+    window.geometry_ = configMainLayout;
 
     QStringList channelArgList = argValue.split(";");
     for (const QString &channelArg : channelArgList)

--- a/src/common/Channel.cpp
+++ b/src/common/Channel.cpp
@@ -320,13 +320,13 @@ void Channel::onConnected()
 // Indirect channel
 //
 IndirectChannel::Data::Data(ChannelPtr _channel, Channel::Type _type)
-    : channel(_channel)
+    : channel(std::move(_channel))
     , type(_type)
 {
 }
 
 IndirectChannel::IndirectChannel(ChannelPtr channel, Channel::Type type)
-    : data_(std::make_unique<Data>(channel, type))
+    : data_(std::make_unique<Data>(std::move(channel), type))
 {
 }
 
@@ -339,7 +339,7 @@ void IndirectChannel::reset(ChannelPtr channel)
 {
     assert(this->data_->type != Channel::Type::Direct);
 
-    this->data_->channel = channel;
+    this->data_->channel = std::move(channel);
     this->data_->changed.invoke();
 }
 

--- a/src/common/ChatterinoSetting.cpp
+++ b/src/common/ChatterinoSetting.cpp
@@ -6,7 +6,7 @@ namespace chatterino {
 
 void _registerSetting(std::weak_ptr<pajlada::Settings::SettingData> setting)
 {
-    _actuallyRegisterSetting(setting);
+    _actuallyRegisterSetting(std::move(setting));
 }
 
 }  // namespace chatterino

--- a/src/controllers/highlights/HighlightPhrase.cpp
+++ b/src/controllers/highlights/HighlightPhrase.cpp
@@ -57,7 +57,7 @@ HighlightPhrase::HighlightPhrase(const QString &pattern, bool showInMentions,
     , isRegex_(isRegex)
     , isCaseSensitive_(isCaseSensitive)
     , soundUrl_(soundUrl)
-    , color_(color)
+    , color_(std::move(color))
     , regex_(isRegex_
                  ? pattern
                  : REGEX_START_BOUNDARY + QRegularExpression::escape(pattern) +

--- a/src/messages/layouts/MessageLayout.cpp
+++ b/src/messages/layouts/MessageLayout.cpp
@@ -39,7 +39,7 @@ namespace {
 }  // namespace
 
 MessageLayout::MessageLayout(MessagePtr message)
-    : message_(message)
+    : message_(std::move(message))
     , container_(std::make_shared<MessageLayoutContainer>())
 {
     DebugCount::increase("message layout");

--- a/src/messages/layouts/MessageLayoutElement.cpp
+++ b/src/messages/layouts/MessageLayoutElement.cpp
@@ -88,7 +88,7 @@ FlagsEnum<MessageElementFlag> MessageLayoutElement::getFlags() const
 ImageLayoutElement::ImageLayoutElement(MessageElement &creator, ImagePtr image,
                                        const QSize &size)
     : MessageLayoutElement(creator, size)
-    , image_(image)
+    , image_(std::move(image))
 {
     this->trailingSpace = creator.hasTrailingSpace();
 }

--- a/src/providers/colors/ColorProvider.cpp
+++ b/src/providers/colors/ColorProvider.cpp
@@ -26,7 +26,7 @@ const std::shared_ptr<QColor> ColorProvider::color(ColorType type) const
 void ColorProvider::updateColor(ColorType type, QColor color)
 {
     auto colorPtr = this->typeColorMap_.at(type);
-    *colorPtr = color;
+    *colorPtr = std::move(color);
 }
 
 QSet<QColor> ColorProvider::recentColors() const

--- a/src/providers/twitch/TwitchAccount.cpp
+++ b/src/providers/twitch/TwitchAccount.cpp
@@ -64,7 +64,7 @@ QColor TwitchAccount::color()
 
 void TwitchAccount::setColor(QColor color)
 {
-    this->color_.set(color);
+    this->color_.set(std::move(color));
 }
 
 bool TwitchAccount::setOAuthClient(const QString &newClientID)
@@ -131,7 +131,7 @@ void TwitchAccount::blockUser(QString userId, std::function<void()> onSuccess,
             }
             onSuccess();
         },
-        onFailure);
+        std::move(onFailure));
 }
 
 void TwitchAccount::unblockUser(QString userId, std::function<void()> onSuccess,
@@ -149,7 +149,7 @@ void TwitchAccount::unblockUser(QString userId, std::function<void()> onSuccess,
             }
             onSuccess();
         },
-        onFailure);
+        std::move(onFailure));
 }
 
 void TwitchAccount::checkFollow(const QString targetUserID,

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -58,7 +58,7 @@ void Helix::getUserByName(QString userName,
                           HelixFailureCallback failureCallback)
 {
     QStringList userIds;
-    QStringList userLogins{userName};
+    QStringList userLogins{std::move(userName)};
 
     this->fetchUsers(
         userIds, userLogins,
@@ -78,7 +78,7 @@ void Helix::getUserById(QString userId,
                         ResultCallback<HelixUser> successCallback,
                         HelixFailureCallback failureCallback)
 {
-    QStringList userIds{userId};
+    QStringList userIds{std::move(userId)};
     QStringList userLogins;
 
     this->fetchUsers(
@@ -136,7 +136,8 @@ void Helix::getUserFollowers(
     QString userId, ResultCallback<HelixUsersFollowsResponse> successCallback,
     HelixFailureCallback failureCallback)
 {
-    this->fetchUsersFollows("", userId, successCallback, failureCallback);
+    this->fetchUsersFollows("", std::move(userId), std::move(successCallback),
+                            std::move(failureCallback));
 }
 
 void Helix::getUserFollow(
@@ -145,7 +146,7 @@ void Helix::getUserFollow(
     HelixFailureCallback failureCallback)
 {
     this->fetchUsersFollows(
-        userId, targetId,
+        std::move(userId), std::move(targetId),
         [successCallback](const auto &response) {
             if (response.data.empty())
             {
@@ -155,7 +156,7 @@ void Helix::getUserFollow(
 
             successCallback(true, response.data[0]);
         },
-        failureCallback);
+        std::move(failureCallback));
 }
 
 void Helix::fetchStreams(
@@ -209,7 +210,7 @@ void Helix::getStreamById(QString userId,
                           ResultCallback<bool, HelixStream> successCallback,
                           HelixFailureCallback failureCallback)
 {
-    QStringList userIds{userId};
+    QStringList userIds{std::move(userId)};
     QStringList userLogins;
 
     this->fetchStreams(
@@ -230,7 +231,7 @@ void Helix::getStreamByName(QString userName,
                             HelixFailureCallback failureCallback)
 {
     QStringList userIds;
-    QStringList userLogins{userName};
+    QStringList userLogins{std::move(userName)};
 
     this->fetchStreams(
         userIds, userLogins,
@@ -299,7 +300,7 @@ void Helix::getGameById(QString gameId,
                         ResultCallback<HelixGame> successCallback,
                         HelixFailureCallback failureCallback)
 {
-    QStringList gameIds{gameId};
+    QStringList gameIds{std::move(gameId)};
     QStringList gameNames;
 
     this->fetchGames(
@@ -409,7 +410,7 @@ void Helix::createClip(QString channelId,
                 break;
             }
         })
-        .finally(finallyCallback)
+        .finally(std::move(finallyCallback))
         .execute();
 }
 
@@ -653,8 +654,8 @@ NetworkRequest Helix::makeRequest(QString url, QUrlQuery urlQuery)
 
 void Helix::update(QString clientId, QString oauthToken)
 {
-    this->clientId = clientId;
-    this->oauthToken = oauthToken;
+    this->clientId = std::move(clientId);
+    this->oauthToken = std::move(oauthToken);
 }
 
 void Helix::initialize()

--- a/src/providers/twitch/api/Kraken.cpp
+++ b/src/providers/twitch/api/Kraken.cpp
@@ -63,8 +63,8 @@ NetworkRequest Kraken::makeRequest(QString url, QUrlQuery urlQuery)
 
 void Kraken::update(QString clientId, QString oauthToken)
 {
-    this->clientId = clientId;
-    this->oauthToken = oauthToken;
+    this->clientId = std::move(clientId);
+    this->oauthToken = std::move(oauthToken);
 }
 
 void Kraken::initialize()

--- a/src/singletons/TooltipPreviewImage.cpp
+++ b/src/singletons/TooltipPreviewImage.cpp
@@ -33,7 +33,7 @@ TooltipPreviewImage::TooltipPreviewImage()
 
 void TooltipPreviewImage::setImage(ImagePtr image)
 {
-    this->image_ = image;
+    this->image_ = std::move(image);
 
     this->refreshTooltipWidgetPixmap();
 }

--- a/src/util/PostToThread.hpp
+++ b/src/util/PostToThread.hpp
@@ -17,7 +17,7 @@ class LambdaRunnable : public QRunnable
 public:
     LambdaRunnable(std::function<void()> action)
     {
-        this->action_ = action;
+        this->action_ = std::move(action);
     }
 
     void run()

--- a/src/widgets/AttachedWindow.cpp
+++ b/src/widgets/AttachedWindow.cpp
@@ -143,7 +143,7 @@ void AttachedWindow::detach(const QString &winId)
 
 void AttachedWindow::setChannel(ChannelPtr channel)
 {
-    this->ui_.split->setChannel(channel);
+    this->ui_.split->setChannel(std::move(channel));
 }
 
 void AttachedWindow::showEvent(QShowEvent *)

--- a/src/widgets/Label.cpp
+++ b/src/widgets/Label.cpp
@@ -5,13 +5,13 @@
 namespace chatterino {
 
 Label::Label(QString text, FontStyle style)
-    : Label(nullptr, text, style)
+    : Label(nullptr, std::move(text), style)
 {
 }
 
 Label::Label(BaseWidget *parent, QString text, FontStyle style)
     : BaseWidget(parent)
-    , text_(text)
+    , text_(std::move(text))
     , fontStyle_(style)
 {
     this->connections_.managedConnect(getFonts()->fontChanged, [this] {

--- a/src/widgets/StreamView.cpp
+++ b/src/widgets/StreamView.cpp
@@ -26,7 +26,7 @@ StreamView::StreamView(ChannelPtr channel, const QUrl &url)
 
     auto chat = layoutCreator.emplace<ChannelView>();
     chat->setFixedWidth(300);
-    chat->setChannel(channel);
+    chat->setChannel(std::move(channel));
 
     this->layout()->setSpacing(0);
     this->layout()->setMargin(0);

--- a/src/widgets/dialogs/NotificationPopup.cpp
+++ b/src/widgets/dialogs/NotificationPopup.cpp
@@ -45,7 +45,7 @@ void NotificationPopup::updatePosition()
 
 void NotificationPopup::addMessage(MessagePtr msg)
 {
-    this->channel_->addMessage(msg);
+    this->channel_->addMessage(std::move(msg));
 
     //    QTimer::singleShot(5000, this, [this, msg] { this->channel->remove });
 }

--- a/src/widgets/helper/Button.cpp
+++ b/src/widgets/helper/Button.cpp
@@ -38,7 +38,7 @@ Button::Button(BaseWidget *parent)
 
 void Button::setMouseEffectColor(boost::optional<QColor> color)
 {
-    this->mouseEffectColor_ = color;
+    this->mouseEffectColor_ = std::move(color);
 }
 
 void Button::setPixmap(const QPixmap &_pixmap)

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -550,7 +550,7 @@ bool ChannelView::getEnableScrollingToBottom() const
 
 void ChannelView::setOverrideFlags(boost::optional<MessageElementFlags> value)
 {
-    this->overrideFlags_ = value;
+    this->overrideFlags_ = std::move(value);
 }
 
 const boost::optional<MessageElementFlags> &ChannelView::getOverrideFlags()
@@ -647,7 +647,7 @@ void ChannelView::setChannel(ChannelPtr underlyingChannel)
     this->channelConnections_.push_back(this->channel_->messageAppended.connect(
         [this](MessagePtr &message,
                boost::optional<MessageFlags> overridingFlags) {
-            this->messageAppended(message, overridingFlags);
+            this->messageAppended(message, std::move(overridingFlags));
         }));
 
     this->channelConnections_.push_back(
@@ -753,7 +753,7 @@ ChannelPtr ChannelView::sourceChannel() const
 
 void ChannelView::setSourceChannel(ChannelPtr sourceChannel)
 {
-    this->sourceChannel_ = sourceChannel;
+    this->sourceChannel_ = std::move(sourceChannel);
 }
 
 bool ChannelView::hasSourceChannel() const

--- a/src/widgets/helper/SearchPopup.cpp
+++ b/src/widgets/helper/SearchPopup.cpp
@@ -66,7 +66,7 @@ SearchPopup::SearchPopup(QWidget *parent)
 
 void SearchPopup::setChannelFilters(FilterSetPtr filters)
 {
-    this->channelFilters_ = filters;
+    this->channelFilters_ = std::move(filters);
 }
 
 void SearchPopup::setChannel(const ChannelPtr &channel)


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Previous PR split into multiple parts, part 1.

std::move added where applicable as per suggested by clang-tidy, and 1 case removed where it was added in error to a trivially copyable object. These are "confident" changes, as applying std::move to non-trivially copyable objects should only result in less temporary copies -> lower overhead -> higher perfomance, unlike const& which can also change code semantics (according to Pajlada's feedback, as apparently const& can degrade perfomance in lambda contexts).

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
