### PR TITLE
chore: replace usages of obsolete twitch struct with backing field

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -71,8 +71,6 @@ Application::Application(Settings &_settings, Paths &_paths)
     this->fonts->fontChanged.connect([this]() {
         this->windows->layoutChannelViews();
     });
-
-    this->twitch.pubsub = this->twitch2->pubsub;
 }
 
 void Application::initialize(Settings &settings, Paths &paths)
@@ -198,7 +196,7 @@ void Application::initNm(Paths &paths)
 
 void Application::initPubsub()
 {
-    this->twitch.pubsub->signals_.moderation.chatCleared.connect(
+    this->twitch2->pubsub->signals_.moderation.chatCleared.connect(
         [this](const auto &action) {
             auto chan =
                 this->twitch2->getChannelOrEmptyByID(action.roomID);
@@ -216,7 +214,7 @@ void Application::initPubsub()
             });
         });
 
-    this->twitch.pubsub->signals_.moderation.modeChanged.connect(
+    this->twitch2->pubsub->signals_.moderation.modeChanged.connect(
         [this](const auto &action) {
             auto chan =
                 this->twitch2->getChannelOrEmptyByID(action.roomID);
@@ -243,7 +241,7 @@ void Application::initPubsub()
             });
         });
 
-    this->twitch.pubsub->signals_.moderation.moderationStateChanged.connect(
+    this->twitch2->pubsub->signals_.moderation.moderationStateChanged.connect(
         [this](const auto &action) {
             auto chan =
                 this->twitch2->getChannelOrEmptyByID(action.roomID);
@@ -265,7 +263,7 @@ void Application::initPubsub()
             });
         });
 
-    this->twitch.pubsub->signals_.moderation.userBanned.connect(
+    this->twitch2->pubsub->signals_.moderation.userBanned.connect(
         [&](const auto &action) {
             auto chan =
                 this->twitch2->getChannelOrEmptyByID(action.roomID);
@@ -282,7 +280,7 @@ void Application::initPubsub()
                 chan->addOrReplaceTimeout(msg);
             });
         });
-    this->twitch.pubsub->signals_.moderation.messageDeleted.connect(
+    this->twitch2->pubsub->signals_.moderation.messageDeleted.connect(
         [&](const auto &action) {
             auto chan =
                 this->twitch2->getChannelOrEmptyByID(action.roomID);
@@ -323,7 +321,7 @@ void Application::initPubsub()
             });
         });
 
-    this->twitch.pubsub->signals_.moderation.userUnbanned.connect(
+    this->twitch2->pubsub->signals_.moderation.userUnbanned.connect(
         [&](const auto &action) {
             auto chan =
                 this->twitch2->getChannelOrEmptyByID(action.roomID);
@@ -340,7 +338,7 @@ void Application::initPubsub()
             });
         });
 
-    this->twitch.pubsub->signals_.moderation.automodMessage.connect(
+    this->twitch2->pubsub->signals_.moderation.automodMessage.connect(
         [&](const auto &action) {
             auto chan =
                 this->twitch2->getChannelOrEmptyByID(action.roomID);
@@ -357,7 +355,7 @@ void Application::initPubsub()
             });
         });
 
-    this->twitch.pubsub->signals_.moderation.automodUserMessage.connect(
+    this->twitch2->pubsub->signals_.moderation.automodUserMessage.connect(
         [&](const auto &action) {
             auto chan =
                 this->twitch2->getChannelOrEmptyByID(action.roomID);
@@ -375,7 +373,7 @@ void Application::initPubsub()
             chan->deleteMessage(msg->id);
         });
 
-    this->twitch.pubsub->signals_.moderation.automodInfoMessage.connect(
+    this->twitch2->pubsub->signals_.moderation.automodInfoMessage.connect(
         [&](const auto &action) {
             auto chan =
                 this->twitch2->getChannelOrEmptyByID(action.roomID);
@@ -391,7 +389,7 @@ void Application::initPubsub()
             });
         });
 
-    this->twitch.pubsub->signals_.pointReward.redeemed.connect([&](auto &data) {
+    this->twitch2->pubsub->signals_.pointReward.redeemed.connect([&](auto &data) {
         QString channelId;
         if (rj::getSafe(data, "channel_id", channelId))
         {
@@ -413,12 +411,12 @@ void Application::initPubsub()
         }
     });
 
-    this->twitch.pubsub->start();
+    this->twitch2->pubsub->start();
 
     auto RequestModerationActions = [=]() {
         this->twitch2->pubsub->unlistenAllModerationActions();
         // TODO(pajlada): Unlisten to all authed topics instead of only
-        // moderation topics this->twitch.pubsub->UnlistenAllAuthedTopics();
+        // moderation topics this->twitch2->pubsub->UnlistenAllAuthedTopics();
 
         this->twitch2->pubsub->listenToWhispers(
             this->accounts->twitch.getCurrent());

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -72,7 +72,6 @@ Application::Application(Settings &_settings, Paths &_paths)
         this->windows->layoutChannelViews();
     });
 
-    this->twitch.server = this->twitch2;
     this->twitch.pubsub = this->twitch2->pubsub;
 }
 
