### PR TITLE
fix overflows in the max image size code

### DIFF
--- a/src/messages/Image.cpp
+++ b/src/messages/Image.cpp
@@ -409,7 +409,7 @@ void Image::actuallyLoad()
             // use "double" to prevent int overflows
             if (double(reader.size().width()) * double(reader.size().height()) *
                     double(reader.imageCount()) * 4.0 >
-                Image::maxBytesRam)
+                double(Image::maxBytesRam))
             {
                 qCDebug(chatterinoImage) << "image too large in RAM";
 

--- a/src/messages/Image.cpp
+++ b/src/messages/Image.cpp
@@ -406,8 +406,9 @@ void Image::actuallyLoad()
             buffer.open(QIODevice::ReadOnly);
             QImageReader reader(&buffer);
 
-            if (reader.size().width() * reader.size().height() *
-                    reader.imageCount() * 4 >
+            // use "double" to prevent int overflows
+            if (double(reader.size().width()) * double(reader.size().height()) *
+                    double(reader.imageCount()) * 4.0 >
                 Image::maxBytesRam)
             {
                 qCDebug(chatterinoImage) << "image too large in RAM";


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Fixes an integer overflow when checking for the maximum image ram usage

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
