### PR TITLE
Add an action to select the word under the cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unversioned
 
-- Major: Added customizable shortcuts. (#2340)
+- Major: Added customizable shortcuts. (#2340, #3633)
 - Minor: Make animated emote playback speed match browser (Firefox and Chrome) behaviour. (#3506)
 - Minor: Added middle click split to open in browser (#3356)
 - Minor: Added new search predicate to filter for messages matching a regex (#3282)

--- a/src/controllers/hotkeys/ActionNames.hpp
+++ b/src/controllers/hotkeys/ActionNames.hpp
@@ -135,6 +135,7 @@ inline const std::map<HotkeyCategory, ActionDefinitionMap> actionNames{
           ActionDefinition{"Choose previously sent message"}},
          {"redo", ActionDefinition{"Redo"}},
          {"selectAll", ActionDefinition{"Select all"}},
+         {"selectWord", ActionDefinition{"Select word"}},
          {"sendMessage",
           ActionDefinition{
               "Send message",

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -456,6 +456,13 @@ void SplitInput::addShortcuts()
              this->ui_.textEdit->selectAll();
              return "";
          }},
+        {"selectWord",
+         [this](std::vector<QString>) -> QString {
+             auto cursor = this->ui_.textEdit->textCursor();
+             cursor.select(QTextCursor::WordUnderCursor);
+             this->ui_.textEdit->setTextCursor(cursor);
+             return "";
+         }},
     };
 
     this->shortcuts_ = getApp()->hotkeys->shortcutsForCategory(


### PR DESCRIPTION
See #3628

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
Adds a new action to Split Input which selects the word under the cursor. There is no default binding, you have to add a hotkey yourself.