### PR TITLE
Optionally remove spaces between emotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Major: Color mentions to match the mentioned users. You can disable this by unchecking "Color @usernames" under `Settings -> General -> Advanced (misc.)`. (#1963, #2284, #2597)
 - Major: Commands `/ignore` and `/unignore` have been renamed to `/block` and `/unblock` in order to keep consistency with Twitch's terms. (#2370)
 - Major: Added support for bit emotes - the ones you unlock after cheering to streamer. (#2550)
+- Minor: Optionally remove spaces between emotes, originally made for Mm2PL/Dankerino. (#2651)
 - Minor: Added `/clearmessages` command - does what "Burger menu -> More -> Clear messages" does. (#2485)
 - Minor: Added `/marker` command - similar to webchat, it creates a stream marker. (#2360)
 - Minor: Added `/chatters` command showing chatter count. (#2344)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+- Minor: Optionally remove spaces between emotes, originally made for Mm2PL/Dankerino. (#2651)
+
 ## 2.3.0
 
 - Major: Added custom FrankerFaceZ VIP Badges. (#2628)
@@ -16,7 +18,6 @@
 - Major: Color mentions to match the mentioned users. You can disable this by unchecking "Color @usernames" under `Settings -> General -> Advanced (misc.)`. (#1963, #2284, #2597)
 - Major: Commands `/ignore` and `/unignore` have been renamed to `/block` and `/unblock` in order to keep consistency with Twitch's terms. (#2370)
 - Major: Added support for bit emotes - the ones you unlock after cheering to streamer. (#2550)
-- Minor: Optionally remove spaces between emotes, originally made for Mm2PL/Dankerino. (#2651)
 - Minor: Added `/clearmessages` command - does what "Burger menu -> More -> Clear messages" does. (#2485)
 - Minor: Added `/marker` command - similar to webchat, it creates a stream marker. (#2360)
 - Minor: Added `/chatters` command showing chatter count. (#2344)

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -148,7 +148,9 @@ void MessageLayoutContainer::_addElement(MessageLayoutElement *element,
         this->currentX_ += element->getRect().width();
     }
 
-    if (element->hasTrailingSpace())
+    if (element->hasTrailingSpace() &&
+        !(getSettings()->removeSpacesBetweenEmotes &&
+          element->getFlags().hasAny(MessageElementFlag::EmoteImages)))
     {
         this->currentX_ += this->spaceWidth_;
     }

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -380,6 +380,15 @@ void TwitchMessageBuilder::addWords(
 
             if (currentTwitchEmote.start == cursor)
             {
+                {
+                    auto &prevElem = this->message().elements.back();
+                    if (getSettings()->removeSpacesBetweenEmotes &&
+                        prevElem->getFlags().hasAny(
+                            MessageElementFlag::EmoteImages))
+                    {
+                        prevElem->setTrailingSpace(false);
+                    }
+                }
                 // This emote exists right at the start of the word!
                 this->emplace<EmoteElement>(currentTwitchEmote.ptr,
                                             MessageElementFlag::TwitchEmote);
@@ -448,6 +457,7 @@ void TwitchMessageBuilder::addTextOrEmoji(EmotePtr emote)
 void TwitchMessageBuilder::addTextOrEmoji(const QString &string_)
 {
     auto string = QString(string_);
+    auto &prevElem = this->message().elements.back();
 
     if (this->hasBits_ && this->tryParseCheermote(string))
     {
@@ -463,6 +473,11 @@ void TwitchMessageBuilder::addTextOrEmoji(const QString &string_)
     if (this->tryAppendEmote({string}))
     {
         // Successfully appended an emote
+        if (getSettings()->removeSpacesBetweenEmotes && prevElem &&
+            prevElem->getFlags().hasAny(MessageElementFlag::EmoteImages))
+        {
+            prevElem->setTrailingSpace(false);
+        }
         return;
     }
 

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -380,15 +380,6 @@ void TwitchMessageBuilder::addWords(
 
             if (currentTwitchEmote.start == cursor)
             {
-                {
-                    auto &prevElem = this->message().elements.back();
-                    if (getSettings()->removeSpacesBetweenEmotes &&
-                        prevElem->getFlags().hasAny(
-                            MessageElementFlag::EmoteImages))
-                    {
-                        prevElem->setTrailingSpace(false);
-                    }
-                }
                 // This emote exists right at the start of the word!
                 this->emplace<EmoteElement>(currentTwitchEmote.ptr,
                                             MessageElementFlag::TwitchEmote);
@@ -473,11 +464,6 @@ void TwitchMessageBuilder::addTextOrEmoji(const QString &string_)
     if (this->tryAppendEmote({string}))
     {
         // Successfully appended an emote
-        if (getSettings()->removeSpacesBetweenEmotes && prevElem &&
-            prevElem->getFlags().hasAny(MessageElementFlag::EmoteImages))
-        {
-            prevElem->setTrailingSpace(false);
-        }
         return;
     }
 

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -118,6 +118,8 @@ public:
                                           -0.5f};
     // BoolSetting useCustomWindowFrame = {"/appearance/useCustomWindowFrame",
     // false};
+    BoolSetting removeSpacesBetweenEmotes = {
+        "/appearance/removeSpacesBetweenEmotes", false};
 
     // Badges
     BoolSetting showBadgesGlobalAuthority = {

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -118,8 +118,6 @@ public:
                                           -0.5f};
     // BoolSetting useCustomWindowFrame = {"/appearance/useCustomWindowFrame",
     // false};
-    BoolSetting removeSpacesBetweenEmotes = {
-        "/appearance/removeSpacesBetweenEmotes", false};
 
     // Badges
     BoolSetting showBadgesGlobalAuthority = {
@@ -176,6 +174,8 @@ public:
     QStringSetting emojiSet = {"/emotes/emojiSet", "Twitter"};
 
     BoolSetting stackBits = {"/emotes/stackBits", false};
+    BoolSetting removeSpacesBetweenEmotes = {
+        "/emotes/removeSpacesBetweenEmotes", false};
 
     /// Links
     BoolSetting linksDoubleClickOnly = {"/links/doubleClickToOpen", false};

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -307,6 +307,8 @@ void GeneralPage::initLayout(GeneralPageView &layout)
             return fuzzyToFloat(args.value, 1.f);
         });
 
+    layout.addCheckbox("Remove spaces between emotes",
+                       s.removeSpacesBetweenEmotes);
     layout.addDropdown<int>(
         "Show info on hover", {"Don't show", "Always show", "Hold shift"},
         s.emotesTooltipPreview,
@@ -325,8 +327,6 @@ void GeneralPage::initLayout(GeneralPageView &layout)
                            "Google",
                        },
                        s.emojiSet);
-    layout.addCheckbox("Remove spaces around emotes",
-                       s.removeSpacesBetweenEmotes);
 
     layout.addTitle("Streamer Mode");
     layout.addDescription(

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -325,6 +325,8 @@ void GeneralPage::initLayout(GeneralPageView &layout)
                            "Google",
                        },
                        s.emojiSet);
+    layout.addCheckbox("Remove spaces around emotes",
+                       s.removeSpacesBetweenEmotes);
 
     layout.addTitle("Streamer Mode");
     layout.addDescription(


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
Adds a setting to optionally remove spaces after emotes. Cherry-picked from Dankerino.
