### PR TITLE
Add Ubuntu packaging script

### DIFF
--- a/.CI/CreateUbuntuDeb.sh
+++ b/.CI/CreateUbuntuDeb.sh
@@ -6,10 +6,8 @@ if [ ! -f ./bin/chatterino ] || [ ! -x ./bin/chatterino ]; then
     exit 1
 fi
 
-# Chatterino's native version format is "Chatterino 2.3.3 (commit 6355742b)",
-# this little magic contraption transforms that into "2.3.3+6355742b"
-chatterino_version=$(bin/chatterino --version 2>&1 | tail -n 1 | sed 's/Chatterino //;s/ (commit /+/;s/)//')
-echo "Found Chatterino version $chatterino_version"
+chatterino_version=$(git describe)
+echo "Found Chatterino version $chatterino_version via git"
 
 rm -vrf "./package" || true  # delete any old packaging dir
 

--- a/.CI/CreateUbuntuDeb.sh
+++ b/.CI/CreateUbuntuDeb.sh
@@ -23,7 +23,7 @@ Priority: optional
 Architecture: amd64
 Maintainer: Mm2PL <mm2pl@kotmisia.pl>
 Description: Testing out chatterino as a Ubuntu package
-Depends: libc6 libqt5concurrent5 libqt5core5a libqt5dbus5 libqt5gui5 libqt5multimedia5 libqt5network5 libqt5svg5 libqt5widgets5 libssl1.1 libstdc++6
+Depends: libc6, libqt5concurrent5, libqt5core5a, libqt5dbus5, libqt5gui5, libqt5multimedia5, libqt5network5, libqt5svg5, libqt5widgets5, libssl1.1, libstdc++6
 EOF
 echo "Version: $chatterino_version" >> "$packaging_dir/DEBIAN/control"
 

--- a/.CI/CreateUbuntuDeb.sh
+++ b/.CI/CreateUbuntuDeb.sh
@@ -33,4 +33,4 @@ DESTDIR="$packaging_dir" make INSTALL_ROOT="$packaging_dir" -j"$(nproc)" install
 echo ""
 
 echo "Building package..."
-dpkg-deb --build "$packaging_dir" "chatterino-$chatterino_version.deb"
+dpkg-deb --build "$packaging_dir" "Chatterino.deb"

--- a/.CI/CreateUbuntuDeb.sh
+++ b/.CI/CreateUbuntuDeb.sh
@@ -23,6 +23,7 @@ Priority: optional
 Architecture: amd64
 Maintainer: Mm2PL <mm2pl@kotmisia.pl>
 Description: Testing out chatterino as a Ubuntu package
+Depends: libc6 libqt5concurrent5 libqt5core5a libqt5dbus5 libqt5gui5 libqt5multimedia5 libqt5network5 libqt5svg5 libqt5widgets5 libssl1.1 libstdc++6
 EOF
 echo "Version: $chatterino_version" >> "$packaging_dir/DEBIAN/control"
 

--- a/.CI/CreateUbuntuDeb.sh
+++ b/.CI/CreateUbuntuDeb.sh
@@ -6,7 +6,7 @@ if [ ! -f ./bin/chatterino ] || [ ! -x ./bin/chatterino ]; then
     exit 1
 fi
 
-chatterino_version=$(git describe | sed 's/^v//')
+chatterino_version=$(git describe | cut -c 2-)
 echo "Found Chatterino version $chatterino_version via git"
 
 rm -vrf "./package" || true  # delete any old packaging dir

--- a/.CI/CreateUbuntuDeb.sh
+++ b/.CI/CreateUbuntuDeb.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+set -e
+
+if [ ! -f ./bin/chatterino ] || [ ! -x ./bin/chatterino ]; then
+    echo "ERROR: No chatterino binary file found. This script must be run in the build folder, and chatterino must be built first."
+    exit 1
+fi
+
+# Chatterino's native version format is "Chatterino 2.3.3 (commit 6355742b)",
+# this little magic contraption transforms that into "2.3.3+6355742b"
+chatterino_version=$(bin/chatterino --version 2>&1 | tail -n 1 | sed 's/Chatterino //;s/ (commit /+/;s/)//')
+echo "Found Chatterino version $chatterino_version"
+
+rm -vrf "./package" || true  # delete any old packaging dir
+
+# create ./package/ from scratch
+mkdir package/DEBIAN -p
+packaging_dir="$(realpath ./package)"
+
+echo "Making control file"
+cat >> "$packaging_dir/DEBIAN/control" << EOF
+Package: chatterino
+Section: net
+Priority: optional
+Architecture: amd64
+Maintainer: Mm2PL <mm2pl@kotmisia.pl>
+Description: Testing out chatterino as a Ubuntu package
+EOF
+echo "Version: $chatterino_version" >> "$packaging_dir/DEBIAN/control"
+
+echo "Running make install in package dir"
+DESTDIR="$packaging_dir" make INSTALL_ROOT="$packaging_dir" -j"$(nproc)" install; find "$packaging_dir/"
+echo ""
+
+echo "Building package..."
+dpkg-deb --build "$packaging_dir" "chatterino-$chatterino_version.deb"

