### PR TITLE
Add #channel in mentions usercard and search popup 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unversioned
 
+- Minor: Made "#channel" in `/mentions` tab show in usercards and in the search popup. (#2802)
 - Minor: Added settings to disable custom FrankerFaceZ VIP/mod badges. (#2693, #2759)
 
 ## 2.3.2

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1013,6 +1013,9 @@ MessageElementFlags ChannelView::getFlags() const
         }
     }
 
+    if (this->sourceChannel_ == app->twitch.server->mentionsChannel)
+        flags.set(MessageElementFlag::ChannelName);
+
     return flags;
 }
 


### PR DESCRIPTION
Pull request checklist:

- [X] `CHANGELOG.md` was updated, if applicable

# Description

Adds the `#channel` prefixed to messages in `/mentions` (`MessageElementFlag::ChannelName`), to messages displayed in usercards and search popups opened from  `/mentions`.
