### PR TITLE
Refactor: fix build warnings

### DIFF
--- a/src/common/ChannelChatters.cpp
+++ b/src/common/ChannelChatters.cpp
@@ -71,10 +71,10 @@ void ChannelChatters::addPartedUser(const QString &user)
 }
 
 void ChannelChatters::updateOnlineChatters(
-    const std::unordered_set<QString> &chatters)
+    const std::unordered_set<QString> &usernames)
 {
-    auto chatters_ = this->chatters_.access();
-    chatters_->updateOnlineChatters(chatters);
+    auto chatters = this->chatters_.access();
+    chatters->updateOnlineChatters(usernames);
 }
 
 size_t ChannelChatters::colorsSize() const

--- a/src/common/ChannelChatters.hpp
+++ b/src/common/ChannelChatters.hpp
@@ -23,7 +23,7 @@ public:
     void addPartedUser(const QString &user);
     const QColor getUserColor(const QString &user);
     void setUserColor(const QString &user, const QColor &color);
-    void updateOnlineChatters(const std::unordered_set<QString> &chatters);
+    void updateOnlineChatters(const std::unordered_set<QString> &usernames);
 
     // colorsSize returns the amount of colors stored in `chatterColors_`
     // NOTE: This function is only meant to be used in tests and benchmarks

--- a/src/common/DownloadManager.hpp
+++ b/src/common/DownloadManager.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "Application.hpp"
-
 #include <QFile>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
@@ -20,9 +18,9 @@ public:
     void setFile(QString fileURL, const QString &channelName);
 
 private:
-    QNetworkAccessManager *manager;
-    QNetworkReply *reply;
-    QFile *file;
+    QNetworkAccessManager *manager_;
+    QNetworkReply *reply_;
+    QFile *file_;
 
 private slots:
     void onDownloadProgress(qint64, qint64);
@@ -33,4 +31,5 @@ private slots:
 signals:
     void downloadComplete();
 };
+
 }  // namespace chatterino

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -951,8 +951,6 @@ QString CommandController::execCommand(const QString &textNoEmoji,
         }
     }
 
-    auto *twitchChannel = dynamic_cast<TwitchChannel *>(channel.get());
-
     {
         // check if user command exists
         const auto it = this->userCommands_.find(commandName);

--- a/src/controllers/filters/parser/Tokenizer.cpp
+++ b/src/controllers/filters/parser/Tokenizer.cpp
@@ -8,9 +8,9 @@ Tokenizer::Tokenizer(const QString &text)
     QRegularExpressionMatchIterator i = tokenRegex.globalMatch(text);
     while (i.hasNext())
     {
-        auto text = i.next().captured();
-        this->tokens_ << text;
-        this->tokenTypes_ << this->tokenize(text);
+        auto capturedText = i.next().captured();
+        this->tokens_ << capturedText;
+        this->tokenTypes_ << this->tokenize(capturedText);
     }
 }
 

