### PR TITLE
Disabled `/popout` and `/streamlink` from working in non-twitch channels (e.g. /whispers) when supplied no arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@
 - Bugfix: Fixed being unable to drag the user card window from certain spots. (#3508)
 - Bugfix: Fixed being unable to open a usercard from inside a usercard while "Automatically close user popup when it loses focus" was enabled. (#3518)
 - Bugfix: Usercards no longer close when the originating window (e.g. a search popup) is closed. (#3518)
+- Bugfix: Disabled /popout and /streamlink from working in non-twitch channels (e.g. /whispers) when supplied no arguments. (#3541)
 - Dev: Batch checking live status for channels with live notifications that aren't connected. (#3442)
 - Dev: Add GitHub action to test builds without precompiled headers enabled. (#3327)
 - Dev: Renamed CMake's build option `USE_SYSTEM_QT5KEYCHAIN` to `USE_SYSTEM_QTKEYCHAIN`. (#3103)

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -657,16 +657,23 @@ void CommandController::initialize(Settings &, Paths &paths)
 
     this->registerCommand("/streamlink", [](const QStringList &words,
                                             ChannelPtr channel) {
-        QString target(words.size() < 2 ? channel->getName() : words[1]);
+        QString target(words.value(1));
 
-        if (words.size() < 2 &&
-            (channel->getType() != Channel::Type::Twitch || channel->isEmpty()))
+        if (target.isEmpty())
         {
-            channel->addMessage(makeSystemMessage(
-                "Usage: /streamlink <channel>. You can also use the "
-                "command without arguments in any Twitch channel to open "
-                "it in streamlink."));
-            return "";
+            if (channel->getType() == Channel::Type::Twitch &&
+                !channel->isEmpty())
+            {
+                target = channel->getName();
+            }
+            else
+            {
+                channel->addMessage(makeSystemMessage(
+                    "Usage: /streamlink <channel>. You can also use the "
+                    "command without arguments in any Twitch channel to open "
+                    "it in streamlink."));
+                return "";
+            }
         }
 
         stripChannelName(target);
@@ -677,16 +684,23 @@ void CommandController::initialize(Settings &, Paths &paths)
 
     this->registerCommand("/popout", [](const QStringList &words,
                                         ChannelPtr channel) {
-        QString target(words.size() < 2 ? channel->getName() : words[1]);
+        QString target(words.value(1));
 
-        if (words.size() < 2 &&
-            (channel->getType() != Channel::Type::Twitch || channel->isEmpty()))
+        if (target.isEmpty())
         {
-            channel->addMessage(makeSystemMessage(
-                "Usage: /popout <channel>. You can also use the command "
-                "without arguments in any Twitch channel to open its "
-                "popout chat."));
-            return "";
+            if (channel->getType() == Channel::Type::Twitch &&
+                !channel->isEmpty())
+            {
+                target = channel->getName();
+            }
+            else
+            {
+                channel->addMessage(makeSystemMessage(
+                    "Usage: /popout <channel>. You can also use the command "
+                    "without arguments in any Twitch channel to open its "
+                    "popout chat."));
+                return "";
+            }
         }
 
         stripChannelName(target);

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -655,47 +655,47 @@ void CommandController::initialize(Settings &, Paths &paths)
         return "";
     });
 
-    this->registerCommand(
-        "/streamlink", [](const QStringList &words, ChannelPtr channel) {
-            QString target(words.size() < 2 ? channel->getName() : words[1]);
+    this->registerCommand("/streamlink", [](const QStringList &words,
+                                            ChannelPtr channel) {
+        QString target(words.size() < 2 ? channel->getName() : words[1]);
 
-            if (words.size() < 2 &&
-                (!channel->isTwitchChannel() || channel->isEmpty()))
-            {
-                channel->addMessage(makeSystemMessage(
-                    "Usage: /streamlink <channel>. You can also use the "
-                    "command without arguments in any Twitch channel to open "
-                    "it in streamlink."));
-                return "";
-            }
-
-            stripChannelName(target);
-            openStreamlinkForChannel(target);
-
+        if (words.size() < 2 &&
+            (channel->getType() != Channel::Type::Twitch || channel->isEmpty()))
+        {
+            channel->addMessage(makeSystemMessage(
+                "Usage: /streamlink <channel>. You can also use the "
+                "command without arguments in any Twitch channel to open "
+                "it in streamlink."));
             return "";
-        });
+        }
 
-    this->registerCommand(
-        "/popout", [](const QStringList &words, ChannelPtr channel) {
-            QString target(words.size() < 2 ? channel->getName() : words[1]);
+        stripChannelName(target);
+        openStreamlinkForChannel(target);
 
-            if (words.size() < 2 &&
-                (!channel->isTwitchChannel() || channel->isEmpty()))
-            {
-                channel->addMessage(makeSystemMessage(
-                    "Usage: /popout <channel>. You can also use the command "
-                    "without arguments in any Twitch channel to open its "
-                    "popout chat."));
-                return "";
-            }
+        return "";
+    });
 
-            stripChannelName(target);
-            QDesktopServices::openUrl(
-                QUrl(QString("https://www.twitch.tv/popout/%1/chat?popout=")
-                         .arg(target)));
+    this->registerCommand("/popout", [](const QStringList &words,
+                                        ChannelPtr channel) {
+        QString target(words.size() < 2 ? channel->getName() : words[1]);
 
+        if (words.size() < 2 &&
+            (channel->getType() != Channel::Type::Twitch || channel->isEmpty()))
+        {
+            channel->addMessage(makeSystemMessage(
+                "Usage: /popout <channel>. You can also use the command "
+                "without arguments in any Twitch channel to open its "
+                "popout chat."));
             return "";
-        });
+        }
+
+        stripChannelName(target);
+        QDesktopServices::openUrl(
+            QUrl(QString("https://www.twitch.tv/popout/%1/chat?popout=")
+                     .arg(target)));
+
+        return "";
+    });
 
     this->registerCommand("/clearmessages", [](const auto & /*words*/,
                                                ChannelPtr channel) {


### PR DESCRIPTION

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description
Fixes #3531

While investigating #3531, I have found that `/popout` had same issue.
This PR should fix both issues.
<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
