### PR TITLE
Rewrite http server logic in boost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,6 @@ find_package(Qt${MAJOR_QT_VERSION} REQUIRED
     Multimedia
     Svg
     Concurrent
-    HttpServer
     )
 
 if (WIN32)

--- a/chatterino.pro
+++ b/chatterino.pro
@@ -20,7 +20,7 @@ MINIMUM_REQUIRED_QT_VERSION = 5.11.0
     error("You're trying to compile with Qt $$QT_VERSION, but minimum required Qt version is $$MINIMUM_REQUIRED_QT_VERSION")
 }
 
-QT                += widgets core gui network multimedia svg concurrent httpserver
+QT                += widgets core gui network multimedia svg concurrent
 CONFIG            += communi
 COMMUNI           += core model util
 

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -35,9 +35,11 @@
 #include "util/RapidjsonHelpers.hpp"
 #include "widgets/Notebook.hpp"
 #include "widgets/Window.hpp"
+#include "widgets/helper/LoginServer.hpp"
 #include "widgets/splits/Split.hpp"
 
 #include <QDesktopServices>
+#include <QtConcurrent>
 
 namespace chatterino {
 
@@ -143,6 +145,15 @@ void Application::initialize(Settings &settings, Paths &paths)
 
 int Application::run(QApplication &qtApp)
 {
+    net::io_context ioContext;
+    auto loginServer = std::make_shared<LoginServer>(nullptr, ioContext);
+    loginServer->start();
+    QtConcurrent::run([&] {
+        qDebug() << "iocontext run";
+        ioContext.run();
+        qDebug() << "iocontext done";
+    });
+
     assert(isAppInitialized);
 
     this->twitch.server->connect();

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -495,7 +495,6 @@ target_link_libraries(${LIBRARY_PROJECT}
         Qt${MAJOR_QT_VERSION}::Multimedia
         Qt${MAJOR_QT_VERSION}::Svg
         Qt${MAJOR_QT_VERSION}::Concurrent
-        Qt${MAJOR_QT_VERSION}::HttpServer
 
         LibCommuni::LibCommuni
         qt${MAJOR_QT_VERSION}keychain

--- a/src/widgets/dialogs/LoginDialog.cpp
+++ b/src/widgets/dialogs/LoginDialog.cpp
@@ -82,19 +82,11 @@ LoginDialog::LoginDialog(QWidget *parent)
 
     QObject::connect(&this->ui_.loginButton, &QPushButton::clicked, [this] {
         // Start listening for credentials
-        if (!this->loginServer_->listen())
-        {
-            qCWarning(chatterinoWidget) << "Failed to start HTTP server";
-        }
-        else
-        {
-            qInfo(chatterinoWidget) << "HTTP server Listening on " +
-                                           this->loginServer_->getAddress();
-        }
+        this->loginServer_->start();
 
         // Open login page
-        QDesktopServices::openUrl(this->loginLink);
-        this->deactivateLoginButton();
+        //        QDesktopServices::openUrl(this->loginLink);
+        //        this->deactivateLoginButton();
     });
 
     QObject::connect(&this->ui_.pasteTokenButton, &QPushButton::clicked, [this] {
@@ -187,7 +179,7 @@ void LoginDialog::logInWithToken(QString token,
 void LoginDialog::hideEvent(QHideEvent *event)
 {
     // Make the port free
-    this->loginServer_->close();
+    this->loginServer_->stop();
     // Restore login button
     this->activateLoginButton();
 }

--- a/src/widgets/dialogs/LoginDialog.cpp
+++ b/src/widgets/dialogs/LoginDialog.cpp
@@ -24,12 +24,7 @@ namespace chatterino {
 
 LoginDialog::LoginDialog(QWidget *parent)
     : QDialog(parent)
-    , iocontext_(1)
-    , acceptor_(this->iocontext_,
-                {net::ip::make_address(this->ip_.toString().toStdString()),
-                 this->port_})
-    , socket_(tcp::socket{this->iocontext_})
-    , server_(new LoginServer(this, &this->socket_))
+    // , server_(std::make_shared<LoginServer>(this))
     //    , socket_(this->iocontext_)
     // By default, QUrl constructor urlencodes our string so we don't have to do this ourselves
     , loginLink(QString("https://id.twitch.tv/oauth2/authorize"
@@ -89,9 +84,6 @@ LoginDialog::LoginDialog(QWidget *parent)
     QObject::connect(&this->ui_.loginButton, &QPushButton::clicked, [this] {
         // Start listening for credentials
         qCDebug(chatterinoWidget) << "Starting the HTTP server";
-        this->server_->loop(&this->iocontext_, &this->acceptor_,
-                            &this->socket_);
-        this->iocontext_.run();
         qDebug() << "before start";
         this->server_->start();
         qDebug() << "after start";
@@ -191,7 +183,7 @@ void LoginDialog::logInWithToken(QString token,
 void LoginDialog::hideEvent(QHideEvent *event)
 {
     // Make the port free
-    this->server_->stop(&this->iocontext_);
+    this->server_->stop();
     // Restore login button
     this->activateLoginButton();
 }

--- a/src/widgets/dialogs/LoginDialog.hpp
+++ b/src/widgets/dialogs/LoginDialog.hpp
@@ -76,6 +76,7 @@ private:
     void hideEvent(QHideEvent *e) override;
 
     friend class LoginServer;
+    friend class LoginBoost;
 };
 
 }  // namespace chatterino

--- a/src/widgets/dialogs/LoginDialog.hpp
+++ b/src/widgets/dialogs/LoginDialog.hpp
@@ -9,6 +9,7 @@
 #include <QDialog>
 #include <QDialogButtonBox>
 #include <QHBoxLayout>
+#include <QHostAddress>
 #include <QJsonArray>
 #include <QJsonObject>
 #include <QLabel>
@@ -16,9 +17,19 @@
 #include <QVBoxLayout>
 #include <QtCore/QVariant>
 
+#include <boost/asio.hpp>
+#include <boost/beast/core.hpp>
+#include <boost/beast/http.hpp>
+#include <boost/beast/version.hpp>
+
 #define LOGIN_BUTTON_START "Click to Log in"
 #define TOKEN_BUTTON_START "Paste token from clipboard"
 #define VALIDATING_TOKEN "Validating your token..."
+
+namespace beast = boost::beast;    // from <boost/beast.hpp>
+namespace http = beast::http;      // from <boost/beast/http.hpp>
+namespace net = boost::asio;       // from <boost/asio.hpp>
+using tcp = boost::asio::ip::tcp;  // from <boost/asio/ip/tcp.hpp>
 
 namespace chatterino {
 
@@ -63,8 +74,23 @@ private:
         QDialogButtonBox buttonBox;
     } ui_;
 
+    QHostAddress ip_ = QHostAddress::LocalHost;
+    unsigned short port_ = 52107;
+
+    // Properties of the LoginServer
+
+    // Input/Output context
+    net::io_context iocontext_;
+
+    // Acceptor
+    tcp::acceptor acceptor_;
+
+    // Socket for the currently connected client
+    tcp::socket socket_;
+
     // Local server listening to login data returned from Twitch
-    LoginServer *loginServer_;
+    LoginServer *server_;
+
     QUrl loginLink;
 
     void deactivateLoginButton();

--- a/src/widgets/dialogs/LoginDialog.hpp
+++ b/src/widgets/dialogs/LoginDialog.hpp
@@ -76,7 +76,7 @@ private:
     void hideEvent(QHideEvent *e) override;
 
     friend class LoginServer;
-    friend class LoginBoost;
+    friend class LoginServer;
 };
 
 }  // namespace chatterino

--- a/src/widgets/dialogs/LoginDialog.hpp
+++ b/src/widgets/dialogs/LoginDialog.hpp
@@ -75,21 +75,11 @@ private:
     } ui_;
 
     QHostAddress ip_ = QHostAddress::LocalHost;
-    unsigned short port_ = 52107;
 
     // Properties of the LoginServer
 
-    // Input/Output context
-    net::io_context iocontext_;
-
-    // Acceptor
-    tcp::acceptor acceptor_;
-
-    // Socket for the currently connected client
-    tcp::socket socket_;
-
     // Local server listening to login data returned from Twitch
-    LoginServer *server_;
+    std::shared_ptr<LoginServer> server_;
 
     QUrl loginLink;
 

--- a/src/widgets/helper/LoginServer.cpp
+++ b/src/widgets/helper/LoginServer.cpp
@@ -217,12 +217,11 @@ void LoginBoost::checkDeadline()
 {
     auto self = shared_from_this();
 
-    deadline_.async_wait([this, self](beast::error_code ec) {
+    deadline_.async_wait([self](beast::error_code ec) {
         if (!ec)
         {
             // Close socket to cancel any outstanding operation
             self->socket_.close(ec);
-            this->socket_.close(ec);
         }
     });
 }

--- a/src/widgets/helper/LoginServer.hpp
+++ b/src/widgets/helper/LoginServer.hpp
@@ -6,6 +6,16 @@
 #include <QTcpServer>
 #include <QtHttpServer/QHttpServer>
 
+#include <boost/asio.hpp>
+#include <boost/beast/core.hpp>
+#include <boost/beast/http.hpp>
+#include <boost/beast/version.hpp>
+
+namespace beast = boost::beast;    // from <boost/beast.hpp>
+namespace http = beast::http;      // from <boost/beast/http.hpp>
+namespace net = boost::asio;       // from <boost/asio.hpp>
+using tcp = boost::asio::ip::tcp;  // from <boost/asio/ip/tcp.hpp>
+
 namespace chatterino {
 
 class LoginDialog;
@@ -31,6 +41,50 @@ private:
     QTcpServer *tcp_;
 
     void initializeRoutes();
+};
+
+class LoginBoost : public std::enable_shared_from_this<LoginBoost>
+{
+public:
+    LoginBoost(tcp::socket socket)
+        : socket_(std::move(socket))
+    {
+    }
+
+    // Initiate the asynchronous operations associated with the connection
+    void start();
+
+private:
+    // The socket for the currently connected client
+    tcp::socket socket_;
+
+    // The buffer for performing reads
+    beast::flat_buffer buffer_{8192};
+
+    // The request message
+    http::request<http::dynamic_body> request_;
+
+    // The response message
+    http::response<http::dynamic_body> response_;
+
+    // The timer for putting a deadline on connection processing
+    net::steady_timer deadline_{socket_.get_executor(),
+                                std::chrono::seconds(15)};
+
+    // Asynchronously receive a complete request message
+    void readRequest();
+
+    // Determine what needs to be done with the request message
+    void processRequest();
+
+    // Construct a response message based on the program state
+    void createResponse();
+
+    // Asynchronously transmit the response message
+    void writeResponse();
+
+    // Check whether we have spent enough time on this connection
+    void checkDeadline();
 };
 
 }  // namespace chatterino

--- a/src/widgets/helper/LoginServer.hpp
+++ b/src/widgets/helper/LoginServer.hpp
@@ -42,50 +42,30 @@ class LoginDialog;
 class LoginServer : public std::enable_shared_from_this<LoginServer>
 {
 public:
-    LoginServer(LoginDialog *parent, tcp::socket *socket);
+    LoginServer(LoginDialog *parent, net::io_context &ioContext);
 
-    // Initiate the asynchronous operations associated with the connection
+    // Kickstarts the acceptor into accepting new sessions
     void start();
 
-    // FeelsGoodMan
-    void loop(net::io_context *iocontext, tcp::acceptor *acceptor,
-              tcp::socket *socket);
+    // Stops the acceptor from accepting new sessions
+    void stop();
 
-    // Stops the HTTP server or something, idk I'm not the engineer
-    void stop(net::io_context *iocontext);
+    unsigned short port_ = 52107;
 
 private:
+    // doAccept starts listening to the acceptor
+    void doAccept();
+
+    // onAccept is called when a client has been accepted by the accptor
+    void onAccept(beast::error_code ec, tcp::socket socket);
+
+    net::io_context &ioContext_;
+
+    // Acceptor
+    tcp::acceptor acceptor_;
+
     // Parent LoginDialog instance
     LoginDialog *parent_;
-
-    // Socket for the currently connected client
-    tcp::socket *socket_;
-
-    // Buffer for performing reads
-    beast::flat_buffer buffer_{8192};
-
-    // Request and response messages
-    http::request<http::dynamic_body> request_;
-    http::response<http::dynamic_body> response_;
-
-    // Timer for putting a deadline on connection processing
-    net::steady_timer deadline_{socket_->get_executor(),
-                                std::chrono::seconds(15)};
-
-    // Asynchronously receive a complete request message
-    void readRequest();
-
-    // Determine what needs to be done with the request message
-    void processRequest();
-
-    // Construct a response message based on the program state
-    void createResponse();
-
-    // Asynchronously transmit the response message
-    void writeResponse();
-
-    // Check whether we have spent enough time on this connection
-    void checkDeadline();
 };
 
 }  // namespace chatterino


### PR DESCRIPTION
For #3065

- xd
- Use self as shared_from_this();
- Basically rewrote everything, but it doesn't work
- Now it at least compiles and serves the response once before crashing
