### PR TITLE
Split list of emote sets into bunches when performing Ivr API reqeusts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Minor: Added `/popout` command. Usage: `/popout [channel]`. It opens browser chat for the provided channel. Can also be used without arguments to open current channels browser chat. (#2556, #2812)
 - Minor: Improved matching of game names when using `/setgame` command (#2636)
 - Bugfix: Fixed FFZ emote links for global emotes (#2807, #2808)
+- Bugfix: Fixed bit emotes not loading in some rare cases. (#2856)
 
 ## 2.3.2
 

--- a/src/providers/IvrApi.hpp
+++ b/src/providers/IvrApi.hpp
@@ -74,8 +74,7 @@ public:
                    ResultCallback<IvrSubage> resultCallback,
                    IvrFailureCallback failureCallback);
 
-    // https://api.ivr.fi/docs#tag/Twitch/paths/~1twitch~1emoteset~1{setid}/get
-    // however, we use undocumented endpoint, which takes ?set_id=1,2,3,4,... as query parameter
+    // https://api.ivr.fi/docs#tag/Twitch/paths/~1twitch~1emoteset/get
     void getBulkEmoteSets(QString emoteSetList,
                           ResultCallback<QJsonArray> successCallback,
                           IvrFailureCallback failureCallback);

--- a/src/providers/twitch/TwitchAccount.cpp
+++ b/src/providers/twitch/TwitchAccount.cpp
@@ -316,7 +316,7 @@ void TwitchAccount::loadUserstateEmotes(QStringList emoteSetKeys)
                              newEmoteSetKeysVector.begin() + last);
     }
 
-    for (const auto &batch : std::move(batches))
+    for (const auto &batch : batches)
     {
         QStringList emoteSetBatch;
 

--- a/src/providers/twitch/TwitchAccount.cpp
+++ b/src/providers/twitch/TwitchAccount.cpp
@@ -353,8 +353,7 @@ void TwitchAccount::loadUserstateEmotes(QStringList emoteSetKeys)
                         auto code = EmoteName{ivrEmote.code};
                         auto cleanCode =
                             EmoteName{TwitchEmotes::cleanUpEmoteCode(code)};
-                        newUserEmoteSet->emotes.emplace_back(
-                            TwitchEmote{id, cleanCode});
+                        newUserEmoteSet->emotes.emplace_back(id, cleanCode);
 
                         emoteData->allEmoteNames.push_back(cleanCode);
 

--- a/src/providers/twitch/TwitchAccount.cpp
+++ b/src/providers/twitch/TwitchAccount.cpp
@@ -306,7 +306,7 @@ void TwitchAccount::loadUserstateEmotes(QStringList emoteSetKeys)
     // splitting newEmoteSetKeys to batches of 100, because Ivr API endpoint accepts a maximum of 100 emotesets at once
     constexpr int batchSize = 100;
 
-    std::vector<QStringList> batches;
+    std::vector<std::vector<QString>> batches;
 
     auto newEmoteSetKeysVector = newEmoteSetKeys.toVector();
     batches.reserve((newEmoteSetKeysVector.size() + 1) / batchSize);
@@ -320,8 +320,14 @@ void TwitchAccount::loadUserstateEmotes(QStringList emoteSetKeys)
 
     for (const auto &batch : batches)
     {
+        QStringList batchList;
+        for (const auto &el : batch)
+        {
+            batchList.push_back(el);
+        }
+
         getIvr()->getBulkEmoteSets(
-            batch.join(","),
+            batchList.join(","),
             [this](QJsonArray emoteSetArray) {
                 auto emoteData = this->emotes_.access();
                 for (auto emoteSet : emoteSetArray)

--- a/src/providers/twitch/TwitchAccount.cpp
+++ b/src/providers/twitch/TwitchAccount.cpp
@@ -306,28 +306,24 @@ void TwitchAccount::loadUserstateEmotes(QStringList emoteSetKeys)
     // splitting newEmoteSetKeys to batches of 100, because Ivr API endpoint accepts a maximum of 100 emotesets at once
     constexpr int batchSize = 100;
 
-    std::vector<std::vector<QString>> batches;
+    std::vector<QStringList> batches;
 
-    auto newEmoteSetKeysVector = newEmoteSetKeys.toVector();
-    batches.reserve((newEmoteSetKeysVector.size() + 1) / batchSize);
+    batches.reserve((newEmoteSetKeys.size() + 1) / batchSize);
 
-    for (int i = 0; i < newEmoteSetKeysVector.size(); i += batchSize)
+    for (int i = 0; i < newEmoteSetKeys.size(); i += batchSize)
     {
-        int last = std::min(newEmoteSetKeysVector.size(), i + batchSize);
-        batches.emplace_back(newEmoteSetKeysVector.begin() + i,
-                             newEmoteSetKeysVector.begin() + last);
+        QStringList batch;
+        for (int j = batchSize * i; i < batchSize; i++)
+        {
+            batch.push_back(newEmoteSetKeys.at(j));
+        }
+        batches.emplace_back(batch);
     }
 
     for (const auto &batch : batches)
     {
-        QStringList batchList;
-        for (const auto &el : batch)
-        {
-            batchList.push_back(el);
-        }
-
         getIvr()->getBulkEmoteSets(
-            batchList.join(","),
+            batch.join(","),
             [this](QJsonArray emoteSetArray) {
                 auto emoteData = this->emotes_.access();
                 for (auto emoteSet : emoteSetArray)

--- a/src/providers/twitch/TwitchAccount.cpp
+++ b/src/providers/twitch/TwitchAccount.cpp
@@ -313,7 +313,7 @@ void TwitchAccount::loadUserstateEmotes(QStringList emoteSetKeys)
     for (int i = 0; i < newEmoteSetKeys.size(); i += batchSize)
     {
         QStringList batch;
-        for (int j = batchSize * i; i < batchSize; i++)
+        for (int j = batchSize * i; j < batchSize; j++)
         {
             batch.push_back(newEmoteSetKeys.at(j));
         }

--- a/src/providers/twitch/TwitchAccount.cpp
+++ b/src/providers/twitch/TwitchAccount.cpp
@@ -308,7 +308,7 @@ void TwitchAccount::loadUserstateEmotes(QStringList emoteSetKeys)
 
     std::vector<QStringList> batches;
 
-    QStringList newEmoteSetKeysVector = newEmoteSetKeys.toVector().toList();
+    auto newEmoteSetKeysVector = newEmoteSetKeys.toVector();
     batches.reserve((newEmoteSetKeysVector.size() + 1) / batchSize);
 
     for (int i = 0; i < newEmoteSetKeysVector.size(); i += batchSize)

--- a/src/providers/twitch/TwitchAccount.cpp
+++ b/src/providers/twitch/TwitchAccount.cpp
@@ -348,7 +348,8 @@ void TwitchAccount::loadUserstateEmotes(QStringList emoteSetKeys)
                         auto code = EmoteName{ivrEmote.code};
                         auto cleanCode =
                             EmoteName{TwitchEmotes::cleanUpEmoteCode(code)};
-                        newUserEmoteSet->emotes.emplace_back({id, cleanCode});
+                        newUserEmoteSet->emotes.push_back(
+                            TwitchEmote{id, cleanCode});
 
                         emoteData->allEmoteNames.push_back(cleanCode);
 

--- a/src/providers/twitch/TwitchAccount.cpp
+++ b/src/providers/twitch/TwitchAccount.cpp
@@ -348,7 +348,7 @@ void TwitchAccount::loadUserstateEmotes(QStringList emoteSetKeys)
                         auto code = EmoteName{ivrEmote.code};
                         auto cleanCode =
                             EmoteName{TwitchEmotes::cleanUpEmoteCode(code)};
-                        newUserEmoteSet->emotes.emplace_back(id, cleanCode);
+                        newUserEmoteSet->emotes.emplace_back({id, cleanCode});
 
                         emoteData->allEmoteNames.push_back(cleanCode);
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Added a helper vector of vectors and some logic that splits QStringList that we receive as a function parameter to avoid getting 400's from Ivr API as it supports fetching 100 emote sets at max.

One unrelated change: updated a link to Ivr API endpoint we're using because it has changed.

P.S. Thanks @talneoran for helping to come up with the solution ![Okayga](https://cdn.frankerfacez.com/emote/287489/1)