### PR TITLE
Add keybindings to tab context menu items

### DIFF
--- a/src/widgets/helper/NotebookTab.cpp
+++ b/src/widgets/helper/NotebookTab.cpp
@@ -60,9 +60,12 @@ NotebookTab::NotebookTab(Notebook *notebook)
         this->showRenameDialog();
     });
 
-    this->menu_.addAction("Close Tab", [=]() {
-        this->notebook_->removePage(this->page);
-    });
+    this->menu_.addAction(
+        "Close Tab",
+        [=]() {
+            this->notebook_->removePage(this->page);
+        },
+        QKeySequence("Ctrl+Shift+W"));
 
     this->menu_.addAction(
         "Popup Tab",
@@ -86,9 +89,12 @@ NotebookTab::NotebookTab(Notebook *notebook)
 
     this->menu_.addSeparator();
 
-    this->menu_.addAction("Toggle visibility of tabs", [this]() {
-        this->notebook_->setShowTabs(!this->notebook_->getShowTabs());
-    });
+    this->menu_.addAction(
+        "Toggle visibility of tabs",
+        [this]() {
+            this->notebook_->setShowTabs(!this->notebook_->getShowTabs());
+        },
+        QKeySequence("Ctrl+U"));
 }
 
 void NotebookTab::showRenameDialog()


### PR DESCRIPTION
Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable

# Description

When the "Popup Tab" entry was added to the tab context menu we added it with the shortcut for it. For consistency with that and with the split context menu it makes sense to add the keybinds for other relevant entries. This also increases user awareness of useful shortcuts.