### PR TITLE
added support for watching streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unversioned
 
+- Major: Allow watching twitch streams with Chatterino StreamView (Windows only)
 - Minor: Remove TwitchEmotes.com attribution and the open/copy options when right-clicking a Twitch Emote. (#2214, #3136)
 - Minor: Strip leading @ and trailing , from username in /user and /usercard commands. (#3143)
 - Minor: Display a system message when reloading subscription emotes to match BTTV/FFZ behavior (#3135)

--- a/chatterino.pro
+++ b/chatterino.pro
@@ -251,6 +251,7 @@ SOURCES += \
     src/util/NuulsUploader.cpp \
     src/util/RapidjsonHelpers.cpp \
     src/util/RatelimitBucket.cpp \
+    src/util/RunStreamView.cpp \
     src/util/SplitCommand.cpp \
     src/util/StreamerMode.cpp \
     src/util/StreamLink.cpp \
@@ -503,6 +504,7 @@ HEADERS += \
     src/util/PostToThread.hpp \
     src/util/QObjectRef.hpp \
     src/util/QStringHash.hpp \
+    src/util/RunStreamView.hpp \
     src/util/rangealgorithm.hpp \
     src/util/RapidjsonHelpers.hpp \
     src/util/RapidJsonSerializeQString.hpp \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -289,6 +289,8 @@ set(SOURCE_FILES
         util/RapidjsonHelpers.hpp
         util/RatelimitBucket.cpp
         util/RatelimitBucket.hpp
+        util/RunStreamView.cpp
+        util/RunStreamView.hpp
         util/SplitCommand.cpp
         util/SplitCommand.hpp
         util/StreamLink.cpp

--- a/src/util/RunStreamView.cpp
+++ b/src/util/RunStreamView.cpp
@@ -1,0 +1,51 @@
+#include "RunStreamView.hpp"
+
+#include <QFile>
+
+#ifdef USEWINSDK
+#    include <Windows.h>
+#    include "widgets/FramelessEmbedWindow.hpp"
+#endif
+
+namespace chatterino {
+
+namespace {
+    QString streamViewPath()
+    {
+        return qApp->applicationDirPath() + "/StreamView/StreamView.exe";
+        // return R"(C:\Users\daniel\Documents\Git\chatterino-streamview\StreamView\StreamView\bin\Debug\StreamView.exe)";
+    }
+}  // namespace
+
+bool canRunStreamView()
+{
+#ifdef USEWINSDK
+    static bool value = QFile(streamViewPath()).exists();
+    return value;
+#else
+    return false;
+#endif
+}
+
+void runStreamView(const QString &channel)
+{
+#ifdef USEWINSDK
+    FramelessEmbedWindow *window = new FramelessEmbedWindow;
+
+    window->createWinId();
+    auto chatHandle = QString::number(window->winId());
+
+    QProcess::startDetached(
+        streamViewPath(), {"--chat-handle", chatHandle, "--channel", channel});
+
+    // Dispose self if there's no parent after 30 seconds
+    QTimer::singleShot(30000, window, [window] {
+        if (GetParent(reinterpret_cast<HWND>(window->winId())) == nullptr)
+        {
+            window->close();
+        }
+    });
+#endif
+}
+
+}  // namespace chatterino

--- a/src/util/RunStreamView.hpp
+++ b/src/util/RunStreamView.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <QString>
+
+namespace chatterino {
+
+bool canRunStreamView();
+void runStreamView(const QString &channel);
+
+}  // namespace chatterino

--- a/src/widgets/FramelessEmbedWindow.hpp
+++ b/src/widgets/FramelessEmbedWindow.hpp
@@ -16,10 +16,12 @@ protected:
     bool nativeEvent(const QByteArray &eventType, void *message,
                      long *result) override;
     void showEvent(QShowEvent *event) override;
+    virtual void scaleChangedEvent(float) override;
 #endif
 
 private:
     Split *split_{};
+    QString hostWindowId{};
 };
 
 }  // namespace chatterino

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -16,6 +16,7 @@
 #include "singletons/WindowManager.hpp"
 #include "util/Clipboard.hpp"
 #include "util/NuulsUploader.hpp"
+#include "util/RunStreamView.hpp"
 #include "util/Shortcut.hpp"
 #include "util/StreamLink.hpp"
 #include "widgets/Notebook.hpp"
@@ -614,6 +615,14 @@ void Split::explainSplitting()
 {
     showTutorialVideo(this, ":/examples/splitting.gif", "Splitting",
                       "Hold <Ctrl+Alt> to add new splits.\n\nExample:");
+}
+
+void Split::startWatching()
+{
+    if (auto channel = this->channel_.get())
+    {
+        runStreamView(channel->getName());
+    }
 }
 
 void Split::popup()

--- a/src/widgets/splits/Split.hpp
+++ b/src/widgets/splits/Split.hpp
@@ -159,6 +159,7 @@ public slots:
     void changeChannel();
     void explainMoving();
     void explainSplitting();
+    void startWatching();
     void popup();
     void clear();
     void openInBrowser();

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -13,6 +13,7 @@
 #include "util/Helpers.hpp"
 #include "util/LayoutCreator.hpp"
 #include "util/LayoutHelper.hpp"
+#include "util/RunStreamView.hpp"
 #include "util/StreamerMode.hpp"
 #include "widgets/Label.hpp"
 #include "widgets/TooltipWidget.hpp"
@@ -369,6 +370,12 @@ std::unique_ptr<QMenu> SplitHeader::createMainMenu()
 
     if (twitchChannel)
     {
+        if (canRunStreamView())
+        {
+            menu->addAction("Start watching", this->split_,
+                            &Split::startWatching);
+        }
+
         menu->addAction(OPEN_IN_BROWSER, this->split_, &Split::openInBrowser);
 #ifndef USEWEBENGINE
         menu->addAction(OPEN_PLAYER_IN_BROWSER, this->split_,


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Allows watching streams from Chatterino. Only works on windows since it uses webview2.
![image](https://user-images.githubusercontent.com/6320036/132103003-15470dbd-035d-469d-b5e8-d3e79f6c0bc8.png)
![image](https://user-images.githubusercontent.com/6320036/132103016-644e7d7e-d051-4337-a1a2-689abca83839.png)


## Testing it

1. Be on Windows.
2. Install [webview2](https://developer.microsoft.com/en-us/microsoft-edge/webview2/#download-section) *or* MS Edge Beta
3. Download StreamView. You can use the prebuilt one from here: [fourtf.com/StreamView-0.zip](https://fourtf.com/StreamView-0.zip)
4. Put it into the Chatterino folder so the `StreamView` folder is on the same level as `chatterino.exe`.
  ![image](https://user-images.githubusercontent.com/6320036/132103211-dbc5c5ed-52c1-4bf6-8877-3b13c25e2c59.png)
5. Run Chatterino or StreamView/StreamView.exe