### PR TITLE
Remove global third party emotes from TwitchChannel class

### DIFF
--- a/src/common/CompletionModel.cpp
+++ b/src/common/CompletionModel.cpp
@@ -148,13 +148,13 @@ void CompletionModel::refresh(const QString &prefix, bool isFirstWord)
         }
 
         // Bttv Global
-        for (auto &emote : *channel->globalBttv().emotes())
+        for (auto &emote : *getApp()->twitch2->getBttvEmotes().emotes())
         {
             addString(emote.first.string, TaggedString::Type::BTTVChannelEmote);
         }
 
         // Ffz Global
-        for (auto &emote : *channel->globalFfz().emotes())
+        for (auto &emote : *getApp()->twitch2->getFfzEmotes().emotes())
         {
             addString(emote.first.string, TaggedString::Type::FFZChannelEmote);
         }

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -144,8 +144,7 @@ namespace {
     }
 }  // namespace
 
-TwitchChannel::TwitchChannel(const QString &name, BttvEmotes &bttv,
-                             FfzEmotes &ffz)
+TwitchChannel::TwitchChannel(const QString &name)
     : Channel(name, Channel::Type::Twitch)
     , ChannelChatters(*static_cast<Channel *>(this))
     , nameOptions{name, name}
@@ -153,8 +152,6 @@ TwitchChannel::TwitchChannel(const QString &name, BttvEmotes &bttv,
     , channelUrl_("https://twitch.tv/" + name)
     , popoutPlayerUrl_("https://player.twitch.tv/?parent=twitch.tv&channel=" +
                        name)
-    , globalBttv_(bttv)
-    , globalFfz_(ffz)
     , bttvEmotes_(std::make_shared<EmoteMap>())
     , ffzEmotes_(std::make_shared<EmoteMap>())
     , mod_(false)
@@ -497,16 +494,6 @@ SharedAccessGuard<const TwitchChannel::StreamStatus>
     TwitchChannel::accessStreamStatus() const
 {
     return this->streamStatus_.accessConst();
-}
-
-const BttvEmotes &TwitchChannel::globalBttv() const
-{
-    return this->globalBttv_;
-}
-
-const FfzEmotes &TwitchChannel::globalFfz() const
-{
-    return this->globalFfz_;
 }
 
 boost::optional<EmotePtr> TwitchChannel::bttvEmote(const EmoteName &name) const

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -87,8 +87,6 @@ public:
     SharedAccessGuard<const StreamStatus> accessStreamStatus() const;
 
     // Emotes
-    const BttvEmotes &globalBttv() const;
-    const FfzEmotes &globalFfz() const;
     boost::optional<EmotePtr> bttvEmote(const EmoteName &name) const;
     boost::optional<EmotePtr> ffzEmote(const EmoteName &name) const;
     std::shared_ptr<const EmoteMap> bttvEmotes() const;
@@ -127,8 +125,7 @@ private:
     } nameOptions;
 
 protected:
-    explicit TwitchChannel(const QString &channelName, BttvEmotes &globalBttv,
-                           FfzEmotes &globalFfz);
+    explicit TwitchChannel(const QString &channelName);
 
 private:
     // Methods
@@ -162,8 +159,6 @@ private:
     UniqueAccess<RoomModes> roomModes_;
 
 protected:
-    BttvEmotes &globalBttv_;
-    FfzEmotes &globalFfz_;
     Atomic<std::shared_ptr<const EmoteMap>> bttvEmotes_;
     Atomic<std::shared_ptr<const EmoteMap>> ffzEmotes_;
     Atomic<boost::optional<EmotePtr>> ffzCustomModBadge_;

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -90,8 +90,8 @@ void TwitchIrcServer::initializeConnection(IrcConnection *connection,
 std::shared_ptr<Channel> TwitchIrcServer::createChannel(
     const QString &channelName)
 {
-    auto channel = std::shared_ptr<TwitchChannel>(
-        new TwitchChannel(channelName, this->bttv, this->ffz));
+    auto channel =
+        std::shared_ptr<TwitchChannel>(new TwitchChannel(channelName));
     channel->initialize();
 
     channel->sendMessageSignal.connect(

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -7,6 +7,7 @@
 #include "messages/Message.hpp"
 #include "messages/MessageBuilder.hpp"
 #include "providers/twitch/TwitchChannel.hpp"
+#include "providers/twitch/TwitchIrcServer.hpp"
 #include "singletons/Emotes.hpp"
 #include "singletons/WindowManager.hpp"
 #include "util/Shortcut.hpp"
@@ -229,9 +230,9 @@ void EmotePopup::loadChannel(ChannelPtr _channel)
         *globalChannel, *subChannel, _channel->getName());
 
     // global
-    addEmotes(*globalChannel, *twitchChannel->globalBttv().emotes(),
+    addEmotes(*globalChannel, *getApp()->twitch2->getBttvEmotes().emotes(),
               "BetterTTV", MessageElementFlag::BttvEmote);
-    addEmotes(*globalChannel, *twitchChannel->globalFfz().emotes(),
+    addEmotes(*globalChannel, *getApp()->twitch2->getFfzEmotes().emotes(),
               "FrankerFaceZ", MessageElementFlag::FfzEmote);
 
     // channel

--- a/src/widgets/splits/InputCompletionPopup.cpp
+++ b/src/widgets/splits/InputCompletionPopup.cpp
@@ -104,9 +104,9 @@ void InputCompletionPopup::updateEmotes(const QString &text, ChannelPtr channel)
             if (auto ffz = tc->ffzEmotes())
                 addEmotes(emotes, *ffz, text, "Channel FrankerFaceZ");
 
-            if (auto bttvG = tc->globalBttv().emotes())
+            if (auto bttvG = getApp()->twitch2->getBttvEmotes().emotes())
                 addEmotes(emotes, *bttvG, text, "Global BetterTTV");
-            if (auto ffzG = tc->globalFfz().emotes())
+            if (auto ffzG = getApp()->twitch2->getFfzEmotes().emotes())
                 addEmotes(emotes, *ffzG, text, "Global FrankerFaceZ");
         }
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Closes #2998
