### PR TITLE
Adjust large stream thumbnail to 16:9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+- Minor: Adjust large stream thumbnail to 16:9 (#3655)
+
 ## 2.3.5
 
 - Major: Added highlights for first messages (#3267)

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -714,7 +714,7 @@ void SplitHeader::updateChannelText()
                     url.append("-160x90.jpg");
                     break;
                 case 3:
-                    url.append("-360x180.jpg");
+                    url.append("-360x203.jpg");
                     break;
                 default:
                     url = "";


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Small and medium stream thumbnails are 16:9, but large stream thumbnails are 2:1 (360×180px). Adjust the large thumbnail to closer to 16:9 (360×203px) instead.

(yes, this is really stupidly minor but it annoys me every time I notice it) 