### PR TITLE
Add clickable usernames in host offline messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ## Unversioned
 
+- Minor: Channel name in `<channel> has gone offline. Exiting host mode.` messages is now clickable. (#2922)
+
 ## 2.3.3
 
 - Major: Added username autocompletion popup menu when typing usernames with an @ prefix. (#1979, #2866)
 - Major: Added ability to toggle visibility of Channel Tabs - This can be done by right-clicking the tab area or pressing the keyboard shortcut (default: Ctrl+U). (#2600)
-- Minor: Channel name in `<channel> has gone offline. Exiting host mode.` messages is now clickable. (#2922)
 - Minor: The /live split now shows channels going offline. (#2880)
 - Minor: Restore automod functionality for moderators (#2817, #2887)
 - Minor: Add setting for username style (#2889, #2891)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Major: Added username autocompletion popup menu when typing usernames with an @ prefix. (#1979, #2866)
 - Major: Added ability to toggle visibility of Channel Tabs - This can be done by right-clicking the tab area or pressing the keyboard shortcut (default: Ctrl+U). (#2600)
+- Minor: Channel name in `<channel> has gone offline. Exiting host mode.` messages is now clickable. (#2922)
 - Minor: The /live split now shows channels going offline. (#2880)
 - Minor: Restore automod functionality for moderators (#2817, #2887)
 - Minor: Add setting for username style (#2889, #2891)

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -819,21 +819,26 @@ void IrcMessageHandler::handleNoticeMessage(Communi::IrcNoticeMessage *message)
                 "Usage: \"/delete <msg-id>\" - can't take more "
                 "than one argument"));
         }
-        else if (tags == "host_on")
+        else if (tags == "host_on" || tags == "host_target_went_offline")
         {
+            bool hostOn = (tags == "host_on");
             QStringList parts = msg->messageText.split(QLatin1Char(' '));
-            if (parts.size() != 3)
+            if ((hostOn && parts.size() != 3) || (!hostOn && parts.size() != 7))
             {
                 return;
             }
-            auto &channelName = parts[2];
+            auto &channelName = hostOn ? parts[2] : parts[0];
             if (channelName.size() < 2)
             {
                 return;
             }
-            channelName.chop(1);
+            if (hostOn)
+            {
+                channelName.chop(1);
+            }
             MessageBuilder builder;
-            TwitchMessageBuilder::hostingSystemMessage(channelName, &builder);
+            TwitchMessageBuilder::hostingSystemMessage(channelName, &builder,
+                                                       hostOn);
             channel->addMessage(builder.release());
         }
         else

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -1337,17 +1337,33 @@ void TwitchMessageBuilder::offlineSystemMessage(const QString &channelName,
 }
 
 void TwitchMessageBuilder::hostingSystemMessage(const QString &channelName,
-                                                MessageBuilder *builder)
+                                                MessageBuilder *builder,
+                                                bool hostOn)
 {
     builder->emplace<TimestampElement>();
     builder->message().flags.set(MessageFlag::System);
     builder->message().flags.set(MessageFlag::DoNotTriggerNotification);
-    builder->emplace<TextElement>("Now hosting", MessageElementFlag::Text,
-                                  MessageColor::System);
-    builder
-        ->emplace<TextElement>(channelName + ".", MessageElementFlag::Username,
-                               MessageColor::System, FontStyle::ChatMediumBold)
-        ->setLink({Link::UserInfo, channelName});
+    if (hostOn)
+    {
+        builder->emplace<TextElement>("Now hosting", MessageElementFlag::Text,
+                                      MessageColor::System);
+        builder
+            ->emplace<TextElement>(
+                channelName + ".", MessageElementFlag::Username,
+                MessageColor::System, FontStyle::ChatMediumBold)
+            ->setLink({Link::UserInfo, channelName});
+    }
+    else
+    {
+        builder
+            ->emplace<TextElement>(channelName, MessageElementFlag::Username,
+                                   MessageColor::System,
+                                   FontStyle::ChatMediumBold)
+            ->setLink({Link::UserInfo, channelName});
+        builder->emplace<TextElement>("has gone offline. Exiting host mode.",
+                                      MessageElementFlag::Text,
+                                      MessageColor::System);
+    }
 }
 
 // irc variant

--- a/src/providers/twitch/TwitchMessageBuilder.hpp
+++ b/src/providers/twitch/TwitchMessageBuilder.hpp
@@ -58,7 +58,7 @@ public:
     static void offlineSystemMessage(const QString &channelName,
                                      MessageBuilder *builder);
     static void hostingSystemMessage(const QString &channelName,
-                                     MessageBuilder *builder);
+                                     MessageBuilder *builder, bool hostOn);
     static void deletionMessage(const MessagePtr originalMessage,
                                 MessageBuilder *builder);
     static void deletionMessage(const DeleteAction &action,


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description
Makes the channel name in `<channel> has gone offline. Exiting host mode.` messages clickable.
Implements missing functionality from #2752 which was described in #2655.
