### PR TITLE
Disable formatting on "contested lines"

### DIFF
--- a/src/messages/MessageBuilder.hpp
+++ b/src/messages/MessageBuilder.hpp
@@ -63,7 +63,10 @@ public:
     void addLink(const QString &origLink, const QString &matchedLink);
 
     template <typename T, typename... Args>
-    T *emplace(Args &&... args)
+    // clang-format off
+    // clang-format can be enabled once clang-format v11+ has been installed in CI
+    T *emplace(Args &&...args)
+    // clang-format on
     {
         static_assert(std::is_base_of<MessageElement, T>::value,
                       "T must extend MessageElement");

--- a/src/util/LayoutCreator.hpp
+++ b/src/util/LayoutCreator.hpp
@@ -43,7 +43,10 @@ public:
     }
 
     template <typename T2, typename... Args>
-    LayoutCreator<T2> emplace(Args &&... args)
+    // clang-format off
+    // clang-format can be enabled once clang-format v11+ has been installed in CI
+    LayoutCreator<T2> emplace(Args &&...args)
+    // clang-format on
     {
         T2 *t = new T2(std::forward<Args>(args)...);
 
@@ -184,7 +187,10 @@ private:
 };
 
 template <typename T, typename... Args>
-LayoutCreator<T> makeDialog(Args &&... args)
+// clang-format off
+// clang-format can be enabled once clang-format v11+ has been installed in CI
+LayoutCreator<T> makeDialog(Args &&...args)
+// clang-format on
 {
     T *t = new T(std::forward<Args>(args)...);
     t->setAttribute(Qt::WA_DeleteOnClose);


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

These lines are formatted differently between clang-format 10 (on CI) and clang-format 11+ (on most dev systems)

This ensures dev systems don't start formatting them, and that our CI doesn't complain about them

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
