### PR TITLE
Include user's operating system information in the About page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Minor: Added quotation marks in the permitted/blocked Automod messages for clarity. (#3654)
 - Minor: Adjust large stream thumbnail to 16:9 (#3655)
+- Minor: Add information about the user's operating system in the About page. (#3663)
 - Bugfix: Fixed live notifications for usernames containing uppercase characters. (#3646)
 
 ## 2.3.5

--- a/src/widgets/settingspages/AboutPage.cpp
+++ b/src/widgets/settingspages/AboutPage.cpp
@@ -85,16 +85,25 @@ AboutPage::AboutPage()
         auto versionInfo = layout.emplace<QGroupBox>("Version");
         {
             auto version = Version::instance();
-            QString text = QString("%1 (commit %2%3)")
-                               .arg(version.fullVersion())
-                               .arg("<a "
-                                    "href=\"https://github.com/Chatterino/"
-                                    "chatterino2/commit/" +
-                                    version.commitHash() + "\">" +
-                                    version.commitHash() + "</a>")
-                               .arg(Modes::instance().isNightly
-                                        ? ", built on " + version.dateOfBuild()
-                                        : "");
+            QString osInfo = QSysInfo::prettyProductName() +
+                             ", kernel: " + QSysInfo::kernelVersion();
+            if (version.isFlatpak())
+            {
+                osInfo += ", running from Flatpak";
+            }
+            QString text =
+                QString("%1 (commit %2%3) running on %4 %5")
+                    .arg(version.fullVersion(),
+                         "<a "
+                         "href=\"https://github.com/Chatterino/"
+                         "chatterino2/commit/" +
+                             version.commitHash() + "\">" +
+                             version.commitHash() + "</a>",
+                         Modes::instance().isNightly
+                             ? ", built on " + version.dateOfBuild()
+                             : "",
+                         osInfo,
+                         version.isSupportedOS() ? "" : " (unsupported OS)");
 
             auto versionLabel = versionInfo.emplace<QLabel>(text);
             versionLabel->setOpenExternalLinks(true);

--- a/src/widgets/settingspages/AboutPage.cpp
+++ b/src/widgets/settingspages/AboutPage.cpp
@@ -91,19 +91,29 @@ AboutPage::AboutPage()
             {
                 osInfo += ", running from Flatpak";
             }
-            QString text =
-                QString("%1 (commit %2%3) running on %4 %5")
-                    .arg(version.fullVersion(),
-                         "<a "
-                         "href=\"https://github.com/Chatterino/"
-                         "chatterino2/commit/" +
-                             version.commitHash() + "\">" +
-                             version.commitHash() + "</a>",
-                         Modes::instance().isNightly
-                             ? ", built on " + version.dateOfBuild()
-                             : "",
-                         osInfo,
-                         version.isSupportedOS() ? "" : " (unsupported OS)");
+
+            QString commitHashLink =
+                QString("<a "
+                        "href=\"https://github.com/Chatterino/chatterino2/"
+                        "commit/%1\">%1</a>")
+                    .arg(version.commitHash());
+
+            QString nightlyBuildInfo;
+            if (Modes::instance().isNightly)
+            {
+                nightlyBuildInfo =
+                    QString(", built on %1").arg(version.dateOfBuild());
+            }
+
+            QString supportedOS;
+            if (!version.isSupportedOS())
+            {
+                supportedOS = "(unsupported OS)";
+            }
+
+            QString text = QString("%1 (commit %2%3) running on %4 %5")
+                               .arg(version.fullVersion(), commitHashLink,
+                                    nightlyBuildInfo, osInfo, supportedOS);
 
             auto versionLabel = versionInfo.emplace<QLabel>(text);
             versionLabel->setOpenExternalLinks(true);


### PR DESCRIPTION
Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable

# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
This uses QSysInfo to get the pretty name of the OS and adds the kernel version. If the OS is unsupported, it will be displayed. I took the liberty of switching to using multi-arg in the existing version string. This should probably also show if Chatterino is running from an AppImage.
Needs testing on Windows and Mac.

Closes #3653