### PR TITLE
Capitalize mentions of "Twitch" in comments and text/settings

### DIFF
--- a/src/common/Args.cpp
+++ b/src/common/Args.cpp
@@ -48,7 +48,7 @@ Args::Args(const QApplication &app)
     parser.addOption(QCommandLineOption(
         {"c", "channels"},
         "Joins only supplied channels on startup. Use letters with colons to "
-        "specify platform. Only twitch channels are supported at the moment.\n"
+        "specify platform. Only Twitch channels are supported at the moment.\n"
         "If platform isn't specified, default is Twitch.",
         "t:channel1;t:channel2;..."));
 

--- a/src/common/WindowDescriptors.hpp
+++ b/src/common/WindowDescriptors.hpp
@@ -29,7 +29,7 @@ namespace chatterino {
 enum class WindowType;
 
 struct SplitDescriptor {
-    // twitch or mentions or watching or whispers or irc
+    // Twitch or mentions or watching or whispers or irc
     QString type_;
 
     // Twitch Channel name or IRC channel name

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -127,7 +127,7 @@ bool appendWhisperMessageWordsLocally(const QStringList &words)
     auto emote = boost::optional<EmotePtr>{};
     for (int i = 2; i < words.length(); i++)
     {
-        {  // twitch emote
+        {  // Twitch emote
             auto it = accemotes.emotes.find({words[i]});
             if (it != accemotes.emotes.end())
             {
@@ -135,7 +135,7 @@ bool appendWhisperMessageWordsLocally(const QStringList &words)
                                         MessageElementFlag::TwitchEmote);
                 continue;
             }
-        }  // twitch emote
+        }  // Twitch emote
 
         {  // bttv/ffz emote
             if ((emote = bttvemotes.emote({words[i]})))
@@ -898,7 +898,7 @@ QString CommandController::execCommand(const QString &textNoEmoji,
 
     QString commandName = words[0];
 
-    // works in a valid twitch channel and /whispers, etc...
+    // works in a valid Twitch channel and /whispers, etc...
     if (!dryRun && channel->isTwitchChannel())
     {
         if (whisperCommands.contains(commandName, Qt::CaseInsensitive))
@@ -934,7 +934,7 @@ QString CommandController::execCommand(const QString &textNoEmoji,
         }
     }
 
-    // works only in a valid twitch channel
+    // works only in a valid Twitch channel
     if (!dryRun && twitchChannel != nullptr)
     {
         // check if command exists

--- a/src/controllers/notifications/NotificationController.cpp
+++ b/src/controllers/notifications/NotificationController.cpp
@@ -165,7 +165,7 @@ void NotificationController::getFakeTwitchChannelLiveStatus(
             if (i != fakeTwitchChannels.end())
             {
                 // We have already pushed the live state of this stream
-                // Could not find stream in fake twitch channels!
+                // Could not find stream in fake Twitch channels!
                 return;
             }
 

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -330,7 +330,7 @@ void IrcMessageHandler::handleRoomStateMessage(Communi::IrcMessage *message)
 {
     const auto &tags = message->tags();
 
-    // get twitch channel
+    // get Twitch channel
     QString chanName;
     if (!trimChannelName(message->parameter(0), chanName))
     {

--- a/src/providers/twitch/PubsubClient.cpp
+++ b/src/providers/twitch/PubsubClient.cpp
@@ -1488,7 +1488,7 @@ void PubSub::handleMessageResponse(const rapidjson::Value &outerData)
 
                 // this message also contains per-word automod data, which could be implemented
 
-                // extract sender data manually because twitch loves not being consistent
+                // extract sender data manually because Twitch loves not being consistent
                 rapidjson::Value senderData;
                 if (!rj::getSafeObject(messageData, "sender", senderData))
                 {

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -211,7 +211,7 @@ MessagePtr TwitchMessageBuilder::build()
         this->bits = iterator.value().toString();
     }
 
-    // twitch emotes
+    // Twitch emotes
     std::vector<TwitchEmoteOccurence> twitchEmotes;
 
     iterator = this->tags.find("emotes");

--- a/src/singletons/Paths.hpp
+++ b/src/singletons/Paths.hpp
@@ -28,7 +28,7 @@ public:
     // Hash of QCoreApplication::applicationFilePath()
     QString applicationFilePathHash;
 
-    // Profile avatars for twitch <appDataDirectory>/cache/twitch
+    // Profile avatars for Twitch <appDataDirectory>/cache/twitch
     QString twitchProfileAvatars;
 
     bool createFolder(const QString &folderPath);

--- a/src/widgets/dialogs/SelectChannelDialog.cpp
+++ b/src/widgets/dialogs/SelectChannelDialog.cpp
@@ -51,7 +51,7 @@ SelectChannelDialog::SelectChannelDialog(QWidget *parent)
         auto channel_btn = vbox.emplace<QRadioButton>("Channel").assign(
             &this->ui_.twitch.channel);
         auto channel_lbl =
-            vbox.emplace<QLabel>("Join a twitch channel by its name.").hidden();
+            vbox.emplace<QLabel>("Join a Twitch channel by its name.").hidden();
         channel_lbl->setWordWrap(true);
         auto channel_edit = vbox.emplace<QLineEdit>().hidden().assign(
             &this->ui_.twitch.channelName);

--- a/src/widgets/dialogs/SelectChannelDialog.cpp
+++ b/src/widgets/dialogs/SelectChannelDialog.cpp
@@ -51,7 +51,7 @@ SelectChannelDialog::SelectChannelDialog(QWidget *parent)
         auto channel_btn = vbox.emplace<QRadioButton>("Channel").assign(
             &this->ui_.twitch.channel);
         auto channel_lbl =
-            vbox.emplace<QLabel>("Join a Twitch channel by its name.").hidden();
+            vbox.emplace<QLabel>("Join a twitch channel by its name.").hidden();
         channel_lbl->setWordWrap(true);
         auto channel_edit = vbox.emplace<QLineEdit>().hidden().assign(
             &this->ui_.twitch.channelName);

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1927,7 +1927,7 @@ void ChannelView::addContextMenuItems(
         crossPlatformCopy(copyString);
     });
 
-    // If is a link to a twitch user/stream
+    // If is a link to a Twitch user/stream
     if (hoveredElement->getLink().type == Link::Url)
     {
         static QRegularExpression twitchChannelRegex(

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -651,7 +651,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     layout.addCheckbox("Only search for username autocompletion with an @",
                        s.userCompletionOnlyWithAt);
 
-    layout.addCheckbox("Show twitch whispers inline", s.inlineWhispers);
+    layout.addCheckbox("Show Twitch whispers inline", s.inlineWhispers);
     layout.addCheckbox("Highlight received inline whispers",
                        s.highlightInlineWhispers);
     layout.addCheckbox("Load message history on connect",

--- a/src/widgets/settingspages/IgnoresPage.cpp
+++ b/src/widgets/settingspages/IgnoresPage.cpp
@@ -73,7 +73,7 @@ void addUsersTab(IgnoresPage &page, LayoutCreator<QVBoxLayout> users,
 {
     auto label = users.emplace<QLabel>(INFO);
     label->setWordWrap(true);
-    users.append(page.createCheckBox("Enable twitch blocked users",
+    users.append(page.createCheckBox("Enable Twitch blocked users",
                                      getSettings()->enableTwitchBlockedUsers));
 
     auto anyways = users.emplace<QHBoxLayout>().withoutMargin();

--- a/src/widgets/splits/Split.hpp
+++ b/src/widgets/splits/Split.hpp
@@ -116,15 +116,15 @@ private:
     void updateInputPlaceholder();
 
     /**
-     * @brief Opens twitch channel stream in a browser player (opens a formatted link)
+     * @brief Opens Twitch channel stream in a browser player (opens a formatted link)
      */
     void openChannelInBrowserPlayer(ChannelPtr channel);
     /**
-     * @brief Opens twitch channel stream in streamlink app (if stream is live and streamlink is installed)
+     * @brief Opens Twitch channel stream in streamlink app (if stream is live and streamlink is installed)
      */
     void openChannelInStreamlink(QString channelName);
     /**
-     * @brief Opens twitch channel chat in a new chatterino tab
+     * @brief Opens Twitch channel chat in a new chatterino tab
      */
     void joinChannelInNewTab(ChannelPtr channel);
 


### PR DESCRIPTION
Pull request checklist:

- [X] `CHANGELOG.md` was updated, if applicable

# Description
Noticed while reviewing `#3273`, I thought to myself `Shouldn't 'twitch' be capitalized?` and here we are.

Changes capitalization in comments along with various mentions in settings.

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
