### PR TITLE
Deprecate C_DEBUG definition in favour of standard NDEBUG

### DIFF
--- a/src/RunGui.cpp
+++ b/src/RunGui.cpp
@@ -134,7 +134,7 @@ namespace {
     // true.
     void initSignalHandler()
     {
-#ifndef C_DEBUG
+#ifdef NDEBUG
         signalsInitTime = std::chrono::steady_clock::now();
 
         signal(SIGSEGV, handleSignal);

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -25,7 +25,7 @@
 #include "widgets/splits/Split.hpp"
 #include "widgets/splits/SplitContainer.hpp"
 
-#ifdef C_DEBUG
+#ifndef NDEBUG
 #    include <rapidjson/document.h>
 #    include "providers/twitch/PubsubClient.hpp"
 #    include "util/SampleCheerMessages.hpp"
@@ -178,7 +178,7 @@ void Window::addCustomTitlebarButtons()
 
 void Window::addDebugStuff()
 {
-#ifdef C_DEBUG
+#ifndef NDEBUG
     std::vector<QString> cheerMessages, subMessages, miscMessages, linkMessages,
         emoteTestMessages;
 


### PR DESCRIPTION

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

The checks for C_DEBUG will need to be reversed now as C_DEBUG defined that debug was enabled, and NDEBUG defines that debug is disabled (NDEBUG=NoDebug)

This PR will fix it so that all the F6 and beyond debug bindings work with CMake properly, sorry @mm2pl if this causes some merge conflicts

- Use NDEBUG instead of C_DEBUG in src/RunGui in the "restart on crash" code
- Use NDEBUG instead of C_DEBUG in the "add debug bindings" code

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
