### PR TITLE
Don't crash upon right-clicking automod badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@
 - Bugfix: Fixed crash that could occur if the user opens/closes ChannelViews (e.g. EmotePopup, or Splits) then modifies the showLastMessageIndicator setting. (#3444)
 - Bugfix: Removed ability to reload emotes really fast (#3450)
 - Bugfix: Re-add date of build to the "About" page on nightly versions. (#3464)
+- Bugfix: Fixed crash that would occur if the user right-clicked AutoMod badge. (#3496)
 - Dev: Batch checking live status for channels with live notifications that aren't connected. (#3442)
 - Dev: Add GitHub action to test builds without precompiled headers enabled. (#3327)
 - Dev: Renamed CMake's build option `USE_SYSTEM_QT5KEYCHAIN` to `USE_SYSTEM_QTKEYCHAIN`. (#3103)

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -28,6 +28,14 @@ MessagePtr makeSystemMessage(const QString &text, const QTime &time)
     return MessageBuilder(systemMessage, text, time).release();
 }
 
+EmotePtr makeAutoModBadge()
+{
+    return std::make_shared<Emote>(Emote{
+        EmoteName{}, ImageSet{Image::fromPixmap(getResources().twitch.automod)},
+        Tooltip{"AutoMod"},
+        Url{"https://dashboard.twitch.tv/settings/moderation/automod"}});
+}
+
 MessagePtr makeAutomodInfoMessage(const AutomodInfoAction &action)
 {
     auto builder = MessageBuilder();
@@ -37,10 +45,8 @@ MessagePtr makeAutomodInfoMessage(const AutomodInfoAction &action)
     builder.message().flags.set(MessageFlag::PubSub);
 
     // AutoMod shield badge
-    builder
-        .emplace<ImageElement>(Image::fromPixmap(getResources().twitch.automod),
-                               MessageElementFlag::BadgeChannelAuthority)
-        ->setTooltip("AutoMod");
+    builder.emplace<BadgeElement>(makeAutoModBadge(),
+                                  MessageElementFlag::BadgeChannelAuthority);
     // AutoMod "username"
     builder.emplace<TextElement>("AutoMod:", MessageElementFlag::BoldUsername,
                                  MessageColor(QColor("blue")),
@@ -95,10 +101,8 @@ std::pair<MessagePtr, MessagePtr> makeAutomodMessage(
     builder.message().flags.set(MessageFlag::PubSub);
 
     // AutoMod shield badge
-    builder
-        .emplace<ImageElement>(Image::fromPixmap(getResources().twitch.automod),
-                               MessageElementFlag::BadgeChannelAuthority)
-        ->setTooltip("AutoMod");
+    builder.emplace<BadgeElement>(makeAutoModBadge(),
+                                  MessageElementFlag::BadgeChannelAuthority);
     // AutoMod "username"
     builder.emplace<TextElement>("AutoMod:", MessageElementFlag::BoldUsername,
                                  MessageColor(QColor("blue")),

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1860,6 +1860,7 @@ void ChannelView::addContextMenuItems(
     auto menu = new QMenu;
     previousMenu = menu;
 
+    // Badge actions
     if (creatorFlags.hasAny({MessageElementFlag::Badges}))
     {
         if (auto badgeElement = dynamic_cast<const BadgeElement *>(&creator))

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1862,17 +1862,16 @@ void ChannelView::addContextMenuItems(
 
     if (creatorFlags.hasAny({MessageElementFlag::Badges}))
     {
-        auto badgeElement = dynamic_cast<const BadgeElement *>(&creator);
-        addEmoteContextMenuItems(*badgeElement->getEmote(), creatorFlags,
-                                 *menu);
+        if (auto badgeElement = dynamic_cast<const BadgeElement *>(&creator))
+            addEmoteContextMenuItems(*badgeElement->getEmote(), creatorFlags,
+                                     *menu);
     }
 
     // Emote actions
     if (creatorFlags.hasAny(
             {MessageElementFlag::EmoteImages, MessageElementFlag::EmojiImage}))
     {
-        const auto emoteElement = dynamic_cast<const EmoteElement *>(&creator);
-        if (emoteElement)
+        if (auto emoteElement = dynamic_cast<const EmoteElement *>(&creator))
             addEmoteContextMenuItems(*emoteElement->getEmote(), creatorFlags,
                                      *menu);
     }


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Following up 675f99e9c, added a check whether result of dynamic_cast is not a `nullptr` to prevent any other crashes caused by faulty badge elements.
Also fixed the AutoMod badge and made it an actual instance of `BadgeElement` which is what it should've been from the beginning, instead of `ImageElement`.

Fixes #2969 