### PR TITLE
Added quotation marks to automod phrases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unversioned
-
+- Minor: Added quotation marks around the automod phrases for clairty 
 ## 2.3.5
 
 - Major: Added highlights for first messages (#3267)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## Unversioned
-- Minor: Added quotation marks around the automod phrases for clairty 
+- Minor: Added quotation marks in the permitted/blocked Automod messages for clarity. (#3654)
+
 ## 2.3.5
 
 - Major: Added highlights for first messages (#3267)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
 ## Unversioned
-- Minor: Added quotation marks in the permitted/blocked Automod messages for clarity. (#3654)
 
+- Minor: Added quotation marks in the permitted/blocked Automod messages for clarity. (#3654)
 - Bugfix: Fixed live notifications for usernames containing uppercase characters. (#3646)
 
 ## 2.3.5

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -403,25 +403,25 @@ MessageBuilder::MessageBuilder(const AutomodUserAction &action)
     switch (action.type)
     {
         case AutomodUserAction::AddPermitted: {
-            text = QString("%1 added %2 as a permitted term on AutoMod.")
+            text = QString("%1 added \"%2\" as a permitted term on AutoMod.")
                        .arg(action.source.login, action.message);
         }
         break;
 
         case AutomodUserAction::AddBlocked: {
-            text = QString("%1 added %2 as a blocked term on AutoMod.")
+            text = QString("%1 added \"%2\" as a blocked term on AutoMod.")
                        .arg(action.source.login, action.message);
         }
         break;
 
         case AutomodUserAction::RemovePermitted: {
-            text = QString("%1 removed %2 as a permitted term on AutoMod.")
+            text = QString("%1 removed \"%2\" as a permitted term on AutoMod.")
                        .arg(action.source.login, action.message);
         }
         break;
 
         case AutomodUserAction::RemoveBlocked: {
-            text = QString("%1 removed %2 as a blocked term on AutoMod.")
+            text = QString("%1 removed \"%2\" as a blocked term on AutoMod.")
                        .arg(action.source.login, action.message);
         }
         break;


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description
Added quotation marks around the automod phrases when they are added/removed from filter so it'll read like:
User added "phrase" to automod rather then User added phrase to automod. This allows for it to be far clearer
