### PR TITLE
Fix /me not going through upon sending an identical message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Minor: Display a system message when reloading subscription emotes to match BTTV/FFZ behavior (#3135)
 - Minor: Added a setting to hide similar messages by any user. (#2716)
 - Minor: Duplicate spaces now count towards the display message length. (#3002)
+- Bugfix: Restored ability to send duplicate `/me` messages. (#3166)
 - Bugfix: Notifications for moderators about other moderators deleting messages can now be disabled. (#3121)
 - Bugfix: Moderation mode and active filters are now preserved when opening a split as a popup. (#3113, #3130)
 - Bugfix: Fixed a bug that caused all badge highlights to use the same color. (#3132, #3134)

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -377,18 +377,15 @@ void TwitchChannel::sendMessage(const QString &message)
             if (parsedMessage == this->lastSentMessage_)
             {
                 auto spaceIndex = parsedMessage.indexOf(' ');
-                // If the message starts with either '/' or a '.' Twitch will treat it as a command
-                // In that case, first space will be omitted and only rest of the arguments treated as actual message content
-                // In cases when user sends a message like ". .a b" first character and space after it is omitted, just like with commands
+                // If the message starts with either '/' or a '.' Twitch will treat it as a command, omitting
+                // first space and only rest of the arguments treated as actual message content
+                // In cases when user sends a message like ". .a b" first character and first space are omitted as well
                 bool ignoreFirstSpace =
                     parsedMessage.at(0) == '/' || parsedMessage.at(0) == '.';
-                qCDebug(chatterinoTwitch) << parsedMessage;
-                qCDebug(chatterinoTwitch) << spaceIndex << ignoreFirstSpace;
                 if (ignoreFirstSpace)
                 {
                     spaceIndex = parsedMessage.indexOf(' ', spaceIndex + 1);
                 }
-                qCDebug(chatterinoTwitch) << spaceIndex;
 
                 if (spaceIndex == -1)
                 {

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -377,7 +377,7 @@ void TwitchChannel::sendMessage(const QString &message)
             if (parsedMessage == this->lastSentMessage_)
             {
                 auto spaceIndex = parsedMessage.indexOf(' ');
-                // If the message starts with either '/' or a '.' Twitch will treat it as a command, omitting
+                // If the message starts with either '/' or '.' Twitch will treat it as a command, omitting
                 // first space and only rest of the arguments treated as actual message content
                 // In cases when user sends a message like ". .a b" first character and first space are omitted as well
                 bool ignoreFirstSpace =

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -377,6 +377,19 @@ void TwitchChannel::sendMessage(const QString &message)
             if (parsedMessage == this->lastSentMessage_)
             {
                 auto spaceIndex = parsedMessage.indexOf(' ');
+                // If the message starts with either '/' or a '.' Twitch will treat it as a command
+                // In that case, first space will be omitted and only rest of the arguments treated as actual message content
+                // In cases when user sends a message like ". .a b" first character and space after it is omitted, just like with commands
+                bool ignoreFirstSpace =
+                    parsedMessage.at(0) == '/' || parsedMessage.at(0) == '.';
+                qCDebug(chatterinoTwitch) << parsedMessage;
+                qCDebug(chatterinoTwitch) << spaceIndex << ignoreFirstSpace;
+                if (ignoreFirstSpace)
+                {
+                    spaceIndex = parsedMessage.indexOf(' ', spaceIndex + 1);
+                }
+                qCDebug(chatterinoTwitch) << spaceIndex;
+
                 if (spaceIndex == -1)
                 {
                     // no spaces found, fall back to old magic character


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Whenever a message starts with `/` or `.` we need to ignore first space as it is not treated as the message content by Twitch. Be it either a command starting with these characters or an escaped message, like `. .foo bar`.

Look at the examples below (for better visibility, spaces were replaced with underscores)
"Goes through" is based on whether sending 2 identical messages in a row through Chatterino works or not.

|Message|Message content<br>(as interpreted by Twitch)|Goes through on master?|Goes through on PR?|
|-|-|-|-|
|`foo`|`foo`|✔️|✔️|
|`foo_bar`|`foo_bar`|✔️|✔️|
|`.foo_bar`|`bar`|❌|✔️|
|`.foo__bar`|`bar`|❌|✔️|
|`.foo_bar_baz`|`bar_baz`|❌|✔️|
|`.foo_bar__baz`|`bar__baz`|❌|✔️|
|`._foo`|`foo`|❌|✔️|
|`._.foo`|`.foo`|❌|✔️|
|`._foo_bar`|`foo_bar`|❌|✔️|
|`._foo__bar`|`foo__bar`|❌|✔️|
|`.__foo_bar`|`foo_bar`|❌|✔️|
|`.__foo__bar`|`foo__bar`|❌|✔️|

Fixes #3141