### PR TITLE
Fix write connection reconnection issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Minor: Added `/popout` command. Usage: `/popout [channel]`. It opens browser chat for the provided channel. Can also be used without arguments to open current channels browser chat. (#2556, #2812)
 - Minor: Improved matching of game names when using `/setgame` command (#2636)
 - Bugfix: Fixed FFZ emote links for global emotes (#2807, #2808)
+- Bugfix: Fix reconnecting when IRC write connection is lost
 
 ## 2.3.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Minor: Added `/popout` command. Usage: `/popout [channel]`. It opens browser chat for the provided channel. Can also be used without arguments to open current channels browser chat. (#2556, #2812)
 - Minor: Improved matching of game names when using `/setgame` command (#2636)
 - Bugfix: Fixed FFZ emote links for global emotes (#2807, #2808)
-- Bugfix: Fix reconnecting when IRC write connection is lost
+- Bugfix: Fix reconnecting when IRC write connection is lost (#1831, #2356, #2850)
 
 ## 2.3.2
 

--- a/src/providers/irc/AbstractIrcServer.cpp
+++ b/src/providers/irc/AbstractIrcServer.cpp
@@ -18,7 +18,7 @@ const int MAX_FALLOFF_COUNTER = 60;
 AbstractIrcServer::AbstractIrcServer()
 {
     // Initialize the connections
-    // XXX: don't create write connection if there is not separate write connection.
+    // XXX: don't create write connection if there is no separate write connection.
     this->writeConnection_.reset(new IrcConnection);
     this->writeConnection_->moveToThread(
         QCoreApplication::instance()->thread());
@@ -32,6 +32,11 @@ AbstractIrcServer::AbstractIrcServer()
                      &Communi::IrcConnection::connected, this, [this] {
                          this->onWriteConnected(this->writeConnection_.get());
                      });
+    this->writeConnection_->connectionLost.connect([this](bool timeout) {
+        qCDebug(chatterinoIrc)
+            << "Write connection reconnect requested. Timeout:" << timeout;
+        this->writeConnection_->smartReconnect.invoke();
+    });
 
     // Listen to read connection message signals
     this->readConnection_.reset(new IrcConnection);
@@ -55,34 +60,17 @@ AbstractIrcServer::AbstractIrcServer()
                      &Communi::IrcConnection::disconnected, this, [this] {
                          this->onDisconnected();
                      });
-    QObject::connect(this->readConnection_.get(),
-                     &Communi::IrcConnection::socketError, this, [this] {
-                         this->onSocketError();
-                     });
-
-    // listen to reconnect request
-    this->readConnection_->reconnectRequested.connect([this] {
-        this->addGlobalSystemMessage(
-            "Server connection timed out, reconnecting");
-        this->connect();
-    });
-    //    this->writeConnection->reconnectRequested.connect([this] {
-    //    this->connect(); });
-    this->reconnectTimer_.setInterval(RECONNECT_BASE_INTERVAL);
-    this->reconnectTimer_.setSingleShot(true);
-    QObject::connect(&this->reconnectTimer_, &QTimer::timeout, [this] {
-        this->reconnectTimer_.setInterval(RECONNECT_BASE_INTERVAL *
-                                          this->falloffCounter_);
-
-        this->falloffCounter_ =
-            std::min(MAX_FALLOFF_COUNTER, this->falloffCounter_ + 1);
-
-        if (!this->readConnection_->isConnected())
+    this->readConnection_->connectionLost.connect([this](bool timeout) {
+        qCDebug(chatterinoIrc)
+            << "Read connection reconnect requested. Timeout:" << timeout;
+        if (timeout)
         {
-            qCDebug(chatterinoIrc)
-                << "Trying to reconnect..." << this->falloffCounter_;
-            this->connect();
+            // Show additional message since this is going to interrupt a
+            // connection that is still "connected"
+            this->addGlobalSystemMessage(
+                "Server connection timed out, reconnecting");
         }
+        this->readConnection_->smartReconnect.invoke();
     });
 }
 
@@ -368,11 +356,6 @@ void AbstractIrcServer::onDisconnected()
 
         chan->addMessage(disconnectedMsg);
     }
-}
-
-void AbstractIrcServer::onSocketError()
-{
-    this->reconnectTimer_.start();
 }
 
 std::shared_ptr<Channel> AbstractIrcServer::getCustomChannel(

--- a/src/providers/irc/AbstractIrcServer.hpp
+++ b/src/providers/irc/AbstractIrcServer.hpp
@@ -70,7 +70,6 @@ protected:
     virtual void onReadConnected(IrcConnection *connection);
     virtual void onWriteConnected(IrcConnection *connection);
     virtual void onDisconnected();
-    virtual void onSocketError();
 
     virtual std::shared_ptr<Channel> getCustomChannel(
         const QString &channelName);

--- a/src/providers/irc/IrcConnection2.cpp
+++ b/src/providers/irc/IrcConnection2.cpp
@@ -1,8 +1,12 @@
 #include "IrcConnection2.hpp"
 
+#include "common/QLogging.hpp"
 #include "common/Version.hpp"
 
 namespace chatterino {
+
+// The minimum interval between attempting to establish a new connection
+const int RECONNECT_MIN_INTERVAL = 15000;
 
 namespace {
 
@@ -13,40 +17,97 @@ namespace {
 IrcConnection::IrcConnection(QObject *parent)
     : Communi::IrcConnection(parent)
 {
-    // send ping every x seconds
+    // Log connection errors for ease-of-debugging
+    QObject::connect(this, &Communi::IrcConnection::socketError, this,
+                     [this](QAbstractSocket::SocketError error) {
+                         qCDebug(chatterinoIrc)
+                             << "Connection error:" << error;
+                     });
+
+    QObject::connect(
+        this, &Communi::IrcConnection::socketStateChanged, this,
+        [this](QAbstractSocket::SocketState state) {
+            if (state == QAbstractSocket::UnconnectedState)
+            {
+                if (!this->expectConnectionLoss_.load())
+                {
+                    // Ensure we always notify our parent that we should
+                    // reconnect; will also be called if we're reconnecting
+                    // manually
+                    this->connectionLost.invoke(false);
+                }
+            }
+        });
+
+    // Schedule a reconnect that won't violate RECONNECT_MIN_INTERVAL
+    this->smartReconnect.connect([this] {
+        if (this->reconnectTimer_.isActive())
+        {
+            return;
+        }
+
+        auto delta =
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - this->lastConnected_)
+                .count();
+        delta = delta < RECONNECT_MIN_INTERVAL
+                    ? (RECONNECT_MIN_INTERVAL - delta)
+                    : 10;
+        qCDebug(chatterinoIrc) << "Reconnecting in" << delta << "ms";
+        this->reconnectTimer_.start(delta);
+    });
+
+    this->reconnectTimer_.setInterval(RECONNECT_MIN_INTERVAL);
+    this->reconnectTimer_.setSingleShot(true);
+    QObject::connect(&this->reconnectTimer_, &QTimer::timeout, [this] {
+        if (this->isConnected())
+        {
+            // E.g. user manually reconnecting doesn't cancel this path, so
+            // just ignore
+            qCDebug(chatterinoIrc) << "Reconnect: already reconnected";
+        }
+        else
+        {
+            qCDebug(chatterinoIrc) << "Reconnecting";
+            this->open();
+        }
+    });
+
+    // Send ping every x seconds
     this->pingTimer_.setInterval(5000);
     this->pingTimer_.start();
     QObject::connect(&this->pingTimer_, &QTimer::timeout, [this] {
         if (this->isConnected())
         {
-            if (this->waitingForPong_.load())
+            if (this->recentlyReceivedMessage_.load())
             {
-                // Not sending another ping as we haven't received the matching pong yet
+                // If we're still receiving messages, all is well
+                this->recentlyReceivedMessage_ = false;
+                this->waitingForPong_ = false;
                 return;
             }
 
-            if (!this->recentlyReceivedMessage_.load())
+            if (this->waitingForPong_.load())
+            {
+                // The remote server did not send a PONG fast enough; close the
+                // connection
+                this->expectConnectionLoss_ = true;
+                this->pingTimer_.stop();
+                this->close();
+                this->connectionLost.invoke(true);
+            }
+            else
             {
                 this->sendRaw("PING " + payload);
-                this->reconnectTimer_.start();
                 this->waitingForPong_ = true;
             }
-            this->recentlyReceivedMessage_ = false;
-        }
-    });
-
-    // reconnect after x seconds without receiving a message
-    this->reconnectTimer_.setInterval(5000);
-    this->reconnectTimer_.setSingleShot(true);
-    QObject::connect(&this->reconnectTimer_, &QTimer::timeout, [this] {
-        if (this->isConnected())
-        {
-            reconnectRequested.invoke();
         }
     });
 
     QObject::connect(this, &Communi::IrcConnection::connected, this, [this] {
         this->waitingForPong_ = false;
+        this->recentlyReceivedMessage_ = false;
+        this->pingTimer_.start();
     });
 
     QObject::connect(this, &Communi::IrcConnection::pongMessageReceived,
@@ -57,20 +118,19 @@ IrcConnection::IrcConnection(QObject *parent)
                          }
                      });
 
-    QObject::connect(
-        this, &Communi::IrcConnection::messageReceived,
-        [this](Communi::IrcMessage *message) {
-            this->recentlyReceivedMessage_ = true;
+    QObject::connect(this, &Communi::IrcConnection::messageReceived,
+                     [this](Communi::IrcMessage *message) {
+                         // This connection is probably still alive
+                         this->recentlyReceivedMessage_ = true;
+                     });
+}
 
-            if (this->reconnectTimer_.isActive())
-            {
-                this->reconnectTimer_.stop();
-
-                // The reconnect timer had started, that means we were waiting for a pong.
-                // Since we received a message, this means that any pong response is meaningless, so we can just stop waiting for the pong and send another ping soon:tm:
-                this->waitingForPong_ = false;
-            }
-        });
+void IrcConnection::open()
+{
+    // Accurately track the time a connection was opened
+    this->lastConnected_ = std::chrono::steady_clock::now();
+    this->expectConnectionLoss_ = false;
+    Communi::IrcConnection::open();
 }
 
 }  // namespace chatterino

--- a/src/providers/irc/IrcConnection2.cpp
+++ b/src/providers/irc/IrcConnection2.cpp
@@ -133,4 +133,10 @@ void IrcConnection::open()
     Communi::IrcConnection::open();
 }
 
+void IrcConnection::close()
+{
+    this->expectConnectionLoss_ = true;
+    Communi::IrcConnection::close();
+}
+
 }  // namespace chatterino

--- a/src/providers/irc/IrcConnection2.cpp
+++ b/src/providers/irc/IrcConnection2.cpp
@@ -20,8 +20,7 @@ IrcConnection::IrcConnection(QObject *parent)
     // Log connection errors for ease-of-debugging
     QObject::connect(this, &Communi::IrcConnection::socketError, this,
                      [this](QAbstractSocket::SocketError error) {
-                         qCDebug(chatterinoIrc)
-                             << "Connection error:" << error;
+                         qCDebug(chatterinoIrc) << "Connection error:" << error;
                      });
 
     QObject::connect(

--- a/src/providers/irc/IrcConnection2.hpp
+++ b/src/providers/irc/IrcConnection2.hpp
@@ -13,8 +13,9 @@ class IrcConnection : public Communi::IrcConnection
 public:
     IrcConnection(QObject *parent = nullptr);
 
-    // Signal to notify that we're no longer connected; signal receiver should
-    // trigger a reconnect, if desired
+    // Signal to notify that we're unexpectedly no longer connected, either due
+    // to a connection error or if we think we've timed out. It's up to the
+    // receiver to trigger a reconnect, if desired
     pajlada::Signals::Signal<bool> connectionLost;
 
     // Request a reconnect with a minimum interval between attempts.

--- a/src/providers/irc/IrcConnection2.hpp
+++ b/src/providers/irc/IrcConnection2.hpp
@@ -4,6 +4,7 @@
 
 #include <IrcConnection>
 #include <QTimer>
+#include <chrono>
 
 namespace chatterino {
 
@@ -12,14 +13,25 @@ class IrcConnection : public Communi::IrcConnection
 public:
     IrcConnection(QObject *parent = nullptr);
 
-    pajlada::Signals::NoArgSignal reconnectRequested;
+    // Signal to notify that we're no longer connected; signal receiver should
+    // trigger a reconnect, if desired
+    pajlada::Signals::Signal<bool> connectionLost;
+
+    // Request a reconnect with a minimum interval between attempts.
+    pajlada::Signals::NoArgSignal smartReconnect;
+
+    virtual void open();
 
 private:
     QTimer pingTimer_;
     QTimer reconnectTimer_;
     std::atomic<bool> recentlyReceivedMessage_{true};
+    std::chrono::steady_clock::time_point lastConnected_;
 
-    // waitingForPong_ is set to true when we send a PING message, and back to false when we receive the matching PONG response
+    std::atomic<bool> expectConnectionLoss_{false};
+
+    // waitingForPong_ is set to true when we send a PING message, and back to
+    // false when we receive the matching PONG response
     std::atomic<bool> waitingForPong_{false};
 };
 

--- a/src/providers/irc/IrcConnection2.hpp
+++ b/src/providers/irc/IrcConnection2.hpp
@@ -21,6 +21,7 @@ public:
     pajlada::Signals::NoArgSignal smartReconnect;
 
     virtual void open();
+    virtual void close();
 
 private:
     QTimer pingTimer_;


### PR DESCRIPTION
Ready for review/feedback. There's a lot of room for (additional) refactoring on the connection logic, but I figured I'd at least fix the issue first.

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Chatterino currently does not handle disconnects of the write connection, which
causes messages to remain buffered until you manually reconnect, after which it
will send all messages at once.

This patch addresses the lack of reconnection specifically, and attempts to
refactor some of the reconnection logic to make it more robust. Backoff behavior
is introduced to *both* read/write cons to avoid reconnection loops.

To replicate the issue, simply lose your (write) connection to TMI. This can be
"simulated" using something like:

    tcpkill -i eth0 host 44.226.36.141 or host 34.217.198.238 or host 100.20.159.232

An alternative/secondary approach would be to detect failures of the underlying
`sendRaw` method (as it returns false if the message can't be sent to the
connection), but better monitoring of the connection state should be sufficient.

The way the code is setup currently doesn't really make it easy to implement
this "cleanly". E.g. calls `initializeConnection` are skipped on reconnect, but
since we're reconnecting with the same parameters, this should have little
actual consequence.

