### PR TITLE
Track timeout/slowmode status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unversioned
 
-- Major: Add countdown to input box to show when you can chat again during slow mode / after a timeout (#3329)
+- Major: Added a countdown to the input box to show when you can chat again during slow mode / after a timeout. (#3329)
 - Minor: Added new search predicate to filter for messages matching a regex (#3282)
 - Minor: Add `{channel.name}`, `{channel.id}`, `{stream.game}`, `{stream.title}`, `{my.id}`, `{my.name}` placeholders for commands (#3155)
 - Minor: Remove TwitchEmotes.com attribution and the open/copy options when right-clicking a Twitch Emote. (#2214, #3136)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unversioned
 
+- Major: Add countdown to input box to show when you can chat again during slow mode / after a timeout (#3329)
 - Minor: Added new search predicate to filter for messages matching a regex (#3282)
 - Minor: Add `{channel.name}`, `{channel.id}`, `{stream.game}`, `{stream.title}`, `{my.id}`, `{my.name}` placeholders for commands (#3155)
 - Minor: Remove TwitchEmotes.com attribution and the open/copy options when right-clicking a Twitch Emote. (#2214, #3136)

--- a/src/common/Channel.hpp
+++ b/src/common/Channel.hpp
@@ -54,7 +54,6 @@ public:
         messageAppended;
     pajlada::Signals::Signal<std::vector<MessagePtr> &> messagesAddedAtStart;
     pajlada::Signals::Signal<size_t, MessagePtr &> messageReplaced;
-    pajlada::Signals::Signal<const QString &> timeoutStatusSignal;
     pajlada::Signals::NoArgSignal destroyed;
     pajlada::Signals::NoArgSignal displayNameChanged;
 

--- a/src/common/Channel.hpp
+++ b/src/common/Channel.hpp
@@ -54,6 +54,7 @@ public:
         messageAppended;
     pajlada::Signals::Signal<std::vector<MessagePtr> &> messagesAddedAtStart;
     pajlada::Signals::Signal<size_t, MessagePtr &> messageReplaced;
+    pajlada::Signals::Signal<const QString &> timeoutStatusSignal;
     pajlada::Signals::NoArgSignal destroyed;
     pajlada::Signals::NoArgSignal displayNameChanged;
 

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -433,7 +433,7 @@ void IrcMessageHandler::handleClearChatMessage(Communi::IrcMessage *message)
             TwitchChannel *tc = dynamic_cast<TwitchChannel *>(chan.get());
             if (tc != nullptr)
             {
-                tc->setTimedOut(durationInSeconds.toInt());
+                tc->setUserTimeoutDuration(durationInSeconds.toInt());
             }
         }
     }
@@ -547,12 +547,12 @@ void IrcMessageHandler::handleUserStateMessage(Communi::IrcMessage *message)
         //
         // TODO: edgecase: we also get USERSTATE if we reconnected after JOIN,
         // which would incorrectly clear the timeout.
-        tc->setTimedOut(-1);
+        tc->setUserTimeoutDuration(-1);
 
         // If we got modded/vipped, clear the slowdown timer.
         if (!hadHighLimit && tc->hasHighRateLimit())
         {
-            tc->setSlowedDown(-1);
+            tc->setUserSlowedDownDuration(-1);
         }
     }
 }
@@ -903,7 +903,7 @@ void IrcMessageHandler::handleNoticeMessage(Communi::IrcNoticeMessage *message)
             TwitchChannel *tc = dynamic_cast<TwitchChannel *>(channel.get());
             if (tc != nullptr)
             {
-                tc->setTimedOut(seconds);
+                tc->setUserTimeoutDuration(seconds);
             }
         }
     }
@@ -915,7 +915,7 @@ void IrcMessageHandler::handleNoticeMessage(Communi::IrcNoticeMessage *message)
             TwitchChannel *tc = dynamic_cast<TwitchChannel *>(channel.get());
             if (tc != nullptr)
             {
-                tc->setSlowedDown(seconds);
+                tc->setUserSlowedDownDuration(seconds);
             }
         }
     }

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -523,6 +523,8 @@ void IrcMessageHandler::handleUserStateMessage(Communi::IrcMessage *message)
     TwitchChannel *tc = dynamic_cast<TwitchChannel *>(c.get());
     if (tc != nullptr)
     {
+        bool hadHighLimit = tc->hasHighRateLimit();
+
         // Checking if currentUser is a VIP or staff member
         QVariant _badges = message->tag("badges");
         if (_badges.isValid())
@@ -545,7 +547,13 @@ void IrcMessageHandler::handleUserStateMessage(Communi::IrcMessage *message)
         //
         // TODO: edgecase: we also get USERSTATE if we reconnected after JOIN,
         // which would incorrectly clear the timeout.
-        tc->setTimedOut(0);
+        tc->setTimedOut(-1);
+
+        // If we got modded/vipped, clear the slowdown timer.
+        if (!hadHighLimit && tc->hasHighRateLimit())
+        {
+            tc->setSlowedDown(-1);
+        }
     }
 }
 

