### PR TITLE
Fix badges not being vertically centered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Minor: Fixed being unable to load Twitch Usercards from the `/mentions` tab. (#3623)
 - Minor: Add information about the user's operating system in the About page. (#3663)
 - Minor: Added chatter count for each category in viewer list. (#3683)
+- Minor: Badges will now appear vertically centered. (#3697)
 - Bugfix: Fixed live notifications for usernames containing uppercase characters. (#3646)
 - Bugfix: Fixed certain settings dialogs appearing behind the main window, when `Always on top` was used. (#3679)
 - Bugfix: Fixed an issue in the emote picker where an emotes tooltip would not properly disappear. (#3686)

--- a/src/messages/MessageElement.cpp
+++ b/src/messages/MessageElement.cpp
@@ -58,12 +58,6 @@ MessageElement *MessageElement::setTrailingSpace(bool value)
     return this;
 }
 
-MessageElement *MessageElement::setVCentered(bool value)
-{
-    this->vCentered = value;
-    return this;
-}
-
 const QString &MessageElement::getTooltip() const
 {
     return this->tooltip_;
@@ -89,9 +83,10 @@ bool MessageElement::hasTrailingSpace() const
     return this->trailingSpace;
 }
 
-bool MessageElement::isVCentered() const
+MessageElement *MessageElement::setFlag(MessageElementFlag flag)
 {
-    return this->vCentered;
+    this->flags_.set(flag);
+    return this;
 }
 
 MessageElementFlags MessageElement::getFlags() const
@@ -204,7 +199,7 @@ BadgeElement::BadgeElement(const EmotePtr &emote, MessageElementFlags flags)
     , emote_(emote)
 {
     this->setTooltip(emote->tooltip.string);
-    this->setVCentered(true);
+    this->setFlag(MessageElementFlag::VerticallyCentered);
 }
 
 void BadgeElement::addToContainer(MessageLayoutContainer &container,

--- a/src/messages/MessageElement.cpp
+++ b/src/messages/MessageElement.cpp
@@ -58,6 +58,12 @@ MessageElement *MessageElement::setTrailingSpace(bool value)
     return this;
 }
 
+MessageElement *MessageElement::setVCentered(bool value)
+{
+    this->vCentered = value;
+    return this;
+}
+
 const QString &MessageElement::getTooltip() const
 {
     return this->tooltip_;
@@ -81,6 +87,11 @@ const Link &MessageElement::getLink() const
 bool MessageElement::hasTrailingSpace() const
 {
     return this->trailingSpace;
+}
+
+bool MessageElement::isVCentered() const
+{
+    return this->vCentered;
 }
 
 MessageElementFlags MessageElement::getFlags() const
@@ -193,6 +204,7 @@ BadgeElement::BadgeElement(const EmotePtr &emote, MessageElementFlags flags)
     , emote_(emote)
 {
     this->setTooltip(emote->tooltip.string);
+    this->setVCentered(true);
 }
 
 void BadgeElement::addToContainer(MessageLayoutContainer &container,

--- a/src/messages/MessageElement.hpp
+++ b/src/messages/MessageElement.hpp
@@ -125,6 +125,9 @@ enum class MessageElementFlag : int64_t {
     // ZeroWidthEmotes are emotes that are supposed to overlay over any pre-existing emotes
     // e.g. BTTV's SoSnowy during christmas season
     ZeroWidthEmote = (1LL << 31),
+    
+    // draw position
+    VerticallyCentered = (1LL << 32),
 
     Default = Timestamp | Badges | Username | BitsStatic | FfzEmoteImage |
               BttvEmoteImage | TwitchEmoteImage | BitsAmount | Text |
@@ -152,16 +155,14 @@ public:
     MessageElement *setTooltip(const QString &tooltip);
     MessageElement *setThumbnailType(const ThumbnailType type);
     MessageElement *setThumbnail(const ImagePtr &thumbnail);
-
+    MessageElement *setFlag(MessageElementFlag flag);
     MessageElement *setTrailingSpace(bool value);
-    MessageElement *setVCentered(bool value);
     const QString &getTooltip() const;
     const ImagePtr &getThumbnail() const;
     const ThumbnailType &getThumbnailType() const;
 
     const Link &getLink() const;
     bool hasTrailingSpace() const;
-    bool isVCentered() const;
     MessageElementFlags getFlags() const;
     MessageElement *updateLink();
 
@@ -173,7 +174,6 @@ public:
 protected:
     MessageElement(MessageElementFlags flags);
     bool trailingSpace = true;
-    bool vCentered = false;
 
 private:
     QString text_;

--- a/src/messages/MessageElement.hpp
+++ b/src/messages/MessageElement.hpp
@@ -125,7 +125,7 @@ enum class MessageElementFlag : int64_t {
     // ZeroWidthEmotes are emotes that are supposed to overlay over any pre-existing emotes
     // e.g. BTTV's SoSnowy during christmas season
     ZeroWidthEmote = (1LL << 31),
-    
+
     // draw position
     VerticallyCentered = (1LL << 32),
 

--- a/src/messages/MessageElement.hpp
+++ b/src/messages/MessageElement.hpp
@@ -154,12 +154,14 @@ public:
     MessageElement *setThumbnail(const ImagePtr &thumbnail);
 
     MessageElement *setTrailingSpace(bool value);
+    MessageElement *setVCentered(bool value);
     const QString &getTooltip() const;
     const ImagePtr &getThumbnail() const;
     const ThumbnailType &getThumbnailType() const;
 
     const Link &getLink() const;
     bool hasTrailingSpace() const;
+    bool isVCentered() const;
     MessageElementFlags getFlags() const;
     MessageElement *updateLink();
 
@@ -171,6 +173,7 @@ public:
 protected:
     MessageElement(MessageElementFlags flags);
     bool trailingSpace = true;
+    bool vCentered = false;
 
 private:
     QString text_;

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -176,15 +176,10 @@ void MessageLayoutContainer::_addElement(MessageLayoutElement *element,
         this->currentX_ -= this->spaceWidth_;
     }
 
-    int yPaintPos = element->getRect().height();
-    if (element->getCreator().isVCentered())
-    {
-        yPaintPos = (this->lineHeight_ / 2) + (element->getRect().height() / 2);
-    }
-
     // set paint position
-    element->setPosition(QPoint(this->currentX_ + xOffset,
-                                this->currentY_ - yPaintPos + yOffset));
+    element->setPosition(
+        QPoint(this->currentX_ + xOffset,
+               this->currentY_ - element->getRect().height() + yOffset));
 
     element->setLine(this->line_);
 
@@ -360,7 +355,10 @@ void MessageLayoutContainer::paintElements(QPainter &painter)
         painter.setPen(QColor(0, 255, 0));
         painter.drawRect(element->getRect());
 #endif
-
+        if (element->getFlags().has(MessageElementFlag::VerticallyCentered))
+        {
+            element->centerVertically(this->lineHeight_);
+        }
         element->paint(painter);
     }
 }

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -176,10 +176,15 @@ void MessageLayoutContainer::_addElement(MessageLayoutElement *element,
         this->currentX_ -= this->spaceWidth_;
     }
 
-    // set move element
-    element->setPosition(
-        QPoint(this->currentX_ + xOffset,
-               this->currentY_ - element->getRect().height() + yOffset));
+    int yPaintPos = element->getRect().height();
+    if (element->getCreator().isVCentered())
+    {
+        yPaintPos = (this->lineHeight_ / 2) + (element->getRect().height() / 2);
+    }
+
+    // set paint position
+    element->setPosition(QPoint(this->currentX_ + xOffset,
+                                this->currentY_ - yPaintPos + yOffset));
 
     element->setLine(this->line_);
 

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -249,8 +249,11 @@ void MessageLayoutContainer::breakLine()
         this->lines_.back().endIndex = this->lineStart_;
         this->lines_.back().endCharIndex = this->charIndex_;
     }
+
+    int finalLineHeight = (2 * this->margin.top * this->scale_) + lineHeight_;
+
     this->lines_.push_back(
-        {(int)lineStart_, 0, this->charIndex_, 0,
+        {(int)lineStart_, 0, this->charIndex_, 0, finalLineHeight,
          QRect(-100000, this->currentY_, 200000, lineHeight_)});
 
     for (int i = this->lineStart_; i < this->elements_.size(); i++)
@@ -357,7 +360,7 @@ void MessageLayoutContainer::paintElements(QPainter &painter)
 #endif
         if (element->getFlags().has(MessageElementFlag::VerticallyCentered))
         {
-            element->centerVertically(this->lineHeight_);
+            element->centerVertically(this->lines_[element->getLine()].height);
         }
         element->paint(painter);
     }

--- a/src/messages/layouts/MessageLayoutContainer.hpp
+++ b/src/messages/layouts/MessageLayoutContainer.hpp
@@ -86,6 +86,7 @@ private:
         int endIndex;
         int startCharIndex;
         int endCharIndex;
+        int height;
         QRect rect;
     };
 

--- a/src/messages/layouts/MessageLayoutElement.cpp
+++ b/src/messages/layouts/MessageLayoutElement.cpp
@@ -38,7 +38,7 @@ MessageElement &MessageLayoutElement::getCreator() const
 
 void MessageLayoutElement::centerVertically(int maxHeight)
 {
-    this->rect_.moveTop((maxHeight / 2) + (this->rect_.height() / 2));
+    this->rect_.moveTop((maxHeight / 2) - (this->rect_.height() / 2));
 }
 
 void MessageLayoutElement::setPosition(QPoint point)

--- a/src/messages/layouts/MessageLayoutElement.cpp
+++ b/src/messages/layouts/MessageLayoutElement.cpp
@@ -36,6 +36,11 @@ MessageElement &MessageLayoutElement::getCreator() const
     return this->creator_;
 }
 
+void MessageLayoutElement::centerVertically(int maxHeight)
+{
+    this->rect_.moveTop((maxHeight / 2) + (this->rect_.height() / 2));
+}
+
 void MessageLayoutElement::setPosition(QPoint point)
 {
     this->rect_.moveTopLeft(point);

--- a/src/messages/layouts/MessageLayoutElement.hpp
+++ b/src/messages/layouts/MessageLayoutElement.hpp
@@ -29,6 +29,7 @@ public:
 
     const QRect &getRect() const;
     MessageElement &getCreator() const;
+    void centerVertically(int maxHeight);
     void setPosition(QPoint point);
     bool hasTrailingSpace() const;
     int getLine() const;


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

closes #1092 
decided adding support for vertical centering at MessageElement level will be better than hardcoding this to MessageFlag::Badges


| Before  | After |
| ------------- | ------------- |
| ![before](https://user-images.githubusercontent.com/28986062/165862316-d76a4adc-91f7-4f72-831e-6089643f3703.png)  | ![after](https://user-images.githubusercontent.com/28986062/165862274-af2d28b7-68a7-4afd-9d9a-9286a5b05bf1.png)  |
(Font size in settings: 16pt, Zoom: 1.4x)