### PR TITLE
fix: provide better UX for HTML color picker edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Minor: Channel name in `<channel> has gone offline. Exiting host mode.` messages is now clickable. (#2922)
 - Minor: Added `/openurl` command. Usage: `/openurl <URL>`. Opens the provided URL in the browser. (#2461, #2926)
 - Bugfix: Fixed large timeout durations in moderation buttons overlapping with usernames or other buttons. (#2865, #2921)
+- Bugfix: Fix bad behavior of the HTML color picker edit when user input is being entered. (#2942)
 
 ## 2.3.3
 

--- a/src/widgets/dialogs/ColorPickerDialog.cpp
+++ b/src/widgets/dialogs/ColorPickerDialog.cpp
@@ -365,12 +365,11 @@ void ColorPickerDialog::initHtmlColor(LayoutCreator<QWidget> &creator)
     html->addWidget(htmlLabel, 0, 0);
     html->addWidget(htmlEdit, 0, 1);
 
-    QObject::connect(htmlEdit, &QLineEdit::textEdited,
-                     [=](const QString &text) {
-                         QColor col(text);
-                         if (col.isValid())
-                             this->selectColor(col, false);
-                     });
+    QObject::connect(htmlEdit, &QLineEdit::editingFinished, [this] {
+        const QColor col(this->ui_.picker.htmlEdit->text());
+        if (col.isValid())
+            this->selectColor(col, false);
+    });
 }
 
 }  // namespace chatterino


### PR DESCRIPTION

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description
Fixes #2939. See there and the commit message for additional context.

Original commit message:

> Before this change, it was checked whether the text of the HTML color
picker line edit represents a valid color. Since the HTML color syntax
allows the format `#RGB` (see [1]), this lead to the lambda setting the
color edit to the full format string (`#RRGGBB`) whenever three
characters have been entered.
Due to the QValidator set up for the line edit, attempts to change the
text again would be rejected.
>
> With this change, validity of the color is only checked when the
`QLineEdit::editingFinished` signal is emitted. (At the time of writing,
this corresponds to "Return" being pressed or a focus loss of the line
edit.) Since the signal is only emitted when the validator approves the
input (see [2] for more information), this will never lead to the color
picker being in an inconsistent state.
>
> [1]: https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#syntax_2
> [2]: https://doc.qt.io/qt-5/qlineedit.html#editingFinished