--- a/src/providers/twitch/IrcMessageHandler.hpp
+++ b/src/providers/twitch/IrcMessageHandler.hpp
@@ -56,6 +56,7 @@ public:
     static void setSimilarityFlags(MessagePtr message, ChannelPtr channel);
 
 private:
+    int parseTimedoutNoticeMessage(Communi::IrcMessage *message);
     void addMessage(Communi::IrcMessage *message, const QString &target,
                     const QString &content, TwitchIrcServer &server,
                     bool isResub, bool isAction);

--- a/src/providers/twitch/IrcMessageHandler.hpp
+++ b/src/providers/twitch/IrcMessageHandler.hpp
@@ -56,7 +56,8 @@ public:
     static void setSimilarityFlags(MessagePtr message, ChannelPtr channel);
 
 private:
-    int parseTimedoutNoticeMessage(Communi::IrcMessage *message);
+    int parseTimedoutNoticeMessage(Communi::IrcNoticeMessage *message);
+    int parseSlowmodeNoticeMessage(Communi::IrcNoticeMessage *message);
     void addMessage(Communi::IrcMessage *message, const QString &target,
                     const QString &content, TwitchIrcServer &server,
                     bool isResub, bool isAction);

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -221,12 +221,14 @@ bool TwitchChannel::isEmpty() const
 void TwitchChannel::resyncChatAgain()
 {
     auto now = std::chrono::steady_clock::now();
-    long seconds = 0;
+    int seconds = 0;
     if (this->timeoutEnds_.has_value())
-        seconds = std::max(
+    {
+        seconds = std::max<int>(
             seconds, (*this->timeoutEnds_ - now) / std::chrono::seconds(1));
+    }
     if (this->slowedEnds_.has_value())
-        seconds = std::max(
+        seconds = std::max<int>(
             seconds, (*this->slowedEnds_ - now) / std::chrono::seconds(1));
     if (seconds <= 0)
     {

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -223,14 +223,13 @@ void TwitchChannel::resyncTimedOut()
     auto now = std::chrono::steady_clock::now();
     int seconds = (this->timeoutEnds_ - now) / std::chrono::seconds(1);
     auto remaining = formatTime(seconds);
-    qCDebug(chatterinoTwitch)
-        << "[TwitchChannel::timeoutCounter_]" << this->getName()
-        << "Timeout remaining:" << remaining;
     if (seconds <= 0)
     {
         this->timeoutCounter_.stop();
         this->timeoutStatusSignal.invoke("");
-    } else {
+    }
+    else
+    {
         this->timeoutStatusSignal.invoke(remaining);
     }
 }
@@ -246,8 +245,9 @@ void TwitchChannel::setTimedOut(int durationInSeconds)
     }
 
     // (Re)set timer
-    this->timeoutEnds_ = std::chrono::steady_clock::now() +
-                         std::chrono::seconds(durationInSeconds);
+    auto now = std::chrono::floor<std::chrono::seconds>(
+        std::chrono::steady_clock::now());
+    this->timeoutEnds_ = now + std::chrono::seconds(durationInSeconds);
     if (!this->timeoutCounter_.isActive())
     {
         this->timeoutCounter_.start(1000);

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -19,6 +19,7 @@
 #include <pajlada/signals/signalholder.hpp>
 
 #include <mutex>
+#include <optional>
 #include <unordered_map>
 
 namespace chatterino {
@@ -74,8 +75,9 @@ public:
     virtual void reconnect() override;
     void refreshTitle();
     void createClip();
+    void setSlowedDown(int durationInSeconds);
     void setTimedOut(int durationInSeconds);
-    void resyncTimedOut();
+    void resyncChatAgain();
 
     // Data
     const QString &subscriptionUrl();
@@ -110,6 +112,7 @@ public:
     pajlada::Signals::NoArgSignal userStateChanged;
     pajlada::Signals::NoArgSignal liveStatusChanged;
     pajlada::Signals::NoArgSignal roomModesChanged;
+    pajlada::Signals::Signal<const QString &> chatAgainSignal;
 
     // Channel point rewards
     pajlada::Signals::SelfDisconnectingSignal<ChannelPointReward>
@@ -124,8 +127,12 @@ private:
         QString displayName;
         QString localizedName;
     } nameOptions;
-    QTimer timeoutCounter_;
-    std::chrono::steady_clock::time_point timeoutEnds_;
+
+    QTimer chatAgainCounter_;
+    // Timepoint at which we can send messages again after a timeout.
+    std::optional<std::chrono::steady_clock::time_point> timeoutEnds_;
+    // Timepoint at which we can send messages again during slow mode.
+    std::optional<std::chrono::steady_clock::time_point> slowedEnds_;
 
 protected:
     explicit TwitchChannel(const QString &channelName);

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -74,6 +74,8 @@ public:
     virtual void reconnect() override;
     void refreshTitle();
     void createClip();
+    void setTimedOut(int durationInSeconds);
+    void resyncTimedOut();
 
     // Data
     const QString &subscriptionUrl();
@@ -122,6 +124,8 @@ private:
         QString displayName;
         QString localizedName;
     } nameOptions;
+    QTimer timeoutCounter_;
+    std::chrono::steady_clock::time_point timeoutEnds_;
 
 protected:
     explicit TwitchChannel(const QString &channelName);

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -75,8 +75,21 @@ public:
     virtual void reconnect() override;
     void refreshTitle();
     void createClip();
-    void setSlowedDown(int durationInSeconds);
-    void setTimedOut(int durationInSeconds);
+
+    /**
+     * @brief Updates the user's slowmode timer
+     **/
+    void setUserSlowedDownDuration(int durationInSeconds);
+
+    /**
+     * @brief Updates the user's timeout duration.
+     *
+     * This is updated when the user gets timed out or when the user tries to
+     * type in a chat where they are timed out.
+     **/
+    void setUserTimeoutDuration(int durationInSeconds);
+
+    // TODO: Figure out a better name for this function
     void resyncChatAgain();
 
     // Data
@@ -128,11 +141,12 @@ private:
         QString localizedName;
     } nameOptions;
 
+    // TODO: Figure out better name for this
     QTimer chatAgainCounter_;
-    // Timepoint at which we can send messages again after a timeout.
-    std::optional<std::chrono::steady_clock::time_point> timeoutEnds_;
-    // Timepoint at which we can send messages again during slow mode.
-    std::optional<std::chrono::steady_clock::time_point> slowedEnds_;
+    // Timepoint at which the user's timeout ends.
+    std::optional<std::chrono::steady_clock::time_point> userTimeoutEnd_;
+    // Timepoint at which the user can send messages again after having slowmode applied to them.
+    std::optional<std::chrono::steady_clock::time_point> userSlowedEnd_;
 
 protected:
     explicit TwitchChannel(const QString &channelName);

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -84,6 +84,8 @@ public:
     BoolSetting showEmptyInput = {"/appearance/showEmptyInputBox", true};
     BoolSetting showMessageLength = {"/appearance/messages/showMessageLength",
                                      false};
+    BoolSetting showChatAgainTimer = {"/appearance/messages/showChatAgainTimer",
+                                      true};
     BoolSetting separateMessages = {"/appearance/messages/separateMessages",
                                     false};
     BoolSetting compactEmotes = {"/appearance/messages/compactEmotes", true};

--- a/src/util/FormatTime.cpp
+++ b/src/util/FormatTime.cpp
@@ -39,7 +39,7 @@ QString formatTime(int totalSeconds)
         }
         appendDuration(minutes, 'm', res);
     }
