### PR TITLE
Fix tooltips ignoring zoom/font changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Minor: Add information about the user's operating system in the About page. (#3663)
 - Bugfix: Fixed live notifications for usernames containing uppercase characters. (#3646)
 - Bugfix: Fixed certain settings dialogs appearing behind the main window, when `Always on top` was used. (#3679)
+- Bugfix: Fixed tooltips not reacting to zoom and font changes. (#3687)
 - Dev: Use Game Name returned by Get Streams instead of querying it from the Get Games API. (#3662)
 
 ## 2.3.5

--- a/src/widgets/TooltipWidget.cpp
+++ b/src/widgets/TooltipWidget.cpp
@@ -82,7 +82,7 @@ void TooltipWidget::scaleChangedEvent(float)
 
 void TooltipWidget::updateFont()
 {
-    this->setFont(
+    this->displayText_->setFont(
         getFonts()->getFont(FontStyle::ChatMediumSmall, this->scale()));
 }
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Currently due to a bug, tooltips (emotes, badges, link preview, split header) are completely ignoring changes of zoom level or font size/style from settings. This PR fixes that.

Example with 1.3x zoom. Left side shows fixed tooltip, with zoom matching rest of the app. Right side is current behavior.
![screen](https://user-images.githubusercontent.com/28986062/164090173-cdaa98a2-7838-4a77-be80-692ca502d092.png)

tested on windows only
