### PR TITLE
Add missing tooltip hide on ChannelView leave event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Minor: Add information about the user's operating system in the About page. (#3663)
 - Bugfix: Fixed live notifications for usernames containing uppercase characters. (#3646)
 - Bugfix: Fixed certain settings dialogs appearing behind the main window, when `Always on top` was used. (#3679)
+- Bugfix: Fixed an issue in the emote picker where an emotes tooltip would not properly disappear. (#3686)
 - Dev: Use Game Name returned by Get Streams instead of querying it from the Get Games API. (#3662)
 
 ## 2.3.5

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1236,7 +1236,7 @@ void ChannelView::enterEvent(QEvent *)
 void ChannelView::leaveEvent(QEvent *)
 {
     TooltipWidget::instance()->hide();
-    
+
     this->unpause(PauseReason::Mouse);
 
     this->queueLayout();

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1235,6 +1235,8 @@ void ChannelView::enterEvent(QEvent *)
 
 void ChannelView::leaveEvent(QEvent *)
 {
+    TooltipWidget::instance()->hide();
+    
     this->unpause(PauseReason::Mouse);
 
     this->queueLayout();


### PR DESCRIPTION
Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable

# Description

closes #3684
leaveEvent is fired only when mouse leaves whole listview, so no performance impact.

do we want changelog for this?