-    if (seconds > 0)
+    if (seconds > 0 || res.isEmpty())
     {
         if (!res.isEmpty())
         {

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -709,25 +709,25 @@ void ChannelView::setChannel(ChannelPtr underlyingChannel)
 
     this->underlyingChannel_ = underlyingChannel;
 
-    this->channelConnections_.push_back(
-        underlyingChannel->timeoutStatusSignal.connect(
-            [this](const QString &text) {
-                Split *split = dynamic_cast<Split *>(this->parentWidget());
-                if (split != nullptr)
-                {
-                    split->getInput().setTimeoutStatus(text);
-                }
-            }));
-
     this->queueLayout();
     this->queueUpdate();
 
-    // Notifications
     if (auto tc = dynamic_cast<TwitchChannel *>(underlyingChannel.get()))
     {
+        // Notifications
         this->connections_.push_back(tc->liveStatusChanged.connect([this]() {
             this->liveStatusChanged.invoke();
         }));
+
+        // Timeouts/slowmode
+        this->channelConnections_.push_back(
+            tc->chatAgainSignal.connect([this](const QString &text) {
+                Split *split = dynamic_cast<Split *>(this->parentWidget());
+                if (split != nullptr)
+                {
+                    split->getInput().setChatAgainStatus(text);
+                }
+            }));
     }
 }
 

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -709,14 +709,15 @@ void ChannelView::setChannel(ChannelPtr underlyingChannel)
 
     this->underlyingChannel_ = underlyingChannel;
 
-    this->channelConnections_.push_back(underlyingChannel->timeoutStatusSignal.connect(
-        [this](const QString &text) {
-            Split *split = dynamic_cast<Split *>(this->parentWidget());
-            if (split != nullptr)
-            {
-                split->getInput().setTimeoutStatus(text);
-            }
-        }));
+    this->channelConnections_.push_back(
+        underlyingChannel->timeoutStatusSignal.connect(
+            [this](const QString &text) {
+                Split *split = dynamic_cast<Split *>(this->parentWidget());
+                if (split != nullptr)
+                {
+                    split->getInput().setTimeoutStatus(text);
+                }
+            }));
 
     this->queueLayout();
     this->queueUpdate();
@@ -728,7 +729,6 @@ void ChannelView::setChannel(ChannelPtr underlyingChannel)
             this->liveStatusChanged.invoke();
         }));
     }
