### PR TITLE
fix: re-add missing Twitch emote reload message

### DIFF
--- a/src/providers/twitch/TwitchAccount.cpp
+++ b/src/providers/twitch/TwitchAccount.cpp
@@ -281,7 +281,7 @@ void TwitchAccount::loadUserstateEmotes(std::weak_ptr<Channel> weakChannel)
                    .arg(batches.at(i).join(","));
         getIvr()->getBulkEmoteSets(
             batches.at(i).join(","),
-            [this](QJsonArray emoteSetArray) {
+            [this, weakChannel](QJsonArray emoteSetArray) {
                 auto emoteData = this->emotes_.access();
                 auto localEmoteData = this->localEmotes_.access();
                 for (auto emoteSet_ : emoteSetArray)

--- a/src/providers/twitch/TwitchAccount.cpp
+++ b/src/providers/twitch/TwitchAccount.cpp
@@ -350,8 +350,8 @@ void TwitchAccount::loadUserstateEmotes(std::weak_ptr<Channel> weakChannel)
 
                     if (auto channel = weakChannel.lock(); channel != nullptr)
                     {
-                        channel->addMessage(
-                            makeSystemMessage("Twitch subscriber emotes reloaded."));
+                        channel->addMessage(makeSystemMessage(
+                            "Twitch subscriber emotes reloaded."));
                     }
                 }
             },

--- a/src/providers/twitch/TwitchAccount.cpp
+++ b/src/providers/twitch/TwitchAccount.cpp
@@ -347,12 +347,12 @@ void TwitchAccount::loadUserstateEmotes(std::weak_ptr<Channel> weakChannel)
                                   return l.name.string < r.name.string;
                               });
                     emoteData->emoteSets.emplace_back(emoteSet);
+                }
 
-                    if (auto channel = weakChannel.lock(); channel != nullptr)
-                    {
-                        channel->addMessage(makeSystemMessage(
-                            "Twitch subscriber emotes reloaded."));
-                    }
+                if (auto channel = weakChannel.lock(); channel != nullptr)
+                {
+                    channel->addMessage(makeSystemMessage(
+                        "Twitch subscriber emotes reloaded."));
                 }
             },
             [] {

--- a/src/providers/twitch/TwitchAccount.cpp
+++ b/src/providers/twitch/TwitchAccount.cpp
@@ -347,6 +347,12 @@ void TwitchAccount::loadUserstateEmotes(std::weak_ptr<Channel> weakChannel)
                                   return l.name.string < r.name.string;
                               });
                     emoteData->emoteSets.emplace_back(emoteSet);
+
+                    if (auto channel = weakChannel.lock(); channel != nullptr)
+                    {
+                        channel->addMessage(
+                            makeSystemMessage("Twitch subscriber emotes reloaded."));
+                    }
                 }
             },
             [] {

--- a/src/providers/twitch/TwitchAccount.cpp
+++ b/src/providers/twitch/TwitchAccount.cpp
@@ -216,7 +216,7 @@ void TwitchAccount::loadEmotes(std::weak_ptr<Channel> weakChannel)
         qCDebug(chatterinoTwitch) << "Cleared emotes!";
     }
 
-    this->loadUserstateEmotes();
+    this->loadUserstateEmotes(weakChannel);
 }
 
 bool TwitchAccount::setUserstateEmoteSets(QStringList newEmoteSets)
@@ -234,7 +234,7 @@ bool TwitchAccount::setUserstateEmoteSets(QStringList newEmoteSets)
     return true;
 }
 
-void TwitchAccount::loadUserstateEmotes()
+void TwitchAccount::loadUserstateEmotes(std::weak_ptr<Channel> weakChannel)
 {
     if (this->userstateEmoteSets_.isEmpty())
     {

--- a/src/providers/twitch/TwitchAccount.hpp
+++ b/src/providers/twitch/TwitchAccount.hpp
@@ -114,7 +114,7 @@ public:
     void loadEmotes(std::weak_ptr<Channel> weakChannel = {});
     // loadUserstateEmotes loads emote sets that are part of the USERSTATE emote-sets key
     // this function makes sure not to load emote sets that have already been loaded
-    void loadUserstateEmotes(std::weak_ptr<Channel> weakChannel);
+    void loadUserstateEmotes(std::weak_ptr<Channel> weakChannel = {});
     // setUserStateEmoteSets sets the emote sets that were parsed from the USERSTATE emote-sets key
     // Returns true if the newly inserted emote sets differ from the ones previously saved
     [[nodiscard]] bool setUserstateEmoteSets(QStringList newEmoteSets);

--- a/src/providers/twitch/TwitchAccount.hpp
+++ b/src/providers/twitch/TwitchAccount.hpp
@@ -114,7 +114,7 @@ public:
     void loadEmotes(std::weak_ptr<Channel> weakChannel = {});
     // loadUserstateEmotes loads emote sets that are part of the USERSTATE emote-sets key
     // this function makes sure not to load emote sets that have already been loaded
-    void loadUserstateEmotes();
+    void loadUserstateEmotes(std::weak_ptr<Channel> weakChannel);
     // setUserStateEmoteSets sets the emote sets that were parsed from the USERSTATE emote-sets key
     // Returns true if the newly inserted emote sets differ from the ones previously saved
     [[nodiscard]] bool setUserstateEmoteSets(QStringList newEmoteSets);


### PR DESCRIPTION
Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable

# Description

This PR aims to fix #3644 by re-adding the system message.

![image](https://user-images.githubusercontent.com/4962764/161411344-e45fc108-5a1f-4876-858d-6ea8feddbec9.png)
