### PR TITLE
Added notes to usercards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unversioned
 
+- Major: Added usercard notes. (#3745)
 - Minor: Added `is:first-msg` search option. (#3700)
 - Minor: Added quotation marks in the permitted/blocked Automod messages for clarity. (#3654)
 - Minor: Adjust large stream thumbnail to 16:9 (#3655)

--- a/chatterino.pro
+++ b/chatterino.pro
@@ -169,6 +169,7 @@ SOURCES += \
     src/controllers/moderationactions/ModerationAction.cpp \
     src/controllers/moderationactions/ModerationActionModel.cpp \
     src/controllers/nicknames/NicknamesModel.cpp \
+    src/controllers/notes/NoteModel.cpp \
     src/controllers/notifications/NotificationController.cpp \
     src/controllers/notifications/NotificationModel.cpp \
     src/controllers/pings/MutedChannelModel.cpp \
@@ -416,6 +417,8 @@ HEADERS += \
     src/controllers/moderationactions/ModerationActionModel.hpp \
     src/controllers/nicknames/Nickname.hpp \
     src/controllers/nicknames/NicknamesModel.hpp \
+    src/controllers/notes/NoteModel.hpp \
+    src/controllers/notes/Note.hpp \
     src/controllers/notifications/NotificationController.hpp \
     src/controllers/notifications/NotificationModel.hpp \
     src/controllers/pings/MutedChannelModel.hpp \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -113,8 +113,8 @@ set(SOURCE_FILES
         controllers/nicknames/NicknamesModel.hpp
         controllers/nicknames/Nickname.hpp
 
-        controllers/notes/NotesModel.cpp
-        controllers/notes/NotesModel.hpp
+        controllers/notes/NoteModel.cpp
+        controllers/notes/NoteModel.hpp
         controllers/notes/Note.hpp  
 
         controllers/notifications/NotificationController.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -113,6 +113,10 @@ set(SOURCE_FILES
         controllers/nicknames/NicknamesModel.hpp
         controllers/nicknames/Nickname.hpp
 
+        controllers/notes/NotesModel.cpp
+        controllers/notes/NotesModel.hpp
+        controllers/notes/Note.hpp  
+
         controllers/notifications/NotificationController.cpp
         controllers/notifications/NotificationController.hpp
         controllers/notifications/NotificationModel.cpp

--- a/src/PrecompiledHeader.hpp
+++ b/src/PrecompiledHeader.hpp
@@ -94,6 +94,7 @@
 #    include <QStyleOption>
 #    include <QTabWidget>
 #    include <QTextEdit>
+#    include <QPlainTextEdit>
 #    include <QThread>
 #    include <QThreadPool>
 #    include <QTime>

--- a/src/PrecompiledHeader.hpp
+++ b/src/PrecompiledHeader.hpp
@@ -74,6 +74,7 @@
 #    include <QPainterPath>
 #    include <QPalette>
 #    include <QPixmap>
+#    include <QPlainTextEdit>
 #    include <QPoint>
 #    include <QProcess>
 #    include <QPropertyAnimation>
@@ -94,7 +95,6 @@
 #    include <QStyleOption>
 #    include <QTabWidget>
 #    include <QTextEdit>
-#    include <QPlainTextEdit>
 #    include <QThread>
 #    include <QThreadPool>
 #    include <QTime>

--- a/src/controllers/notes/Note.hpp
+++ b/src/controllers/notes/Note.hpp
@@ -56,7 +56,7 @@ struct Serialize<chatterino::Note> {
 template <>
 struct Deserialize<chatterino::Note> {
     static chatterino::Note get(const rapidjson::Value &value,
-                                    bool *error = nullptr)
+                                bool *error = nullptr)
     {
         if (!value.IsObject())
         {

--- a/src/controllers/notes/Note.hpp
+++ b/src/controllers/notes/Note.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+#include "controllers/accounts/AccountController.hpp"
+#include "util/RapidJsonSerializeQString.hpp"
+#include "util/RapidjsonHelpers.hpp"
+
+#include <QString>
+#include <pajlada/serialize.hpp>
+
+#include <memory>
+
+namespace chatterino {
+
+class Note
+{
+public:
+    Note(const QString &id, const QString &note)
+        : id_(id)
+        , note_(note)
+    {
+    }
+
+    [[nodiscard]] const QString &id() const
+    {
+        return this->id_;
+    }
+
+    [[nodiscard]] const QString &note() const
+    {
+        return this->note_;
+    }
+
+private:
+    QString id_;
+    QString note_;
+};
+
+}  // namespace chatterino
+
+namespace pajlada {
+
+template <>
+struct Serialize<chatterino::Note> {
+    static rapidjson::Value get(const chatterino::Note &value,
+                                rapidjson::Document::AllocatorType &a)
+    {
+        rapidjson::Value ret(rapidjson::kObjectType);
+
+        chatterino::rj::set(ret, "id", value.id(), a);
+        chatterino::rj::set(ret, "note", value.note(), a);
+
+        return ret;
+    }
+};
+
+template <>
+struct Deserialize<chatterino::Note> {
+    static chatterino::Note get(const rapidjson::Value &value,
+                                    bool *error = nullptr)
+    {
+        if (!value.IsObject())
+        {
+            PAJLADA_REPORT_ERROR(error)
+            return chatterino::Note(QString(), QString());
+        }
+
+        QString _id;
+        QString _note;
+
+        chatterino::rj::getSafe(value, "id", _id);
+        chatterino::rj::getSafe(value, "note", _note);
+
+        return chatterino::Note(_id, _note);
+    }
+};
+
+}  // namespace pajlada

--- a/src/controllers/notes/NoteModel.cpp
+++ b/src/controllers/notes/NoteModel.cpp
@@ -14,15 +14,15 @@ NotesModel::NotesModel(QObject *parent)
 
 // turn a vector item into a model row
 Note NotesModel::getItemFromRow(std::vector<QStandardItem *> &row,
-                                        const Note &original)
+                                const Note &original)
 {
     return Note{row[0]->data(Qt::DisplayRole).toString(),
-                    row[1]->data(Qt::DisplayRole).toString()};
+                row[1]->data(Qt::DisplayRole).toString()};
 }
 
 // turns a row in the model into a vector item
 void NotesModel::getRowFromItem(const Note &item,
-                                    std::vector<QStandardItem *> &row)
+                                std::vector<QStandardItem *> &row)
 {
     setStringItem(row[0], item.id());
     setStringItem(row[1], item.note());

--- a/src/controllers/notes/NoteModel.cpp
+++ b/src/controllers/notes/NoteModel.cpp
@@ -1,0 +1,31 @@
+#include "NoteModel.hpp"
+
+#include "Application.hpp"
+#include "providers/twitch/api/Helix.hpp"
+#include "singletons/Settings.hpp"
+#include "util/StandardItemHelper.hpp"
+
+namespace chatterino {
+
+NotesModel::NotesModel(QObject *parent)
+    : SignalVectorModel<Note>(4, parent)
+{
+}
+
+// turn a vector item into a model row
+Note NotesModel::getItemFromRow(std::vector<QStandardItem *> &row,
+                                        const Note &original)
+{
+    return Note{row[0]->data(Qt::DisplayRole).toString(),
+                    row[1]->data(Qt::DisplayRole).toString()};
+}
+
+// turns a row in the model into a vector item
+void NotesModel::getRowFromItem(const Note &item,
+                                    std::vector<QStandardItem *> &row)
+{
+    setStringItem(row[0], item.id());
+    setStringItem(row[1], item.note());
+}
+
+}  // namespace chatterino

--- a/src/controllers/notes/NoteModel.hpp
+++ b/src/controllers/notes/NoteModel.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <QObject>
+
+#include "common/SignalVectorModel.hpp"
+#include "controllers/notes/Note.hpp"
+
+namespace chatterino {
+
+class NotesModel : public SignalVectorModel<Note>
+{
+public:
+    explicit NotesModel(QObject *parent);
+
+protected:
+    // turn a vector item into a model row
+    virtual Note getItemFromRow(std::vector<QStandardItem *> &row,
+                                    const NOte &original) override;
+
+    // turns a row in the model into a vector item
+    virtual void getRowFromItem(const Note &item,
+                                std::vector<QStandardItem *> &row) override;
+};
+
+}  // namespace chatterino

--- a/src/controllers/notes/NoteModel.hpp
+++ b/src/controllers/notes/NoteModel.hpp
@@ -15,7 +15,7 @@ public:
 protected:
     // turn a vector item into a model row
     virtual Note getItemFromRow(std::vector<QStandardItem *> &row,
-                                    const NOte &original) override;
+                                const Note &original) override;
 
     // turns a row in the model into a vector item
     virtual void getRowFromItem(const Note &item,

--- a/src/singletons/Settings.cpp
+++ b/src/singletons/Settings.cpp
@@ -25,6 +25,7 @@ ConcurrentSettings::ConcurrentSettings()
     , filterRecords(*new SignalVector<FilterRecordPtr>())
     , nicknames(*new SignalVector<Nickname>())
     , moderationActions(*new SignalVector<ModerationAction>)
+    , notes(*new SignalVector<Note>())
 {
     persist(this->highlightedMessages, "/highlighting/highlights");
     persist(this->blacklistedUsers, "/highlighting/blacklist");
@@ -36,6 +37,7 @@ ConcurrentSettings::ConcurrentSettings()
     persist(this->nicknames, "/nicknames");
     // tagged users?
     persist(this->moderationActions, "/moderation/actions");
+    persist(this->notes, "/notes");
 }
 
 bool ConcurrentSettings::isHighlightedUser(const QString &username)

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -11,6 +11,7 @@
 #include "controllers/highlights/HighlightPhrase.hpp"
 #include "controllers/moderationactions/ModerationAction.hpp"
 #include "controllers/nicknames/Nickname.hpp"
+#include "controllers/notes/Note.hpp"
 #include "singletons/Toasts.hpp"
 #include "util/StreamerMode.hpp"
 #include "widgets/Notebook.hpp"
@@ -40,6 +41,7 @@ public:
     SignalVector<FilterRecordPtr> &filterRecords;
     SignalVector<Nickname> &nicknames;
     SignalVector<ModerationAction> &moderationActions;
+    SignalVector<Note> &notes;
 
     bool isHighlightedUser(const QString &username);
     bool isBlacklistedUser(const QString &username);

--- a/src/widgets/dialogs/UserInfoPopup.hpp
+++ b/src/widgets/dialogs/UserInfoPopup.hpp
@@ -86,6 +86,9 @@ private:
         QCheckBox *block = nullptr;
         QCheckBox *ignoreHighlights = nullptr;
 
+        QPushButton *saveNoteButton = nullptr;
+        QPlainTextEdit *note = nullptr;
+
         Label *noMessagesLabel = nullptr;
         ChannelView *latestMessages = nullptr;
         QPushButton *refreshButton = nullptr;


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Allows users to set notes for other people. The note is stored alongside the user's ID so a username change wont affect them. All clientside and doesn't have to do with mod comments. Works kind of like the discord notes. would close #2413

**Functionality is all there, just need to make the UI look better**

Example:

https://user-images.githubusercontent.com/35087590/168693634-fdd9c20d-a54a-4eee-b8ab-9f2067b0eb3c.mp4


