### PR TITLE
Resize tooltip thumbnails clientsize to prevent memory leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+- Bugfix: Fixed Chatterino eating up all the RAM and crashing after hovering over certain image links with link thumbnails turned on. (#2920)
+
 ## 2.3.3
 
 - Major: Added username autocompletion popup menu when typing usernames with an @ prefix. (#1979, #2866)


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

By default we do proxy thumbnails for images in the Chatterino API, however in the case of custom resolvers we directly pass a link to the image. Chatterino then attempts to load those links and in the result if a link is enormously big it may crash Chatterino and even make it to eat up all the available RAM before crashing.
By resizing thumbnails that are bigger than 300 pixels (optimal, hardcoded default value used by the Chatterino API) we are ensuring that we won't try to load into memory something way too big - we won't even see any difference anyway, because big images are resized by the API anyway.
