### PR TITLE
Fix QJsonArray assert failing while attempting to index an empty array

### DIFF
--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -712,7 +712,7 @@ void Helix::getEmoteSetData(QString emoteSetId,
             QJsonObject root = result.parseJson();
             auto data = root.value("data");
 
-            if (!data.isArray())
+            if (!data.isArray() || data.toArray().isEmpty())
             {
                 failureCallback();
                 return Failure;


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Result of the API call inside of `Helix::getEmoteSetData` might sometimes skip some (or all) given emotesets and return an empty array. This is a Twitch bug and is being tracked in twitchdev/issues#445.
Regardless, we now add a check which ensures that we don't attempt to access the first element of the QJsonArray if it doesn't exist which fixes some assert magic inside of QJsonArray class.
This isn't anything that crashes Chatterino, but just a "warning" that's popping up while compiling Chatterino on Windows sometimes.
Example below:

![anatole FDM](https://cdn.discordapp.com/attachments/817359178259365919/872750241558970418/unknown.png)
