### PR TITLE
fix: disable duplicate automod caught message handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Minor: Sorted usernames in /vips message to be case-insensitive. (#3696)
 - Minor: Added option to open a user's chat in a new tab from the usercard profile picture context menu. (#3625)
 - Minor: Fixed tag parsing for consecutive escaped characters. (#3711)
+- Minor: Fixed automod caught message notice appearing twice for mods. (#3717)
 - Bugfix: Fixed live notifications for usernames containing uppercase characters. (#3646)
 - Bugfix: Fixed live notifications not getting updated for closed streams going offline. (#3678)
 - Bugfix: Fixed certain settings dialogs appearing behind the main window, when `Always on top` was used. (#3679)

--- a/src/providers/twitch/PubSubManager.cpp
+++ b/src/providers/twitch/PubSubManager.cpp
@@ -279,6 +279,8 @@ PubSub::PubSub(const QString &host, std::chrono::seconds pingInterval)
         this->signals_.moderation.userUnbanned.invoke(action);
     };
 
+    /*
+    // This handler is no longer required as we use the automod-queue topic now
     this->moderationActionHandlers["automod_rejected"] =
         [this](const auto &data, const auto &roomID) {
             AutomodAction action(data, roomID);
@@ -309,6 +311,7 @@ PubSub::PubSub(const QString &host, std::chrono::seconds pingInterval)
 
             this->signals_.moderation.autoModMessageBlocked.invoke(action);
         };
+    */
 
     this->moderationActionHandlers["automod_message_rejected"] =
         [this](const auto &data, const auto &roomID) {


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description
The `automod_rejected` action over moderator actions pubsub is sent to mods when automod catches an offending message (`automod_message_rejected`, on the other hand, is sent to the offending user, so we do not disable that).

However, we also use the (better) `automod-queue` topic for this info in [Application](https://github.com/Chatterino/chatterino2/blob/65301a3359aacc8a570e848b1fc4d2dd276f0e56/src/Application.cpp#L335-L425), resulting in a duplicated event handler. 

Fixes #3133 
