### PR TITLE
Pin down libcommuni's branch we're using

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "lib/libcommuni"]
 	path = lib/libcommuni
 	url = https://github.com/Chatterino/libcommuni
+	branch = chatterino-cmake
 [submodule "lib/qBreakpad"]
 	path = lib/qBreakpad
 	url = https://github.com/jiakuan/qBreakpad.git


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Just so silly dependabot won't try to remove our cmake stuff