--- a/.CI/CreateUbuntuDeb.sh
+++ b/.CI/CreateUbuntuDeb.sh
@@ -6,7 +6,7 @@ if [ ! -f ./bin/chatterino ] || [ ! -x ./bin/chatterino ]; then
     exit 1
 fi
 
-chatterino_version=$(git describe)
+chatterino_version=$(git describe | sed 's/^v//')
 echo "Found Chatterino version $chatterino_version via git"
 
 rm -vrf "./package" || true  # delete any old packaging dir

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,7 @@ jobs:
       - uses: actions/checkout@v2.3.4
         with:
           submodules: true
+          fetch-depth: 0  # allows for tags access
 
       - name: Cache Qt
         id: cache-qt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -276,6 +276,16 @@ jobs:
 
       - uses: actions/download-artifact@v2.0.10
         with:
+          name: Chatterino-5.15.2-qmake.deb
+          path: ubuntu/
+
+      - uses: actions/download-artifact@v2.0.10
+        with:
+          name: Chatterino-5.15.2-cmake.deb
+          path: ubuntu-cmake/
+
+      - uses: actions/download-artifact@v2.0.10
+        with:
           name: chatterino-osx-5.15.2-qmake.dmg
           path: macos/
 
@@ -330,6 +340,26 @@ jobs:
           asset_path: ./linux-cmake/Chatterino-x86_64.AppImage
           asset_name: test-cmake-Chatterino-x86_64.AppImage
           asset_content_type: application/x-executable
+
+      - name: Upload release asset (Ubuntu .deb)
+        uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./ubuntu/Chatterino.deb
+          asset_name: Chatterino-x86_64.deb
+          asset_content_type: application/vnd.debian.binary-package
+
+      - name: Upload release asset (Ubuntu .deb) CMake
+        uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./ubuntu-cmake/Chatterino.deb
+          asset_name: test-cmake-Chatterino-x86_64.deb
+          asset_content_type: application/vnd.debian.binary-package
 
       - name: Upload release asset (MacOS)
         uses: actions/upload-release-asset@v1.0.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,19 +161,33 @@ jobs:
             make -j8
         shell: bash
 
-      - name: Package (Ubuntu)
+      - name: Package - AppImage (Ubuntu)
         if: startsWith(matrix.os, 'ubuntu')
         run: |
             cd build
             sh ./../.CI/CreateAppImage.sh
         shell: bash
 
-      - name: Upload artifact (Ubuntu)
+      - name: Package - .deb (Ubuntu)
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+            cd build
+            sh ./../.CI/CreateUbuntuDeb.sh
+        shell: bash
+
+      - name: Upload artifact - AppImage (Ubuntu)
         if: startsWith(matrix.os, 'ubuntu')
         uses: actions/upload-artifact@v2.2.4
         with:
           name: Chatterino-x86_64-${{ matrix.qt-version }}-${{ matrix.build-system }}.AppImage
           path: build/Chatterino-x86_64.AppImage
