### PR TITLE
Raise ratelimit cooldown for JOIN messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Bugfix: Fixed a bug that caused all badge highlights to use the same color. (#3132, #3134)
 - Bugfix: Allow starting Streamlink from Chatterino when running as a Flatpak. (#3178)
 - Bugfix: Fixed own IRC messages not having metadata and a link to a usercard. (#3203)
+- Bugfix: Fixed some channels still not loading in rare cases. (#3219)
 - Dev: Renamed CMake's build option `USE_SYSTEM_QT5KEYCHAIN` to `USE_SYSTEM_QTKEYCHAIN`. (#3103)
 - Dev: Add benchmarks that can be compiled with the `BUILD_BENCHMARKS` CMake flag. Off by default. (#3038)
 

--- a/src/providers/irc/AbstractIrcServer.cpp
+++ b/src/providers/irc/AbstractIrcServer.cpp
@@ -17,7 +17,7 @@ const int MAX_FALLOFF_COUNTER = 60;
 
 // Ratelimits for joinBucket_
 const int JOIN_RATELIMIT_BUDGET = 18;
-const int JOIN_RATELIMIT_COOLDOWN = 10500;
+const int JOIN_RATELIMIT_COOLDOWN = 12500;
 
 AbstractIrcServer::AbstractIrcServer()
 {


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

This basically ensures we will actually join all the channels just fine - in some rare cases, even with ratelimitting logic, our JOINs can get lost in a limbo.

Even though we use the "18 JOINs / 10.5s" system now, sometimes sending messages to IRC can hit a small lagspike and (as quoted by @Felanbird, who also keeps getting this issue): "if the lag ends up being over .5s then eventually it will catch up to you and you'll be joining slightly faster than 10s and Twitch say NO". I got this issue a couple times myself as well.
