### PR TITLE
Update Settings and Signals version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 - Bugfix: Fixed Chatterino attempting to send empty messages (#3355)
 - Bugfix: Fixed IRC highlights not triggering sounds or alerts properly. (#3368)
 - Bugfix: Fixed IRC /kick command crashing if parameters were malformed. (#3382)
+- Bugfix: Fixed IRC crash that would occurr if the user tries to modify the currently connected IRC connection. (#3398)
 - Bugfix: Fixed a crash that could occur on certain Linux systems when toggling the Always on Top flag. (#3385)
 - Bugfix: Fixed zero-width emotes sometimes wrapping lines incorrectly. (#3389)
 - Bugfix: Fixed using special chars in Windows username breaking the storage of custom commands (#3397)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@
 - Bugfix: Fixed Chatterino attempting to send empty messages (#3355)
 - Bugfix: Fixed IRC highlights not triggering sounds or alerts properly. (#3368)
 - Bugfix: Fixed IRC /kick command crashing if parameters were malformed. (#3382)
-- Bugfix: Fixed IRC crash that would occurr if the user tries to modify the currently connected IRC connection. (#3398)
+- Bugfix: Fixed crash that would occur if the user tries to modify the currently connected IRC connection. (#3398)
 - Bugfix: Fixed a crash that could occur on certain Linux systems when toggling the Always on Top flag. (#3385)
 - Bugfix: Fixed zero-width emotes sometimes wrapping lines incorrectly. (#3389)
 - Bugfix: Fixed using special chars in Windows username breaking the storage of custom commands (#3397)

--- a/src/messages/layouts/MessageLayoutElement.cpp
+++ b/src/messages/layouts/MessageLayoutElement.cpp
@@ -224,8 +224,6 @@ void TextLayoutElement::listenToLinkChanges()
 {
     this->managedConnections_.managedConnect(
         static_cast<TextElement &>(this->getCreator()).linkChanged, [this]() {
-            // log("Old link: {}", this->getCreator().getLink().value);
-            // log("This link: {}", this->getLink().value);
             this->setLink(this->getCreator().getLink());
         });
 }

--- a/src/messages/layouts/MessageLayoutElement.cpp
+++ b/src/messages/layouts/MessageLayoutElement.cpp
@@ -222,13 +222,12 @@ TextLayoutElement::TextLayoutElement(MessageElement &_creator, QString &_text,
 
 void TextLayoutElement::listenToLinkChanges()
 {
-    this->managedConnections_.emplace_back(
-        static_cast<TextElement &>(this->getCreator())
-            .linkChanged.connect([this]() {
-                // log("Old link: {}", this->getCreator().getLink().value);
-                // log("This link: {}", this->getLink().value);
-                this->setLink(this->getCreator().getLink());
-            }));
+    this->managedConnections_.managedConnect(
+        static_cast<TextElement &>(this->getCreator()).linkChanged, [this]() {
+            // log("Old link: {}", this->getCreator().getLink().value);
+            // log("This link: {}", this->getLink().value);
+            this->setLink(this->getCreator().getLink());
+        });
 }
 
 void TextLayoutElement::addCopyTextToString(QString &str, int from,

--- a/src/messages/layouts/MessageLayoutElement.hpp
+++ b/src/messages/layouts/MessageLayoutElement.hpp
@@ -11,6 +11,8 @@
 #include "messages/MessageColor.hpp"
 #include "messages/MessageElement.hpp"
 
+#include <pajlada/signals/signalholder.hpp>
+
 class QPainter;
 
 namespace chatterino {
@@ -114,7 +116,7 @@ protected:
     FontStyle style_;
     float scale_;
 
-    std::vector<pajlada::Signals::ScopedConnection> managedConnections_;
+    pajlada::Signals::SignalHolder managedConnections_;
 };
 
 // TEXT ICON

--- a/src/providers/irc/AbstractIrcServer.hpp
+++ b/src/providers/irc/AbstractIrcServer.hpp
@@ -20,8 +20,6 @@ class AbstractIrcServer : public QObject
 public:
     enum ConnectionType { Read = 1, Write = 2, Both = 3 };
 
-    virtual ~AbstractIrcServer() = default;
-
     // initializeIrc must be called from the derived class
     // this allows us to initialize the abstract IRC server based on the derived class's parameters
     void initializeIrc();

--- a/src/providers/irc/AbstractIrcServer.hpp
+++ b/src/providers/irc/AbstractIrcServer.hpp
@@ -20,6 +20,8 @@ class AbstractIrcServer : public QObject
 public:
     enum ConnectionType { Read = 1, Write = 2, Both = 3 };
 
+    virtual ~AbstractIrcServer() = default;
+
     // initializeIrc must be called from the derived class
     // this allows us to initialize the abstract IRC server based on the derived class's parameters
     void initializeIrc();

--- a/src/providers/irc/IrcConnection2.cpp
+++ b/src/providers/irc/IrcConnection2.cpp
@@ -117,6 +117,12 @@ IrcConnection::IrcConnection(QObject *parent)
                      });
 }
 
+IrcConnection::~IrcConnection()
+{
+    // Prematurely disconnect all QObject connections
+    this->disconnect();
+}
+
 void IrcConnection::open()
 {
     this->expectConnectionLoss_ = false;

--- a/src/providers/irc/IrcConnection2.hpp
+++ b/src/providers/irc/IrcConnection2.hpp
@@ -13,6 +13,7 @@ class IrcConnection : public Communi::IrcConnection
 {
 public:
     IrcConnection(QObject *parent = nullptr);
+    ~IrcConnection() override;
 
     // Signal to notify that we're unexpectedly no longer connected, either due
     // to a connection error or if we think we've timed out. It's up to the

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -158,14 +158,16 @@ TwitchChannel::TwitchChannel(const QString &name)
 {
     qCDebug(chatterinoTwitch) << "[TwitchChannel" << name << "] Opened";
 
-    this->managedConnect(getApp()->accounts->twitch.currentUserChanged, [=] {
-        this->setMod(false);
-    });
+    this->signalHolder_.managedConnect(
+        getApp()->accounts->twitch.currentUserChanged, [=] {
+            this->setMod(false);
+        });
 
     // pubsub
-    this->managedConnect(getApp()->accounts->twitch.currentUserChanged, [=] {
-        this->refreshPubsub();
-    });
+    this->signalHolder_.managedConnect(
+        getApp()->accounts->twitch.currentUserChanged, [=] {
+            this->refreshPubsub();
+        });
     this->refreshPubsub();
     this->userStateChanged.connect([this] {
         this->refreshPubsub();

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -35,9 +35,7 @@ class BttvEmotes;
 
 class TwitchIrcServer;
 
-class TwitchChannel : public Channel,
-                      public ChannelChatters,
-                      pajlada::Signals::SignalHolder
+class TwitchChannel : public Channel, public ChannelChatters
 {
 public:
     struct StreamStatus {
@@ -183,6 +181,8 @@ private:
     QElapsedTimer titleRefreshedTimer_;
     QElapsedTimer clipCreationTimer_;
     bool isClipCreationInProgress{false};
+
+    pajlada::Signals::SignalHolder signalHolder_;
 
     friend class TwitchIrcServer;
     friend class TwitchMessageBuilder;

--- a/src/singletons/TooltipPreviewImage.cpp
+++ b/src/singletons/TooltipPreviewImage.cpp
@@ -16,19 +16,19 @@ TooltipPreviewImage::TooltipPreviewImage()
 {
     auto windows = getApp()->windows;
 
-    this->connections_.push_back(windows->gifRepaintRequested.connect([&] {
+    this->connections_.managedConnect(windows->gifRepaintRequested, [&] {
         if (this->image_ && this->image_->animated())
         {
             this->refreshTooltipWidgetPixmap();
         }
-    }));
+    });
 
-    this->connections_.push_back(windows->miscUpdate.connect([&] {
+    this->connections_.managedConnect(windows->miscUpdate, [&] {
         if (this->attemptRefresh)
         {
             this->refreshTooltipWidgetPixmap();
         }
-    }));
+    });
 }
 
 void TooltipPreviewImage::setImage(ImagePtr image)

--- a/src/singletons/TooltipPreviewImage.hpp
+++ b/src/singletons/TooltipPreviewImage.hpp
@@ -2,6 +2,8 @@
 
 #include "messages/Image.hpp"
 
+#include <pajlada/signals/signalholder.hpp>
+
 namespace chatterino {
 
 class TooltipPreviewImage
@@ -21,7 +23,7 @@ private:
     int imageWidth_ = 0;
     int imageHeight_ = 0;
 
-    std::vector<pajlada::Signals::ScopedConnection> connections_;
+    pajlada::Signals::SignalHolder connections_;
 
     // attemptRefresh is set to true in case we want to preview an image that has not loaded yet (if pixmapOrLoad fails)
     bool attemptRefresh{false};

--- a/src/singletons/WindowManager.hpp
+++ b/src/singletons/WindowManager.hpp
@@ -5,6 +5,7 @@
 #include "common/FlagsEnum.hpp"
 #include "common/Singleton.hpp"
 #include "common/WindowDescriptors.hpp"
+
 #include "pajlada/settings/settinglistener.hpp"
 #include "widgets/splits/SplitContainer.hpp"
 

--- a/src/widgets/BaseWindow.cpp
+++ b/src/widgets/BaseWindow.cpp
@@ -229,7 +229,7 @@ void BaseWindow::init()
                                    0, 0, 0,
                                    SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
                 },
-                this->managedConnections_);
+                this->connections_);
         });
     }
 #else
@@ -245,7 +245,7 @@ void BaseWindow::init()
                     this->show();
                 }
             },
-            this->managedConnections_);
+            this->connections_);
     }
 #endif
 }

--- a/src/widgets/BaseWindow.hpp
+++ b/src/widgets/BaseWindow.hpp
@@ -134,7 +134,6 @@ private:
 #endif
 
     pajlada::Signals::SignalHolder connections_;
-    std::vector<pajlada::Signals::ScopedConnection> managedConnections_;
 
     friend class BaseWidget;
 };

--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -759,7 +759,7 @@ void SplitNotebook::addCustomButtons()
         [settingsBtn](bool hide, auto) {
             settingsBtn->setVisible(!hide);
         },
-        this->connections_);
+        this->signalHolder_);
 
     settingsBtn->setIcon(NotebookButton::Settings);
 
@@ -774,7 +774,7 @@ void SplitNotebook::addCustomButtons()
         [userBtn](bool hide, auto) {
             userBtn->setVisible(!hide);
         },
-        this->connections_);
+        this->signalHolder_);
 
     userBtn->setIcon(NotebookButton::User);
     QObject::connect(userBtn, &NotebookButton::leftClicked, [this, userBtn] {

--- a/src/widgets/Notebook.hpp
+++ b/src/widgets/Notebook.hpp
@@ -101,7 +101,7 @@ private:
     NotebookTabDirection tabDirection_ = NotebookTabDirection::Horizontal;
 };
 
-class SplitNotebook : public Notebook, pajlada::Signals::SignalHolder
+class SplitNotebook : public Notebook
 {
 public:
     SplitNotebook(Window *parent);
@@ -117,8 +117,6 @@ private:
     void addCustomButtons();
 
     pajlada::Signals::SignalHolder signalHolder_;
-
-    std::vector<pajlada::Signals::ScopedConnection> connections_;
 };
 
 }  // namespace chatterino

--- a/src/widgets/dialogs/LastRunCrashDialog.cpp
+++ b/src/widgets/dialogs/LastRunCrashDialog.cpp
@@ -83,7 +83,7 @@ LastRunCrashDialog::LastRunCrashDialog()
     //    };
 
     //    updateUpdateLabel();
-    //    this->managedConnect(updateManager.statusUpdated,
+    //    this->signalHolder_.managedConnect(updateManager.statusUpdated,
     //    [updateUpdateLabel](auto) mutable {
     //        postToThread([updateUpdateLabel]() mutable { updateUpdateLabel();
     //        });

--- a/src/widgets/dialogs/LastRunCrashDialog.hpp
+++ b/src/widgets/dialogs/LastRunCrashDialog.hpp
@@ -5,10 +5,13 @@
 
 namespace chatterino {
 
-class LastRunCrashDialog : public QDialog, pajlada::Signals::SignalHolder
+class LastRunCrashDialog : public QDialog
 {
 public:
     LastRunCrashDialog();
+
+private:
+    pajlada::Signals::SignalHolder signalHolder_;
 };
 
 }  // namespace chatterino

--- a/src/widgets/dialogs/UserInfoPopup.hpp
+++ b/src/widgets/dialogs/UserInfoPopup.hpp
@@ -3,6 +3,7 @@
 #include "widgets/BaseWindow.hpp"
 #include "widgets/helper/ChannelView.hpp"
 
+#include <pajlada/signals/scoped-connection.hpp>
 #include <pajlada/signals/signal.hpp>
 
 class QCheckBox;
@@ -19,7 +20,6 @@ class UserInfoPopup final : public BaseWindow
 
 public:
     UserInfoPopup(bool closeAutomatically, QWidget *parent);
-    ~UserInfoPopup();
 
     void setData(const QString &name, const ChannelPtr &channel);
 
@@ -43,8 +43,7 @@ private:
 
     pajlada::Signals::NoArgSignal userStateChanged_;
 
-    // replace with ScopedConnection once https://github.com/pajlada/signals/pull/10 gets merged
-    pajlada::Signals::Connection refreshConnection_;
+    std::unique_ptr<pajlada::Signals::ScopedConnection> refreshConnection_;
 
     std::shared_ptr<bool> hack_;
 

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -184,34 +184,35 @@ void ChannelView::initializeScrollbar()
 
 void ChannelView::initializeSignals()
 {
-    this->connections_.push_back(
-        getApp()->windows->wordFlagsChanged.connect([this] {
-            this->queueLayout();
-            this->update();
-        }));
+    this->signalHolder_.managedConnect(getApp()->windows->wordFlagsChanged,
+                                       [this] {
+                                           this->queueLayout();
+                                           this->update();
+                                       });
 
     getSettings()->showLastMessageIndicator.connect(
         [this](auto, auto) {
             this->update();
         },
-        this->connections_);
+        this);
 
-    connections_.push_back(getApp()->windows->gifRepaintRequested.connect([&] {
-        this->queueUpdate();
-    }));
+    this->signalHolder_.managedConnect(getApp()->windows->gifRepaintRequested,
+                                       [&] {
+                                           this->queueUpdate();
+                                       });
 
-    connections_.push_back(
-        getApp()->windows->layoutRequested.connect([&](Channel *channel) {
+    this->signalHolder_.managedConnect(
+        getApp()->windows->layoutRequested, [&](Channel *channel) {
             if (this->isVisible() &&
                 (channel == nullptr || this->channel_.get() == channel))
             {
                 this->queueLayout();
             }
-        }));
+        });
 
-    connections_.push_back(getApp()->fonts->fontChanged.connect([this] {
+    this->signalHolder_.managedConnect(getApp()->fonts->fontChanged, [this] {
         this->queueLayout();
-    }));
+    });
 }
 
 bool ChannelView::pausable() const
@@ -597,87 +598,87 @@ void ChannelView::setChannel(ChannelPtr underlyingChannel)
     // Use a proxy channel to keep filtered messages past the time they are removed from their origin channel
     //
 
-    this->channelConnections_.push_back(
-        underlyingChannel->messageAppended.connect(
-            [this](MessagePtr &message,
-                   boost::optional<MessageFlags> overridingFlags) {
-                if (this->shouldIncludeMessage(message))
+    this->channelConnections_.managedConnect(
+        underlyingChannel->messageAppended,
+        [this](MessagePtr &message,
+               boost::optional<MessageFlags> overridingFlags) {
+            if (this->shouldIncludeMessage(message))
+            {
+                if (this->channel_->lastDate_ != QDate::currentDate())
                 {
-                    if (this->channel_->lastDate_ != QDate::currentDate())
-                    {
-                        this->channel_->lastDate_ = QDate::currentDate();
-                        auto msg = makeSystemMessage(
-                            QLocale().toString(QDate::currentDate(),
-                                               QLocale::LongFormat),
-                            QTime(0, 0));
-                        this->channel_->addMessage(msg);
-                    }
-                    // When the message was received in the underlyingChannel,
-                    // logging will be handled. Prevent duplications.
-                    if (overridingFlags)
-                    {
-                        overridingFlags.get().set(MessageFlag::DoNotLog);
-                    }
-                    else
-                    {
-                        overridingFlags = MessageFlags(message->flags);
-                        overridingFlags.get().set(MessageFlag::DoNotLog);
-                    }
-
-                    this->channel_->addMessage(message, overridingFlags);
+                    this->channel_->lastDate_ = QDate::currentDate();
+                    auto msg = makeSystemMessage(
+                        QLocale().toString(QDate::currentDate(),
+                                           QLocale::LongFormat),
+                        QTime(0, 0));
+                    this->channel_->addMessage(msg);
                 }
-            }));
+                // When the message was received in the underlyingChannel,
+                // logging will be handled. Prevent duplications.
+                if (overridingFlags)
+                {
+                    overridingFlags.get().set(MessageFlag::DoNotLog);
+                }
+                else
+                {
+                    overridingFlags = MessageFlags(message->flags);
+                    overridingFlags.get().set(MessageFlag::DoNotLog);
+                }
 
-    this->channelConnections_.push_back(
-        underlyingChannel->messagesAddedAtStart.connect(
-            [this](std::vector<MessagePtr> &messages) {
-                std::vector<MessagePtr> filtered;
-                std::copy_if(messages.begin(), messages.end(),
-                             std::back_inserter(filtered),
-                             [this](MessagePtr msg) {
-                                 return this->shouldIncludeMessage(msg);
-                             });
+                this->channel_->addMessage(message, overridingFlags);
+            }
+        });
 
-                if (!filtered.empty())
-                    this->channel_->addMessagesAtStart(filtered);
-            }));
+    this->channelConnections_.managedConnect(
+        underlyingChannel->messagesAddedAtStart,
+        [this](std::vector<MessagePtr> &messages) {
+            std::vector<MessagePtr> filtered;
+            std::copy_if(messages.begin(), messages.end(),
+                         std::back_inserter(filtered), [this](MessagePtr msg) {
+                             return this->shouldIncludeMessage(msg);
+                         });
 
-    this->channelConnections_.push_back(
-        underlyingChannel->messageReplaced.connect(
-            [this](size_t index, MessagePtr replacement) {
-                if (this->shouldIncludeMessage(replacement))
-                    this->channel_->replaceMessage(index, replacement);
-            }));
+            if (!filtered.empty())
+                this->channel_->addMessagesAtStart(filtered);
+        });
+
+    this->channelConnections_.managedConnect(
+        underlyingChannel->messageReplaced,
+        [this](size_t index, MessagePtr replacement) {
+            if (this->shouldIncludeMessage(replacement))
+                this->channel_->replaceMessage(index, replacement);
+        });
 
     //
     // Standard channel connections
     //
 
     // on new message
-    this->channelConnections_.push_back(this->channel_->messageAppended.connect(
+    this->channelConnections_.managedConnect(
+        this->channel_->messageAppended,
         [this](MessagePtr &message,
                boost::optional<MessageFlags> overridingFlags) {
             this->messageAppended(message, std::move(overridingFlags));
-        }));
+        });
 
-    this->channelConnections_.push_back(
-        this->channel_->messagesAddedAtStart.connect(
-            [this](std::vector<MessagePtr> &messages) {
-                this->messageAddedAtStart(messages);
-            }));
+    this->channelConnections_.managedConnect(
+        this->channel_->messagesAddedAtStart,
+        [this](std::vector<MessagePtr> &messages) {
+            this->messageAddedAtStart(messages);
+        });
 
     // on message removed
-    this->channelConnections_.push_back(
-        this->channel_->messageRemovedFromStart.connect(
-            [this](MessagePtr &message) {
-                this->messageRemoveFromStart(message);
-            }));
+    this->channelConnections_.managedConnect(
+        this->channel_->messageRemovedFromStart, [this](MessagePtr &message) {
+            this->messageRemoveFromStart(message);
+        });
 
     // on message replaced
-    this->channelConnections_.push_back(this->channel_->messageReplaced.connect(
+    this->channelConnections_.managedConnect(
+        this->channel_->messageReplaced,
         [this](size_t index, MessagePtr replacement) {
             this->messageReplaced(index, replacement);
-        }));
+        });
 
     auto snapshot = underlyingChannel->getMessageSnapshot();
 
@@ -715,9 +716,10 @@ void ChannelView::setChannel(ChannelPtr underlyingChannel)
     // Notifications
     if (auto tc = dynamic_cast<TwitchChannel *>(underlyingChannel.get()))
     {
-        this->connections_.push_back(tc->liveStatusChanged.connect([this]() {
-            this->liveStatusChanged.invoke();
-        }));
+        this->channelConnections_.managedConnect(
+            tc->liveStatusChanged, [this]() {
+                this->liveStatusChanged.invoke();
+            });
     }
 }
 

--- a/src/widgets/helper/ChannelView.hpp
+++ b/src/widgets/helper/ChannelView.hpp
@@ -238,8 +238,10 @@ private:
 
     LimitedQueue<MessageLayoutPtr> messages_;
 
-    std::vector<pajlada::Signals::ScopedConnection> connections_;
-    std::vector<pajlada::Signals::ScopedConnection> channelConnections_;
+    pajlada::Signals::SignalHolder signalHolder_;
+
+    // channelConnections_ will be cleared when the underlying channel of the channelview changes
+    pajlada::Signals::SignalHolder channelConnections_;
 
     std::unordered_set<std::shared_ptr<MessageLayout>> messagesOnScreen_;
 

--- a/src/widgets/helper/NotebookTab.hpp
+++ b/src/widgets/helper/NotebookTab.hpp
@@ -7,7 +7,7 @@
 #include <QMenu>
 #include <QPropertyAnimation>
 #include <pajlada/settings/setting.hpp>
-#include <pajlada/signals/connection.hpp>
+#include <pajlada/signals/signalholder.hpp>
 
 namespace chatterino {
 
@@ -105,7 +105,7 @@ private:
 
     QMenu menu_;
 
-    std::vector<pajlada::Signals::ScopedConnection> managedConnections_;
+    pajlada::Signals::SignalHolder managedConnections_;
 };
 
 }  // namespace chatterino

