### PR TITLE
Add search to emote popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - Minor: Added autocompletion for default Twitch commands starting with the dot (e.g. `.mods` which does the same as `/mods`). (#3144)
 - Minor: Sorted usernames in `Users joined/parted` messages alphabetically. (#3421)
 - Minor: Mod list, VIP list, and Users joined/parted messages are now searchable. (#3426)
+- Minor: Add search to emote popup. (#3404)
 - Bugfix: Fix Split Input hotkeys not being available when input is hidden (#3362)
 - Bugfix: Fixed colored usernames sometimes not working. (#3170)
 - Bugfix: Restored ability to send duplicate `/me` messages. (#3166)

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -220,6 +220,8 @@ EmotePopup::EmotePopup(QWidget *parent)
                                            this->clearShortcuts();
                                            this->addShortcuts();
                                        });
+
+    this->search_->setFocus();
 }
 
 void EmotePopup::addShortcuts()

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -168,6 +168,9 @@ EmotePopup::EmotePopup(QWidget *parent)
     this->search_ = new QLineEdit();
     this->search_->setPlaceholderText("Search all emotes...");
     this->search_->setValidator(searchValidator);
+    this->search_->setClearButtonEnabled(true);
+    this->search_->findChild<QAbstractButton *>()->setIcon(
+        QPixmap(":/buttons/clearSearch.png"));
     layout->addWidget(this->search_);
 
     QObject::connect(this->search_, &QLineEdit::textChanged, this,

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -143,7 +143,7 @@ EmotePopup::EmotePopup(QWidget *parent)
     auto layout = new QVBoxLayout(this);
     this->getLayoutContainer()->setLayout(layout);
 
-    QRegExp searchRegex("[A-Za-z0-9]*");
+    QRegExp searchRegex("\\S*");
     searchRegex.setCaseSensitivity(Qt::CaseInsensitive);
     QValidator *searchValidator = new QRegExpValidator(searchRegex);
 

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -370,8 +370,12 @@ void EmotePopup::filterEmotes(const QString &text)
         // Start with a copy of the emote sets
         std::vector<std::shared_ptr<TwitchAccount::EmoteSet>>
             twitchGlobalEmotes{};
-        twitchGlobalEmotes.assign(twitchEmoteSets.begin(),
-                                  twitchEmoteSets.end());
+
+        for (const auto set : twitchEmoteSets)
+        {
+            twitchGlobalEmotes.push_back(
+                std::make_shared<TwitchAccount::EmoteSet>(*set));
+        }
 
         // Remove sets without filtered emotes
         auto allSetsIt = std::remove_if(

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -165,7 +165,7 @@ EmotePopup::EmotePopup(QWidget *parent)
     this->getLayoutContainer()->setLayout(layout);
 
     QRegularExpression searchRegex("\\S*");
-    searchRegex.setCaseSensitivity(Qt::CaseInsensitive);
+    searchRegex.setPatternOptions(QRegularExpression::CaseInsensitiveOption);
     QValidator *searchValidator = new QRegularExpressionValidator(searchRegex);
 
     this->search_ = new QLineEdit();

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -305,7 +305,12 @@ void EmotePopup::addShortcuts()
 
         {"reject", nullptr},
         {"accept", nullptr},
-        {"search", nullptr},
+        {"search",
+         [this](std::vector<QString>) -> QString {
+             this->search_->setFocus();
+             this->search_->selectAll();
+             return "";
+         }},
     };
 
     this->shortcuts_ = getApp()->hotkeys->shortcutsForCategory(

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -327,7 +327,9 @@ void EmotePopup::loadChannel(ChannelPtr channel)
     this->setWindowTitle("Emotes in #" + this->channel_->getName());
 
     if (this->twitchChannel_ == nullptr)
+    {
         return;
+    }
 
     auto subChannel = std::make_shared<Channel>("", Channel::Type::None);
     auto globalChannel = std::make_shared<Channel>("", Channel::Type::None);
@@ -397,7 +399,7 @@ void EmotePopup::filterEmotes(const QString &searchText)
         getApp()->accounts->twitch.getCurrent()->accessEmotes()->emoteSets;
     std::vector<std::shared_ptr<TwitchAccount::EmoteSet>> twitchGlobalEmotes{};
 
-    for (const auto set : twitchEmoteSets)
+    for (const auto &set : twitchEmoteSets)
     {
         auto setCopy = std::make_shared<TwitchAccount::EmoteSet>(*set);
         auto setIt =
@@ -468,7 +470,7 @@ EmoteMap *EmotePopup::filterEmoteMap(const QString &text,
 {
     auto filteredMap = new EmoteMap();
 
-    for (const auto emote : *emotes)
+    for (const auto &emote : *emotes)
     {
         if (emote.first.string.contains(text, Qt::CaseInsensitive))
         {

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -284,15 +284,12 @@ void EmotePopup::addShortcuts()
         HotkeyCategory::PopupWindow, actions, this);
 }
 
-void EmotePopup::setChannel(ChannelPtr channel)
-{
-    this->channel_ = channel;
-    this->twitchChannel_ = dynamic_cast<TwitchChannel *>(this->channel_.get());
-}
-
-void EmotePopup::loadChannel()
+void EmotePopup::loadChannel(ChannelPtr channel)
 {
     BenchmarkGuard guard("loadChannel");
+
+    this->channel_ = channel;
+    this->twitchChannel_ = dynamic_cast<TwitchChannel *>(this->channel_.get());
 
     this->setWindowTitle("Emotes in #" + this->channel_->getName());
 

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -155,30 +155,32 @@ EmotePopup::EmotePopup(QWidget *parent)
     QObject::connect(this->search_, &QLineEdit::textChanged, this,
                      &EmotePopup::filterEmotes);
 
-    this->searchView_ = new ChannelView();
-    this->searchView_->hide();
-    layout->addWidget(this->searchView_);
-
-    this->notebook_ = new Notebook(this);
-    layout->addWidget(this->notebook_);
-    layout->setMargin(0);
-
     auto clicked = [this](const Link &link) {
         this->linkClicked.invoke(link);
     };
 
-    auto makeView = [&](QString tabTitle) {
+    auto makeView = [&](QString tabTitle, bool addToNotebook = true) {
         auto view = new ChannelView();
 
         view->setOverrideFlags(MessageElementFlags{
             MessageElementFlag::Default, MessageElementFlag::AlwaysShow,
             MessageElementFlag::EmoteImages});
         view->setEnableScrollingToBottom(false);
-        this->notebook_->addPage(view, tabTitle);
         view->linkClicked.connect(clicked);
+
+        if (addToNotebook)
+            this->notebook_->addPage(view, tabTitle);
 
         return view;
     };
+
+    this->searchView_ = makeView("", false);
+    this->searchView_->hide();
+    layout->addWidget(this->searchView_);
+
+    this->notebook_ = new Notebook(this);
+    layout->addWidget(this->notebook_);
+    layout->setMargin(0);
 
     this->subEmotesView_ = makeView("Subs");
     this->channelEmotesView_ = makeView("Channel");

--- a/src/widgets/dialogs/EmotePopup.hpp
+++ b/src/widgets/dialogs/EmotePopup.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "providers/emoji/Emojis.hpp"
 #include "providers/twitch/TwitchChannel.hpp"
 #include "widgets/BasePopup.hpp"
 #include "widgets/Notebook.hpp"
@@ -19,7 +20,6 @@ public:
     EmotePopup(QWidget *parent = nullptr);
 
     void loadChannel(ChannelPtr channel);
-    void loadEmojis();
 
     virtual void closeEvent(QCloseEvent *event) override;
 
@@ -38,6 +38,8 @@ private:
     QLineEdit *search_;
     Notebook *notebook_;
 
+    void loadEmojis(ChannelView &view, EmojiMap &emojiMap);
+    void loadEmojis(Channel &channel, EmojiMap &emojiMap, const QString &title);
     void filterEmotes(const QString &text);
     EmoteMap *filterEmoteMap(const QString &text,
                              std::shared_ptr<const EmoteMap> emotes);

--- a/src/widgets/dialogs/EmotePopup.hpp
+++ b/src/widgets/dialogs/EmotePopup.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "providers/twitch/TwitchChannel.hpp"
 #include "widgets/BasePopup.hpp"
 #include "widgets/Notebook.hpp"
 
@@ -17,7 +18,8 @@ class EmotePopup : public BasePopup
 public:
     EmotePopup(QWidget *parent = nullptr);
 
-    void loadChannel(ChannelPtr channel);
+    void setChannel(ChannelPtr channel);
+    void loadChannel();
     void loadEmojis();
 
     virtual void closeEvent(QCloseEvent *event) override;
@@ -29,8 +31,17 @@ private:
     ChannelView *channelEmotesView_{};
     ChannelView *subEmotesView_{};
     ChannelView *viewEmojis_{};
+    ChannelView *searchView_{};
 
+    ChannelPtr channel_;
+    TwitchChannel *twitchChannel_;
+
+    QLineEdit *search_;
     Notebook *notebook_;
+
+    void filterEmotes(const QString &text);
+    EmoteMap *filterEmoteMap(const QString &text,
+                             std::shared_ptr<const EmoteMap> emotes);
     void addShortcuts() override;
 };
 

--- a/src/widgets/dialogs/EmotePopup.hpp
+++ b/src/widgets/dialogs/EmotePopup.hpp
@@ -7,6 +7,8 @@
 
 #include <pajlada/signals/signal.hpp>
 
+#include <QLineEdit>
+
 namespace chatterino {
 
 struct Link;
@@ -37,7 +39,7 @@ private:
     ChannelView *searchView_{};
 
     ChannelPtr channel_;
-    TwitchChannel *twitchChannel_;
+    TwitchChannel *twitchChannel_{};
 
     QLineEdit *search_;
     Notebook *notebook_;

--- a/src/widgets/dialogs/EmotePopup.hpp
+++ b/src/widgets/dialogs/EmotePopup.hpp
@@ -30,6 +30,10 @@ private:
     ChannelView *channelEmotesView_{};
     ChannelView *subEmotesView_{};
     ChannelView *viewEmojis_{};
+    /**
+     * @brief Visible only when the user has specified a search query into the `search_` input.
+     * Otherwise the `notebook_` and all other views are visible.
+     */
     ChannelView *searchView_{};
 
     ChannelPtr channel_;

--- a/src/widgets/dialogs/EmotePopup.hpp
+++ b/src/widgets/dialogs/EmotePopup.hpp
@@ -18,8 +18,7 @@ class EmotePopup : public BasePopup
 public:
     EmotePopup(QWidget *parent = nullptr);
 
-    void setChannel(ChannelPtr channel);
-    void loadChannel();
+    void loadChannel(ChannelPtr channel);
     void loadEmojis();
 
     virtual void closeEvent(QCloseEvent *event) override;

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -208,8 +208,7 @@ void SplitInput::openEmotePopup()
 
     this->emotePopup_->resize(int(300 * this->emotePopup_->scale()),
                               int(500 * this->emotePopup_->scale()));
-    this->emotePopup_->setChannel(this->split_->getChannel());
-    this->emotePopup_->loadChannel();
+    this->emotePopup_->loadChannel(this->split_->getChannel());
     this->emotePopup_->show();
     this->emotePopup_->activateWindow();
 }

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -208,7 +208,8 @@ void SplitInput::openEmotePopup()
 
     this->emotePopup_->resize(int(300 * this->emotePopup_->scale()),
                               int(500 * this->emotePopup_->scale()));
-    this->emotePopup_->loadChannel(this->split_->getChannel());
+    this->emotePopup_->setChannel(this->split_->getChannel());
+    this->emotePopup_->loadChannel();
     this->emotePopup_->show();
     this->emotePopup_->activateWindow();
 }


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

A search bar at the top of the emote popup that filters all emotes across every tab as you type. Uses a new ChannelView to combine all emote sets and is initially hidden until something is typed.

![emote_search](https://user-images.githubusercontent.com/8650006/146172435-90ba1bcd-de79-4488-9da7-d9ce3b155f8f.gif)

[1]: https://cdn.betterttv.net/emote/60477a2f306b602acc599abf/1x