### PR TITLE
fix: unlisten to automod on user change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Bugfix: Fixed an issue in the emote picker where an emotes tooltip would not properly disappear. (#3686)
 - Bugfix: Fixed incorrect spacing of settings icons at high DPI. (#3698)
 - Bugfix: Fixed existing emote popups not being raised from behind other windows when refocusing them on macOS (#3713)
+- Bugfix: Fixed automod queue pubsub topic persisting after user change. (#3718)
 - Dev: Use Game Name returned by Get Streams instead of querying it from the Get Games API. (#3662)
 
 ## 2.3.5

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -507,6 +507,7 @@ void Application::initPubSub()
     this->accounts->twitch.currentUserChanged.connect(
         [=] {
             this->twitch->pubsub->unlistenAllModerationActions();
+            this->twitch->pubsub->unlistenAutomod();
             this->twitch->pubsub->unlistenWhispers();
         },
         boost::signals2::at_front);

--- a/src/providers/twitch/PubSubManager.cpp
+++ b/src/providers/twitch/PubSubManager.cpp
@@ -549,7 +549,8 @@ void PubSub::unlistenAutomod()
     for (const auto &p : this->clients)
     {
         const auto &client = p.second;
-        if (const auto &[topics, nonce] = client->unlistenPrefix("automod-queue.");
+        if (const auto &[topics, nonce] =
+                client->unlistenPrefix("automod-queue.");
             !topics.empty())
         {
             this->registerNonce(nonce, {

--- a/src/providers/twitch/PubSubManager.cpp
+++ b/src/providers/twitch/PubSubManager.cpp
@@ -544,6 +544,24 @@ void PubSub::unlistenAllModerationActions()
     }
 }
 
+void PubSub::unlistenAutomod()
+{
+    for (const auto &p : this->clients)
+    {
+        const auto &client = p.second;
+        if (const auto &[topics, nonce] = client->unlistenPrefix("automod-queue.");
+            !topics.empty())
+        {
+            this->registerNonce(nonce, {
+                                           client,
+                                           "UNLISTEN",
+                                           topics,
+                                           topics.size(),
+                                       });
+        }
+    }
+}
+
 void PubSub::unlistenWhispers()
 {
     for (const auto &p : this->clients)

--- a/src/providers/twitch/PubSubManager.hpp
+++ b/src/providers/twitch/PubSubManager.hpp
@@ -119,6 +119,7 @@ public:
     } signals_;
 
     void unlistenAllModerationActions();
+    void unlistenAutomod();
     void unlistenWhispers();
 
     bool listenToWhispers();


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description
Calls `unlistenAutomod` on `currentUserChanged`

Edit: confirmed fixed by badoge, related to #3133 