--- a/src/widgets/settingspages/GeneralPageView.hpp
+++ b/src/widgets/settingspages/GeneralPageView.hpp
@@ -2,6 +2,7 @@
 
 #include <QDebug>
 #include <boost/variant.hpp>
+#include <pajlada/signals/signalholder.hpp>
 #include "Application.hpp"
 #include "common/ChatterinoSetting.hpp"
 #include "singletons/WindowManager.hpp"
@@ -218,7 +219,7 @@ private:
     QVBoxLayout *navigationLayout_;
 
     std::vector<Group> groups_;
-    std::vector<pajlada::Signals::ScopedConnection> managedConnections_;
+    pajlada::Signals::SignalHolder managedConnections_;
 };
 
 }  // namespace chatterino

--- a/src/widgets/settingspages/NotificationPage.cpp
+++ b/src/widgets/settingspages/NotificationPage.cpp
@@ -55,9 +55,7 @@ NotificationPage::NotificationPage()
                     // implementation of custom combobox done
                     // because addComboBox only can handle strings-settings
                     // int setting for the ToastReaction is desired
-                    openIn
-                        .append(this->createToastReactionComboBox(
-                            this->managedConnections_))
+                    openIn.append(this->createToastReactionComboBox())
                         ->setSizePolicy(QSizePolicy::Maximum,
                                         QSizePolicy::Preferred);
                 }