-
 }
 
 void ChannelView::setFilters(const QList<QUuid> &ids)

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -709,6 +709,15 @@ void ChannelView::setChannel(ChannelPtr underlyingChannel)
 
     this->underlyingChannel_ = underlyingChannel;
 
+    this->channelConnections_.push_back(underlyingChannel->timeoutStatusSignal.connect(
+        [this](const QString &text) {
+            Split *split = dynamic_cast<Split *>(this->parentWidget());
+            if (split != nullptr)
+            {
+                split->getInput().setTimeoutStatus(text);
+            }
+        }));
+
     this->queueLayout();
     this->queueUpdate();
 
@@ -719,6 +728,7 @@ void ChannelView::setChannel(ChannelPtr underlyingChannel)
             this->liveStatusChanged.invoke();
         }));
     }
+
 }
 
 void ChannelView::setFilters(const QList<QUuid> &ids)

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -224,6 +224,8 @@ void GeneralPage::initLayout(GeneralPageView &layout)
                        s.enableSmoothScrollingNewMessages);
     layout.addCheckbox("Show input when it's empty", s.showEmptyInput);
     layout.addCheckbox("Show message length while typing", s.showMessageLength);
+    layout.addCheckbox("Show countdown on slow mode/when timed out",
+                       s.showChatAgainTimer);
     layout.addCheckbox("Allow sending duplicate messages",
                        s.allowDuplicateMessages);
 

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -73,6 +73,9 @@ void SplitInput::initLayout()
         auto textEditLength =
             box.emplace<QLabel>().assign(&this->ui_.textEditLength);
         textEditLength->setAlignment(Qt::AlignRight);
