### PR TITLE
fix: compilation on macOS without precompiled headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@
 - Bugfix: Fixed automod queue pubsub topic persisting after user change. (#3718)
 - Bugfix: Fixed viewer list not closing after pressing escape key. (#3734)
 - Dev: Use Game Name returned by Get Streams instead of querying it from the Get Games API. (#3662)
-- Dev: Fix compiling on macOS without precompiled headers (#3741)
 
 ## 2.3.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Bugfix: Fixed automod queue pubsub topic persisting after user change. (#3718)
 - Bugfix: Fixed viewer list not closing after pressing escape key. (#3734)
 - Dev: Use Game Name returned by Get Streams instead of querying it from the Get Games API. (#3662)
+- Dev: Fix compiling on macOS without precompiled headers (#3741)
 
 ## 2.3.5
 

--- a/src/providers/ffz/FfzBadges.hpp
+++ b/src/providers/ffz/FfzBadges.hpp
@@ -9,8 +9,8 @@
 #include <map>
 #include <memory>
 #include <shared_mutex>
-#include <vector>
 #include <unordered_map>
+#include <vector>
 
 #include <QColor>
 

--- a/src/providers/ffz/FfzBadges.hpp
+++ b/src/providers/ffz/FfzBadges.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <shared_mutex>
 #include <vector>
+#include <unordered_map>
 
 #include <QColor>
 

--- a/src/widgets/splits/SplitContainer.hpp
+++ b/src/widgets/splits/SplitContainer.hpp
@@ -15,6 +15,7 @@
 #include <pajlada/signals/signal.hpp>
 #include <pajlada/signals/signalholder.hpp>
 #include <vector>
+#include <unordered_map>
 
 class QJsonObject;
 

--- a/src/widgets/splits/SplitContainer.hpp
+++ b/src/widgets/splits/SplitContainer.hpp
@@ -14,8 +14,8 @@
 #include <functional>
 #include <pajlada/signals/signal.hpp>
 #include <pajlada/signals/signalholder.hpp>
-#include <vector>
 #include <unordered_map>
+#include <vector>
 
 class QJsonObject;
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

So for whatever reason apple-clang on macOS needs additional imports to successfully compile without precompiled headers. This issue does not exist when using gcc on ubuntu, which is what chatterinos CI is doing. I only just noticed it myself when compiling locally.

<details>
<summary>Compile errors</summary>


```
[ 22%] Building CXX object src/CMakeFiles/chatterino-lib.dir/common/Args.cpp.o
In file included from /Users/lassepetzel/code/chatterino2/src/common/Args.cpp:5:
In file included from /Users/lassepetzel/code/chatterino2/src/singletons/WindowManager.hpp:10:
/Users/lassepetzel/code/chatterino2/src/widgets/splits/SplitContainer.hpp:260:10: error: no template named 'unordered_map' in namespace 'std'
    std::unordered_map<Split *, pajlada::Signals::SignalHolder>
    ~~~~~^
1 error generated.
```

```
[ 44%] Building CXX object src/CMakeFiles/chatterino-lib.dir/providers/ffz/FfzBadges.cpp.o
In file included from /Users/lassepetzel/code/chatterino7/src/providers/ffz/FfzBadges.cpp:1:
/Users/lassepetzel/code/chatterino7/src/providers/ffz/FfzBadges.hpp:35:10: error: no template named 'unordered_map' in namespace 'std'
    std::unordered_map<QString, int> badgeMap;
    ~~~~~^
/Users/lassepetzel/code/chatterino7/src/providers/ffz/FfzBadges.hpp:37:10: error: no template named 'unordered_map' in namespace 'std'
    std::unordered_map<int, QColor> colorMap;
    ~~~~~^
2 errors generated.
```

</details>