### PR TITLE
Show system message when reloading subscriber emotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unversioned
 
+- Minor: Display a system message when reloading subscription emotes to match BTTV/FFZ behavior (#3135)
 - Bugfix: Moderation mode and active filters are now preserved when opening a split as a popup. (#3113, #3130)
 
 ## 2.3.4

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -552,7 +552,7 @@ void IrcMessageHandler::handleGlobalUserStateMessage(
     // emoteSetsChanged, since we want to trigger emote reloads when
     // "currentUserChanged" signal is emitted
     qCDebug(chatterinoTwitch) << emoteSetsChanged << message->toData();
-    currentUser->loadEmotes(nullptr);
+    currentUser->loadEmotes();
 }
 
 void IrcMessageHandler::handleWhisperMessage(Communi::IrcMessage *message)

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -552,7 +552,7 @@ void IrcMessageHandler::handleGlobalUserStateMessage(
     // emoteSetsChanged, since we want to trigger emote reloads when
     // "currentUserChanged" signal is emitted
     qCDebug(chatterinoTwitch) << emoteSetsChanged << message->toData();
-    currentUser->loadEmotes();
+    currentUser->loadEmotes(nullptr);
 }
 
 void IrcMessageHandler::handleWhisperMessage(Communi::IrcMessage *message)

--- a/src/providers/twitch/TwitchAccount.cpp
+++ b/src/providers/twitch/TwitchAccount.cpp
@@ -228,8 +228,11 @@ void TwitchAccount::loadEmotes(const std::shared_ptr<Channel> &channel)
     this->loadUserstateEmotes([this, channel] {
         // Fill up emoteData with emote sets that were returned in a Kraken call, but aren't present in emoteData.
         this->loadKrakenEmotes();
-        channel->addMessage(makeSystemMessage(
-            "Twitch subscriber emotes reloaded."));
+        if (channel != nullptr)
+        {
+            channel->addMessage(makeSystemMessage(
+                "Twitch subscriber emotes reloaded."));
+        }
     });
 }
 

--- a/src/providers/twitch/TwitchAccount.cpp
+++ b/src/providers/twitch/TwitchAccount.cpp
@@ -200,30 +200,7 @@ SharedAccessGuard<const std::set<QString>> TwitchAccount::accessBlockedUserIds()
 
 void TwitchAccount::loadEmotes()
 {
-    qCDebug(chatterinoTwitch)
-        << "Loading Twitch emotes for user" << this->getUserName();
-
-    if (this->getOAuthClient().isEmpty() || this->getOAuthToken().isEmpty())
-    {
-        qCDebug(chatterinoTwitch)
-            << "Aborted loadEmotes due to missing Client ID and/or OAuth token";
-        return;
-    }
-
-    {
-        auto emoteData = this->emotes_.access();
-        emoteData->emoteSets.clear();
-        emoteData->emotes.clear();
-        qCDebug(chatterinoTwitch) << "Cleared emotes!";
-    }
-
-    // TODO(zneix): Once Helix adds Get User Emotes we could remove this hacky solution
-    // For now, this is necessary as Kraken's equivalent doesn't return all emotes
-    // See: https://twitch.uservoice.com/forums/310213-developers/suggestions/43599900
-    this->loadUserstateEmotes([=] {
-        // Fill up emoteData with emote sets that were returned in a Kraken call, but aren't present in emoteData.
-        this->loadKrakenEmotes();
-    });
+    loadEmotes(nullptr);
 }
 
 void TwitchAccount::loadEmotes(const std::shared_ptr<Channel> &channel)

--- a/src/providers/twitch/TwitchAccount.cpp
+++ b/src/providers/twitch/TwitchAccount.cpp
@@ -226,6 +226,36 @@ void TwitchAccount::loadEmotes()
     });
 }
 
