### PR TITLE
updated BUILDING_ON_LINUX to include chromebook

### DIFF
--- a/BUILDING_ON_LINUX.md
+++ b/BUILDING_ON_LINUX.md
@@ -81,3 +81,11 @@ _`gstreamer-plugins-good` package is retired in Fedora 31, see: [rhbz#1735324](h
 ### Using CMake
 
 1. `cmake .. && make`
+
+
+## chromebook using Debian 10
+1. On your Chromebook, at the bottom right, select the time.
+2. Select Settings  and then Advanced and then Developers.
+3. Next to "Linux development environment," select Turn On.
+4. Follow the on-screen instructions.
+5. follow the ubuntu instructions. https://github.com/Chatterino/chatterino2/blob/master/BUILDING_ON_LINUX.md#ubuntu-1804


### PR DESCRIPTION
Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable

# Description
as they use a Debian 10 environment  https://support.google.com/chromebook/answer/9145439 was wondering if we should have a  BUILDING_ON_CHROMEBOOK section or keep it here
<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
