### PR TITLE
ci: cancel previous runs on PR update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,11 @@ on:
       - master
   pull_request:
 
+concurrency: 
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,6 @@ concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 
-
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 concurrency: 
-  group: ${{ github.ref }}
+  group: build-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 concurrency: 
-  group: ${{ github.ref }}
+  group: check-formatting-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -7,6 +7,10 @@ on:
       - master
   pull_request:
 
+concurrency: 
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubuntu-20.04

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,10 @@ on:
       - master
   pull_request:
 
+concurrency: 
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 concurrency: 
-  group: ${{ github.ref }}
+  group: lint-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/push-aur.yml
+++ b/.github/workflows/push-aur.yml
@@ -7,6 +7,10 @@ on:
       - master
   pull_request:
 
+concurrency: 
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/push-aur.yml
+++ b/.github/workflows/push-aur.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 concurrency: 
-  group: ${{ github.ref }}
+  group: build-archlinux-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,10 @@ on:
 env:
   TWITCH_PUBSUB_SERVER_IMAGE: ghcr.io/chatterino/twitch-pubsub-server-test:v1.0.3
 
+concurrency: 
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ env:
   TWITCH_PUBSUB_SERVER_IMAGE: ghcr.io/chatterino/twitch-pubsub-server-test:v1.0.3
 
 concurrency: 
-  group: ${{ github.ref }}
+  group: test-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

This PR aims to fix #3701 where updates to a PR did not cancel previous PR workflow runs. This is solved by using GitHub Actions' `concurrency` control option where each concurrent workflow is tagged with its name + the PR reference.

Video breakdown:
 - Start with a PR that has kicked off some workflows
 - Close the PR (workflows continue running, not sure how to solve that)
 - Reopen the PR (new action, same as a push to source branch)
 - Old workflows are cancelled and new workflows are created in place

Video:
https://user-images.githubusercontent.com/4962764/168783377-75d13c0b-fca6-4b89-bdc2-a685da5bbf19.mp4
