### PR TITLE
Fix filter crash introduced in #3092

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Minor: Added informative messages for recent-messages API's errors. (#3029)
 - Minor: Added section with helpful Chatterino-related links to the About page. (#3068)
 - Minor: Now uses spaces instead of magic Unicode character for sending duplicate messages (#3081)
-- Minor: Added `channel.live` filter variable (#3092)
+- Minor: Added `channel.live` filter variable (#3092, #3110)
 - Bugfix: Fixed "smiley" emotes being unable to be "Tabbed" with autocompletion, introduced in v2.3.3. (#3010)
 - Bugfix: Fixed PubSub not properly trying to resolve pending listens when the pending listens list was larger than 50. (#3037)
 - Bugfix: Copy buttons in usercard now show properly in light mode (#3057)

--- a/src/controllers/filters/FilterRecord.hpp
+++ b/src/controllers/filters/FilterRecord.hpp
@@ -60,11 +60,6 @@ public:
         return this->parser_->valid();
     }
 
-    bool filter(const MessagePtr &message) const
-    {
-        return this->parser_->execute(message);
-    }
-
     bool filter(const filterparser::ContextMap &context) const
     {
         return this->parser_->execute(context);

--- a/src/controllers/filters/FilterSet.hpp
+++ b/src/controllers/filters/FilterSet.hpp
@@ -36,12 +36,13 @@ public:
         this->listener_.disconnect();
     }
 
-    bool filter(const MessagePtr &m) const
+    bool filter(const MessagePtr &m, ChannelPtr channel) const
     {
         if (this->filters_.size() == 0)
             return true;
 
-        filterparser::ContextMap context = filterparser::buildContextMap(m);
+        filterparser::ContextMap context =
+            filterparser::buildContextMap(m, channel.get());
         for (const auto &f : this->filters_.values())
         {
             if (!f->valid() || !f->filter(context))

--- a/src/controllers/filters/parser/FilterParser.cpp
+++ b/src/controllers/filters/parser/FilterParser.cpp
@@ -1,12 +1,13 @@
 #include "FilterParser.hpp"
 
 #include "Application.hpp"
+#include "common/Channel.hpp"
 #include "controllers/filters/parser/Types.hpp"
 #include "providers/twitch/TwitchIrcServer.hpp"
 
 namespace filterparser {
 
-ContextMap buildContextMap(const MessagePtr &m)
+ContextMap buildContextMap(const MessagePtr &m, chatterino::Channel *channel)
 {
     auto watchingChannel =
         chatterino::getApp()->twitch.server->watchingChannel.get();
@@ -83,9 +84,8 @@ ContextMap buildContextMap(const MessagePtr &m)
     };
     {
         using namespace chatterino;
-        auto channel = getApp()->twitch2->getChannelOrEmpty(m->channelName);
-        auto *tc = dynamic_cast<TwitchChannel *>(channel.get());
-        if (!channel->isEmpty() && tc)
+        auto *tc = dynamic_cast<TwitchChannel *>(channel);
+        if (channel && !channel->isEmpty() && tc)
         {
             vars["channel.live"] = tc->isLive();
         }
@@ -102,12 +102,6 @@ FilterParser::FilterParser(const QString &text)
     , tokenizer_(Tokenizer(text))
     , builtExpression_(this->parseExpression(true))
 {
-}
-
-bool FilterParser::execute(const MessagePtr &message) const
-{
-    auto context = buildContextMap(message);
-    return this->execute(context);
 }
 
 bool FilterParser::execute(const ContextMap &context) const

--- a/src/controllers/filters/parser/FilterParser.hpp
+++ b/src/controllers/filters/parser/FilterParser.hpp
@@ -3,15 +3,20 @@
 #include "controllers/filters/parser/Tokenizer.hpp"
 #include "controllers/filters/parser/Types.hpp"
 
+namespace chatterino {
+
+class Channel;
+
+}  // namespace chatterino
+
 namespace filterparser {
 
-ContextMap buildContextMap(const MessagePtr &m);
+ContextMap buildContextMap(const MessagePtr &m, chatterino::Channel *channel);
 
 class FilterParser
 {
 public:
     FilterParser(const QString &text);
-    bool execute(const MessagePtr &message) const;
     bool execute(const ContextMap &context) const;
     bool valid() const;
 

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -754,7 +754,7 @@ bool ChannelView::shouldIncludeMessage(const MessagePtr &m) const
                 m->loginName, Qt::CaseInsensitive) == 0)
             return true;
 
-        return this->channelFilters_->filter(m);
+        return this->channelFilters_->filter(m, this->channel_);
     }
 
     return true;

--- a/src/widgets/helper/SearchPopup.cpp
+++ b/src/widgets/helper/SearchPopup.cpp
@@ -44,7 +44,7 @@ ChannelPtr SearchPopup::filter(const QString &text, const QString &channelName,
         }
 
         if (accept && filterSet)
-            accept = filterSet->filter(message);
+            accept = filterSet->filter(message, channel);
 
         // If all predicates match, add the message to the channel
         if (accept)


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Reason for crash was a deadlock; we were already inside the channel lock while trying to lock it again to find the channel.
Instead of finding the channel again, we pass the channel all the way down to the filter.

Dev: Removed `FilterRecord::filter(message)` function as it was unused and would've required more changes.

Fixes crash introduced in #3092 
Fix #3108

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
