### PR TITLE
Add newline to dontSaveSettings error

### DIFF
--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -59,7 +59,7 @@ void WindowManager::showSettingsDialog(QWidget *parent,
     if (getArgs().dontSaveSettings)
     {
         QMessageBox::critical(parent, "Chatterino - Editing Settings Forbidden",
-                              "Settings cannot be edited when running with \n"
+                              "Settings cannot be edited when running with\n"
                               "commandline arguments such as '-c'.");
     }
     else

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -59,7 +59,7 @@ void WindowManager::showSettingsDialog(QWidget *parent,
     if (getArgs().dontSaveSettings)
     {
         QMessageBox::critical(parent, "Chatterino - Editing Settings Forbidden",
-                              "Settings cannot be edited when running with "
+                              "Settings cannot be edited when running with \n"
                               "commandline arguments such as '-c'.");
     }
     else


### PR DESCRIPTION
before;
![image](https://user-images.githubusercontent.com/41973452/160303315-e95c7ba8-e69e-4bb6-80b8-5bad9f158930.png)
after:
![image](https://user-images.githubusercontent.com/41973452/160303338-8c4be841-0f69-4dc7-8692-f1367eae1e1c.png)

I put the `\n` in the same spot the formatter already broke the line at.