### PR TITLE
Make usernames clickable in reward redemption messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unversioned
 
+- Minor: Username in channel points rewards redemption messages is now clickable. (#2673, #2953)
 - Minor: Channel name in `<channel> has gone offline. Exiting host mode.` messages is now clickable. (#2922)
 - Minor: Added `/openurl` command. Usage: `/openurl <URL>`. Opens the provided URL in the browser. (#2461, #2926)
 - Bugfix: Now deleting cache files that weren't modified in the past 14 days. (#2947)

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -1269,9 +1269,11 @@ void TwitchMessageBuilder::appendChannelPointRewardMessage(
     QString redeemed = "Redeemed";
     if (!reward.isUserInputRequired)
     {
-        builder->emplace<TextElement>(
-            reward.user.login, MessageElementFlag::ChannelPointReward,
-            MessageColor::Text, FontStyle::ChatMediumBold);
+        builder
+            ->emplace<TextElement>(
+                reward.user.login, MessageElementFlag::ChannelPointReward,
+                MessageColor::Text, FontStyle::ChatMediumBold)
+            ->setLink({Link::UserInfo, reward.user.login});
         redeemed = "redeemed";
     }
     builder->emplace<TextElement>(redeemed,


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description
In title.
![image](https://user-images.githubusercontent.com/43518924/124382700-6377c000-dcd1-11eb-8c39-7de14cf907e5.png)

Implements part of #2673