### PR TITLE
Add moderation buttons in search popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unversioned
 
+- Minor: Added moderation buttons to search popup when searching in a split with moderation mode enabled. (#2148, #2803)
 - Minor: Added settings to disable custom FrankerFaceZ VIP/mod badges. (#2693, #2759)
 
 ## 2.3.2

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -46,6 +46,7 @@
 #include "widgets/dialogs/SettingsDialog.hpp"
 #include "widgets/dialogs/UserInfoPopup.hpp"
 #include "widgets/helper/EffectLabel.hpp"
+#include "widgets/helper/SearchPopup.hpp"
 #include "widgets/splits/Split.hpp"
 
 #define DRAW_WIDTH (this->width())
@@ -998,6 +999,16 @@ MessageElementFlags ChannelView::getFlags() const
     MessageElementFlags flags = app->windows->getWordFlags();
 
     Split *split = dynamic_cast<Split *>(this->parentWidget());
+
+    if (split == nullptr)
+    {
+        SearchPopup *searchPopup =
+            dynamic_cast<SearchPopup *>(this->parentWidget());
+        if (searchPopup != nullptr)
+        {
+            split = dynamic_cast<Split *>(searchPopup->parentWidget());
+        }
+    }
 
     if (split != nullptr)
     {

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -2067,14 +2067,26 @@ void ChannelView::handleLinkClick(QMouseEvent *event, const Link &link,
         case Link::UserAction: {
             QString value = link.value;
 
+            ChannelPtr channel = this->underlyingChannel_;
+            SearchPopup *searchPopup =
+                dynamic_cast<SearchPopup *>(this->parentWidget());
+            if (searchPopup != nullptr)
+            {
+                Split *split =
+                    dynamic_cast<Split *>(searchPopup->parentWidget());
+                if (split != nullptr)
+                {
+                    channel = split->getChannel();
+                }
+            }
+
             value.replace("{user}", layout->getMessage()->loginName)
                 .replace("{channel}", this->channel_->getName())
                 .replace("{msg-id}", layout->getMessage()->id)
                 .replace("{message}", layout->getMessage()->messageText);
 
-            value = getApp()->commands->execCommand(
-                value, this->underlyingChannel_, false);
-            this->underlyingChannel_->sendMessage(value);
+            value = getApp()->commands->execCommand(value, channel, false);
+            channel->sendMessage(value);
         }
         break;
 


### PR DESCRIPTION
Pull request checklist:

- [X] `CHANGELOG.md` was updated, if applicable

# Description

This PR adds moderation buttons to messages in a search popup opened from a split where moderation mode is active.

While this does seem to work for the cases I tested, I'm not really sure about the implementation and would like some input:

With the way the existing imlementation of adding the `MessageElementFlag` works, the `ChannelView` object "queries" the parent widget (by `dynamic_cast`), expecting it to be a split and checking for moderation mode in that split. The addition here is checking if the parent widget is actually a search popup, fetching the parent of the search widget which should be a split, and using that split to determine moderation mode. I'm just not sure if this is a good way of going about it. (A similar thing applies to determining the channel for performing the moderation actions when clicking the buttons)

To test, simply add whichever moderation buttons you would like to test, open a split with moderation mode enabled, open a search popup, and try the buttons.


Closes #2148 