@@ -118,8 +116,7 @@ NotificationPage::NotificationPage()
         }
     }
 }
-QComboBox *NotificationPage::createToastReactionComboBox(
-    std::vector<pajlada::Signals::ScopedConnection> managedConnections)
+QComboBox *NotificationPage::createToastReactionComboBox()
 {
     QComboBox *toastReactionOptions = new QComboBox();
 
@@ -135,7 +132,7 @@ QComboBox *NotificationPage::createToastReactionComboBox(
         [toastReactionOptions](const int &index, auto) {
             toastReactionOptions->setCurrentIndex(index);
         },
-        managedConnections);
+        this->managedConnections_);
 
     QObject::connect(toastReactionOptions,
                      QOverload<int>::of(&QComboBox::currentIndexChanged),

--- a/src/widgets/settingspages/NotificationPage.hpp
+++ b/src/widgets/settingspages/NotificationPage.hpp
@@ -15,8 +15,7 @@ public:
     NotificationPage();
 
 private:
-    QComboBox *createToastReactionComboBox(
-        std::vector<pajlada::Signals::ScopedConnection> managedConnections);
+    QComboBox *createToastReactionComboBox();
 };
 
 }  // namespace chatterino

--- a/src/widgets/settingspages/SettingsPage.cpp
+++ b/src/widgets/settingspages/SettingsPage.cpp
@@ -157,9 +157,11 @@ QSpinBox *SettingsPage::createSpinBox(pajlada::Settings::Setting<int> &setting,
     w->setMinimum(min);
     w->setMaximum(max);
 
-    setting.connect([w](const int &value, auto) {
-        w->setValue(value);
-    });
+    setting.connect(
+        [w](const int &value, auto) {
+            w->setValue(value);
+        },
+        this->managedConnections_);
     QObject::connect(w, QOverload<int>::of(&QSpinBox::valueChanged),
                      [&setting](int value) {
                          setting.setValue(value);

--- a/src/widgets/settingspages/SettingsPage.hpp
+++ b/src/widgets/settingspages/SettingsPage.hpp
@@ -75,7 +75,7 @@ public:
 protected:
     SettingsDialogTab *tab_;
     pajlada::Signals::NoArgSignal onCancel_;
-    std::vector<pajlada::Signals::ScopedConnection> managedConnections_;
+    pajlada::Signals::SignalHolder managedConnections_;
 };
 
 }  // namespace chatterino

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -175,7 +175,7 @@ Split::Split(QWidget *parent)
                 this->input_->show();
             }
         },
