### PR TITLE
Make join and part messages have user links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Minor: IRC now parses/displays links like Twitch chat. (#3334)
 - Minor: Added button & label for copying login name of user instead of display name in the user info popout. (#3335)
 - Minor: Make `/delete` errors a bit more verbose (#3350)
+- Minor: Made join and part message have links to usercards. (#3358)
 - Bugfix: Fixed colored usernames sometimes not working. (#3170)
 - Bugfix: Restored ability to send duplicate `/me` messages. (#3166)
 - Bugfix: Notifications for moderators about other moderators deleting messages can now be disabled. (#3121)

--- a/src/common/ChannelChatters.cpp
+++ b/src/common/ChannelChatters.cpp
@@ -2,6 +2,7 @@
 
 #include "messages/Message.hpp"
 #include "messages/MessageBuilder.hpp"
+#include "providers/twitch/TwitchMessageBuilder.hpp"
 
 namespace chatterino {
 
@@ -34,8 +35,9 @@ void ChannelChatters::addJoinedUser(const QString &user)
         QTimer::singleShot(500, &this->lifetimeGuard_, [this] {
             auto joinedUsers = this->joinedUsers_.access();
 
-            MessageBuilder builder(systemMessage,
-                                   "Users joined: " + joinedUsers->join(", "));
+            MessageBuilder builder;
+            TwitchMessageBuilder::listOfUsersSystemMessage(
+                "Users joined:", *joinedUsers, &this->channel_, &builder);
             builder->flags.set(MessageFlag::Collapsed);
             joinedUsers->clear();
             this->channel_.addMessage(builder.release());
@@ -56,8 +58,9 @@ void ChannelChatters::addPartedUser(const QString &user)
         QTimer::singleShot(500, &this->lifetimeGuard_, [this] {
             auto partedUsers = this->partedUsers_.access();
 
-            MessageBuilder builder(systemMessage,
-                                   "Users parted: " + partedUsers->join(", "));
+            MessageBuilder builder;
+            TwitchMessageBuilder::listOfUsersSystemMessage(
+                "Users parted:", *partedUsers, &this->channel_, &builder);
             builder->flags.set(MessageFlag::Collapsed);
             this->channel_.addMessage(builder.release());
             partedUsers->clear();

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -865,8 +865,8 @@ void IrcMessageHandler::handleNoticeMessage(Communi::IrcNoticeMessage *message)
             auto users = msgParts.at(1)
                              .mid(1)  // there is a space before the first user
                              .split(", ");
-            TwitchMessageBuilder::modsOrVipsSystemMessage(msgParts.at(0), users,
-                                                          tc, &builder);
+            TwitchMessageBuilder::listOfUsersSystemMessage(msgParts.at(0),
+                                                           users, tc, &builder);
             channel->addMessage(builder.release());
         }
         else

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -1444,10 +1444,10 @@ void TwitchMessageBuilder::deletionMessage(const DeleteAction &action,
     builder->message().timeoutUser = "msg:" + action.messageId;
 }
 
-void TwitchMessageBuilder::modsOrVipsSystemMessage(QString prefix,
-                                                   QStringList users,
-                                                   TwitchChannel *channel,
-                                                   MessageBuilder *builder)
+void TwitchMessageBuilder::listOfUsersSystemMessage(QString prefix,
+                                                    QStringList users,
+                                                    Channel *channel,
+                                                    MessageBuilder *builder)
 {
     builder->emplace<TimestampElement>();
     builder->message().flags.set(MessageFlag::System);
@@ -1455,6 +1455,7 @@ void TwitchMessageBuilder::modsOrVipsSystemMessage(QString prefix,
     builder->emplace<TextElement>(prefix, MessageElementFlag::Text,
                                   MessageColor::System);
     bool isFirst = true;
+    auto tc = dynamic_cast<TwitchChannel *>(channel);
     for (const QString &username : users)
     {
         if (!isFirst)
@@ -1467,9 +1468,9 @@ void TwitchMessageBuilder::modsOrVipsSystemMessage(QString prefix,
 
         MessageColor color = MessageColor::System;
 
-        if (getSettings()->colorUsernames)
+        if (tc && getSettings()->colorUsernames)
         {
-            if (auto userColor = channel->getUserColor(username);
+            if (auto userColor = tc->getUserColor(username);
                 userColor.isValid())
             {
                 color = MessageColor(userColor);

--- a/src/providers/twitch/TwitchMessageBuilder.hpp
+++ b/src/providers/twitch/TwitchMessageBuilder.hpp
@@ -64,9 +64,9 @@ public:
                                 MessageBuilder *builder);
     static void deletionMessage(const DeleteAction &action,
                                 MessageBuilder *builder);
-    static void modsOrVipsSystemMessage(QString prefix, QStringList users,
-                                        TwitchChannel *channel,
-                                        MessageBuilder *builder);
+    static void listOfUsersSystemMessage(QString prefix, QStringList users,
+                                         Channel *channel,
+                                         MessageBuilder *builder);
 
 private:
     void parseUsernameColor() override;


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
Also I renamed `TwitchMessageBuilder::modsOrVipsSystemMessage` to `listOfUsersSystemMessage` because I wanted to reuse it. Part of #2673