+void TwitchAccount::loadEmotes(const std::shared_ptr<Channel> &channel)
+{
+    qCDebug(chatterinoTwitch)
+        << "Loading Twitch emotes for user" << this->getUserName();
+
+    if (this->getOAuthClient().isEmpty() || this->getOAuthToken().isEmpty())
+    {
+        qCDebug(chatterinoTwitch)
+            << "Aborted loadEmotes due to missing Client ID and/or OAuth token";
+        return;
+    }
+
+    {
+        auto emoteData = this->emotes_.access();
+        emoteData->emoteSets.clear();
+        emoteData->emotes.clear();
+        qCDebug(chatterinoTwitch) << "Cleared emotes!";
+    }
+
+    // TODO(zneix): Once Helix adds Get User Emotes we could remove this hacky solution
+    // For now, this is necessary as Kraken's equivalent doesn't return all emotes
+    // See: https://twitch.uservoice.com/forums/310213-developers/suggestions/43599900
+    this->loadUserstateEmotes([this, channel] {
+        // Fill up emoteData with emote sets that were returned in a Kraken call, but aren't present in emoteData.
+        this->loadKrakenEmotes();
+        channel->addMessage(makeSystemMessage(
+            "Twitch subscriber emotes reloaded."));
+    });
+}
+
 bool TwitchAccount::setUserstateEmoteSets(QStringList newEmoteSets)
 {
     newEmoteSets.sort();

--- a/src/providers/twitch/TwitchAccount.cpp
+++ b/src/providers/twitch/TwitchAccount.cpp
@@ -198,13 +198,6 @@ SharedAccessGuard<const std::set<QString>> TwitchAccount::accessBlockedUserIds()
     return this->ignoresUserIds_.accessConst();
 }
 
-// this overload is for compatability with the IRCMessageHandler
-// since it doesn't have access to the channel
-void TwitchAccount::loadEmotes()
-{
-    this->loadEmotes(nullptr);
-}
-
 void TwitchAccount::loadEmotes(const std::shared_ptr<Channel> &channel)
 {
     qCDebug(chatterinoTwitch)

--- a/src/providers/twitch/TwitchAccount.cpp
+++ b/src/providers/twitch/TwitchAccount.cpp
@@ -198,6 +198,8 @@ SharedAccessGuard<const std::set<QString>> TwitchAccount::accessBlockedUserIds()
     return this->ignoresUserIds_.accessConst();
 }
 
+// this overload is for compatability with the IRCMessageHandler
+// since it doesn't have access to the channel
 void TwitchAccount::loadEmotes()
 {
     this->loadEmotes(nullptr);

--- a/src/providers/twitch/TwitchAccount.cpp
+++ b/src/providers/twitch/TwitchAccount.cpp
@@ -200,7 +200,7 @@ SharedAccessGuard<const std::set<QString>> TwitchAccount::accessBlockedUserIds()
 
 void TwitchAccount::loadEmotes()
 {
-    loadEmotes(nullptr);
+    this->loadEmotes(nullptr);
 }
 
 void TwitchAccount::loadEmotes(const std::shared_ptr<Channel> &channel)

--- a/src/providers/twitch/TwitchAccount.cpp
+++ b/src/providers/twitch/TwitchAccount.cpp
@@ -230,8 +230,8 @@ void TwitchAccount::loadEmotes(const std::shared_ptr<Channel> &channel)
         this->loadKrakenEmotes();
         if (channel != nullptr)
         {
-            channel->addMessage(makeSystemMessage(
-                "Twitch subscriber emotes reloaded."));
+            channel->addMessage(
+                makeSystemMessage("Twitch subscriber emotes reloaded."));
         }
     });
 }

--- a/src/providers/twitch/TwitchAccount.cpp
+++ b/src/providers/twitch/TwitchAccount.cpp
@@ -198,7 +198,7 @@ SharedAccessGuard<const std::set<QString>> TwitchAccount::accessBlockedUserIds()
     return this->ignoresUserIds_.accessConst();
 }
 
