### PR TITLE
Add support for Emoji in IRC.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Minor: IRC now parses/displays links like Twitch chat. (#3334)
 - Minor: Added button & label for copying login name of user instead of display name in the user info popout. (#3335)
 - Minor: Make `/delete` errors a bit more verbose (#3350)
+- Minor: Add support for Emoji in IRC (#3354)
 - Bugfix: Fixed colored usernames sometimes not working. (#3170)
 - Bugfix: Restored ability to send duplicate `/me` messages. (#3166)
 - Bugfix: Notifications for moderators about other moderators deleting messages can now be disabled. (#3121)

--- a/src/providers/irc/IrcMessageBuilder.hpp
+++ b/src/providers/irc/IrcMessageBuilder.hpp
@@ -36,6 +36,8 @@ private:
     void appendUsername();
 
     void addWords(const QStringList &words);
+    void addText(const QString &text, const QColor &color,
+                 bool addSpace = true);
 };
 
 }  // namespace chatterino


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
Adds emoji support that behaves like Twitch for IRC.

My test message:
```
3test🕹😂
```

This doesn't add support for emoji in the client-side echo message.
