### PR TITLE
fix: remove deprecated windows-2016/vs-2017 action runner from build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,16 +16,7 @@ jobs:
         qt-version: [5.15.2, 5.12.10]
         build-system: [qmake, cmake]
         pch: [true]
-        exclude:
-          - os: windows-latest
-            qt-version: 5.12.10
-            build-system: cmake
-            pch: true
         include:
-          - os: windows-2019
-            qt-version: 5.12.10
-            build-system: cmake
-            pch: true
           - os: ubuntu-latest
             qt-version: 5.15.2
             build-system: cmake
@@ -37,12 +28,6 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: |
             echo "vs_version=2019" >> $GITHUB_ENV
-        shell: bash
-
-      - name: Set environment variables for windows-2016
-        if: matrix.os == 'windows-2016'
-        run: |
-            echo "vs_version=2017" >> $GITHUB_ENV
         shell: bash
 
       - uses: actions/checkout@v2.4.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
             build-system: cmake
             pch: true
         include:
-          - os: windows-2016
+          - os: windows-2019
             qt-version: 5.12.10
             build-system: cmake
             pch: true


### PR DESCRIPTION
Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable

# Description

This PR aims to remove the deprecated win2016 runner from the build matrix. See [this GH blog post](https://github.blog/changelog/2021-10-19-github-actions-the-windows-2016-runner-image-will-be-removed-from-github-hosted-runners-on-march-15-2022/)

According to @pajlada this was required due to some cmake/qt build issue, but I've been unable to reproduce on my fork. Tested build pipeline using `windows-latest`/`windows-2022`, executable ran and connected without issue.