### PR TITLE
Fix 'First Message' scrollbar highlights not being disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - Bugfix: Fixed `QCharRef with an index pointing outside the valid range of a QString` warning that was emitted on every Tab press. (#3234)
 - Bugfix: Fixed being unable to disable `First Message` highlights (#3293)
 - Bugfix: Fixed `First Message` custom sound not persisting through restart. (#3303)
+- Bugfix: Fixed `First Message` scrollbar highlights not being disabled. (#3325)
 - Dev: Renamed CMake's build option `USE_SYSTEM_QT5KEYCHAIN` to `USE_SYSTEM_QTKEYCHAIN`. (#3103)
 - Dev: Add benchmarks that can be compiled with the `BUILD_BENCHMARKS` CMake flag. Off by default. (#3038)
 

--- a/src/messages/Message.cpp
+++ b/src/messages/Message.cpp
@@ -46,7 +46,7 @@ SBHighlight Message::getScrollBarHighlight() const
     {
         return SBHighlight(
             ColorProvider::instance().color(ColorType::FirstMessageHighlight),
-            SBHighlight::Default, true);
+            SBHighlight::Default, false, true);
     }
     return SBHighlight();
 }

--- a/src/widgets/Scrollbar.cpp
+++ b/src/widgets/Scrollbar.cpp
@@ -251,6 +251,8 @@ void Scrollbar::paintEvent(QPaintEvent *)
     painter.fillRect(rect(), this->theme->scrollbars.background);
 
     bool enableRedeemedHighlights = getSettings()->enableRedeemedHighlight;
+    bool enableFirstMessageHighlights =
+        getSettings()->enableFirstMessageHighlight;
 
     //    painter.fillRect(QRect(xOffset, 0, width(), this->buttonHeight),
     //                     this->themeManager->ScrollbarArrow);
@@ -293,7 +295,10 @@ void Scrollbar::paintEvent(QPaintEvent *)
 
         if (!highlight.isNull())
         {
-            if (!highlight.isRedeemedHighlight() || enableRedeemedHighlights)
+            if ((!highlight.isRedeemedHighlight() ||
+                 enableRedeemedHighlights) &&
+                (!highlight.isFirstMessageHighlight() ||
+                 enableFirstMessageHighlights))
             {
                 QColor color = highlight.getColor();
                 color.setAlpha(255);

--- a/src/widgets/helper/ScrollbarHighlight.cpp
+++ b/src/widgets/helper/ScrollbarHighlight.cpp
@@ -13,10 +13,12 @@ ScrollbarHighlight::ScrollbarHighlight()
 }
 
 ScrollbarHighlight::ScrollbarHighlight(const std::shared_ptr<QColor> color,
-                                       Style style, bool isRedeemedHighlight)
+                                       Style style, bool isRedeemedHighlight,
+                                       bool isFirstMessageHighlight)
     : color_(color)
     , style_(style)
     , isRedeemedHighlight_(isRedeemedHighlight)
+    , isFirstMessageHighlight_(isFirstMessageHighlight)
 {
 }
 
@@ -33,6 +35,11 @@ ScrollbarHighlight::Style ScrollbarHighlight::getStyle() const
 bool ScrollbarHighlight::isRedeemedHighlight() const
 {
     return this->isRedeemedHighlight_;
+}
+
+bool ScrollbarHighlight::isFirstMessageHighlight() const
+{
+    return this->isFirstMessageHighlight_;
 }
 
 bool ScrollbarHighlight::isNull() const

--- a/src/widgets/helper/ScrollbarHighlight.hpp
+++ b/src/widgets/helper/ScrollbarHighlight.hpp
@@ -21,17 +21,20 @@ public:
     ScrollbarHighlight();
 
     ScrollbarHighlight(const std::shared_ptr<QColor> color,
-                       Style style = Default, bool isRedeemedHighlight = false);
+                       Style style = Default, bool isRedeemedHighlight = false,
+                       bool isFirstMessageHighlight = false);
 
     QColor getColor() const;
     Style getStyle() const;
     bool isRedeemedHighlight() const;
+    bool isFirstMessageHighlight() const;
     bool isNull() const;
 
 private:
     std::shared_ptr<QColor> color_;
     Style style_;
     bool isRedeemedHighlight_;
+    bool isFirstMessageHighlight_;
 };
 
 }  // namespace chatterino


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Added const method `isFirstMessageHighlight()` to check if a highlight is a first message highlight similar to `isRedeemedHighlight()`. Considered this new method and whether or not first message highlights were enabled in the settings while painting scrollbar highlights.

 Bug can be reproduced by looking at a chat with first message highlights, going into the settings and disabling first message highlights and then observing that the scrollbar still shows the highlights for the first messages.

Closes #3317
