### PR TITLE
Fixed viewer list not being closable with the escape key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Bugfix: Fixed highlights triggering from own resub messages. (#3707)
 - Bugfix: Fixed existing emote popups not being raised from behind other windows when refocusing them on macOS (#3713)
 - Bugfix: Fixed automod queue pubsub topic persisting after user change. (#3718)
+- Bugfix: Fixed viewer list not closing after pressing escape key. (#3569)
 - Dev: Use Game Name returned by Get Streams instead of querying it from the Get Games API. (#3662)
 
 ## 2.3.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - Bugfix: Fixed highlights triggering from own resub messages. (#3707)
 - Bugfix: Fixed existing emote popups not being raised from behind other windows when refocusing them on macOS (#3713)
 - Bugfix: Fixed automod queue pubsub topic persisting after user change. (#3718)
-- Bugfix: Fixed viewer list not closing after pressing escape key. (#3569)
+- Bugfix: Fixed viewer list not closing after pressing escape key. (#3734)
 - Dev: Use Game Name returned by Get Streams instead of querying it from the Get Games API. (#3662)
 
 ## 2.3.5

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -1077,7 +1077,12 @@ void Split::showViewerList()
         {"reject", nullptr},
         {"scrollPage", nullptr},
         {"openTab", nullptr},
-        {"search", nullptr},
+        {"search",
+         [searchBar](std::vector<QString>) -> QString {
+             searchBar->setFocus();
+             searchBar->selectAll();
+             return "";
+         }},
     };
 
     getApp()->hotkeys->shortcutsForCategory(HotkeyCategory::PopupWindow,

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -1067,6 +1067,22 @@ void Split::showViewerList()
         listDoubleClick(resultList->currentItem()->text());
     });
 
+    HotkeyController::HotkeyMap actions{
+        {"delete",
+         [viewerDock](std::vector<QString>) -> QString {
+             viewerDock->close();
+             return "";
+         }},
+        {"accept", nullptr},
+        {"reject", nullptr},
+        {"scrollPage", nullptr},
+        {"openTab", nullptr},
+        {"search", nullptr},
+    };
+
+    getApp()->hotkeys->shortcutsForCategory(HotkeyCategory::PopupWindow,
+                                            actions, viewerDock);
+
     dockVbox->addWidget(searchBar);
     dockVbox->addWidget(loadingLabel);
     dockVbox->addWidget(chattersList);


### PR DESCRIPTION
changelog

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description
Currently the viewer list isn't able to be closed using the escape key like the rest of the popups. This PR adds the PopupWindow hotkeys to the viewer list QDockWidget so that you can close it with the escape key and use the search hotkey to select the search field.

Closes #3569 