### PR TITLE
Downgrade back to windows-2019

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-2019, ubuntu-latest, macos-latest]
         qt-version: [5.15.2, 5.12.10]
         build-system: [qmake, cmake]
         pch: [true]
@@ -24,8 +24,8 @@ jobs:
       fail-fast: false
 
     steps:
-      - name: Set environment variables for windows-latest
-        if: matrix.os == 'windows-latest'
+      - name: Set environment variables for windows-2019
+        if: matrix.os == 'windows-2019'
         run: |
             echo "vs_version=2019" >> $GITHUB_ENV
         shell: bash


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

As per the expected changes from actions/virtual-environments#4856 - we have been randomly bumped to windows-2022, but our pre-compiled headers fail to build against this.

see: https://github.com/Felanbird/chatterino2/actions/runs/1856697316 
or https://github.com/Chatterino/chatterino2/actions/runs/1889705271


This PR moves to downgrade us back to windows-2019 as a workaround, so our windows builds actually build.

