### PR TITLE
:construction_worker: Fixed qt caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,8 +39,8 @@ jobs:
         id: cache-qt
         uses: actions/cache@v2.1.7
         with:
-          path: ../Qt
-          key: ${{ runner.os }}-QtCache-${{ matrix.qt-version }}-20210109
+          path: "${{ github.workspace }}/qt/"
+          key: ${{ runner.os }}-QtCache-${{ matrix.qt-version }}
 
       # LINUX
       - name: Install p7zip (Ubuntu)
@@ -54,6 +54,7 @@ jobs:
           cached: ${{ steps.cache-qt.outputs.cache-hit }}
           extra: --external 7z
           version: ${{ matrix.qt-version }}
+          dir: "${{ github.workspace }}/qt/"
 
       # WINDOWS
       - name: Cache conan packages part 1


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Due to a recent update to `actions/cache`, relative paths are no longer working (see https://github.com/Chatterino/chatterino2/runs/5365112238?check_suite_focus=true#step:49:2)
This PR fixes it by simply installing qt in the workspace instead of a directory higher 
