### PR TITLE
Switch to Twitch v2 emote API for animated emote support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Minor: Limit the number of recent chatters to improve memory usage and reduce freezes. (#2796, #2814)
 - Minor: Added `/popout` command. Usage: `/popout [channel]`. It opens browser chat for the provided channel. Can also be used without arguments to open current channels browser chat. (#2556, #2812)
 - Minor: Improved matching of game names when using `/setgame` command (#2636)
+- Minor: Switch to Twitch v2 emote API for animated emote support
 - Bugfix: Fixed FFZ emote links for global emotes (#2807, #2808)
 
 ## 2.3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Minor: Limit the number of recent chatters to improve memory usage and reduce freezes. (#2796, #2814)
 - Minor: Added `/popout` command. Usage: `/popout [channel]`. It opens browser chat for the provided channel. Can also be used without arguments to open current channels browser chat. (#2556, #2812)
 - Minor: Improved matching of game names when using `/setgame` command (#2636)
-- Minor: Switch to Twitch v2 emote API for animated emote support
+- Minor: Switch to Twitch v2 emote API for animated emote support. (#2863)
 - Bugfix: Fixed FFZ emote links for global emotes (#2807, #2808)
 
 ## 2.3.2

--- a/src/providers/twitch/TwitchEmotes.hpp
+++ b/src/providers/twitch/TwitchEmotes.hpp
@@ -10,8 +10,10 @@
 
 #include <memory>
 
+// NB: "default" can be replaced with "static" to always get a non-animated
+// variant
 #define TWITCH_EMOTE_TEMPLATE \
-    "https://static-cdn.jtvnw.net/emoticons/v1/{id}/{scale}"
+    "https://static-cdn.jtvnw.net/emoticons/v2/{id}/default/dark/{scale}"
 
 namespace chatterino {
 struct Emote;


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Using v2 paths is required for animated emotes, as can be seen in the following example.

Example of an animated emote:

    https://static-cdn.jtvnw.net/emoticons/v1/303999817/3.0
    https://static-cdn.jtvnw.net/emoticons/v2/303999817/default/dark/3.0
    https://static-cdn.jtvnw.net/emoticons/v2/303999817/static/dark/3.0