-        this->managedConnections_);
+        this->signalHolder_);
 
     this->header_->updateModerationModeIcon();
     this->overlay_->hide();
@@ -183,29 +183,29 @@ Split::Split(QWidget *parent)
     this->setSizePolicy(QSizePolicy::MinimumExpanding,
                         QSizePolicy::MinimumExpanding);
 
-    this->managedConnect(modifierStatusChanged, [this](Qt::KeyboardModifiers
-                                                           status) {
-        if ((status ==
-             showSplitOverlayModifiers /*|| status == showAddSplitRegions*/) &&
-            this->isMouseOver_)
-        {
-            this->overlay_->show();
-        }
-        else
-        {
-            this->overlay_->hide();
-        }
+    this->signalHolder_.managedConnect(
+        modifierStatusChanged, [this](Qt::KeyboardModifiers status) {
+            if ((status ==
+                 showSplitOverlayModifiers /*|| status == showAddSplitRegions*/) &&
+                this->isMouseOver_)
+            {
+                this->overlay_->show();
+            }
+            else
+            {
+                this->overlay_->hide();
+            }
 
-        if (getSettings()->pauseChatModifier.getEnum() != Qt::NoModifier &&
-            status == getSettings()->pauseChatModifier.getEnum())
-        {
-            this->view_->pause(PauseReason::KeyboardModifier);
-        }
-        else
-        {
-            this->view_->unpause(PauseReason::KeyboardModifier);
-        }
-    });
+            if (getSettings()->pauseChatModifier.getEnum() != Qt::NoModifier &&
+                status == getSettings()->pauseChatModifier.getEnum())
+            {
+                this->view_->pause(PauseReason::KeyboardModifier);
+            }
+            else
+            {
+                this->view_->unpause(PauseReason::KeyboardModifier);
+            }
+        });
 
     this->input_->ui_.textEdit->focused.connect([this] {
         this->focused.invoke();
@@ -250,12 +250,13 @@ Split::Split(QWidget *parent)
         [this](const bool &val) {
             this->setAcceptDrops(val);
         },
-        this->managedConnections_);
+        this->signalHolder_);
     this->addShortcuts();
