### PR TITLE
Hide completion popup when cursor is at first position

### DIFF
--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -480,7 +480,7 @@ void SplitInput::updateCompletionPopup()
     auto text = edit.toPlainText();
     auto position = edit.textCursor().position() - 1;
 
-    if (text.length() == 0)
+    if (text.length() == 0 || position == -1)
     {
         this->hideCompletionPopup();
         return;


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description
Fixes a bug where the completion popup (both emote and username) is still shown when the cursor is before a completion prefix, if the cursor position is the first position (beginning of the input). 

Example of the bug (by jeffboys123#6969 in Chatterino discord):

![unknown](https://user-images.githubusercontent.com/43518924/123544430-e4780a00-d75b-11eb-9a3d-0f789674c6b7.png)

https://user-images.githubusercontent.com/43518924/123544362-9cf17e00-d75b-11eb-9ca3-55bd6c3369ba.mp4

