### PR TITLE
Make `/delete` errors a bit more verbose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Minor: Clean up chat messages of special line characters prior to sending. (#3312)
 - Minor: IRC now parses/displays links like Twitch chat. (#3334)
 - Minor: Added button & label for copying login name of user instead of display name in the user info popout. (#3335)
+- Minor: Make `/delete` errors a bit more verbose (#3350)
 - Bugfix: Fixed colored usernames sometimes not working. (#3170)
 - Bugfix: Restored ability to send duplicate `/me` messages. (#3166)
 - Bugfix: Notifications for moderators about other moderators deleting messages can now be disabled. (#3121)

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -868,6 +868,8 @@ void CommandController::initialize(Settings &, Paths &paths)
     });
     this->registerCommand(
         "/delete", [](const QStringList &words, ChannelPtr channel) -> QString {
+            // This is a wrapper over the standard Twitch /delete command
+            // We use this to ensure the user gets better error messages for missing or malformed arguments
             if (words.size() < 2)
             {
                 channel->addMessage(
@@ -875,17 +877,18 @@ void CommandController::initialize(Settings &, Paths &paths)
                                       "specified message."));
                 return "";
             }
-            auto msg_id = words.at(1);
-            auto uuid = QUuid(msg_id);
+
+            auto messageID = words.at(1);
+            auto uuid = QUuid(messageID);
             if (uuid.isNull())
             {
-                // failed to parse
-
+                // The message id must be a valid UUID
                 channel->addMessage(makeSystemMessage(
-                    QString("Invalid msg-id: \"%1\"").arg(msg_id)));
+                    QString("Invalid msg-id: \"%1\"").arg(messageID)));
                 return "";
             }
-            auto msg = channel->findMessage(msg_id);
+
+            auto msg = channel->findMessage(messageID);
             if (msg != nullptr)
             {
                 if (msg->loginName == channel->getName() &&
@@ -897,7 +900,8 @@ void CommandController::initialize(Settings &, Paths &paths)
                     return "";
                 }
             }
-            return QString("/delete ") + msg_id;
+
+            return QString("/delete ") + messageID;
         });
 
     this->registerCommand("/raw", [](const QStringList &words, ChannelPtr) {

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -807,10 +807,17 @@ void IrcMessageHandler::handleNoticeMessage(Communi::IrcNoticeMessage *message)
         }
 
         QString tags = message->tags().value("msg-id").toString();
-        if (tags == "bad_delete_message_error" || tags == "usage_delete")
+        if (tags == "usage_delete")
         {
             channel->addMessage(makeSystemMessage(
-                "Usage: /delete <msg-id>. Can't take more than one argument"));
+                "Usage: /delete <msg-id> - Deletes the specified message. "
+                "Can't take more than one argument."));
+        }
+        else if (tags == "bad_delete_message_error")
+        {
+            channel->addMessage(
+                makeSystemMessage("There was a problem deleting the message. "
+                                  "It might be from another channel"));
         }
         else if (tags == "host_on" || tags == "host_target_went_offline")
         {

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -815,9 +815,9 @@ void IrcMessageHandler::handleNoticeMessage(Communi::IrcNoticeMessage *message)
         }
         else if (tags == "bad_delete_message_error")
         {
-            channel->addMessage(
-                makeSystemMessage("There was a problem deleting the message. "
-                                  "It might be from another channel"));
+            channel->addMessage(makeSystemMessage(
+                "There was a problem deleting the message. "
+                "It might be from another channel or too old to delete."));
         }
         else if (tags == "host_on" || tags == "host_target_went_offline")
         {


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
Closes #3241 
Turns out that delete errors generally don't have a message.