### PR TITLE
Remove JOINs from write connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Major: Newly uploaded Twitch emotes are once again present in emote picker and can be autocompleted with Tab as well. (#2992)
 - Major: Added the ability to add nicknames for users. (#137, #2981)
+- Major: Work on rate-limiting JOINs and PARTs. (#3112)
 - Minor: Added autocompletion in /whispers for Twitch emotes, Global Bttv/Ffz emotes and emojis. (#2999, #3033)
 - Minor: Received Twitch messages now use the exact same timestamp (obtained from Twitch's server) for every Chatterino user instead of assuming message timestamp on client's side. (#3021)
 - Minor: Received IRC messages use `time` message tag for timestamp if it's available. (#3021)

--- a/src/providers/irc/AbstractIrcServer.cpp
+++ b/src/providers/irc/AbstractIrcServer.cpp
@@ -232,14 +232,6 @@ ChannelPtr AbstractIrcServer::getOrAddChannel(const QString &dirtyChannelName)
                 this->readConnection_->sendRaw("JOIN #" + channelName);
             }
         }
-
-        if (this->writeConnection_ && this->hasSeparateWriteConnection())
-        {
-            if (this->readConnection_->isConnected())
-            {
-                this->writeConnection_->sendRaw("JOIN #" + channelName);
-            }
-        }
     }
 
     return chan;

--- a/src/providers/irc/AbstractIrcServer.cpp
+++ b/src/providers/irc/AbstractIrcServer.cpp
@@ -214,11 +214,6 @@ ChannelPtr AbstractIrcServer::getOrAddChannel(const QString &dirtyChannelName)
             {
                 this->readConnection_->sendRaw("PART #" + channelName);
             }
-
-            if (this->writeConnection_ && this->hasSeparateWriteConnection())
-            {
-                this->writeConnection_->sendRaw("PART #" + channelName);
-            }
         }));
 
     // join irc channel

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -202,30 +202,8 @@ void TwitchIrcServer::writeConnectionMessageReceived(
     }
     else if (command == "NOTICE")
     {
-        // Expected NOTICE messages on write connection
-
-        // Ban / timeout other user.
-        // While connected to PubSub you'll receive a better message from there.
-        //
-        // ban_success
-        // timeout_success
-
-        // Other moderator events
-        //
-        // mod_success
-        // unmod_success
-        // vip_success
-        // unvip_success
-
-        // Channel suspended notice
-        //
-        // msg_channel_suspended
-
-        // We tried to send a message where we're banned / timed out
-        //
-        // msg_banned
-        // msg_timedout
-
+        // List of expected NOTICE messages on write connection
+        // https://git.kotmisia.pl/Mm2PL/docs/src/branch/master/irc_msg_ids.md#command-results
         handler.handleNoticeMessage(
             static_cast<Communi::IrcNoticeMessage *>(message));
     }

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -197,33 +197,34 @@ void TwitchIrcServer::writeConnectionMessageReceived(
     // Below commands enabled through the twitch.tv/commands CAP REQ
     if (command == "USERSTATE")
     {
-        // Received USERSTATE upon PRIVMSGing
+        // Received USERSTATE upon sending PRIVMSG messages
         handler.handleUserStateMessage(message);
     }
     else if (command == "NOTICE")
     {
-        static std::unordered_set<std::string> readConnectionOnlyIDs{
-            "host_on",
-            "host_off",
-            "host_target_went_offline",
-            "emote_only_on",
-            "emote_only_off",
-            "slow_on",
-            "slow_off",
-            "subs_on",
-            "subs_off",
-            "r9k_on",
-            "r9k_off",
+        // Expected NOTICE messages on write connection
 
-            // Display for user who times someone out. This implies you're a
-            // moderator, at which point you will be connected to PubSub and receive
-            // a better message from there.
-            "timeout_success",
-            "ban_success",
+        // Ban / timeout other user.
+        // While connected to PubSub you'll receive a better message from there.
+        //
+        // ban_success
+        // timeout_success
 
-            // Channel suspended notices
-            "msg_channel_suspended",
-        };
+        // Other moderator events
+        //
+        // mod_success
+        // unmod_success
+        // vip_success
+        // unvip_success
+
+        // Channel suspended notice
+        //
+        // msg_channel_suspended
+
+        // We tried to send a message where we're banned / timed out
+        //
+        // msg_banned
+        // msg_timedout
 
         handler.handleNoticeMessage(
             static_cast<Communi::IrcNoticeMessage *>(message));


### PR DESCRIPTION
- Remove JOINs on write connection
- Add changelog entry

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

By not joining on the WRITE connection, we:
a) save some bandwidth
b) reduce the amount of JOINs we do, allowing users to have more initial splits open for now until we add proper rate limiting

Works toward fixing #3107


<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
