### PR TITLE
Add ability to hide Twitch Prediction badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+- Minor: Added a setting to hide Twitch Predictions badges. (#2668)
+
 ## 2.3.0
 
 - Major: Added custom FrankerFaceZ VIP Badges. (#2628)

--- a/src/messages/MessageElement.hpp
+++ b/src/messages/MessageElement.hpp
@@ -44,58 +44,65 @@ enum class MessageElementFlag : int64_t {
     ChannelPointReward = (1LL << 8),
     ChannelPointRewardImage = ChannelPointReward | TwitchEmoteImage,
 
-    FfzEmoteImage = (1LL << 10),
-    FfzEmoteText = (1LL << 11),
+    FfzEmoteImage = (1LL << 9),
+    FfzEmoteText = (1LL << 10),
     FfzEmote = FfzEmoteImage | FfzEmoteText,
     EmoteImages = TwitchEmoteImage | BttvEmoteImage | FfzEmoteImage,
     EmoteText = TwitchEmoteText | BttvEmoteText | FfzEmoteText,
 
-    BitsStatic = (1LL << 12),
-    BitsAnimated = (1LL << 13),
+    BitsStatic = (1LL << 11),
+    BitsAnimated = (1LL << 12),
 
     // Slot 1: Twitch
     // - Staff badge
     // - Admin badge
     // - Global Moderator badge
-    BadgeGlobalAuthority = (1LL << 14),
+    BadgeGlobalAuthority = (1LL << 13),
 
     // Slot 2: Twitch
+    // - Predictions badge
+    BadgePredictions = (1LL << 14),
+
+    // Slot 3: Twitch
     // - VIP badge
     // - Moderator badge
     // - Broadcaster badge
     BadgeChannelAuthority = (1LL << 15),
 
-    // Slot 3: Twitch
+    // Slot 4: Twitch
     // - Subscription badges
     BadgeSubscription = (1LL << 16),
 
-    // Slot 4: Twitch
+    // Slot 5: Twitch
     // - Turbo badge
     // - Prime badge
     // - Bit badges
     // - Game badges
     BadgeVanity = (1LL << 17),
 
-    // Slot 5: Chatterino
+    // Slot 6: Chatterino
     // - Chatterino developer badge
+    // - Chatterino contributor badge
     // - Chatterino donator badge
     // - Chatterino top donator badge
+    // - Chatterino special pepe badge
+    // - Chatterino gnome badge
     BadgeChatterino = (1LL << 18),
 
-    // Slot 6: FrankerFaceZ
+    // Slot 7: FrankerFaceZ
     // - FFZ developer badge
     // - FFZ bot badge
     // - FFZ donator badge
-    BadgeFfz = (1LL << 32),
+    BadgeFfz = (1LL << 19),
 
-    Badges = BadgeGlobalAuthority | BadgeChannelAuthority | BadgeSubscription |
-             BadgeVanity | BadgeChatterino | BadgeFfz,
+    Badges = BadgeGlobalAuthority | BadgePredictions | BadgeChannelAuthority |
+             BadgeSubscription | BadgeVanity | BadgeChatterino | BadgeFfz,
 
-    ChannelName = (1LL << 19),
+    ChannelName = (1LL << 20),
 
-    BitsAmount = (1LL << 20),
+    BitsAmount = (1LL << 21),
 
-    ModeratorTools = (1LL << 21),
+    ModeratorTools = (1LL << 22),
 
     EmojiImage = (1LL << 23),
     EmojiText = (1LL << 24),
@@ -118,8 +125,6 @@ enum class MessageElementFlag : int64_t {
     // ZeroWidthEmotes are emotes that are supposed to overlay over any pre-existing emotes
     // e.g. BTTV's SoSnowy during christmas season
     ZeroWidthEmote = (1LL << 31),
-
-    // (1LL << 32) is used by BadgeFfz, it is next to BadgeChatterino
 
     Default = Timestamp | Badges | Username | BitsStatic | FfzEmoteImage |
               BttvEmoteImage | TwitchEmoteImage | BitsAmount | Text |

--- a/src/providers/twitch/TwitchBadge.cpp
+++ b/src/providers/twitch/TwitchBadge.cpp
@@ -7,6 +7,7 @@ namespace chatterino {
 // set of badge IDs that should be given specific flags.
 // vanity flag is left out on purpose as it is our default flag
 const QSet<QString> globalAuthority{"staff", "admin", "global_mod"};
+const QSet<QString> predictions{"predictions"};
 const QSet<QString> channelAuthority{"moderator", "vip", "broadcaster"};
 const QSet<QString> subBadges{"subscriber", "founder"};
 
@@ -17,6 +18,10 @@ Badge::Badge(QString key, QString value)
     if (globalAuthority.contains(this->key_))
     {
         this->flag_ = MessageElementFlag::BadgeGlobalAuthority;
+    }
+    else if (predictions.contains(this->key_))
+    {
+        this->flag_ = MessageElementFlag::BadgePredictions;
     }
     else if (channelAuthority.contains(this->key_))
     {

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -122,6 +122,8 @@ public:
     // Badges
     BoolSetting showBadgesGlobalAuthority = {
         "/appearance/badges/GlobalAuthority", true};
+    BoolSetting showBadgesPredictions = {"/appearance/badges/predictions",
+                                         true};
     BoolSetting showBadgesChannelAuthority = {
         "/appearance/badges/ChannelAuthority", true};
     BoolSetting showBadgesSubscription = {"/appearance/badges/subscription",

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -104,6 +104,7 @@ WindowManager::WindowManager()
 
     this->wordFlagsListener_.addSetting(settings->showTimestamps);
     this->wordFlagsListener_.addSetting(settings->showBadgesGlobalAuthority);
+    this->wordFlagsListener_.addSetting(settings->showBadgesPredictions);
     this->wordFlagsListener_.addSetting(settings->showBadgesChannelAuthority);
     this->wordFlagsListener_.addSetting(settings->showBadgesSubscription);
     this->wordFlagsListener_.addSetting(settings->showBadgesVanity);
@@ -167,6 +168,8 @@ void WindowManager::updateWordTypeMask()
     // badges
     flags.set(settings->showBadgesGlobalAuthority ? MEF::BadgeGlobalAuthority
                                                   : MEF::None);
+    flags.set(settings->showBadgesPredictions ? MEF::BadgePredictions
+                                              : MEF::None);
     flags.set(settings->showBadgesChannelAuthority ? MEF::BadgeChannelAuthority
                                                    : MEF::None);
     flags.set(settings->showBadgesSubscription ? MEF::BadgeSubscription

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -545,16 +545,15 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         });
 
     layout.addSubtitle("Visible badges");
-    layout.addCheckbox("Authority (staff, admin)",
-                       getSettings()->showBadgesGlobalAuthority);
+    layout.addCheckbox("Authority (staff, admin)", s.showBadgesGlobalAuthority);
+    layout.addCheckbox("Predictions", s.showBadgesPredictions);
     layout.addCheckbox("Channel (broadcaster, moderator)",
-                       getSettings()->showBadgesChannelAuthority);
-    layout.addCheckbox("Subscriber ", getSettings()->showBadgesSubscription);
-    layout.addCheckbox("Vanity (prime, bits, subgifter)",
-                       getSettings()->showBadgesVanity);
-    layout.addCheckbox("Chatterino", getSettings()->showBadgesChatterino);
+                       s.showBadgesChannelAuthority);
+    layout.addCheckbox("Subscriber ", s.showBadgesSubscription);
+    layout.addCheckbox("Vanity (prime, bits, subgifter)", s.showBadgesVanity);
+    layout.addCheckbox("Chatterino", s.showBadgesChatterino);
     layout.addCheckbox("FrankerFaceZ (Bot, FFZ Supporter, FFZ Developer)",
-                       getSettings()->showBadgesFfz);
+                       s.showBadgesFfz);
 
     layout.addSubtitle("Miscellaneous");
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

This makes predictions badges being acknowledged as an actual separate message element on its own, thus making it possible to configure those (which I also added in this PR).

Examples of messages with those badges: 
```
@badge-info=predictions/No;badges=predictions/pink-2,vip/1;color=#DAA520;display-name=Somso2e;emotes=;flags=;id=cc518b04-801a-473d-85c4-af139d7dd520;mod=0;room-id=99631238;subscriber=0;tmi-sent-ts=1619164205224;turbo=0;user-id=153573952;user-type= :somso2e!somso2e@somso2e.tmi.twitch.tv PRIVMSG #zneix :-tags
```
```
@badge-info=predictions/Yes;badges=predictions/blue-1;color=#0000FF;display-name=Hpixpoke;emotes=;flags=;id=02cfc1c1-8ce8-4d7b-b9e7-64b6d8da1a30;mod=0;room-id=99631238;subscriber=0;tmi-sent-ts=1619164206713;turbo=0;user-id=108748290;user-type= :hpixpoke!hpixpoke@hpixpoke.tmi.twitch.tv PRIVMSG #zneix :-tags
```

I also reordered MessageElementFlag enums and added some missing comments regarding Chatterino badges (no idea whether we should keep those really or not - `10:39:34.373 pajlada: I wonder if we need to keep a list of badges in general`).

Closes #2664
