### PR TITLE
Allow building against Qt 5.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Bugfix: Fixed comma appended to username completion when not at the beginning of the message. (#3060)
 - Bugfix: Fixed bug misplacing chat when zooming on Chrome with Chatterino Native Host extension (#1936)
 - Bugfix: Channel point redemptions from ignored users are now properly blocked. (#3102)
+- Dev: Allow building against Qt 5.11 (#3105)
 - Dev: Ubuntu packages are now available (#2936)
 - Dev: Disabled update checker on Flatpak. (#3051)
 - Dev: Add logging for HTTP requests (#2991)

--- a/chatterino.pro
+++ b/chatterino.pro
@@ -14,7 +14,7 @@ CCACHE_BIN = $$system(which ccache)
   CONFIG+=ccache
 }
 
-MINIMUM_REQUIRED_QT_VERSION = 5.12.0
+MINIMUM_REQUIRED_QT_VERSION = 5.11.0
 
 !versionAtLeast(QT_VERSION, $$MINIMUM_REQUIRED_QT_VERSION) {
     error("You're trying to compile with Qt $$QT_VERSION, but minimum required Qt version is $$MINIMUM_REQUIRED_QT_VERSION")

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -134,14 +134,18 @@ void SplitInput::themeChangedEvent()
     QPalette palette, placeholderPalette;
 
     palette.setColor(QPalette::WindowText, this->theme->splits.input.text);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 12, 0))
     placeholderPalette.setColor(
         QPalette::PlaceholderText,
         this->theme->messages.textColors.chatPlaceholder);
+#endif
 
     this->updateEmoteButton();
     this->ui_.textEditLength->setPalette(palette);
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 12, 0))
     this->ui_.textEdit->setPalette(placeholderPalette);
+#endif
     this->ui_.textEdit->setStyleSheet(this->theme->splits.input.styleSheet);
 
     this->ui_.hbox->setMargin(


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Current stable debian Linux is Buster, which still ships Qt 5.11.3, so I've had this patch to build chatterino locally, for the last several months.
Since `QPalette::placeholderText` seems to be the only codebase feature depending on QT 5.12, the build has been running perfectly fine.
The Qt docs say
> Before Qt 5.12, the placeholder text color was hard-coded in the code as QPalette::text().color() where an alpha of 128 was applied.

and based on my testing, theme changes look just fine.