### PR TITLE
Keyboard integration for streamlink quality confirmation

### DIFF
--- a/src/widgets/dialogs/QualityPopup.cpp
+++ b/src/widgets/dialogs/QualityPopup.cpp
@@ -1,5 +1,4 @@
 #include "QualityPopup.hpp"
-#include <qnamespace.h>
 #include "Application.hpp"
 #include "common/QLogging.hpp"
 #include "singletons/WindowManager.hpp"

--- a/src/widgets/dialogs/QualityPopup.cpp
+++ b/src/widgets/dialogs/QualityPopup.cpp
@@ -1,4 +1,5 @@
 #include "QualityPopup.hpp"
+#include <qnamespace.h>
 #include "Application.hpp"
 #include "common/QLogging.hpp"
 #include "singletons/WindowManager.hpp"
@@ -44,6 +45,18 @@ void QualityPopup::showDialog(const QString &channelName, QStringList options)
     instance->activateWindow();
     instance->raise();
     instance->setFocus();
+}
+
+void QualityPopup::keyPressEvent(QKeyEvent *event)
+{
+    if (event->key() == Qt::Key_Enter || event->key() == Qt::Key_Return)
+    {
+        this->okButtonClicked();
+    }
+    else if (event->key() == Qt::Key_Escape)
+    {
+        this->cancelButtonClicked();
+    }
 }
 
 void QualityPopup::okButtonClicked()

--- a/src/widgets/dialogs/QualityPopup.cpp
+++ b/src/widgets/dialogs/QualityPopup.cpp
@@ -2,6 +2,7 @@
 #include "Application.hpp"
 #include "common/QLogging.hpp"
 #include "singletons/WindowManager.hpp"
+#include "util/Shortcut.hpp"
 #include "util/StreamLink.hpp"
 #include "widgets/Window.hpp"
 
@@ -30,6 +31,10 @@ QualityPopup::QualityPopup(const QString &_channelName, QStringList options)
     this->ui_.vbox.addWidget(&this->ui_.selector);
     this->ui_.vbox.addWidget(&this->ui_.buttonBox);
 
+    createWindowShortcut(this, "Return", [=] {
+        this->okButtonClicked();
+    });
+
     this->setLayout(&this->ui_.vbox);
 }
 
@@ -44,18 +49,6 @@ void QualityPopup::showDialog(const QString &channelName, QStringList options)
     instance->activateWindow();
     instance->raise();
     instance->setFocus();
-}
-
-void QualityPopup::keyPressEvent(QKeyEvent *event)
-{
-    if (event->key() == Qt::Key_Enter || event->key() == Qt::Key_Return)
-    {
-        this->okButtonClicked();
-    }
-    else if (event->key() == Qt::Key_Escape)
-    {
-        this->cancelButtonClicked();
-    }
 }
 
 void QualityPopup::okButtonClicked()

--- a/src/widgets/dialogs/QualityPopup.hpp
+++ b/src/widgets/dialogs/QualityPopup.hpp
@@ -28,9 +28,6 @@ private:
     } ui_;
 
     QString channelName_;
-
-protected:
-    void keyPressEvent(QKeyEvent *event);
 };
 
 }  // namespace chatterino

--- a/src/widgets/dialogs/QualityPopup.hpp
+++ b/src/widgets/dialogs/QualityPopup.hpp
@@ -28,6 +28,9 @@ private:
     } ui_;
 
     QString channelName_;
+
+protected:
+    void keyPressEvent(QKeyEvent *event);
 };
 
 }  // namespace chatterino


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

This pr allows the confirmation of the streamlink quality selection by hitting Enter, without having to tab to the "Ok"-Button. 

Not experienced with qt, so feedback appreciated :) 
