### PR TITLE
Fix missing information in locally-generated IRC messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Bugfix: Moderation mode and active filters are now preserved when opening a split as a popup. (#3113, #3130)
 - Bugfix: Fixed a bug that caused all badge highlights to use the same color. (#3132, #3134)
 - Bugfix: Allow starting Streamlink from Chatterino when running as a Flatpak. (#3178)
+- Bugfix: Fixed own IRC messages not having metadata and a link to a usercard. (#3203)
 - Dev: Renamed CMake's build option `USE_SYSTEM_QT5KEYCHAIN` to `USE_SYSTEM_QTKEYCHAIN`. (#3103)
 - Dev: Add benchmarks that can be compiled with the `BUILD_BENCHMARKS` CMake flag. Off by default. (#3038)
 

--- a/src/providers/irc/IrcChannel2.cpp
+++ b/src/providers/irc/IrcChannel2.cpp
@@ -1,6 +1,7 @@
 #include "IrcChannel2.hpp"
 
 #include "debug/AssertInGuiThread.hpp"
+#include "messages/Message.hpp"
 #include "messages/MessageBuilder.hpp"
 #include "providers/irc/IrcCommands.hpp"
 #include "providers/irc/IrcServer.hpp"
@@ -33,9 +34,14 @@ void IrcChannel::sendMessage(const QString &message)
 
         MessageBuilder builder;
         builder.emplace<TimestampElement>();
-        builder.emplace<TextElement>(this->server()->nick() + ":",
-                                     MessageElementFlag::Username);
+        const auto &nick = this->server()->nick();
+        builder.emplace<TextElement>(nick + ":", MessageElementFlag::Username)
+            ->setLink({Link::UserInfo, nick});
         builder.emplace<TextElement>(message, MessageElementFlag::Text);
+        builder.message().messageText = message;
+        builder.message().searchText = nick + ": " + message;
+        builder.message().loginName = nick;
+        builder.message().displayName = nick;
         this->addMessage(builder.release());
     }
 }


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
Adds a link onto the username which opens a usercard, `messageText`/`searchText`, `loginName`/`displayName`.
Closes #1422