### PR TITLE
Added missing default twitch commands

### DIFF
--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -28,10 +28,10 @@
 #include <QFile>
 #include <QRegularExpression>
 
-#define TWITCH_DEFAULT_COMMANDS                                               \
-    "/help", "/w", "/me", "/disconnect", "/mods", "/color", "/ban", "/unban", \
-        "/timeout", "/untimeout", "/slow", "/slowoff", "/r9kbeta",            \
-        "/r9kbetaoff", "/emoteonly", "/emoteonlyoff", "/clear",               \
+#define TWITCH_DEFAULT_COMMANDS                                              \
+    "/help", "/w", "/me", "/disconnect", "/mods", "/vips", "/color", "/ban", \
+        "/unban", "/timeout", "/untimeout", "/slow", "/slowoff", "/r9kbeta", \
+        "/r9kbetaoff", "/emoteonly", "/emoteonlyoff", "/clear",              \
         "/subscribers", "/subscribersoff", "/followers", "/followersoff"
 
 namespace {

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -34,7 +34,7 @@
         "/timeout", "/untimeout", "/slow", "/slowoff", "/r9kbeta",           \
         "/r9kbetaoff", "/emoteonly", "/emoteonlyoff", "/clear",              \
         "/subscribers", "/subscribersoff", "/followers", "/followersoff",    \
-        "/host", "/unhost", "/raid", "/unraid", "/marker"
+        "/host", "/unhost", "/raid", "/unraid"
 
 namespace {
 using namespace chatterino;

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -29,10 +29,12 @@
 #include <QRegularExpression>
 
 #define TWITCH_DEFAULT_COMMANDS                                              \
-    "/help", "/w", "/me", "/disconnect", "/mods", "/vips", "/color", "/ban", \
-        "/unban", "/timeout", "/untimeout", "/slow", "/slowoff", "/r9kbeta", \
+    "/help", "/w", "/me", "/disconnect", "/mods", "/vips", "/color",         \
+        "/commercial", "/mod", "/unmod", "/vip", "/unvip", "/ban", "/unban", \
+        "/timeout", "/untimeout", "/slow", "/slowoff", "/r9kbeta",           \
         "/r9kbetaoff", "/emoteonly", "/emoteonlyoff", "/clear",              \
-        "/subscribers", "/subscribersoff", "/followers", "/followersoff"
+        "/subscribers", "/subscribersoff", "/followers", "/followersoff",    \
+        "/host", "/unhost", "/raid", "/unraid", "/marker"
 
 namespace {
 using namespace chatterino;


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Added `/vips`.
By the way, we do include standard moderator commands in `TWITCH_DEFAULT_COMMANDS` define, but not the ones available to channel editors (such as `/commercial`, `/host`, `/raid`). Should we add those?
