### PR TITLE
Made emote search not crash in non-Twitch channels.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@
 - Minor: Added autocompletion for default Twitch commands starting with the dot (e.g. `.mods` which does the same as `/mods`). (#3144)
 - Minor: Sorted usernames in `Users joined/parted` messages alphabetically. (#3421)
 - Minor: Mod list, VIP list, and Users joined/parted messages are now searchable. (#3426)
-- Minor: Add search to emote popup. (#3404)
+- Minor: Add search to emote popup. (#3404, #3527)
 - Minor: Messages can now be highlighted by subscriber or founder badges. (#3445)
 - Minor: Add workaround for multipart emoji as described in [the RFC](https://mm2pl.github.io/emoji_rfc.pdf). (#3469)
 - Minor: Add feedback when using the whisper command `/w` incorrectly. (#3439)

--- a/src/widgets/dialogs/EmotePopup.hpp
+++ b/src/widgets/dialogs/EmotePopup.hpp
@@ -46,6 +46,8 @@ private:
 
     void loadEmojis(ChannelView &view, EmojiMap &emojiMap);
     void loadEmojis(Channel &channel, EmojiMap &emojiMap, const QString &title);
+    void filterTwitchEmotes(std::shared_ptr<Channel> searchChannel,
+                            const QString &searchText);
     void filterEmotes(const QString &text);
     EmoteMap *filterEmoteMap(const QString &text,
                              std::shared_ptr<const EmoteMap> emotes);


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
I encased all Twitch-specific functionality in a check for a Twitch channel.

Closes #3526