### PR TITLE
Show feedback upon opening a channel in streamlink in more places

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - Minor: Add workaround for multipart emoji as described in [the RFC](https://mm2pl.github.io/emoji_rfc.pdf). (#3469)
 - Minor: Add feedback when using the whisper command `/w` incorrectly. (#3439)
 - Minor: Add feedback when writing a non-command message in the `/whispers` split. (#3439)
+- Minor: Opening streamlink through hotkeys and/or split header menu matches `/streamlink` command and shows feedback in chat as well. (#3510)
 - Bugfix: Fix Split Input hotkeys not being available when input is hidden (#3362)
 - Bugfix: Fixed colored usernames sometimes not working. (#3170)
 - Bugfix: Restored ability to send duplicate `/me` messages. (#3166)

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -670,8 +670,6 @@ void CommandController::initialize(Settings &, Paths &paths)
             }
 
             stripChannelName(target);
-            channel->addMessage(makeSystemMessage(
-                QString("Opening %1 in streamlink...").arg(target)));
             openStreamlinkForChannel(target);
 
             return "";

--- a/src/util/StreamLink.cpp
+++ b/src/util/StreamLink.cpp
@@ -213,8 +213,15 @@ void openStreamlinkForChannel(const QString &channel)
 
     auto *currentPage = dynamic_cast<SplitContainer *>(
         getApp()->windows->getMainWindow().getNotebook().getSelectedPage());
-    currentPage->getSelectedSplit()->getChannel()->addMessage(
-        makeSystemMessage(INFO_TEMPLATE.arg(channel)));
+    if (currentPage != nullptr)
+    {
+        if (auto currentSplit = currentPage->getSelectedSplit();
+            currentSplit != nullptr)
+        {
+            currentSplit->getChannel()->addMessage(
+                makeSystemMessage(INFO_TEMPLATE.arg(channel)));
+        }
+    }
 
     QString channelURL = "twitch.tv/" + channel;
 

--- a/src/util/StreamLink.cpp
+++ b/src/util/StreamLink.cpp
@@ -1,10 +1,14 @@
 #include "util/StreamLink.hpp"
 
 #include "Application.hpp"
+#include "providers/irc/IrcMessageBuilder.hpp"
 #include "singletons/Settings.hpp"
+#include "singletons/WindowManager.hpp"
 #include "util/Helpers.hpp"
 #include "util/SplitCommand.hpp"
+#include "widgets/Window.hpp"
 #include "widgets/dialogs/QualityPopup.hpp"
+#include "widgets/splits/Split.hpp"
 
 #include <QErrorMessage>
 #include <QFileInfo>
@@ -205,6 +209,11 @@ void openStreamlink(const QString &channelURL, const QString &quality,
 
 void openStreamlinkForChannel(const QString &channel)
 {
+    auto *currentPage = dynamic_cast<SplitContainer *>(
+        getApp()->windows->getMainWindow().getNotebook().getSelectedPage());
+    currentPage->getSelectedSplit()->getChannel()->addMessage(
+        makeSystemMessage(QString("Opening %1 in streamlink...").arg(channel)));
+
     QString channelURL = "twitch.tv/" + channel;
 
     QString preferredQuality = getSettings()->preferredQuality.getValue();

--- a/src/util/StreamLink.cpp
+++ b/src/util/StreamLink.cpp
@@ -209,10 +209,12 @@ void openStreamlink(const QString &channelURL, const QString &quality,
 
 void openStreamlinkForChannel(const QString &channel)
 {
+    static const QString INFO_TEMPLATE("Opening %1 in Streamlink ...");
+
     auto *currentPage = dynamic_cast<SplitContainer *>(
         getApp()->windows->getMainWindow().getNotebook().getSelectedPage());
     currentPage->getSelectedSplit()->getChannel()->addMessage(
-        makeSystemMessage(QString("Opening %1 in streamlink...").arg(channel)));
+        makeSystemMessage(INFO_TEMPLATE.arg(channel)));
 
     QString channelURL = "twitch.tv/" + channel;
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Note: we could perhaps also show feedback when opening stream fails (e.g. channel is offline and/or child process quits with 1), but that's for another PR.

Fixes #3488
