### PR TITLE
Add chatter count for each category in viewer list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Minor: Added chatter count for each category in viewer list. (#3683)
 - Bugfix: Fixed live notifications for usernames containing uppercase characters. (#3646)
 - Bugfix: Fixed certain settings dialogs appearing behind the main window, when `Always on top` was used. (#3679)
+- Bugfix: Fixed an issue in the emote picker where an emotes tooltip would not properly disappear. (#3686)
 - Dev: Use Game Name returned by Get Streams instead of querying it from the Get Games API. (#3662)
 
 ## 2.3.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Minor: Adjust large stream thumbnail to 16:9 (#3655)
 - Minor: Fixed being unable to load Twitch Usercards from the `/mentions` tab. (#3623)
 - Minor: Add information about the user's operating system in the About page. (#3663)
+- Minor: Added chatter count for each category in viewer list. (#3683)
 - Bugfix: Fixed live notifications for usernames containing uppercase characters. (#3646)
 - Bugfix: Fixed certain settings dialogs appearing behind the main window, when `Always on top` was used. (#3679)
 - Dev: Use Game Name returned by Get Streams instead of querying it from the Get Games API. (#3662)

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1235,6 +1235,8 @@ void ChannelView::enterEvent(QEvent *)
 
 void ChannelView::leaveEvent(QEvent *)
 {
+    TooltipWidget::instance()->hide();
+
     this->unpause(PauseReason::Mouse);
 
     this->queueLayout();

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -1009,8 +1009,7 @@ void Split::showViewerList()
 
                 auto label = formatListItemText(
                     QString("%1 (%2)")
-                        .arg(labels.at(i))
-                        .arg(localizeNumbers(currentCategory.size())));
+                        .arg(labels.at(i), localizeNumbers(currentCategory.size())))
                 label->setForeground(this->theme->accent);
                 chattersList->addItem(label);
                 foreach (const QJsonValue &v, currentCategory)

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -998,18 +998,6 @@ void Split::showViewerList()
                     .arg(localizeNumbers(obj.value("chatter_count").toInt())));
 
             loadingLabel->hide();
-            QList<QListWidgetItem *> labelList;
-            for (int i = 0; i < labels.size(); i++)
-            {
-                auto label = formatListItemText(
-                    QString("%1 (%2)")
-                        .arg(labels.at(i))
-                        .arg(localizeNumbers(chattersObj.value(jsonLabels.at(i))
-                                                 .toArray()
-                                                 .size())));
-                label->setForeground(this->theme->accent);
-                labelList.append(label);
-            }
             for (int i = 0; i < jsonLabels.size(); i++)
             {
                 auto currentCategory =
@@ -1019,7 +1007,14 @@ void Split::showViewerList()
                 if (currentCategory.empty())
                     continue;
 
-                chattersList->addItem(labelList.at(i));
+                auto label = formatListItemText(
+                    QString("%1 (%2)")
+                        .arg(labels.at(i))
+                        .arg(localizeNumbers(chattersObj.value(jsonLabels.at(i))
+                                                 .toArray()
+                                                 .size())));
+                label->setForeground(this->theme->accent);
+                chattersList->addItem(label);
                 foreach (const QJsonValue &v, currentCategory)
                 {
                     chattersList->addItem(formatListItemText(v.toString()));
@@ -1060,7 +1055,9 @@ void Split::showViewerList()
     });
 
     auto listDoubleClick = [=](QString userName) {
-        if (!labels.contains(userName) && !userName.isEmpty())
+        //if the list item contains a parentheses it means that
+        //it's a category label so don't show a usercard
+        if (!userName.contains("(") && !userName.isEmpty())
         {
             this->view_->showUserInfoPopup(userName);
         }

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -983,13 +983,6 @@ void Split::showViewerList()
     static QStringList jsonLabels = {"broadcaster", "moderators", "vips",
                                      "staff",       "admins",     "global_mods",
                                      "viewers"};
-    QList<QListWidgetItem *> labelList;
-    for (auto &x : labels)
-    {
-        auto label = formatListItemText(x);
-        label->setForeground(this->theme->accent);
-        labelList.append(label);
-    }
     auto loadingLabel = new QLabel("Loading...");
 
     NetworkRequest::twitchRequest("https://tmi.twitch.tv/group/user/" +
@@ -1005,6 +998,18 @@ void Split::showViewerList()
                     .arg(localizeNumbers(obj.value("chatter_count").toInt())));
 
             loadingLabel->hide();
+            QList<QListWidgetItem *> labelList;
+            for (int i = 0; i < labels.size(); i++)
+            {
+                auto label = formatListItemText(
+                    QString("%1 (%2)")
+                        .arg(labels.at(i))
+                        .arg(localizeNumbers(chattersObj.value(jsonLabels.at(i))
+                                                 .toArray()
+                                                 .size())));
+                label->setForeground(this->theme->accent);
+                labelList.append(label);
+            }
             for (int i = 0; i < jsonLabels.size(); i++)
             {
                 auto currentCategory =

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -1007,10 +1007,9 @@ void Split::showViewerList()
                 if (currentCategory.empty())
                     continue;
 
-                auto label = formatListItemText(
-                    QString("%1 (%2)")
-                        .arg(labels.at(i), localizeNumbers(currentCategory.size())))
-                label->setForeground(this->theme->accent);
+                auto label = formatListItemText(QString("%1 (%2)").arg(
+                    labels.at(i), localizeNumbers(currentCategory.size())))
+                                 label->setForeground(this->theme->accent);
                 chattersList->addItem(label);
                 foreach (const QJsonValue &v, currentCategory)
                 {

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -1051,8 +1051,8 @@ void Split::showViewerList()
     });
 
     auto listDoubleClick = [=](QString userName) {
-        //if the list item contains a parentheses it means that
-        //it's a category label so don't show a usercard
+        // if the list item contains a parentheses it means that
+        // it's a category label so don't show a usercard
         if (!userName.contains("(") && !userName.isEmpty())
         {
             this->view_->showUserInfoPopup(userName);

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -1010,9 +1010,7 @@ void Split::showViewerList()
                 auto label = formatListItemText(
                     QString("%1 (%2)")
                         .arg(labels.at(i))
-                        .arg(localizeNumbers(chattersObj.value(jsonLabels.at(i))
-                                                 .toArray()
-                                                 .size())));
+                        .arg(localizeNumbers(currentCategory.size())));
                 label->setForeground(this->theme->accent);
                 chattersList->addItem(label);
                 foreach (const QJsonValue &v, currentCategory)

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -1008,8 +1008,8 @@ void Split::showViewerList()
                     continue;
 
                 auto label = formatListItemText(QString("%1 (%2)").arg(
-                    labels.at(i), localizeNumbers(currentCategory.size())))
-                                 label->setForeground(this->theme->accent);
+                    labels.at(i), localizeNumbers(currentCategory.size())));
+                label->setForeground(this->theme->accent);
                 chattersList->addItem(label);
                 foreach (const QJsonValue &v, currentCategory)
                 {


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description
Adds the number of chatters to each category label in the viewer list.
![image](https://user-images.githubusercontent.com/18620902/163705873-d1e9424b-edc3-4f39-8b00-adb7a69f8662.png)

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
