### PR TITLE
Handle bits badge tier notification messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 - Minor: Added `/streamlink` command. Usage: `/streamlink <channel>`. You can also use the command without arguments in any twitch channel to open it in streamlink. (#2443, #2495)
 - Minor: Humanized all numbers visible to end-users. (#2488)
 - Minor: Added a context menu to avatar in usercard. It opens on right-clicking the avatar in usercard. (#2517)
+- Minor: Handle messages that users can share after unlocking a new bits badge. (#2611)
 - Bugfix: Fix crash occurring when pressing Escape in the Color Picker Dialog (#1843)
 - Bugfix: Fix bug where the "check user follow state" event could trigger a network request requesting the user to follow or unfollow a user. By itself its quite harmless as it just repeats to Twitch the same follow state we had, so no follows should have been lost by this but it meant there was a rogue network request that was fired that could cause a crash (#1906)
 - Bugfix: /usercard command will now respect the "Automatically close user popup" setting (#1918)

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -14,6 +14,7 @@
 #include "singletons/Settings.hpp"
 #include "singletons/WindowManager.hpp"
 #include "util/FormatTime.hpp"
+#include "util/Helpers.hpp"
 #include "util/IrcHelpers.hpp"
 
 #include <IrcMessage>
@@ -579,10 +580,11 @@ std::vector<MessagePtr> IrcMessageHandler::parseUserNoticeMessage(
         content = parameters[1];
     }
 
-    if (msgType == "sub" || msgType == "resub" || msgType == "subgift")
+    if (msgType == "sub" || msgType == "resub" || msgType == "subgift" ||
+        msgType == "bitsbadgetier")
     {
-        // Sub-specific message. I think it's only allowed for "resub" messages
-        // atm
+        // Sub-specific and bits badge upgrade specific message.
+        // It's only allowed for "resub" messages.
         if (!content.isEmpty())
         {
             MessageParseArgs args;
@@ -600,9 +602,18 @@ std::vector<MessagePtr> IrcMessageHandler::parseUserNoticeMessage(
 
     if (it != tags.end())
     {
-        auto b =
-            MessageBuilder(systemMessage, parseTagString(it.value().toString()),
-                           calculateMessageTimestamp(message));
+        QString messageText = it.value().toString();
+
+        if (msgType == "bitsbadgetier")
+        {
+            messageText = QString("%1 just earned a new %2 Bits badge!")
+                              .arg(tags.value("display-name").toString())
+                              .arg(kFormatNumbers(
+                                  tags.value("msg-param-threshold").toInt()));
+        }
+
+        auto b = MessageBuilder(systemMessage, parseTagString(messageText),
+                                calculateMessageTimestamp(message));
 
         b->flags.set(MessageFlag::Subscription);
         auto newMessage = b.release();
@@ -628,10 +639,11 @@ void IrcMessageHandler::handleUserNoticeMessage(Communi::IrcMessage *message,
         content = parameters[1];
     }
 
-    if (msgType == "sub" || msgType == "resub" || msgType == "subgift")
+    if (msgType == "sub" || msgType == "resub" || msgType == "subgift" ||
+        msgType == "bitsbadgetier")
     {
-        // Sub-specific message. I think it's only allowed for "resub" messages
-        // atm
+        // Sub-specific and bits badge upgrade specific message.
+        // It's only allowed for "resub" messages.
         if (!content.isEmpty())
         {
             this->addMessage(message, target, content, server, true, false);
@@ -642,9 +654,18 @@ void IrcMessageHandler::handleUserNoticeMessage(Communi::IrcMessage *message,
 
     if (it != tags.end())
     {
-        auto b =
-            MessageBuilder(systemMessage, parseTagString(it.value().toString()),
-                           calculateMessageTimestamp(message));
+        QString messageText = it.value().toString();
+
+        if (msgType == "bitsbadgetier")
+        {
+            messageText = QString("%1 just earned a new %2 Bits badge!")
+                              .arg(tags.value("display-name").toString())
+                              .arg(kFormatNumbers(
+                                  tags.value("msg-param-threshold").toInt()));
+        }
+
+        auto b = MessageBuilder(systemMessage, parseTagString(messageText),
+                                calculateMessageTimestamp(message));
 
         b->flags.set(MessageFlag::Subscription);
         auto newMessage = b.release();

--- a/src/util/Helpers.cpp
+++ b/src/util/Helpers.cpp
@@ -42,4 +42,9 @@ QString localizeNumbers(const int &number)
     return locale.toString(number);
 }
 
+QString kFormatNumbers(const int &number)
+{
+    return QString("%1K").arg(number / 1000);
+}
+
 }  // namespace chatterino

--- a/src/util/Helpers.hpp
+++ b/src/util/Helpers.hpp
@@ -15,4 +15,6 @@ QString shortenString(const QString &str, unsigned maxWidth = 50);
 
 QString localizeNumbers(const int &number);
 
+QString kFormatNumbers(const int &number);
+
 }  // namespace chatterino


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

We didn't handle those messages before, now we do.

Example of how it looks (thanks @KararTY  for testing):
![PagMan](https://cdn.zneix.eu/jVPOXYw.png)

Examples of how it looks in webchat:

![KomodoHype](https://i.imgur.com/YOhZ2Ad.png)

![Hi mm2pl and leon pajaHi](https://i.imgur.com/U1i33TQ.png)
