### PR TITLE
Load 100 blocked users instead of default 20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Minor: Added a message that displays a new date on new day. (#1016)
 - Minor: Hosting messages are now clickable. (#2655)
 - Minor: Messages held by automod are now shown to the user. (#2626)
+- Minor: Load 100 blocked users rather than the default 20. (#2772)
 - Bugfix: Strip newlines from stream titles to prevent text going off of split header (#2755)
 - Bugfix: Automod messages now work properly again. (#2682)
 - Bugfix: `Login expired` message no longer highlights all tabs. (#2735)

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -547,6 +547,7 @@ void Helix::loadBlocks(QString userId,
 {
     QUrlQuery urlQuery;
     urlQuery.addQueryItem("broadcaster_id", userId);
+    urlQuery.addQueryItem("first", "100");
 
     this->makeRequest("users/blocks", urlQuery)
         .onSuccess([successCallback, failureCallback](auto result) -> Outcome {


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Work towards #2767 so that at least up to 100 blocked users are returned rather than the default 20
