### PR TITLE
sort /vips output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Minor: Fixed being unable to load Twitch Usercards from the `/mentions` tab. (#3623)
 - Minor: Add information about the user's operating system in the About page. (#3663)
 - Minor: Added chatter count for each category in viewer list. (#3683)
+- Minor: Sorted usernames in /vips message. (#3696)
 - Bugfix: Fixed live notifications for usernames containing uppercase characters. (#3646)
 - Bugfix: Fixed certain settings dialogs appearing behind the main window, when `Always on top` was used. (#3679)
 - Bugfix: Fixed an issue in the emote picker where an emotes tooltip would not properly disappear. (#3686)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Minor: Fixed being unable to load Twitch Usercards from the `/mentions` tab. (#3623)
 - Minor: Add information about the user's operating system in the About page. (#3663)
 - Minor: Added chatter count for each category in viewer list. (#3683)
-- Minor: Sorted usernames in /vips message. (#3696)
+- Minor: Sorted usernames in /vips message to be case-insensitive. (#3696)
 - Bugfix: Fixed live notifications for usernames containing uppercase characters. (#3646)
 - Bugfix: Fixed certain settings dialogs appearing behind the main window, when `Always on top` was used. (#3679)
 - Bugfix: Fixed an issue in the emote picker where an emotes tooltip would not properly disappear. (#3686)

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -883,11 +883,7 @@ void IrcMessageHandler::handleNoticeMessage(Communi::IrcNoticeMessage *message)
             auto users = msgParts.at(1)
                              .mid(1)  // there is a space before the first user
                              .split(", ");
-            for (int i = 0; i < users.size(); i++)
-            {
-                users[i] = users[i].toLower();
-            }
-            users.sort();
+            users.sort(Qt::CaseInsensitive);
             TwitchMessageBuilder::listOfUsersSystemMessage(msgParts.at(0),
                                                            users, tc, &builder);
             channel->addMessage(builder.release());

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -883,6 +883,11 @@ void IrcMessageHandler::handleNoticeMessage(Communi::IrcNoticeMessage *message)
             auto users = msgParts.at(1)
                              .mid(1)  // there is a space before the first user
                              .split(", ");
+            for (int i = 0; i < users.size(); i++)
+            {
+                users[i] = users[i].toLower();
+            }
+            users.sort();
             TwitchMessageBuilder::listOfUsersSystemMessage(msgParts.at(0),
                                                            users, tc, &builder);
             channel->addMessage(builder.release());


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description
Twitch returns display names when you use the /vips command so usernames that start with uppercase letters get placed before names that start with lowercase letters.
