### PR TITLE
Open a new tab/split by shift/alt + middle clicking a username

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 - Minor: Make Tab Layout setting only accept predefined values (#3564)
 - Minor: Added librewolf, icecat, and waterfox incognito support. (#3588)
 - Minor: Updated to Emoji v14.0 (#3612)
+- Minor: Added the ability to open a user's chat in a new tab/split by holding shift/alt + middle clicking their name. (#3630)
 - Bugfix: Fix Split Input hotkeys not being available when input is hidden (#3362)
 - Bugfix: Fixed colored usernames sometimes not working. (#3170)
 - Bugfix: Restored ability to send duplicate `/me` messages. (#3166)

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1718,17 +1718,25 @@ void ChannelView::mouseReleaseEvent(QMouseEvent *event)
             {
                 if (event->modifiers() == Qt::ShiftModifier)
                 {
-                    this->openChannelIn.invoke(
-                        hoverLayoutElement->getLink().value,
-                        FromTwitchLinkOpenChannelIn::Tab);
+                    ChannelPtr channel = getApp()->twitch->getOrAddChannel(
+                        hoverLayoutElement->getLink().value);
+                    auto &nb = getApp()->windows->getMainWindow().getNotebook();
+                    SplitContainer *container = nb.addPage(true);
+                    Split *split = new Split(container);
+                    split->setChannel(channel);
+                    container->appendSplit(split);
                     return;
                 }
 
                 if (event->modifiers() == Qt::AltModifier)
                 {
-                    this->openChannelIn.invoke(
-                        hoverLayoutElement->getLink().value,
-                        FromTwitchLinkOpenChannelIn::Split);
+                    ChannelPtr channel = getApp()->twitch->getOrAddChannel(
+                        hoverLayoutElement->getLink().value);
+                    auto &nb = getApp()->windows->getMainWindow().getNotebook();
+                    SplitContainer *container = nb.getOrAddSelectedPage();
+                    Split *split = new Split(container);
+                    split->setChannel(channel);
+                    container->appendSplit(split);
                     return;
                 }
 

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1716,6 +1716,22 @@ void ChannelView::mouseReleaseEvent(QMouseEvent *event)
             else if (hoverLayoutElement->getFlags().has(
                          MessageElementFlag::Username))
             {
+                if (event->modifiers() == Qt::ShiftModifier)
+                {
+                    this->openChannelIn.invoke(
+                        hoverLayoutElement->getLink().value,
+                        FromTwitchLinkOpenChannelIn::Tab);
+                    return;
+                }
+
+                if (event->modifiers() == Qt::AltModifier)
+                {
+                    this->openChannelIn.invoke(
+                        hoverLayoutElement->getLink().value,
+                        FromTwitchLinkOpenChannelIn::Split);
+                    return;
+                }
+
                 openTwitchUsercard(this->channel_->getName(),
                                    hoverLayoutElement->getLink().value);
                 return;


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description
Just more ways to quickly open new tabs/splits :)
<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
