### PR TITLE
Updated contribution guide to include exemptions to the parameters

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -223,7 +223,7 @@ Keep the element on the stack if possible. If you need a pointer or have complex
 When informing the user about how a command is supposed to be used, we aim to follow [this standard](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html) where possible.
 
 - Square brackets are reserved for `[optional arguments]`.
-- Angle brackets are reserved for `<required arguments>`.
+- Angle brackets are reserved for `<required arguments>`. There are exemptions in such cases where using the command without a parameter also returns a valid response. In such cases, the parameter becomes required and we should inform users as such: `/streamlink <channel>`.
 - The word _Usage_ should be capitalized and must be followed by a colon.
 - If the usage deserves a description, put a dot after all parameters and explain it briefly.
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

In certain scenarios, a parameter is required; whilst also being optional. The response returned should indicate that a parameter is required in order to get the desired outcome on the usage of a command. For example, `/streamlink` is a valid command, in order to open a specific channel; you MUST use the channel parameter, thus making it a required parameter: `/streamlink <channel>`