-void TwitchAccount::loadEmotes(const std::shared_ptr<Channel> &channel)
+void TwitchAccount::loadEmotes(std::weak_ptr<Channel> weakChannel)
 {
     qCDebug(chatterinoTwitch)
         << "Loading Twitch emotes for user" << this->getUserName();
@@ -220,10 +220,10 @@ void TwitchAccount::loadEmotes(const std::shared_ptr<Channel> &channel)
     // TODO(zneix): Once Helix adds Get User Emotes we could remove this hacky solution
     // For now, this is necessary as Kraken's equivalent doesn't return all emotes
     // See: https://twitch.uservoice.com/forums/310213-developers/suggestions/43599900
-    this->loadUserstateEmotes([this, channel] {
+    this->loadUserstateEmotes([this, weakChannel] {
         // Fill up emoteData with emote sets that were returned in a Kraken call, but aren't present in emoteData.
         this->loadKrakenEmotes();
-        if (channel != nullptr)
+        if (auto channel = weakChannel.lock(); channel != nullptr)
         {
             channel->addMessage(
                 makeSystemMessage("Twitch subscriber emotes reloaded."));

--- a/src/providers/twitch/TwitchAccount.hpp
+++ b/src/providers/twitch/TwitchAccount.hpp
@@ -111,7 +111,6 @@ public:
     SharedAccessGuard<const std::set<QString>> accessBlockedUserIds() const;
     SharedAccessGuard<const std::set<TwitchUser>> accessBlocks() const;
 
-    void loadEmotes();
     void loadEmotes(const std::shared_ptr<Channel> &channel);
     // loadUserstateEmotes loads emote sets that are part of the USERSTATE emote-sets key
     // this function makes sure not to load emote sets that have already been loaded

--- a/src/providers/twitch/TwitchAccount.hpp
+++ b/src/providers/twitch/TwitchAccount.hpp
@@ -111,7 +111,7 @@ public:
     SharedAccessGuard<const std::set<QString>> accessBlockedUserIds() const;
     SharedAccessGuard<const std::set<TwitchUser>> accessBlocks() const;
 
-    void loadEmotes(const std::shared_ptr<Channel> &channel);
+    void loadEmotes(std::weak_ptr<Channel> weakChannel = {});
     // loadUserstateEmotes loads emote sets that are part of the USERSTATE emote-sets key
     // this function makes sure not to load emote sets that have already been loaded
     void loadUserstateEmotes(std::function<void()> callback);

--- a/src/providers/twitch/TwitchAccount.hpp
+++ b/src/providers/twitch/TwitchAccount.hpp
@@ -112,6 +112,7 @@ public:
     SharedAccessGuard<const std::set<TwitchUser>> accessBlocks() const;
 
     void loadEmotes();
+    void loadEmotes(const std::shared_ptr<Channel> &channel);
     // loadUserstateEmotes loads emote sets that are part of the USERSTATE emote-sets key
     // this function makes sure not to load emote sets that have already been loaded
     void loadUserstateEmotes(std::function<void()> callback);

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -870,8 +870,8 @@ void Split::showSearch()
 
 void Split::reloadChannelAndSubscriberEmotes()
 {
-    getApp()->accounts->twitch.getCurrent()->loadEmotes();
     auto channel = this->getChannel();
+    getApp()->accounts->twitch.getCurrent()->loadEmotes(channel);
 
     if (auto twitchChannel = dynamic_cast<TwitchChannel *>(channel.get()))
     {

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -933,7 +933,8 @@ void SplitHeader::reloadChannelEmotes()
 
 void SplitHeader::reloadSubscriberEmotes()
 {
-    getApp()->accounts->twitch.getCurrent()->loadEmotes();
+    auto channel = this->split_->getChannel();
+    getApp()->accounts->twitch.getCurrent()->loadEmotes(channel);
 }
 
 void SplitHeader::reconnect()

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -916,10 +916,6 @@ void SplitHeader::themeChangedEvent()
     }
 }
 
-void SplitHeader::moveSplit()
-{
-}
-
 void SplitHeader::reloadChannelEmotes()
 {
     auto channel = this->split_->getChannel();

--- a/src/widgets/splits/SplitHeader.hpp
+++ b/src/widgets/splits/SplitHeader.hpp
@@ -85,7 +85,6 @@ private:
     std::vector<pajlada::Signals::ScopedConnection> channelConnections_;
 
 public slots:
-    void moveSplit();
     void reloadChannelEmotes();
     void reloadSubscriberEmotes();
     void reconnect();


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

This PR aims to display a system message when reloading subscriber emotes. This behaviour is in line with the BTTV/FFZ emote reload behaviour. 

I've passed through the channel to `loadEmotes` which might be ugly to some people but it ensures you get a 'reloaded' messages when the reloading has started instead of when the method was called. Also kept the old `loadEmotes()` overload around for the call in `IRCMessagehandler`.