### PR TITLE
Add `flags.reward_message` filter variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Minor: Colorizing usernames on IRC, originally made for Mm2PL/dankerino (#3206)
 - Minor: Fixed `/streamlink` command not stripping leading @'s or #'s (#3215)
 - Minor: Strip leading @ and trailing , from username in `/popout` command. (#3217)
+- Minor: Added `flags.reward_message` filter variable (#3231)
 - Bugfix: Fixed colored usernames sometimes not working. (#3170)
 - Bugfix: Restored ability to send duplicate `/me` messages. (#3166)
 - Bugfix: Notifications for moderators about other moderators deleting messages can now be disabled. (#3121)

--- a/src/controllers/filters/parser/FilterParser.cpp
+++ b/src/controllers/filters/parser/FilterParser.cpp
@@ -28,6 +28,7 @@ ContextMap buildContextMap(const MessagePtr &m, chatterino::Channel *channel)
      * flags.points_redeemed
      * flags.sub_message
      * flags.system_message
+     * flags.reward_message
      * flags.whisper
      *
      * message.content
@@ -77,6 +78,7 @@ ContextMap buildContextMap(const MessagePtr &m, chatterino::Channel *channel)
         {"flags.points_redeemed", m->flags.has(MessageFlag::RedeemedHighlight)},
         {"flags.sub_message", m->flags.has(MessageFlag::Subscription)},
         {"flags.system_message", m->flags.has(MessageFlag::System)},
+        {"flags.reward_message", m->flags.has(MessageFlag::RedeemedChannelPointReward)},
         {"flags.whisper", m->flags.has(MessageFlag::Whisper)},
 
         {"message.content", m->messageText},

--- a/src/controllers/filters/parser/FilterParser.cpp
+++ b/src/controllers/filters/parser/FilterParser.cpp
@@ -78,7 +78,8 @@ ContextMap buildContextMap(const MessagePtr &m, chatterino::Channel *channel)
         {"flags.points_redeemed", m->flags.has(MessageFlag::RedeemedHighlight)},
         {"flags.sub_message", m->flags.has(MessageFlag::Subscription)},
         {"flags.system_message", m->flags.has(MessageFlag::System)},
-        {"flags.reward_message", m->flags.has(MessageFlag::RedeemedChannelPointReward)},
+        {"flags.reward_message",
+         m->flags.has(MessageFlag::RedeemedChannelPointReward)},
         {"flags.whisper", m->flags.has(MessageFlag::Whisper)},
 
         {"message.content", m->messageText},

--- a/src/controllers/filters/parser/Tokenizer.hpp
+++ b/src/controllers/filters/parser/Tokenizer.hpp
@@ -22,6 +22,7 @@ static const QMap<QString, QString> validIdentifiersMap = {
     {"flags.points_redeemed", "redeemed points?"},
     {"flags.sub_message", "sub/resub message?"},
     {"flags.system_message", "system message?"},
+    {"flags.reward_message", "channel point reward message?"},
     {"flags.whisper", "whisper message?"},
     {"message.content", "message text"},
     {"message.length", "message length"}};


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Adds `flags.reward_message` variable for filtering on channel point reward messages.
