### PR TITLE
Add missing vector header

### DIFF
--- a/src/controllers/hotkeys/Hotkey.hpp
+++ b/src/controllers/hotkeys/Hotkey.hpp
@@ -5,6 +5,8 @@
 #include <QKeySequence>
 #include <QString>
 
+#include <vector>
+
 namespace chatterino {
 
 class Hotkey


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

This fixes compilation under GCC 12.1.0 by adding a missing `<vector>` header
