### PR TITLE
Fix crash and completion in other special channels than /whispers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unversioned
 
 - Major: Newly uploaded Twitch emotes are once again present in emote picker and can be autocompleted with Tab as well. (#2992)
-- Minor: Added autocompletion in /whispers for Twitch emotes, Global Bttv/Ffz emotes and emojis. (#2999)
+- Minor: Added autocompletion in /whispers for Twitch emotes, Global Bttv/Ffz emotes and emojis. (#2999, #3033)
 - Minor: Received Twitch messages now use the exact same timestamp (obtained from Twitch's server) for every Chatterino user instead of assuming message timestamp on client's side. (#3021)
 - Minor: Received IRC messages use `time` message tag for timestamp if it's available. (#3021)
 - Bugfix: Fixed "smiley" emotes being unable to be "Tabbed" with autocompletion, introduced in v2.3.3. (#3010)

--- a/src/widgets/splits/InputCompletionPopup.cpp
+++ b/src/widgets/splits/InputCompletionPopup.cpp
@@ -75,8 +75,8 @@ void InputCompletionPopup::updateEmotes(const QString &text, ChannelPtr channel)
 {
     std::vector<_Emote> emotes;
     auto tc = dynamic_cast<TwitchChannel *>(channel.get());
-    auto wc = channel.get()->getType() == Channel::Type::TwitchWhispers;
-    if (tc || wc)
+    // returns true also for special Twitch channels (/live, /mentions, /whispers, etc.)
+    if (channel->isTwitchChannel())
     {
         if (auto user = getApp()->accounts->twitch.getCurrent())
         {
@@ -86,7 +86,8 @@ void InputCompletionPopup::updateEmotes(const QString &text, ChannelPtr channel)
 
             // Twitch Emotes available locally
             auto localEmoteData = user->accessLocalEmotes();
-            if (localEmoteData->find(tc->roomId()) != localEmoteData->end())
+            if (tc &&
+                localEmoteData->find(tc->roomId()) != localEmoteData->end())
             {
                 if (auto localEmotes = &localEmoteData->at(tc->roomId()))
                 {
@@ -103,12 +104,12 @@ void InputCompletionPopup::updateEmotes(const QString &text, ChannelPtr channel)
                 addEmotes(emotes, *bttv, text, "Channel BetterTTV");
             if (auto ffz = tc->ffzEmotes())
                 addEmotes(emotes, *ffz, text, "Channel FrankerFaceZ");
-
-            if (auto bttvG = getApp()->twitch2->getBttvEmotes().emotes())
-                addEmotes(emotes, *bttvG, text, "Global BetterTTV");
-            if (auto ffzG = getApp()->twitch2->getFfzEmotes().emotes())
-                addEmotes(emotes, *ffzG, text, "Global FrankerFaceZ");
         }
+
+        if (auto bttvG = getApp()->twitch2->getBttvEmotes().emotes())
+            addEmotes(emotes, *bttvG, text, "Global BetterTTV");
+        if (auto ffzG = getApp()->twitch2->getFfzEmotes().emotes())
+            addEmotes(emotes, *ffzG, text, "Global FrankerFaceZ");
 
         addEmojis(emotes, getApp()->emotes->emojis.emojis, text);
     }

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -464,8 +464,7 @@ void SplitInput::updateCompletionPopup()
     auto channel = this->split_->getChannel().get();
     auto tc = dynamic_cast<TwitchChannel *>(channel);
     bool showEmoteCompletion =
-        getSettings()->emoteCompletionWithColon &&
-        (tc || (channel->getType() == Channel::Type::TwitchWhispers));
+        channel->isTwitchChannel() && getSettings()->emoteCompletionWithColon;
     bool showUsernameCompletion =
         tc && getSettings()->showUsernameCompletionMenu;
     if (!showEmoteCompletion && !showUsernameCompletion)


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

In #2999 I didn't include Global third-party (I think it's due to a fauly resolve of a merge conflict). Confirmed it works now 👍
In #2951 I introduced a crash upon trying to bring up `InputCompletionPopup`. Confirmed it doesn't crash now.
Also made it, so `InputCompletionPopup` is brought up while typing in special Twitch channels other than `#/whispers`. So it's basically an extension of #2999.

Closes #3032
