### PR TITLE
Add Twitch Chat Pronouns badge provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unversioned
 
+- Major: Add Twitch Chat Pronouns badge provider (#3346)
 - Minor: Added new search predicate to filter for messages matching a regex (#3282)
 - Minor: Add `{channel.name}`, `{channel.id}`, `{stream.game}`, `{stream.title}`, `{my.id}`, `{my.name}` placeholders for commands (#3155)
 - Minor: Remove TwitchEmotes.com attribution and the open/copy options when right-clicking a Twitch Emote. (#2214, #3136)

--- a/chatterino.pro
+++ b/chatterino.pro
@@ -205,6 +205,7 @@ SOURCES += \
     src/providers/irc/IrcServer.cpp \
     src/providers/IvrApi.cpp \
     src/providers/LinkResolver.cpp \
+    src/providers/pronouns/PronounsBadges.cpp \
     src/providers/twitch/api/Helix.cpp \
     src/providers/twitch/api/Kraken.cpp \
     src/providers/twitch/ChannelPointReward.cpp \
@@ -443,6 +444,7 @@ HEADERS += \
     src/providers/irc/IrcServer.hpp \
     src/providers/IvrApi.hpp \
     src/providers/LinkResolver.hpp \
+    src/providers/pronouns/PronounsBadges.hpp \
     src/providers/twitch/api/Helix.hpp \
     src/providers/twitch/api/Kraken.hpp \
     src/providers/twitch/ChannelPointReward.hpp \

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -16,6 +16,7 @@
 #include "providers/ffz/FfzBadges.hpp"
 #include "providers/ffz/FfzEmotes.hpp"
 #include "providers/irc/Irc2.hpp"
+#include "providers/pronouns/PronounsBadges.hpp"
 #include "providers/twitch/PubsubClient.hpp"
 #include "providers/twitch/TwitchIrcServer.hpp"
 #include "providers/twitch/TwitchMessageBuilder.hpp"
@@ -62,6 +63,7 @@ Application::Application(Settings &_settings, Paths &_paths)
     , twitch2(&this->emplace<TwitchIrcServer>())
     , chatterinoBadges(&this->emplace<ChatterinoBadges>())
     , ffzBadges(&this->emplace<FfzBadges>())
+    , pronounsBadges(&this->emplace<PronounsBadges>())
     , logging(&this->emplace<Logging>())
 {
     this->instance = this;

--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -27,6 +27,7 @@ class Fonts;
 class Toasts;
 class ChatterinoBadges;
 class FfzBadges;
+class PronounsBadges;
 
 class Application
 {
@@ -59,6 +60,7 @@ public:
     TwitchIrcServer *const twitch2{};
     ChatterinoBadges *const chatterinoBadges{};
     FfzBadges *const ffzBadges{};
+    PronounsBadges *const pronounsBadges{};
 
     /*[[deprecated]]*/ Logging *const logging{};
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -195,6 +195,9 @@ set(SOURCE_FILES
         providers/irc/IrcServer.cpp
         providers/irc/IrcServer.hpp
 
+        providers/pronouns/PronounsBadges.cpp
+        providers/pronouns/PronounsBadges.hpp
+
         providers/twitch/ChannelPointReward.cpp
         providers/twitch/ChannelPointReward.hpp
         providers/twitch/IrcMessageHandler.cpp

--- a/src/messages/MessageElement.hpp
+++ b/src/messages/MessageElement.hpp
@@ -95,8 +95,12 @@ enum class MessageElementFlag : int64_t {
     // - FFZ donator badge
     BadgeFfz = (1LL << 19),
 
+    // Slot 8: Pronouns
+    BadgePronouns = (1LL << 32),
+
     Badges = BadgeGlobalAuthority | BadgePredictions | BadgeChannelAuthority |
-             BadgeSubscription | BadgeVanity | BadgeChatterino | BadgeFfz,
+             BadgeSubscription | BadgeVanity | BadgeChatterino | BadgeFfz |
+             BadgePronouns,
 
     ChannelName = (1LL << 20),
 

--- a/src/providers/pronouns/PronounsBadges.cpp
+++ b/src/providers/pronouns/PronounsBadges.cpp
@@ -1,0 +1,81 @@
+#include "PronounsBadges.hpp"
+
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QJsonValue>
+#include <QUrl>
+#include <map>
+#include <shared_mutex>
+#include "common/NetworkRequest.hpp"
+#include "common/Outcome.hpp"
+
+namespace chatterino {
+
+void PronounsBadges::initialize(Settings &settings, Paths &paths)
+{
+    this->loadPronouns();
+}
+
+boost::optional<QString> PronounsBadges::getPronouns(const UserId &id,
+                                                     const QString &userName)
+{
+    std::shared_lock lock(this->mutex_);
+
+    auto it = this->userPronounsMap.find(id.string);
+    if (it != this->userPronounsMap.end())
+    {
+        return it->second;
+    }
+    else
+    {
+        this->userPronounsMap[id.string] = boost::none;
+
+        QUrl url("https://pronouns.alejo.io/api/users/" + userName);
+
+        NetworkRequest(url)
+            .onSuccess([this, id, userName](auto result) -> Outcome {
+                std::unique_lock lock(this->mutex_);
+                auto jsonRoot = result.parseJsonArray();
+                for (const auto &jsonUser_ : jsonRoot)
+                {
+                    auto jsonUser = jsonUser_.toObject();
+                    auto pronounId = jsonUser.value("pronoun_id").toString();
+
+                    auto it = this->pronounsMap.find(pronounId);
+                    if (it != this->pronounsMap.end())
+                    {
+                        this->userPronounsMap[id.string] = it->second;
+                    }
+                }
+
+                return Success;
+            })
+            .execute();
+    }
+    return boost::none;
+}
+
+void PronounsBadges::loadPronouns()
+{
+    static QUrl url("https://pronouns.alejo.io/api/pronouns");
+
+    NetworkRequest(url)
+        .onSuccess([this](auto result) -> Outcome {
+            std::unique_lock lock(this->mutex_);
+
+            auto jsonRoot = result.parseJsonArray();
+            for (const auto &jsonPronouns_ : jsonRoot)
+            {
+                auto jsonPronouns = jsonPronouns_.toObject();
+                auto name = jsonPronouns.value("name").toString();
+                auto display = jsonPronouns.value("display").toString();
+
+                this->pronounsMap[name] = display;
+            }
+
+            return Success;
+        })
+        .execute();
+}
+
+}  // namespace chatterino

--- a/src/providers/pronouns/PronounsBadges.hpp
+++ b/src/providers/pronouns/PronounsBadges.hpp
@@ -4,6 +4,7 @@
 #include <common/Singleton.hpp>
 
 #include "common/Aliases.hpp"
+#include "pajlada/settings/settinglistener.hpp"
 #include "util/QStringHash.hpp"
 
 #include <map>
@@ -25,10 +26,14 @@ public:
 private:
     void loadPronouns();
 
+    bool enabled_;
+
     std::shared_mutex mutex_;
 
-    std::unordered_map<QString, boost::optional<QString>> userPronounsMap;
-    std::unordered_map<QString, QString> pronounsMap;
+    std::unordered_map<QString, boost::optional<QString>> userPronounsMap_;
+    std::unordered_map<QString, QString> pronounsMap_;
+
+    pajlada::SettingListener settingListener_;
 };
 
 }  // namespace chatterino

--- a/src/providers/pronouns/PronounsBadges.hpp
+++ b/src/providers/pronouns/PronounsBadges.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <boost/optional.hpp>
+#include <common/Singleton.hpp>
+
+#include "common/Aliases.hpp"
+#include "util/QStringHash.hpp"
+
+#include <map>
+#include <memory>
+#include <shared_mutex>
+#include <vector>
+
+namespace chatterino {
+
+class PronounsBadges : public Singleton
+{
+public:
+    virtual void initialize(Settings &settings, Paths &paths) override;
+    PronounsBadges() = default;
+
+    boost::optional<QString> getPronouns(const UserId &id,
+                                         const QString &userName);
+
+private:
+    void loadPronouns();
+
+    std::shared_mutex mutex_;
+
+    std::unordered_map<QString, boost::optional<QString>> userPronounsMap;
+    std::unordered_map<QString, QString> pronounsMap;
+};
+
+}  // namespace chatterino

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -7,6 +7,7 @@
 #include "messages/Message.hpp"
 #include "providers/chatterino/ChatterinoBadges.hpp"
 #include "providers/ffz/FfzBadges.hpp"
+#include "providers/pronouns/PronounsBadges.hpp"
 #include "providers/twitch/TwitchBadges.hpp"
 #include "providers/twitch/TwitchChannel.hpp"
 #include "providers/twitch/TwitchIrcServer.hpp"
@@ -199,6 +200,7 @@ MessagePtr TwitchMessageBuilder::build()
 
     this->appendChatterinoBadges();
     this->appendFfzBadges();
+    this->appendProunounsBadges();
 
     this->appendUsername();
 
@@ -1127,6 +1129,20 @@ void TwitchMessageBuilder::appendFfzBadges()
         {
             this->emplace<FfzBadgeElement>(*badge, MessageElementFlag::BadgeFfz,
                                            color.get());
+        }
+    }
+}
+
+void TwitchMessageBuilder::appendProunounsBadges()
+{
+    if (!this->historicalMessage_)
+    {
+        if (auto badge = getApp()->pronounsBadges->getPronouns({this->userId_},
+                                                               this->userName))
+        {
+            this->emplace<TextElement>(
+                *badge, MessageElementFlag::BadgePronouns, this->usernameColor_,
+                FontStyle::ChatMediumSmall);
         }
     }
 }

--- a/src/providers/twitch/TwitchMessageBuilder.hpp
+++ b/src/providers/twitch/TwitchMessageBuilder.hpp
@@ -91,6 +91,7 @@ private:
     void appendTwitchBadges();
     void appendChatterinoBadges();
     void appendFfzBadges();
+    void appendProunounsBadges();
     Outcome tryParseCheermote(const QString &string);
 
     bool shouldAddModerationElements() const;

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -144,7 +144,7 @@ public:
     BoolSetting showBadgesVanity = {"/appearance/badges/vanity", true};
     BoolSetting showBadgesChatterino = {"/appearance/badges/chatterino", true};
     BoolSetting showBadgesFfz = {"/appearance/badges/ffz", true};
-    BoolSetting showBadgesPronouns = {"/appearance/badges/pronouns", true};
+    BoolSetting showBadgesPronouns = {"/appearance/badges/pronouns", false};
     BoolSetting useCustomFfzModeratorBadges = {
         "/appearance/badges/useCustomFfzModeratorBadges", true};
     BoolSetting useCustomFfzVipBadges = {

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -144,6 +144,7 @@ public:
     BoolSetting showBadgesVanity = {"/appearance/badges/vanity", true};
     BoolSetting showBadgesChatterino = {"/appearance/badges/chatterino", true};
     BoolSetting showBadgesFfz = {"/appearance/badges/ffz", true};
+    BoolSetting showBadgesPronouns = {"/appearance/badges/pronouns", true};
     BoolSetting useCustomFfzModeratorBadges = {
         "/appearance/badges/useCustomFfzModeratorBadges", true};
     BoolSetting useCustomFfzVipBadges = {

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -110,6 +110,7 @@ WindowManager::WindowManager()
     this->wordFlagsListener_.addSetting(settings->showBadgesVanity);
     this->wordFlagsListener_.addSetting(settings->showBadgesChatterino);
     this->wordFlagsListener_.addSetting(settings->showBadgesFfz);
+    this->wordFlagsListener_.addSetting(settings->showBadgesPronouns);
     this->wordFlagsListener_.addSetting(settings->enableEmoteImages);
     this->wordFlagsListener_.addSetting(settings->boldUsernames);
     this->wordFlagsListener_.addSetting(settings->lowercaseDomains);
@@ -178,6 +179,7 @@ void WindowManager::updateWordTypeMask()
     flags.set(settings->showBadgesChatterino ? MEF::BadgeChatterino
                                              : MEF::None);
     flags.set(settings->showBadgesFfz ? MEF::BadgeFfz : MEF::None);
+    flags.set(settings->showBadgesPronouns ? MEF::BadgePronouns : MEF::None);
 
     // username
     flags.set(MEF::Username);

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -582,6 +582,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     layout.addCheckbox("Chatterino", s.showBadgesChatterino);
     layout.addCheckbox("FrankerFaceZ (Bot, FFZ Supporter, FFZ Developer)",
                        s.showBadgesFfz);
+    layout.addCheckbox("Pronouns", s.showBadgesPronouns);
     layout.addSeperator();
     layout.addCheckbox("Use custom FrankerFaceZ moderator badges",
                        s.useCustomFfzModeratorBadges);


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Adds badge provider for Twitch Chat Pronouns (https://pronouns.alejo.io/) API.
Pronouns are shown as a small text before username.
Pronoun badges are not displayed for historic messages to limit requests on startup.
Requests are made lazily, once when a user sends a message, so badge won't show for user's first message in current session.

![image](https://user-images.githubusercontent.com/5550792/141186823-1a61e2e6-e787-4ec5-a5b0-bf3360ae3e89.png)

This is a very naive implementation, so let me know if anything can be done better.
