### PR TITLE
Add the ability to lock NotebookTab layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 - Minor: Make Tab Layout setting only accept predefined values (#3564)
 - Minor: Added librewolf, icecat, and waterfox incognito support. (#3588)
 - Minor: Updated to Emoji v14.0 (#3612)
+- Minor: Add support for locking tab arrangement (#3627)
 - Bugfix: Fix Split Input hotkeys not being available when input is hidden (#3362)
 - Bugfix: Fixed colored usernames sometimes not working. (#3170)
 - Bugfix: Restored ability to send duplicate `/me` messages. (#3166)

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -386,6 +386,7 @@ public:
     BoolSetting askOnImageUpload = {"/misc/askOnImageUpload", true};
     BoolSetting informOnTabVisibilityToggle = {"/misc/askOnTabVisibilityToggle",
                                                true};
+    BoolSetting lockNotebookLayout = {"/misc/lockNotebookLayout", false};
 
     /// Debug
     BoolSetting showUnhandledIrcMessages = {"/debug/showUnhandledIrcMessages",

--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -41,22 +41,22 @@ Notebook::Notebook(QWidget *parent)
         },
         QKeySequence("Ctrl+U"));
 
-    lockNotebookLayoutAction_ = new QAction("Lock Tab Layout", &this->menu_);
+    this->lockNotebookLayoutAction_ = new QAction("Lock Tab Layout", &this->menu_);
 
     // Load lock notebook layout state from settings
     this->setLockNotebookLayout(getSettings()->lockNotebookLayout.getValue());
 
-    lockNotebookLayoutAction_->setCheckable(true);
-    lockNotebookLayoutAction_->setChecked(this->lockNotebookLayout_);
+    this->lockNotebookLayoutAction_->setCheckable(true);
+    this->lockNotebookLayoutAction_->setChecked(this->lockNotebookLayout_);
 
     // Update lockNotebookLayout_ value anytime the user changes the checkbox state
-    QObject::connect(lockNotebookLayoutAction_, &QAction::triggered,
+    QObject::connect(this->lockNotebookLayoutAction_, &QAction::triggered,
                      [this](bool value) {
                          this->setLockNotebookLayout(value);
                      });
 
     // Append it to our current menu actions
-    this->menu_.addAction(lockNotebookLayoutAction_);
+    this->menu_.addAction(this->lockNotebookLayoutAction_);
 }
 
 NotebookTab *Notebook::addPage(QWidget *page, QString title, bool select)

--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -35,7 +35,7 @@ Notebook::Notebook(QWidget *parent)
     this->addButton_->setHidden(true);
 
     this->menu_.addAction(
-        "Toggle visibility of tabs",
+        "Toggle Visibility of Tabs",
         [this]() {
             this->setShowTabs(!this->getShowTabs());
         },

--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -48,8 +48,6 @@ Notebook::Notebook(QWidget *parent)
                          this->setLockNotebookLayout(value);
                      });
 
-    // Append it to our current menu actions
-
     this->addNotebookActionsToMenu(&this->menu_);
 }
 

--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -41,7 +41,7 @@ Notebook::Notebook(QWidget *parent)
         },
         QKeySequence("Ctrl+U"));
 
-    this->lockNotebookLayoutAction_ = new QAction("Lock Tab Layout", &this->menu_);
+    this->lockNotebookLayoutAction_ = new QAction("Lock Tab Layout", this);
 
     // Load lock notebook layout state from settings
     this->setLockNotebookLayout(getSettings()->lockNotebookLayout.getValue());

--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -35,7 +35,7 @@ Notebook::Notebook(QWidget *parent)
     this->addButton_->setHidden(true);
 
     this->menu_.addAction(
-        "Toggle Visibility of Tabs",
+        "Toggle visibility of tabs",
         [this]() {
             this->setShowTabs(!this->getShowTabs());
         },

--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -34,13 +34,6 @@ Notebook::Notebook(QWidget *parent)
 
     this->addButton_->setHidden(true);
 
-    this->menu_.addAction(
-        "Toggle visibility of tabs",
-        [this]() {
-            this->setShowTabs(!this->getShowTabs());
-        },
-        QKeySequence("Ctrl+U"));
-
     this->lockNotebookLayoutAction_ = new QAction("Lock Tab Layout", this);
 
     // Load lock notebook layout state from settings
@@ -56,7 +49,8 @@ Notebook::Notebook(QWidget *parent)
                      });
 
     // Append it to our current menu actions
-    this->menu_.addAction(this->lockNotebookLayoutAction_);
+
+    this->addNotebookActionsToMenu(&this->menu_);
 }
 
 NotebookTab *Notebook::addPage(QWidget *page, QString title, bool select)
