### PR TITLE
Added links to discussions when trying to create an issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+    - name: Suggestions or feature request
+      url: https://github.com/chatterino/chatterino2/discussions/categories/ideas
+      about: Got something you think should change or be added? Search for or start a new discussion!
+    - name: Help
+      url: https://github.com/chatterino/chatterino2/discussions/categories/q-a
+      about: osu! not working as you'd expect? Not sure it's a bug? Check the Q&A section!

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,4 +5,4 @@ contact_links:
       about: Got something you think should change or be added? Search for or start a new discussion!
     - name: Help
       url: https://github.com/chatterino/chatterino2/discussions/categories/q-a
-      about: osu! not working as you'd expect? Not sure it's a bug? Check the Q&A section!
+      about: Chatterino2 not working as you'd expect? Not sure it's a bug? Check the Q&A section!


### PR DESCRIPTION
Taken from ![osu!lazer](https://github.com/ppy/osu/blob/master/.github/ISSUE_TEMPLATE/config.yml)
This is what it looks like:
https://github.com/ppy/osu/issues/new/choose

# Description
Makes a link to discussions when trying to create an issue when you should instead create an enhancement.
<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
