### PR TITLE
Fix badge highlights using the same color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+- Bugfix: Fixed a bug that caused all badge highlights to use the same color. (#3132, #3134)
+
 ## 2.3.4
 
 - Major: Newly uploaded Twitch emotes are once again present in emote picker and can be autocompleted with Tab as well. (#2992)

--- a/src/widgets/settingspages/HighlightingPage.cpp
+++ b/src/widgets/settingspages/HighlightingPage.cpp
@@ -195,7 +195,7 @@ HighlightingPage::HighlightingPage()
                         }
                         getSettings()->highlightedBadges.append(HighlightBadge{
                             s->badgeName(), s->displayName(), false, false, "",
-                            ColorProvider::instance().color(
+                            *ColorProvider::instance().color(
                                 ColorType::SelfHighlight)});
                     }
                 });


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Seems to have been caused by all badge highlights sharing the same color instance.
Not 100% sure about the cause and fix though so would like someone else to look at it.

Fixes #3132