### PR TITLE
Fix automod messages not being parsed/showing up properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unversioned
+
 - Bugfix: Automod messages now work properly again. (#2682)
 
 ## 2.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unversioned
+- Bugfix: Automod messages now work properly again. (#2682)
 
 ## 2.3.1
 

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -336,7 +336,7 @@ MessageBuilder::MessageBuilder(const AutomodUserAction &action)
         break;
 
         case AutomodUserAction::RemovePermitted: {
-            text = QString("%1 removed %2 as a permitted term term on AutoMod.")
+            text = QString("%1 removed %2 as a permitted term on AutoMod.")
                        .arg(action.source.name)
                        .arg(action.message);
         }

--- a/src/providers/twitch/PubsubClient.cpp
+++ b/src/providers/twitch/PubsubClient.cpp
@@ -532,7 +532,6 @@ PubSub::PubSub()
 
     this->moderationActionHandlers["automod_rejected"] =
         [this](const auto &data, const auto &roomID) {
-            qCDebug(chatterinoPubsub) << "automod_rejected";
             // Display the automod message and prompt the allow/deny
             AutomodAction action(data, roomID);
 
@@ -586,8 +585,6 @@ PubSub::PubSub()
 
     this->channelTermsActionHandlers["add_permitted_term"] =
         [this](const auto &data, const auto &roomID) {
-            qCDebug(chatterinoPubsub)
-                << "channelTermsActionHandlers add_permitted_term";
             // This term got a pass through automod
             AutomodUserAction action(data, roomID);
             getCreatedByUser(data, action.source);
@@ -616,8 +613,6 @@ PubSub::PubSub()
 
     this->channelTermsActionHandlers["add_blocked_term"] =
         [this](const auto &data, const auto &roomID) {
-            qCDebug(chatterinoPubsub)
-                << "channelTermsActionHandlers add_blocked_term";
             // A term has been added
             AutomodUserAction action(data, roomID);
             getCreatedByUser(data, action.source);
@@ -646,8 +641,6 @@ PubSub::PubSub()
 
     this->moderationActionHandlers["delete_permitted_term"] =
         [this](const auto &data, const auto &roomID) {
-            qCDebug(chatterinoPubsub)
-                << "moderationActionHandlers delete_permitted_term";
             // This term got deleted
             AutomodUserAction action(data, roomID);
             getCreatedByUser(data, action.source);
@@ -677,8 +670,6 @@ PubSub::PubSub()
         };
     this->channelTermsActionHandlers["delete_permitted_term"] =
         [this](const auto &data, const auto &roomID) {
-            qCDebug(chatterinoPubsub)
-                << "channelTermsActionHandlers delete_permitted_term";
             // This term got deleted
             AutomodUserAction action(data, roomID);
             getCreatedByUser(data, action.source);
@@ -707,8 +698,6 @@ PubSub::PubSub()
 
     this->moderationActionHandlers["delete_blocked_term"] =
         [this](const auto &data, const auto &roomID) {
-            qCDebug(chatterinoPubsub)
-                << "moderationActionHandlers delete_blocked_term";
             // This term got deleted
             AutomodUserAction action(data, roomID);
 
@@ -739,8 +728,6 @@ PubSub::PubSub()
         };
     this->channelTermsActionHandlers["delete_blocked_term"] =
         [this](const auto &data, const auto &roomID) {
-            qCDebug(chatterinoPubsub)
-                << "channelTermsActionHandlers delete_blocked_term";
             // This term got deleted
             AutomodUserAction action(data, roomID);
 
@@ -773,7 +760,6 @@ PubSub::PubSub()
     //
     //this->moderationActionHandlers["modified_automod_properties"] =
     //    [this](const auto &data, const auto &roomID) {
-    //        qCDebug(chatterinoPubsub) << "modified_automod_properties";
     //        // The automod settings got modified
     //        AutomodUserAction action(data, roomID);
     //        getCreatedByUser(data, action.source);
@@ -785,7 +771,6 @@ PubSub::PubSub()
                                                                       &data,
                                                                   const auto
                                                                       &roomID) {
-        qCDebug(chatterinoPubsub) << "denied_automod_message";
         // This message got denied by a moderator
         // qCDebug(chatterinoPubsub) << QString::fromStdString(rj::stringify(data));
     };
@@ -793,7 +778,6 @@ PubSub::PubSub()
     this->moderationActionHandlers
         ["approved_automod_message"] = [](const auto &data,
                                           const auto &roomID) {
-        qCDebug(chatterinoPubsub) << "approved_automod_message";
         // This message got approved by a moderator
         // qCDebug(chatterinoPubsub) << QString::fromStdString(rj::stringify(data));
     };

--- a/src/providers/twitch/PubsubClient.hpp
+++ b/src/providers/twitch/PubsubClient.hpp
@@ -179,6 +179,10 @@ private:
                                                        const QString &)>>
         moderationActionHandlers;
 
+    std::unordered_map<std::string, std::function<void(const rapidjson::Value &,
+                                                       const QString &)>>
+        channelTermsActionHandlers;
+
     void onMessage(websocketpp::connection_hdl hdl, WebsocketMessagePtr msg);
     void onConnectionOpen(websocketpp::connection_hdl hdl);
     void onConnectionClose(websocketpp::connection_hdl hdl);


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description
Automod didn't work properly but this is now fixed.
Closes #2682
<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
The steps to reproduce the bug are discussed in the issue.

Otherwise:

1. Enable automod to level 4 (for simplicity)
2. Use some account and type something vulgur
3. As a moderator see that the message was held up
4. Click Approve or Deny
5. See that nothing happened to the AutoMod message that was shown when it's supposed to fade to gray


This also fixed automod pubsub messages in general.

Some notes for devs:
When I implemented it 
```
chatterino.pubsub: moderationActionHandlers delete_blocked_term
chatterino.pubsub: moderationActionHandlers delete_permitted_term
chatterino.pubsub: channelTermsActionHandlers add_permitted_term
chatterino.pubsub: channelTermsActionHandlers add_blocked_term
chatterino.pubsub: channelTermsActionHandlers delete_blocked_term
chatterino.pubsub: channelTermsActionHandlers delete_permitted_term
```

Happened while allowing/denying messages and also adding and removing phrases in twitch automod gui.