### PR TITLE
Fix zero-width emotes sometimes wrapping lines incorrectly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unversioned
 
 - Major: Added customizable shortcuts. (#2340)
+- Minor: Disregard trailing zero-width emotes for line breaks (#3389)
 - Minor: Added middle click split to open in browser (#3356)
 - Minor: Added new search predicate to filter for messages matching a regex (#3282)
 - Minor: Add `{channel.name}`, `{channel.id}`, `{stream.game}`, `{stream.title}`, `{my.id}`, `{my.name}` placeholders for commands (#3155)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unversioned
 
 - Major: Added customizable shortcuts. (#2340)
-- Minor: Disregard trailing zero-width emotes for line breaks (#3389)
+- Bugfix: Fixed zero-width emotes sometimes wrapping lines incorrectly. (#3389)
 - Minor: Added middle click split to open in browser (#3356)
 - Minor: Added new search predicate to filter for messages matching a regex (#3282)
 - Minor: Add `{channel.name}`, `{channel.id}`, `{stream.game}`, `{stream.title}`, `{my.id}`, `{my.name}` placeholders for commands (#3155)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## Unversioned
 
 - Major: Added customizable shortcuts. (#2340)
-- Bugfix: Fixed zero-width emotes sometimes wrapping lines incorrectly. (#3389)
 - Minor: Added middle click split to open in browser (#3356)
 - Minor: Added new search predicate to filter for messages matching a regex (#3282)
 - Minor: Add `{channel.name}`, `{channel.id}`, `{stream.game}`, `{stream.title}`, `{my.id}`, `{my.name}` placeholders for commands (#3155)
@@ -66,6 +65,7 @@
 - Bugfix: Fixed IRC highlights not triggering sounds or alerts properly. (#3368)
 - Bugfix: Fixed IRC /kick command crashing if parameters were malformed. (#3382)
 - Bugfix: Fixed a crash that could occur on certain Linux systems when toggling the Always on Top flag. (#3385)
+- Bugfix: Fixed zero-width emotes sometimes wrapping lines incorrectly. (#3389)
 - Dev: Add GitHub action to test builds without precompiled headers enabled. (#3327)
 - Dev: Renamed CMake's build option `USE_SYSTEM_QT5KEYCHAIN` to `USE_SYSTEM_QTKEYCHAIN`. (#3103)
 - Dev: Add benchmarks that can be compiled with the `BUILD_BENCHMARKS` CMake flag. Off by default. (#3038)

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -65,7 +65,8 @@ void MessageLayoutContainer::clear()
 
 void MessageLayoutContainer::addElement(MessageLayoutElement *element)
 {
-    bool isZeroWidth = element->getFlags().has(MessageElementFlag::ZeroWidthEmote);
+    bool isZeroWidth =
+        element->getFlags().has(MessageElementFlag::ZeroWidthEmote);
 
     if (!isZeroWidth && !this->fitsInLine(element->getRect().width()))
     {

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -65,7 +65,9 @@ void MessageLayoutContainer::clear()
 
 void MessageLayoutContainer::addElement(MessageLayoutElement *element)
 {
-    if (!this->fitsInLine(element->getRect().width()))
+    bool isZeroWidth = element->getFlags().has(MessageElementFlag::ZeroWidthEmote);
+
+    if (!isZeroWidth && !this->fitsInLine(element->getRect().width()))
     {
         this->breakLine();
     }


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Prevents trailing zero-width emotes from individually line breaking by considering their width as 0 instead of the calculated width of a space. For example, typing `LUL cvHazmat` will result in only the width of `LUL`, with `cvHazmat` completely disregarded. This in turn also prevents zero-width emotes from being shifted out of bounds to the left when individually line broken.

One side effect of this change is that stacked zero-width emotes (e.g., `cvHazmat cvHazmat cvHazmat`) will run out of bounds to the right if at the end of a line since they would now only be considered overflow from the base emote (e.g., `LUL`).

Fixes #3147 