### PR TITLE
Fix large timeout duration in moderation buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+- Bugfix: Fixed large timeout durations in moderation buttons overlapping with usernames or other buttons. (#2865, #2921)
+
 ## 2.3.3
 
 - Major: Added username autocompletion popup menu when typing usernames with an @ prefix. (#1979, #2866)
@@ -19,7 +21,6 @@
 - Minor: Now shows deletions of messages like timeouts (#1155, #2841, #2867, #2874)
 - Minor: Added a link to accounts page in settings to "You need to be logged in to send messages" message. (#2862)
 - Minor: Switch to Twitch v2 emote API for animated emote support. (#2863)
-- Bugfix: Fixed large timeout durations in moderation buttons overlapping with usernames or other buttons. (#2865, #2921)
 - Bugfix: Moderation buttons now show the correct time unit when using units other than seconds. (#1719, #2864)
 - Bugfix: Fixed FFZ emote links for global emotes (#2807, #2808)
 - Bugfix: Fixed pasting text with URLs included (#1688, #2855)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Minor: Now shows deletions of messages like timeouts (#1155, #2841, #2867, #2874)
 - Minor: Added a link to accounts page in settings to "You need to be logged in to send messages" message. (#2862)
 - Minor: Switch to Twitch v2 emote API for animated emote support. (#2863)
+- Bugfix: Fixed large timeout durations in moderation buttons overlapping with usernames or other buttons. (#2865, #2921)
 - Bugfix: Moderation buttons now show the correct time unit when using units other than seconds. (#1719, #2864)
 - Bugfix: Fixed FFZ emote links for global emotes (#2807, #2808)
 - Bugfix: Fixed pasting text with URLs included (#1688, #2855)

--- a/src/controllers/moderationactions/ModerationAction.cpp
+++ b/src/controllers/moderationactions/ModerationAction.cpp
@@ -86,7 +86,15 @@ ModerationAction::ModerationAction(const QString &action)
         }
         else
         {
-            this->line1_ = QString::number(amount / week);
+            // limit to max timeout duration
+            if (amount > 2 * week)
+            {
+                this->line1_ = ">2";
+            }
+            else
+            {
+                this->line1_ = QString::number(amount / week);
+            }
             this->line2_ = "w";
         }
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description
Limits the duration displayed in timeout moderation buttons to the max timeout duration, 2 weeks.

Initially I wanted to cut down the duration inputted by the user, but with the current implementation, that will require changing the inputted action after it has already been saved, which I'm not sure about. 
Instead I opted for simply displaying `>2w` in the button when the duration exceeds the max duration, without changing the underlying action. I would like to hear if anyone has better ideas, or thinks that editing the action somehow is still the right way to go.

Fixes #2865