### PR TITLE
Updated build instructions

### DIFF
--- a/BUILDING_ON_LINUX.md
+++ b/BUILDING_ON_LINUX.md
@@ -2,7 +2,7 @@
 
 Note on Qt version compatibility: If you are installing Qt from a package manager, please ensure the version you are installing is at least **Qt 5.12 or newer**.
 
-## Ubuntu 18.04
+## Ubuntu 20.04
 
 _Most likely works the same for other Debian-like distros_
 


### PR DESCRIPTION
Pull request checklist:

- [X] `CHANGELOG.md` was updated, if applicable (not applicable)

# Description

Building on Ubuntu 18.04 no longer works as documented

```
CMake Error at lib/settings/CMakeLists.txt:132 (message):
  GCC version must be at least 8.0 if using std filesystem
```

I verified the build instructions on Ubuntu 20.04 and they work as advertised.

