### PR TITLE
Flatten the scrollbar highlight iteration

### DIFF
--- a/src/widgets/Scrollbar.cpp
+++ b/src/widgets/Scrollbar.cpp
@@ -287,36 +287,38 @@ void Scrollbar::paintEvent(QPaintEvent *)
     int highlightHeight =
         int(std::ceil(std::max<float>(this->scale() * 2, dY)));
 
-    for (size_t i = 0; i < snapshotLength; i++)
+    for (size_t i = 0; i < snapshotLength; i++, y += dY)
     {
         ScrollbarHighlight const &highlight = snapshot[i];
 
-        if (!highlight.isNull())
+        if (highlight.isNull())
         {
-            if (!highlight.isRedeemedHighlight() || enableRedeemedHighlights)
-            {
-                QColor color = highlight.getColor();
-                color.setAlpha(255);
-
-                switch (highlight.getStyle())
-                {
-                    case ScrollbarHighlight::Default: {
-                        painter.fillRect(w / 8 * 3, int(y), w / 4,
-                                         highlightHeight, color);
-                    }
-                    break;
-
-                    case ScrollbarHighlight::Line: {
-                        painter.fillRect(0, int(y), w, 1, color);
-                    }
-                    break;
-
-                    case ScrollbarHighlight::None:;
-                }
-            }
+            continue;
         }
 
-        y += dY;
+        if (highlight.isRedeemedHighlight() && !enableRedeemedHighlights)
+        {
+            continue;
+        }
+
+        QColor color = highlight.getColor();
+        color.setAlpha(255);
+
+        switch (highlight.getStyle())
+        {
+            case ScrollbarHighlight::Default: {
+                painter.fillRect(w / 8 * 3, int(y), w / 4, highlightHeight,
+                                 color);
+            }
+            break;
+
+            case ScrollbarHighlight::Line: {
+                painter.fillRect(0, int(y), w, 1, color);
+            }
+            break;
+
+            case ScrollbarHighlight::None:;
+        }
     }
 }
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

There might be a warning due to us having a float variable in the loop end-stage https://wiki.sei.cmu.edu/confluence/display/c/FLP30-C.+Do+not+use+floating-point+variables+as+loop+counters but we don't use it as the counter, so we are good.

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
