### PR TITLE
Remove twitchemotes.com-related functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unversioned
 
+- Minor: Remove TwitchEmotes.com attribution and the open/copy options when right-clicking a Twitch Emote. (#3136)
 - Bugfix: Moderation mode and active filters are now preserved when opening a split as a popup. (#3113, #3130)
 - Bugfix: Fixed a bug that caused all badge highlights to use the same color. (#3132, #3134)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unversioned
 
-- Minor: Remove TwitchEmotes.com attribution and the open/copy options when right-clicking a Twitch Emote. (#3136)
+- Minor: Remove TwitchEmotes.com attribution and the open/copy options when right-clicking a Twitch Emote. (#2214, #3136)
 - Bugfix: Moderation mode and active filters are now preserved when opening a split as a popup. (#3113, #3130)
 - Bugfix: Fixed a bug that caused all badge highlights to use the same color. (#3132, #3134)
 

--- a/src/providers/twitch/TwitchEmotes.cpp
+++ b/src/providers/twitch/TwitchEmotes.cpp
@@ -57,7 +57,7 @@ EmotePtr TwitchEmotes::getOrCreateEmote(const EmoteId &id,
                 Image::fromUrl(getEmoteLink(id, "3.0"), 0.25),
             },
             Tooltip{name.toHtmlEscaped() + "<br>Twitch Emote"},
-            Url{QString("https://twitchemotes.com/emotes/%1").arg(id.string)}});
+        });
     }
 
     return shared;

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -108,11 +108,7 @@ namespace {
                                 });
         };
 
-        if (creatorFlags.has(MessageElementFlag::TwitchEmote))
-        {
-            addPageLink("TwitchEmotes");
-        }
-        else if (creatorFlags.has(MessageElementFlag::BttvEmote))
+        if (creatorFlags.has(MessageElementFlag::BttvEmote))
         {
             addPageLink("BTTV");
         }

--- a/src/widgets/settingspages/AboutPage.cpp
+++ b/src/widgets/settingspages/AboutPage.cpp
@@ -161,7 +161,6 @@ AboutPage::AboutPage()
             l.emplace<QLabel>("Google emojis provided by <a href=\"https://google.com\">Google</a>")->setOpenExternalLinks(true);
             l.emplace<QLabel>("Emoji datasource provided by <a href=\"https://www.iamcal.com/\">Cal Henderson</a>"
                               "(<a href=\"https://github.com/iamcal/emoji-data/blob/master/LICENSE\">show license</a>)")->setOpenExternalLinks(true);
-            l.emplace<QLabel>("Twitch emote data provided by <a href=\"https://twitchemotes.com/\">twitchemotes.com</a> through the <a href=\"https://github.com/Chatterino/api\">Chatterino API</a>")->setOpenExternalLinks(true);
             // clang-format on
         }
 


### PR DESCRIPTION
- Remove attribution to twitchemotes.com API as we now pull data from Helix directly
- Remove "Open TwitchEmotes emote link" and "Copy TwitchEmotes emote link" menu options when right-clicking Twitch emotes
- Add changelog entry

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->

Fixes #3114 
Fixes #2745
Fixes #3126