### PR TITLE
Handle moderation mode and filters in split popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+- Minor: Moderation mode and active filters are now preserved when opening a split as a popup. (#3113, #3130)
+
 ## 2.3.4
 
 - Major: Newly uploaded Twitch emotes are once again present in emote picker and can be autocompleted with Tab as well. (#2992)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unversioned
 
-- Minor: Moderation mode and active filters are now preserved when opening a split as a popup. (#3113, #3130)
+- Bugfix: Moderation mode and active filters are now preserved when opening a split as a popup. (#3113, #3130)
 
 ## 2.3.4
 

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -624,8 +624,10 @@ void Split::popup()
         window.getNotebook().getOrAddSelectedPage()));
 
     split->setChannel(this->getIndirectChannel());
-    window.getNotebook().getOrAddSelectedPage()->appendSplit(split);
+    split->setModerationMode(this->getModerationMode());
+    split->setFilters(this->getFilters());
 
+    window.getNotebook().getOrAddSelectedPage()->appendSplit(split);
     window.show();
 }
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Respect moderation mode status and active filters when opening a split as a popup.

Fixes #3113