### PR TITLE
Fixed deprecated method Qt::SystemLocaleLongDate

### DIFF
--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -754,7 +754,7 @@ void TwitchChannel::loadRecentMessages()
                     {
                         shared.get()->lastDate_ = msgDate;
                         auto msg = makeSystemMessage(
-                            msgDate.toString(Qt::SystemLocaleLongDate),
+                            QLocale().toString(msgDate, QLocale::LongFormat),
                             QTime(0, 0));
                         msg->flags.set(MessageFlag::RecentMessage);
                         allBuiltMessages.emplace_back(msg);

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -607,10 +607,10 @@ void ChannelView::setChannel(ChannelPtr underlyingChannel)
                     if (this->channel_->lastDate_ != QDate::currentDate())
                     {
                         this->channel_->lastDate_ = QDate::currentDate();
-                        auto msg =
-                            makeSystemMessage(QDate::currentDate().toString(
-                                                  Qt::SystemLocaleLongDate),
-                                              QTime(0, 0));
+                        auto msg = makeSystemMessage(
+                            QLocale().toString(QDate::currentDate(),
+                                               QLocale::LongFormat),
+                            QTime(0, 0));
                         this->channel_->addMessage(msg);
                     }
                     // When the message was received in the underlyingChannel,


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Fixes deprecation notices introduced in #2748

Behavior is untouched (left master, right this PR):
![](https://cdn.zneix.eu/3xngQ6M.png)

Reference: https://doc.qt.io/qt-5/qt.html#DateFormat-enum
Replacement: https://doc.qt.io/qt-5/qlocale.html#FormatType-enum
