### PR TITLE
Add tests to Twitch User/Channel name strip functions

### DIFF
--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -35,32 +35,6 @@
 namespace {
 using namespace chatterino;
 
-// stripUserName removes any @ prefix or , suffix to make it more suitable for command use
-void stripUserName(QString &userName)
-{
-    if (userName.startsWith('@'))
-    {
-        userName.remove(0, 1);
-    }
-    if (userName.endsWith(','))
-    {
-        userName.chop(1);
-    }
-}
-
-// stripChannelName removes any @ prefix or , suffix to make it more suitable for command use
-void stripChannelName(QString &channelName)
-{
-    if (channelName.startsWith('@') || channelName.startsWith('#'))
-    {
-        channelName.remove(0, 1);
-    }
-    if (channelName.endsWith(','))
-    {
-        channelName.chop(1);
-    }
-}
-
 void sendWhisperMessage(const QString &text)
 {
     // (hemirt) pajlada: "we should not be sending whispers through jtv, but

--- a/src/util/Twitch.cpp
+++ b/src/util/Twitch.cpp
@@ -10,4 +10,29 @@ void openTwitchUsercard(QString channel, QString username)
     QDesktopServices::openUrl("https://www.twitch.tv/popout/" + channel +
                               "/viewercard/" + username);
 }
+
+void stripUserName(QString &userName)
+{
+    if (userName.startsWith('@'))
+    {
+        userName.remove(0, 1);
+    }
+    if (userName.endsWith(','))
+    {
+        userName.chop(1);
+    }
+}
+
+void stripChannelName(QString &channelName)
+{
+    if (channelName.startsWith('@') || channelName.startsWith('#'))
+    {
+        channelName.remove(0, 1);
+    }
+    if (channelName.endsWith(','))
+    {
+        channelName.chop(1);
+    }
+}
+
 }  // namespace chatterino

--- a/src/util/Twitch.hpp
+++ b/src/util/Twitch.hpp
@@ -6,4 +6,10 @@ namespace chatterino {
 
 void openTwitchUsercard(const QString channel, const QString username);
 
+// stripUserName removes any @ prefix or , suffix to make it more suitable for command use
+void stripUserName(QString &userName);
+
+// stripChannelName removes any @ prefix or , suffix to make it more suitable for command use
+void stripChannelName(QString &channelName);
+
 }  // namespace chatterino

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ set(test_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/src/Helpers.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/RatelimitBucket.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/Hotkeys.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/UtilTwitch.cpp
     # Add your new file above this line!
     )
 

--- a/tests/src/UtilTwitch.cpp
+++ b/tests/src/UtilTwitch.cpp
@@ -1,0 +1,161 @@
+#include "util/Twitch.hpp"
+
+#include <gtest/gtest.h>
+#include <QApplication>
+#include <QDebug>
+#include <QtConcurrent>
+
+#include <chrono>
+#include <thread>
+
+using namespace chatterino;
+
+TEST(UtilTwitch, StripUserName)
+{
+    struct TestCase {
+        QString inputUserName;
+        QString expectedUserName;
+    };
+
+    std::vector<TestCase> tests{
+        {
+            "pajlada",
+            "pajlada",
+        },
+        {
+            "Pajlada",
+            "Pajlada",
+        },
+        {
+            "@Pajlada",
+            "Pajlada",
+        },
+        {
+            "@Pajlada,",
+            "Pajlada",
+        },
+        {
+            "@@Pajlada,",
+            "@Pajlada",
+        },
+        {
+            "@@Pajlada,,",
+            "@Pajlada,",
+        },
+        {
+            "",
+            "",
+        },
+        {
+            "@",
+            "",
+        },
+        {
+            ",",
+            "",
+        },
+        {
+            // We purposefully don't handle spaces at the end, as all expected usages of this function split the message up by space and strip the parameters by themselves
+            ", ",
+            ", ",
+        },
+        {
+            // We purposefully don't handle spaces at the start, as all expected usages of this function split the message up by space and strip the parameters by themselves
+            " @",
+            " @",
+        },
+    };
+
+    for (const auto &[inputUserName, expectedUserName] : tests)
+    {
+        QString userName = inputUserName;
+        stripUserName(userName);
+
+        EXPECT_EQ(userName, expectedUserName)
+            << qUtf8Printable(userName) << " (" << qUtf8Printable(inputUserName)
+            << ") did not match expected value "
+            << qUtf8Printable(expectedUserName);
+    }
+}
+
+TEST(UtilTwitch, StripChannelName)
+{
+    struct TestCase {
+        QString inputChannelName;
+        QString expectedChannelName;
+    };
+
+    std::vector<TestCase> tests{
+        {
+            "pajlada",
+            "pajlada",
+        },
+        {
+            "Pajlada",
+            "Pajlada",
+        },
+        {
+            "@Pajlada",
+            "Pajlada",
+        },
+        {
+            "#Pajlada",
+            "Pajlada",
+        },
+        {
+            "#Pajlada,",
+            "Pajlada",
+        },
+        {
+            "#Pajlada,",
+            "Pajlada",
+        },
+        {
+            "@@Pajlada,",
+            "@Pajlada",
+        },
+        {
+            // We only strip one character off the front
+            "#@Pajlada,",
+            "@Pajlada",
+        },
+        {
+            "@@Pajlada,,",
+            "@Pajlada,",
+        },
+        {
+            "",
+            "",
+        },
+        {
+            "@",
+            "",
+        },
+        {
+            ",",
+            "",
+        },
+        {
+            // We purposefully don't handle spaces at the end, as all expected usages of this function split the message up by space and strip the parameters by themselves
+            ", ",
+            ", ",
+        },
+        {
+            // We purposefully don't handle spaces at the start, as all expected usages of this function split the message up by space and strip the parameters by themselves
+            " #",
+            " #",
+        },
+    };
+
+    for (const auto &[inputChannelName, expectedChannelName] : tests)
+    {
+        QString userName = inputChannelName;
+        stripChannelName(userName);
+
+        EXPECT_EQ(userName, expectedChannelName)
+            << qUtf8Printable(userName) << " ("
+            << qUtf8Printable(inputChannelName)
+            << ") did not match expected value "
+            << qUtf8Printable(expectedChannelName);
+    }
+}


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

- move stripUserName and stripChannelName to `util/Twitch.hpp`
- Add tests to stripUserName and stripChannelName

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
