### PR TITLE
Rate limit outgoing JOIN messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Major: Newly uploaded Twitch emotes are once again present in emote picker and can be autocompleted with Tab as well. (#2992)
 - Major: Added the ability to add nicknames for users. (#137, #2981)
-- Major: Fixed constant disconnections with more than 20 channels by rate-limitting outgoing JOIN messages. (#3112, #3115)
+- Major: Fixed constant disconnections with more than 20 channels by rate-limiting outgoing JOIN messages. (#3112, #3115)
 - Minor: Added autocompletion in /whispers for Twitch emotes, Global Bttv/Ffz emotes and emojis. (#2999, #3033)
 - Minor: Received Twitch messages now use the exact same timestamp (obtained from Twitch's server) for every Chatterino user instead of assuming message timestamp on client's side. (#3021)
 - Minor: Received IRC messages use `time` message tag for timestamp if it's available. (#3021)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Major: Newly uploaded Twitch emotes are once again present in emote picker and can be autocompleted with Tab as well. (#2992)
 - Major: Added the ability to add nicknames for users. (#137, #2981)
-- Major: Work on rate-limiting JOINs and PARTs. (#3112)
+- Major: Fixed constant disconnections with more than 20 channels by rate-limitting outgoing JOIN messages. (#3112, #3115)
 - Minor: Added autocompletion in /whispers for Twitch emotes, Global Bttv/Ffz emotes and emojis. (#2999, #3033)
 - Minor: Received Twitch messages now use the exact same timestamp (obtained from Twitch's server) for every Chatterino user instead of assuming message timestamp on client's side. (#3021)
 - Minor: Received IRC messages use `time` message tag for timestamp if it's available. (#3021)

--- a/chatterino.pro
+++ b/chatterino.pro
@@ -252,6 +252,7 @@ SOURCES += \
     src/util/LayoutHelper.cpp \
     src/util/NuulsUploader.cpp \
     src/util/RapidjsonHelpers.cpp \
+    src/util/RatelimitBucket.cpp \
     src/util/SplitCommand.cpp \
     src/util/StreamerMode.cpp \
     src/util/StreamLink.cpp \
@@ -509,6 +510,7 @@ HEADERS += \
     src/util/rangealgorithm.hpp \
     src/util/RapidjsonHelpers.hpp \
     src/util/RapidJsonSerializeQString.hpp \
+    src/util/RatelimitBucket.hpp \
     src/util/RemoveScrollAreaBackground.hpp \
     src/util/SampleCheerMessages.hpp \
     src/util/SampleLinks.hpp \
@@ -583,6 +585,7 @@ HEADERS += \
     src/widgets/settingspages/IgnoresPage.hpp \
     src/widgets/settingspages/KeyboardSettingsPage.hpp \
     src/widgets/settingspages/ModerationPage.hpp \
+    src/widgets/settingspages/NicknamesPage.hpp \
     src/widgets/settingspages/NotificationPage.hpp \
     src/widgets/settingspages/SettingsPage.hpp \
     src/widgets/splits/ClosedSplits.hpp \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -292,6 +292,8 @@ set(SOURCE_FILES
         util/NuulsUploader.hpp
         util/RapidjsonHelpers.cpp
         util/RapidjsonHelpers.hpp
+        util/RatelimitBucket.cpp
+        util/RatelimitBucket.hpp
         util/SplitCommand.cpp
         util/SplitCommand.hpp
         util/StreamLink.cpp

--- a/src/providers/irc/AbstractIrcServer.cpp
+++ b/src/providers/irc/AbstractIrcServer.cpp
@@ -24,13 +24,11 @@ AbstractIrcServer::AbstractIrcServer()
         QCoreApplication::instance()->thread());
 
     // Apply a leaky bucket rate limiting to JOIN messages
-    this->joinBucket_.reset(new RatelimitBucket(
-        18, 10500,
-        [&](QString message) {
-            qCDebug(chatterinoIrc) << "joining" << message;
-            this->readConnection_->sendRaw("JOIN #" + message);
-        },
-        this));
+    auto actuallyJoin = [&](QString message) {
+        qCDebug(chatterinoIrc) << "joining" << message;
+        this->readConnection_->sendRaw("JOIN #" + message);
+    };
+    this->joinBucket_.reset(new RatelimitBucket(18, 10500, actuallyJoin, this));
 
     QObject::connect(this->writeConnection_.get(),
                      &Communi::IrcConnection::messageReceived, this,

--- a/src/providers/irc/AbstractIrcServer.cpp
+++ b/src/providers/irc/AbstractIrcServer.cpp
@@ -15,6 +15,10 @@ const int RECONNECT_BASE_INTERVAL = 2000;
 // 60 falloff counter means it will try to reconnect at most every 60*2 seconds
 const int MAX_FALLOFF_COUNTER = 60;
 
+// Ratelimits for joinBucket_
+const int JOIN_RATELIMIT_BUDGET = 18;
+const int JOIN_RATELIMIT_COOLDOWN = 10500;
+
 AbstractIrcServer::AbstractIrcServer()
 {
     // Initialize the connections
@@ -34,7 +38,8 @@ AbstractIrcServer::AbstractIrcServer()
         }
         this->readConnection_->sendRaw("JOIN #" + message);
     };
-    this->joinBucket_.reset(new RatelimitBucket(18, 10500, actuallyJoin, this));
+    this->joinBucket_.reset(new RatelimitBucket(
+        JOIN_RATELIMIT_BUDGET, JOIN_RATELIMIT_COOLDOWN, actuallyJoin, this));
 
     QObject::connect(this->writeConnection_.get(),
                      &Communi::IrcConnection::messageReceived, this,

--- a/src/providers/irc/AbstractIrcServer.cpp
+++ b/src/providers/irc/AbstractIrcServer.cpp
@@ -31,9 +31,6 @@ AbstractIrcServer::AbstractIrcServer()
     auto actuallyJoin = [&](QString message) {
         if (!this->channels.contains(message))
         {
-            qCDebug(chatterinoIrc)
-                << QString("attempted to join %1 but it does not exist anymore")
-                       .arg(message);
             return;
         }
         this->readConnection_->sendRaw("JOIN #" + message);
@@ -302,7 +299,6 @@ void AbstractIrcServer::onReadConnected(IrcConnection *connection)
     {
         if (auto channel = weak.lock())
         {
-            qCDebug(chatterinoIrc) << "queued joining" << channel->getName();
             this->joinBucket_->send(channel->getName());
         }
     }

--- a/src/providers/irc/AbstractIrcServer.cpp
+++ b/src/providers/irc/AbstractIrcServer.cpp
@@ -24,13 +24,13 @@ AbstractIrcServer::AbstractIrcServer()
         QCoreApplication::instance()->thread());
 
     // Apply a leaky bucket rate limitting to JOIN mesasges
-    this->bucket_ = std::make_unique<RatelimitBucket>(
+    this->bucket_.reset(new RatelimitBucket(
         18, 10500,
         [&](QString message) {
             qCDebug(chatterinoIrc) << "joining" << message;
             this->readConnection_->sendRaw("JOIN #" + message);
         },
-        this);
+        this));
 
     QObject::connect(this->writeConnection_.get(),
                      &Communi::IrcConnection::messageReceived, this,

--- a/src/providers/irc/AbstractIrcServer.cpp
+++ b/src/providers/irc/AbstractIrcServer.cpp
@@ -293,7 +293,7 @@ void AbstractIrcServer::onReadConnected(IrcConnection *connection)
     {
         if (auto channel = weak.lock())
         {
-            qCDebug(chatterinoIrc) << "sending to bucket" << channel->getName();
+            qCDebug(chatterinoIrc) << "queued joining" << channel->getName();
             this->bucket_->send(channel->getName());
         }
     }

--- a/src/providers/irc/AbstractIrcServer.cpp
+++ b/src/providers/irc/AbstractIrcServer.cpp
@@ -23,7 +23,7 @@ AbstractIrcServer::AbstractIrcServer()
     this->writeConnection_->moveToThread(
         QCoreApplication::instance()->thread());
 
-    // Apply a leaky bucket rate limitting to JOIN mesasges
+    // Apply a leaky bucket rate limiting to JOIN messages
     this->joinBucket_.reset(new RatelimitBucket(
         18, 10500,
         [&](QString message) {

--- a/src/providers/irc/AbstractIrcServer.cpp
+++ b/src/providers/irc/AbstractIrcServer.cpp
@@ -24,11 +24,13 @@ AbstractIrcServer::AbstractIrcServer()
         QCoreApplication::instance()->thread());
 
     // Apply a leaky bucket rate limitting to JOIN mesasges
-    this->bucket_ =
-        std::make_unique<RatelimitBucket>(18, 10500, [&](QString message) {
+    this->bucket_ = std::make_unique<RatelimitBucket>(
+        18, 10500,
+        [&](QString message) {
             qCDebug(chatterinoIrc) << "joining" << message;
             this->readConnection_->sendRaw("JOIN #" + message);
-        });
+        },
+        this);
 
     QObject::connect(this->writeConnection_.get(),
                      &Communi::IrcConnection::messageReceived, this,

--- a/src/providers/irc/AbstractIrcServer.cpp
+++ b/src/providers/irc/AbstractIrcServer.cpp
@@ -24,7 +24,7 @@ AbstractIrcServer::AbstractIrcServer()
         QCoreApplication::instance()->thread());
 
     // Apply a leaky bucket rate limitting to JOIN mesasges
-    this->bucket_.reset(new RatelimitBucket(
+    this->joinBucket_.reset(new RatelimitBucket(
         18, 10500,
         [&](QString message) {
             qCDebug(chatterinoIrc) << "joining" << message;
@@ -233,7 +233,7 @@ ChannelPtr AbstractIrcServer::getOrAddChannel(const QString &dirtyChannelName)
         {
             if (this->readConnection_->isConnected())
             {
-                this->bucket_->send(channelName);
+                this->joinBucket_->send(channelName);
             }
         }
     }
@@ -294,7 +294,7 @@ void AbstractIrcServer::onReadConnected(IrcConnection *connection)
         if (auto channel = weak.lock())
         {
             qCDebug(chatterinoIrc) << "queued joining" << channel->getName();
-            this->bucket_->send(channel->getName());
+            this->joinBucket_->send(channel->getName());
         }
     }
 

--- a/src/providers/irc/AbstractIrcServer.cpp
+++ b/src/providers/irc/AbstractIrcServer.cpp
@@ -25,7 +25,13 @@ AbstractIrcServer::AbstractIrcServer()
 
     // Apply a leaky bucket rate limiting to JOIN messages
     auto actuallyJoin = [&](QString message) {
-        qCDebug(chatterinoIrc) << "joining" << message;
+        if (!this->channels.contains(message))
+        {
+            qCDebug(chatterinoIrc)
+                << QString("attempted to join %1 but it does not exist anymore")
+                       .arg(message);
+            return;
+        }
         this->readConnection_->sendRaw("JOIN #" + message);
     };
     this->joinBucket_.reset(new RatelimitBucket(18, 10500, actuallyJoin, this));

--- a/src/providers/irc/AbstractIrcServer.hpp
+++ b/src/providers/irc/AbstractIrcServer.hpp
@@ -8,6 +8,7 @@
 
 #include "common/Common.hpp"
 #include "providers/irc/IrcConnection2.hpp"
+#include "util/RatelimitBucket.hpp"
 
 namespace chatterino {
 
@@ -88,6 +89,7 @@ private:
     QObjectPtr<IrcConnection> writeConnection_ = nullptr;
     QObjectPtr<IrcConnection> readConnection_ = nullptr;
 
+    std::unique_ptr<RatelimitBucket> bucket_;
     QTimer reconnectTimer_;
     int falloffCounter_ = 1;
 

--- a/src/providers/irc/AbstractIrcServer.hpp
+++ b/src/providers/irc/AbstractIrcServer.hpp
@@ -89,7 +89,10 @@ private:
     QObjectPtr<IrcConnection> writeConnection_ = nullptr;
     QObjectPtr<IrcConnection> readConnection_ = nullptr;
 
-    QObjectPtr<RatelimitBucket> bucket_;
+    // Our rate limiting bucket for the Twitch join rate limits
+    // https://dev.twitch.tv/docs/irc/guide#rate-limits
+    QObjectPtr<RatelimitBucket> joinBucket_;
+
     QTimer reconnectTimer_;
     int falloffCounter_ = 1;
 

--- a/src/providers/irc/AbstractIrcServer.hpp
+++ b/src/providers/irc/AbstractIrcServer.hpp
@@ -89,7 +89,7 @@ private:
     QObjectPtr<IrcConnection> writeConnection_ = nullptr;
     QObjectPtr<IrcConnection> readConnection_ = nullptr;
 
-    std::unique_ptr<RatelimitBucket> bucket_;
+    QObjectPtr<RatelimitBucket> bucket_;
     QTimer reconnectTimer_;
     int falloffCounter_ = 1;
 

--- a/src/util/RatelimitBucket.cpp
+++ b/src/util/RatelimitBucket.cpp
@@ -20,11 +20,11 @@ void RatelimitBucket::send(QString message)
 
     if (this->pending_ < this->limit_)
     {
-        this->execute();
+        this->handleOne();
     }
 }
 
-void RatelimitBucket::execute()
+void RatelimitBucket::handleOne()
 {
     if (queue_.isEmpty())
     {
@@ -38,7 +38,7 @@ void RatelimitBucket::execute()
 
     QTimer::singleShot(cooldown_, this, [this] {
         this->pending_--;
-        this->execute();
+        this->handleOne();
     });
 }
 

--- a/src/util/RatelimitBucket.cpp
+++ b/src/util/RatelimitBucket.cpp
@@ -5,8 +5,10 @@
 namespace chatterino {
 
 RatelimitBucket::RatelimitBucket(int limit, int cooldown,
-                                 std::function<void(QString)> callback)
-    : limit_(limit)
+                                 std::function<void(QString)> callback,
+                                 QObject *parent)
+    : QObject(parent)
+    , limit_(limit)
     , cooldown_(cooldown)
     , callback_(callback)
 {
@@ -34,7 +36,7 @@ void RatelimitBucket::execute()
     this->pending_++;
     callback_(item);
 
-    QTimer::singleShot(cooldown_, [this] {
+    QTimer::singleShot(cooldown_, this, [this] {
         this->pending_--;
         this->execute();
     });

--- a/src/util/RatelimitBucket.cpp
+++ b/src/util/RatelimitBucket.cpp
@@ -4,11 +4,11 @@
 
 namespace chatterino {
 
-RatelimitBucket::RatelimitBucket(int limit, int cooldown,
+RatelimitBucket::RatelimitBucket(int budget, int cooldown,
                                  std::function<void(QString)> callback,
                                  QObject *parent)
     : QObject(parent)
-    , budget_(limit)
+    , budget_(budget)
     , cooldown_(cooldown)
     , callback_(callback)
 {

--- a/src/util/RatelimitBucket.cpp
+++ b/src/util/RatelimitBucket.cpp
@@ -14,9 +14,9 @@ RatelimitBucket::RatelimitBucket(int budget, int cooldown,
 {
 }
 
-void RatelimitBucket::send(QString message)
+void RatelimitBucket::send(QString channel)
 {
-    this->queue_.append(message);
+    this->queue_.append(channel);
 
     if (this->budget_ > 0)
     {

--- a/src/util/RatelimitBucket.cpp
+++ b/src/util/RatelimitBucket.cpp
@@ -1,0 +1,43 @@
+#include "RatelimitBucket.hpp"
+
+#include <QTimer>
+
+namespace chatterino {
+
+RatelimitBucket::RatelimitBucket(int limit, int cooldown,
+                                 std::function<void(QString)> callback)
+    : limit_(limit)
+    , cooldown_(cooldown)
+    , callback_(callback)
+{
+}
+
+void RatelimitBucket::send(QString message)
+{
+    this->queue_.append(message);
+
+    if (this->pending_ < this->limit_)
+    {
+        this->execute();
+    }
+}
+
+void RatelimitBucket::execute()
+{
+    if (queue_.isEmpty())
+    {
+        return;
+    }
+
+    auto item = queue_.takeFirst();
+
+    this->pending_++;
+    callback_(item);
+
+    QTimer::singleShot(cooldown_, [this] {
+        this->pending_--;
+        this->execute();
+    });
+}
+
+}  // namespace chatterino

--- a/src/util/RatelimitBucket.cpp
+++ b/src/util/RatelimitBucket.cpp
@@ -8,7 +8,7 @@ RatelimitBucket::RatelimitBucket(int limit, int cooldown,
                                  std::function<void(QString)> callback,
                                  QObject *parent)
     : QObject(parent)
-    , limit_(limit)
+    , budget_(limit)
     , cooldown_(cooldown)
     , callback_(callback)
 {
@@ -18,7 +18,7 @@ void RatelimitBucket::send(QString message)
 {
     this->queue_.append(message);
 
-    if (this->pending_ < this->limit_)
+    if (this->budget_ > 0)
     {
         this->handleOne();
     }
@@ -33,11 +33,11 @@ void RatelimitBucket::handleOne()
 
     auto item = queue_.takeFirst();
 
-    this->pending_++;
+    this->budget_--;
     callback_(item);
 
     QTimer::singleShot(cooldown_, this, [this] {
-        this->pending_--;
+        this->budget_++;
         this->handleOne();
     });
 }

--- a/src/util/RatelimitBucket.hpp
+++ b/src/util/RatelimitBucket.hpp
@@ -21,7 +21,13 @@ private:
     std::function<void(QString)> callback_;
     QList<QString> queue_;
 
-    void execute();
+    /**
+     * @brief Run the callback on one entry in the queue.
+     *
+     * This will start a timer that runs after cooldown_ milliseconds that
+     * gives back one "token" to the bucket and calls handleOne again.
+     **/
+    void handleOne();
 };
 
 }  // namespace chatterino

--- a/src/util/RatelimitBucket.hpp
+++ b/src/util/RatelimitBucket.hpp
@@ -1,15 +1,16 @@
 #pragma once
 
 #include <QList>
+#include <QObject>
 #include <QString>
 
 namespace chatterino {
 
-class RatelimitBucket
+class RatelimitBucket : public QObject
 {
 public:
     RatelimitBucket(int limit, int cooldown,
-                    std::function<void(QString)> callback);
+                    std::function<void(QString)> callback, QObject *parent);
 
     void send(QString message);
 

--- a/src/util/RatelimitBucket.hpp
+++ b/src/util/RatelimitBucket.hpp
@@ -9,7 +9,7 @@ namespace chatterino {
 class RatelimitBucket : public QObject
 {
 public:
-    RatelimitBucket(int limit, int cooldown,
+    RatelimitBucket(int budget, int cooldown,
                     std::function<void(QString)> callback, QObject *parent);
 
     void send(QString message);

--- a/src/util/RatelimitBucket.hpp
+++ b/src/util/RatelimitBucket.hpp
@@ -15,9 +15,16 @@ public:
     void send(QString message);
 
 private:
-    int limit_;
-    int pending_ = 0;
+    /**
+     * @brief budget_ denotes the amount of calls that can be handled before we need to wait for the cooldown
+     **/
+    int budget_;
+
+    /**
+     * @ brief This is the amount of time it takes for one used up budget to be put back into the bucket for use elsewhere
+     **/
     int cooldown_;
+
     std::function<void(QString)> callback_;
     QList<QString> queue_;
 

--- a/src/util/RatelimitBucket.hpp
+++ b/src/util/RatelimitBucket.hpp
@@ -21,7 +21,7 @@ private:
     int budget_;
 
     /**
-     * @ brief This is the amount of time it takes for one used up budget to be put back into the bucket for use elsewhere
+     * @brief This is the amount of time in milliseconds it takes for one used up budget to be put back into the bucket for use elsewhere
      **/
     int cooldown_;
 

--- a/src/util/RatelimitBucket.hpp
+++ b/src/util/RatelimitBucket.hpp
@@ -23,7 +23,7 @@ private:
     /**
      * @brief This is the amount of time in milliseconds it takes for one used up budget to be put back into the bucket for use elsewhere
      **/
-    int cooldown_;
+    const int cooldown_;
 
     std::function<void(QString)> callback_;
     QList<QString> queue_;

--- a/src/util/RatelimitBucket.hpp
+++ b/src/util/RatelimitBucket.hpp
@@ -12,7 +12,7 @@ public:
     RatelimitBucket(int budget, int cooldown,
                     std::function<void(QString)> callback, QObject *parent);
 
-    void send(QString message);
+    void send(QString channel);
 
 private:
     /**

--- a/src/util/RatelimitBucket.hpp
+++ b/src/util/RatelimitBucket.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <QList>
+#include <QString>
+
+namespace chatterino {
+
+class RatelimitBucket
+{
+public:
+    RatelimitBucket(int limit, int cooldown,
+                    std::function<void(QString)> callback);
+
+    void send(QString message);
+
+private:
+    int limit_;
+    int pending_ = 0;
+    int cooldown_;
+    std::function<void(QString)> callback_;
+    QList<QString> queue_;
+
+    void execute();
+};
+
+}  // namespace chatterino

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ set(test_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/src/ExponentialBackoff.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/TwitchAccount.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/Helpers.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/RatelimitBucket.cpp
     )
 
 add_executable(${PROJECT_NAME} ${test_SOURCES})

--- a/tests/src/RatelimitBucket.cpp
+++ b/tests/src/RatelimitBucket.cpp
@@ -1,0 +1,46 @@
+#include "util/RatelimitBucket.hpp"
+
+#include <gtest/gtest.h>
+#include <QApplication>
+#include <QDebug>
+#include <QtConcurrent>
+
+#include <chrono>
+#include <thread>
+
+using namespace chatterino;
+
+TEST(RatelimitBucket, BatchTwoParts)
+{
+    const int cooldown = 100;
+    int n = 0;
+    auto cb = [&n](QString msg) {
+        qDebug() << msg;
+        ++n;
+    };
+    auto bucket = std::make_unique<RatelimitBucket>(5, cooldown, cb, nullptr);
+    bucket->send("1");
+    EXPECT_EQ(n, 1);
+
+    bucket->send("2");
+    EXPECT_EQ(n, 2);
+
+    bucket->send("3");
+    EXPECT_EQ(n, 3);
+
+    bucket->send("4");
+    EXPECT_EQ(n, 4);
+
+    bucket->send("5");
+    EXPECT_EQ(n, 5);
+
+    bucket->send("6");
+    // Rate limit reached, n will not have changed yet. If we wait for the cooldown to run, n should have changed
+    EXPECT_EQ(n, 5);
+
+    QCoreApplication::processEvents();
+    std::this_thread::sleep_for(std::chrono::milliseconds{cooldown});
+    QCoreApplication::processEvents();
+
+    EXPECT_EQ(n, 6);
+}


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Added experimental rate-limitting for outgoing JOIN messages with some imitation of Leaky bucket rate limitting. Huge thanks to @leon-richardt for helping me figure out the theory.
Tested it out and Twitch does not kill our connection - we conform to Twitch's 20 JOIN messages / 10s limit by sending at most 18 JOIN messages per 10.5s.

This might not be the best solution and I believe there could be a better one, but after about 24 hours of thinking this is the most sane solution I could come up with and given how important this bug is I think it's better than nothing.

~~There's still debug prints in the code, to make it easier for reviewers to test. After approving the PR I'll remove them.~~ already removed.

Closes #3107
