### PR TITLE
Fix word backspacing not closing/updating colon emote picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Bugfix: `Login expired` message no longer highlights all tabs. (#2735)
 - Bugfix: Fix a deadlock that would occur during user badge loading. (#1704, #2756)
 - Bugfix: Tabbing in `Select a channel to open` is now consistent. (#1797)
+- Bugfix: Fix Ctrl + Backspace not closing colon emote picker (#2780)
 
 ## 2.3.1
 

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -451,6 +451,7 @@ void SplitInput::installKeyPressedEvent()
 
 void SplitInput::onTextChanged()
 {
+    this->updateColonMenu();
 }
 
 void SplitInput::onCursorPositionChanged()

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -87,7 +87,7 @@ void SplitInput::initLayout()
     QObject::connect(this->ui_.textEdit, &QTextEdit::cursorPositionChanged,
                      this, &SplitInput::onCursorPositionChanged);
     QObject::connect(this->ui_.textEdit, &QTextEdit::textChanged, this,
-		      &SplitInput::onTextChanged);
+                     &SplitInput::onTextChanged);
 
     this->managedConnections_.push_back(app->fonts->fontChanged.connect([=]() {
         this->ui_.textEdit->setFont(

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -87,7 +87,7 @@ void SplitInput::initLayout()
     QObject::connect(this->ui_.textEdit, &QTextEdit::cursorPositionChanged,
                      this, &SplitInput::onCursorPositionChanged);
     QObject::connect(this->ui_.textEdit, &QTextEdit::textChanged, this,
-		     &SplitInput::onTextChanged);
+		      &SplitInput::onTextChanged);
 
     this->managedConnections_.push_back(app->fonts->fontChanged.connect([=]() {
         this->ui_.textEdit->setFont(

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -86,8 +86,8 @@ void SplitInput::initLayout()
         app->fonts->getFont(FontStyle::ChatMedium, this->scale()));
     QObject::connect(this->ui_.textEdit, &QTextEdit::cursorPositionChanged,
                      this, &SplitInput::onCursorPositionChanged);
-    QObject::connect(this->ui_.textEdit, &QTextEdit::textChanged,
-                     this, &SplitInput::onTextChanged);
+    QObject::connect(this->ui_.textEdit, &QTextEdit::textChanged, this,
+		     &SplitInput::onTextChanged);
 
     this->managedConnections_.push_back(app->fonts->fontChanged.connect([=]() {
         this->ui_.textEdit->setFont(

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -86,6 +86,8 @@ void SplitInput::initLayout()
         app->fonts->getFont(FontStyle::ChatMedium, this->scale()));
     QObject::connect(this->ui_.textEdit, &QTextEdit::cursorPositionChanged,
                      this, &SplitInput::onCursorPositionChanged);
+    QObject::connect(this->ui_.textEdit, &QTextEdit::textChanged,
+                     this, &SplitInput::onTextChanged);
 
     this->managedConnections_.push_back(app->fonts->fontChanged.connect([=]() {
         this->ui_.textEdit->setFont(

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -447,6 +447,10 @@ void SplitInput::installKeyPressedEvent()
     });
 }
 
+void SplitInput::onTextChanged()
+{
+}
+
 void SplitInput::onCursorPositionChanged()
 {
     this->updateColonMenu();

--- a/src/widgets/splits/SplitInput.hpp
+++ b/src/widgets/splits/SplitInput.hpp
@@ -46,6 +46,7 @@ private:
     void initLayout();
     void installKeyPressedEvent();
     void onCursorPositionChanged();
+    void onTextChanged();
     void updateEmoteButton();
     void updateColonMenu();
     void showColonMenu(const QString &text);


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

Fixes #2780

At the moment the handler can be called twice when the user types a character because both the text input updates and cursor changes position. If anyone has a good way to block one of the events when the other is triggered please suggest.