### PR TITLE
Removed ability to reload emotes really fast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 - Bugfix: Fixed using special chars in Windows username breaking the storage of custom commands (#3397)
 - Bugfix: Fixed character counter changing fonts after going over the limit. (#3422)
 - Bugfix: Fixed crash that could occur if the user opens/closes ChannelViews (e.g. EmotePopup, or Splits) then modifies the showLastMessageIndicator setting. (#3444)
+- Bugfix: Removed ability to reload emotes really fast (#3450)
 - Dev: Batch checking live status for channels with live notifications that aren't connected. (#3442)
 - Dev: Add GitHub action to test builds without precompiled headers enabled. (#3327)
 - Dev: Renamed CMake's build option `USE_SYSTEM_QT5KEYCHAIN` to `USE_SYSTEM_QTKEYCHAIN`. (#3103)

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -913,6 +913,15 @@ void SplitHeader::themeChangedEvent()
 
 void SplitHeader::reloadChannelEmotes()
 {
+    using namespace std::chrono_literals;
+
+    auto now = std::chrono::steady_clock::now();
+    if (this->lastReloadedChannelEmotes_ + 30s > now)
+    {
+        return;
+    }
+    this->lastReloadedChannelEmotes_ = now;
+
     auto channel = this->split_->getChannel();
 
     if (auto twitchChannel = dynamic_cast<TwitchChannel *>(channel.get()))
@@ -924,6 +933,15 @@ void SplitHeader::reloadChannelEmotes()
 
 void SplitHeader::reloadSubscriberEmotes()
 {
+    using namespace std::chrono_literals;
+
+    auto now = std::chrono::steady_clock::now();
+    if (this->lastReloadedSubEmotes_ + 30s > now)
+    {
+        return;
+    }
+    this->lastReloadedSubEmotes_ = now;
+
     auto channel = this->split_->getChannel();
     getApp()->accounts->twitch.getCurrent()->loadEmotes(channel);
 }

--- a/src/widgets/splits/SplitHeader.hpp
+++ b/src/widgets/splits/SplitHeader.hpp
@@ -64,6 +64,8 @@ private:
     bool isLive_{false};
     QString thumbnail_;
     QElapsedTimer lastThumbnail_;
+    std::chrono::steady_clock::time_point lastReloadedChannelEmotes_;
+    std::chrono::steady_clock::time_point lastReloadedSubEmotes_;
 
     // ui
     Button *dropdownButton_{};


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
Rate limit is per split but i can't see anyone using >30 splits to reload emotes fast enough for this to be an issue. Closes #3402.