### PR TITLE
Feature: execute commands on chat messages using the context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Minor: Fixed tag parsing for consecutive escaped characters. (#3711)
 - Minor: Prevent user from entering incorrect characters in Live Notifications channels list. (#3715)
 - Minor: Fixed automod caught message notice appearing twice for mods. (#3717)
+- Minor: Added ability to execute commands on chat messages using the message context menu. (#3738)
 - Bugfix: Fixed live notifications for usernames containing uppercase characters. (#3646)
 - Bugfix: Fixed live notifications not getting updated for closed streams going offline. (#3678)
 - Bugfix: Fixed certain settings dialogs appearing behind the main window, when `Always on top` was used. (#3679)

--- a/src/controllers/commands/Command.cpp
+++ b/src/controllers/commands/Command.cpp
@@ -15,11 +15,14 @@ Command::Command(const QString &_text)
 
     this->name = _text.mid(0, index).trimmed();
     this->func = _text.mid(index + 1).trimmed();
+    this->showInMsgContextMenu = false;
 }
 
-Command::Command(const QString &_name, const QString &_func)
+Command::Command(const QString &_name, const QString &_func,
+                 bool _showInMsgContextMenu)
     : name(_name.trimmed())
     , func(_func.trimmed())
+    , showInMsgContextMenu(_showInMsgContextMenu)
 {
 }
 

--- a/src/controllers/commands/Command.hpp
+++ b/src/controllers/commands/Command.hpp
@@ -67,6 +67,8 @@ struct Deserialize<chatterino::Command> {
                                      command.showInMsgContextMenu))
         {
             PAJLADA_REPORT_ERROR(error);
+
+            command.showInMsgContextMenu = false;
             return command;
         }
 

--- a/src/controllers/commands/Command.hpp
+++ b/src/controllers/commands/Command.hpp
@@ -66,9 +66,10 @@ struct Deserialize<chatterino::Command> {
         if (!chatterino::rj::getSafe(value, "showInMsgContextMenu",
                                      command.showInMsgContextMenu))
         {
+            command.showInMsgContextMenu = false;
+
             PAJLADA_REPORT_ERROR(error);
 
-            command.showInMsgContextMenu = false;
             return command;
         }
 

--- a/src/controllers/commands/Command.hpp
+++ b/src/controllers/commands/Command.hpp
@@ -10,10 +10,12 @@ namespace chatterino {
 struct Command {
     QString name;
     QString func;
+    bool showInMsgContextMenu;
 
     Command() = default;
     explicit Command(const QString &text);
-    Command(const QString &name, const QString &func);
+    Command(const QString &name, const QString &func,
+            bool showInMsgContextMenu = false);
 
     QString toString() const;
 };
@@ -31,6 +33,8 @@ struct Serialize<chatterino::Command> {
 
         chatterino::rj::set(ret, "name", value.name, a);
         chatterino::rj::set(ret, "func", value.func, a);
+        chatterino::rj::set(ret, "showInMsgContextMenu",
+                            value.showInMsgContextMenu, a);
 
         return ret;
     }
@@ -55,6 +59,12 @@ struct Deserialize<chatterino::Command> {
             return command;
         }
         if (!chatterino::rj::getSafe(value, "func", command.func))
+        {
+            PAJLADA_REPORT_ERROR(error);
+            return command;
+        }
+        if (!chatterino::rj::getSafe(value, "showInMsgContextMenu",
+                                     command.showInMsgContextMenu))
         {
             PAJLADA_REPORT_ERROR(error);
             return command;

--- a/src/controllers/commands/CommandModel.cpp
+++ b/src/controllers/commands/CommandModel.cpp
@@ -6,7 +6,7 @@ namespace chatterino {
 
 // commandmodel
 CommandModel::CommandModel(QObject *parent)
-    : SignalVectorModel<Command>(2, parent)
+    : SignalVectorModel<Command>(Column::COUNT, parent)
 {
 }
 
@@ -14,16 +14,21 @@ CommandModel::CommandModel(QObject *parent)
 Command CommandModel::getItemFromRow(std::vector<QStandardItem *> &row,
                                      const Command &original)
 {
-    return Command(row[0]->data(Qt::EditRole).toString(),
-                   row[1]->data(Qt::EditRole).toString());
+    return Command(row[Column::Trigger]->data(Qt::EditRole).toString(),
+                   row[Column::CommandFunc]->data(Qt::EditRole).toString(),
+                   row[Column::ShowInMessageContextMenu]
+                       ->data(Qt::CheckStateRole)
+                       .toBool());
 }
 
 // turns a row in the model into a vector item
 void CommandModel::getRowFromItem(const Command &item,
                                   std::vector<QStandardItem *> &row)
 {
-    setStringItem(row[0], item.name);
-    setStringItem(row[1], item.func);
+    setStringItem(row[Column::Trigger], item.name);
+    setStringItem(row[Column::CommandFunc], item.func);
+    setBoolItem(row[Column::ShowInMessageContextMenu],
+                item.showInMsgContextMenu);
 }
 
 }  // namespace chatterino

--- a/src/controllers/commands/CommandModel.hpp
+++ b/src/controllers/commands/CommandModel.hpp
@@ -11,14 +11,13 @@ class CommandController;
 
 class CommandModel : public SignalVectorModel<Command>
 {
-public:
     explicit CommandModel(QObject *parent);
 
     enum Column {
         Trigger = 0,
         CommandFunc = 1,
         ShowInMessageContextMenu = 2,
-        COUNT
+        COUNT,
     };
 
 protected:

--- a/src/controllers/commands/CommandModel.hpp
+++ b/src/controllers/commands/CommandModel.hpp
@@ -11,7 +11,15 @@ class CommandController;
 
 class CommandModel : public SignalVectorModel<Command>
 {
+public:
     explicit CommandModel(QObject *parent);
+
+    enum Column {
+        Trigger = 0,
+        CommandFunc = 1,
+        ShowInMessageContextMenu = 2,
+        COUNT
+    };
 
 protected:
     // turn a vector item into a model row

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -2116,10 +2116,19 @@ void ChannelView::addCommandExecutionContextMenuItems(
         inputText.push_front(cmd.name + " ");
 
         cmdMenu->addAction(cmd.name, [this, inputText] {
-            QString value = getApp()->commands->execCommand(
-                inputText, this->underlyingChannel_, false);
+            ChannelPtr channel;
 
-            this->underlyingChannel_->sendMessage(value);
+            /* Search popups and user message history's underlyingChannels aren't of type TwitchChannel, but
+             * we would still like to execute commands from them. Use their source channel instead if applicable. */
+            if (this->hasSourceChannel())
+                channel = this->sourceChannel();
+            else
+                channel = this->underlyingChannel_;
+
+            QString value =
+                getApp()->commands->execCommand(inputText, channel, false);
+
+            channel->sendMessage(value);
         });
     }
 }

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -2096,11 +2096,15 @@ void ChannelView::addCommandExecutionContextMenuItems(
     for (auto &cmd : getApp()->commands->items)
     {
         if (cmd.showInMsgContextMenu)
+        {
             cmds.push_back(cmd);
+        }
     }
 
     if (cmds.empty())
+    {
         return;
+    }
 
     menu.addSeparator();
     auto executeAction = menu.addAction("Execute command");
@@ -2121,9 +2125,13 @@ void ChannelView::addCommandExecutionContextMenuItems(
             /* Search popups and user message history's underlyingChannels aren't of type TwitchChannel, but
              * we would still like to execute commands from them. Use their source channel instead if applicable. */
             if (this->hasSourceChannel())
+            {
                 channel = this->sourceChannel();
+            }
             else
+            {
                 channel = this->underlyingChannel_;
+            }
 
             QString value =
                 getApp()->commands->execCommand(inputText, channel, false);

--- a/src/widgets/helper/ChannelView.hpp
+++ b/src/widgets/helper/ChannelView.hpp
@@ -184,6 +184,10 @@ private:
     void addHiddenContextMenuItems(const MessageLayoutElement *hoveredElement,
                                    MessageLayoutPtr layout, QMouseEvent *event,
                                    QMenu &menu);
+    void addCommandExecutionContextMenuItems(
+        const MessageLayoutElement *hoveredElement, MessageLayoutPtr layout,
+        QMouseEvent *event, QMenu &menu);
+
     int getLayoutWidth() const;
     void updatePauses();
     void unpaused();

--- a/src/widgets/settingspages/CommandPage.cpp
+++ b/src/widgets/settingspages/CommandPage.cpp
@@ -44,8 +44,9 @@ CommandPage::CommandPage()
         layout.emplace<EditableModelView>(app->commands->createModel(nullptr))
             .getElement();
 
-    view->setTitles({"Trigger", "Command"});
-    view->getTableView()->horizontalHeader()->setStretchLastSection(true);
+    view->setTitles({"Trigger", "Command", "Show In\nMessage Menu"});
+    view->getTableView()->horizontalHeader()->setSectionResizeMode(
+        1, QHeaderView::Stretch);
     view->addButtonPressed.connect([] {
         getApp()->commands->items.append(
             Command{"/command", "I made a new command HeyGuys"});


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description
The command page will receive a checkbox column that will allow for a user to specify whether they want that command to appear on the message context menu. Upon right clicking a message, if there are any commands available that were checked to appear, you will receive an additional menu action to execute a command. It will take the text of the message you selected, either the whole message or only the selected portion if there is one, and pass it into the command like normal.

For example:
The command /google: `/openurl https://www.google.com/search?q={1+}` will allow you to quickly google the whole or a selected portion of a chat message.

# Preview
![image](https://user-images.githubusercontent.com/59930937/168460495-acc0e877-78af-41a4-a876-5db4d9bb616f.png)
![image](https://user-images.githubusercontent.com/59930937/168460722-73f1d881-797e-4564-b733-96ac4e8e1848.png)


Closes #3603
Closes #2058