+
+      - name: Upload artifact - .deb (Ubuntu)
+        if: startsWith(matrix.os, 'ubuntu')
+        uses: actions/upload-artifact@v2.2.4
+        with:
+          name: Chatterino-${{ matrix.qt-version }}-${{ matrix.build-system }}.deb
+          path: build/Chatterino.deb
 
       # MACOS
       - name: Install dependencies (MacOS)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unversioned
 
 - Bugfix: Fixed "smiley" emotes being unable to be "Tabbed" with autocompletion, introduced in v2.3.3. (#3010)
+- Dev: Ubuntu packages are now available (#2936)
 
 ## 2.3.3
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->

TODO: 
 - [x] figure out deps - Chatterino starts after installing from package in a clean chroot.
   - this is what was installed when i installed chatterino (from totally clean chroot without graphical env installed)
  ```
adwaita-icon-theme at-spi2-core dbus dbus-user-session dconf-gsettings-backend dconf-service dmsetup file fontconfig fontconfig-config fonts-dejavu-core gir1.2-glib-2.0 glib-networking glib-networking-common glib-networking-services gsettings-desktop-schemas
  gtk-update-icon-cache hicolor-icon-theme humanity-icon-theme krb5-locales libapparmor1 libargon2-1 libasyncns0 libatk-bridge2.0-0 libatk1.0-0 libatk1.0-data libatspi2.0-0 libavahi-client3 libavahi-common-data libavahi-common3 libbrotli1 libbsd0 libcairo-gobject2
  libcairo2 libcap2 libcolord2 libcryptsetup12 libcups2 libdatrie1 libdbus-1-3 libdconf1 libdevmapper1.02.1 libdouble-conversion3 libdrm-amdgpu1 libdrm-common libdrm-intel1 libdrm-nouveau2 libdrm-radeon1 libdrm2 libedit2 libegl-mesa0 libegl1 libelf1 libepoxy0 libevdev2
  libexpat1 libflac8 libfontconfig1 libfreetype6 libfribidi0 libgbm1 libgdk-pixbuf2.0-0 libgdk-pixbuf2.0-bin libgdk-pixbuf2.0-common libgirepository-1.0-1 libgl1 libgl1-mesa-dri libglapi-mesa libglib2.0-0 libglib2.0-data libglvnd0 libglx-mesa0 libglx0 libgraphite2-3
  libgssapi-krb5-2 libgtk-3-0 libgtk-3-bin libgtk-3-common libgudev-1.0-0 libharfbuzz0b libice6 libicu66 libinput-bin libinput10 libip4tc2 libjbig0 libjpeg-turbo8 libjpeg8 libjson-c4 libjson-glib-1.0-0 libjson-glib-1.0-common libk5crypto3 libkeyutils1 libkmod2 libkrb5-3
  libkrb5support0 liblcms2-2 libllvm9 libmagic-mgc libmagic1 libmpdec2 libmtdev1 libnss-systemd libogg0 libpam-systemd libpango-1.0-0 libpangocairo-1.0-0 libpangoft2-1.0-0 libpciaccess0 libpcre2-16-0 libpixman-1-0 libpng16-16 libproxy1v5 libpsl5 libpulse0
  libpython3-stdlib libpython3.8-minimal libpython3.8-stdlib libqt5concurrent5 libqt5core5a libqt5dbus5 libqt5gui5 libqt5multimedia5 libqt5network5 libqt5svg5 libqt5widgets5 libreadline8 librest-0.7-0 librsvg2-2 librsvg2-common libsensors-config libsensors5 libsm6
  libsndfile1 libsoup-gnome2.4-1 libsoup2.4-1 libsqlite3-0 libthai-data libthai0 libtiff5 libvorbis0a libvorbisenc2 libvulkan1 libwacom-bin libwacom-common libwacom2 libwayland-client0 libwayland-cursor0 libwayland-egl1 libwayland-server0 libwebp6 libwrap0 libx11-6
  libx11-data libx11-xcb1 libxau6 libxcb-dri2-0 libxcb-dri3-0 libxcb-glx0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-present0 libxcb-randr0 libxcb-render-util0 libxcb-render0 libxcb-shape0 libxcb-shm0 libxcb-sync1 libxcb-util1 libxcb-xfixes0 libxcb-xinerama0
  libxcb-xinput0 libxcb-xkb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxdmcp6 libxext6 libxfixes3 libxi6 libxinerama1 libxkbcommon-x11-0 libxkbcommon0 libxml2 libxrandr2 libxrender1 libxshmfence1 libxtst6 libxxf86vm1 mesa-vulkan-drivers mime-support
  networkd-dispatcher publicsuffix python3 python3-dbus python3-gi python3-minimal python3.8 python3.8-minimal qt5-gtk-platformtheme qttranslations5-l10n readline-common shared-mime-info systemd systemd-sysv systemd-timesyncd tzdata ubuntu-mono ucf x11-common
  xdg-user-dirs xkb-data
```
 - the image of the chroot I used (packages above not included) is available at `https://kotmisia.pl/mm2pl_s_focal_chroot.img.zst`, unzstd and mount -o loop,rw, chroot
 - [x] git-describe / git-tag instead of chatterino --version
 - [x] do github actions magic
 - [x] WHY IN THE FLIP DOES THIS SEGFAULT
