### PR TITLE
Sorted usernames in "Users joined/parted:" messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Minor: Show picked outcome in prediction badges. (#3357)
 - Minor: Add support for Emoji in IRC (#3354)
 - Minor: Moved `/live` logs to its own subdirectory. (Logs from before this change will still be available in `Channels -> live`). (#3393)
+- Minor: Sorted usernames in `Users joined/parted` messages alphabetically. (#3421)
 - Bugfix: Fix Split Input hotkeys not being available when input is hidden (#3362)
 - Bugfix: Fixed colored usernames sometimes not working. (#3170)
 - Bugfix: Restored ability to send duplicate `/me` messages. (#3166)

--- a/src/common/ChannelChatters.cpp
+++ b/src/common/ChannelChatters.cpp
@@ -35,14 +35,11 @@ void ChannelChatters::addJoinedUser(const QString &user)
         QTimer::singleShot(500, &this->lifetimeGuard_, [this] {
             auto joinedUsers = this->joinedUsers_.access();
             joinedUsers->sort();
-            QString text = "Users joined: " + joinedUsers->join(", ");
 
             MessageBuilder builder;
             TwitchMessageBuilder::listOfUsersSystemMessage(
                 "Users joined:", *joinedUsers, &this->channel_, &builder);
             builder->flags.set(MessageFlag::Collapsed);
-            builder->messageText = text;
-            builder->searchText = text;
             this->channel_.addMessage(builder.release());
 
             joinedUsers->clear();
@@ -63,14 +60,11 @@ void ChannelChatters::addPartedUser(const QString &user)
         QTimer::singleShot(500, &this->lifetimeGuard_, [this] {
             auto partedUsers = this->partedUsers_.access();
             partedUsers->sort();
-            QString text = "Users parted: " + partedUsers->join(", ");
 
             MessageBuilder builder;
             TwitchMessageBuilder::listOfUsersSystemMessage(
                 "Users parted:", *partedUsers, &this->channel_, &builder);
             builder->flags.set(MessageFlag::Collapsed);
-            builder->messageText = text;
-            builder->searchText = text;
             this->channel_.addMessage(builder.release());
 
             partedUsers->clear();

--- a/src/common/ChannelChatters.cpp
+++ b/src/common/ChannelChatters.cpp
@@ -34,13 +34,18 @@ void ChannelChatters::addJoinedUser(const QString &user)
 
         QTimer::singleShot(500, &this->lifetimeGuard_, [this] {
             auto joinedUsers = this->joinedUsers_.access();
+            joinedUsers->sort();
+            QString text = "Users joined: " + joinedUsers->join(", ");
 
             MessageBuilder builder;
             TwitchMessageBuilder::listOfUsersSystemMessage(
                 "Users joined:", *joinedUsers, &this->channel_, &builder);
             builder->flags.set(MessageFlag::Collapsed);
-            joinedUsers->clear();
+            builder->messageText = text;
+            builder->searchText = text;
             this->channel_.addMessage(builder.release());
+
+            joinedUsers->clear();
             this->joinedUsersMergeQueued_ = false;
         });
     }
@@ -57,14 +62,18 @@ void ChannelChatters::addPartedUser(const QString &user)
 
         QTimer::singleShot(500, &this->lifetimeGuard_, [this] {
             auto partedUsers = this->partedUsers_.access();
+            partedUsers->sort();
+            QString text = "Users parted: " + partedUsers->join(", ");
 
             MessageBuilder builder;
             TwitchMessageBuilder::listOfUsersSystemMessage(
                 "Users parted:", *partedUsers, &this->channel_, &builder);
             builder->flags.set(MessageFlag::Collapsed);
+            builder->messageText = text;
+            builder->searchText = text;
             this->channel_.addMessage(builder.release());
-            partedUsers->clear();
 
+            partedUsers->clear();
             this->partedUsersMergeQueued_ = false;
         });
     }


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Sorted usernames in these messages alphabetically. While I was at it, I noticed that `messageText` and `searchText` properties were missing, so I've also added them here. Sorted out some code and added an early-out.

Fixes #3420

