### PR TITLE
Added is:<flags> search predicate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+- Minor: Added `is:<flags>` search filter to find messages of specific types. (#2653, #2671)
+
 ## 2.3.0
 
 - Major: Added custom FrankerFaceZ VIP Badges. (#2628)

--- a/chatterino.pro
+++ b/chatterino.pro
@@ -182,6 +182,7 @@ SOURCES += \
     src/messages/search/AuthorPredicate.cpp \
     src/messages/search/ChannelPredicate.cpp \
     src/messages/search/LinkPredicate.cpp \
+    src/messages/search/MessageFlagsPredicate.cpp \
     src/messages/search/SubstringPredicate.cpp \
     src/messages/SharedMessageBuilder.cpp \
     src/providers/bttv/BttvEmotes.cpp \
@@ -411,6 +412,7 @@ HEADERS += \
     src/messages/search/AuthorPredicate.hpp \
     src/messages/search/ChannelPredicate.hpp \
     src/messages/search/LinkPredicate.hpp \
+    src/messages/search/MessageFlagsPredicate.hpp \
     src/messages/search/MessagePredicate.hpp \
     src/messages/search/SubstringPredicate.hpp \
     src/messages/Selection.hpp \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -139,6 +139,8 @@ set(SOURCE_FILES main.cpp
         messages/search/ChannelPredicate.hpp
         messages/search/LinkPredicate.cpp
         messages/search/LinkPredicate.hpp
+        messages/search/MessageFlagsPredicate.cpp
+        messages/search/MessageFlagsPredicate.hpp
         messages/search/SubstringPredicate.cpp
         messages/search/SubstringPredicate.hpp
 

--- a/src/messages/search/MessageFlagsPredicate.cpp
+++ b/src/messages/search/MessageFlagsPredicate.cpp
@@ -2,34 +2,31 @@
 
 namespace chatterino {
 
-MessageFlagsPredicate::MessageFlagsPredicate(const QStringList &flags)
+MessageFlagsPredicate::MessageFlagsPredicate(const QString &flags)
     : flags_()
 {
     // Check if any comma-seperated values were passed and transform those
-    for (const auto &entry : flags)
+    for (const auto &flag : flags.split(',', QString::SkipEmptyParts))
     {
-        for (const auto &flag : entry.split(',', QString::SkipEmptyParts))
+        if (flag == "deleted" || flag == "disabled")
         {
-            if (flag == "deleted" || flag == "disabled")
-            {
-                this->flags_.set(MessageFlag::Disabled);
-            }
-            else if (flag == "sub" || flag == "subscription")
-            {
-                this->flags_.set(MessageFlag::Subscription);
-            }
-            else if (flag == "timeout")
-            {
-                this->flags_.set(MessageFlag::Timeout);
-            }
-            else if (flag == "highlighted")
-            {
-                this->flags_.set(MessageFlag::Highlighted);
-            }
-            else if (flag == "system")
-            {
-                this->flags_.set(MessageFlag::System);
-            }
+            this->flags_.set(MessageFlag::Disabled);
+        }
+        else if (flag == "sub" || flag == "subscription")
+        {
+            this->flags_.set(MessageFlag::Subscription);
+        }
+        else if (flag == "timeout")
+        {
+            this->flags_.set(MessageFlag::Timeout);
+        }
+        else if (flag == "highlighted")
+        {
+            this->flags_.set(MessageFlag::Highlighted);
+        }
+        else if (flag == "system")
+        {
+            this->flags_.set(MessageFlag::System);
         }
     }
 }

--- a/src/messages/search/MessageFlagsPredicate.cpp
+++ b/src/messages/search/MessageFlagsPredicate.cpp
@@ -10,7 +10,7 @@ MessageFlagsPredicate::MessageFlagsPredicate(const QStringList &flags)
     {
         for (const auto &flag : entry.split(',', QString::SkipEmptyParts))
         {
-            if (flag == "deleted")
+            if (flag == "deleted" || flag == "disabled")
             {
                 this->flags_.set(MessageFlag::Disabled);
             }

--- a/src/messages/search/MessageFlagsPredicate.cpp
+++ b/src/messages/search/MessageFlagsPredicate.cpp
@@ -1,0 +1,42 @@
+#include "messages/search/MessageFlagsPredicate.hpp"
+
+namespace chatterino {
+
+MessageFlagsPredicate::MessageFlagsPredicate(const QStringList &flags)
+    : flags_()
+{
+    // Check if any comma-seperated values were passed and transform those
+    for (const auto &entry : flags)
+    {
+        for (const auto &flag : entry.split(',', QString::SkipEmptyParts))
+        {
+            if (flag == "deleted")
+            {
+                this->flags_.set(MessageFlag::Disabled);
+            }
+            else if (flag == "sub" || flag == "subscription")
+            {
+                this->flags_.set(MessageFlag::Subscription);
+            }
+            else if (flag == "timeout")
+            {
+                this->flags_.set(MessageFlag::Timeout);
+            }
+            else if (flag == "highlighted")
+            {
+                this->flags_.set(MessageFlag::Highlighted);
+            }
+            else if (flag == "system")
+            {
+                this->flags_.set(MessageFlag::System);
+            }
+        }
+    }
+}
+
+bool MessageFlagsPredicate::appliesTo(const Message &message)
+{
+    return message.flags.hasAny(flags_);
+}
+
+}  // namespace chatterino

--- a/src/messages/search/MessageFlagsPredicate.cpp
+++ b/src/messages/search/MessageFlagsPredicate.cpp
@@ -1,4 +1,3 @@
-
 #include "messages/search/MessageFlagsPredicate.hpp"
 
 namespace chatterino {

--- a/src/messages/search/MessageFlagsPredicate.cpp
+++ b/src/messages/search/MessageFlagsPredicate.cpp
@@ -1,3 +1,4 @@
+
 #include "messages/search/MessageFlagsPredicate.hpp"
 
 namespace chatterino {
@@ -33,6 +34,11 @@ MessageFlagsPredicate::MessageFlagsPredicate(const QString &flags)
 
 bool MessageFlagsPredicate::appliesTo(const Message &message)
 {
+    // Exclude timeout messages from system flag when timeout flag isn't present
+    if (this->flags_.has(MessageFlag::System) &&
+        !this->flags_.has(MessageFlag::Timeout))
+        return message.flags.hasAny(flags_) &&
+               !message.flags.has(MessageFlag::Timeout);
     return message.flags.hasAny(flags_);
 }
 

--- a/src/messages/search/MessageFlagsPredicate.cpp
+++ b/src/messages/search/MessageFlagsPredicate.cpp
@@ -16,7 +16,7 @@ MessageFlagsPredicate::MessageFlagsPredicate(const QString &flags)
         {
             this->flags_.set(MessageFlag::Subscription);
         }
-        else if (flag == "timeout")
+        else if (flag == "timeout" || flag == "ban")
         {
             this->flags_.set(MessageFlag::Timeout);
         }

--- a/src/messages/search/MessageFlagsPredicate.hpp
+++ b/src/messages/search/MessageFlagsPredicate.hpp
@@ -26,9 +26,9 @@ public:
      * "highlighted" is used for the "Highlighted" flag.
      * "system" is used for the "System" flag.
      *
-     * @param flags a list of names for the flags a message should have
+     * @param flags a string comma seperated list of names for the flags a message should have
      */
-    MessageFlagsPredicate(const QStringList &flags);
+    MessageFlagsPredicate(const QString &flags);
 
     /**
      * @brief Checks whether the message has any of the flags passed

--- a/src/messages/search/MessageFlagsPredicate.hpp
+++ b/src/messages/search/MessageFlagsPredicate.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "common/FlagsEnum.hpp"
+#include "messages/search/MessagePredicate.hpp"
+
+namespace chatterino {
+
+using MessageFlags = FlagsEnum<MessageFlag>;
+
+/**
+ * @brief MessagePredicate checking for message flags.
+ *
+ * This predicate will only allow messages with a list of flags.
+ * specified by user friendly names for the flags.
+ */
+class MessageFlagsPredicate : public MessagePredicate
+{
+public:
+    /**
+     * @brief Create a MessageFlagsPredicate with a list of flags to search for.
+     *
+     * @param flags a list of names for the flags a message should have
+     */
+    MessageFlagsPredicate(const QStringList &flags);
+
+    /**
+     * @brief Checks whether the message has any of the flags passed
+     *        in the constructor.
+     *
+     * @param message the message to check
+     * @return true if the message has at least one of the specified flags,
+     *         false otherwise
+     */
+    bool appliesTo(const Message &message);
+
+private:
+    /// Holds the flags that will be searched for
+    MessageFlags flags_;
+};
+
+}  // namespace chatterino

--- a/src/messages/search/MessageFlagsPredicate.hpp
+++ b/src/messages/search/MessageFlagsPredicate.hpp
@@ -11,13 +11,20 @@ using MessageFlags = FlagsEnum<MessageFlag>;
  * @brief MessagePredicate checking for message flags.
  *
  * This predicate will only allow messages with a list of flags.
- * specified by user friendly names for the flags.
+ * Specified by user-friendly names for the flags.
  */
 class MessageFlagsPredicate : public MessagePredicate
 {
 public:
     /**
      * @brief Create a MessageFlagsPredicate with a list of flags to search for.
+     *
+     * The flags can be specified by user-friendly names.
+     * "deleted" and "disabled" are used for the "Disabled" flag.
+     * "sub" and "subscription" are used for the "Subscription" flag.
+     * "timeout" is used for the "Timeout" flag.
+     * "highlighted" is used for the "Highlighted" flag.
+     * "system" is used for the "System" flag.
      *
      * @param flags a list of names for the flags a message should have
      */

--- a/src/widgets/helper/SearchPopup.cpp
+++ b/src/widgets/helper/SearchPopup.cpp
@@ -170,7 +170,6 @@ std::vector<std::unique_ptr<MessagePredicate>> SearchPopup::parsePredicates(
     auto words = input.split(' ', QString::SkipEmptyParts);
     QStringList authors;
     QStringList channels;
-    QStringList flags;
 
     for (auto it = words.begin(); it != words.end();)
     {
@@ -196,7 +195,8 @@ std::vector<std::unique_ptr<MessagePredicate>> SearchPopup::parsePredicates(
             }
             else if (name == "is")
             {
-                flags.append(value);
+                predicates.push_back(
+                    std::make_unique<MessageFlagsPredicate>(value));
             }
             else
             {
@@ -217,9 +217,6 @@ std::vector<std::unique_ptr<MessagePredicate>> SearchPopup::parsePredicates(
 
     if (!channels.empty())
         predicates.push_back(std::make_unique<ChannelPredicate>(channels));
-
-    if (!flags.empty())
-        predicates.push_back(std::make_unique<MessageFlagsPredicate>(flags));
 
     if (!words.empty())
         predicates.push_back(

--- a/src/widgets/helper/SearchPopup.cpp
+++ b/src/widgets/helper/SearchPopup.cpp
@@ -10,6 +10,7 @@
 #include "messages/search/AuthorPredicate.hpp"
 #include "messages/search/ChannelPredicate.hpp"
 #include "messages/search/LinkPredicate.hpp"
+#include "messages/search/MessageFlagsPredicate.hpp"
 #include "messages/search/SubstringPredicate.hpp"
 #include "util/Shortcut.hpp"
 #include "widgets/helper/ChannelView.hpp"
@@ -169,6 +170,7 @@ std::vector<std::unique_ptr<MessagePredicate>> SearchPopup::parsePredicates(
     auto words = input.split(' ', QString::SkipEmptyParts);
     QStringList authors;
     QStringList channels;
+    QStringList flags;
 
     for (auto it = words.begin(); it != words.end();)
     {
@@ -192,6 +194,10 @@ std::vector<std::unique_ptr<MessagePredicate>> SearchPopup::parsePredicates(
             {
                 channels.append(value);
             }
+            else if (name == "is")
+            {
+                flags.append(value);
+            }
             else
             {
                 remove = false;
@@ -211,6 +217,9 @@ std::vector<std::unique_ptr<MessagePredicate>> SearchPopup::parsePredicates(
 
     if (!channels.empty())
         predicates.push_back(std::make_unique<ChannelPredicate>(channels));
+
+    if (!flags.empty())
+        predicates.push_back(std::make_unique<MessageFlagsPredicate>(flags));
 
     if (!words.empty())
         predicates.push_back(


### PR DESCRIPTION
Pull request checklist:

- [X] `CHANGELOG.md` was updated, if applicable

# Description

This PR adds a search predicate that allows filtering messages based on some of their flags.
Usage: `is:<flags>` where flags is a comma seperated list of one of the following currently supported options:

- `deleted`: Checks for `MessageFlag::Disabled`
- `sub` or `subscription`: Checks for `MessageFlag::Subscription`
- `timeout`: Checks for `MessageFlag::Timeout`
- `highlighted`: Checks for `MessageFlag::Highlighted`
- `system`: Checks for `MessageFlag::System`

Examples:
`is:deleted` would show deleted (disabled) messages
`is:sub,timeout` would show messages that are either a subscription message or a timeout message

Obviously if this is added I'm open to changes and additions to the current options and their naming (these are just the options that I initially thought of given the available flags), as well as changes to the phrasing of the changelog entry.

Closes #2653 