### PR TITLE
Remove actions/checkout from changelog check action

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -9,8 +9,6 @@ jobs:
   check-changelog:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.0
-
       # Gives an error if there's no change in the changelog (except using label)
       - name: Changelog check
         uses: dangoslen/changelog-enforcer@v3


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

With #3436, changelog enforcer action updates to v3; according to their [changelog](https://github.com/dangoslen/changelog-enforcer/blob/master/CHANGELOG.md#v300) `actions/checkout` is no longer required.

Related chatterino/api#256
