### PR TITLE
fix: re-add build date to "About" page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
 - Bugfix: Fixed character counter changing fonts after going over the limit. (#3422)
 - Bugfix: Fixed crash that could occur if the user opens/closes ChannelViews (e.g. EmotePopup, or Splits) then modifies the showLastMessageIndicator setting. (#3444)
 - Bugfix: Removed ability to reload emotes really fast (#3450)
+- Bugfix: Re-add date of build to the "About" page on nightly versions. (#3464)
 - Dev: Batch checking live status for channels with live notifications that aren't connected. (#3442)
 - Dev: Add GitHub action to test builds without precompiled headers enabled. (#3327)
 - Dev: Renamed CMake's build option `USE_SYSTEM_QT5KEYCHAIN` to `USE_SYSTEM_QTKEYCHAIN`. (#3103)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -593,6 +593,12 @@ set_target_properties(${LIBRARY_PROJECT}
     AUTOUIC ON
     )
 
+# Used to provide a date of build in the About page (for nightly builds). Getting the actual time of
+# compilation in CMake is a more involved, as documented in https://stackoverflow.com/q/24292898.
+# For CI runs, however, the date of build file generation should be consistent with the date of
+# compilation so this approximation is "good enough" for our purpose.
+string(TIMESTAMP cmake_gen_date "%Y-%m-%d")
+
 target_compile_definitions(${LIBRARY_PROJECT} PUBLIC
     CHATTERINO
     UNICODE
@@ -604,6 +610,8 @@ target_compile_definitions(${LIBRARY_PROJECT} PUBLIC
     CHATTERINO_GIT_HASH=\"${GIT_HASH}\"
     CHATTERINO_GIT_RELEASE=\"${GIT_RELEASE}\"
     CHATTERINO_GIT_COMMIT=\"${GIT_COMMIT}\"
+
+    CHATTERINO_CMAKE_GEN_DATE=\"${cmake_gen_date}\"
     )
 if (USE_SYSTEM_QTKEYCHAIN)
     target_compile_definitions(${LIBRARY_PROJECT} PUBLIC

--- a/src/common/Version.cpp
+++ b/src/common/Version.cpp
@@ -11,10 +11,8 @@ namespace chatterino {
 
 Version::Version()
 {
-    // Version
     this->version_ = CHATTERINO_VERSION;
 
-    // Commit hash
     this->commitHash_ =
         QString(FROM_EXTERNAL_DEFINE(CHATTERINO_GIT_HASH)).remove('"');
 

--- a/src/common/Version.cpp
+++ b/src/common/Version.cpp
@@ -18,12 +18,10 @@ Version::Version()
     this->commitHash_ =
         QString(FROM_EXTERNAL_DEFINE(CHATTERINO_GIT_HASH)).remove('"');
 
-    // Date of build, this is depended on the format not changing
-#ifdef CHATTERINO_NIGHTLY_VERSION_STRING
+    // Date of build file generation (≈ date of build)
+#ifdef CHATTERINO_CMAKE_GEN_DATE
     this->dateOfBuild_ =
-        QString(FROM_EXTERNAL_DEFINE(CHATTERINO_NIGHTLY_VERSION_STRING))
-            .remove('"')
-            .split(' ')[0];
+        QString(FROM_EXTERNAL_DEFINE(CHATTERINO_CMAKE_GEN_DATE)).remove('"');
 #endif
 
     // "Full" version string, as displayed in window title

--- a/src/widgets/settingspages/AboutPage.cpp
+++ b/src/widgets/settingspages/AboutPage.cpp
@@ -93,7 +93,7 @@ AboutPage::AboutPage()
                                     version.commitHash() + "\">" +
                                     version.commitHash() + "</a>")
                                .arg(Modes::instance().isNightly
-                                        ? ", " + version.dateOfBuild()
+                                        ? ", built on " + version.dateOfBuild()
                                         : "");
 
             auto versionLabel = versionInfo.emplace<QLabel>(text);


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description
Fixes #3430.

Relevant commit message:
> The date of build has previously been provided via a define supplied by
the CI runner. During the migration to GitHub Actions, this seems to
have been missed.
>
> This fix relies on CMake generating and providing the timestamp itself,
and passing it to the binary. Note that the timestamp will be of the
date when the **build files** were generated, i.e., not when the project
was compiled! For CI runs, however, the date of build file generation
should be consistent with the date of compilation so this approximation
is "good enough" for our purpose.

**Note that this only works for CMake-based builds so the QMake builds are out of luck**. I won't bother figuring out how to supply the information platform-independently (Windows, macOS, Linux) with QMake. If someone wants to do so, please go ahead.

Commit 3e02e26 (also part of this PR) removes some comments which I felt were redundant, feel free to drop/revert the commit if you think otherwise.