### PR TITLE
Remove unused Env member for emoteset resolver url

### DIFF
--- a/src/common/Env.cpp
+++ b/src/common/Env.cpp
@@ -54,9 +54,6 @@ Env::Env()
     , linkResolverUrl(readStringEnv(
           "CHATTERINO2_LINK_RESOLVER_URL",
           "https://braize.pajlada.com/chatterino/link_resolver/%1"))
-    , twitchEmoteSetResolverUrl(readStringEnv(
-          "CHATTERINO2_TWITCH_EMOTE_SET_RESOLVER_URL",
-          "https://braize.pajlada.com/chatterino/twitchemotes/set/%1/"))
     , twitchServerHost(
           readStringEnv("CHATTERINO2_TWITCH_SERVER_HOST", "irc.chat.twitch.tv"))
     , twitchServerPort(readPortEnv("CHATTERINO2_TWITCH_SERVER_PORT", 443))

--- a/src/common/Env.hpp
+++ b/src/common/Env.hpp
@@ -13,7 +13,6 @@ public:
 
     const QString recentMessagesApiUrl;
     const QString linkResolverUrl;
-    const QString twitchEmoteSetResolverUrl;
     const QString twitchServerHost;
     const uint16_t twitchServerPort;
     const bool twitchServerSecure;

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -448,7 +448,6 @@ void CommandController::initialize(Settings &, Paths &paths)
         QStringList debugMessages{
             "recentMessagesApiUrl: " + env.recentMessagesApiUrl,
             "linkResolverUrl: " + env.linkResolverUrl,
-            "twitchEmoteSetResolverUrl: " + env.twitchEmoteSetResolverUrl,
             "twitchServerHost: " + env.twitchServerHost,
             "twitchServerPort: " + QString::number(env.twitchServerPort),
             "twitchServerSecure: " + QString::number(env.twitchServerSecure),


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

This is a follow-up to GH-2905, this code should've been removed back then.

I forgot how to use git when I made GH-3742
