### PR TITLE
Add /openurl command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Major: Added username autocompletion popup menu when typing usernames with an @ prefix. (#1979, #2866)
 - Major: Added ability to toggle visibility of Channel Tabs - This can be done by right-clicking the tab area or pressing the keyboard shortcut (default: Ctrl+U). (#2600)
+- Minor: Added `/openurl` command. Usage: `/openurl <URL>`. Opens the provided URL in the browser. (#2461, #2926)
 - Minor: The /live split now shows channels going offline. (#2880)
 - Minor: Restore automod functionality for moderators (#2817, #2887)
 - Minor: Add setting for username style (#2889, #2891)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ## Unversioned
 
+- Minor: Added `/openurl` command. Usage: `/openurl <URL>`. Opens the provided URL in the browser. (#2461, #2926)
+
 ## 2.3.3
 
 - Major: Added username autocompletion popup menu when typing usernames with an @ prefix. (#1979, #2866)
 - Major: Added ability to toggle visibility of Channel Tabs - This can be done by right-clicking the tab area or pressing the keyboard shortcut (default: Ctrl+U). (#2600)
-- Minor: Added `/openurl` command. Usage: `/openurl <URL>`. Opens the provided URL in the browser. (#2461, #2926)
 - Minor: The /live split now shows channels going offline. (#2880)
 - Minor: Restore automod functionality for moderators (#2817, #2887)
 - Minor: Add setting for username style (#2889, #2891)

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -798,7 +798,9 @@ void CommandController::initialize(Settings &, Paths &paths)
 
         QString link(words[1]);
         if (getSettings()->openLinksIncognito && supportsIncognitoLinks())
+        {
             openLinkIncognito(link);
+        }
         else
         {
             QUrl url = QUrl::fromUserInput(link);

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -800,7 +800,13 @@ void CommandController::initialize(Settings &, Paths &paths)
         if (getSettings()->openLinksIncognito && supportsIncognitoLinks())
             openLinkIncognito(link);
         else
-            QDesktopServices::openUrl(QUrl(link));
+        {
+            QUrl url = QUrl::fromUserInput(link);
+            if (!url.isValid() || !QDesktopServices::openUrl(url))
+            {
+                channel->addMessage(makeSystemMessage("Could not open URL."));
+            }
+        }
 
         return "";
     });

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -18,6 +18,7 @@
 #include "util/CombinePath.hpp"
 #include "util/FormatTime.hpp"
 #include "util/Helpers.hpp"
+#include "util/IncognitoBrowser.hpp"
 #include "util/StreamLink.hpp"
 #include "util/Twitch.hpp"
 #include "widgets/Window.hpp"
@@ -784,6 +785,23 @@ void CommandController::initialize(Settings &, Paths &paths)
             channel->addMessage(
                 makeSystemMessage("Unable to set game of non-Twitch channel."));
         }
+        return "";
+    });
+
+    this->registerCommand("/openurl", [](const QStringList &words,
+                                         const ChannelPtr channel) {
+        if (words.size() < 2)
+        {
+            channel->addMessage(makeSystemMessage("Usage: /openurl <URL>."));
+            return "";
+        }
+
+        QString link(words[1]);
+        if (getSettings()->openLinksIncognito && supportsIncognitoLinks())
+            openLinkIncognito(link);
+        else
+            QDesktopServices::openUrl(QUrl(link));
+
         return "";
     });
 }

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -804,7 +804,6 @@ void CommandController::initialize(Settings &, Paths &paths)
         }
 
         bool res = false;
-
         if (supportsIncognitoLinks() && getSettings()->openLinksIncognito)
         {
             res = openLinkIncognito(url.toString(QUrl::FullyEncoded));

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -797,12 +797,24 @@ void CommandController::initialize(Settings &, Paths &paths)
         }
 
         QUrl url = QUrl::fromUserInput(words.mid(1).join(" "));
-        if (url.isValid() && getSettings()->openLinksIncognito &&
-            supportsIncognitoLinks())
+        if (!url.isValid())
         {
-            openLinkIncognito(url.toString(QUrl::FullyEncoded));
+            channel->addMessage(makeSystemMessage("Invalid URL specified."));
+            return "";
         }
-        else if (!url.isValid() || !QDesktopServices::openUrl(url))
+
+        bool res = false;
+
+        if (supportsIncognitoLinks() && getSettings()->openLinksIncognito)
+        {
+            res = openLinkIncognito(url.toString(QUrl::FullyEncoded));
+        }
+        else
+        {
+            res = QDesktopServices::openUrl(url);
+        }
+
+        if (!res)
         {
             channel->addMessage(makeSystemMessage("Could not open URL."));
         }

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -796,18 +796,15 @@ void CommandController::initialize(Settings &, Paths &paths)
             return "";
         }
 
-        QString link(words[1]);
-        if (getSettings()->openLinksIncognito && supportsIncognitoLinks())
+        QUrl url = QUrl::fromUserInput(words.mid(1).join(" "));
+        if (url.isValid() && getSettings()->openLinksIncognito &&
+            supportsIncognitoLinks())
         {
-            openLinkIncognito(link);
+            openLinkIncognito(url.toString(QUrl::FullyEncoded));
         }
-        else
+        else if (!url.isValid() || !QDesktopServices::openUrl(url))
         {
-            QUrl url = QUrl::fromUserInput(link);
-            if (!url.isValid() || !QDesktopServices::openUrl(url))
-            {
-                channel->addMessage(makeSystemMessage("Could not open URL."));
-            }
+            channel->addMessage(makeSystemMessage("Could not open URL."));
         }
 
         return "";

--- a/src/util/IncognitoBrowser.cpp
+++ b/src/util/IncognitoBrowser.cpp
@@ -84,12 +84,14 @@ bool supportsIncognitoLinks()
 #endif
 }
 
-void openLinkIncognito(const QString &link)
+bool openLinkIncognito(const QString &link)
 {
 #ifdef Q_OS_WIN
     auto command = getCommand(link);
 
-    QProcess::startDetached(command);
+    return QProcess::startDetached(command);
+#else
+    return false;
 #endif
 }
 

--- a/src/util/IncognitoBrowser.hpp
+++ b/src/util/IncognitoBrowser.hpp
@@ -5,6 +5,6 @@
 namespace chatterino {
 
 bool supportsIncognitoLinks();
-void openLinkIncognito(const QString &link);
+bool openLinkIncognito(const QString &link);
 
 }  // namespace chatterino


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description
Add a `/openurl <URL>` built-in command that allows opening URLs through chat.
This is mostly useful for usage in custom commands, for example a command `/report` with the definition `/openurl twitch.tv/{1}/report` can be used to open the user report page of the user given as the first argument.

Closes #2461.