### PR TITLE
Fix underlying text from disabled emotes not being colorized after using /me

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - Bugfix: Fixed being unable to disable `First Message` highlights (#3293)
 - Bugfix: Fixed `First Message` custom sound not persisting through restart. (#3303)
 - Bugfix: Fixed `First Message` scrollbar highlights not being disabled. (#3325)
+- Bugfix: Fixed underlying text from disabled emotes not being colorized properly. (#3333)
 - Dev: Add GitHub action to test builds without precompiled headers enabled. (#3327)
 - Dev: Renamed CMake's build option `USE_SYSTEM_QT5KEYCHAIN` to `USE_SYSTEM_QTKEYCHAIN`. (#3103)
 - Dev: Add benchmarks that can be compiled with the `BUILD_BENCHMARKS` CMake flag. Off by default. (#3038)

--- a/src/messages/MessageElement.cpp
+++ b/src/messages/MessageElement.cpp
@@ -142,12 +142,13 @@ void ImageElement::addToContainer(MessageLayoutContainer &container,
 }
 
 // EMOTE
-EmoteElement::EmoteElement(const EmotePtr &emote, MessageElementFlags flags)
+EmoteElement::EmoteElement(const EmotePtr &emote, MessageElementFlags flags,
+                           const MessageColor &textElementColor)
     : MessageElement(flags)
     , emote_(emote)
 {
-    this->textElement_.reset(
-        new TextElement(emote->getCopyString(), MessageElementFlag::Misc));
+    this->textElement_.reset(new TextElement(
+        emote->getCopyString(), MessageElementFlag::Misc, textElementColor));
 
     this->setTooltip(emote->tooltip.string);
 }

--- a/src/messages/MessageElement.hpp
+++ b/src/messages/MessageElement.hpp
@@ -238,7 +238,8 @@ private:
 class EmoteElement : public MessageElement
 {
 public:
-    EmoteElement(const EmotePtr &data, MessageElementFlags flags_);
+    EmoteElement(const EmotePtr &data, MessageElementFlags flags_,
+                 const MessageColor &textElementColor = MessageColor::Text);
 
     void addToContainer(MessageLayoutContainer &container,
                         MessageElementFlags flags_) override;

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -319,7 +319,9 @@ void TwitchMessageBuilder::addWords(
             {
                 // This emote exists right at the start of the word!
                 this->emplace<EmoteElement>(currentTwitchEmote.ptr,
-                                            MessageElementFlag::TwitchEmote);
+                                            MessageElementFlag::TwitchEmote,
+                                            this->textColor_);
+
                 auto len = currentTwitchEmote.name.string.length();
                 cursor += len;
                 word = word.mid(len);
@@ -1007,7 +1009,7 @@ Outcome TwitchMessageBuilder::tryAppendEmote(const EmoteName &name)
 
     if (emote)
     {
-        this->emplace<EmoteElement>(emote.get(), flags);
+        this->emplace<EmoteElement>(emote.get(), flags, this->textColor_);
         return Success;
     }
 
@@ -1162,12 +1164,14 @@ Outcome TwitchMessageBuilder::tryParseCheermote(const QString &string)
         if (cheerEmote.staticEmote)
         {
             this->emplace<EmoteElement>(cheerEmote.staticEmote,
-                                        MessageElementFlag::BitsStatic);
+                                        MessageElementFlag::BitsStatic,
+                                        this->textColor_);
         }
         if (cheerEmote.animatedEmote)
         {
             this->emplace<EmoteElement>(cheerEmote.animatedEmote,
-                                        MessageElementFlag::BitsAnimated);
+                                        MessageElementFlag::BitsAnimated,
+                                        this->textColor_);
         }
         if (cheerEmote.color != QColor())
         {
@@ -1195,12 +1199,14 @@ Outcome TwitchMessageBuilder::tryParseCheermote(const QString &string)
     if (cheerEmote.staticEmote)
     {
         this->emplace<EmoteElement>(cheerEmote.staticEmote,
-                                    MessageElementFlag::BitsStatic);
+                                    MessageElementFlag::BitsStatic,
+                                    this->textColor_);
     }
     if (cheerEmote.animatedEmote)
     {
         this->emplace<EmoteElement>(cheerEmote.animatedEmote,
-                                    MessageElementFlag::BitsAnimated);
+                                    MessageElementFlag::BitsAnimated,
+                                    this->textColor_);
     }
     if (cheerEmote.color != QColor())
     {


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Allow the inner `textElement_` for a EmoteElement to be reset with a text color if it is available upon creation of the EmoteElement. When emplacing EmoteElement's with a TextElement `color_` available, use it.

To reproduce this bug, disable emotes in settings and use /me with any emote. The text will not be colored accordingly.

Closes #3201
