### PR TITLE
Notebook::select now takes the optional parameter "focusPage".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@
 - Dev: Renamed CMake's build option `USE_SYSTEM_QT5KEYCHAIN` to `USE_SYSTEM_QTKEYCHAIN`. (#3103)
 - Dev: Add benchmarks that can be compiled with the `BUILD_BENCHMARKS` CMake flag. Off by default. (#3038)
 - Dev: Added CMake build option `BUILD_WITH_QTKEYCHAIN` to build with or without Qt5Keychain support (On by default). (#3318)
+- Dev: Notebook::select\* functions now take an optional `focusPage` parameter (true by default) which keeps the default behaviour of selecting the page after it has been selected. If set to false, the page is _not_ focused after being selected. (#3446)
 
 ## 2.3.4
 

--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -131,7 +131,7 @@ int Notebook::indexOf(QWidget *page) const
     return -1;
 }
 
-void Notebook::select(QWidget *page)
+void Notebook::select(QWidget *page, bool focusPage)
 {
     if (page == this->selectedPage_)
     {
@@ -148,20 +148,23 @@ void Notebook::select(QWidget *page)
         item.tab->setSelected(true);
         item.tab->raise();
 
-        if (item.selectedWidget == nullptr)
+        if (focusPage)
         {
-            item.page->setFocus();
-        }
-        else
-        {
-            if (containsChild(page, item.selectedWidget))
+            if (item.selectedWidget == nullptr)
             {
-                item.selectedWidget->setFocus(Qt::MouseFocusReason);
+                item.page->setFocus();
             }
             else
             {
-                qCDebug(chatterinoWidget)
-                    << "Notebook: selected child of page doesn't exist anymore";
+                if (containsChild(page, item.selectedWidget))
+                {
+                    item.selectedWidget->setFocus(Qt::MouseFocusReason);
+                }
+                else
+                {
+                    qCDebug(chatterinoWidget) << "Notebook: selected child of "
+                                                 "page doesn't exist anymore";
+                }
             }
         }
     }
@@ -216,17 +219,17 @@ bool Notebook::containsChild(const QObject *obj, const QObject *child)
                        });
 }
 
-void Notebook::selectIndex(int index)
+void Notebook::selectIndex(int index, bool focusPage)
 {
     if (index < 0 || this->items_.count() <= index)
     {
         return;
     }
 
-    this->select(this->items_[index].page);
+    this->select(this->items_[index].page, focusPage);
 }
 
-void Notebook::selectNextTab()
+void Notebook::selectNextTab(bool focusPage)
 {
     if (this->items_.size() <= 1)
     {
@@ -236,10 +239,10 @@ void Notebook::selectNextTab()
     auto index =
         (this->indexOf(this->selectedPage_) + 1) % this->items_.count();
 
-    this->select(this->items_[index].page);
+    this->select(this->items_[index].page, focusPage);
 }
 
-void Notebook::selectPreviousTab()
+void Notebook::selectPreviousTab(bool focusPage)
 {
     if (this->items_.size() <= 1)
     {
@@ -253,10 +256,10 @@ void Notebook::selectPreviousTab()
         index += this->items_.count();
     }
 
-    this->select(this->items_[index].page);
+    this->select(this->items_[index].page, focusPage);
 }
 
-void Notebook::selectLastTab()
+void Notebook::selectLastTab(bool focusPage)
 {
     const auto size = this->items_.size();
     if (size <= 1)
@@ -264,7 +267,7 @@ void Notebook::selectLastTab()
         return;
     }
 
-    this->select(this->items_[size - 1].page);
+    this->select(this->items_[size - 1].page, focusPage);
 }
 
 int Notebook::getPageCount() const
@@ -806,7 +809,7 @@ SplitContainer *SplitNotebook::getOrAddSelectedPage()
                                    : this->addPage();
 }
 
-void SplitNotebook::select(QWidget *page)
+void SplitNotebook::select(QWidget *page, bool focusPage)
 {
     if (auto selectedPage = this->getSelectedPage())
     {
@@ -818,7 +821,7 @@ void SplitNotebook::select(QWidget *page)
             }
         }
     }
-    this->Notebook::select(page);
+    this->Notebook::select(page, focusPage);
 }
 
 }  // namespace chatterino

--- a/src/widgets/Notebook.hpp
+++ b/src/widgets/Notebook.hpp
@@ -33,11 +33,11 @@ public:
     void removeCurrentPage();
 
     int indexOf(QWidget *page) const;
-    virtual void select(QWidget *page);
-    void selectIndex(int index);
-    void selectNextTab();
-    void selectPreviousTab();
-    void selectLastTab();
+    virtual void select(QWidget *page, bool focusPage = true);
+    void selectIndex(int index, bool focusPage = true);
+    void selectNextTab(bool focusPage = true);
+    void selectPreviousTab(bool focusPage = true);
+    void selectLastTab(bool focusPage = true);
 
     int getPageCount() const;
     QWidget *getPageAt(int index) const;
@@ -108,7 +108,7 @@ public:
 
     SplitContainer *addPage(bool select = false);
     SplitContainer *getOrAddSelectedPage();
-    void select(QWidget *page) override;
+    void select(QWidget *page, bool focusPage = true) override;
 
 protected:
     void showEvent(QShowEvent *event) override;

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -203,7 +203,7 @@ void EmotePopup::addShortcuts()
                  int result = target.toInt(&ok);
                  if (ok)
                  {
-                     this->notebook_->selectIndex(result);
+                     this->notebook_->selectIndex(result, false);
                  }
                  else
                  {


### PR DESCRIPTION
This parameter is true by default, and when set to false ensures that
the page that was just selected will not be focused.

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
