### PR TITLE
Add missing QDebug header

### DIFF
--- a/src/providers/twitch/PubSubActions.hpp
+++ b/src/providers/twitch/PubSubActions.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <QColor>
+#include <QDebug>
 #include <QJsonObject>
 #include <QString>
-#include <QDebug>
 
 #include <chrono>
 #include <cinttypes>

--- a/src/providers/twitch/PubSubActions.hpp
+++ b/src/providers/twitch/PubSubActions.hpp
@@ -3,6 +3,7 @@
 #include <QColor>
 #include <QJsonObject>
 #include <QString>
+#include <QDebug>
 
 #include <chrono>
 #include <cinttypes>


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Fixes compilation on Qt 5.12.x without precompiled headers. Found in https://github.com/Chatterino/chatterino2/runs/6420848248?check_suite_focus=true#step:18:256
