### PR TITLE
Fix spacing of tab visibility keybind in keybindings page

### DIFF
--- a/src/widgets/settingspages/KeyboardSettingsPage.cpp
+++ b/src/widgets/settingspages/KeyboardSettingsPage.cpp
@@ -59,7 +59,7 @@ KeyboardSettingsPage::KeyboardSettingsPage()
 
     form->addRow(new QLabel("Alt + ←/↑/→/↓"),
                  new QLabel("Select left/upper/right/bottom split"));
-    form->addRow(new QLabel("Ctrl+U"), new QLabel("Toggle visibility of tabs"));
+    form->addRow(new QLabel("Ctrl + U"), new QLabel("Toggle visibility of tabs"));
 
     form->addItem(new QSpacerItem(16, 16));
     form->addRow(new QLabel("Ctrl + R"), new QLabel("Change channel"));


### PR DESCRIPTION
Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable

# Description

Simply for consistency with the rest of the keybindings in the page.
