### PR TITLE
fix: remove stickiness from login dialog which persisted to main window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+- BugFix: Prevent login window from rendering main window unmovable (#3636)
+
 ## 2.3.5
 
 - Major: Added highlights for first messages (#3267)

--- a/src/widgets/dialogs/LoginDialog.cpp
+++ b/src/widgets/dialogs/LoginDialog.cpp
@@ -243,7 +243,7 @@ LoginWidget::LoginWidget(QWidget *parent)
 {
 #ifdef USEWINSDK
     ::SetWindowPos(HWND(this->winId()), HWND_TOPMOST, 0, 0, 0, 0,
-                   SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
+                   SWP_SHOWWINDOW);
 #endif
 
     this->setWindowTitle("Chatterino - add new account");

--- a/src/widgets/dialogs/LoginDialog.cpp
+++ b/src/widgets/dialogs/LoginDialog.cpp
@@ -49,12 +49,6 @@ namespace {
         if (errors.length() > 0)
         {
             QMessageBox messageBox;
-// Set error window on top
-#ifdef USEWINSDK
-            ::SetWindowPos(HWND(messageBox.winId()), HWND_TOPMOST, 0, 0, 0, 0,
-                           0);
-
-#endif
             messageBox.setWindowTitle(
                 "Chatterino - invalid account credentials");
             messageBox.setIcon(QMessageBox::Critical);
@@ -241,10 +235,6 @@ void AdvancedLoginWidget::refreshButtons()
 LoginWidget::LoginWidget(QWidget *parent)
     : QDialog(parent)
 {
-#ifdef USEWINSDK
-    ::SetWindowPos(HWND(this->winId()), HWND_TOPMOST, 0, 0, 0, 0, 0);
-#endif
-
     this->setWindowTitle("Chatterino - add new account");
 
     this->setLayout(&this->ui_.mainLayout);

--- a/src/widgets/dialogs/LoginDialog.cpp
+++ b/src/widgets/dialogs/LoginDialog.cpp
@@ -52,7 +52,7 @@ namespace {
 // Set error window on top
 #ifdef USEWINSDK
             ::SetWindowPos(HWND(messageBox.winId()), HWND_TOPMOST, 0, 0, 0, 0,
-                           SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
+                           SWP_SHOWWINDOW);
 
 #endif
             messageBox.setWindowTitle(

--- a/src/widgets/dialogs/LoginDialog.cpp
+++ b/src/widgets/dialogs/LoginDialog.cpp
@@ -52,7 +52,7 @@ namespace {
 // Set error window on top
 #ifdef USEWINSDK
             ::SetWindowPos(HWND(messageBox.winId()), HWND_TOPMOST, 0, 0, 0, 0,
-                           SWP_SHOWWINDOW);
+                           0);
 
 #endif
             messageBox.setWindowTitle(
@@ -242,8 +242,7 @@ LoginWidget::LoginWidget(QWidget *parent)
     : QDialog(parent)
 {
 #ifdef USEWINSDK
-    ::SetWindowPos(HWND(this->winId()), HWND_TOPMOST, 0, 0, 0, 0,
-                   SWP_SHOWWINDOW);
+    ::SetWindowPos(HWND(this->winId()), HWND_TOPMOST, 0, 0, 0, 0, 0);
 #endif
 
     this->setWindowTitle("Chatterino - add new account");


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

This PR aims to fix an issue where Windows users couldn't move the main window after opening the login dialog. Since the user doesn't need to be restricted on move/resize of the login dialog, this constraint was removed.

Fixes #2378