### PR TITLE
Fix usercards showing all messages in IRC channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Bugfix: Middle mouse click no longer scrolls in not fully populated usercards and splits. (#2933)
 - Bugfix: Fix bad behavior of the HTML color picker edit when user input is being entered. (#2942)
 - Bugfix: Fixed founder badge not being respected by `author.subbed` filter. (#2971)
+- Bugfix: Usercards on IRC will now only show user's messages. (#1780, #2979)
 
 ## 2.3.3
 

--- a/src/providers/irc/IrcMessageBuilder.cpp
+++ b/src/providers/irc/IrcMessageBuilder.cpp
@@ -74,6 +74,7 @@ void IrcMessageBuilder::appendUsername()
 
     QString username = this->userName;
     this->message().loginName = username;
+    this->message().displayName = username;
 
     // The full string that will be rendered in the chat widget
     QString usernameText = username;
@@ -85,7 +86,7 @@ void IrcMessageBuilder::appendUsername()
 
     this->emplace<TextElement>(usernameText, MessageElementFlag::Username,
                                this->usernameColor_, FontStyle::ChatMediumBold)
-        ->setLink({Link::UserInfo, this->message().displayName});
+        ->setLink({Link::UserInfo, this->message().loginName});
 }
 
 }  // namespace chatterino


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
Closes #1780. Usercards still don't have IRC-specific behavior.