### PR TITLE
Fixed away command in IRC

### DIFF
--- a/src/providers/irc/IrcCommands.cpp
+++ b/src/providers/irc/IrcCommands.cpp
@@ -47,7 +47,7 @@ Outcome invokeIrcCommand(const QString &commandName, const QString &allParams,
     }
     else if (cmd == "away")
     {
-        sendRaw("AWAY" + params[0] + " :" + paramsAfter(0));
+        sendRaw("AWAY " + params[0] + " :" + paramsAfter(0));
     }
     else if (cmd == "knock")
     {


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

It didn't have space in between actual command and parameters, making it impossible to use it.
![secret-irc-network-btw](https://i.imgur.com/hmQeOKN.png)
Fixes a mistake from 765a75f15.
The commit is almost 2 year old and the fact that nobody noticed it was broken until now makes me think that a changelog entry is not needed for this one.