### PR TITLE
Clean up chat messages of special line characters prior to sending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 - Minor: Ignore out of bounds check for tiling wms (#3270)
 - Minor: Added `flags.first_message` filter variable (#3292)
 - Minor: Removed duplicate setting for toggling `Channel Point Redeemed Message` highlights (#3296)
-- Minor: Parse chat message to remove new lines and other special line characters prior to sending (#3312)
+- Minor: Clean up chat messages of special line characters prior to sending. (#3312)
 - Bugfix: Fixed colored usernames sometimes not working. (#3170)
 - Bugfix: Restored ability to send duplicate `/me` messages. (#3166)
 - Bugfix: Notifications for moderators about other moderators deleting messages can now be disabled. (#3121)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Minor: Ignore out of bounds check for tiling wms (#3270)
 - Minor: Added `flags.first_message` filter variable (#3292)
 - Minor: Removed duplicate setting for toggling `Channel Point Redeemed Message` highlights (#3296)
+- Minor: Parse chat message to remove new lines and other special line characters prior to sending (#3312)
 - Bugfix: Fixed colored usernames sometimes not working. (#3170)
 - Bugfix: Restored ability to send duplicate `/me` messages. (#3166)
 - Bugfix: Notifications for moderators about other moderators deleting messages can now be disabled. (#3121)

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -363,7 +363,7 @@ void TwitchChannel::sendMessage(const QString &message)
     // Do last message processing
     QString parsedMessage = app->emotes->emojis.replaceShortCodes(message);
 
-    parsedMessage = parsedMessage.trimmed();
+    parsedMessage = parsedMessage.simplified();
 
     if (parsedMessage.isEmpty())
     {


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

If you add a command that contains a new line in the message, it does not correctly send the message. It will only send the first line of the command. The issue does not occur if you manually input the message with new lines into the chat box and hit send. This behavior only seems to occur with commands.

![image](https://user-images.githubusercontent.com/6964154/139110188-6af28baf-2a86-43c8-a91a-f89bdfa4109a.png)

For example, if you have a command set to the following (including the new line):
```
This line will be sent.
This line should not send.
```

The solution I found was to remove the new line characters from the message. Instead of removing it from the command itself when users add or update a command, it might be best to do so prior to sending the message as done in this PR. Also, I wasn't sure if messages would have a difference between `\n` and `\r\n` depending on their OS, so I found `QString::simplified` to be useful as it replaces escape characters with a space. This way ascii arts shouldn't be affected either, and text messages would be more readable too (no added space versus an added space).