### PR TITLE
Added in:<channels> search predicate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+- Minor: Added `in:<channels>` search filter to find messages sent in specific channels. (#2299, #2634)
+
 ## 2.3.0
 
 - Major: Added clip creation support. You can create clips with `/clip` command, `Alt+X` keybind or `Create a clip` option in split header's context menu. This requires a new authentication scope so re-authentication will be required to use it. (#2271, #2377, #2528)

--- a/chatterino.pro
+++ b/chatterino.pro
@@ -179,6 +179,7 @@ SOURCES += \
     src/messages/MessageContainer.cpp \
     src/messages/MessageElement.cpp \
     src/messages/search/AuthorPredicate.cpp \
+    src/messages/search/ChannelPredicate.cpp \
     src/messages/search/LinkPredicate.cpp \
     src/messages/search/SubstringPredicate.cpp \
     src/messages/SharedMessageBuilder.cpp \
@@ -406,6 +407,7 @@ HEADERS += \
     src/messages/MessageElement.hpp \
     src/messages/MessageParseArgs.hpp \
     src/messages/search/AuthorPredicate.hpp \
+    src/messages/search/ChannelPredicate.hpp \
     src/messages/search/LinkPredicate.hpp \
     src/messages/search/MessagePredicate.hpp \
     src/messages/search/SubstringPredicate.hpp \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -133,8 +133,8 @@ set(SOURCE_FILES main.cpp
         messages/layouts/MessageLayoutElement.hpp
         messages/search/AuthorPredicate.cpp
         messages/search/AuthorPredicate.hpp
-		messages/search/ChannelPredicate.cpp
-		messages/search/ChannelPredicate.hpp
+        messages/search/ChannelPredicate.cpp
+        messages/search/ChannelPredicate.hpp
         messages/search/LinkPredicate.cpp
         messages/search/LinkPredicate.hpp
         messages/search/SubstringPredicate.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -133,6 +133,8 @@ set(SOURCE_FILES main.cpp
         messages/layouts/MessageLayoutElement.hpp
         messages/search/AuthorPredicate.cpp
         messages/search/AuthorPredicate.hpp
+		messages/search/ChannelPredicate.cpp
+		messages/search/ChannelPredicate.hpp
         messages/search/LinkPredicate.cpp
         messages/search/LinkPredicate.hpp
         messages/search/SubstringPredicate.cpp

--- a/src/messages/search/ChannelPredicate.cpp
+++ b/src/messages/search/ChannelPredicate.cpp
@@ -1,0 +1,23 @@
+#include "messages/search/ChannelPredicate.hpp"
+
+namespace chatterino {
+
+ChannelPredicate::ChannelPredicate(const QStringList &channels)
+    : channels_()
+{
+    // Check if any comma-seperated values were passed and transform those
+    for (const auto &entry : channels)
+    {
+        for (const auto &channel : entry.split(',', QString::SkipEmptyParts))
+        {
+            this->channels_ << channel;
+        }
+    }
+}
+
+bool ChannelPredicate::appliesTo(const Message &message)
+{
+    return channels_.contains(message.channelName, Qt::CaseInsensitive);
+}
+
+}  // namespace chatterino

--- a/src/messages/search/ChannelPredicate.hpp
+++ b/src/messages/search/ChannelPredicate.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "messages/search/MessagePredicate.hpp"
+
+namespace chatterino {
+
+/**
+ * @brief MessagePredicate checking for the channel a message was sent in.
+ *
+ * This predicate will only allow messages that are sent in a list of channels,
+ * specified by their names.
+ */
+class ChannelPredicate : public MessagePredicate
+{
+public:
+    /**
+     * @brief Create a ChannelPredicate with a list of channels to search for.
+     *
+     * @param channels a list of channel names that a message should be sent in
+     */
+    ChannelPredicate(const QStringList &channels);
+
+    /**
+     * @brief Checks whether the message was sent in any of the channels passed
+     *        in the constructor.
+     *
+     * @param message the message to check
+     * @return true if the message was sent in one of the specified channels,
+     *         false otherwise
+     */
+    bool appliesTo(const Message &message);
+
+private:
+    /// Holds the channel names that will be searched for
+    QStringList channels_;
+};
+
+}  // namespace chatterino

--- a/src/widgets/helper/SearchPopup.cpp
+++ b/src/widgets/helper/SearchPopup.cpp
@@ -165,10 +165,10 @@ std::vector<std::unique_ptr<MessagePredicate>> SearchPopup::parsePredicates(
 {
     static QRegularExpression predicateRegex(R"(^(\w+):([\w,]+)$)");
 
-    auto predicates = std::vector<std::unique_ptr<MessagePredicate>>();
+    std::vector<std::unique_ptr<MessagePredicate>> predicates;
     auto words = input.split(' ', QString::SkipEmptyParts);
-    auto authors = QStringList();
-    auto channels = QStringList();
+    QStringList authors;
+    QStringList channels;
 
     for (auto it = words.begin(); it != words.end();)
     {

--- a/src/widgets/helper/SearchPopup.cpp
+++ b/src/widgets/helper/SearchPopup.cpp
@@ -8,6 +8,7 @@
 #include "common/Channel.hpp"
 #include "messages/Message.hpp"
 #include "messages/search/AuthorPredicate.hpp"
+#include "messages/search/ChannelPredicate.hpp"
 #include "messages/search/LinkPredicate.hpp"
 #include "messages/search/SubstringPredicate.hpp"
 #include "util/Shortcut.hpp"
@@ -167,6 +168,7 @@ std::vector<std::unique_ptr<MessagePredicate>> SearchPopup::parsePredicates(
     auto predicates = std::vector<std::unique_ptr<MessagePredicate>>();
     auto words = input.split(' ', QString::SkipEmptyParts);
     auto authors = QStringList();
+    auto channels = QStringList();
 
     for (auto it = words.begin(); it != words.end();)
     {
@@ -186,6 +188,10 @@ std::vector<std::unique_ptr<MessagePredicate>> SearchPopup::parsePredicates(
             {
                 predicates.push_back(std::make_unique<LinkPredicate>());
             }
+            else if (name == "in")
+            {
+                channels.append(value);
+            }
             else
             {
                 remove = false;
@@ -202,6 +208,9 @@ std::vector<std::unique_ptr<MessagePredicate>> SearchPopup::parsePredicates(
 
     if (!authors.empty())
         predicates.push_back(std::make_unique<AuthorPredicate>(authors));
+
+    if (!channels.empty())
+        predicates.push_back(std::make_unique<ChannelPredicate>(channels));
 
     if (!words.empty())
         predicates.push_back(


### PR DESCRIPTION
Pull request checklist:

- [X] `CHANGELOG.md` was updated, if applicable

# Description
See #2299 for more information.
This PR adds a search predicate (according to #1237) that allows filtering messages based on the channel they were sent in, meant for usage in /mentions. 
This is also inspired by the similar filter in [Discord](https://support.discord.com/hc/en-us/articles/115000468588-Using-Search).
Example usage:
`in:fourtf` would show messages originally sent in fourtf channel.
`in:fourtf,pajlada` would show messages originally sent in either fourtf or pajlada channels.

The things I'm not completely sure about now are:

1. Currently the filter works everywhere, but is only useful in /mentions. If used in a regular split it will either show all messages or none, depending on whether or not the channel list includes the current channel. I'm wondering if there is a need to enforce this filter only being useable in /mentions, or if the current state is fine (at least to me the current functionality makes sense). 
2. The wording of the changelog entry / explanation of the feature.

Closes #2299 