### PR TITLE
Add ability to disable precompiled headers with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ option(BUILD_TESTS "Build the tests for Chatterino" OFF)
 option(USE_SYSTEM_PAJLADA_SETTINGS "Use system pajlada settings library" OFF)
 option(USE_SYSTEM_LIBCOMMUNI "Use system communi library" OFF)
 option(USE_SYSTEM_QT5KEYCHAIN "Use system Qt5Keychain library" OFF)
+option(USE_PRECOMPILED_HEADERS "Use precompiled headers" ON)
 
 option(USE_CONAN "Use conan" OFF)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -476,7 +476,9 @@ source_group(TREE ${CMAKE_SOURCE_DIR} FILES ${SOURCE_FILES})
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
 add_sanitizers(${PROJECT_NAME})
 
-target_precompile_headers(${PROJECT_NAME} PRIVATE PrecompiledHeader.hpp)
+if (USE_PRECOMPILED_HEADERS)
+    target_precompile_headers(${PROJECT_NAME} PRIVATE PrecompiledHeader.hpp)
+endif ()
 
 # Enable autogeneration of Qts MOC/RCC/UIC
 set_target_properties(${PROJECT_NAME}

--- a/src/common/Args.cpp
+++ b/src/common/Args.cpp
@@ -1,15 +1,17 @@
 #include "Args.hpp"
 
-#include <QApplication>
-#include <QCommandLineParser>
-#include <QDebug>
-#include <QStringList>
 #include "common/QLogging.hpp"
 #include "singletons/Paths.hpp"
 #include "singletons/WindowManager.hpp"
 #include "util/AttachToConsole.hpp"
 #include "util/CombinePath.hpp"
 #include "widgets/Window.hpp"
+
+#include <QApplication>
+#include <QCommandLineParser>
+#include <QDebug>
+#include <QStringList>
+#include <QUuid>
 
 namespace chatterino {
 

--- a/src/common/ChannelChatters.hpp
+++ b/src/common/ChannelChatters.hpp
@@ -7,6 +7,8 @@
 
 #include "lrucache/lrucache.hpp"
 
+#include <QRgb>
+
 namespace chatterino {
 
 class ChannelChatters

--- a/src/common/Credentials.cpp
+++ b/src/common/Credentials.cpp
@@ -6,6 +6,9 @@
 #include "util/CombinePath.hpp"
 #include "util/Overloaded.hpp"
 
+#include <QJsonDocument>
+#include <QJsonObject>
+
 #ifdef CMAKE_BUILD
 #    include "qt5keychain/keychain.h"
 #else

--- a/src/common/Credentials.hpp
+++ b/src/common/Credentials.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <QObject>
 #include <QString>
+
 #include <functional>
 
 namespace chatterino {

--- a/src/common/FlagsEnum.hpp
+++ b/src/common/FlagsEnum.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <initializer_list>
 #include <type_traits>
 
 namespace chatterino {

--- a/src/common/LinkParser.cpp
+++ b/src/common/LinkParser.cpp
@@ -3,6 +3,7 @@
 #include <QFile>
 #include <QMap>
 #include <QRegularExpression>
+#include <QSet>
 #include <QString>
 #include <QStringRef>
 #include <QTextStream>

--- a/src/common/SignalVectorModel.hpp
+++ b/src/common/SignalVectorModel.hpp
@@ -3,6 +3,7 @@
 #include "common/SignalVector.hpp"
 
 #include <QAbstractTableModel>
+#include <QMimeData>
 #include <QStandardItem>
 #include <boost/optional.hpp>
 

--- a/src/common/WindowDescriptors.cpp
+++ b/src/common/WindowDescriptors.cpp
@@ -3,6 +3,10 @@
 #include "common/QLogging.hpp"
 #include "widgets/Window.hpp"
 
+#include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+
 namespace chatterino {
 
 namespace {

--- a/src/common/WindowDescriptors.hpp
+++ b/src/common/WindowDescriptors.hpp
@@ -1,6 +1,10 @@
 #pragma once
 
+#include <QJsonObject>
+#include <QList>
+#include <QRect>
 #include <QString>
+#include <QUuid>
 
 #include <optional>
 #include <variant>

--- a/src/controllers/moderationactions/ModerationAction.hpp
+++ b/src/controllers/moderationactions/ModerationAction.hpp
@@ -6,6 +6,8 @@
 
 #include "util/RapidjsonHelpers.hpp"
 
+#include <memory>
+
 namespace chatterino {
 
 class Image;

--- a/src/debug/Benchmark.hpp
+++ b/src/debug/Benchmark.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QElapsedTimer>
+#include <QString>
 #include <boost/noncopyable.hpp>
 
 namespace chatterino {

--- a/src/messages/SharedMessageBuilder.cpp
+++ b/src/messages/SharedMessageBuilder.cpp
@@ -10,6 +10,9 @@
 #include "singletons/WindowManager.hpp"
 #include "util/StreamerMode.hpp"
 
+#include <QFileInfo>
+#include <QMediaPlayer>
+
 namespace chatterino {
 
 namespace {

--- a/src/messages/SharedMessageBuilder.hpp
+++ b/src/messages/SharedMessageBuilder.hpp
@@ -5,6 +5,7 @@
 
 #include <IrcMessage>
 #include <QColor>
+#include <QUrl>
 
 namespace chatterino {
 

--- a/src/providers/IvrApi.hpp
+++ b/src/providers/IvrApi.hpp
@@ -3,6 +3,8 @@
 #include "common/NetworkRequest.hpp"
 #include "messages/Link.hpp"
 
+#include <boost/noncopyable.hpp>
+
 #include <functional>
 
 namespace chatterino {

--- a/src/providers/ffz/FfzBadges.hpp
+++ b/src/providers/ffz/FfzBadges.hpp
@@ -10,6 +10,8 @@
 #include <shared_mutex>
 #include <vector>
 
+#include <QColor>
+
 namespace chatterino {
 
 struct Emote;

--- a/src/providers/irc/Irc2.cpp
+++ b/src/providers/irc/Irc2.cpp
@@ -11,6 +11,8 @@
 #include <QSaveFile>
 #include <QtConcurrent>
 
+#include <unordered_set>
+
 namespace chatterino {
 
 namespace {

--- a/src/providers/irc/IrcCommands.hpp
+++ b/src/providers/irc/IrcCommands.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QString>
 #include "common/Outcome.hpp"
 
 namespace chatterino {

--- a/src/providers/irc/IrcServer.cpp
+++ b/src/providers/irc/IrcServer.cpp
@@ -11,6 +11,8 @@
 #include "singletons/Settings.hpp"
 #include "util/QObjectRef.hpp"
 
+#include <QMetaEnum>
+
 namespace chatterino {
 
 IrcServer::IrcServer(const IrcServerData &data)

--- a/src/providers/twitch/ChannelPointReward.hpp
+++ b/src/providers/twitch/ChannelPointReward.hpp
@@ -4,6 +4,8 @@
 #include "messages/Image.hpp"
 #include "messages/ImageSet.hpp"
 
+#include <rapidjson/document.h>
+
 #define TWITCH_CHANNEL_POINT_REWARD_URL(x)                                  \
     QString("https://static-cdn.jtvnw.net/custom-reward-images/default-%1") \
         .arg(x)

--- a/src/providers/twitch/TwitchBadges.cpp
+++ b/src/providers/twitch/TwitchBadges.cpp
@@ -1,5 +1,8 @@
 #include "TwitchBadges.hpp"
 
+#include <QBuffer>
+#include <QIcon>
+#include <QImageReader>
 #include <QJsonArray>
 #include <QJsonObject>
 #include <QJsonValue>

--- a/src/providers/twitch/TwitchBadges.hpp
+++ b/src/providers/twitch/TwitchBadges.hpp
@@ -11,6 +11,7 @@
 
 #include "pajlada/signals/signal.hpp"
 
+#include <memory>
 #include <shared_mutex>
 
 namespace chatterino {

--- a/src/providers/twitch/TwitchBadges.hpp
+++ b/src/providers/twitch/TwitchBadges.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QMap>
 #include <QString>
 #include <boost/optional.hpp>
 #include <unordered_map>
@@ -12,6 +13,7 @@
 #include "pajlada/signals/signal.hpp"
 
 #include <memory>
+#include <queue>
 #include <shared_mutex>
 
 namespace chatterino {

--- a/src/providers/twitch/TwitchEmotes.hpp
+++ b/src/providers/twitch/TwitchEmotes.hpp
@@ -8,6 +8,8 @@
 #include "common/Aliases.hpp"
 #include "common/UniqueAccess.hpp"
 
+#include <memory>
+
 #define TWITCH_EMOTE_TEMPLATE \
     "https://static-cdn.jtvnw.net/emoticons/v1/{id}/{scale}"
 

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -17,6 +17,8 @@
 #include "providers/twitch/TwitchHelpers.hpp"
 #include "util/PostToThread.hpp"
 
+#include <QMetaEnum>
+
 // using namespace Communi;
 using namespace std::chrono_literals;
 

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -3,6 +3,8 @@
 #include "common/Outcome.hpp"
 #include "common/QLogging.hpp"
 
+#include <QJsonDocument>
+
 namespace chatterino {
 
 static Helix *instance = nullptr;

--- a/src/singletons/Toasts.hpp
+++ b/src/singletons/Toasts.hpp
@@ -3,6 +3,8 @@
 #include "Application.hpp"
 #include "common/Singleton.hpp"
 
+#include <pajlada/settings/setting.hpp>
+
 namespace chatterino {
 
 enum class Platform : uint8_t;

--- a/src/util/Clipboard.cpp
+++ b/src/util/Clipboard.cpp
@@ -1,6 +1,8 @@
 #include "util/Clipboard.hpp"
 #include <QApplication>
 
+#include <QClipboard>
+
 namespace chatterino {
 
 void crossPlatformCopy(const QString &text)

--- a/src/util/DisplayBadge.hpp
+++ b/src/util/DisplayBadge.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <QString>
+
 namespace chatterino {
 class DisplayBadge
 {

--- a/src/util/IrcHelpers.hpp
+++ b/src/util/IrcHelpers.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <IrcMessage>
 #include <QString>
 
 namespace chatterino {

--- a/src/util/StandardItemHelper.hpp
+++ b/src/util/StandardItemHelper.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QStandardItem>
+#include <QUrl>
 
 namespace chatterino {
 

--- a/src/util/StreamerMode.cpp
+++ b/src/util/StreamerMode.cpp
@@ -19,6 +19,8 @@
 #    pragma comment(lib, "Wtsapi32.lib")
 #endif
 
+#include <QProcess>
+
 namespace chatterino {
 
 constexpr int cooldownInS = 10;

--- a/src/util/StreamerMode.hpp
+++ b/src/util/StreamerMode.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <QStringList>
+
 namespace chatterino {
 
 enum StreamerModeSetting { Disabled = 0, Enabled = 1, DetectObs = 2 };

--- a/src/util/Twitch.cpp
+++ b/src/util/Twitch.cpp
@@ -1,6 +1,7 @@
 #include "util/Twitch.hpp"
 
 #include <QDesktopServices>
+#include <QUrl>
 
 namespace chatterino {
 

--- a/src/widgets/BasePopup.cpp
+++ b/src/widgets/BasePopup.cpp
@@ -1,5 +1,7 @@
 #include "widgets/BasePopup.hpp"
 
+#include <QKeyEvent>
+
 namespace chatterino {
 
 BasePopup::BasePopup(FlagsEnum<Flags> _flags, QWidget *parent)

--- a/src/widgets/TooltipWidget.cpp
+++ b/src/widgets/TooltipWidget.cpp
@@ -12,6 +12,8 @@
 #    include <Windows.h>
 #endif
 
+#include <QPainter>
+
 namespace chatterino {
 
 TooltipWidget *TooltipWidget::instance()

--- a/src/widgets/dialogs/BadgePickerDialog.cpp
+++ b/src/widgets/dialogs/BadgePickerDialog.cpp
@@ -4,6 +4,9 @@
 
 #include "providers/twitch/TwitchBadges.hpp"
 
+#include <QDialogButtonBox>
+#include <QVBoxLayout>
+
 namespace chatterino {
 
 BadgePickerDialog::BadgePickerDialog(QList<DisplayBadge> badges,

--- a/src/widgets/dialogs/BadgePickerDialog.hpp
+++ b/src/widgets/dialogs/BadgePickerDialog.hpp
@@ -2,7 +2,9 @@
 
 #include "util/DisplayBadge.hpp"
 
+#include <QComboBox>
 #include <QDialog>
+#include <boost/optional.hpp>
 
 namespace chatterino {
 

--- a/src/widgets/dialogs/ChannelFilterEditorDialog.cpp
+++ b/src/widgets/dialogs/ChannelFilterEditorDialog.cpp
@@ -2,6 +2,9 @@
 
 #include "controllers/filters/parser/FilterParser.hpp"
 
+#include <QLabel>
+#include <QPushButton>
+
 namespace chatterino {
 
 namespace {

--- a/src/widgets/dialogs/ChannelFilterEditorDialog.hpp
+++ b/src/widgets/dialogs/ChannelFilterEditorDialog.hpp
@@ -1,5 +1,11 @@
 #pragma once
 
+#include <QComboBox>
+#include <QDialog>
+#include <QHBoxLayout>
+#include <QLineEdit>
+#include <QVBoxLayout>
+
 namespace chatterino {
 class ChannelFilterEditorDialog : public QDialog
 {

--- a/src/widgets/dialogs/ColorPickerDialog.cpp
+++ b/src/widgets/dialogs/ColorPickerDialog.cpp
@@ -3,6 +3,9 @@
 #include "providers/colors/ColorProvider.hpp"
 #include "singletons/Theme.hpp"
 
+#include <QDialogButtonBox>
+#include <QLineEdit>
+
 namespace chatterino {
 
 ColorPickerDialog::ColorPickerDialog(const QColor &initial, QWidget *parent)

--- a/src/widgets/dialogs/ColorPickerDialog.hpp
+++ b/src/widgets/dialogs/ColorPickerDialog.hpp
@@ -9,6 +9,8 @@
 
 #include <array>
 
+#include <QLabel>
+
 namespace chatterino {
 
 /**

--- a/src/widgets/dialogs/IrcConnectionEditor.hpp
+++ b/src/widgets/dialogs/IrcConnectionEditor.hpp
@@ -5,6 +5,8 @@
 #include "providers/irc/Irc2.hpp"
 #include "widgets/BaseWindow.hpp"
 
+#include <QDialog>
+
 namespace Ui {
 class IrcConnectionEditor;
 }

--- a/src/widgets/dialogs/NotificationPopup.cpp
+++ b/src/widgets/dialogs/NotificationPopup.cpp
@@ -8,6 +8,8 @@
 #include <QDesktopWidget>
 #include <QScreen>
 
+#include <QVBoxLayout>
+
 namespace chatterino {
 
 NotificationPopup::NotificationPopup()

--- a/src/widgets/dialogs/SelectChannelDialog.cpp
+++ b/src/widgets/dialogs/SelectChannelDialog.cpp
@@ -20,6 +20,9 @@
 #include "providers/irc/Irc2.hpp"
 #include "widgets/helper/EditableModelView.hpp"
 
+#include <QHeaderView>
+#include <QPushButton>
+
 #define TAB_TWITCH 0
 #define TAB_IRC 1
 

--- a/src/widgets/dialogs/SelectChannelDialog.hpp
+++ b/src/widgets/dialogs/SelectChannelDialog.hpp
@@ -9,6 +9,8 @@
 #include <QLabel>
 #include <QRadioButton>
 
+#include <QLineEdit>
+
 namespace chatterino {
 
 class Notebook;

--- a/src/widgets/dialogs/SelectChannelFiltersDialog.cpp
+++ b/src/widgets/dialogs/SelectChannelFiltersDialog.cpp
@@ -2,6 +2,11 @@
 
 #include "singletons/Settings.hpp"
 
+#include <QCheckBox>
+#include <QLabel>
+#include <QPushButton>
+#include <QVBoxLayout>
+
 namespace chatterino {
 
 SelectChannelFiltersDialog::SelectChannelFiltersDialog(

--- a/src/widgets/dialogs/SettingsDialog.hpp
+++ b/src/widgets/dialogs/SettingsDialog.hpp
@@ -10,6 +10,8 @@
 #include <pajlada/settings/setting.hpp>
 #include "widgets/helper/SettingsDialogTab.hpp"
 
+#include <QFrame>
+
 class QLineEdit;
 
 namespace chatterino {

--- a/src/widgets/dialogs/switcher/QuickSwitcherPopup.hpp
+++ b/src/widgets/dialogs/switcher/QuickSwitcherPopup.hpp
@@ -8,6 +8,8 @@
 
 #include <functional>
 
+#include <QLineEdit>
+
 namespace chatterino {
 
 class GenericListView;

--- a/src/widgets/helper/ColorButton.hpp
+++ b/src/widgets/helper/ColorButton.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <QPushButton>
+
 namespace chatterino {
 
 class ColorButton : public QPushButton

--- a/src/widgets/helper/EditableModelView.cpp
+++ b/src/widgets/helper/EditableModelView.cpp
@@ -9,6 +9,8 @@
 #include <QTableView>
 #include <QVBoxLayout>
 
+#include <QLabel>
+
 namespace chatterino {
 
 EditableModelView::EditableModelView(QAbstractTableModel *model, bool movable)

--- a/src/widgets/helper/NotebookButton.cpp
+++ b/src/widgets/helper/NotebookButton.cpp
@@ -10,6 +10,8 @@
 #include <QPainterPath>
 #include <QRadialGradient>
 
+#include <QMimeData>
+
 #define nuuls nullptr
 
 namespace chatterino {

--- a/src/widgets/helper/NotebookTab.cpp
+++ b/src/widgets/helper/NotebookTab.cpp
@@ -14,6 +14,9 @@
 
 #include <QApplication>
 #include <QDebug>
+#include <QDialogButtonBox>
+#include <QLabel>
+#include <QLineEdit>
 #include <QLinearGradient>
 #include <QMimeData>
 #include <QPainter>

--- a/src/widgets/helper/QColorPicker.cpp
+++ b/src/widgets/helper/QColorPicker.cpp
@@ -38,6 +38,9 @@
 ****************************************************************************/
 #include "widgets/helper/QColorPicker.hpp"
 
+#include <QMouseEvent>
+#include <QPainter>
+
 #include <qdrawutil.h>
 
 /*

--- a/src/widgets/helper/QColorPicker.hpp
+++ b/src/widgets/helper/QColorPicker.hpp
@@ -38,6 +38,7 @@
 ****************************************************************************/
 #pragma once
 
+#include <QFrame>
 #include <QSpinBox>
 
 namespace chatterino {

--- a/src/widgets/helper/ScrollbarHighlight.hpp
+++ b/src/widgets/helper/ScrollbarHighlight.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <memory>
+
+#include <QColor>
+
 namespace chatterino {
 
 class ScrollbarHighlight

--- a/src/widgets/helper/TitlebarButton.cpp
+++ b/src/widgets/helper/TitlebarButton.cpp
@@ -2,6 +2,8 @@
 
 #include "BaseTheme.hpp"
 
+#include <QPainterPath>
+
 namespace chatterino {
 
 TitleBarButton::TitleBarButton()

--- a/src/widgets/listview/GenericListItem.hpp
+++ b/src/widgets/listview/GenericListItem.hpp
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <QIcon>
+#include <QPainter>
+#include <QRect>
+#include <QVariant>
+
 namespace chatterino {
 
 class GenericListItem

--- a/src/widgets/listview/GenericListModel.hpp
+++ b/src/widgets/listview/GenericListModel.hpp
@@ -1,5 +1,8 @@
 #include "widgets/listview/GenericListItem.hpp"
 
+#include <QAbstractListModel>
+#include <QWidget>
+
 namespace chatterino {
 
 class GenericListModel : public QAbstractListModel

--- a/src/widgets/listview/GenericListView.cpp
+++ b/src/widgets/listview/GenericListView.cpp
@@ -2,6 +2,8 @@
 #include "singletons/Theme.hpp"
 #include "widgets/listview/GenericListModel.hpp"
 
+#include <QKeyEvent>
+
 namespace chatterino {
 
 GenericListView::GenericListView()

--- a/src/widgets/settingspages/FiltersPage.cpp
+++ b/src/widgets/settingspages/FiltersPage.cpp
@@ -10,6 +10,8 @@
 
 #include <QTableView>
 
+#include <QHeaderView>
+
 #define FILTERS_DOCUMENTATION "https://wiki.chatterino.com/Filters/"
 
 namespace chatterino {

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -18,6 +18,9 @@
 #include "widgets/helper/Line.hpp"
 #include "widgets/settingspages/GeneralPageView.hpp"
 
+#include <QDesktopServices>
+#include <QFileDialog>
+
 #define CHROME_EXTENSION_LINK                                           \
     "https://chrome.google.com/webstore/detail/chatterino-native-host/" \
     "glknmaideaikkmemifbfkhnomoknepka"

--- a/src/widgets/settingspages/GeneralPageView.hpp
+++ b/src/widgets/settingspages/GeneralPageView.hpp
@@ -7,6 +7,11 @@
 #include "singletons/WindowManager.hpp"
 #include "widgets/helper/SignalLabel.hpp"
 
+#include <QCheckBox>
+#include <QComboBox>
+#include <QPushButton>
+#include <QSpinBox>
+
 class QScrollArea;
 
 namespace chatterino {

--- a/src/widgets/settingspages/SettingsPage.hpp
+++ b/src/widgets/settingspages/SettingsPage.hpp
@@ -8,6 +8,10 @@
 
 #include "singletons/Settings.hpp"
 
+#include <QLabel>
+#include <QPainter>
+#include <QPushButton>
+
 #define SETTINGS_PAGE_WIDGET_BOILERPLATE(type, parent) \
     class type : public parent                         \
     {                                                  \

--- a/src/widgets/splits/SplitHeader.hpp
+++ b/src/widgets/splits/SplitHeader.hpp
@@ -10,6 +10,8 @@
 #include <pajlada/signals/signalholder.hpp>
 #include <vector>
 
+#include <QElapsedTimer>
+
 namespace chatterino {
 
 class Button;


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

- Add missing includes to a bunch of files
- Added CMake setting `USE_PRECOMPILED_HEADERS` allowing users to disable the use of precompiled headers.

As per [the discussion](https://github.com/Chatterino/chatterino2/discussions/2725)

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
