### PR TITLE
Fix completion menu completing from wrong position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Bugfix: Allow starting Streamlink from Chatterino when running as a Flatpak. (#3178)
 - Bugfix: Fixed own IRC messages not having metadata and a link to a usercard. (#3203)
 - Bugfix: Fixed some channels still not loading in rare cases. (#3219)
+- Bugfix: Fixed a bug with usernames or emotes completing from the wrong position. (#3229)
 - Dev: Renamed CMake's build option `USE_SYSTEM_QT5KEYCHAIN` to `USE_SYSTEM_QTKEYCHAIN`. (#3103)
 - Dev: Add benchmarks that can be compiled with the `BUILD_BENCHMARKS` CMake flag. Off by default. (#3038)
 

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -562,7 +562,7 @@ void SplitInput::insertCompletionText(const QString &input_)
     auto input = input_ + ' ';
 
     auto text = edit.toPlainText();
-    auto position = edit.textCursor().position();
+    auto position = edit.textCursor().position() - 1;
 
     for (int i = clamp(position, 0, text.length() - 1); i >= 0; i--)
     {
@@ -583,7 +583,7 @@ void SplitInput::insertCompletionText(const QString &input_)
         if (done)
         {
             auto cursor = edit.textCursor();
-            edit.setText(text.remove(i, position - i).insert(i, input));
+            edit.setText(text.remove(i, position - i + 1).insert(i, input));
 
             cursor.setPosition(i + input.size());
             edit.setTextCursor(cursor);


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description
Applies to both username and emote completion using the completion menu.
Could probably change to `position - 1` in line 567 instead but this way it's consistent with `SplitInput::updateCompletionPopup`.

Fixes #3225