### PR TITLE
Fix a deadlock that would occur when loading Twitch badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Minor: Messages held by automod are now shown to the user. (#2626)
 - Bugfix: Automod messages now work properly again. (#2682)
 - Bugfix: `Login expired` message no longer highlights all tabs. (#2735)
+- Bugfix: Fix a deadlock that would occur during user badge loading. (#1704, #2756)
 
 ## 2.3.1
 

--- a/src/providers/twitch/TwitchBadges.cpp
+++ b/src/providers/twitch/TwitchBadges.cpp
@@ -88,6 +88,10 @@ void TwitchBadges::loaded()
 
     // Flush callback queue
     std::unique_lock queueLock(this->queueMutex_);
+
+    // Once we have gained unique access of the queue, we can release our unique access of the loaded mutex allowing future calls to read locked_
+    loadedLock.unlock();
+
     while (!this->callbackQueue_.empty())
     {
         auto callback = this->callbackQueue_.front();


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
