### PR TITLE
Fixed Cirrus CI action

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,5 +9,5 @@ task:
     git submodule update
     mkdir build
     cd build
-    qmake RAPIDJSON_SYSTEM=1 QMAKE_CC="cc" QMAKE_CXX="c++"  QMAKE_LINK_C="cc" QMAKE_LINK_C_SHLIB="cc"  QMAKE_LINK="c++" QMAKE_LINK_SHLIB="c++"  QMAKE_CFLAGS="-O2 -pipe  -fstack-protector-strong -fno-strict-aliasing "  QMAKE_CXXFLAGS="-O2 -pipe -fstack-protector-strong -fno-strict-aliasing  "  QMAKE_LFLAGS="-fstack-protector-strong"  QMAKE_LIBS=""  QMAKE_CFLAGS_DEBUG=""  QMAKE_CFLAGS_RELEASE=""  QMAKE_CXXFLAGS_DEBUG=""  QMAKE_CXXFLAGS_RELEASE=""  PREFIX="/usr/local" CONFIG+="release"  CONFIG-="debug separate_debug_info" -recursive ..
+    qmake-qt5 RAPIDJSON_SYSTEM=1 QMAKE_CC="cc" QMAKE_CXX="c++"  QMAKE_LINK_C="cc" QMAKE_LINK_C_SHLIB="cc"  QMAKE_LINK="c++" QMAKE_LINK_SHLIB="c++"  QMAKE_CFLAGS="-O2 -pipe  -fstack-protector-strong -fno-strict-aliasing "  QMAKE_CXXFLAGS="-O2 -pipe -fstack-protector-strong -fno-strict-aliasing  "  QMAKE_LFLAGS="-fstack-protector-strong"  QMAKE_LIBS=""  QMAKE_CFLAGS_DEBUG=""  QMAKE_CFLAGS_RELEASE=""  QMAKE_CXXFLAGS_DEBUG=""  QMAKE_CXXFLAGS_RELEASE=""  PREFIX="/usr/local" CONFIG+="release"  CONFIG-="debug separate_debug_info" -recursive ..
     make -j $(getconf _NPROCESSORS_ONLN)


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Turns out name of the qmake binary has changed to `qmake-qt5`
Action Terminal turned out ultra useful for debugging
![cirrus ci action terminal](https://cdn.zneix.eu/NAvrduK.png)
