### PR TITLE
add "show live tabs only" option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Major: Added multi-channel searching to search dialog via keyboard shortcut. [Ctrl+Shift+F by default] (#3694)
 - Minor: Added `is:first-msg` search option. (#3700)
+- Minor: Added option to show only live tabs. (#3658)
 - Minor: Added quotation marks in the permitted/blocked Automod messages for clarity. (#3654)
 - Minor: Adjust large stream thumbnail to 16:9 (#3655)
 - Minor: Fixed being unable to load Twitch Usercards from the `/mentions` tab. (#3623)

--- a/src/controllers/hotkeys/ActionNames.hpp
+++ b/src/controllers/hotkeys/ActionNames.hpp
@@ -206,7 +206,7 @@ inline const std::map<HotkeyCategory, ActionDefinitionMap> actionNames{
           }},
          {"setShowLiveOnly",
           ActionDefinition{
-              "Show live tabs only",
+              "Only show live tabs",
               "[on, off, or toggle. default: toggle]",
               0,
               1,

--- a/src/controllers/hotkeys/ActionNames.hpp
+++ b/src/controllers/hotkeys/ActionNames.hpp
@@ -203,6 +203,13 @@ inline const std::map<HotkeyCategory, ActionDefinitionMap> actionNames{
               "[on, off, or toggle. default: toggle]",
               0,
               1,
+          }},
+         {"setShowLiveOnly",
+          ActionDefinition{
+              "Show live tabs only",
+              "[on, off, or toggle. default: toggle]",
+              0,
+              1,
           }}}},
 };
 

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -387,6 +387,7 @@ public:
     BoolSetting informOnTabVisibilityToggle = {"/misc/askOnTabVisibilityToggle",
                                                true};
     BoolSetting lockNotebookLayout = {"/misc/lockNotebookLayout", false};
+    BoolSetting showLiveOnly = {"/misc/showLiveOnly", false};
 
     /// Debug
     BoolSetting showUnhandledIrcMessages = {"/debug/showUnhandledIrcMessages",

--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -142,11 +142,12 @@ void Notebook::removeCurrentPage()
     }
 }
 
-int Notebook::indexOf(QWidget *page) const
+int Notebook::indexOf(QWidget *page, bool liveOnly) const
 {
-    for (int i = 0; i < this->allItems_.count(); i++)
+    const auto items_ = liveOnly ? this->items_ : this->allItems_;
+    for (int i = 0; i < items_.count(); i++)
     {
-        if (this->allItems_[i].page == page)
+        if (items_[i].page == page)
         {
             return i;
         }
@@ -255,43 +256,49 @@ void Notebook::selectIndex(int index, bool focusPage)
 
 void Notebook::selectNextTab(bool focusPage)
 {
-    if (this->allItems_.size() <= 1)
+    bool showLiveOnly_ = this->getShowLiveOnly();
+    const auto items_ = showLiveOnly_ ? this->items_ : this->allItems_;
+    if (items_.size() <= 1)
     {
         return;
     }
 
-    auto index =
-        (this->indexOf(this->selectedPage_) + 1) % this->allItems_.count();
+    auto index = (this->indexOf(this->selectedPage_, showLiveOnly_) + 1) %
+                 items_.count();
 
-    this->select(this->allItems_[index].page, focusPage);
+    this->select(items_[index].page, focusPage);
 }
 
 void Notebook::selectPreviousTab(bool focusPage)
 {
-    if (this->allItems_.size() <= 1)
+    bool showLiveOnly_ = this->getShowLiveOnly();
+    const auto items_ = showLiveOnly_ ? this->items_ : this->allItems_;
+    if (items_.size() <= 1)
     {
         return;
     }
 
-    int index = this->indexOf(this->selectedPage_) - 1;
+    int index = this->indexOf(this->selectedPage_, showLiveOnly_) - 1;
 
     if (index < 0)
     {
-        index += this->allItems_.count();
+        index += items_.count();
     }
 
-    this->select(this->allItems_[index].page, focusPage);
+    this->select(items_[index].page, focusPage);
 }
 
 void Notebook::selectLastTab(bool focusPage)
 {
-    const auto size = this->allItems_.size();
+    const auto items_ =
+        this->getShowLiveOnly() ? this->items_ : this->allItems_;
+    const auto size = items_.size();
     if (size <= 1)
     {
         return;
     }
 
-    this->select(this->allItems_[size - 1].page, focusPage);
+    this->select(this->items_[size - 1].page, focusPage);
 }
 
 int Notebook::getPageCount() const

--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -106,17 +106,17 @@ void Notebook::removePage(QWidget *page)
     {
         if (this->allItems_[i].page == page)
         {
-            if (this->allItems_.count() == 1)
+            if (this->items_.count() == 1)
             {
                 this->select(nullptr);
             }
-            else if (i == this->allItems_.count() - 1)
+            else if (i == this->items_.count() - 1)
             {
-                this->select(this->allItems_[i - 1].page);
+                this->select(this->items_[i - 1].page);
             }
             else
             {
-                this->select(this->allItems_[i + 1].page);
+                this->select(this->items_[i + 1].page);
             }
 
             this->allItems_[i].page->deleteLater();

--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -817,7 +817,7 @@ SplitNotebook::SplitNotebook(Window *parent)
 
     this->signalHolder_.managedConnect(
         getApp()->windows->selectSplit, [this](Split *split) {
-            for (auto &&item : this->items())
+            for (auto &&item : this->allItems())
             {
                 if (auto sc = dynamic_cast<SplitContainer *>(item.page))
                 {

--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -408,11 +408,13 @@ bool Notebook::getShowLiveOnly() const
 {
     return this->showLiveOnly_;
 }
+
 void Notebook::setShowLiveOnly(bool value)
 {
     this->showLiveOnly_ = value;
     this->showLiveOnlyAction_->setChecked(value);
-    //check and disable the "lock tabs" button
+
+    // check and disable the "lock tabs" button
     this->lockNotebookLayoutAction_->setEnabled(!value);
     this->lockNotebookLayoutAction_->setChecked(value ||
                                                 this->lockNotebookLayout_);

--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -889,7 +889,7 @@ SplitContainer *SplitNotebook::addPage(bool select)
     auto tab = Notebook::addPage(container, QString(), select);
     container->setTab(tab);
     tab->setParent(this);
-    tab->setVisible(this->getShowTabs());
+    tab->setVisible(this->getShowTabs() && !this->getShowLiveOnly());
     return container;
 }
 

--- a/src/widgets/Notebook.hpp
+++ b/src/widgets/Notebook.hpp
@@ -53,6 +53,9 @@ public:
     bool getShowTabs() const;
     void setShowTabs(bool value);
 
+    bool getShowLiveOnly() const;
+    void setShowLiveOnly(bool value);
+
     bool getShowAddButton() const;
     void setShowAddButton(bool value);
 
@@ -80,6 +83,10 @@ protected:
         QWidget *selectedWidget{};
     };
 
+    const QList<Item> allItems()
+    {
+        return allItems_;
+    }
     const QList<Item> items()
     {
         return items_;
@@ -92,6 +99,7 @@ private:
     static bool containsChild(const QObject *obj, const QObject *child);
     NotebookTab *getTabFromPage(QWidget *page);
 
+    QList<Item> allItems_;
     QList<Item> items_;
     QMenu menu_;
     QWidget *selectedPage_ = nullptr;
@@ -101,11 +109,13 @@ private:
 
     bool allowUserTabManagement_ = false;
     bool showTabs_ = true;
+    bool showLiveOnly_ = false;
     bool showAddButton_ = false;
     int lineOffset_ = 20;
     bool lockNotebookLayout_ = false;
     NotebookTabDirection tabDirection_ = NotebookTabDirection::Horizontal;
     QAction *lockNotebookLayoutAction_;
+    QAction *showLiveOnlyAction_;
 };
 
 class SplitNotebook : public Notebook

--- a/src/widgets/Notebook.hpp
+++ b/src/widgets/Notebook.hpp
@@ -32,7 +32,7 @@ public:
     void removePage(QWidget *page);
     void removeCurrentPage();
 
-    int indexOf(QWidget *page) const;
+    int indexOf(QWidget *page, bool liveOnly = true) const;
     virtual void select(QWidget *page, bool focusPage = true);
     void selectIndex(int index, bool focusPage = true);
     void selectNextTab(bool focusPage = true);

--- a/src/widgets/Notebook.hpp
+++ b/src/widgets/Notebook.hpp
@@ -87,6 +87,7 @@ protected:
     {
         return allItems_;
     }
+
     const QList<Item> items()
     {
         return items_;

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -602,6 +602,53 @@ void Window::addShortcuts()
              }
              return "";
          }},
+        {"setShowLiveOnly",
+         [this](std::vector<QString> arguments) -> QString {
+             auto mode = 2;
+             if (arguments.size() != 0)
+             {
+                 auto arg = arguments.at(0);
+                 if (arg == "off")
+                 {
+                     mode = 0;
+                 }
+                 else if (arg == "on")
+                 {
+                     mode = 1;
+                 }
+                 else if (arg == "toggle")
+                 {
+                     mode = 2;
+                 }
+                 else
+                 {
+                     qCWarning(chatterinoHotkeys)
+                         << "Invalid argument for setShowLiveOnly hotkey: "
+                         << arg;
+                     return QString("Invalid argument for setShowLiveOnly "
+                                    "hotkey: %1. Use \"on\" or \"off\".")
+                         .arg(arg);
+                 }
+             }
+
+             if (mode == 0)
+             {
+                 getSettings()->showLiveOnly.setValue(false);
+                 this->notebook_->setShowLiveOnly(false);
+             }
+             else if (mode == 1)
+             {
+                 getSettings()->showLiveOnly.setValue(true);
+                 this->notebook_->setShowLiveOnly(true);
+             }
+             else if (mode == 2)
+             {
+                 auto value = this->notebook_->getShowLiveOnly();
+                 getSettings()->showLiveOnly.setValue(!value);
+                 this->notebook_->setShowLiveOnly(!value);
+             }
+             return "";
+         }},
     };
 
     this->addDebugStuff(actions);

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -604,48 +604,35 @@ void Window::addShortcuts()
          }},
         {"setShowLiveOnly",
          [this](std::vector<QString> arguments) -> QString {
-             auto mode = 2;
+             auto arg = "toggle";
              if (arguments.size() != 0)
              {
                  auto arg = arguments.at(0);
-                 if (arg == "off")
-                 {
-                     mode = 0;
-                 }
-                 else if (arg == "on")
-                 {
-                     mode = 1;
-                 }
-                 else if (arg == "toggle")
-                 {
-                     mode = 2;
-                 }
-                 else
-                 {
-                     qCWarning(chatterinoHotkeys)
-                         << "Invalid argument for setShowLiveOnly hotkey: "
-                         << arg;
-                     return QString("Invalid argument for setShowLiveOnly "
-                                    "hotkey: %1. Use \"on\" or \"off\".")
-                         .arg(arg);
-                 }
              }
-
-             if (mode == 0)
+             if (arg == "off")
              {
                  getSettings()->showLiveOnly.setValue(false);
                  this->notebook_->setShowLiveOnly(false);
              }
-             else if (mode == 1)
+             else if (arg == "on")
              {
                  getSettings()->showLiveOnly.setValue(true);
                  this->notebook_->setShowLiveOnly(true);
              }
-             else if (mode == 2)
+             else if (arg == "toggle")
              {
                  auto value = this->notebook_->getShowLiveOnly();
                  getSettings()->showLiveOnly.setValue(!value);
                  this->notebook_->setShowLiveOnly(!value);
+             }
+             else
+             {
+                 qCWarning(chatterinoHotkeys)
+                     << "Invalid argument for setShowLiveOnly hotkey: " << arg;
+                 return QString(
+                            "Invalid argument for setShowLiveOnly "
+                            "hotkey: %1. Use \"on\", \"off\", or \"toggle\".")
+                     .arg(arg);
              }
              return "";
          }},

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -203,8 +203,7 @@ void ChannelView::initializeSignals()
 
     this->signalHolder_.managedConnect(
         getApp()->windows->layoutRequested, [&](Channel *channel) {
-            if (this->isVisible() &&
-                (channel == nullptr || this->channel_.get() == channel))
+            if ((channel == nullptr || this->channel_.get() == channel))
             {
                 this->queueLayout();
             }

--- a/src/widgets/helper/NotebookTab.cpp
+++ b/src/widgets/helper/NotebookTab.cpp
@@ -294,6 +294,11 @@ void NotebookTab::setLive(bool isLive)
     {
         this->isLive_ = isLive;
         this->update();
+        if (this->notebook_->getShowLiveOnly())
+        {
+            this->setHidden(!isLive);
+            this->notebook_->performLayout();
+        }
     }
 }
 
@@ -685,6 +690,11 @@ QRect NotebookTab::getXRect()
     return QRect(this->width() - static_cast<int>(20 * s),
                  static_cast<int>(9 * s), static_cast<int>(16 * s),
                  static_cast<int>(16 * s));
+}
+
+bool NotebookTab::getIsLive() const
+{
+    return this->isLive_;
 }
 
 }  // namespace chatterino

--- a/src/widgets/helper/NotebookTab.hpp
+++ b/src/widgets/helper/NotebookTab.hpp
@@ -54,6 +54,8 @@ public:
     void growWidth(int width);
     int normalTabWidth();
 
+    bool getIsLive() const;
+
 protected:
     virtual void themeChangedEvent() override;
 


### PR DESCRIPTION
Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable

# Description
This PR adds a "show live tabs only" option that hides tabs which are not marked as live. By default, it is disabled and has no hotkey bound to it. While active, it locks the tab layout, since it's not clear how a change in layout should translate when offline tabs are unhidden. When tabs are marked as live/not live, they will automatically be inserted/hidden appropriately. 

A video demonstration of the core functionality can be found [here](https://streamable.com/8v900l).

I'd appreciate your feedback. Thank you.

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->


