### PR TITLE
Add .cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ Thumbs.db
 .vscode
 .idea
 dependencies
+.cache
 
 ### CMake ###
 CMakeLists.txt.user


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

While compiling with `cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=YES` cmake can create a bunch of files in `.cache/`, indexing all codebase, allowing coc.nvim to make use of it, giving full rich autocompletion with all definitions etc. on NeoVim

credits to amazing @mm2pl who found this.