-    this->managedConnect(getApp()->hotkeys->onItemsUpdated, [this]() {
-        this->clearShortcuts();
-        this->addShortcuts();
-    });
+    this->signalHolder_.managedConnect(getApp()->hotkeys->onItemsUpdated,
+                                       [this]() {
+                                           this->clearShortcuts();
+                                           this->addShortcuts();
+                                       });
 }
 
 void Split::addShortcuts()

--- a/src/widgets/splits/Split.hpp
+++ b/src/widgets/splits/Split.hpp
@@ -31,7 +31,7 @@ class SelectChannelDialog;
 //   - Responsible for rendering and handling user text input
 //
 // Each sub-element has a reference to the parent Chat Widget
-class Split : public BaseWidget, pajlada::Signals::SignalHolder
+class Split : public BaseWidget
 {
     friend class SplitInput;
 
@@ -151,8 +151,6 @@ private:
 
     pajlada::Signals::Connection indirectChannelChangedConnection_;
     pajlada::Signals::SignalHolder signalHolder_;
-
-    std::vector<pajlada::Signals::ScopedConnection> managedConnections_;
 
 public slots:
     void addSibling();

--- a/src/widgets/splits/SplitContainer.cpp
+++ b/src/widgets/splits/SplitContainer.cpp
@@ -41,39 +41,40 @@ SplitContainer::SplitContainer(Notebook *parent)
 {
     this->refreshTabTitle();
 
-    this->managedConnect(Split::modifierStatusChanged, [this](auto modifiers) {
-        this->layout();
+    this->signalHolder_.managedConnect(
+        Split::modifierStatusChanged, [this](auto modifiers) {
+            this->layout();
 
-        if (modifiers == showResizeHandlesModifiers)
-        {
-            for (auto &handle : this->resizeHandles_)
+            if (modifiers == showResizeHandlesModifiers)
             {
-                handle->show();
-                handle->raise();
+                for (auto &handle : this->resizeHandles_)
+                {
+                    handle->show();
+                    handle->raise();
+                }
             }
-        }
-        else
-        {
-            for (auto &handle : this->resizeHandles_)
+            else
             {
-                handle->hide();
+                for (auto &handle : this->resizeHandles_)
+                {
+                    handle->hide();
+                }
             }
-        }
 
-        if (modifiers == showSplitOverlayModifiers)
-        {
-            this->setCursor(Qt::PointingHandCursor);
-        }
-        else
-        {
-            this->unsetCursor();
-        }
-    });
+            if (modifiers == showSplitOverlayModifiers)
+            {
+                this->setCursor(Qt::PointingHandCursor);
+            }
+            else
+            {
+                this->unsetCursor();
+            }
+        });
 
     this->setCursor(Qt::PointingHandCursor);
     this->setAcceptDrops(true);
 
-    this->managedConnect(this->overlay_.dragEnded, [this]() {
+    this->signalHolder_.managedConnect(this->overlay_.dragEnded, [this]() {
         this->isDragging_ = false;
         this->layout();
     });

--- a/src/widgets/splits/SplitContainer.hpp
+++ b/src/widgets/splits/SplitContainer.hpp
@@ -29,7 +29,7 @@ class Notebook;
 // inside but it doesn't expose any of it publicly.
 //
 
-class SplitContainer final : public BaseWidget, pajlada::Signals::SignalHolder
+class SplitContainer final : public BaseWidget
 {
     Q_OBJECT
 
@@ -259,6 +259,8 @@ private:
 
     std::unordered_map<Split *, pajlada::Signals::SignalHolder>
         connectionsPerSplit_;
+
+    pajlada::Signals::SignalHolder signalHolder_;
 
     bool isDragging_ = false;
 };

--- a/src/widgets/splits/SplitHeader.hpp
+++ b/src/widgets/splits/SplitHeader.hpp
@@ -19,7 +19,7 @@ class EffectLabel;
 class Label;
 class Split;
 
-class SplitHeader final : public BaseWidget, pajlada::Signals::SignalHolder
+class SplitHeader final : public BaseWidget
 {
     Q_OBJECT
 
@@ -81,8 +81,8 @@ private:
 
     // signals
     pajlada::Signals::NoArgSignal modeUpdateRequested_;
-    std::vector<pajlada::Signals::ScopedConnection> managedConnections_;
-    std::vector<pajlada::Signals::ScopedConnection> channelConnections_;
+    pajlada::Signals::SignalHolder managedConnections_;
+    pajlada::Signals::SignalHolder channelConnections_;
 
 public slots:
     void reloadChannelEmotes();

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -99,10 +99,10 @@ void SplitInput::initLayout()
     QObject::connect(this->ui_.textEdit, &QTextEdit::textChanged, this,
                      &SplitInput::onTextChanged);
 
-    this->managedConnections_.push_back(app->fonts->fontChanged.connect([=]() {
+    this->managedConnections_.managedConnect(app->fonts->fontChanged, [=]() {
         this->ui_.textEdit->setFont(
             app->fonts->getFont(FontStyle::ChatMedium, this->scale()));
-    }));
+    });
 
     // open emote popup
     QObject::connect(this->ui_.emoteButton, &EffectLabel::leftClicked, [=] {

--- a/src/widgets/splits/SplitInput.hpp
+++ b/src/widgets/splits/SplitInput.hpp
@@ -69,7 +69,7 @@ private:
         QHBoxLayout *hbox;
     } ui_;
 
-    std::vector<pajlada::Signals::ScopedConnection> managedConnections_;
+    pajlada::Signals::SignalHolder managedConnections_;
     QStringList prevMsg_;
     QString currMsg_;
     int prevIndex_ = 0;

--- a/src/widgets/splits/SplitOverlay.cpp
+++ b/src/widgets/splits/SplitOverlay.cpp
@@ -75,7 +75,7 @@ SplitOverlay::SplitOverlay(Split *parent)
     up->setCursor(Qt::PointingHandCursor);
     down->setCursor(Qt::PointingHandCursor);
 
-    this->managedConnect(this->scaleChanged, [=](float _scale) {
+    this->signalHolder_.managedConnect(this->scaleChanged, [=](float _scale) {
         int a = int(_scale * 30);
         QSize size(a, a);
 

--- a/src/widgets/splits/SplitOverlay.hpp
+++ b/src/widgets/splits/SplitOverlay.hpp
@@ -10,7 +10,7 @@ namespace chatterino {
 
 class Split;
 
-class SplitOverlay : public BaseWidget, pajlada::Signals::SignalHolder
+class SplitOverlay : public BaseWidget
 {
 public:
     explicit SplitOverlay(Split *parent = nullptr);
@@ -51,6 +51,8 @@ private:
     QPushButton *up_;
     QPushButton *right_;
     QPushButton *down_;
+
+    pajlada::Signals::SignalHolder signalHolder_;
 
     friend class ButtonEventFilter;
 };


### PR DESCRIPTION
- Clean up all usages of ScopedConnections/SignalHolders
- Add changelog entry

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

A SignalHolder should not be inherited from, due to the risk of its held
connections being disconnected too late.

Before the SignalHolder has time to go out of scope (thus disconnecting
        its connectins), all the members of the class that has
SignalHolder has its base class are already destroyed.

A future version of the signals library will disallow inheriting from SignalHolder.



src/providers/irc/IrcConnection2.cpp: Manually disconnect all QObject connections in the constructor. This ensures that that the socket state change that happens when the underlying IRC connection dies does not fire its "death signals" into already destroyed members.
src/providers/irc/AbstractIrcServer.cpp: Make use of SignalHolder everywhere
src/messages/layouts/MessageLayoutElement.cpp: Replace vector<ScopedConnection> with SignalHolder
src/providers/twitch/TwitchChannel.cpp: Replace derivative SignalHolder with SignalHolder
src/singletons/TooltipPreviewImage.cpp: Replace vector<ScopedConnection> with SignalHolder
src/widgets/BaseWindow.hpp: Removed the vector of scoped connections managedConnections_ in favour of the already existing SignalHolder at connections_
src/widgets/Notebook.hpp: No longer derivative of SignalHolder.
src/widgets/Notebook.hpp: Removed vector<ScopedConnection> connections_ in favour of the already existing SignalHolder signalHolder_
src/widgets/dialogs/LastRunCrashDialog.cpp: No longer derivative of SignalHolder, rather use SignalHolder signalHolder_ instead
src/widgets/dialogs/UserInfoPopup.cpp: Replace raw Connection with a unique_ptr to a ScopedConnection
src/widgets/ChannelView.hpp: Replace both vector<ScopedConnection>s with SignalHolders
src/widgets/ChannelView.hpp: Move liveStatusChanged connection from 'global' SignalHolder to 'channel-scoped' SignalHolder
src/widgets/helper/NotebookTab.hpp: Replace vector<ScopedConnection> with SignalHolder
src/widgets/settingspages/GeneralPageView.hpp: Replace vector<ScopedConnection> with SignalHolder
src/widgets/settingspages/NotificationPage.hpp: Use this->managedConnections_ instead of passing a copy of the scoped connections when creating a toast reaction combo box
src/widgets/settingspages/SettingsPage.cpp: Replace vector<ScopedConnection> with SignalHolder
src/widgets/settingspages/SettingsPage.cpp: use managedConnections_ in spin box creator
src/widgets/split/Split.cpp: No longer derivative of SignalHolder
src/widgets/split/Split.cpp: Removed "duplicate" managedConnections_ vector<ScopedConnection>, instead fully rely on the already defined SignalHolder signalHolder_
src/widgets/split/SplitContainer.cpp: No longer derivative of SignalHolder, instead store our own SignalHolder signalHolder_
src/widgets/split/SplitHeader.cpp: No longer derivative of SignalHolder
src/widgets/split/SplitHeader.cpp: Replace both vector<ScopedConnection>s with SignalHolders
src/widgets/split/SplitInput.cpp: Replace vector<ScopedConnection> with SignalHolder
src/widgets/split/SplitOverlay.cpp: No longer derivative of SignalHolder, instead store our own SignalHolder signalHolder_



<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
