### PR TITLE
Add option to control whether to gray out history of messages

### DIFF
--- a/src/messages/layouts/MessageLayout.cpp
+++ b/src/messages/layouts/MessageLayout.cpp
@@ -213,7 +213,8 @@ void MessageLayout::paint(QPainter &painter, int width, int y, int messageIndex,
         //                         QBrush(QColor(64, 64, 64, 64)));
     }
 
-    if (this->message_->flags.has(MessageFlag::RecentMessage))
+    if (this->message_->flags.has(MessageFlag::RecentMessage) &&
+        getSettings()->grayOutHistory)
     {
         painter.fillRect(0, y, pixmap->width(), pixmap->height(),
                          app->themes->messages.disabled);

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -838,11 +838,16 @@ void TwitchChannel::loadRecentMessages()
 
             if (!getSettings()->grayOutHistory)
             {
-                const auto date = QDateTime::currentDateTime().toString("dd/MM/yy");
-                const auto time = QTime::currentTime().toString("hh:mm");
-                const auto msg = QString("[​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ▲ Chat history before %1 %2 ▲ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​]").arg(date).arg(time);
-                const auto block_line = makeSystemMessage(msg, QTime::currentTime());
-                allBuiltMessages.emplace_back(block_line);
+                const auto str =
+                    QString(
+                        "[​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ "
+                        "​ ​ ​ ​ ​ ​ ​ ​ ​ ▲ Chat history "
+                        "before %1 %2 ▲ ​ ​ ​ ​ ​ ​ ​ ​ ​ "
+                        "​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​]")
+                        .arg(QDateTime::currentDateTime().toString("dd/MM/yy"),
+                             QTime::currentTime().toString("hh:mm"));
+                const auto msg = makeSystemMessage(str);
+                allBuiltMessages.emplace_back(msg);
             }
 
             postToThread([this, shared, root,

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -836,6 +836,15 @@ void TwitchChannel::loadRecentMessages()
                 }
             }
 
+            if (!getSettings()->grayOutHistory)
+            {
+                const auto date = QDateTime::currentDateTime().toString("dd/MM/yy");
+                const auto time = QTime::currentTime().toString("hh:mm");
+                const auto msg = QString("[​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ▲ Chat history before %1 %2 ▲ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​]").arg(date).arg(time);
+                const auto block_line = makeSystemMessage(msg, QTime::currentTime());
+                allBuiltMessages.emplace_back(block_line);
+            }
+
             postToThread([this, shared, root,
                           messages = std::move(allBuiltMessages)]() mutable {
                 shared->addMessagesAtStart(messages);

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -86,6 +86,7 @@ public:
                                      false};
     BoolSetting separateMessages = {"/appearance/messages/separateMessages",
                                     false};
+    BoolSetting grayOutHistory = {"/appearance/messages/grayOutHistory", true};
     BoolSetting compactEmotes = {"/appearance/messages/compactEmotes", true};
     BoolSetting hideModerated = {"/appearance/messages/hideModerated", false};
     BoolSetting hideModerationActions = {

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -288,7 +288,8 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     layout.addColorButton("Line color",
                           QColor(getSettings()->lastMessageColor.getValue()),
                           getSettings()->lastMessageColor);
-    layout.addCheckbox("Gray-out message history before connecting.", s.grayOutHistory);
+    layout.addCheckbox("Gray-out message history before connecting.",
+                       s.grayOutHistory);
 
     layout.addTitle("Emotes");
     layout.addCheckbox("Enable", s.enableEmoteImages);

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -288,6 +288,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     layout.addColorButton("Line color",
                           QColor(getSettings()->lastMessageColor.getValue()),
                           getSettings()->lastMessageColor);
+    layout.addCheckbox("Gray-out message history before connecting.", s.grayOutHistory);
 
     layout.addTitle("Emotes");
     layout.addCheckbox("Enable", s.enableEmoteImages);


### PR DESCRIPTION
I think this should do it for #3545.

This is what the setting looks like in the General Page: 
![settings_generalpage](https://user-images.githubusercontent.com/51851906/151562767-577c6c5e-3787-49d3-9a2e-58b98f5d71b2.png)

And this is the setting in action:
![Screenshot from 2022-01-25 17-10-58](https://user-images.githubusercontent.com/51851906/151562801-37683077-a731-44f5-87df-108015814a5e.png)

