### PR TITLE
Fix IRC mentions not showing up in the /mentions split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 - Bugfix: Fixed IRC highlights not triggering sounds or alerts properly. (#3368)
 - Bugfix: Fixed IRC /kick command crashing if parameters were malformed. (#3382)
 - Bugfix: Fixed crash that would occur if the user tries to modify the currently connected IRC connection. (#3398)
+- Bugfix: Fixed IRC mentions not showing up in the /mentions split. (#3400)
 - Bugfix: Fixed a crash that could occur on certain Linux systems when toggling the Always on Top flag. (#3385)
 - Bugfix: Fixed zero-width emotes sometimes wrapping lines incorrectly. (#3389)
 - Bugfix: Fixed using special chars in Windows username breaking the storage of custom commands (#3397)


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

- Mentions in IRC channels now get put into the /mentions split
- Add changelog entry

The /mentions split is technically categorized both in our code and in the "new split" dialog as under Twitch, however the description indicates that it should show mentions from **all** channels, not just all Twitch channels.
This solution works but it's not super pretty in the code as we're importing and using the Twitch server to fetch the special mentions channel.

I have tested clicking the channel name and it finds the split correctly.
I have tested not having any Twitch channels open, and it still works as expected.

Fixes #3381

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
