### PR TITLE
Fix crash on missing parameters with IRC /kick command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 - Bugfix: Fixed the first usercard being broken in `/mods` and `/vips` (#3349)
 - Bugfix: Fixed Chatterino attempting to send empty messages (#3355)
 - Bugfix: Fixed IRC highlights not triggering sounds or alerts properly. (#3368)
+- Bugfix: Fixed IRC /kick command crashing if parameters were malformed. (#3382)
 - Dev: Add GitHub action to test builds without precompiled headers enabled. (#3327)
 - Dev: Renamed CMake's build option `USE_SYSTEM_QT5KEYCHAIN` to `USE_SYSTEM_QTKEYCHAIN`. (#3103)
 - Dev: Add benchmarks that can be compiled with the `BUILD_BENCHMARKS` CMake flag. Off by default. (#3038)

--- a/src/providers/irc/IrcCommands.cpp
+++ b/src/providers/irc/IrcCommands.cpp
@@ -55,11 +55,24 @@ Outcome invokeIrcCommand(const QString &commandName, const QString &allParams,
     }
     else if (cmd == "kick")
     {
-        if (paramsAfter(1).isEmpty())
-            sendRaw("KICK " + params[0] + " " + params[1]);
+        if (params.size() < 2)
+        {
+            channel.addMessage(
+                makeSystemMessage("Usage: /kick <channel> <client> [message]"));
+            return Failure;
+        }
+        const auto &channelParam = params[0];
+        const auto &clientParam = params[1];
+        const auto &messageParam = paramsAfter(1);
+        if (messageParam.isEmpty())
+        {
+            sendRaw("KICK " + channelParam + " " + clientParam);
+        }
         else
-            sendRaw("KICK " + params[0] + " " + params[1] + " :" +
-                    paramsAfter(1));
+        {
+            sendRaw("KICK " + channelParam + " " + clientParam + " :" +
+                    messageParam);
+        }
     }
     else if (cmd == "wallops")
     {


### PR DESCRIPTION
If the user tries to use /kick with less than the 2 required parameters (channel and client), we would crash.

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
