### PR TITLE
Add a function in NetworkCommon `parseHeaderList` which parses a header list as a string into a vector of header pairs

### DIFF
--- a/chatterino.pro
+++ b/chatterino.pro
@@ -134,6 +134,7 @@ SOURCES += \
     src/common/Env.cpp \
     src/common/LinkParser.cpp \
     src/common/Modes.cpp \
+    src/common/NetworkCommon.cpp \
     src/common/NetworkManager.cpp \
     src/common/NetworkPrivate.cpp \
     src/common/NetworkRequest.cpp \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,6 +30,8 @@ set(SOURCE_FILES main.cpp
         common/LinkParser.hpp
         common/Modes.cpp
         common/Modes.hpp
+        common/NetworkCommon.cpp
+        common/NetworkCommon.hpp
         common/NetworkManager.cpp
         common/NetworkManager.hpp
         common/NetworkPrivate.cpp

--- a/src/common/NetworkCommon.cpp
+++ b/src/common/NetworkCommon.cpp
@@ -4,10 +4,10 @@
 
 namespace chatterino {
 
-std::vector<std::pair<QString, QString>> parseHeaderList(
+std::vector<std::pair<QByteArray, QByteArray>> parseHeaderList(
     const QString &headerListString)
 {
-    std::vector<std::pair<QString, QString>> res;
+    std::vector<std::pair<QByteArray, QByteArray>> res;
 
     // Split the string into a list of header pairs
     // e.g. "Authorization:secretkey;NextHeader:boo" turning into ["Authorization:secretkey","NextHeader:boo"]

--- a/src/common/NetworkCommon.cpp
+++ b/src/common/NetworkCommon.cpp
@@ -1,0 +1,38 @@
+#include "common/NetworkCommon.hpp"
+
+#include <QStringList>
+
+namespace chatterino {
+
+std::vector<std::pair<QString, QString>> parseHeaderList(
+    const QString &headerListString)
+{
+    std::vector<std::pair<QString, QString>> res;
+
+    // Split the string into a list of header pairs
+    // e.g. "Authorization:secretkey;NextHeader:boo" turning into ["Authorization:secretkey","NextHeader:boo"]
+    auto headerPairs = headerListString.split(";");
+
+    for (const auto &headerPair : headerPairs)
+    {
+        // Split the header pair into a list of parts
+        // We expect the first part to be the header name, and the second part to be the header value
+        auto headerParts = headerPair.trimmed().split(":");
+
+        if (headerParts.size() != 2)
+        {
+            // The header part either didn't contain a : or contained too many :, making it an invalid header pair
+            // Skip the value
+            continue;
+        }
+
+        const auto headerName = headerParts[0].trimmed().toUtf8();
+        const auto headerValue = headerParts[1].trimmed().toUtf8();
+
+        res.emplace_back(headerName, headerValue);
+    }
+
+    return res;
+}
+
+}  // namespace chatterino

--- a/src/common/NetworkCommon.cpp
+++ b/src/common/NetworkCommon.cpp
@@ -15,19 +15,16 @@ std::vector<std::pair<QByteArray, QByteArray>> parseHeaderList(
 
     for (const auto &headerPair : headerPairs)
     {
-        // Split the header pair into a list of parts
-        // We expect the first part to be the header name, and the second part to be the header value
-        auto headerParts = headerPair.trimmed().split(":");
+        const auto headerName =
+            headerPair.section(":", 0, 0).trimmed().toUtf8();
+        const auto headerValue = headerPair.section(":", 1).trimmed().toUtf8();
 
-        if (headerParts.size() != 2)
+        if (headerName.isEmpty() || headerValue.isEmpty())
         {
-            // The header part either didn't contain a : or contained too many :, making it an invalid header pair
+            // The header part either didn't contain a : or the name/value was empty
             // Skip the value
             continue;
         }
-
-        const auto headerName = headerParts[0].trimmed().toUtf8();
-        const auto headerValue = headerParts[1].trimmed().toUtf8();
 
         res.emplace_back(headerName, headerValue);
     }

--- a/src/common/NetworkCommon.hpp
+++ b/src/common/NetworkCommon.hpp
@@ -31,7 +31,7 @@ enum class NetworkRequestType {
 // We return a vector of pairs, where the first value is the header name and the second value is the header value
 //
 // e.g. "Authorization:secretkey;NextHeader:boo" will return [{"Authorization", "secretkey"}, {"NextHeader", "boo"}]
-std::vector<std::pair<QString, QString>> parseHeaderList(
+std::vector<std::pair<QByteArray, QByteArray>> parseHeaderList(
     const QString &headerListString);
 
 }  // namespace chatterino

--- a/src/common/NetworkCommon.hpp
+++ b/src/common/NetworkCommon.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <functional>
+#include <vector>
+
+#include <QString>
 
 class QNetworkReply;
 
@@ -21,5 +24,14 @@ enum class NetworkRequestType {
     Delete,
     Patch,
 };
+
+// parseHeaderList takes a list of headers in string form,
+// where each header pair is separated by semicolons (;) and the header name and value is divided by a colon (:)
+//
+// We return a vector of pairs, where the first value is the header name and the second value is the header value
+//
+// e.g. "Authorization:secretkey;NextHeader:boo" will return [{"Authorization", "secretkey"}, {"NextHeader", "boo"}]
+std::vector<std::pair<QString, QString>> parseHeaderList(
+    const QString &headerListString);
 
 }  // namespace chatterino

--- a/src/common/NetworkRequest.cpp
+++ b/src/common/NetworkRequest.cpp
@@ -106,16 +106,12 @@ NetworkRequest NetworkRequest::header(const char *headerName,
     return std::move(*this);
 }
 
-NetworkRequest NetworkRequest::headerList(const QStringList &headers) &&
+NetworkRequest NetworkRequest::headerList(
+    const std::vector<std::pair<QByteArray, QByteArray>> &headers) &&
 {
-    for (const QString &header : headers)
+    for (const auto &[headerName, headerValue] : headers)
     {
-        const QStringList thisHeader = header.trimmed().split(":");
-        if (thisHeader.size() == 2)
-        {
-            this->data->request_.setRawHeader(thisHeader[0].trimmed().toUtf8(),
-                                              thisHeader[1].trimmed().toUtf8());
-        }
+        this->data->request_.setRawHeader(headerName, headerValue);
     }
     return std::move(*this);
 }

--- a/src/common/NetworkRequest.hpp
+++ b/src/common/NetworkRequest.hpp
@@ -54,7 +54,8 @@ public:
     NetworkRequest header(const char *headerName, const char *value) &&;
     NetworkRequest header(const char *headerName, const QByteArray &value) &&;
     NetworkRequest header(const char *headerName, const QString &value) &&;
-    NetworkRequest headerList(const QStringList &headers) &&;
+    NetworkRequest headerList(
+        const std::vector<std::pair<QByteArray, QByteArray>> &headers) &&;
     NetworkRequest timeout(int ms) &&;
     NetworkRequest concurrent() &&;
     NetworkRequest authorizeTwitchV5(const QString &clientID,

--- a/src/util/NuulsUploader.cpp
+++ b/src/util/NuulsUploader.cpp
@@ -128,8 +128,8 @@ void uploadImageToNuuls(RawImageData imageData, ChannelPtr channel,
         getSettings()->imageUploaderFormField.getValue().isEmpty()
             ? getSettings()->imageUploaderFormField.getDefaultValue()
             : getSettings()->imageUploaderFormField);
-    QStringList extraHeaders(
-        getSettings()->imageUploaderHeaders.getValue().split(";"));
+    auto extraHeaders =
+        parseHeaderList(getSettings()->imageUploaderHeaders.getValue());
     QString originalFilePath = imageData.filePath;
 
     QHttpMultiPart *payload = new QHttpMultiPart(QHttpMultiPart::FormDataType);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,6 +36,7 @@ set(chatterino_SOURCES
 
 set(test_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/src/main.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/NetworkCommon.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/NetworkRequest.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/UsernameSet.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/HighlightPhrase.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ set(chatterino_SOURCES
 
     ${CMAKE_SOURCE_DIR}/src/common/ChatterinoSetting.cpp
     ${CMAKE_SOURCE_DIR}/src/common/Modes.cpp
+    ${CMAKE_SOURCE_DIR}/src/common/NetworkCommon.cpp
     ${CMAKE_SOURCE_DIR}/src/common/NetworkManager.cpp
     ${CMAKE_SOURCE_DIR}/src/common/NetworkPrivate.cpp
     ${CMAKE_SOURCE_DIR}/src/common/NetworkRequest.cpp

--- a/tests/src/NetworkCommon.cpp
+++ b/tests/src/NetworkCommon.cpp
@@ -7,7 +7,7 @@ using namespace chatterino;
 TEST(NetworkCommon, parseHeaderList1)
 {
     const QString input = "Authorization:secretKey;NextHeader:boo";
-    const std::vector<std::pair<QString, QString>> expected = {
+    const std::vector<std::pair<QByteArray, QByteArray>> expected = {
         {"Authorization", "secretKey"},
         {"NextHeader", "boo"},
     };
@@ -20,7 +20,7 @@ TEST(NetworkCommon, parseHeaderList1)
 TEST(NetworkCommon, parseHeaderListTrimmed)
 {
     const QString input = "Authorization:  secretKey; NextHeader   :boo";
-    const std::vector<std::pair<QString, QString>> expected = {
+    const std::vector<std::pair<QByteArray, QByteArray>> expected = {
         {"Authorization", "secretKey"},
         {"NextHeader", "boo"},
     };
@@ -34,7 +34,7 @@ TEST(NetworkCommon, parseHeaderListBadPair)
 {
     // The input values first header pair contains an invalid value, too many colons. We expect this value to be skipped
     const QString input = "Authorization:  secretKey:bad; NextHeader   :boo";
-    const std::vector<std::pair<QString, QString>> expected = {
+    const std::vector<std::pair<QByteArray, QByteArray>> expected = {
         {"NextHeader", "boo"},
     };
 
@@ -48,7 +48,7 @@ TEST(NetworkCommon, parseHeaderListBadPair2)
 {
     // The input values first header pair doesn't have a colon, so we don't know where the header name and value start/end
     const QString input = "Authorization  secretKeybad; NextHeader   :boo";
-    const std::vector<std::pair<QString, QString>> expected = {
+    const std::vector<std::pair<QByteArray, QByteArray>> expected = {
         {"NextHeader", "boo"},
     };
 

--- a/tests/src/NetworkCommon.cpp
+++ b/tests/src/NetworkCommon.cpp
@@ -30,21 +30,21 @@ TEST(NetworkCommon, parseHeaderListTrimmed)
     ASSERT_EQ(expected, actual);
 }
 
-TEST(NetworkCommon, parseHeaderListBadPair)
+TEST(NetworkCommon, parseHeaderListColonInValue)
 {
     // The input values first header pair contains an invalid value, too many colons. We expect this value to be skipped
-    const QString input = "Authorization:  secretKey:bad; NextHeader   :boo";
+    const QString input = "Authorization:  secretKey:hehe; NextHeader   :boo";
     const std::vector<std::pair<QByteArray, QByteArray>> expected = {
+        {"Authorization", "secretKey:hehe"},
         {"NextHeader", "boo"},
     };
 
     const auto actual = parseHeaderList(input);
 
     ASSERT_EQ(expected, actual);
-    ASSERT_EQ(1, actual.size());
 }
 
-TEST(NetworkCommon, parseHeaderListBadPair2)
+TEST(NetworkCommon, parseHeaderListBadPair)
 {
     // The input values first header pair doesn't have a colon, so we don't know where the header name and value start/end
     const QString input = "Authorization  secretKeybad; NextHeader   :boo";

--- a/tests/src/NetworkCommon.cpp
+++ b/tests/src/NetworkCommon.cpp
@@ -29,3 +29,31 @@ TEST(NetworkCommon, parseHeaderListTrimmed)
 
     ASSERT_EQ(expected, actual);
 }
+
+TEST(NetworkCommon, parseHeaderListBadPair)
+{
+    // The input values first header pair contains an invalid value, too many colons. We expect this value to be skipped
+    const QString input = "Authorization:  secretKey:bad; NextHeader   :boo";
+    const std::vector<std::pair<QString, QString>> expected = {
+        {"NextHeader", "boo"},
+    };
+
+    const auto actual = parseHeaderList(input);
+
+    ASSERT_EQ(expected, actual);
+    ASSERT_EQ(1, actual.size());
+}
+
+TEST(NetworkCommon, parseHeaderListBadPair2)
+{
+    // The input values first header pair doesn't have a colon, so we don't know where the header name and value start/end
+    const QString input = "Authorization  secretKeybad; NextHeader   :boo";
+    const std::vector<std::pair<QString, QString>> expected = {
+        {"NextHeader", "boo"},
+    };
+
+    const auto actual = parseHeaderList(input);
+
+    ASSERT_EQ(expected, actual);
+    ASSERT_EQ(1, actual.size());
+}

--- a/tests/src/NetworkCommon.cpp
+++ b/tests/src/NetworkCommon.cpp
@@ -1,10 +1,12 @@
 #include "common/NetworkCommon.hpp"
 
+#include <gtest/gtest.h>
+
 using namespace chatterino;
 
 TEST(NetworkCommon, parseHeaderList1)
 {
-    const QString input = "Authorization:secretkey;NextHeader:boo";
+    const QString input = "Authorization:secretKey;NextHeader:boo";
     const std::vector<std::pair<QString, QString>> expected = {
         {"Authorization", "secretKey"},
         {"NextHeader", "boo"},
@@ -17,7 +19,7 @@ TEST(NetworkCommon, parseHeaderList1)
 
 TEST(NetworkCommon, parseHeaderListTrimmed)
 {
-    const QString input = "Authorization:  secretkey; NextHeader   :boo";
+    const QString input = "Authorization:  secretKey; NextHeader   :boo";
     const std::vector<std::pair<QString, QString>> expected = {
         {"Authorization", "secretKey"},
         {"NextHeader", "boo"},

--- a/tests/src/NetworkCommon.cpp
+++ b/tests/src/NetworkCommon.cpp
@@ -1,0 +1,29 @@
+#include "common/NetworkCommon.hpp"
+
+using namespace chatterino;
+
+TEST(NetworkCommon, parseHeaderList1)
+{
+    const QString input = "Authorization:secretkey;NextHeader:boo";
+    const std::vector<std::pair<QString, QString>> expected = {
+        {"Authorization", "secretKey"},
+        {"NextHeader", "boo"},
+    };
+
+    const auto actual = parseHeaderList(input);
+
+    ASSERT_EQ(expected, actual);
+}
+
+TEST(NetworkCommon, parseHeaderListTrimmed)
+{
+    const QString input = "Authorization:  secretkey; NextHeader   :boo";
+    const std::vector<std::pair<QString, QString>> expected = {
+        {"Authorization", "secretKey"},
+        {"NextHeader", "boo"},
+    };
+
+    const auto actual = parseHeaderList(input);
+
+    ASSERT_EQ(expected, actual);
+}


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
