### PR TITLE
Refactored system message received upon trying to send a message while anonymous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Minor: Limit the number of recent chatters to improve memory usage and reduce freezes. (#2796, #2814)
 - Minor: Added `/popout` command. Usage: `/popout [channel]`. It opens browser chat for the provided channel. Can also be used without arguments to open current channels browser chat. (#2556, #2812)
 - Minor: Improved matching of game names when using `/setgame` command (#2636)
+- Minor: Added a link to accounts page in settings to "You need to be logged in to send messages" message. (#2862)
 - Bugfix: Fixed FFZ emote links for global emotes (#2807, #2808)
 
 ## 2.3.2

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -328,30 +328,33 @@ void TwitchChannel::sendMessage(const QString &message)
 
     if (!app->accounts->twitch.isLoggedIn())
     {
-        if (!message.isEmpty())
+        if (message.isEmpty())
         {
-            const auto linkColor = MessageColor(MessageColor::Link);
-            const auto accountsLink = Link(Link::OpenAccountsPage, QString());
-            const auto currentUser = getApp()->accounts->twitch.getCurrent();
-            const auto expirationText =
-                QString("You need to log in to send messages. You can link "
-                        "your Twitch account");
-            const auto loginPromptText = QString(" in the settings.");
-
-            auto builder = MessageBuilder();
-            builder.message().flags.set(MessageFlag::System);
-            builder.message().flags.set(MessageFlag::DoNotTriggerNotification);
-
-            builder.emplace<TimestampElement>();
-            builder.emplace<TextElement>(
-                expirationText, MessageElementFlag::Text, MessageColor::System);
-            builder
-                .emplace<TextElement>(loginPromptText, MessageElementFlag::Text,
-                                      linkColor)
-                ->setLink(accountsLink);
-
-            this->addMessage(builder.release());
+            return;
         }
+
+        const auto linkColor = MessageColor(MessageColor::Link);
+        const auto accountsLink = Link(Link::OpenAccountsPage, QString());
+        const auto currentUser = getApp()->accounts->twitch.getCurrent();
+        const auto expirationText =
+            QString("You need to log in to send messages. You can link your "
+                    "Twitch account");
+        const auto loginPromptText = QString(" in the settings.");
+
+        auto builder = MessageBuilder();
+        builder.message().flags.set(MessageFlag::System);
+        builder.message().flags.set(MessageFlag::DoNotTriggerNotification);
+
+        builder.emplace<TimestampElement>();
+        builder.emplace<TextElement>(expirationText, MessageElementFlag::Text,
+                                     MessageColor::System);
+        builder
+            .emplace<TextElement>(loginPromptText, MessageElementFlag::Text,
+                                  linkColor)
+            ->setLink(accountsLink);
+
+        this->addMessage(builder.release());
+
         return;
     }
 
@@ -359,8 +362,9 @@ void TwitchChannel::sendMessage(const QString &message)
         << "[TwitchChannel" << this->getName() << "] Send message:" << message;
 
     // Do last message processing
-    QString parsedMessage(
-        app->emotes->emojis.replaceShortCodes(message).trimmed());
+    QString parsedMessage(app->emotes->emojis.replaceShortCodes(message));
+
+    parsedMessage = parsedMessage.trimmed();
 
     if (parsedMessage.isEmpty())
     {

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -362,7 +362,7 @@ void TwitchChannel::sendMessage(const QString &message)
         << "[TwitchChannel" << this->getName() << "] Send message:" << message;
 
     // Do last message processing
-    QString parsedMessage(app->emotes->emojis.replaceShortCodes(message));
+    QString parsedMessage = app->emotes->emojis.replaceShortCodes(message);
 
     parsedMessage = parsedMessage.trimmed();
 

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -371,10 +371,15 @@ void TwitchChannel::sendMessage(const QString &message)
         return;
     }
 
-    if (!this->hasHighRateLimit() && getSettings()->allowDuplicateMessages &&
-        parsedMessage == this->lastSentMessage_)
+    if (!this->hasHighRateLimit())
     {
-        parsedMessage.append(MAGIC_MESSAGE_SUFFIX);
+        if (getSettings()->allowDuplicateMessages)
+        {
+            if (parsedMessage == this->lastSentMessage_)
+            {
+                parsedMessage.append(MAGIC_MESSAGE_SUFFIX);
+            }
+        }
     }
 
     bool messageSent = false;

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -339,7 +339,7 @@ void TwitchChannel::sendMessage(const QString &message)
         const auto expirationText =
             QString("You need to log in to send messages. You can link your "
                     "Twitch account");
-        const auto loginPromptText = QString(" in the settings.");
+        const auto loginPromptText = QString("in the settings.");
 
         auto builder = MessageBuilder();
         builder.message().flags.set(MessageFlag::System);


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

![I CAAAAAAN'T MegaLUL](https://cdn.zneix.eu/KG60ywo.png)

Moment when I reconnected, I switched to anonymous mode

This also gets rid of mentioned notice upon sending an empty message (usually happens upon executing a command while being anonymous)
