### PR TITLE
Move '/live' logs to its own subDirectory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Minor: Made join and part message have links to usercards. (#3358)
 - Minor: Show picked outcome in prediction badges. (#3357)
 - Minor: Add support for Emoji in IRC (#3354)
+- Minor: Moved `/live` logs to its own subdirectory. (Logs from before this change will still be available in `Channels -> live`). (#3393)
 - Bugfix: Fix Split Input hotkeys not being available when input is hidden (#3362)
 - Bugfix: Fixed colored usernames sometimes not working. (#3170)
 - Bugfix: Restored ability to send duplicate `/me` messages. (#3166)

--- a/src/singletons/helper/LoggingChannel.cpp
+++ b/src/singletons/helper/LoggingChannel.cpp
@@ -24,6 +24,10 @@ LoggingChannel::LoggingChannel(const QString &_channelName)
     {
         this->subDirectory = "Mentions";
     }
+    else if (channelName.startsWith("/live"))
+    {
+        this->subDirectory = "Live";
+    }
     else
     {
         this->subDirectory =


### PR DESCRIPTION
Pull request checklist:

- [X] `CHANGELOG.md` was updated, if applicable

# Description

This PR moves to relocate `/live` logs to it's own directory, as it is a special channel.

This change as expected will cause users who use `/live` to have 2 different logging files, but from what I've seen, this channel is nowhere near as used as `/mentions` or `/whispers`, and coupling that with how many users do not log, this change shouldn't be too disruptive.

That being said, I've included said information in the changelog entry, and included a changelog entry for that reason.