### PR TITLE
Fix cheermotes not loading when user is connected to many channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Bugfix: Fixed pasting text with URLs included (#1688, #2855)
 - Bugfix: Fix reconnecting when IRC write connection is lost (#1831, #2356, #2850)
 - Bugfix: Fixed bit emotes not loading in some rare cases. (#2856)
+- Bugfix: Fixed cheer emotes timing out when user has many splits open (#2900)
 
 ## 2.3.2
 

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -732,6 +732,7 @@ void Helix::getCheermotes(
     urlQuery.addQueryItem("broadcaster_id", broadcasterId);
 
     this->makeRequest("bits/cheermotes", urlQuery)
+        .timeout(10000)
         .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
             auto root = result.parseJson();
             auto data = root.value("data");


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

This PR aims to fix the cheermote fetch timeouts when users have a large number of channels/splits open. A 10s timeout was added to the Helix request in order to handle the slow response.

I've personally noticed this with 73 individual channels open but it's been reported for counts as low as 20.