### PR TITLE
Fixed automod and unban messages showing when moderation actions were disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@
 - Bugfix: Fixed being unable to open a usercard from inside a usercard while "Automatically close user popup when it loses focus" was enabled. (#3518)
 - Bugfix: Usercards no longer close when the originating window (e.g. a search popup) is closed. (#3518)
 - Bugfix: Disabled /popout and /streamlink from working in non-twitch channels (e.g. /whispers) when supplied no arguments. (#3541)
+- Bugfix: Fixed automod and unban messages showing when moderation actions were disabled (#3548)
 - Dev: Batch checking live status for channels with live notifications that aren't connected. (#3442)
 - Dev: Add GitHub action to test builds without precompiled headers enabled. (#3327)
 - Dev: Renamed CMake's build option `USE_SYSTEM_QT5KEYCHAIN` to `USE_SYSTEM_QTKEYCHAIN`. (#3103)

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -98,6 +98,8 @@ std::pair<MessagePtr, MessagePtr> makeAutomodMessage(
     // Builder for AutoMod message with explanation
     builder.message().loginName = "automod";
     builder.message().flags.set(MessageFlag::PubSub);
+    builder.message().flags.set(MessageFlag::Timeout);
+    builder.message().flags.set(MessageFlag::AutoMod);
 
     // AutoMod shield badge
     builder.emplace<BadgeElement>(makeAutoModBadge(),
@@ -129,7 +131,6 @@ std::pair<MessagePtr, MessagePtr> makeAutomodMessage(
     // ID of message caught by AutoMod
     //    builder.emplace<TextElement>(action.msgID, MessageElementFlag::Text,
     //                                 MessageColor::Text);
-    builder.message().flags.set(MessageFlag::AutoMod);
     auto text1 =
         QString("AutoMod: Held a message for reason: %1. Allow will post "
                 "it in chat. Allow Deny")
@@ -145,6 +146,8 @@ std::pair<MessagePtr, MessagePtr> makeAutomodMessage(
     builder2.emplace<TwitchModerationElement>();
     builder2.message().loginName = action.target.login;
     builder2.message().flags.set(MessageFlag::PubSub);
+    builder2.message().flags.set(MessageFlag::Timeout);
+    builder2.message().flags.set(MessageFlag::AutoMod);
 
     // sender username
     builder2
@@ -160,7 +163,6 @@ std::pair<MessagePtr, MessagePtr> makeAutomodMessage(
     // sender's message caught by AutoMod
     builder2.emplace<TextElement>(action.message, MessageElementFlag::Text,
                                   MessageColor::Text);
-    builder2.message().flags.set(MessageFlag::AutoMod);
     auto text2 =
         QString("%1: %2").arg(action.target.displayName, action.message);
     builder2.message().messageText = text2;

--- a/src/messages/layouts/MessageLayout.cpp
+++ b/src/messages/layouts/MessageLayout.cpp
@@ -135,7 +135,8 @@ void MessageLayout::actuallyLayout(int width, MessageElementFlags flags)
         }
 
         if (getSettings()->hideModerationActions &&
-            this->message_->flags.has(MessageFlag::Timeout))
+            (this->message_->flags.has(MessageFlag::Timeout) ||
+             this->message_->flags.has(MessageFlag::Untimeout)))
         {
             continue;
         }


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
I added appropriate flags to AutoMod messages and made the hideModerationActions setting ignore Untimeout (unban) messages. Fixes #3547.

Note: this does not hide messages notifying users that their message was held, just the moderation variants.