### PR TITLE
Fix "Change channel" popup title

### DIFF
--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -466,6 +466,7 @@ void Split::showChangeChannelPopup(const char *dialogTitle, bool empty,
         dialog->setSelectedChannel(this->getIndirectChannel());
     }
     dialog->setAttribute(Qt::WA_DeleteOnClose);
+    dialog->setWindowTitle(dialogTitle);
     dialog->show();
     dialog->closed.connect([=] {
         if (dialog->hasSeletedChannel())


### PR DESCRIPTION
Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable

# Description

A simple fix; The `dialogTitle` parameter when calling `showChangeChannelPopup` was unused.

Fixes #3269