@@ -147,7 +146,7 @@ int Application::run(QApplication &qtApp)
 {
     assert(isAppInitialized);
 
-    this->twitch.server->connect();
+    this->twitch2->connect();
 
     if (!getArgs().isFramelessEmbed)
     {
@@ -202,7 +201,7 @@ void Application::initPubsub()
     this->twitch.pubsub->signals_.moderation.chatCleared.connect(
         [this](const auto &action) {
             auto chan =
-                this->twitch.server->getChannelOrEmptyByID(action.roomID);
+                this->twitch2->getChannelOrEmptyByID(action.roomID);
             if (chan->isEmpty())
             {
                 return;
@@ -220,7 +219,7 @@ void Application::initPubsub()
     this->twitch.pubsub->signals_.moderation.modeChanged.connect(
         [this](const auto &action) {
             auto chan =
-                this->twitch.server->getChannelOrEmptyByID(action.roomID);
+                this->twitch2->getChannelOrEmptyByID(action.roomID);
             if (chan->isEmpty())
             {
                 return;
@@ -247,7 +246,7 @@ void Application::initPubsub()
     this->twitch.pubsub->signals_.moderation.moderationStateChanged.connect(
         [this](const auto &action) {
             auto chan =
-                this->twitch.server->getChannelOrEmptyByID(action.roomID);
+                this->twitch2->getChannelOrEmptyByID(action.roomID);
             if (chan->isEmpty())
             {
                 return;
@@ -269,7 +268,7 @@ void Application::initPubsub()
     this->twitch.pubsub->signals_.moderation.userBanned.connect(
         [&](const auto &action) {
             auto chan =
-                this->twitch.server->getChannelOrEmptyByID(action.roomID);
+                this->twitch2->getChannelOrEmptyByID(action.roomID);
 
             if (chan->isEmpty())
             {
@@ -286,7 +285,7 @@ void Application::initPubsub()
     this->twitch.pubsub->signals_.moderation.messageDeleted.connect(
         [&](const auto &action) {
             auto chan =
-                this->twitch.server->getChannelOrEmptyByID(action.roomID);
+                this->twitch2->getChannelOrEmptyByID(action.roomID);
 
             if (chan->isEmpty() || getSettings()->hideDeletionActions)
             {
@@ -327,7 +326,7 @@ void Application::initPubsub()
     this->twitch.pubsub->signals_.moderation.userUnbanned.connect(
         [&](const auto &action) {
             auto chan =
-                this->twitch.server->getChannelOrEmptyByID(action.roomID);
+                this->twitch2->getChannelOrEmptyByID(action.roomID);
 
             if (chan->isEmpty())
             {
@@ -344,7 +343,7 @@ void Application::initPubsub()
     this->twitch.pubsub->signals_.moderation.automodMessage.connect(
         [&](const auto &action) {
             auto chan =
-                this->twitch.server->getChannelOrEmptyByID(action.roomID);
+                this->twitch2->getChannelOrEmptyByID(action.roomID);
 
             if (chan->isEmpty())
             {
@@ -361,7 +360,7 @@ void Application::initPubsub()
     this->twitch.pubsub->signals_.moderation.automodUserMessage.connect(
         [&](const auto &action) {
             auto chan =
-                this->twitch.server->getChannelOrEmptyByID(action.roomID);
+                this->twitch2->getChannelOrEmptyByID(action.roomID);
 
             if (chan->isEmpty())
             {
@@ -379,7 +378,7 @@ void Application::initPubsub()
     this->twitch.pubsub->signals_.moderation.automodInfoMessage.connect(
         [&](const auto &action) {
             auto chan =
-                this->twitch.server->getChannelOrEmptyByID(action.roomID);
+                this->twitch2->getChannelOrEmptyByID(action.roomID);
 
             if (chan->isEmpty())
             {
@@ -396,7 +395,7 @@ void Application::initPubsub()
         QString channelId;
         if (rj::getSafe(data, "channel_id", channelId))
         {
-            auto chan = this->twitch.server->getChannelOrEmptyByID(channelId);
+            auto chan = this->twitch2->getChannelOrEmptyByID(channelId);
 
             auto reward = ChannelPointReward(data);
 
@@ -417,11 +416,11 @@ void Application::initPubsub()
     this->twitch.pubsub->start();
 
     auto RequestModerationActions = [=]() {
-        this->twitch.server->pubsub->unlistenAllModerationActions();
+        this->twitch2->pubsub->unlistenAllModerationActions();
         // TODO(pajlada): Unlisten to all authed topics instead of only
         // moderation topics this->twitch.pubsub->UnlistenAllAuthedTopics();
 
-        this->twitch.server->pubsub->listenToWhispers(
+        this->twitch2->pubsub->listenToWhispers(
             this->accounts->twitch.getCurrent());
     };
 

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -198,8 +198,7 @@ void Application::initPubsub()
 {
     this->twitch->pubsub->signals_.moderation.chatCleared.connect(
         [this](const auto &action) {
-            auto chan =
-                this->twitch->getChannelOrEmptyByID(action.roomID);
+            auto chan = this->twitch->getChannelOrEmptyByID(action.roomID);
             if (chan->isEmpty())
             {
                 return;
@@ -216,8 +215,7 @@ void Application::initPubsub()
 
     this->twitch->pubsub->signals_.moderation.modeChanged.connect(
         [this](const auto &action) {
-            auto chan =
-                this->twitch->getChannelOrEmptyByID(action.roomID);
+            auto chan = this->twitch->getChannelOrEmptyByID(action.roomID);
             if (chan->isEmpty())
             {
                 return;
@@ -243,8 +241,7 @@ void Application::initPubsub()
 
     this->twitch->pubsub->signals_.moderation.moderationStateChanged.connect(
         [this](const auto &action) {
-            auto chan =
-                this->twitch->getChannelOrEmptyByID(action.roomID);
+            auto chan = this->twitch->getChannelOrEmptyByID(action.roomID);
             if (chan->isEmpty())
             {
                 return;
@@ -265,8 +262,7 @@ void Application::initPubsub()
 
     this->twitch->pubsub->signals_.moderation.userBanned.connect(
         [&](const auto &action) {
-            auto chan =
-                this->twitch->getChannelOrEmptyByID(action.roomID);
+            auto chan = this->twitch->getChannelOrEmptyByID(action.roomID);
 
             if (chan->isEmpty())
             {
@@ -282,8 +278,7 @@ void Application::initPubsub()
         });
     this->twitch->pubsub->signals_.moderation.messageDeleted.connect(
         [&](const auto &action) {
-            auto chan =
-                this->twitch->getChannelOrEmptyByID(action.roomID);
+            auto chan = this->twitch->getChannelOrEmptyByID(action.roomID);
 
             if (chan->isEmpty() || getSettings()->hideDeletionActions)
             {
@@ -323,8 +318,7 @@ void Application::initPubsub()
 
     this->twitch->pubsub->signals_.moderation.userUnbanned.connect(
         [&](const auto &action) {
-            auto chan =
-                this->twitch->getChannelOrEmptyByID(action.roomID);
+            auto chan = this->twitch->getChannelOrEmptyByID(action.roomID);
 
             if (chan->isEmpty())
             {
@@ -340,8 +334,7 @@ void Application::initPubsub()
 
     this->twitch->pubsub->signals_.moderation.automodMessage.connect(
         [&](const auto &action) {
-            auto chan =
-                this->twitch->getChannelOrEmptyByID(action.roomID);
+            auto chan = this->twitch->getChannelOrEmptyByID(action.roomID);
 
             if (chan->isEmpty())
             {
@@ -357,8 +350,7 @@ void Application::initPubsub()
 
     this->twitch->pubsub->signals_.moderation.automodUserMessage.connect(
         [&](const auto &action) {
-            auto chan =
-                this->twitch->getChannelOrEmptyByID(action.roomID);
+            auto chan = this->twitch->getChannelOrEmptyByID(action.roomID);
 
             if (chan->isEmpty())
             {
@@ -375,8 +367,7 @@ void Application::initPubsub()
 
     this->twitch->pubsub->signals_.moderation.automodInfoMessage.connect(
         [&](const auto &action) {
-            auto chan =
-                this->twitch->getChannelOrEmptyByID(action.roomID);
+            auto chan = this->twitch->getChannelOrEmptyByID(action.roomID);
 
             if (chan->isEmpty())
             {
@@ -389,27 +380,29 @@ void Application::initPubsub()
             });
         });
 
-    this->twitch->pubsub->signals_.pointReward.redeemed.connect([&](auto &data) {
-        QString channelId;
-        if (rj::getSafe(data, "channel_id", channelId))
-        {
-            auto chan = this->twitch->getChannelOrEmptyByID(channelId);
+    this->twitch->pubsub->signals_.pointReward.redeemed.connect(
+        [&](auto &data) {
+            QString channelId;
+            if (rj::getSafe(data, "channel_id", channelId))
+            {
+                auto chan = this->twitch->getChannelOrEmptyByID(channelId);
 
-            auto reward = ChannelPointReward(data);
+                auto reward = ChannelPointReward(data);
 
-            postToThread([chan, reward] {
-                if (auto channel = dynamic_cast<TwitchChannel *>(chan.get()))
-                {
-                    channel->addChannelPointReward(reward);
-                }
-            });
-        }
-        else
-        {
-            qCDebug(chatterinoApp)
-                << "Couldn't find channel id of point reward";
-        }
-    });
+                postToThread([chan, reward] {
+                    if (auto channel =
+                            dynamic_cast<TwitchChannel *>(chan.get()))
+                    {
+                        channel->addChannelPointReward(reward);
+                    }
+                });
+            }
+            else
+            {
+                qCDebug(chatterinoApp)
+                    << "Couldn't find channel id of point reward";
+            }
+        });
 
     this->twitch->pubsub->start();
 

--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -58,7 +58,7 @@ public:
 
     CommandController *const commands{};
     NotificationController *const notifications{};
-    TwitchIrcServer *const twitch2{};
+    TwitchIrcServer *const twitch{};
     ChatterinoBadges *const chatterinoBadges{};
     FfzBadges *const ffzBadges{};
 

--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -64,12 +64,6 @@ public:
 
     /*[[deprecated]]*/ Logging *const logging{};
 
-    /// Provider-specific
-    struct {
-        /*[[deprecated("use twitch2 instead")]]*/ TwitchIrcServer *server{};
-        /*[[deprecated("use twitch2->pubsub instead")]]*/ PubSub *pubsub{};
-    } twitch;
-
 private:
     void addSingleton(Singleton *singleton);
     void initPubsub();

--- a/src/common/CompletionModel.cpp
+++ b/src/common/CompletionModel.cpp
@@ -142,13 +142,13 @@ void CompletionModel::refresh(const QString &prefix, bool isFirstWord)
     }
 
     // Bttv Global
-    for (auto &emote : *getApp()->twitch2->getBttvEmotes().emotes())
+    for (auto &emote : *getApp()->twitch->getBttvEmotes().emotes())
     {
         addString(emote.first.string, TaggedString::Type::BTTVChannelEmote);
     }
 
     // Ffz Global
-    for (auto &emote : *getApp()->twitch2->getFfzEmotes().emotes())
+    for (auto &emote : *getApp()->twitch->getFfzEmotes().emotes())
     {
         addString(emote.first.string, TaggedString::Type::FFZChannelEmote);
     }

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -48,7 +48,7 @@ void sendWhisperMessage(const QString &text)
     // Constants used here are defined in TwitchChannel.hpp
     toSend.replace(ZERO_WIDTH_JOINER, ESCAPE_TAG);
 
-    app->twitch.server->sendMessage("jtv", toSend);
+    app->twitch2->sendMessage("jtv", toSend);
 }
 
 bool appendWhisperMessageWordsLocally(const QStringList &words)
@@ -68,8 +68,8 @@ bool appendWhisperMessageWordsLocally(const QStringList &words)
 
     const auto &acc = app->accounts->twitch.getCurrent();
     const auto &accemotes = *acc->accessEmotes();
-    const auto &bttvemotes = app->twitch.server->getBttvEmotes();
-    const auto &ffzemotes = app->twitch.server->getFfzEmotes();
+    const auto &bttvemotes = app->twitch2->getBttvEmotes();
+    const auto &ffzemotes = app->twitch2->getFfzEmotes();
     auto flags = MessageElementFlags();
     auto emote = boost::optional<EmotePtr>{};
     for (int i = 2; i < words.length(); i++)
@@ -136,14 +136,14 @@ bool appendWhisperMessageWordsLocally(const QStringList &words)
     b->flags.set(MessageFlag::Whisper);
     auto messagexD = b.release();
 
-    app->twitch.server->whispersChannel->addMessage(messagexD);
+    app->twitch2->whispersChannel->addMessage(messagexD);
 
     auto overrideFlags = boost::optional<MessageFlags>(messagexD->flags);
     overrideFlags->set(MessageFlag::DoNotLog);
 
     if (getSettings()->inlineWhispers)
     {
-        app->twitch.server->forEachChannel(
+        app->twitch2->forEachChannel(
             [&messagexD, overrideFlags](ChannelPtr _channel) {
                 _channel->addMessage(messagexD, overrideFlags);
             });
@@ -723,7 +723,7 @@ void CommandController::initialize(Settings &, Paths &paths)
         auto *split = new Split(static_cast<SplitContainer *>(
             window.getNotebook().getOrAddSelectedPage()));
 
-        split->setChannel(app->twitch.server->getOrAddChannel(target));
+        split->setChannel(app->twitch2->getOrAddChannel(target));
 
         window.getNotebook().getOrAddSelectedPage()->appendSplit(split);
 

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -48,7 +48,7 @@ void sendWhisperMessage(const QString &text)
     // Constants used here are defined in TwitchChannel.hpp
     toSend.replace(ZERO_WIDTH_JOINER, ESCAPE_TAG);
 
-    app->twitch2->sendMessage("jtv", toSend);
+    app->twitch->sendMessage("jtv", toSend);
 }
 
 bool appendWhisperMessageWordsLocally(const QStringList &words)
@@ -68,8 +68,8 @@ bool appendWhisperMessageWordsLocally(const QStringList &words)
 
     const auto &acc = app->accounts->twitch.getCurrent();
     const auto &accemotes = *acc->accessEmotes();
-    const auto &bttvemotes = app->twitch2->getBttvEmotes();
-    const auto &ffzemotes = app->twitch2->getFfzEmotes();
+    const auto &bttvemotes = app->twitch->getBttvEmotes();
+    const auto &ffzemotes = app->twitch->getFfzEmotes();
     auto flags = MessageElementFlags();
     auto emote = boost::optional<EmotePtr>{};
     for (int i = 2; i < words.length(); i++)
@@ -136,14 +136,14 @@ bool appendWhisperMessageWordsLocally(const QStringList &words)
     b->flags.set(MessageFlag::Whisper);
     auto messagexD = b.release();
 
-    app->twitch2->whispersChannel->addMessage(messagexD);
+    app->twitch->whispersChannel->addMessage(messagexD);
 
     auto overrideFlags = boost::optional<MessageFlags>(messagexD->flags);
     overrideFlags->set(MessageFlag::DoNotLog);
 
     if (getSettings()->inlineWhispers)
     {
-        app->twitch2->forEachChannel(
+        app->twitch->forEachChannel(
             [&messagexD, overrideFlags](ChannelPtr _channel) {
                 _channel->addMessage(messagexD, overrideFlags);
             });
@@ -501,7 +501,7 @@ void CommandController::initialize(Settings &, Paths &paths)
             stripChannelName(channelName);
 
             ChannelPtr channelTemp =
-                getApp()->twitch2->getChannelOrEmpty(channelName);
+                getApp()->twitch->getChannelOrEmpty(channelName);
 
             if (channelTemp->isEmpty())
             {
@@ -723,7 +723,7 @@ void CommandController::initialize(Settings &, Paths &paths)
         auto *split = new Split(static_cast<SplitContainer *>(
             window.getNotebook().getOrAddSelectedPage()));
 
-        split->setChannel(app->twitch2->getOrAddChannel(target));
+        split->setChannel(app->twitch->getOrAddChannel(target));
 
         window.getNotebook().getOrAddSelectedPage()->appendSplit(split);
 
@@ -907,7 +907,7 @@ void CommandController::initialize(Settings &, Paths &paths)
         });
 
     this->registerCommand("/raw", [](const QStringList &words, ChannelPtr) {
-        getApp()->twitch2->sendRawMessage(words.mid(1).join(" "));
+        getApp()->twitch->sendRawMessage(words.mid(1).join(" "));
         return "";
     });
 #ifndef NDEBUG
@@ -922,7 +922,7 @@ void CommandController::initialize(Settings &, Paths &paths)
                 return "";
             }
             auto ircText = words.mid(1).join(" ");
-            getApp()->twitch2->addFakeMessage(ircText);
+            getApp()->twitch->addFakeMessage(ircText);
             return "";
         });
 #endif

--- a/src/controllers/filters/parser/FilterParser.cpp
+++ b/src/controllers/filters/parser/FilterParser.cpp
@@ -10,7 +10,7 @@ namespace filterparser {
 ContextMap buildContextMap(const MessagePtr &m, chatterino::Channel *channel)
 {
     auto watchingChannel =
-        chatterino::getApp()->twitch.server->watchingChannel.get();
+        chatterino::getApp()->twitch2->watchingChannel.get();
 
     /* Known Identifiers
      *

--- a/src/controllers/filters/parser/FilterParser.cpp
+++ b/src/controllers/filters/parser/FilterParser.cpp
@@ -10,7 +10,7 @@ namespace filterparser {
 ContextMap buildContextMap(const MessagePtr &m, chatterino::Channel *channel)
 {
     auto watchingChannel =
-        chatterino::getApp()->twitch2->watchingChannel.get();
+        chatterino::getApp()->twitch->watchingChannel.get();
 
     /* Known Identifiers
      *

--- a/src/controllers/filters/parser/FilterParser.cpp
+++ b/src/controllers/filters/parser/FilterParser.cpp
@@ -9,8 +9,7 @@ namespace filterparser {
 
 ContextMap buildContextMap(const MessagePtr &m, chatterino::Channel *channel)
 {
-    auto watchingChannel =
-        chatterino::getApp()->twitch->watchingChannel.get();
+    auto watchingChannel = chatterino::getApp()->twitch->watchingChannel.get();
 
     /* Known Identifiers
      *

--- a/src/controllers/notifications/NotificationController.cpp
+++ b/src/controllers/notifications/NotificationController.cpp
@@ -163,7 +163,7 @@ void NotificationController::fetchFakeChannels()
     for (std::vector<int>::size_type i = 0;
          i != channelMap[Platform::Twitch].raw().size(); i++)
     {
-        auto chan = getApp()->twitch.server->getChannelOrEmpty(
+        auto chan = getApp()->twitch2->getChannelOrEmpty(
             channelMap[Platform::Twitch].raw()[i]);
         if (chan->isEmpty())
         {

--- a/src/controllers/notifications/NotificationController.cpp
+++ b/src/controllers/notifications/NotificationController.cpp
@@ -163,7 +163,7 @@ void NotificationController::fetchFakeChannels()
     for (std::vector<int>::size_type i = 0;
          i != channelMap[Platform::Twitch].raw().size(); i++)
     {
-        auto chan = getApp()->twitch2->getChannelOrEmpty(
+        auto chan = getApp()->twitch->getChannelOrEmpty(
             channelMap[Platform::Twitch].raw()[i]);
         if (chan->isEmpty())
         {
@@ -236,7 +236,7 @@ void NotificationController::checkStream(bool live, QString channelName)
     }
     MessageBuilder builder;
     TwitchMessageBuilder::liveMessage(channelName, &builder);
-    getApp()->twitch2->liveChannel->addMessage(builder.release());
+    getApp()->twitch->liveChannel->addMessage(builder.release());
 
     // Indicate that we have pushed notifications for this stream
     fakeTwitchChannels.push_back(channelName);

--- a/src/providers/irc/IrcServer.cpp
+++ b/src/providers/irc/IrcServer.cpp
@@ -195,7 +195,7 @@ void IrcServer::privateMessageReceived(Communi::IrcPrivateMessage *message)
 
             if (highlighted && showInMentions)
             {
-                getApp()->twitch2->mentionsChannel->addMessage(msg);
+                getApp()->twitch->mentionsChannel->addMessage(msg);
             }
         }
         else

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -887,8 +887,8 @@ void IrcMessageHandler::handleNoticeMessage(Communi::IrcNoticeMessage *message)
 
 void IrcMessageHandler::handleJoinMessage(Communi::IrcMessage *message)
 {
-    auto channel = getApp()->twitch->getChannelOrEmpty(
-        message->parameter(0).remove(0, 1));
+    auto channel =
+        getApp()->twitch->getChannelOrEmpty(message->parameter(0).remove(0, 1));
 
     auto *twitchChannel = dynamic_cast<TwitchChannel *>(channel.get());
     if (!twitchChannel)
@@ -906,8 +906,8 @@ void IrcMessageHandler::handleJoinMessage(Communi::IrcMessage *message)
 
 void IrcMessageHandler::handlePartMessage(Communi::IrcMessage *message)
 {
-    auto channel = getApp()->twitch->getChannelOrEmpty(
-        message->parameter(0).remove(0, 1));
+    auto channel =
+        getApp()->twitch->getChannelOrEmpty(message->parameter(0).remove(0, 1));
 
     auto *twitchChannel = dynamic_cast<TwitchChannel *>(channel.get());
     if (!twitchChannel)

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -343,7 +343,7 @@ void IrcMessageHandler::handleRoomStateMessage(Communi::IrcMessage *message)
     {
         return;
     }
-    auto chan = getApp()->twitch2->getChannelOrEmpty(chanName);
+    auto chan = getApp()->twitch->getChannelOrEmpty(chanName);
 
     auto *twitchChannel = dynamic_cast<TwitchChannel *>(chan.get());
     if (!twitchChannel)
@@ -404,7 +404,7 @@ void IrcMessageHandler::handleClearChatMessage(Communi::IrcMessage *message)
     }
 
     // get channel
-    auto chan = getApp()->twitch2->getChannelOrEmpty(chanName);
+    auto chan = getApp()->twitch->getChannelOrEmpty(chanName);
 
     if (chan->isEmpty())
     {
@@ -463,7 +463,7 @@ void IrcMessageHandler::handleClearMessageMessage(Communi::IrcMessage *message)
     }
 
     // get channel
-    auto chan = getApp()->twitch2->getChannelOrEmpty(chanName);
+    auto chan = getApp()->twitch->getChannelOrEmpty(chanName);
 
     if (chan->isEmpty())
     {
@@ -510,7 +510,7 @@ void IrcMessageHandler::handleUserStateMessage(Communi::IrcMessage *message)
         return;
     }
 
-    auto c = getApp()->twitch2->getChannelOrEmpty(channelName);
+    auto c = getApp()->twitch->getChannelOrEmpty(channelName);
     if (c->isEmpty())
     {
         return;
@@ -565,7 +565,7 @@ void IrcMessageHandler::handleWhisperMessage(Communi::IrcMessage *message)
 
     args.isReceivedWhisper = true;
 
-    auto c = getApp()->twitch2->whispersChannel.get();
+    auto c = getApp()->twitch->whispersChannel.get();
 
     TwitchMessageBuilder builder(
         c, message, args,
@@ -581,11 +581,11 @@ void IrcMessageHandler::handleWhisperMessage(Communi::IrcMessage *message)
     MessagePtr _message = builder.build();
     builder.triggerHighlights();
 
-    getApp()->twitch2->lastUserThatWhisperedMe.set(builder.userName);
+    getApp()->twitch->lastUserThatWhisperedMe.set(builder.userName);
 
     if (_message->flags.has(MessageFlag::Highlighted))
     {
-        getApp()->twitch2->mentionsChannel->addMessage(_message);
+        getApp()->twitch->mentionsChannel->addMessage(_message);
     }
 
     c->addMessage(_message);
@@ -596,7 +596,7 @@ void IrcMessageHandler::handleWhisperMessage(Communi::IrcMessage *message)
 
     if (getSettings()->inlineWhispers)
     {
-        getApp()->twitch2->forEachChannel(
+        getApp()->twitch->forEachChannel(
             [&_message, overrideFlags](ChannelPtr channel) {
                 channel->addMessage(_message, overrideFlags);
             });
@@ -797,7 +797,7 @@ void IrcMessageHandler::handleNoticeMessage(Communi::IrcNoticeMessage *message)
         {
             // Notice wasn't targeted at a single channel, send to all twitch
             // channels
-            getApp()->twitch2->forEachChannelAndSpecialChannels(
+            getApp()->twitch->forEachChannelAndSpecialChannels(
                 [msg](const auto &c) {
                     c->addMessage(msg);
                 });
@@ -805,7 +805,7 @@ void IrcMessageHandler::handleNoticeMessage(Communi::IrcNoticeMessage *message)
             return;
         }
 
-        auto channel = getApp()->twitch2->getChannelOrEmpty(channelName);
+        auto channel = getApp()->twitch->getChannelOrEmpty(channelName);
 
         if (channel->isEmpty())
         {
@@ -887,7 +887,7 @@ void IrcMessageHandler::handleNoticeMessage(Communi::IrcNoticeMessage *message)
 
 void IrcMessageHandler::handleJoinMessage(Communi::IrcMessage *message)
 {
-    auto channel = getApp()->twitch2->getChannelOrEmpty(
+    auto channel = getApp()->twitch->getChannelOrEmpty(
         message->parameter(0).remove(0, 1));
 
     auto *twitchChannel = dynamic_cast<TwitchChannel *>(channel.get());
@@ -906,7 +906,7 @@ void IrcMessageHandler::handleJoinMessage(Communi::IrcMessage *message)
 
 void IrcMessageHandler::handlePartMessage(Communi::IrcMessage *message)
 {
-    auto channel = getApp()->twitch2->getChannelOrEmpty(
+    auto channel = getApp()->twitch->getChannelOrEmpty(
         message->parameter(0).remove(0, 1));
 
     auto *twitchChannel = dynamic_cast<TwitchChannel *>(channel.get());

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -343,7 +343,7 @@ void IrcMessageHandler::handleRoomStateMessage(Communi::IrcMessage *message)
     {
         return;
     }
-    auto chan = getApp()->twitch.server->getChannelOrEmpty(chanName);
+    auto chan = getApp()->twitch2->getChannelOrEmpty(chanName);
 
     auto *twitchChannel = dynamic_cast<TwitchChannel *>(chan.get());
     if (!twitchChannel)
@@ -404,7 +404,7 @@ void IrcMessageHandler::handleClearChatMessage(Communi::IrcMessage *message)
     }
 
     // get channel
-    auto chan = getApp()->twitch.server->getChannelOrEmpty(chanName);
+    auto chan = getApp()->twitch2->getChannelOrEmpty(chanName);
 
     if (chan->isEmpty())
     {
@@ -463,7 +463,7 @@ void IrcMessageHandler::handleClearMessageMessage(Communi::IrcMessage *message)
     }
 
     // get channel
-    auto chan = getApp()->twitch.server->getChannelOrEmpty(chanName);
+    auto chan = getApp()->twitch2->getChannelOrEmpty(chanName);
 
     if (chan->isEmpty())
     {
@@ -510,7 +510,7 @@ void IrcMessageHandler::handleUserStateMessage(Communi::IrcMessage *message)
         return;
     }
 
-    auto c = getApp()->twitch.server->getChannelOrEmpty(channelName);
+    auto c = getApp()->twitch2->getChannelOrEmpty(channelName);
     if (c->isEmpty())
     {
         return;
@@ -565,7 +565,7 @@ void IrcMessageHandler::handleWhisperMessage(Communi::IrcMessage *message)
 
     args.isReceivedWhisper = true;
 
-    auto c = getApp()->twitch.server->whispersChannel.get();
+    auto c = getApp()->twitch2->whispersChannel.get();
 
     TwitchMessageBuilder builder(
         c, message, args,
@@ -581,11 +581,11 @@ void IrcMessageHandler::handleWhisperMessage(Communi::IrcMessage *message)
     MessagePtr _message = builder.build();
     builder.triggerHighlights();
 
-    getApp()->twitch.server->lastUserThatWhisperedMe.set(builder.userName);
+    getApp()->twitch2->lastUserThatWhisperedMe.set(builder.userName);
 
     if (_message->flags.has(MessageFlag::Highlighted))
     {
-        getApp()->twitch.server->mentionsChannel->addMessage(_message);
+        getApp()->twitch2->mentionsChannel->addMessage(_message);
     }
 
     c->addMessage(_message);
@@ -596,7 +596,7 @@ void IrcMessageHandler::handleWhisperMessage(Communi::IrcMessage *message)
 
     if (getSettings()->inlineWhispers)
     {
-        getApp()->twitch.server->forEachChannel(
+        getApp()->twitch2->forEachChannel(
             [&_message, overrideFlags](ChannelPtr channel) {
                 channel->addMessage(_message, overrideFlags);
             });
@@ -797,7 +797,7 @@ void IrcMessageHandler::handleNoticeMessage(Communi::IrcNoticeMessage *message)
         {
             // Notice wasn't targeted at a single channel, send to all twitch
             // channels
-            getApp()->twitch.server->forEachChannelAndSpecialChannels(
+            getApp()->twitch2->forEachChannelAndSpecialChannels(
                 [msg](const auto &c) {
                     c->addMessage(msg);
                 });
@@ -805,7 +805,7 @@ void IrcMessageHandler::handleNoticeMessage(Communi::IrcNoticeMessage *message)
             return;
         }
 
-        auto channel = getApp()->twitch.server->getChannelOrEmpty(channelName);
+        auto channel = getApp()->twitch2->getChannelOrEmpty(channelName);
 
         if (channel->isEmpty())
         {
@@ -887,7 +887,7 @@ void IrcMessageHandler::handleNoticeMessage(Communi::IrcNoticeMessage *message)
 
 void IrcMessageHandler::handleJoinMessage(Communi::IrcMessage *message)
 {
-    auto channel = getApp()->twitch.server->getChannelOrEmpty(
+    auto channel = getApp()->twitch2->getChannelOrEmpty(
         message->parameter(0).remove(0, 1));
 
     auto *twitchChannel = dynamic_cast<TwitchChannel *>(channel.get());
@@ -906,7 +906,7 @@ void IrcMessageHandler::handleJoinMessage(Communi::IrcMessage *message)
 
 void IrcMessageHandler::handlePartMessage(Communi::IrcMessage *message)
 {
-    auto channel = getApp()->twitch.server->getChannelOrEmpty(
+    auto channel = getApp()->twitch2->getChannelOrEmpty(
         message->parameter(0).remove(0, 1));
 
     auto *twitchChannel = dynamic_cast<TwitchChannel *>(channel.get());

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -482,7 +482,7 @@ bool TwitchChannel::canReconnect() const
 
 void TwitchChannel::reconnect()
 {
-    getApp()->twitch.server->connect();
+    getApp()->twitch2->connect();
 }
 
 QString TwitchChannel::roomId() const

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -877,8 +877,7 @@ void TwitchChannel::refreshPubsub()
         return;
 
     auto account = getApp()->accounts->twitch.getCurrent();
-    getApp()->twitch->pubsub->listenToChannelModerationActions(roomId,
-                                                                account);
+    getApp()->twitch->pubsub->listenToChannelModerationActions(roomId, account);
     getApp()->twitch->pubsub->listenToAutomod(roomId, account);
     getApp()->twitch->pubsub->listenToChannelPointRewards(roomId, account);
 }

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -482,7 +482,7 @@ bool TwitchChannel::canReconnect() const
 
 void TwitchChannel::reconnect()
 {
-    getApp()->twitch2->connect();
+    getApp()->twitch->connect();
 }
 
 QString TwitchChannel::roomId() const
@@ -611,7 +611,7 @@ void TwitchChannel::setLive(bool newLiveStatus)
                 MessageBuilder builder2;
                 TwitchMessageBuilder::liveMessage(this->getDisplayName(),
                                                   &builder2);
-                getApp()->twitch2->liveChannel->addMessage(builder2.release());
+                getApp()->twitch->liveChannel->addMessage(builder2.release());
 
                 // Notify on all channels with a ping sound
                 if (getSettings()->notificationOnAnyChannel &&
@@ -631,7 +631,7 @@ void TwitchChannel::setLive(bool newLiveStatus)
 
                 // "delete" old 'CHANNEL is live' message
                 LimitedQueueSnapshot<MessagePtr> snapshot =
-                    getApp()->twitch2->liveChannel->getMessageSnapshot();
+                    getApp()->twitch->liveChannel->getMessageSnapshot();
                 int snapshotLength = snapshot.size();
 
                 // MSVC hates this code if the parens are not there
@@ -877,10 +877,10 @@ void TwitchChannel::refreshPubsub()
         return;
 
     auto account = getApp()->accounts->twitch.getCurrent();
-    getApp()->twitch2->pubsub->listenToChannelModerationActions(roomId,
+    getApp()->twitch->pubsub->listenToChannelModerationActions(roomId,
                                                                 account);
-    getApp()->twitch2->pubsub->listenToAutomod(roomId, account);
-    getApp()->twitch2->pubsub->listenToChannelPointRewards(roomId, account);
+    getApp()->twitch->pubsub->listenToAutomod(roomId, account);
+    getApp()->twitch->pubsub->listenToChannelPointRewards(roomId, account);
 }
 
 void TwitchChannel::refreshChatters()

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -972,8 +972,8 @@ Outcome TwitchMessageBuilder::tryAppendEmote(const EmoteName &name)
 {
     auto *app = getApp();
 
-    const auto &globalBttvEmotes = app->twitch2->getBttvEmotes();
-    const auto &globalFfzEmotes = app->twitch2->getFfzEmotes();
+    const auto &globalBttvEmotes = app->twitch->getBttvEmotes();
+    const auto &globalFfzEmotes = app->twitch->getFfzEmotes();
 
     auto flags = MessageElementFlags();
     auto emote = boost::optional<EmotePtr>{};

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -972,8 +972,8 @@ Outcome TwitchMessageBuilder::tryAppendEmote(const EmoteName &name)
 {
     auto *app = getApp();
 
-    const auto &globalBttvEmotes = app->twitch.server->getBttvEmotes();
-    const auto &globalFfzEmotes = app->twitch.server->getFfzEmotes();
+    const auto &globalBttvEmotes = app->twitch2->getBttvEmotes();
+    const auto &globalFfzEmotes = app->twitch2->getFfzEmotes();
 
     auto flags = MessageElementFlags();
     auto emote = boost::optional<EmotePtr>{};

--- a/src/singletons/NativeMessaging.cpp
+++ b/src/singletons/NativeMessaging.cpp
@@ -240,8 +240,8 @@ void NativeMessagingServer::ReceiverThread::handleMessage(
             postToThread([=] {
                 if (!name.isEmpty())
                 {
-                    app->twitch.server->watchingChannel.reset(
-                        app->twitch.server->getOrAddChannel(name));
+                    app->twitch2->watchingChannel.reset(
+                        app->twitch2->getOrAddChannel(name));
                 }
 
                 if (attach || attachFullscreen)
@@ -253,7 +253,7 @@ void NativeMessagingServer::ReceiverThread::handleMessage(
                     if (!name.isEmpty())
                     {
                         window->setChannel(
-                            app->twitch.server->getOrAddChannel(name));
+                            app->twitch2->getOrAddChannel(name));
                     }
 //                    }
 //                    window->show();

--- a/src/singletons/NativeMessaging.cpp
+++ b/src/singletons/NativeMessaging.cpp
@@ -252,8 +252,7 @@ void NativeMessagingServer::ReceiverThread::handleMessage(
                         AttachedWindow::get(::GetForegroundWindow(), args);
                     if (!name.isEmpty())
                     {
-                        window->setChannel(
-                            app->twitch->getOrAddChannel(name));
+                        window->setChannel(app->twitch->getOrAddChannel(name));
                     }
 //                    }
 //                    window->show();

--- a/src/singletons/NativeMessaging.cpp
+++ b/src/singletons/NativeMessaging.cpp
@@ -240,8 +240,8 @@ void NativeMessagingServer::ReceiverThread::handleMessage(
             postToThread([=] {
                 if (!name.isEmpty())
                 {
-                    app->twitch2->watchingChannel.reset(
-                        app->twitch2->getOrAddChannel(name));
+                    app->twitch->watchingChannel.reset(
+                        app->twitch->getOrAddChannel(name));
                 }
 
                 if (attach || attachFullscreen)
@@ -253,7 +253,7 @@ void NativeMessagingServer::ReceiverThread::handleMessage(
                     if (!name.isEmpty())
                     {
                         window->setChannel(
-                            app->twitch2->getOrAddChannel(name));
+                            app->twitch->getOrAddChannel(name));
                     }
 //                    }
 //                    window->show();

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -605,23 +605,23 @@ IndirectChannel WindowManager::decodeChannel(const SplitDescriptor &descriptor)
 
     if (descriptor.type_ == "twitch")
     {
-        return app->twitch2->getOrAddChannel(descriptor.channelName_);
+        return app->twitch->getOrAddChannel(descriptor.channelName_);
     }
     else if (descriptor.type_ == "mentions")
     {
-        return app->twitch2->mentionsChannel;
+        return app->twitch->mentionsChannel;
     }
     else if (descriptor.type_ == "watching")
     {
-        return app->twitch2->watchingChannel;
+        return app->twitch->watchingChannel;
     }
     else if (descriptor.type_ == "whispers")
     {
-        return app->twitch2->whispersChannel;
+        return app->twitch->whispersChannel;
     }
     else if (descriptor.type_ == "live")
     {
-        return app->twitch2->liveChannel;
+        return app->twitch->liveChannel;
     }
     else if (descriptor.type_ == "irc")
     {

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -605,23 +605,23 @@ IndirectChannel WindowManager::decodeChannel(const SplitDescriptor &descriptor)
 
     if (descriptor.type_ == "twitch")
     {
-        return app->twitch.server->getOrAddChannel(descriptor.channelName_);
+        return app->twitch2->getOrAddChannel(descriptor.channelName_);
     }
     else if (descriptor.type_ == "mentions")
     {
-        return app->twitch.server->mentionsChannel;
+        return app->twitch2->mentionsChannel;
     }
     else if (descriptor.type_ == "watching")
     {
-        return app->twitch.server->watchingChannel;
+        return app->twitch2->watchingChannel;
     }
     else if (descriptor.type_ == "whispers")
     {
-        return app->twitch.server->whispersChannel;
+        return app->twitch2->whispersChannel;
     }
     else if (descriptor.type_ == "live")
     {
-        return app->twitch.server->liveChannel;
+        return app->twitch2->liveChannel;
     }
     else if (descriptor.type_ == "irc")
     {

--- a/src/util/StreamerMode.cpp
+++ b/src/util/StreamerMode.cpp
@@ -76,7 +76,7 @@ bool isInStreamerMode()
             {
                 shouldShowWarning = false;
 
-                getApp()->twitch2->addGlobalSystemMessage(
+                getApp()->twitch->addGlobalSystemMessage(
                     "Streamer Mode is set to Automatic, but pgrep is missing. "
                     "Install it to fix the issue or set Streamer Mode to "
                     "Enabled or Disabled in the Settings.");

--- a/src/widgets/FramelessEmbedWindow.cpp
+++ b/src/widgets/FramelessEmbedWindow.cpp
@@ -49,7 +49,7 @@ bool FramelessEmbedWindow::nativeEvent(const QByteArray &eventType,
                 auto channelName = root.value("channel-name").toString();
 
                 this->split_->setChannel(
-                    getApp()->twitch2->getOrAddChannel(channelName));
+                    getApp()->twitch->getOrAddChannel(channelName));
             }
         }
     }

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -283,14 +283,14 @@ void Window::addDebugStuff(HotkeyController::HotkeyMap &actions)
         {
             doc.Parse(channelRewardMessage);
             app->twitch2->addFakeMessage(channelRewardIRCMessage);
-            app->twitch.pubsub->signals_.pointReward.redeemed.invoke(
+            app->twitch2->pubsub->signals_.pointReward.redeemed.invoke(
                 doc["data"]["message"]["data"]["redemption"]);
             alt = !alt;
         }
         else
         {
             doc.Parse(channelRewardMessage2);
-            app->twitch.pubsub->signals_.pointReward.redeemed.invoke(
+            app->twitch2->pubsub->signals_.pointReward.redeemed.invoke(
                 doc["data"]["message"]["data"]["redemption"]);
             alt = !alt;
         }

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -254,7 +254,7 @@ void Window::addDebugStuff(HotkeyController::HotkeyMap &actions)
         static int index = 0;
         auto app = getApp();
         const auto &msg = messages[index++ % messages.size()];
-        app->twitch2->addFakeMessage(msg);
+        app->twitch->addFakeMessage(msg);
         return "";
     });
 
@@ -262,7 +262,7 @@ void Window::addDebugStuff(HotkeyController::HotkeyMap &actions)
         const auto &messages = cheerMessages;
         static int index = 0;
         const auto &msg = messages[index++ % messages.size()];
-        getApp()->twitch2->addFakeMessage(msg);
+        getApp()->twitch->addFakeMessage(msg);
         return "";
     });
 
@@ -271,7 +271,7 @@ void Window::addDebugStuff(HotkeyController::HotkeyMap &actions)
         static int index = 0;
         auto app = getApp();
         const auto &msg = messages[index++ % messages.size()];
-        app->twitch2->addFakeMessage(msg);
+        app->twitch->addFakeMessage(msg);
         return "";
     });
 
@@ -282,15 +282,15 @@ void Window::addDebugStuff(HotkeyController::HotkeyMap &actions)
         if (alt)
         {
             doc.Parse(channelRewardMessage);
-            app->twitch2->addFakeMessage(channelRewardIRCMessage);
-            app->twitch2->pubsub->signals_.pointReward.redeemed.invoke(
+            app->twitch->addFakeMessage(channelRewardIRCMessage);
+            app->twitch->pubsub->signals_.pointReward.redeemed.invoke(
                 doc["data"]["message"]["data"]["redemption"]);
             alt = !alt;
         }
         else
         {
             doc.Parse(channelRewardMessage2);
-            app->twitch2->pubsub->signals_.pointReward.redeemed.invoke(
+            app->twitch->pubsub->signals_.pointReward.redeemed.invoke(
                 doc["data"]["message"]["data"]["redemption"]);
             alt = !alt;
         }
@@ -301,7 +301,7 @@ void Window::addDebugStuff(HotkeyController::HotkeyMap &actions)
         const auto &messages = emoteTestMessages;
         static int index = 0;
         const auto &msg = messages[index++ % messages.size()];
-        getApp()->twitch2->addFakeMessage(msg);
+        getApp()->twitch->addFakeMessage(msg);
         return "";
     });
 #endif
@@ -466,7 +466,7 @@ void Window::addShortcuts()
              this->notebook_->select(splitContainer);
              Split *split = new Split(splitContainer);
              split->setChannel(
-                 getApp()->twitch2->getOrAddChannel(si.channelName));
+                 getApp()->twitch->getOrAddChannel(si.channelName));
              split->setFilters(si.filters);
              splitContainer->appendSplit(split);
              return "";

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -254,7 +254,7 @@ void Window::addDebugStuff(HotkeyController::HotkeyMap &actions)
         static int index = 0;
         auto app = getApp();
         const auto &msg = messages[index++ % messages.size()];
-        app->twitch.server->addFakeMessage(msg);
+        app->twitch2->addFakeMessage(msg);
         return "";
     });
 
@@ -262,7 +262,7 @@ void Window::addDebugStuff(HotkeyController::HotkeyMap &actions)
         const auto &messages = cheerMessages;
         static int index = 0;
         const auto &msg = messages[index++ % messages.size()];
-        getApp()->twitch.server->addFakeMessage(msg);
+        getApp()->twitch2->addFakeMessage(msg);
         return "";
     });
 
@@ -271,7 +271,7 @@ void Window::addDebugStuff(HotkeyController::HotkeyMap &actions)
         static int index = 0;
         auto app = getApp();
         const auto &msg = messages[index++ % messages.size()];
-        app->twitch.server->addFakeMessage(msg);
+        app->twitch2->addFakeMessage(msg);
         return "";
     });
 
@@ -282,7 +282,7 @@ void Window::addDebugStuff(HotkeyController::HotkeyMap &actions)
         if (alt)
         {
             doc.Parse(channelRewardMessage);
-            app->twitch.server->addFakeMessage(channelRewardIRCMessage);
+            app->twitch2->addFakeMessage(channelRewardIRCMessage);
             app->twitch.pubsub->signals_.pointReward.redeemed.invoke(
                 doc["data"]["message"]["data"]["redemption"]);
             alt = !alt;
@@ -301,7 +301,7 @@ void Window::addDebugStuff(HotkeyController::HotkeyMap &actions)
         const auto &messages = emoteTestMessages;
         static int index = 0;
         const auto &msg = messages[index++ % messages.size()];
-        getApp()->twitch.server->addFakeMessage(msg);
+        getApp()->twitch2->addFakeMessage(msg);
         return "";
     });
 #endif
@@ -466,7 +466,7 @@ void Window::addShortcuts()
              this->notebook_->select(splitContainer);
              Split *split = new Split(splitContainer);
              split->setChannel(
-                 getApp()->twitch.server->getOrAddChannel(si.channelName));
+                 getApp()->twitch2->getOrAddChannel(si.channelName));
              split->setFilters(si.filters);
              splitContainer->appendSplit(split);
              return "";

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -341,9 +341,9 @@ void EmotePopup::loadChannel(ChannelPtr channel)
         *globalChannel, *subChannel, this->channel_->getName());
 
     // global
-    addEmotes(*globalChannel, *getApp()->twitch2->getBttvEmotes().emotes(),
+    addEmotes(*globalChannel, *getApp()->twitch->getBttvEmotes().emotes(),
               "BetterTTV", MessageElementFlag::BttvEmote);
-    addEmotes(*globalChannel, *getApp()->twitch2->getFfzEmotes().emotes(),
+    addEmotes(*globalChannel, *getApp()->twitch->getFfzEmotes().emotes(),
               "FrankerFaceZ", MessageElementFlag::FfzEmote);
 
     // channel
@@ -406,9 +406,9 @@ void EmotePopup::filterTwitchEmotes(std::shared_ptr<Channel> searchChannel,
     }
 
     auto bttvGlobalEmotes = this->filterEmoteMap(
-        searchText, getApp()->twitch2->getBttvEmotes().emotes());
+        searchText, getApp()->twitch->getBttvEmotes().emotes());
     auto ffzGlobalEmotes = this->filterEmoteMap(
-        searchText, getApp()->twitch2->getFfzEmotes().emotes());
+        searchText, getApp()->twitch->getFfzEmotes().emotes());
 
     // twitch
     addEmoteSets(twitchGlobalEmotes, *searchChannel, *searchChannel,

--- a/src/widgets/dialogs/SelectChannelDialog.cpp
+++ b/src/widgets/dialogs/SelectChannelDialog.cpp
@@ -350,24 +350,24 @@ IndirectChannel SelectChannelDialog::getSelectedChannel() const
         case TAB_TWITCH: {
             if (this->ui_.twitch.channel->isChecked())
             {
-                return app->twitch.server->getOrAddChannel(
+                return app->twitch2->getOrAddChannel(
                     this->ui_.twitch.channelName->text().trimmed());
             }
             else if (this->ui_.twitch.watching->isChecked())
             {
-                return app->twitch.server->watchingChannel;
+                return app->twitch2->watchingChannel;
             }
             else if (this->ui_.twitch.mentions->isChecked())
             {
-                return app->twitch.server->mentionsChannel;
+                return app->twitch2->mentionsChannel;
             }
             else if (this->ui_.twitch.whispers->isChecked())
             {
-                return app->twitch.server->whispersChannel;
+                return app->twitch2->whispersChannel;
             }
             else if (this->ui_.twitch.live->isChecked())
             {
-                return app->twitch.server->liveChannel;
+                return app->twitch2->liveChannel;
             }
         }
         break;

--- a/src/widgets/dialogs/SelectChannelDialog.cpp
+++ b/src/widgets/dialogs/SelectChannelDialog.cpp
@@ -350,24 +350,24 @@ IndirectChannel SelectChannelDialog::getSelectedChannel() const
         case TAB_TWITCH: {
             if (this->ui_.twitch.channel->isChecked())
             {
-                return app->twitch2->getOrAddChannel(
+                return app->twitch->getOrAddChannel(
                     this->ui_.twitch.channelName->text().trimmed());
             }
             else if (this->ui_.twitch.watching->isChecked())
             {
-                return app->twitch2->watchingChannel;
+                return app->twitch->watchingChannel;
             }
             else if (this->ui_.twitch.mentions->isChecked())
             {
-                return app->twitch2->mentionsChannel;
+                return app->twitch->mentionsChannel;
             }
             else if (this->ui_.twitch.whispers->isChecked())
             {
-                return app->twitch2->whispersChannel;
+                return app->twitch->whispersChannel;
             }
             else if (this->ui_.twitch.live->isChecked())
             {
-                return app->twitch2->liveChannel;
+                return app->twitch->liveChannel;
             }
         }
         break;

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -301,7 +301,7 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically, QWidget *parent)
                                 auto split = window.getNotebook()
                                                  .getOrAddSelectedPage()
                                                  ->appendNewSplit(false);
-                                split->setChannel(app->twitch2->getOrAddChannel(
+                                split->setChannel(app->twitch->getOrAddChannel(
                                     loginName.toLower()));
                             });
 

--- a/src/widgets/dialogs/switcher/NewTabItem.cpp
+++ b/src/widgets/dialogs/switcher/NewTabItem.cpp
@@ -26,7 +26,7 @@ void NewTabItem::action()
 
     Split *split = new Split(container);
     split->setChannel(
-        getApp()->twitch2->getOrAddChannel(this->channelName_));
+        getApp()->twitch->getOrAddChannel(this->channelName_));
     container->appendSplit(split);
 }
 

--- a/src/widgets/dialogs/switcher/NewTabItem.cpp
+++ b/src/widgets/dialogs/switcher/NewTabItem.cpp
@@ -25,8 +25,7 @@ void NewTabItem::action()
     SplitContainer *container = nb.addPage(true);
 
     Split *split = new Split(container);
-    split->setChannel(
-        getApp()->twitch->getOrAddChannel(this->channelName_));
+    split->setChannel(getApp()->twitch->getOrAddChannel(this->channelName_));
     container->appendSplit(split);
 }
 

--- a/src/widgets/dialogs/switcher/NewTabItem.cpp
+++ b/src/widgets/dialogs/switcher/NewTabItem.cpp
@@ -26,7 +26,7 @@ void NewTabItem::action()
 
     Split *split = new Split(container);
     split->setChannel(
-        getApp()->twitch.server->getOrAddChannel(this->channelName_));
+        getApp()->twitch2->getOrAddChannel(this->channelName_));
     container->appendSplit(split);
 }
 

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1016,15 +1016,15 @@ MessageElementFlags ChannelView::getFlags() const
         {
             flags.set(MessageElementFlag::ModeratorTools);
         }
-        if (this->underlyingChannel_ == app->twitch.server->mentionsChannel ||
-            this->underlyingChannel_ == app->twitch.server->liveChannel)
+        if (this->underlyingChannel_ == app->twitch2->mentionsChannel ||
+            this->underlyingChannel_ == app->twitch2->liveChannel)
         {
             flags.set(MessageElementFlag::ChannelName);
             flags.unset(MessageElementFlag::ChannelPointReward);
         }
     }
 
-    if (this->sourceChannel_ == app->twitch.server->mentionsChannel)
+    if (this->sourceChannel_ == app->twitch2->mentionsChannel)
         flags.set(MessageElementFlag::ChannelName);
 
     return flags;
@@ -1072,7 +1072,7 @@ void ChannelView::drawMessages(QPainter &painter)
 
     auto app = getApp();
     bool isMentions =
-        this->underlyingChannel_ == app->twitch.server->mentionsChannel;
+        this->underlyingChannel_ == app->twitch2->mentionsChannel;
 
     for (size_t i = start; i < messagesSnapshot.size(); ++i)
     {

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1071,8 +1071,7 @@ void ChannelView::drawMessages(QPainter &painter)
     bool windowFocused = this->window() == QApplication::activeWindow();
 
     auto app = getApp();
-    bool isMentions =
-        this->underlyingChannel_ == app->twitch->mentionsChannel;
+    bool isMentions = this->underlyingChannel_ == app->twitch->mentionsChannel;
 
     for (size_t i = start; i < messagesSnapshot.size(); ++i)
     {

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1016,15 +1016,15 @@ MessageElementFlags ChannelView::getFlags() const
         {
             flags.set(MessageElementFlag::ModeratorTools);
         }
-        if (this->underlyingChannel_ == app->twitch2->mentionsChannel ||
-            this->underlyingChannel_ == app->twitch2->liveChannel)
+        if (this->underlyingChannel_ == app->twitch->mentionsChannel ||
+            this->underlyingChannel_ == app->twitch->liveChannel)
         {
             flags.set(MessageElementFlag::ChannelName);
             flags.unset(MessageElementFlag::ChannelPointReward);
         }
     }
 
-    if (this->sourceChannel_ == app->twitch2->mentionsChannel)
+    if (this->sourceChannel_ == app->twitch->mentionsChannel)
         flags.set(MessageElementFlag::ChannelName);
 
     return flags;
@@ -1072,7 +1072,7 @@ void ChannelView::drawMessages(QPainter &painter)
 
     auto app = getApp();
     bool isMentions =
-        this->underlyingChannel_ == app->twitch2->mentionsChannel;
+        this->underlyingChannel_ == app->twitch->mentionsChannel;
 
     for (size_t i = start; i < messagesSnapshot.size(); ++i)
     {

--- a/src/widgets/splits/InputCompletionPopup.cpp
+++ b/src/widgets/splits/InputCompletionPopup.cpp
@@ -106,9 +106,9 @@ void InputCompletionPopup::updateEmotes(const QString &text, ChannelPtr channel)
                 addEmotes(emotes, *ffz, text, "Channel FrankerFaceZ");
         }
 
-        if (auto bttvG = getApp()->twitch2->getBttvEmotes().emotes())
+        if (auto bttvG = getApp()->twitch->getBttvEmotes().emotes())
             addEmotes(emotes, *bttvG, text, "Global BetterTTV");
-        if (auto ffzG = getApp()->twitch2->getFfzEmotes().emotes())
+        if (auto ffzG = getApp()->twitch->getFfzEmotes().emotes())
             addEmotes(emotes, *ffzG, text, "Global FrankerFaceZ");
 
         addEmojis(emotes, getApp()->emotes->emojis.emojis, text);

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -125,8 +125,7 @@ Split::Split(QWidget *parent)
     this->view_->openChannelIn.connect([this](
                                            QString twitchChannel,
                                            FromTwitchLinkOpenChannelIn openIn) {
-        ChannelPtr channel =
-            getApp()->twitch->getOrAddChannel(twitchChannel);
+        ChannelPtr channel = getApp()->twitch->getOrAddChannel(twitchChannel);
         switch (openIn)
         {
             case FromTwitchLinkOpenChannelIn::Split:

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -126,7 +126,7 @@ Split::Split(QWidget *parent)
                                            QString twitchChannel,
                                            FromTwitchLinkOpenChannelIn openIn) {
         ChannelPtr channel =
-            getApp()->twitch2->getOrAddChannel(twitchChannel);
+            getApp()->twitch->getOrAddChannel(twitchChannel);
         switch (openIn)
         {
             case FromTwitchLinkOpenChannelIn::Split:

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -126,7 +126,7 @@ Split::Split(QWidget *parent)
                                            QString twitchChannel,
                                            FromTwitchLinkOpenChannelIn openIn) {
         ChannelPtr channel =
-            getApp()->twitch.server->getOrAddChannel(twitchChannel);
+            getApp()->twitch2->getOrAddChannel(twitchChannel);
         switch (openIn)
         {
             case FromTwitchLinkOpenChannelIn::Split:

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -687,7 +687,7 @@ void SplitInput::editTextChanged()
     if (text.startsWith("/r ", Qt::CaseInsensitive) &&
         this->split_->getChannel()->isTwitchChannel())
     {
-        QString lastUser = app->twitch2->lastUserThatWhisperedMe.get();
+        QString lastUser = app->twitch->lastUserThatWhisperedMe.get();
         if (!lastUser.isEmpty())
         {
             this->ui_.textEdit->setPlainText("/w " + lastUser + text.mid(2));

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -687,7 +687,7 @@ void SplitInput::editTextChanged()
     if (text.startsWith("/r ", Qt::CaseInsensitive) &&
         this->split_->getChannel()->isTwitchChannel())
     {
-        QString lastUser = app->twitch.server->lastUserThatWhisperedMe.get();
+        QString lastUser = app->twitch2->lastUserThatWhisperedMe.get();
         if (!lastUser.isEmpty())
         {
             this->ui_.textEdit->setPlainText("/w " + lastUser + text.mid(2));


### PR DESCRIPTION
Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable

# Description

This PR aims to replace usages of `Application#twitch` with `Application#twitch2` as it was marked as obsolete. The name of `twitch2` has been changed to `twitch` for clarity.