### PR TITLE
Add "drops" as an ignoredUsername for context menu twitch links

### DIFF
--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1935,7 +1935,7 @@ void ChannelView::addContextMenuItems(
             QRegularExpression::CaseInsensitiveOption);
         static QSet<QString> ignoredUsernames{
             "videos",    "settings", "directory",     "jobs",     "friends",
-            "inventory", "payments", "subscriptions", "messages",
+            "inventory", "payments", "subscriptions", "messages", "drops",
         };
 
         auto twitchMatch =


### PR DESCRIPTION
Pull request checklist:

- [X] `CHANGELOG.md` was updated, if applicable

# Description

Noticed in #3309 - both `/drops` and `/inventory` re-direct to `/drops/inventory`

Note: if we were to alphabetize these, in their current state the `};` would move to 1938 and save us 1 line ‼️ 
