### PR TITLE
Strip leading @ and trailing , from /user and /usercard commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unversioned
 
 - Minor: Remove TwitchEmotes.com attribution and the open/copy options when right-clicking a Twitch Emote. (#2214, #3136)
-- Minor: Strip leading @ from username in /user and /usercard commands (#3143)
+- Minor: Strip leading @ and trailing , from username in /user and /usercard commands. (#3143)
 - Bugfix: Moderation mode and active filters are now preserved when opening a split as a popup. (#3113, #3130)
 - Bugfix: Fixed a bug that caused all badge highlights to use the same color. (#3132, #3134)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unversioned
 
 - Minor: Remove TwitchEmotes.com attribution and the open/copy options when right-clicking a Twitch Emote. (#2214, #3136)
+- Minor: Strip leading @ from username in /user and /usercard commands (#3143)
 - Bugfix: Moderation mode and active filters are now preserved when opening a split as a popup. (#3113, #3130)
 - Bugfix: Fixed a bug that caused all badge highlights to use the same color. (#3132, #3134)
 

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -70,6 +70,32 @@ static const QStringList twitchDefaultCommands{
 
 static const QStringList whisperCommands{"/w", ".w"};
 
+// stripUserName removes any @ prefix or , suffix to make it more suitable for command use
+void stripUserName(QString &userName)
+{
+    if (userName.startsWith('@'))
+    {
+        userName.remove(0, 1);
+    }
+    if (userName.endsWith(','))
+    {
+        userName.chop(1);
+    }
+}
+
+// stripChannelName removes any @ prefix or , suffix to make it more suitable for command use
+void stripChannelName(QString &channelName)
+{
+    if (channelName.startsWith('@') || channelName.startsWith('#'))
+    {
+        channelName.remove(0, 1);
+    }
+    if (channelName.endsWith(','))
+    {
+        channelName.chop(1);
+    }
+}
+
 void sendWhisperMessage(const QString &text)
 {
     // (hemirt) pajlada: "we should not be sending whispers through jtv, but
@@ -431,18 +457,14 @@ void CommandController::initialize(Settings &, Paths &paths)
             return "";
         }
         QString userName = words[1];
-        if (userName[0] == '@')
-        {
-            userName.remove(0, 1);
-        }
+        stripUserName(userName);
+
         QString channelName = channel->getName();
+
         if (words.size() > 2)
         {
             channelName = words[2];
-            if (channelName[0] == '#' || channelName[0] == '@')
-            {
-                channelName.remove(0, 1);
-            }
+            stripChannelName(channelName);
         }
         openTwitchUsercard(channelName, userName);
 
@@ -457,10 +479,7 @@ void CommandController::initialize(Settings &, Paths &paths)
         }
 
         QString userName = words[1];
-        if (userName[0] == '@')
-        {
-            userName.remove(0, 1);
-        }
+        stripUserName(userName);
         auto *userPopup = new UserInfoPopup(
             getSettings()->autoCloseUserPopup,
             static_cast<QWidget *>(&(getApp()->windows->getMainWindow())));

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -439,7 +439,7 @@ void CommandController::initialize(Settings &, Paths &paths)
         if (words.size() > 2)
         {
             channelName = words[2];
-            if (channelName[0] == '#')
+            if (channelName[0] == '#' || channelName[0] == '@')
             {
                 channelName.remove(0, 1);
             }

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -430,6 +430,11 @@ void CommandController::initialize(Settings &, Paths &paths)
                 makeSystemMessage("Usage /user [user] (channel)"));
             return "";
         }
+        QString userName = words[1];
+        if (userName[0] == '@')
+        {
+            userName.remove(0, 1);
+        }
         QString channelName = channel->getName();
         if (words.size() > 2)
         {
@@ -439,7 +444,7 @@ void CommandController::initialize(Settings &, Paths &paths)
                 channelName.remove(0, 1);
             }
         }
-        openTwitchUsercard(channelName, words[1]);
+        openTwitchUsercard(channelName, userName);
 
         return "";
     });
@@ -451,10 +456,15 @@ void CommandController::initialize(Settings &, Paths &paths)
             return "";
         }
 
+        QString userName = words[1];
+        if (userName[0] == '@')
+        {
+            userName.remove(0, 1);
+        }
         auto *userPopup = new UserInfoPopup(
             getSettings()->autoCloseUserPopup,
             static_cast<QWidget *>(&(getApp()->windows->getMainWindow())));
-        userPopup->setData(words[1], channel);
+        userPopup->setData(userName, channel);
         userPopup->move(QCursor::pos());
         userPopup->show();
         return "";


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Strip the leading `@` from the username when using the `/user` and `/usercard` commands. Fixes a minor annoyance when these commands are used along with the *Only search for username autocompletion with an @* option.