### PR TITLE
Maximum Timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Minor: Adjust large stream thumbnail to 16:9 (#3655)
 - Minor: Fixed being unable to load Twitch Usercards from the `/mentions` tab. (#3623)
 - Minor: Add information about the user's operating system in the About page. (#3663)
+- Minor: Added a safety check for max timeouts to prevent a crash 
 - Bugfix: Fixed live notifications for usernames containing uppercase characters. (#3646)
 - Dev: Use Game Name returned by Get Streams instead of querying it from the Get Games API. (#3662)
 

--- a/src/widgets/settingspages/ModerationPage.cpp
+++ b/src/widgets/settingspages/ModerationPage.cpp
@@ -224,11 +224,13 @@ void ModerationPage::addModerationButtonSettings(
         if (unit == "d" && duration > 14)
         {
             line->setText("14");
+            duration->setValue(14); //Safety Mechanism as when it exceeds 2w it can cause huge issues with connecting
             return;
         }
         else if (unit == "w" && duration > 2)
         {
             line->setText("2");
+            duration->setValue(2); //Safety Mechanism as when it exceeds 2w it can cause huge issues with connecting
             return;
         }
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

I have capped the user timeouts at 2W as when it is above this it can cause issues with the IRC client causing some parts of the app to not load in fully