### PR TITLE
Prepare CMake for Qt6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Minor: Remove TwitchEmotes.com attribution and the open/copy options when right-clicking a Twitch Emote. (#2214, #3136)
 - Bugfix: Moderation mode and active filters are now preserved when opening a split as a popup. (#3113, #3130)
 - Bugfix: Fixed a bug that caused all badge highlights to use the same color. (#3132, #3134)
+- Dev: Renamed CMake's build option `USE_SYSTEM_QT5KEYCHAIN` to `USE_SYSTEM_QTKEYCHAIN`. (#3103)
 
 ## 2.3.4
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,10 +13,17 @@ option(BUILD_APP "Build Chatterino" ON)
 option(BUILD_TESTS "Build the tests for Chatterino" OFF)
 option(USE_SYSTEM_PAJLADA_SETTINGS "Use system pajlada settings library" OFF)
 option(USE_SYSTEM_LIBCOMMUNI "Use system communi library" OFF)
-option(USE_SYSTEM_QT5KEYCHAIN "Use system Qt5Keychain library" OFF)
+option(USE_SYSTEM_QTKEYCHAIN "Use system QtKeychain library" OFF)
 option(USE_PRECOMPILED_HEADERS "Use precompiled headers" ON)
+option(BUILD_WITH_QT6 "Use Qt6 instead of default Qt5" OFF)
 
 option(USE_CONAN "Use conan" OFF)
+
+if (BUILD_WITH_QT6)
+    set(MAJOR_QT_VERSION "6")
+else()
+    set(MAJOR_QT_VERSION "5")
+endif()
 
 if (USE_CONAN OR CONAN_EXPORTED)
     include(${CMAKE_CURRENT_BINARY_DIR}/conanbuildinfo.cmake)
@@ -31,7 +38,7 @@ endif ()
 
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/GIT.cmake)
 
-find_package(Qt5 REQUIRED
+find_package(Qt${MAJOR_QT_VERSION} REQUIRED
     COMPONENTS
     Core
     Widgets
@@ -72,17 +79,17 @@ endif()
 # Link QtKeychain statically
 option(QTKEYCHAIN_STATIC "" ON)
 
-if (USE_SYSTEM_QT5KEYCHAIN)
-    find_package(Qt5Keychain REQUIRED)
+if (USE_SYSTEM_QTKEYCHAIN)
+    find_package(Qt${MAJOR_QT_VERSION}Keychain REQUIRED)
 else()
-    set(QT5KEYCHAIN_ROOT_LIB_FOLDER "${CMAKE_SOURCE_DIR}/lib/qtkeychain")
-    if (NOT EXISTS "${QT5KEYCHAIN_ROOT_LIB_FOLDER}/CMakeLists.txt")
+    set(QTKEYCHAIN_ROOT_LIB_FOLDER "${CMAKE_SOURCE_DIR}/lib/qtkeychain")
+    if (NOT EXISTS "${QTKEYCHAIN_ROOT_LIB_FOLDER}/CMakeLists.txt")
         message(FATAL_ERROR "Submodules probably not loaded, unable to find lib/qtkeychain/CMakeLists.txt")
     endif()
 
-    add_subdirectory("${QT5KEYCHAIN_ROOT_LIB_FOLDER}" EXCLUDE_FROM_ALL)
-    if (NOT TARGET qt5keychain)
-        message(FATAL_ERROR "qt5keychain target was not created :@")
+    add_subdirectory("${QTKEYCHAIN_ROOT_LIB_FOLDER}" EXCLUDE_FROM_ALL)
+    if (NOT TARGET qt${MAJOR_QT_VERSION}keychain)
+        message(FATAL_ERROR "qt${MAJOR_QT_VERSION}keychain target was not created :@")
     endif()
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -482,16 +482,16 @@ add_library(${LIBRARY_PROJECT} OBJECT ${SOURCE_FILES})
 
 target_link_libraries(${LIBRARY_PROJECT}
         PUBLIC
-        Qt5::Core
-        Qt5::Widgets
-        Qt5::Gui
-        Qt5::Network
-        Qt5::Multimedia
-        Qt5::Svg
-        Qt5::Concurrent
+        Qt${MAJOR_QT_VERSION}::Core
+        Qt${MAJOR_QT_VERSION}::Widgets
+        Qt${MAJOR_QT_VERSION}::Gui
+        Qt${MAJOR_QT_VERSION}::Network
+        Qt${MAJOR_QT_VERSION}::Multimedia
+        Qt${MAJOR_QT_VERSION}::Svg
+        Qt${MAJOR_QT_VERSION}::Concurrent
 
         LibCommuni::LibCommuni
-        qt5keychain
+        qt${MAJOR_QT_VERSION}keychain
         Pajlada::Serialize
         Pajlada::Settings
         Pajlada::Signals
@@ -520,8 +520,8 @@ if (BUILD_APP)
         )
 
     if (MSVC)
-        get_target_property(Qt5_Core_Location Qt5::Core LOCATION)
-        get_filename_component(QT_BIN_DIR ${Qt5_Core_Location} DIRECTORY)
+        get_target_property(Qt_Core_Location Qt${MAJOR_QT_VERSION}::Core LOCATION)
+        get_filename_component(QT_BIN_DIR ${Qt_Core_Location} DIRECTORY)
         set(WINDEPLOYQT_COMMAND "${QT_BIN_DIR}/windeployqt.exe" $<TARGET_FILE:${EXECUTABLE_PROJECT}> --release --no-compiler-runtime --no-translations --no-opengl-sw)
 
         install(TARGETS ${EXECUTABLE_PROJECT}
@@ -578,7 +578,7 @@ target_compile_definitions(${LIBRARY_PROJECT} PUBLIC
     CHATTERINO_GIT_RELEASE=\"${GIT_RELEASE}\"
     CHATTERINO_GIT_COMMIT=\"${GIT_COMMIT}\"
     )
-if (USE_SYSTEM_QT5KEYCHAIN)
+if (USE_SYSTEM_QTKEYCHAIN)
     target_compile_definitions(${LIBRARY_PROJECT} PUBLIC
         CMAKE_BUILD
         )


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Renamed variables of QT5KEYCHAIN to just QTKEYCHAIN due to how qt keychain library changes its target name from `qt5keychain` to `qt6keychain` if we build against Qt6.

⚠ Important note: qtkeychain already uses `BUILD_WITH_QT6` CMake parameter, so I thought it would be convenient to just reuse that. No idea if that's a bad practice to use one variable/option that affects multiple things at once, but pretty sure that in this scope it wouldn't change anything.

Required for Chatterino/libcommuni#2
