### PR TITLE
Fix incorrect spacing of settings icons at high DPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Bugfix: Fixed live notifications for usernames containing uppercase characters. (#3646)
 - Bugfix: Fixed certain settings dialogs appearing behind the main window, when `Always on top` was used. (#3679)
 - Bugfix: Fixed an issue in the emote picker where an emotes tooltip would not properly disappear. (#3686)
+- Bugfix: Fixed incorrect spacing of settings icons at high DPI. (#3698)
 - Dev: Use Game Name returned by Get Streams instead of querying it from the Get Games API. (#3662)
 
 ## 2.3.5

--- a/src/widgets/helper/SettingsDialogTab.cpp
+++ b/src/widgets/helper/SettingsDialogTab.cpp
@@ -57,15 +57,17 @@ void SettingsDialogTab::paintEvent(QPaintEvent *)
 
     this->style()->drawPrimitive(QStyle::PE_Widget, &opt, &painter, this);
 
-    int a = (this->height() - (20 * this->scale())) / 2;
+    int iconSize = 20 * this->scale();
+    int pad = (this->height() - iconSize) / 2;
     QPixmap pixmap = this->ui_.icon.pixmap(
-        QSize(this->height() - a * 2, this->height() - a * 2));
+        QSize(this->height() - pad * 2, this->height() - pad * 2));
 
-    painter.drawPixmap(a, a, pixmap);
+    painter.drawPixmap(pad, pad, pixmap);
 
-    a = a + a + 20 + a;
+    pad = (3 * pad) + iconSize;
 
-    this->style()->drawItemText(&painter, QRect(a, 0, width() - a, height()),
+    this->style()->drawItemText(&painter,
+                                QRect(pad, 0, width() - pad, height()),
                                 Qt::AlignLeft | Qt::AlignVCenter,
                                 this->palette(), false, this->ui_.labelText);
 }


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

closes #755
icon scale was missing in text padding calculation 

|  | Before | After |
| ------------- | ------------- | ------------- |
| High DPI  | ![b1](https://user-images.githubusercontent.com/28986062/165867391-b2072f24-e227-4638-97cc-011a26b956ef.png)  | ![a1](https://user-images.githubusercontent.com/28986062/165867456-ec60d841-f91e-4cc7-a6e4-762037c608aa.png)  |
| 96 DPI  | ![b2](https://user-images.githubusercontent.com/28986062/165867426-1185d014-ba3d-4ddc-b808-acfc2ab7f252.png)  | ![a2](https://user-images.githubusercontent.com/28986062/165867475-8d2b3710-0102-4d39-b2b1-d9735ee3aad8.png)  |