### PR TITLE
Add missing parent pointer to few QMessageBox and QFontDialog 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Minor: Fixed being unable to load Twitch Usercards from the `/mentions` tab. (#3623)
 - Minor: Add information about the user's operating system in the About page. (#3663)
 - Bugfix: Fixed live notifications for usernames containing uppercase characters. (#3646)
-- Bugfix: Fixed certain setting dialogs from appearing behind main window, when `Always on top` was used. (#3679)
+- Bugfix: Fixed certain settings dialogs appearing behind the main window, when `Always on top` was used. (#3679)
 - Dev: Use Game Name returned by Get Streams instead of querying it from the Get Games API. (#3662)
 
 ## 2.3.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Minor: Fixed being unable to load Twitch Usercards from the `/mentions` tab. (#3623)
 - Minor: Add information about the user's operating system in the About page. (#3663)
 - Bugfix: Fixed live notifications for usernames containing uppercase characters. (#3646)
+- Bugfix: Fixed certain setting dialogs from appearing behind main window, when `Always on top` was used. (#3679)
 - Dev: Use Game Name returned by Get Streams instead of querying it from the Get Games API. (#3662)
 
 ## 2.3.5

--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -368,7 +368,7 @@ void Notebook::setShowTabs(bool value)
     // show a popup upon hiding tabs
     if (!value && getSettings()->informOnTabVisibilityToggle.getValue())
     {
-        QMessageBox msgBox;
+        QMessageBox msgBox(this->window());
         msgBox.window()->setWindowTitle("Chatterino - hidden tabs");
         msgBox.setText("You've just hidden your tabs.");
         msgBox.setInformativeText(

--- a/src/widgets/settingspages/FiltersPage.cpp
+++ b/src/widgets/settingspages/FiltersPage.cpp
@@ -88,7 +88,7 @@ void FiltersPage::tableCellClicked(const QModelIndex &clicked,
     // valid column
     if (clicked.column() == 2)
     {
-        QMessageBox popup;
+        QMessageBox popup(this->window());
 
         filterparser::FilterParser f(
             view->getModel()->data(clicked.siblingAtColumn(1)).toString());

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -735,10 +735,8 @@ QString GeneralPage::getFont(const DropdownArgs &args) const
         args.combobox->setEditText("Choosing...");
         QFontDialog dialog(getApp()->fonts->getFont(FontStyle::ChatMedium, 1.));
 
-        dialog.setWindowFlag(Qt::WindowStaysOnTopHint);
-
         auto ok = bool();
-        auto font = dialog.getFont(&ok);
+        auto font = dialog.getFont(&ok, this->window());
 
         if (ok)
             return font.family();

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -219,7 +219,7 @@ Split::Split(QWidget *parent)
 
             if (getSettings()->askOnImageUpload.getValue())
             {
-                QMessageBox msgBox;
+                QMessageBox msgBox(this->window());
                 msgBox.setWindowTitle("Chatterino");
                 msgBox.setText("Image upload");
                 msgBox.setInformativeText(


### PR DESCRIPTION
Pull request checklist:

- [x]  `CHANGELOG.md` was updated


# Description

This PR gives parent ptr to poor orphaned children, preventing them from appearing behind main chatterino window when _Always on top_ is used. 

tested on windows only

closes #3672 