+        auto timeoutStatus =
+            box.emplace<QLabel>().assign(&this->ui_.timeoutStatus);
+        timeoutStatus->setAlignment(Qt::AlignRight);
 
         box->addStretch(1);
         box.emplace<EffectLabel>().assign(&this->ui_.emoteButton);
@@ -615,6 +618,11 @@ QString SplitInput::getInputText() const
 void SplitInput::insertText(const QString &text)
 {
     this->ui_.textEdit->insertPlainText(text);
+}
+
+void SplitInput::setTimeoutStatus(const QString &text)
+{
+    this->ui_.timeoutStatus->setText(text);
 }
 
 void SplitInput::editTextChanged()

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -69,16 +69,27 @@ void SplitInput::initLayout()
     // right box
     auto box = layout.emplace<QVBoxLayout>().withoutMargin();
     box->setSpacing(0);
+    box->setAlignment(Qt::AlignRight);
     {
-        auto textEditLength =
-            box.emplace<QLabel>().assign(&this->ui_.textEditLength);
-        textEditLength->setAlignment(Qt::AlignRight);
-        auto timeoutStatus =
-            box.emplace<QLabel>().assign(&this->ui_.timeoutStatus);
-        timeoutStatus->setAlignment(Qt::AlignRight);
+        auto hbox = box.emplace<QHBoxLayout>().withoutMargin();
+        {
+            auto timeoutStatus =
+                hbox.emplace<QLabel>().assign(&this->ui_.timeoutStatus);
+            timeoutStatus->setStyleSheet("color: gold");
+            auto textEditLength =
+                hbox.emplace<QLabel>().assign(&this->ui_.textEditLength);
+            textEditLength->setAlignment(Qt::AlignRight);
+
+            timeoutStatus->setText("1m 5s");
+            textEditLength->setText("10");
+        }
 
         box->addStretch(1);
-        box.emplace<EffectLabel>().assign(&this->ui_.emoteButton);
+        auto emoteButton = box.emplace<EffectLabel>().assign(&this->ui_.emoteButton);
+        // Keep the emote button in the bottom/right corner, instead of it
+        // following the size of the above hbox
+        emoteButton->getLabel().setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+        // TODO: make it so the label doesn't stretch
     }
 
     this->ui_.emoteButton->getLabel().setTextFormat(Qt::RichText);

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -73,14 +73,14 @@ void SplitInput::initLayout()
     {
         auto hbox = box.emplace<QHBoxLayout>().withoutMargin();
         {
-            auto timeoutStatus =
-                hbox.emplace<QLabel>().assign(&this->ui_.timeoutStatus);
-            timeoutStatus->setStyleSheet("color: gold");
+            auto chatAgainStatus =
+                hbox.emplace<QLabel>().assign(&this->ui_.chatAgainStatus);
+            chatAgainStatus->setStyleSheet("color: gold");
             auto textEditLength =
                 hbox.emplace<QLabel>().assign(&this->ui_.textEditLength);
             textEditLength->setAlignment(Qt::AlignRight);
 
-            timeoutStatus->setText("1m 5s");
+            chatAgainStatus->setText("1m 5s");
             textEditLength->setText("10");
         }
 
@@ -632,9 +632,9 @@ void SplitInput::insertText(const QString &text)
     this->ui_.textEdit->insertPlainText(text);
 }
 
