### PR TITLE
Make the browser extension issue template properly redirect

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+    - name: Issue about the Chatterino Browser Extension
+      url: https://github.com/Chatterino/chatterino-browser-ext/issues
+      about: Make a suggestion or report a bug about the Chatterino browser extension.
     - name: Suggestions or feature request
       url: https://github.com/chatterino/chatterino2/discussions/categories/ideas
       about: Got something you think should change or be added? Search for or start a new discussion!

--- a/.github/ISSUE_TEMPLATE/z_browser_extension.md
+++ b/.github/ISSUE_TEMPLATE/z_browser_extension.md
@@ -1,7 +1,0 @@
----
-name: Issue about the Chatterino Browser Extension
-about: Make a suggestion or report a bug about the Chatterino browser extension.
-
----
-
-Issues for the extension are tracked here: https://github.com/chatterino/chatterino-browser-ext


### PR DESCRIPTION
<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
Made the chatterino extension issue template a url instead.
(I just copied what was in the md file to the config)