### PR TITLE
fix: parse irc tags with consecutive escapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Minor: Added chatter count for each category in viewer list. (#3683)
 - Minor: Sorted usernames in /vips message to be case-insensitive. (#3696)
 - Minor: Added option to open a user's chat in a new tab from the usercard profile picture context menu. (#3625)
+- Minor: Fixed tag parsing for consecutive escaped characters. (#3711)
 - Bugfix: Fixed live notifications for usernames containing uppercase characters. (#3646)
 - Bugfix: Fixed live notifications not getting updated for closed streams going offline. (#3678)
 - Bugfix: Fixed certain settings dialogs appearing behind the main window, when `Always on top` was used. (#3679)

--- a/src/util/IrcHelpers.hpp
+++ b/src/util/IrcHelpers.hpp
@@ -51,7 +51,6 @@ inline QString parseTagString(const QString &input)
                 break;
             }
 
-            i++;
             length--;
         }
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ set(test_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/src/RatelimitBucket.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/Hotkeys.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/UtilTwitch.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/IrcHelpers.cpp
     # Add your new file above this line!
     )
 

--- a/tests/src/IrcHelpers.cpp
+++ b/tests/src/IrcHelpers.cpp
@@ -1,0 +1,61 @@
+#include "util/IrcHelpers.hpp"
+
+#include <gtest/gtest.h>
+#include <QApplication>
+#include <QDebug>
+#include <QtConcurrent>
+
+#include <chrono>
+#include <thread>
+
+using namespace chatterino;
+
+TEST(IrcHelpers, ParseTagString)
+{
+    struct TestCase {
+        QString input;
+        QString expected;
+    };
+
+    std::vector<TestCase> tests{
+        {
+            // No space escapes (normal string)
+            R"(DefectiveCloak gifted a Tier 1 sub to aliiscrying!)",
+            "DefectiveCloak gifted a Tier 1 sub to aliiscrying!",
+        },
+        {
+            // space at end
+            R"(DefectiveCloak\s\sgifted\sa\sTier\s1\ssub\sto\s)",
+            "DefectiveCloak  gifted a Tier 1 sub to ",
+        },
+        {
+            // consecutive spaces
+            R"(DefectiveCloak\s\sgifted\sa\sTier\s1\ssub\sto\saliiscrying!)",
+            "DefectiveCloak  gifted a Tier 1 sub to aliiscrying!",
+        },
+        {
+            // non-consecutive spaces
+            R"(DefectiveCloak\sgifted\sa\sTier\s1\ssub\sto\saliiscrying!)",
+            "DefectiveCloak gifted a Tier 1 sub to aliiscrying!",
+        },
+        {
+            // colon to semicolon
+            R"(foo\:bar)",
+            "foo;bar",
+        },
+        {
+            // backslash
+            R"(foo\\bar)",
+            R"(foo\bar)",
+        },
+    };
+
+    for (const auto &[input, expected] : tests)
+    {
+        const auto actual = parseTagString(input);
+
+        EXPECT_EQ(actual, expected)
+            << qUtf8Printable(actual) << " (" << qUtf8Printable(input)
+            << ") did not match expected value " << qUtf8Printable(expected);
+    }
+}


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description
When an irc tag has multiple escaped characters in a row, the current `parseTagString` function fails to see the 2nd `\` due to the extra `i++` (since the loop declaration already has `i++` and the string replacement eats two characters)

Example: `system-msg=DefectiveCloak\s\sgifted\sa\sTier\s1\ssub\sto\saliiscrying!` (weird case where their display name has a trailing space)

![image](https://user-images.githubusercontent.com/8106344/167074200-40072cf6-dcd9-4ec0-af0b-b0dda7add116.png)