@@ -705,6 +699,18 @@ void Notebook::setLockNotebookLayout(bool value)
     this->lockNotebookLayout_ = value;
     this->lockNotebookLayoutAction_->setChecked(value);
     getSettings()->lockNotebookLayout.setValue(value);
+}
+
+void Notebook::addNotebookActionsToMenu(QMenu *menu)
+{
+    menu->addAction(
+        "Toggle visibility of tabs",
+        [this]() {
+            this->setShowTabs(!this->getShowTabs());
+        },
+        QKeySequence("Ctrl+U"));
+
+    menu->addAction(this->lockNotebookLayoutAction_);
 }
 
 NotebookButton *Notebook::getAddButton()

--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -52,7 +52,7 @@ Notebook::Notebook(QWidget *parent)
     // Update lockNotebookLayout_ value anytime the user changes the checkbox state
     QObject::connect(lockNotebookLayoutAction_, &QAction::triggered,
                      [this](bool value) {
-                         this->lockNotebookLayout_ = value;
+                         this->setLockNotebookLayout(value);
                      });
 
     // Append it to our current menu actions

--- a/src/widgets/Notebook.hpp
+++ b/src/widgets/Notebook.hpp
@@ -63,6 +63,8 @@ public:
     bool isNotebookLayoutLocked() const;
     void setLockNotebookLayout(bool value);
 
+    void addNotebookActionsToMenu(QMenu *menu);
+
 protected:
     virtual void scaleChangedEvent(float scale_) override;
     virtual void resizeEvent(QResizeEvent *) override;

--- a/src/widgets/Notebook.hpp
+++ b/src/widgets/Notebook.hpp
@@ -60,6 +60,9 @@ public:
 
     void setTabDirection(NotebookTabDirection direction);
 
+    bool isNotebookLayoutLocked() const;
+    void setLockNotebookLayout(bool value);
+
 protected:
     virtual void scaleChangedEvent(float scale_) override;
     virtual void resizeEvent(QResizeEvent *) override;
@@ -98,7 +101,9 @@ private:
     bool showTabs_ = true;
     bool showAddButton_ = false;
     int lineOffset_ = 20;
+    bool lockNotebookLayout_ = false;
     NotebookTabDirection tabDirection_ = NotebookTabDirection::Horizontal;
+    QAction *lockNotebookLayoutAction_;
 };
 
 class SplitNotebook : public Notebook

--- a/src/widgets/helper/NotebookTab.cpp
+++ b/src/widgets/helper/NotebookTab.cpp
@@ -89,12 +89,7 @@ NotebookTab::NotebookTab(Notebook *notebook)
 
     this->menu_.addSeparator();
 
-    this->menu_.addAction(
-        "Toggle visibility of tabs",
-        [this]() {
-            this->notebook_->setShowTabs(!this->notebook_->getShowTabs());
-        },
-        QKeySequence("Ctrl+U"));
+    this->notebook_->addNotebookActionsToMenu(&this->menu_);
 }
 
 void NotebookTab::showRenameDialog()


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Gives users the ability to lock their tabs on Chatterino to prevent accidental movement.


https://user-images.githubusercontent.com/6964154/159972762-331d7f15-3baa-4f8d-b007-5ff848b4d5d4.mp4



# Additional Comments

I'm not sure if it would be better practice to rely only on the `ChatterinoSetting` rather than also using a private variable `lockNotebookLayout_`. Would appreciate some guidance.