### PR TITLE
Messages held by automod are now shown to the user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unversioned
 
+- Minor: Messages held by automod are now shown to the user. (#2626)
 - Bugfix: Automod messages now work properly again. (#2682)
 - Bugfix: `Login expired` message no longer highlights all tabs. (#2735)
 

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -314,7 +314,7 @@ void Application::initPubsub()
             }
 
             postToThread([chan, action] {
-                auto p = makeAutomodMessage(action);
+                const auto p = makeAutomodMessage(action);
                 chan->addMessage(p.first);
                 chan->addMessage(p.second);
             });
@@ -336,6 +336,22 @@ void Application::initPubsub()
                 chan->addMessage(msg);
             });
             chan->deleteMessage(msg->id);
+        });
+
+    this->twitch.pubsub->signals_.moderation.automodInfoMessage.connect(
+        [&](const auto &action) {
+            auto chan =
+                this->twitch.server->getChannelOrEmptyByID(action.roomID);
+
+            if (chan->isEmpty())
+            {
+                return;
+            }
+
+            postToThread([chan, action] {
+                const auto p = makeAutomodInfoMessage(action);
+                chan->addMessage(p);
+            });
         });
 
     this->twitch.pubsub->signals_.pointReward.redeemed.connect([&](auto &data) {

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -29,6 +29,53 @@ MessagePtr makeSystemMessage(const QString &text, const QTime &time)
     return MessageBuilder(systemMessage, text, time).release();
 }
 
+MessagePtr makeAutomodInfoMessage(const AutomodInfoAction &action)
+{
+    auto builder = MessageBuilder();
+
+    builder.emplace<TimestampElement>();
+    builder.message().flags.set(MessageFlag::PubSub);
+
+    builder
+        .emplace<ImageElement>(Image::fromPixmap(getResources().twitch.automod),
+                               MessageElementFlag::BadgeChannelAuthority)
+        ->setTooltip("AutoMod");
+    builder.emplace<TextElement>("AutoMod:", MessageElementFlag::BoldUsername,
+                                 MessageColor(QColor("blue")),
+                                 FontStyle::ChatMediumBold);
+    builder.emplace<TextElement>(
+        "AutoMod:", MessageElementFlag::NonBoldUsername,
+        MessageColor(QColor("blue")));
+    switch (action.type)
+    {
+        case AutomodInfoAction::OnHold: {
+            builder.emplace<TextElement>(("Hey! Your message is being checked "
+                                          "by mods and has not been sent."),
+                                         MessageElementFlag::Text,
+                                         MessageColor::Text);
+        }
+        break;
+        case AutomodInfoAction::Denied: {
+            builder.emplace<TextElement>(("Mods have removed your message."),
+                                         MessageElementFlag::Text,
+                                         MessageColor::Text);
+        }
+        break;
+        case AutomodInfoAction::Approved: {
+            builder.emplace<TextElement>(("Mods have accepted your message."),
+                                         MessageElementFlag::Text,
+                                         MessageColor::Text);
+        }
+        break;
+    }
+
+    builder.message().flags.set(MessageFlag::AutoMod);
+
+    auto message = builder.release();
+
+    return message;
+}
+
 std::pair<MessagePtr, MessagePtr> makeAutomodMessage(
     const AutomodAction &action)
 {

--- a/src/messages/MessageBuilder.hpp
+++ b/src/messages/MessageBuilder.hpp
@@ -11,6 +11,7 @@ struct BanAction;
 struct UnbanAction;
 struct AutomodAction;
 struct AutomodUserAction;
+struct AutomodInfoAction;
 struct Message;
 using MessagePtr = std::shared_ptr<const Message>;
 
@@ -25,6 +26,7 @@ MessagePtr makeSystemMessage(const QString &text);
 MessagePtr makeSystemMessage(const QString &text, const QTime &time);
 std::pair<MessagePtr, MessagePtr> makeAutomodMessage(
     const AutomodAction &action);
+MessagePtr makeAutomodInfoMessage(const AutomodInfoAction &action);
 
 struct MessageParseArgs {
     bool disablePingSounds = false;
@@ -60,7 +62,7 @@ public:
     void addLink(const QString &origLink, const QString &matchedLink);
 
     template <typename T, typename... Args>
-    T *emplace(Args &&... args)
+    T *emplace(Args &&...args)
     {
         static_assert(std::is_base_of<MessageElement, T>::value,
                       "T must extend MessageElement");

--- a/src/messages/MessageBuilder.hpp
+++ b/src/messages/MessageBuilder.hpp
@@ -62,7 +62,7 @@ public:
     void addLink(const QString &origLink, const QString &matchedLink);
 
     template <typename T, typename... Args>
-    T *emplace(Args &&...args)
+    T *emplace(Args &&... args)
     {
         static_assert(std::is_base_of<MessageElement, T>::value,
                       "T must extend MessageElement");

--- a/src/providers/twitch/PubsubActions.hpp
+++ b/src/providers/twitch/PubsubActions.hpp
@@ -133,4 +133,13 @@ struct AutomodUserAction : PubSubAction {
     QString message;
 };
 
+struct AutomodInfoAction : PubSubAction {
+    using PubSubAction::PubSubAction;
+    enum {
+        OnHold,
+        Denied,
+        Approved,
+    } type;
+};
+
 }  // namespace chatterino

--- a/src/providers/twitch/PubsubClient.cpp
+++ b/src/providers/twitch/PubsubClient.cpp
@@ -583,6 +583,27 @@ PubSub::PubSub()
             }
         };
 
+    this->moderationActionHandlers["automod_message_rejected"] =
+        [this](const auto &data, const auto &roomID) {
+            AutomodInfoAction action(data, roomID);
+            action.type = AutomodInfoAction::OnHold;
+            this->signals_.moderation.automodInfoMessage.invoke(action);
+        };
+
+    this->moderationActionHandlers["automod_message_denied"] =
+        [this](const auto &data, const auto &roomID) {
+            AutomodInfoAction action(data, roomID);
+            action.type = AutomodInfoAction::Denied;
+            this->signals_.moderation.automodInfoMessage.invoke(action);
+        };
+
+    this->moderationActionHandlers["automod_message_approved"] =
+        [this](const auto &data, const auto &roomID) {
+            AutomodInfoAction action(data, roomID);
+            action.type = AutomodInfoAction::Approved;
+            this->signals_.moderation.automodInfoMessage.invoke(action);
+        };
+
     this->channelTermsActionHandlers["add_permitted_term"] =
         [this](const auto &data, const auto &roomID) {
             // This term got a pass through automod

--- a/src/providers/twitch/PubsubClient.hpp
+++ b/src/providers/twitch/PubsubClient.hpp
@@ -132,6 +132,7 @@ public:
 
             Signal<AutomodAction> automodMessage;
             Signal<AutomodUserAction> automodUserMessage;
+            Signal<AutomodInfoAction> automodInfoMessage;
         } moderation;
 
         struct {


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description
**Requires #2742**
Closes #2626
Now shows when a message is being held by automod through pubsub.
<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->

Sent two profane messages and then accepted the first and denied the second. (There are badges and stuff so it looks good but I have them disabled and forgot to enable them for this screenshot)
![](https://i.nuuls.com/goizr.png)

(I don't know why formatting failed I have clang-format version 11.1.0)