### PR TITLE
refactor(TwitchChannel): remove getGameById call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Minor: Adjust large stream thumbnail to 16:9 (#3655)
 - Minor: Fixed being unable to load Twitch Usercards from the `/mentions` tab. (#3623)
 - Bugfix: Fixed live notifications for usernames containing uppercase characters. (#3646)
+- Dev: Use Game Name returned by Get Streams instead of querying it from the Get Games API. (#3662)
 
 ## 2.3.5
 

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -735,39 +735,8 @@ void TwitchChannel::parseLiveStatus(bool live, const HelixStream &stream)
     {
         auto status = this->streamStatus_.access();
         status->viewerCount = stream.viewerCount;
-        if (status->gameId != stream.gameId)
-        {
-            status->gameId = stream.gameId;
-
-            if (!stream.gameId.isEmpty())
-            {
-                // Resolve game ID to game name
-                getHelix()->getGameById(
-                    stream.gameId,
-                    [this, weak = weakOf<Channel>(this)](const auto &game) {
-                        ChannelPtr shared = weak.lock();
-                        if (!shared)
-                        {
-                            return;
-                        }
-
-                        {
-                            auto status = this->streamStatus_.access();
-                            status->game = game.name;
-                        }
-
-                        this->liveStatusChanged.invoke();
-                    },
-                    [] {
-                        // failure
-                    });
-            }
-            else
-            {
-                // Game is nothing and can't be resolved by the API, force empty
-                status->game = "";
-            }
-        }
+        status->gameId = stream.gameId;
+        status->game = stream.gameName;
         status->title = stream.title;
         QDateTime since = QDateTime::fromString(stream.startedAt, Qt::ISODate);
         auto diff = since.secsTo(QDateTime::currentDateTime());


### PR DESCRIPTION
Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable - let me know if this warrants an entry

# Description

Removes unnecessary helix call (`getGameById`) now that `HelixStream` contains `gameName` (follow-up from https://github.com/Chatterino/chatterino2/pull/3648#issuecomment-1086924644)
