### PR TITLE
Restart the application bundle instead of the underlying executable when crashing on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Bugfix: Fixed own IRC messages not having metadata and a link to a usercard. (#3203)
 - Bugfix: Fixed some channels still not loading in rare cases. (#3219)
 - Bugfix: Fixed a bug with usernames or emotes completing from the wrong position. (#3229)
+- Bugfix: Fixed second chatterino icon appearing in the dock when restarting on a crash in macOS. (#3268)
 - Dev: Renamed CMake's build option `USE_SYSTEM_QT5KEYCHAIN` to `USE_SYSTEM_QTKEYCHAIN`. (#3103)
 - Dev: Add benchmarks that can be compiled with the `BUILD_BENCHMARKS` CMake flag. Off by default. (#3038)
 

--- a/src/RunGui.cpp
+++ b/src/RunGui.cpp
@@ -28,6 +28,10 @@
 #    include <QBreakpadHandler.h>
 #endif
 
+#ifdef Q_OS_MAC
+#    include "corefoundation/CFBundle.h"
+#endif
+
 namespace chatterino {
 namespace {
     void installCustomPalette()
@@ -122,8 +126,29 @@ namespace {
             std::chrono::steady_clock::now() - signalsInitTime > 30s)
         {
             QProcess proc;
+
+#ifdef Q_OS_MAC
+            // On macOS, programs are bundled into ".app" Application bundles,
+            // when restarting chatterino that bundle should be opened with the "open"
+            // terminal command instead of directly starting the underlying executable,
+            // as those are 2 different things for the OS and i.e. do not use
+            // the same dock icon (resulting in a second chatterino icon on restarting)
+            CFURLRef appUrlRef = CFBundleCopyBundleURL(CFBundleGetMainBundle());
+            CFStringRef macPath =
+                CFURLCopyFileSystemPath(appUrlRef, kCFURLPOSIXPathStyle);
+            const char *pathPtr =
+                CFStringGetCStringPtr(macPath, CFStringGetSystemEncoding());
+
+            proc.setProgram("open");
+            proc.setArguments({pathPtr, "--args", "--crash-recovery"});
+
+            CFRelease(appUrlRef);
+            CFRelease(macPath);
+#else
             proc.setProgram(QApplication::applicationFilePath());
             proc.setArguments({"--crash-recovery"});
+#endif
+
             proc.startDetached();
         }
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

On macOS, programs are contained in ".app" application bundles. When chatterino restarts on a crash, it currently just looks for the executable path obtained via `QApplication::applicationFilePath()` and starts that again, which for macOS is the underlying unix executable inside of the application bundle. Unfortunately, for macOS those 2 are absolutely different, resulting in i.e. a second chatterino icon being added to the dock, due to the OS not recognizing that it is the same application.

This PR changes the restart logic for macOS to use Apples CoreFoundation API to get the path of the application bundle, and open this using the built-in "open" command. For every other OS, just starting the executable directly is, at least afaik, perfectly fine.