### PR TITLE
Use server time in received IRC messages where available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unversioned
 
+- Minor: Received Twitch messages now use the exact same timestamp (obtained from Twitch's server) for every Chatterino user instead of assuming message timestamp on client's side. (#3021)
+- Minor: Received IRC messages use `time` message tag for timestamp if it's available. (#3021)
+
 ## 2.3.3
 
 - Major: Added username autocompletion popup menu when typing usernames with an @ prefix. (#1979, #2866)

--- a/src/providers/irc/IrcMessageBuilder.cpp
+++ b/src/providers/irc/IrcMessageBuilder.cpp
@@ -40,7 +40,8 @@ MessagePtr IrcMessageBuilder::build()
     // PUSH ELEMENTS
     this->appendChannelName();
 
-    this->emplace<TimestampElement>();
+    this->emplace<TimestampElement>(
+        calculateMessageTimestamp(this->ircMessage));
 
     this->appendUsername();
 
@@ -70,8 +71,6 @@ void IrcMessageBuilder::addWords(const QStringList &words)
 
 void IrcMessageBuilder::appendUsername()
 {
-    auto app = getApp();
-
     QString username = this->userName;
     this->message().loginName = username;
     this->message().displayName = username;

--- a/src/providers/irc/IrcServer.cpp
+++ b/src/providers/irc/IrcServer.cpp
@@ -9,6 +9,7 @@
 #include "providers/irc/IrcChannel2.hpp"
 #include "providers/irc/IrcMessageBuilder.hpp"
 #include "singletons/Settings.hpp"
+#include "util/IrcHelpers.hpp"
 #include "util/QObjectRef.hpp"
 
 #include <QMetaEnum>
@@ -92,7 +93,8 @@ void IrcServer::initializeConnectionSignals(IrcConnection *connection,
                          // XD PAJLADA
                          MessageBuilder builder;
 
-                         builder.emplace<TimestampElement>();
+                         builder.emplace<TimestampElement>(
+                             calculateMessageTimestamp(message));
                          builder.emplace<TextElement>(
                              message->nick(), MessageElementFlag::Username);
                          builder.emplace<TextElement>(
@@ -259,7 +261,8 @@ void IrcServer::readConnectionMessageReceived(Communi::IrcMessage *message)
             {
                 MessageBuilder builder;
 
-                builder.emplace<TimestampElement>();
+                builder.emplace<TimestampElement>(
+                    calculateMessageTimestamp(message));
                 builder.emplace<TextElement>(message->toData(),
                                              MessageElementFlag::Text);
                 builder->flags.set(MessageFlag::Debug);

--- a/src/util/IrcHelpers.hpp
+++ b/src/util/IrcHelpers.hpp
@@ -75,7 +75,7 @@ inline QTime calculateMessageTimestamp(const Communi::IrcMessage *message)
         return QDateTime::fromMSecsSinceEpoch(ts).time();
     }
 
-    // If present, handle tmi-sent-ts tag and use it as for timestamp
+    // If present, handle tmi-sent-ts tag and use it as timestamp
     if (message->tags().contains("tmi-sent-ts"))
     {
         auto ts = message->tags().value("tmi-sent-ts").toLongLong();

--- a/src/util/IrcHelpers.hpp
+++ b/src/util/IrcHelpers.hpp
@@ -65,7 +65,7 @@ inline QTime calculateMessageTimestamp(const Communi::IrcMessage *message)
     if (message->tags().contains("historical"))
     {
         bool customReceived = false;
-        qint64 ts =
+        auto ts =
             message->tags().value("rm-received-ts").toLongLong(&customReceived);
         if (!customReceived)
         {
@@ -74,10 +74,27 @@ inline QTime calculateMessageTimestamp(const Communi::IrcMessage *message)
 
         return QDateTime::fromMSecsSinceEpoch(ts).time();
     }
-    else
+
+    // If present, handle tmi-sent-ts tag and use it as for timestamp
+    if (message->tags().contains("tmi-sent-ts"))
     {
-        return QTime::currentTime();
+        auto ts = message->tags().value("tmi-sent-ts").toLongLong();
+        return QDateTime::fromMSecsSinceEpoch(ts).time();
     }
+
+    // Some IRC Servers might have server-time tag containing UTC date in ISO format, use it as timestamp
+    // See: https://ircv3.net/irc/#server-time
+    if (message->tags().contains("time"))
+    {
+        QString timedate = message->tags().value("time").toString();
+
+        auto date = QDateTime::fromString(timedate, Qt::ISODate);
+        date.setTimeSpec(Qt::TimeSpec::UTC);
+        return date.toLocalTime().time();
+    }
+
+    // Fallback to current time
+    return QTime::currentTime();
 }
 
 }  // namespace chatterino


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

### Twitch-related changes

Use `tmi-sent-ts` if it's present for timestamp value. This will make timestamp values equal for everyone - before, it used `QTime::currentTime()`, which could vary by around 100-200ms for everyone and was rather inconsistent (as opposed to recent-messages, where timestamp value is equal to everyone).

### IRC-related changes
We check for IRCv3's [server-time](https://ircv3.net/irc/#server-time), which is according to its specification a message tag `"time"`, containing a proper ISO date (in UTC format). If the tag is available, we use it instead of `QTime::currentTime();`.