### PR TITLE
Add some commented First Message code for consistency

### DIFF
--- a/src/controllers/highlights/HighlightModel.cpp
+++ b/src/controllers/highlights/HighlightModel.cpp
@@ -253,7 +253,7 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
                 }
                 else if (rowIndex == 4)
                 {
-                    // getSettings()->enableFirstMessageHiglightTaskbar.setValue(
+                    // getSettings()->enableFirstMessageHighlightTaskbar.setValue(
                     //     value.toBool());
                 }
             }

--- a/src/controllers/highlights/HighlightModel.cpp
+++ b/src/controllers/highlights/HighlightModel.cpp
@@ -159,6 +159,12 @@ void HighlightModel::afterInit()
     firstMessageRow[Column::Pattern]->setData("First Messages",
                                               Qt::DisplayRole);
     firstMessageRow[Column::ShowInMentions]->setFlags({});
+    //    setBoolItem(redeemedRow[Column::FlashTaskbar],
+    //                getSettings()->enableFirstMessageHighlightTaskbar.getValue(),
+    //                true, false);
+    //    setBoolItem(redeemedRow[Column::PlaySound],
+    //                getSettings()->enableFirstMessageHighlightSound.getValue(),
+    //                true, false);
     firstMessageRow[Column::FlashTaskbar]->setFlags({});
     firstMessageRow[Column::PlaySound]->setFlags({});
     firstMessageRow[Column::UseRegex]->setFlags({});
@@ -245,6 +251,11 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
                     // getSettings()->enableRedeemedHighlightTaskbar.setValue(
                     //     value.toBool());
                 }
+                else if (rowIndex == 4)
+                {
+                    // getSettings()->enableFirstMessageHiglightTaskbar.setValue(
+                    //     value.toBool());
+                }
             }
         }
         break;
@@ -269,6 +280,11 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
                 else if (rowIndex == 3)
                 {
                     // getSettings()->enableRedeemedHighlightSound.setValue(
+                    //     value.toBool());
+                }
+                else if (rowIndex == 4)
+                {
+                    // getSettings()->enableFirstMessageHighlightSound.setValue(
                     //     value.toBool());
                 }
             }

--- a/src/controllers/highlights/HighlightModel.cpp
+++ b/src/controllers/highlights/HighlightModel.cpp
@@ -159,10 +159,10 @@ void HighlightModel::afterInit()
     firstMessageRow[Column::Pattern]->setData("First Messages",
                                               Qt::DisplayRole);
     firstMessageRow[Column::ShowInMentions]->setFlags({});
-    //    setBoolItem(redeemedRow[Column::FlashTaskbar],
+    //    setBoolItem(firstMessageRow[Column::FlashTaskbar],
     //                getSettings()->enableFirstMessageHighlightTaskbar.getValue(),
     //                true, false);
-    //    setBoolItem(redeemedRow[Column::PlaySound],
+    //    setBoolItem(firstMessageRow[Column::PlaySound],
     //                getSettings()->enableFirstMessageHighlightSound.getValue(),
     //                true, false);
     firstMessageRow[Column::FlashTaskbar]->setFlags({});

--- a/src/messages/SharedMessageBuilder.cpp
+++ b/src/messages/SharedMessageBuilder.cpp
@@ -130,6 +130,7 @@ void SharedMessageBuilder::parseHighlights()
 {
     auto app = getApp();
 
+    // Highlight because it's a subscription
     if (this->message().flags.has(MessageFlag::Subscription) &&
         getSettings()->enableSubHighlight)
     {

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -275,6 +275,10 @@ public:
 
     BoolSetting enableFirstMessageHighlight = {
         "/highlighting/firstMessageHighlight/highlighted", true};
+    //    BoolSetting enableFirstMessageHiglightSound = {
+    //        "/highlighting/firstMessageHiglight/enableSound", false};
+    //    BoolSetting enableFirstMessageHiglightTaskbar = {
+    //        "/highlighting/firstMessageHighlight/enableTaskbarFlashing", false};
     QStringSetting firstMessageHighlightSoundUrl = {
         "/highlighting/firstMessageHighlightSoundUrl", ""};
     QStringSetting firstMessageHighlightColor = {

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -275,9 +275,9 @@ public:
 
     BoolSetting enableFirstMessageHighlight = {
         "/highlighting/firstMessageHighlight/highlighted", true};
-    //    BoolSetting enableFirstMessageHiglightSound = {
-    //        "/highlighting/firstMessageHiglight/enableSound", false};
-    //    BoolSetting enableFirstMessageHiglightTaskbar = {
+    //    BoolSetting enableFirstMessageHighlightSound = {
+    //        "/highlighting/firstMessageHighlight/enableSound", false};
+    //    BoolSetting enableFirstMessageHighlightTaskbar = {
     //        "/highlighting/firstMessageHighlight/enableTaskbarFlashing", false};
     QStringSetting firstMessageHighlightSoundUrl = {
         "/highlighting/firstMessageHighlightSoundUrl", ""};


### PR DESCRIPTION
Pull request checklist:

- [X] `CHANGELOG.md` was updated, if applicable

# Description

This PR adds "missing" code for `HighlightTaskbar` & `HighlightSound` for the `First Message` highlight. 
Standard comes from the above code for `Highlights Redeemed with Channel Points`

I also added a technically unrelated comment in SharedMessageBuilder.cpp because I was in there to make sure this actually works and I remembered wanting that comment last time I played around with first-msg sounds.