### PR TITLE
Retry BTTV emote loading on timeout

### DIFF
--- a/src/providers/bttv/BttvEmotes.cpp
+++ b/src/providers/bttv/BttvEmotes.cpp
@@ -207,7 +207,7 @@ void BttvEmotes::loadChannel(std::weak_ptr<Channel> channel,
             }
             return pair.first;
         })
-        .onError([channelId, channel, manualRefresh](auto result) {
+        .onError([channelId, channel, channelDisplayName, callback, manualRefresh, retryCount](auto result) {
             auto shared = channel.lock();
             if (!shared)
                 return;
@@ -229,6 +229,8 @@ void BttvEmotes::loadChannel(std::weak_ptr<Channel> channel,
                         QString("Failed to fetch BetterTTV channel emotes. (timed out, retrying %1/%2)")
                         .arg(QString::number(retryCount + 1), QString::number(MAX_BTTV_RETRY_COUNT));
                 shared->addMessage(makeSystemMessage(sysMessage));
+
+                loadChannel(channel, channelId, channelDisplayName, callback, manualRefresh, retryCount + 1);
             }
             else
             {

--- a/src/providers/bttv/BttvEmotes.cpp
+++ b/src/providers/bttv/BttvEmotes.cpp
@@ -158,7 +158,8 @@ void BttvEmotes::loadChannel(std::weak_ptr<Channel> channel,
                              const QString &channelId,
                              const QString &channelDisplayName,
                              std::function<void(EmoteMap &&)> callback,
-                             bool manualRefresh)
+                             bool manualRefresh,
+                             int retryCount)
 {
     NetworkRequest(QString(bttvChannelEmoteApiUrl) + channelId)
         .timeout(3000)

--- a/src/providers/bttv/BttvEmotes.cpp
+++ b/src/providers/bttv/BttvEmotes.cpp
@@ -163,6 +163,22 @@ void BttvEmotes::loadChannel(std::weak_ptr<Channel> channel,
                              bool manualRefresh,
                              int retryCount)
 {
+    if (retryCount == MAX_BTTV_RETRY_COUNT)
+    {
+        auto shared = channel.lock();
+        if (!shared)
+            return;
+        qCWarning(chatterinoBttv)
+            << "Fetching BTTV emotes for channel" << channelId
+            << "failed after " << MAX_BTTV_RETRY_COUNT
+            << "retries. Will not continue.";
+
+        const QString sysMessage =
+                QString("Failed to fetch BetterTTV channel emotes. (timed out, max retry %1/%2)")
+                .arg(QString::number(retryCount + 1), QString::number(MAX_BTTV_RETRY_COUNT));
+        shared->addMessage(makeSystemMessage(sysMessage));
+    }
+
     NetworkRequest(QString(bttvChannelEmoteApiUrl) + channelId)
         .timeout(3000)
         .onSuccess([callback = std::move(callback), channel,

--- a/src/providers/bttv/BttvEmotes.cpp
+++ b/src/providers/bttv/BttvEmotes.cpp
@@ -18,6 +18,8 @@ namespace {
     const QString CHANNEL_HAS_NO_EMOTES(
         "This channel has no BetterTTV channel emotes.");
 
+    const int MAX_BTTV_RETRY_COUNT = 5;
+
     QString emoteLinkFormat("https://betterttv.com/emotes/%1");
 
     Url getEmoteLink(QString urlTemplate, const EmoteId &id,

--- a/src/providers/bttv/BttvEmotes.cpp
+++ b/src/providers/bttv/BttvEmotes.cpp
@@ -179,7 +179,7 @@ void BttvEmotes::loadChannel(std::weak_ptr<Channel> channel,
         shared->addMessage(makeSystemMessage(sysMessage));
     }
 
-    const int timeout = 2 ^ retryCount * 1000;
+    const int timeout = pow(2, retryCount + 1) * 1000;
 
     NetworkRequest(QString(bttvChannelEmoteApiUrl) + channelId)
         .timeout(timeout)

--- a/src/providers/bttv/BttvEmotes.cpp
+++ b/src/providers/bttv/BttvEmotes.cpp
@@ -179,8 +179,10 @@ void BttvEmotes::loadChannel(std::weak_ptr<Channel> channel,
         shared->addMessage(makeSystemMessage(sysMessage));
     }
 
+    const int timeout = 2 ^ retryCount * 1000;
+
     NetworkRequest(QString(bttvChannelEmoteApiUrl) + channelId)
-        .timeout(3000)
+        .timeout(timeout)
         .onSuccess([callback = std::move(callback), channel,
                     &channelDisplayName,
                     manualRefresh](auto result) -> Outcome {

--- a/src/providers/bttv/BttvEmotes.cpp
+++ b/src/providers/bttv/BttvEmotes.cpp
@@ -220,12 +220,15 @@ void BttvEmotes::loadChannel(std::weak_ptr<Channel> channel,
             }
             else if (result.status() == NetworkResult::timedoutStatus)
             {
-                // TODO: Auto retry in case of a timeout, with a delay
                 qCWarning(chatterinoBttv)
                     << "Fetching BTTV emotes for channel" << channelId
-                    << "failed due to timeout";
-                shared->addMessage(makeSystemMessage(
-                    "Failed to fetch BetterTTV channel emotes. (timed out)"));
+                    << "failed due to timeout after" << retryCount
+                    << "retries";
+
+                const QString sysMessage =
+                        QString("Failed to fetch BetterTTV channel emotes. (timed out, retrying %1/%2)")
+                        .arg(QString::number(retryCount + 1), QString::number(MAX_BTTV_RETRY_COUNT));
+                shared->addMessage(makeSystemMessage(sysMessage));
             }
             else
             {

--- a/src/providers/bttv/BttvEmotes.hpp
+++ b/src/providers/bttv/BttvEmotes.hpp
@@ -29,7 +29,8 @@ public:
                             const QString &channelId,
                             const QString &channelDisplayName,
                             std::function<void(EmoteMap &&)> callback,
-                            bool manualRefresh);
+                            bool manualRefresh,
+                            int retryCount = 0);
 
 private:
     Atomic<std::shared_ptr<const EmoteMap>> global_;


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

When loading BTTV emotes fails due to BTTV timing out, the loading is retried a maximum of 5 (const) times before giving up.
This aims to fix BTTV timesouts (as reported in #2676).