-void SplitInput::setTimeoutStatus(const QString &text)
+void SplitInput::setChatAgainStatus(const QString &text)
 {
-    this->ui_.timeoutStatus->setText(text);
+    this->ui_.chatAgainStatus->setText(text);
 }
 
 void SplitInput::editTextChanged()

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -85,7 +85,8 @@ void SplitInput::initLayout()
         }
 
         box->addStretch(1);
-        auto emoteButton = box.emplace<EffectLabel>().assign(&this->ui_.emoteButton);
+        auto emoteButton =
+            box.emplace<EffectLabel>().assign(&this->ui_.emoteButton);
         // Keep the emote button in the bottom/right corner, instead of it
         // following the size of the above hbox
         emoteButton->getLabel().setAlignment(Qt::AlignRight | Qt::AlignVCenter);

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -128,6 +128,12 @@ void SplitInput::initLayout()
             this->editTextChanged();
         },
         this->managedConnections_);
+
+    getSettings()->showChatAgainTimer.connect(
+        [this](const bool &value, auto) {
+            this->ui_.chatAgainStatus->setHidden(!value);
+        },
+        this->managedConnections_);
 }
 
 void SplitInput::scaleChangedEvent(float scale)

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -79,9 +79,6 @@ void SplitInput::initLayout()
             auto textEditLength =
                 hbox.emplace<QLabel>().assign(&this->ui_.textEditLength);
             textEditLength->setAlignment(Qt::AlignRight);
-
-            chatAgainStatus->setText("1m 5s");
-            textEditLength->setText("10");
         }
 
         box->addStretch(1);

--- a/src/widgets/splits/SplitInput.hpp
+++ b/src/widgets/splits/SplitInput.hpp
@@ -31,7 +31,7 @@ public:
     bool isEditFirstWord() const;
     QString getInputText() const;
     void insertText(const QString &text);
-    void setTimeoutStatus(const QString &text);
+    void setChatAgainStatus(const QString &text);
 
     pajlada::Signals::Signal<const QString &> textChanged;
 
@@ -63,7 +63,7 @@ private:
     struct {
         ResizingTextEdit *textEdit;
         QLabel *textEditLength;
-        QLabel *timeoutStatus;
+        QLabel *chatAgainStatus;
         EffectLabel *emoteButton;
 
         QHBoxLayout *hbox;

--- a/src/widgets/splits/SplitInput.hpp
+++ b/src/widgets/splits/SplitInput.hpp
@@ -31,6 +31,7 @@ public:
     bool isEditFirstWord() const;
     QString getInputText() const;
     void insertText(const QString &text);
+    void setTimeoutStatus(const QString &text);
 
     pajlada::Signals::Signal<const QString &> textChanged;
 
@@ -62,6 +63,7 @@ private:
     struct {
         ResizingTextEdit *textEdit;
         QLabel *textEditLength;
+        QLabel *timeoutStatus;
         EffectLabel *emoteButton;
 
         QHBoxLayout *hbox;


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

This PR adds a timer to the chat input box (on the left side of the message length counter) that reflects how long until you can chat again. It supports timeouts (on CLEARCHAT and on error notice) and slowmode (including the error notice), but doesn't query e.g. an existing timeout on application restart.

Some of the choices were made in good faith but may be a bit arbitrary, so please nitpick away and let me know if anything should be changed:
* The `color: gold` text for the timer label
* Minor refactor/cleanup of how notices are handled (nb: the PR makes sure to keep logic with side-effects in the `handle*` function instead of `parse*`, which does mean parsing the notice twice)
* Technically, if the timer is between 1s and 0s Twitch will still block you from sending, ~but at <1s the timer label goes away~. Let me know if this is something that should be "fixed".