### PR TITLE
Fix edge case where hotkeys would be empty after a crash, causing Chatterino to be unusable unless the user reset their hotkeys

### DIFF
--- a/src/controllers/hotkeys/HotkeyController.cpp
+++ b/src/controllers/hotkeys/HotkeyController.cpp
@@ -271,6 +271,7 @@ void HotkeyController::saveHotkeys()
         pajlada::Settings::Setting<std::vector<QString>>::set(
             section + "/arguments", hotkey->arguments());
     }
+    pajlada::Settings::SettingManager::getInstance()->save();
 }
 
 void HotkeyController::addDefaults(std::set<QString> &addedHotkeys)

--- a/src/controllers/hotkeys/HotkeyController.cpp
+++ b/src/controllers/hotkeys/HotkeyController.cpp
@@ -201,8 +201,15 @@ void HotkeyController::loadHotkeys()
     auto set = std::set<QString>(defaultHotkeysAdded.begin(),
                                  defaultHotkeysAdded.end());
 
+    // set is currently "defaults added in settings"
+    auto numDefaultsFromSettings = set.size();
+
     auto keys = pajlada::Settings::SettingManager::getObjectKeys("/hotkeys");
     this->addDefaults(set);
+
+    // set is currently "all defaults (defaults defined from application + defaults defined in settings)"
+    auto numCombinedDefaults = set.size();
+
     pajlada::Settings::Setting<std::vector<QString>>::set(
         "/hotkeys/addedDefaults", std::vector<QString>(set.begin(), set.end()));
 
@@ -239,6 +246,12 @@ void HotkeyController::loadHotkeys()
             *category, QKeySequence(keySequence), action, arguments,
             QString::fromStdString(key)));
     }
+
+    if (numDefaultsFromSettings != numCombinedDefaults)
+    {
+        // some default that the user was not aware of has been added to the application, force a save to ensure shared state between hotkey controller and settings
+        this->saveHotkeys();
+    }
 }
 
 void HotkeyController::saveHotkeys()
@@ -271,7 +284,6 @@ void HotkeyController::saveHotkeys()
         pajlada::Settings::Setting<std::vector<QString>>::set(
             section + "/arguments", hotkey->arguments());
     }
-    pajlada::Settings::SettingManager::getInstance()->save();
 }
 
 void HotkeyController::addDefaults(std::set<QString> &addedHotkeys)


### PR DESCRIPTION
Pull request checklist:

- [ ] ~~`CHANGELOG.md` was updated, if applicable~~ I don't think this should get a changelog entry because custom hotkeys have not been into a stable yet. pajaDent

# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
This forces a save of settings after hotkeys have been saved into memory. I can't really reproduce the bug so this is the best fix I can do rn.