### PR TITLE
Use login name for NotificationController lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unversioned
 
 - Bugfix: Fixed rendering of moderator announcements. (#3639)
+- Bugfix: Fixed display name dependence of live status calls. (#3646)
 
 ## 2.3.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unversioned
 
-- Bugfix: Fixed display name dependence of live status calls. (#3646)
+- Bugfix: Fixed live notifications for usernames containing uppercase characters. (#3646)
 
 ## 2.3.5
 

--- a/src/controllers/notifications/NotificationController.cpp
+++ b/src/controllers/notifications/NotificationController.cpp
@@ -178,12 +178,12 @@ void NotificationController::fetchFakeChannels()
                 std::unordered_set<QString> liveStreams;
                 for (const auto &stream : streams)
                 {
-                    liveStreams.insert(stream.userName);
+                    liveStreams.insert(stream.userLogin);
                 }
 
                 for (const auto &name : batch)
                 {
-                    auto it = liveStreams.find(name);
+                    auto it = liveStreams.find(name.toLower());
                     this->checkStream(it != liveStreams.end(), name);
                 }
             },

--- a/src/providers/twitch/api/Helix.hpp
+++ b/src/providers/twitch/api/Helix.hpp
@@ -86,8 +86,10 @@ struct HelixUsersFollowsResponse {
 struct HelixStream {
     QString id;  // stream id
     QString userId;
+    QString userLogin;
     QString userName;
     QString gameId;
+    QString gameName;
     QString type;
     QString title;
     int viewerCount;
@@ -98,8 +100,10 @@ struct HelixStream {
     HelixStream()
         : id("")
         , userId("")
+        , userLogin("")
         , userName("")
         , gameId("")
+        , gameName("")
         , type("")
         , title("")
         , viewerCount()
@@ -112,8 +116,10 @@ struct HelixStream {
     explicit HelixStream(QJsonObject jsonObject)
         : id(jsonObject.value("id").toString())
         , userId(jsonObject.value("user_id").toString())
+        , userLogin(jsonObject.value("user_login").toString())
         , userName(jsonObject.value("user_name").toString())
         , gameId(jsonObject.value("game_id").toString())
+        , gameName(jsonObject.value("game_name").toString())
         , type(jsonObject.value("type").toString())
         , title(jsonObject.value("title").toString())
         , viewerCount(jsonObject.value("viewer_count").toInt())


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description
Fixes #3646
* Add `userLogin`, `gameName` to `HelixStream`
* Store `userLogin` instead of `userName` from streams response
* Lookup lowercase `name` in `liveStreams` set
