### PR TITLE
Fix Split Input hotkeys not being available when input is hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Minor: Made join and part message have links to usercards. (#3358)
 - Minor: Show picked outcome in prediction badges. (#3357)
 - Minor: Add support for Emoji in IRC (#3354)
+- Bugfix: Fix Split Input hotkeys not being available when input is hidden (#3362)
 - Bugfix: Fixed colored usernames sometimes not working. (#3170)
 - Bugfix: Restored ability to send duplicate `/me` messages. (#3166)
 - Bugfix: Notifications for moderators about other moderators deleting messages can now be disabled. (#3121)

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -457,7 +457,7 @@ void SplitInput::addShortcuts()
     };
 
     this->shortcuts_ = getApp()->hotkeys->shortcutsForCategory(
-        HotkeyCategory::SplitInput, actions, this);
+        HotkeyCategory::SplitInput, actions, this->parentWidget());
 }
 
 bool SplitInput::eventFilter(QObject *obj, QEvent *event)


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
I wonder if I :b: roke something. I don't think so but you can never be truly sure.

Closes #3361