### PR TITLE
Fix FFZ emote links for global emotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Minor: Made "#channel" in `/mentions` tab show in usercards and in the search popup. (#2802)
 - Minor: Added settings to disable custom FrankerFaceZ VIP/mod badges. (#2693, #2759)
+- Bugfix: Fixed FFZ emote links for global emotes (#2807, #2808)
 
 ## 2.3.2
 

--- a/src/providers/ffz/FfzEmotes.cpp
+++ b/src/providers/ffz/FfzEmotes.cpp
@@ -67,7 +67,8 @@ namespace {
                 auto jsonEmote = jsonEmoteValue.toObject();
 
                 auto name = EmoteName{jsonEmote.value("name").toString()};
-                auto id = EmoteId{jsonEmote.value("id").toString()};
+                auto id =
+                    EmoteId{QString::number(jsonEmote.value("id").toInt())};
                 auto urls = jsonEmote.value("urls").toObject();
 
                 auto emote = Emote();


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
Updates parsing of Global FFZ emotes to be the same as channel emotes to fix #2807. 
