### PR TITLE
fix: raise existing emote popups from behind other windows (macOS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Bugfix: Fixed certain settings dialogs appearing behind the main window, when `Always on top` was used. (#3679)
 - Bugfix: Fixed an issue in the emote picker where an emotes tooltip would not properly disappear. (#3686)
 - Bugfix: Fixed incorrect spacing of settings icons at high DPI. (#3698)
+- Bugfix: Fixed existing emote popups not being raised from behind other windows when refocusing them on macOS (#3713)
 - Dev: Use Game Name returned by Get Streams instead of querying it from the Get Games API. (#3662)
 
 ## 2.3.5

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -210,6 +210,7 @@ void SplitInput::openEmotePopup()
                               int(500 * this->emotePopup_->scale()));
     this->emotePopup_->loadChannel(this->split_->getChannel());
     this->emotePopup_->show();
+    this->emotePopup_->raise();
     this->emotePopup_->activateWindow();
 }
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Chatterino tries to refocus an existing emote popup instead of opening a new one, which works fine until the existing emote popup is now behind some other application. In that case chatterino still focuses the existing emote popup, but doesn't actually bring it to the front, resulting in no visible window being focused (since the main application has now lost focus) and you having to search for the emote popup somewhere on your desktop.

It seems like the issue is macOS specific since on other platforms/WMs you apparently just can't hide the emote popup behind something else as long as chatterino is focused, so this change should not affect any of them.

[felanbird]: here's his `.mov` showing the issue that github doesn't like https://i.nuuls.com/PgiHt.mp4