### PR TITLE
chore: use system logical core count for Ubuntu/macOS builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,7 +167,7 @@ jobs:
               -DPAJLADA_SETTINGS_USE_BOOST_FILESYSTEM=On \
               -DUSE_PRECOMPILED_HEADERS=${{ matrix.pch }} \
               ..
-            make -j$(nrpoc)
+            make -j$(nproc)
         shell: bash
 
       - name: Package - AppImage (Ubuntu)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -211,7 +211,7 @@ jobs:
             mkdir build
             cd build
             $Qt5_DIR/bin/qmake .. DEFINES+=$dateOfBuild
-            make -j8
+            make -j$(sysctl -n hw.logicalcpu)
         shell: bash
 
       - name: Build with CMake (MacOS)
@@ -224,7 +224,7 @@ jobs:
                 -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl \
                 -DUSE_PRECOMPILED_HEADERS=${{ matrix.pch }} \
                 ..
-            make -j8
+            make -j$(sysctl -n hw.logicalcpu)
         shell: bash
 
       - name: Package (MacOS)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,7 +153,7 @@ jobs:
             mkdir build
             cd build
             qmake PREFIX=/usr ..
-            make -j8
+            make -j$(nproc)
         shell: bash
 
       - name: Build with CMake (Ubuntu)
@@ -167,7 +167,7 @@ jobs:
               -DPAJLADA_SETTINGS_USE_BOOST_FILESYSTEM=On \
               -DUSE_PRECOMPILED_HEADERS=${{ matrix.pch }} \
               ..
-            make -j8
+            make -j$(nrpoc)
         shell: bash
 
       - name: Package - AppImage (Ubuntu)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@
 - Dev: Added CMake build option `BUILD_WITH_QTKEYCHAIN` to build with or without Qt5Keychain support (On by default). (#3318)
 - Dev: Added /fakemsg command for debugging (#3448)
 - Dev: Notebook::select\* functions now take an optional `focusPage` parameter (true by default) which keeps the default behaviour of selecting the page after it has been selected. If set to false, the page is _not_ focused after being selected. (#3446)
+- Dev: Use system logical core count for Ubuntu/macOS GitHub actions builds
 
 ## 2.3.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,7 +109,7 @@
 - Dev: Added CMake build option `BUILD_WITH_QTKEYCHAIN` to build with or without Qt5Keychain support (On by default). (#3318)
 - Dev: Added /fakemsg command for debugging (#3448)
 - Dev: Notebook::select\* functions now take an optional `focusPage` parameter (true by default) which keeps the default behaviour of selecting the page after it has been selected. If set to false, the page is _not_ focused after being selected. (#3446)
-- Dev: Use system logical core count for Ubuntu/macOS GitHub actions builds
+- Dev: Use system logical core count for Ubuntu/macOS GitHub actions builds. (#3602)
 
 ## 2.3.4
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

This PR aims to replace the hardcoded `-j8` make flag with a logical core count lookup. 

Ubuntu uses nproc (available on Linux), whereas macOS has to use a sysctl call. Could also use `getconf _NPROCESSORS_ONLN` as it returns the same result on both platforms.