### PR TITLE
Fixed bttv modifier emotes not being on top of animated emotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@
 - Bugfix: Usercards no longer close when the originating window (e.g. a search popup) is closed. (#3518)
 - Bugfix: Disabled /popout and /streamlink from working in non-twitch channels (e.g. /whispers) when supplied no arguments. (#3541)
 - Bugfix: Fixed automod and unban messages showing when moderation actions were disabled (#3548)
+- Bugfix: Fixed bttv modifier emotes not being on top of animated emotes (#3551)
 - Dev: Batch checking live status for channels with live notifications that aren't connected. (#3442)
 - Dev: Add GitHub action to test builds without precompiled headers enabled. (#3327)
 - Dev: Renamed CMake's build option `USE_SYSTEM_QT5KEYCHAIN` to `USE_SYSTEM_QTKEYCHAIN`. (#3103)

--- a/src/messages/Emote.cpp
+++ b/src/messages/Emote.cpp
@@ -4,6 +4,13 @@
 
 namespace chatterino {
 
+void Emote::animate() const
+{
+    images.getImage1().get()->setAnimated(true);
+    images.getImage2().get()->setAnimated(true);
+    images.getImage3().get()->setAnimated(true);
+}
+
 bool operator==(const Emote &a, const Emote &b)
 {
     return std::tie(a.homePage, a.name, a.tooltip, a.images) ==

--- a/src/messages/Emote.cpp
+++ b/src/messages/Emote.cpp
@@ -6,9 +6,9 @@ namespace chatterino {
 
 void Emote::animate() const
 {
-    images.getImage1().get()->setAnimated(true);
-    images.getImage2().get()->setAnimated(true);
-    images.getImage3().get()->setAnimated(true);
+    images.getImage1()->setAnimated(true);
+    images.getImage2()->setAnimated(true);
+    images.getImage3()->setAnimated(true);
 }
 
 bool operator==(const Emote &a, const Emote &b)

--- a/src/messages/Emote.hpp
+++ b/src/messages/Emote.hpp
@@ -20,6 +20,7 @@ struct Emote {
     {
         return name.string;
     }
+    void animate() const;
 };
 
 bool operator==(const Emote &a, const Emote &b);

--- a/src/messages/Image.cpp
+++ b/src/messages/Image.cpp
@@ -373,7 +373,12 @@ bool Image::animated() const
 {
     assertInGuiThread();
 
-    return this->frames_->animated();
+    return this->frames_->animated() || this->animated_;
+}
+
+void Image::setAnimated(bool animate)
+{
+    this->animated_ = animate;
 }
 
 int Image::width() const

--- a/src/messages/Image.hpp
+++ b/src/messages/Image.hpp
@@ -69,6 +69,7 @@ public:
     int width() const;
     int height() const;
     bool animated() const;
+    void setAnimated(bool animate);
 
     bool operator==(const Image &image) const;
     bool operator!=(const Image &image) const;
@@ -84,6 +85,7 @@ private:
     const Url url_{};
     const qreal scale_{1};
     std::atomic_bool empty_{false};
+    bool animated_{false};
 
     // gui thread only
     bool shouldLoad_{false};

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -1003,6 +1003,8 @@ Outcome TwitchMessageBuilder::tryAppendEmote(const EmoteName &name)
         if (zeroWidthEmotes.contains(name.string))
         {
             flags.set(MessageElementFlag::ZeroWidthEmote);
+            if (auto emoteptr = globalBttvEmotes.emote(name))
+                emoteptr.get()->animate();
         }
     }
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description
Closes #2994
A temporary fix. It should have almost negligible impact on performance since there are many animated emotes and 8 more is nothing compared to hundreds that some channels have.
In the long term, the way that modifier emotes are handled should be rewritten.
Also works as intended when having `Emotes > Animate` turned off.
<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
