### PR TITLE
Fix IRC colors not being applied correctly to NOTICE messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 - Bugfix: Fixed IRC ACTION messages (/me) not being colorized properly. (#3341)
 - Bugfix: Fixed splits losing filters when closing and reopening them (#3351)
 - Bugfix: Fixed the first usercard being broken in `/mods` and `/vips` (#3349)
+- Bugfix: Fixed IRC colors not being applied correctly to NOTICE messages. (#3383)
 - Bugfix: Fixed Chatterino attempting to send empty messages (#3355)
 - Bugfix: Fixed IRC highlights not triggering sounds or alerts properly. (#3368)
 - Dev: Add GitHub action to test builds without precompiled headers enabled. (#3327)

--- a/src/providers/irc/IrcMessageBuilder.cpp
+++ b/src/providers/irc/IrcMessageBuilder.cpp
@@ -42,6 +42,13 @@ IrcMessageBuilder::IrcMessageBuilder(Channel *_channel,
     assert(false);
 }
 
+IrcMessageBuilder::IrcMessageBuilder(
+    const Communi::IrcNoticeMessage *_ircMessage, const MessageParseArgs &_args)
+    : SharedMessageBuilder(Channel::getEmpty().get(), _ircMessage, _args,
+                           _ircMessage->content(), false)
+{
+}
+
 MessagePtr IrcMessageBuilder::build()
 {
     // PARSE
@@ -203,14 +210,30 @@ void IrcMessageBuilder::appendUsername()
     // The full string that will be rendered in the chat widget
     QString usernameText = username;
 
-    if (!this->action_)
+    if (this->args.isReceivedWhisper)
     {
-        usernameText += ":";
-    }
+        this->emplace<TextElement>(usernameText, MessageElementFlag::Username,
+                                   this->usernameColor_,
+                                   FontStyle::ChatMediumBold)
+            ->setLink({Link::UserWhisper, this->message().displayName});
 
-    this->emplace<TextElement>(usernameText, MessageElementFlag::Username,
-                               this->usernameColor_, FontStyle::ChatMediumBold)
-        ->setLink({Link::UserInfo, this->message().loginName});
+        // Separator
+        this->emplace<TextElement>("->", MessageElementFlag::Username,
+                                   MessageColor::System, FontStyle::ChatMedium);
+
+        this->emplace<TextElement>("you:", MessageElementFlag::Username);
+    }
+    else
+    {
+        if (!this->action_)
+        {
+            usernameText += ":";
+        }
+        this->emplace<TextElement>(usernameText, MessageElementFlag::Username,
+                                   this->usernameColor_,
+                                   FontStyle::ChatMediumBold)
+            ->setLink({Link::UserInfo, this->message().loginName});
+    }
 }
 
 }  // namespace chatterino

--- a/src/providers/irc/IrcMessageBuilder.hpp
+++ b/src/providers/irc/IrcMessageBuilder.hpp
@@ -30,6 +30,12 @@ public:
                                const MessageParseArgs &_args, QString content,
                                bool isAction);
 
+    /**
+     * @brief used for global notice messages (i.e. notice messages without a channel as its target)
+     **/
+    explicit IrcMessageBuilder(const Communi::IrcNoticeMessage *_ircMessage,
+                               const MessageParseArgs &_args);
+
     MessagePtr build() override;
 
 private:

--- a/src/providers/irc/IrcServer.cpp
+++ b/src/providers/irc/IrcServer.cpp
@@ -90,23 +90,20 @@ void IrcServer::initializeConnectionSignals(IrcConnection *connection,
 
     QObject::connect(connection, &Communi::IrcConnection::noticeMessageReceived,
                      this, [this](Communi::IrcNoticeMessage *message) {
-                         // XD PAJLADA
-                         MessageBuilder builder;
+                         MessageParseArgs args;
+                         args.isReceivedWhisper = true;
 
-                         builder.emplace<TimestampElement>(
-                             calculateMessageTimestamp(message));
-                         builder.emplace<TextElement>(
-                             message->nick(), MessageElementFlag::Username);
-                         builder.emplace<TextElement>(
-                             "-> you:", MessageElementFlag::Username);
-                         builder.emplace<TextElement>(message->content(),
-                                                      MessageElementFlag::Text);
+                         IrcMessageBuilder builder(message, args);
 
-                         auto msg = builder.release();
+                         auto msg = builder.build();
 
                          for (auto &&weak : this->channels)
+                         {
                              if (auto shared = weak.lock())
+                             {
                                  shared->addMessage(msg);
+                             }
+                         }
                      });
 }
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

- Normalize NOTICE message parsing for IRC

This fixes color parsing for NOTICE messages

Fixes #1782

NOTE: This does *NOT* fix color parsing for unhandled IRC messages.
When we promote a message type from Unhandled to Handled, we would make sure it used the standard path, thus enabling color parsing for free.

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
