### PR TITLE
Check for ignored phrases/users in channel point redemptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Bugfix: Copy buttons in usercard now show properly in light mode (#3057)
 - Bugfix: Fixed comma appended to username completion when not at the beginning of the message. (#3060)
 - Bugfix: Fixed bug misplacing chat when zooming on Chrome with Chatterino Native Host extension (#1936)
+- Bugfix: Channel point redemptions from ignored users are now properly blocked. (#3102)
 - Dev: Ubuntu packages are now available (#2936)
 - Dev: Disabled update checker on Flatpak. (#3051)
 - Dev: Add logging for HTTP requests (#2991)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,7 @@ else()
     add_subdirectory("${CMAKE_SOURCE_DIR}/lib/settings" EXCLUDE_FROM_ALL)
 endif()
 
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if (BUILD_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,7 @@ else()
     add_subdirectory("${CMAKE_SOURCE_DIR}/lib/settings" EXCLUDE_FROM_ALL)
 endif()
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if (BUILD_TESTS)

--- a/chatterino.pro
+++ b/chatterino.pro
@@ -159,6 +159,7 @@ SOURCES += \
     src/controllers/highlights/HighlightModel.cpp \
     src/controllers/highlights/HighlightPhrase.cpp \
     src/controllers/highlights/UserHighlightModel.cpp \
+    src/controllers/ignores/IgnoreController.cpp \
     src/controllers/ignores/IgnoreModel.cpp \
     src/controllers/moderationactions/ModerationAction.cpp \
     src/controllers/moderationactions/ModerationActionModel.cpp \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -88,6 +88,8 @@ set(SOURCE_FILES
         controllers/highlights/UserHighlightModel.cpp
         controllers/highlights/UserHighlightModel.hpp
 
+        controllers/ignores/IgnoreController.cpp
+        controllers/ignores/IgnoreController.hpp
         controllers/ignores/IgnoreModel.cpp
         controllers/ignores/IgnoreModel.hpp
 

--- a/src/controllers/ignores/IgnoreController.cpp
+++ b/src/controllers/ignores/IgnoreController.cpp
@@ -1,0 +1,63 @@
+#include "controllers/ignores/IgnoreController.hpp"
+
+#include "common/QLogging.hpp"
+#include "controllers/ignores/IgnorePhrase.hpp"
+#include "singletons/Settings.hpp"
+
+namespace chatterino {
+
+bool isIgnoredMessage(IgnoredMessageParameters &&params)
+{
+    if (!params.message.isEmpty())
+    {
+        // TODO(pajlada): Do we need to check if the phrase is valid first?
+        auto phrases = getCSettings().ignoredMessages.readOnly();
+        for (const auto &phrase : *phrases)
+        {
+            if (phrase.isBlock() && phrase.isMatch(params.message))
+            {
+                qCDebug(chatterinoMessage)
+                    << "Blocking message because it contains ignored phrase"
+                    << phrase.getPattern();
+                return true;
+            }
+        }
+    }
+
+    if (!params.twitchUserID.isEmpty() &&
+        getSettings()->enableTwitchBlockedUsers)
+    {
+        auto sourceUserID = params.twitchUserID;
+
+        auto blocks =
+            getApp()->accounts->twitch.getCurrent()->accessBlockedUserIds();
+
+        if (auto it = blocks->find(sourceUserID); it != blocks->end())
+        {
+            switch (static_cast<ShowIgnoredUsersMessages>(
+                getSettings()->showBlockedUsersMessages.getValue()))
+            {
+                case ShowIgnoredUsersMessages::IfModerator:
+                    if (params.isMod || params.isBroadcaster)
+                    {
+                        return false;
+                    }
+                    break;
+                case ShowIgnoredUsersMessages::IfBroadcaster:
+                    if (params.isBroadcaster)
+                    {
+                        return false;
+                    }
+                    break;
+                case ShowIgnoredUsersMessages::Never:
+                    break;
+            }
+
+            return true;
+        }
+    }
+
+    return false;
+}
+
+}  // namespace chatterino

--- a/src/controllers/ignores/IgnoreController.hpp
+++ b/src/controllers/ignores/IgnoreController.hpp
@@ -1,7 +1,19 @@
 #pragma once
 
+#include <QString>
+
 namespace chatterino {
 
 enum class ShowIgnoredUsersMessages { Never, IfModerator, IfBroadcaster };
+
+struct IgnoredMessageParameters {
+    QString message;
+
+    QString twitchUserID;
+    bool isMod;
+    bool isBroadcaster;
+};
+
+bool isIgnoredMessage(IgnoredMessageParameters &&params);
 
 }  // namespace chatterino

--- a/src/messages/SharedMessageBuilder.cpp
+++ b/src/messages/SharedMessageBuilder.cpp
@@ -2,6 +2,7 @@
 
 #include "Application.hpp"
 #include "common/QLogging.hpp"
+#include "controllers/ignores/IgnoreController.hpp"
 #include "controllers/ignores/IgnorePhrase.hpp"
 #include "messages/Message.hpp"
 #include "messages/MessageElement.hpp"
@@ -104,20 +105,9 @@ void SharedMessageBuilder::parse()
 
 bool SharedMessageBuilder::isIgnored() const
 {
-    // TODO(pajlada): Do we need to check if the phrase is valid first?
-    auto phrases = getCSettings().ignoredMessages.readOnly();
-    for (const auto &phrase : *phrases)
-    {
-        if (phrase.isBlock() && phrase.isMatch(this->originalMessage_))
-        {
-            qCDebug(chatterinoMessage)
-                << "Blocking message because it contains ignored phrase"
-                << phrase.getPattern();
-            return true;
-        }
-    }
-
-    return false;
+    return isIgnoredMessage({
+        .message = this->originalMessage_,
+    });
 }
 
 void SharedMessageBuilder::parseUsernameColor()

--- a/src/messages/SharedMessageBuilder.cpp
+++ b/src/messages/SharedMessageBuilder.cpp
@@ -106,7 +106,7 @@ void SharedMessageBuilder::parse()
 bool SharedMessageBuilder::isIgnored() const
 {
     return isIgnoredMessage({
-        .message = this->originalMessage_,
+        /*.message = */ this->originalMessage_,
     });
 }
 

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -286,7 +286,8 @@ void TwitchChannel::addChannelPointReward(const ChannelPointReward &reward)
     if (!reward.isUserInputRequired)
     {
         MessageBuilder builder;
-        TwitchMessageBuilder::appendChannelPointRewardMessage(reward, &builder);
+        TwitchMessageBuilder::appendChannelPointRewardMessage(
+            reward, &builder, this->isMod(), this->isBroadcaster());
         this->addMessage(builder.release());
         return;
     }

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -114,44 +114,12 @@ TwitchMessageBuilder::TwitchMessageBuilder(
 
 bool TwitchMessageBuilder::isIgnored() const
 {
-    if (SharedMessageBuilder::isIgnored())
-    {
-        return true;
-    }
-
-    auto app = getApp();
-
-    if (getSettings()->enableTwitchBlockedUsers &&
-        this->tags.contains("user-id"))
-    {
-        auto sourceUserID = this->tags.value("user-id").toString();
-
-        auto blocks =
-            app->accounts->twitch.getCurrent()->accessBlockedUserIds();
-
-        if (auto it = blocks->find(sourceUserID); it != blocks->end())
-        {
-            switch (static_cast<ShowIgnoredUsersMessages>(
-                getSettings()->showBlockedUsersMessages.getValue()))
-            {
-                case ShowIgnoredUsersMessages::IfModerator:
-                    if (this->channel->isMod() ||
-                        this->channel->isBroadcaster())
-                        return false;
-                    break;
-                case ShowIgnoredUsersMessages::IfBroadcaster:
-                    if (this->channel->isBroadcaster())
-                        return false;
-                    break;
-                case ShowIgnoredUsersMessages::Never:
-                    break;
-            }
-
-            return true;
-        }
-    }
-
-    return false;
+    return isIgnoredMessage({
+        .message = this->originalMessage_,
+        .twitchUserID = this->tags.value("user-id").toString(),
+        .isMod = this->channel->isMod(),
+        .isBroadcaster = this->channel->isBroadcaster(),
+    });
 }
 
 void TwitchMessageBuilder::triggerHighlights()
@@ -190,7 +158,9 @@ MessagePtr TwitchMessageBuilder::build()
             this->args.channelPointRewardId);
         if (reward)
         {
-            this->appendChannelPointRewardMessage(reward.get(), this);
+            this->appendChannelPointRewardMessage(
+                reward.get(), this, this->channel->isMod(),
+                this->channel->isBroadcaster());
         }
     }
 
@@ -1261,8 +1231,18 @@ Outcome TwitchMessageBuilder::tryParseCheermote(const QString &string)
 }
 
 void TwitchMessageBuilder::appendChannelPointRewardMessage(
-    const ChannelPointReward &reward, MessageBuilder *builder)
+    const ChannelPointReward &reward, MessageBuilder *builder, bool isMod,
+    bool isBroadcaster)
 {
+    if (isIgnoredMessage({
+            .twitchUserID = reward.user.id,
+            .isMod = isMod,
+            .isBroadcaster = isBroadcaster,
+        }))
+    {
+        return;
+    }
+
     builder->emplace<TimestampElement>();
     QString redeemed = "Redeemed";
     QStringList textList;

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -115,10 +115,10 @@ TwitchMessageBuilder::TwitchMessageBuilder(
 bool TwitchMessageBuilder::isIgnored() const
 {
     return isIgnoredMessage({
-        .message = this->originalMessage_,
-        .twitchUserID = this->tags.value("user-id").toString(),
-        .isMod = this->channel->isMod(),
-        .isBroadcaster = this->channel->isBroadcaster(),
+        /*.message = */ this->originalMessage_,
+        /*.twitchUserID = */ this->tags.value("user-id").toString(),
+        /*.isMod = */ this->channel->isMod(),
+        /*.isBroadcaster = */ this->channel->isBroadcaster(),
     });
 }
 
@@ -1235,9 +1235,10 @@ void TwitchMessageBuilder::appendChannelPointRewardMessage(
     bool isBroadcaster)
 {
     if (isIgnoredMessage({
-            .twitchUserID = reward.user.id,
-            .isMod = isMod,
-            .isBroadcaster = isBroadcaster,
+            /*.message = */ "",
+            /*.twitchUserID = */ reward.user.id,
+            /*.isMod = */ isMod,
+            /*.isBroadcaster = */ isBroadcaster,
         }))
     {
         return;

--- a/src/providers/twitch/TwitchMessageBuilder.hpp
+++ b/src/providers/twitch/TwitchMessageBuilder.hpp
@@ -46,7 +46,8 @@ public:
     MessagePtr build() override;
 
     static void appendChannelPointRewardMessage(
-        const ChannelPointReward &reward, MessageBuilder *builder);
+        const ChannelPointReward &reward, MessageBuilder *builder, bool isMod,
+        bool isBroadcaster);
 
     // Message in the /live chat for channel going live
     static void liveMessage(const QString &channelName,


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Dev note:
Because a channel point message is contextless (i.e. has no channel attached), we have to attach the relevant parameters to the function call itself. The alternative to this would be to make the function non-static, but we'd have to rework TwitchMessageBuilder and SharedMessageBuilder to work with a null ircmessage which is not something I want to do.

Fixes #3098
