### PR TITLE
Raised bttv emote timeout value

### DIFF
--- a/src/providers/bttv/BttvEmotes.cpp
+++ b/src/providers/bttv/BttvEmotes.cpp
@@ -161,7 +161,7 @@ void BttvEmotes::loadChannel(std::weak_ptr<Channel> channel,
                              bool manualRefresh)
 {
     NetworkRequest(QString(bttvChannelEmoteApiUrl) + channelId)
-        .timeout(3000)
+        .timeout(30000)
         .onSuccess([callback = std::move(callback), channel,
                     &channelDisplayName,
                     manualRefresh](auto result) -> Outcome {

--- a/src/providers/bttv/BttvEmotes.cpp
+++ b/src/providers/bttv/BttvEmotes.cpp
@@ -161,7 +161,7 @@ void BttvEmotes::loadChannel(std::weak_ptr<Channel> channel,
                              bool manualRefresh)
 {
     NetworkRequest(QString(bttvChannelEmoteApiUrl) + channelId)
-        .timeout(30000)
+        .timeout(20000)
         .onSuccess([callback = std::move(callback), channel,
                     &channelDisplayName,
                     manualRefresh](auto result) -> Outcome {


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

This should elimnate the BTTV Channel Emote loading timeout, often reported by many users. Originally brought up by jammehcow in https://github.com/Chatterino/chatterino2/pull/2677#issuecomment-826249993
That seems like an ancient typo introduced in https://github.com/Chatterino/chatterino2/commit/c768bd9bd9d696c86a7525eabefffebf046d66c3#diff-b626f88008195f94729ebb0738b8c7c883fb01f0d4aceb7bc55f137ee6a24a38R131
