### PR TITLE
Match game names exactly when using /setgame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Minor: Added settings to disable custom FrankerFaceZ VIP/mod badges. (#2693, #2759)
 - Minor: Limit the number of recent chatters to improve memory usage and reduce freezes. (#2796, #2814)
 - Minor: Added `/popout` command. Usage: `/popout [channel]`. It opens browser chat for the provided channel. Can also be used without arguments to open current channels browser chat. (#2556, #2812)
+- Minor: Improved matching of game names when using `/setgame` command (#2636)
 - Bugfix: Fixed FFZ emote links for global emotes (#2807, #2808)
 
 ## 2.3.2

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -722,7 +722,7 @@ void CommandController::initialize(Settings &, Paths &paths)
         return "";
     });
     this->registerCommand("/setgame", [](const QStringList &words,
-                                         ChannelPtr channel) {
+                                         const ChannelPtr& channel) {
         if (words.size() < 2)
         {
             channel->addMessage(
@@ -747,7 +747,7 @@ void CommandController::initialize(Settings &, Paths &paths)
                         auto status = twitchChannel->accessStreamStatus();
                         getHelix()->updateChannel(
                             twitchChannel->roomId(), matchedGame.id, "", "",
-                            [channel, games, matchedGame](NetworkResult) {
+                            [channel, games, matchedGame](const NetworkResult&) {
                                 channel->addMessage(makeSystemMessage(
                                     QString("Updated game to %1")
                                         .arg(matchedGame.name)));

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -744,6 +744,19 @@ void CommandController::initialize(Settings &, Paths &paths)
                     else  // 1 or more games
                     {
                         auto matchedGame = games.at(0);
+
+                        if (games.size() > 1)
+                        {
+                            // attempt to find the best looking game by matching lowercase values
+                            for (auto &game : games) {
+                                if (game.name.toLower() == gameName.toLower())
+                                {
+                                    matchedGame = game;
+                                    break;
+                                }
+                            }
+                        }
+
                         auto status = twitchChannel->accessStreamStatus();
                         getHelix()->updateChannel(
                             twitchChannel->roomId(), matchedGame.id, "", "",

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -743,13 +743,14 @@ void CommandController::initialize(Settings &, Paths &paths)
                     }
                     else  // 1 or more games
                     {
+                        auto matchedGame = games.at(0);
                         auto status = twitchChannel->accessStreamStatus();
                         getHelix()->updateChannel(
-                            twitchChannel->roomId(), games.at(0).id, "", "",
-                            [channel, games](NetworkResult) {
+                            twitchChannel->roomId(), matchedGame.id, "", "",
+                            [channel, games, matchedGame](NetworkResult) {
                                 channel->addMessage(makeSystemMessage(
                                     QString("Updated game to %1")
-                                        .arg(games.at(0).name)));
+                                        .arg(matchedGame.name)));
                             },
                             [channel] {
                                 channel->addMessage(makeSystemMessage(

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -735,7 +735,8 @@ void CommandController::initialize(Settings &, Paths &paths)
 
             getHelix()->searchGames(
                 gameName,
-                [channel, twitchChannel, gameName](std::vector<HelixGame> games) {
+                [channel, twitchChannel,
+                 gameName](std::vector<HelixGame> games) {
                     if (games.empty())
                     {
                         channel->addMessage(
@@ -760,7 +761,8 @@ void CommandController::initialize(Settings &, Paths &paths)
                         auto status = twitchChannel->accessStreamStatus();
                         getHelix()->updateChannel(
                             twitchChannel->roomId(), matchedGame.id, "", "",
-                            [channel, games, matchedGame](const NetworkResult&) {
+                            [channel, games,
+                             matchedGame](const NetworkResult&) {
                                 channel->addMessage(makeSystemMessage(
                                     QString("Updated game to %1")
                                         .arg(matchedGame.name)));

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -763,7 +763,7 @@ void CommandController::initialize(Settings &, Paths &paths)
                         getHelix()->updateChannel(
                             twitchChannel->roomId(), matchedGame.id, "", "",
                             [channel, games,
-                             matchedGame](const NetworkResult&) {
+                             matchedGame](const NetworkResult &) {
                                 channel->addMessage(makeSystemMessage(
                                     QString("Updated game to %1")
                                         .arg(matchedGame.name)));

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -722,7 +722,7 @@ void CommandController::initialize(Settings &, Paths &paths)
         return "";
     });
     this->registerCommand("/setgame", [](const QStringList &words,
-                                         const ChannelPtr& channel) {
+                                         const ChannelPtr channel) {
         if (words.size() < 2)
         {
             channel->addMessage(

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -735,7 +735,7 @@ void CommandController::initialize(Settings &, Paths &paths)
 
             getHelix()->searchGames(
                 gameName,
-                [channel, twitchChannel](std::vector<HelixGame> games) {
+                [channel, twitchChannel, gameName](std::vector<HelixGame> games) {
                     if (games.empty())
                     {
                         channel->addMessage(

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -731,7 +731,7 @@ void CommandController::initialize(Settings &, Paths &paths)
         }
         if (auto twitchChannel = dynamic_cast<TwitchChannel *>(channel.get()))
         {
-            auto gameName = words.mid(1).join(" ");
+            const auto gameName = words.mid(1).join(" ");
 
             getHelix()->searchGames(
                 gameName,

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -736,7 +736,7 @@ void CommandController::initialize(Settings &, Paths &paths)
             getHelix()->searchGames(
                 gameName,
                 [channel, twitchChannel,
-                 gameName](std::vector<HelixGame> games) {
+                 gameName](const std::vector<HelixGame> &games) {
                     if (games.empty())
                     {
                         channel->addMessage(

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -731,8 +731,10 @@ void CommandController::initialize(Settings &, Paths &paths)
         }
         if (auto twitchChannel = dynamic_cast<TwitchChannel *>(channel.get()))
         {
+            auto gameName = words.mid(1).join(" ");
+
             getHelix()->searchGames(
-                words.mid(1).join(" "),
+                gameName,
                 [channel, twitchChannel](std::vector<HelixGame> games) {
                     if (games.empty())
                     {

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -749,7 +749,7 @@ void CommandController::initialize(Settings &, Paths &paths)
                         if (games.size() > 1)
                         {
                             // attempt to find the best looking game by matching lowercase values
-                            for (auto &game : games)
+                            for (const auto &game : games)
                             {
                                 if (game.name.toLower() == gameName.toLower())
                                 {

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -749,7 +749,8 @@ void CommandController::initialize(Settings &, Paths &paths)
                         if (games.size() > 1)
                         {
                             // attempt to find the best looking game by matching lowercase values
-                            for (auto &game : games) {
+                            for (auto &game : games)
+                            {
                                 if (game.name.toLower() == gameName.toLower())
                                 {
                                     matchedGame = game;


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

When using `/setgame` the first game returned by Helix is used. This PR aims to fix the shotty behaviour of `/setgame` by attempting to match the user's input with the games returned. It would be nice if this matching could also do some kind of fuzzy search but that's beyond the scope of this PR.

Fixes #2636 