### PR TITLE
fix: build user timeout/ban message in GUI thread

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -269,11 +269,10 @@ void Application::initPubsub()
                 return;
             }
 
-            MessageBuilder msg(action);
-            msg->flags.set(MessageFlag::PubSub);
-
-            postToThread([chan, msg = msg.release()] {
-                chan->addOrReplaceTimeout(msg);
+            postToThread([chan, action] {
+                MessageBuilder msg(action);
+                msg->flags.set(MessageFlag::PubSub);
+                chan->addOrReplaceTimeout(msg.release());
             });
         });
     this->twitch->pubsub->signals_.moderation.messageDeleted.connect(


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

[`MessageBuilder(BanAction, uint32_t)`](https://github.com/Chatterino/chatterino2/blob/3afdb3367f8d318abad1eee8de093c28819b5539/src/messages/MessageBuilder.cpp#L281) calls [`getApp()`](https://github.com/Chatterino/chatterino2/blob/3afdb3367f8d318abad1eee8de093c28819b5539/src/Application.cpp#L427) which is required to run in the GUI thread.

I'm not sure if it's safe to just [add the `action` to the captures](https://github.com/Nerixyz/chatterino2/blob/6d205057ce17836004df7c1478b07142576a74c0/src/Application.cpp#L272) but since it's done for the [`automodMessage`](https://github.com/Nerixyz/chatterino2/blob/6d205057ce17836004df7c1478b07142576a74c0/src/Application.cpp#L343) as well, it should be okay.