### PR TITLE
Add subscriber and founder badge highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - Minor: Added autocompletion for default Twitch commands starting with the dot (e.g. `.mods` which does the same as `/mods`). (#3144)
 - Minor: Sorted usernames in `Users joined/parted` messages alphabetically. (#3421)
 - Minor: Mod list, VIP list, and Users joined/parted messages are now searchable. (#3426)
+- Minor: Messages can now be highlighted by subscriber or founder badges. (#3445)
 - Bugfix: Fix Split Input hotkeys not being available when input is hidden (#3362)
 - Bugfix: Fixed colored usernames sometimes not working. (#3170)
 - Bugfix: Restored ability to send duplicate `/me` messages. (#3166)

--- a/src/widgets/settingspages/HighlightingPage.cpp
+++ b/src/widgets/settingspages/HighlightingPage.cpp
@@ -38,6 +38,8 @@ namespace {
         {"Moderator", "moderator"},
         {"Verified", "partner"},
         {"VIP", "vip"},
+        {"Founder", "founder"},
+        {"Subscriber", "subscriber"},
         {"Predicted Blue", "predictions/blue-1,predictions/blue-2"},
         {"Predicted Pink", "predictions/pink-2,predictions/pink-1"},
     };


### PR DESCRIPTION
Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable

# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->


Added the capability to highlight messages from sub or founder badges as they were missing to begin with. FWIW Founder badge highlighting does not fall under the subscriber badge. For example, 1/3/6/etc month sub would highlight via the Subscriber badge highlight, but you would have to have a separate highlight for Founder badge highlighting.

![image](https://user-images.githubusercontent.com/6964154/147868152-f1e0383b-eb61-4387-8731-440e83c5146a.png)
