### PR TITLE
Add PgUp / PgDown for scrolling in the emote popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@
 - Minor: Show channels live now enabled by default
 - Minor: Bold usernames enabled by default
 - Minor: Improve UX of the "Login expired!" message (#2029)
-- Minor: PageUp and PageDown now scroll in the selected split (#2070, #2081)
+- Minor: PageUp and PageDown now scroll in the selected split and in the emote popup (#2070, #2081, #2410, #2607)
 - Minor: Allow highlights to be excluded from `/mentions`. Excluded highlights will not trigger tab highlights either. (#1793, #2036)
 - Minor: Flag all popup dialogs as actual dialogs so they get the relevant window manager hints (#1843, #2182, #2185, #2232, #2234)
 - Minor: Don't show update button for nightly builds on macOS and Linux, this was already the case for Windows (#2163, #2164)

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -11,8 +11,8 @@
 #include "singletons/WindowManager.hpp"
 #include "util/Shortcut.hpp"
 #include "widgets/Notebook.hpp"
-#include "widgets/helper/ChannelView.hpp"
 #include "widgets/Scrollbar.hpp"
+#include "widgets/helper/ChannelView.hpp"
 
 #include <QHBoxLayout>
 #include <QShortcut>
@@ -182,11 +182,15 @@ EmotePopup::EmotePopup(QWidget *parent)
 
     // Scroll with Page Up / Page Down
     createWindowShortcut(this, "PgUp", [=] {
-        auto &scrollbar = dynamic_cast<ChannelView *>(notebook->getSelectedPage())->getScrollBar();
+        auto &scrollbar =
+            dynamic_cast<ChannelView *>(notebook->getSelectedPage())
+                ->getScrollBar();
         scrollbar.offset(-scrollbar.getLargeChange());
     });
     createWindowShortcut(this, "PgDown", [=] {
-        auto &scrollbar = dynamic_cast<ChannelView *>(notebook->getSelectedPage())->getScrollBar();
+        auto &scrollbar =
+            dynamic_cast<ChannelView *>(notebook->getSelectedPage())
+                ->getScrollBar();
         scrollbar.offset(scrollbar.getLargeChange());
     });
 }

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -12,6 +12,7 @@
 #include "util/Shortcut.hpp"
 #include "widgets/Notebook.hpp"
 #include "widgets/helper/ChannelView.hpp"
+#include "widgets/Scrollbar.hpp"
 
 #include <QHBoxLayout>
 #include <QShortcut>
@@ -177,6 +178,16 @@ EmotePopup::EmotePopup(QWidget *parent)
     });
     createWindowShortcut(this, "CTRL+Shift+Tab", [=] {
         notebook->selectPreviousTab();
+    });
+
+    // Scroll with Page Up / Page Down
+    createWindowShortcut(this, "PgUp", [=] {
+        auto &scrollbar = dynamic_cast<ChannelView *>(notebook->getSelectedPage())->getScrollBar();
+        scrollbar.offset(-scrollbar.getLargeChange());
+    });
+    createWindowShortcut(this, "PgDown", [=] {
+        auto &scrollbar = dynamic_cast<ChannelView *>(notebook->getSelectedPage())->getScrollBar();
+        scrollbar.offset(scrollbar.getLargeChange());
     });
 }
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Added Page Up and Page Down shortcuts for scrolling up and down in the emote popup, to be consistent with the same shortcuts in channel views.

Closes #2410 