### PR TITLE
Very small fix for a bug with the new restart logic in macOS

### DIFF
--- a/src/RunGui.cpp
+++ b/src/RunGui.cpp
@@ -140,7 +140,7 @@ namespace {
                 CFStringGetCStringPtr(macPath, CFStringGetSystemEncoding());
 
             proc.setProgram("open");
-            proc.setArguments({pathPtr, "--args", "--crash-recovery"});
+            proc.setArguments({pathPtr, "-n", "--args", "--crash-recovery"});
 
             CFRelease(appUrlRef);
             CFRelease(macPath);


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable (Definitely does not need a changelog entry)

# Description

Fixes an issue I missed in #3268 

Because of the way the `open` command behaves, it would sometimes just try and select/focus the crashing application instead of starting a new one (inconsistent, so probably a timing thing, which is why I just didnt notice it initially). This obviously means that the re-selected instance is still just going to crash without a new one being opened.

This PR simply adds the `-n` option when running `open` to always create a new instance regardless of any other instances that might be available to switch to. Should have just added that in the first place, but thought everything was running fine without it.