--- a/src/messages/search/MessagePredicate.hpp
+++ b/src/messages/search/MessagePredicate.hpp
@@ -17,6 +17,8 @@ namespace chatterino {
 class MessagePredicate
 {
 public:
+    virtual ~MessagePredicate() = default;
+
     /**
      * @brief Checks whether this predicate applies to the passed message.
      *

--- a/src/providers/irc/IrcMessageBuilder.cpp
+++ b/src/providers/irc/IrcMessageBuilder.cpp
@@ -113,7 +113,6 @@ void IrcMessageBuilder::addWords(const QStringList &words)
             continue;
         }
 
-        int pos = 0;
         int lastPos = 0;
 
         while (i.hasNext())

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -827,18 +827,18 @@ void IrcMessageHandler::handleNoticeMessage(Communi::IrcNoticeMessage *message)
             {
                 return;
             }
-            auto &channelName = hostOn ? parts[2] : parts[0];
-            if (channelName.size() < 2)
+            auto &hostedChannelName = hostOn ? parts[2] : parts[0];
+            if (hostedChannelName.size() < 2)
             {
                 return;
             }
             if (hostOn)
             {
-                channelName.chop(1);
+                hostedChannelName.chop(1);
             }
             MessageBuilder builder;
-            TwitchMessageBuilder::hostingSystemMessage(channelName, &builder,
-                                                       hostOn);
+            TwitchMessageBuilder::hostingSystemMessage(hostedChannelName,
+                                                       &builder, hostOn);
             channel->addMessage(builder.release());
         }
         else if (tags == "room_mods" || tags == "vips_success")

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -312,7 +312,6 @@ void TwitchMessageBuilder::addWords(
         while (doesWordContainATwitchEmote(cursor, word, twitchEmotes,
                                            currentTwitchEmoteIt))
         {
-            auto wordEnd = cursor + word.length();
             const auto &currentTwitchEmote = *currentTwitchEmoteIt;
 
             if (currentTwitchEmote.start == cursor)

--- a/src/widgets/settingspages/ModerationPage.cpp
+++ b/src/widgets/settingspages/ModerationPage.cpp
@@ -71,7 +71,6 @@ QString fetchLogDirectorySize()
 
 ModerationPage::ModerationPage()
 {
-    auto app = getApp();
     LayoutCreator<ModerationPage> layoutCreator(this);
 
     auto tabs = layoutCreator.emplace<QTabWidget>();

--- a/src/widgets/splits/SplitContainer.cpp
+++ b/src/widgets/splits/SplitContainer.cpp
@@ -819,8 +819,6 @@ void SplitContainer::applyFromDescriptorRecursively(
 
         bool vertical = containerNode.vertical_;
 
-        Direction direction = vertical ? Direction::Below : Direction::Right;
-
         node->type_ =
             vertical ? Node::VerticalContainer : Node::HorizontalContainer;
 


### PR DESCRIPTION
Pull request checklist:

- ~~[] `CHANGELOG.md` was updated, if applicable~~ Not applicable

# Description
I've made a few code refactors to try and reduce build warnings. I understand there has been a previous attempt by someone else that got rejected because a number of the changes were solely aimed at reducing warnings without caring about readability. So I only tried to fix those warnings I can find a justification for.

## Single change
- Resolve "C4189: local variable initialized by not referenced" warnings
  - Delete `twitchChannel` local variable in `CommandController.cpp`
  - Delete `pos` local variable in `IrcMessageBuilder.cpp`
  - Delete `direction` local variable in `SplitContainer.cpp`
  - Delete `app` local variable in `ModerationPage.cpp`
- Resolve warning: C4457: declaration of 'text' hides function parameter
  - Rename local variable `text` to `capturedText` in `Tokenizer.cpp`
- Resolve warning: C5205: delete of an abstract class 'chatterino::MessagePredicate' that has a non-virtual destructor results in undefined behavior
  - Add virtual destructor in `MessagePredicate.hpp`

## Multiple changes
- In `DownloadManager.hpp`, `DownloadManager.cpp`
	- Append `_` to private member variable - consistent with private member variable naming in other classes
		- Resolves warning C4458: declaration of 'reply' hides class member
- In `IrcMessageBuilder.cpp`
	- Delete `wordEnd` local variable
		- Resolves warning: C4189: 'wordEnd': local variable is initialized but not referenced
	- Rename `channelName` to `hostedChannelName`
		- Resolves warning: C4456: declaration of 'channelName' hides previous local declaration
		- Based on original [PR](https://github.com/Chatterino/chatterino2/issues/2655) this should refer to the hosted channel's name
- In `ChannelChatters.hpp`, `ChannelChatters.cpp`
	- Rename argument to `usernames`
		- Consistent with the intention of the call to [`ChatterSet::updateOnlineChatters()`](https://github.com/Chatterino/chatterino2/blob/master/src/common/ChatterSet.hpp#L29)
		- Allow us to declare `chatters` to resolve warning: C4458: declaration of 'chatters_' hides class member
			- Also consistent with the naming style of variables in other methods in the class

## Potential changes
- To resolve "Resolves warning: C4458: declaration of 'channels' hides class member"
  - Rename protected member variable from `channels` to `channels_`
    - And similarly `channelMutex` to `channelMutex_` for consistency, this naming style has been used else where in the project ([example](https://github.com/Chatterino/chatterino2/blob/master/src/providers/twitch/TwitchChannel.hpp#L160))
  - Affects `AbstractIrcServer.hpp`, `AbstractIrcServer.cpp`, `IrcServer.cpp`, and `TwitchIrcServer.cpp`

I have done a successful build with the renamed `channels_` and `channelMutex_` but since the contributing docs doesn't explicitly mention what naming style to use for protected member variables, I wasn't sure if I should include this. Please let me know your thoughts.