### PR TITLE
Fixed deprecated method QWheelEvent::delta

### DIFF
--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1098,7 +1098,7 @@ void ChannelView::drawMessages(QPainter &painter)
 
 void ChannelView::wheelEvent(QWheelEvent *event)
 {
-    if (event->angleDelta().x())
+    if (!event->angleDelta().y())
     {
         return;
     }

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1098,8 +1098,10 @@ void ChannelView::drawMessages(QPainter &painter)
 
 void ChannelView::wheelEvent(QWheelEvent *event)
 {
-    if (event->orientation() != Qt::Vertical)
+    if (event->angleDelta().x())
+    {
         return;
+    }
 
     if (event->modifiers() & Qt::ControlModifier)
     {
@@ -1112,7 +1114,7 @@ void ChannelView::wheelEvent(QWheelEvent *event)
         float mouseMultiplier = getSettings()->mouseScrollMultiplier;
 
         qreal desired = this->scrollBar_->getDesiredValue();
-        qreal delta = event->delta() * qreal(1.5) * mouseMultiplier;
+        qreal delta = event->angleDelta().y() * qreal(1.5) * mouseMultiplier;
 
         auto snapshot = this->getMessagesSnapshot();
         int snapshotLength = int(snapshot.size());

--- a/src/widgets/helper/NotebookTab.cpp
+++ b/src/widgets/helper/NotebookTab.cpp
@@ -600,7 +600,7 @@ void NotebookTab::mouseMoveEvent(QMouseEvent *event)
 void NotebookTab::wheelEvent(QWheelEvent *event)
 {
     const auto defaultMouseDelta = 120;
-    const auto delta = event->delta();
+    const auto horizontalDelta = event->angleDelta().y();
     const auto selectTab = [this](int delta) {
         delta > 0 ? this->notebook_->selectPreviousTab()
                   : this->notebook_->selectNextTab();
@@ -608,9 +608,9 @@ void NotebookTab::wheelEvent(QWheelEvent *event)
     // If it's true
     // Then the user uses the trackpad or perhaps the most accurate mouse
     // Which has small delta.
-    if (std::abs(delta) < defaultMouseDelta)
+    if (std::abs(horizontalDelta) < defaultMouseDelta)
     {
-        this->mouseWheelDelta_ += delta;
+        this->mouseWheelDelta_ += horizontalDelta;
         if (std::abs(this->mouseWheelDelta_) >= defaultMouseDelta)
         {
             selectTab(this->mouseWheelDelta_);
@@ -619,7 +619,7 @@ void NotebookTab::wheelEvent(QWheelEvent *event)
     }
     else
     {
-        selectTab(delta);
+        selectTab(horizontalDelta);
     }
 }
 

--- a/src/widgets/helper/NotebookTab.cpp
+++ b/src/widgets/helper/NotebookTab.cpp
@@ -600,7 +600,7 @@ void NotebookTab::mouseMoveEvent(QMouseEvent *event)
 void NotebookTab::wheelEvent(QWheelEvent *event)
 {
     const auto defaultMouseDelta = 120;
-    const auto horizontalDelta = event->angleDelta().y();
+    const auto verticalDelta = event->angleDelta().y();
     const auto selectTab = [this](int delta) {
         delta > 0 ? this->notebook_->selectPreviousTab()
                   : this->notebook_->selectNextTab();
@@ -608,9 +608,9 @@ void NotebookTab::wheelEvent(QWheelEvent *event)
     // If it's true
     // Then the user uses the trackpad or perhaps the most accurate mouse
     // Which has small delta.
-    if (std::abs(horizontalDelta) < defaultMouseDelta)
+    if (std::abs(verticalDelta) < defaultMouseDelta)
     {
-        this->mouseWheelDelta_ += horizontalDelta;
+        this->mouseWheelDelta_ += verticalDelta;
         if (std::abs(this->mouseWheelDelta_) >= defaultMouseDelta)
         {
             selectTab(this->mouseWheelDelta_);
@@ -619,7 +619,7 @@ void NotebookTab::wheelEvent(QWheelEvent *event)
     }
     else
     {
-        selectTab(horizontalDelta);
+        selectTab(verticalDelta);
     }
 }
 


### PR DESCRIPTION
And some other method that's also replaced with QWheelEvent::angleDelta

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Reference: https://doc.qt.io/qt-5/qwheelevent-obsolete.html#delta and https://doc.qt.io/qt-5/qwheelevent-obsolete.html#orientation

### Changes in behavior

Change from `event->delta()` to `event->angleDelta().y()` makes it, so you can no longer scroll horizontally (with trackpad / touchpad) to select next/previous tab (until now, you were able to do it, but I believe this is wrong anyways).
