### PR TITLE
Updated link to VCRedist in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Windows users can also install Chatterino [from Chocolatey](https://chocolatey.o
 
 You can download the latest Chatterino 2 build over [here](https://github.com/Chatterino/chatterino2/releases/tag/nightly-build)
 
-You might also need to install the [VC++ 2017 Redistributable](https://aka.ms/vs/15/release/vc_redist.x64.exe) from Microsoft if you do not have it installed already.  
+You might also need to install the [VC++ Redistributables](https://aka.ms/vs/17/release/vc_redist.x64.exe) from Microsoft if you do not have it installed already.  
 If you still receive an error about `MSVCR120.dll missing`, then you should install the [VC++ 2013 Restributable](https://download.microsoft.com/download/2/E/6/2E61CFA4-993B-4DD4-91DA-3737CD5CD6E3/vcredist_x64.exe).
 
 ## Building


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

As per fabZeef's experience after Windows reinstall, both .exe's from links from current README didn't work and he had to install the 'all' version. I think it's better. The new permalink link points to "VCRedist 2015-2022", which ensures you get everything you might need.
The new permalink is taken from Micro$oft's downloads page: https://docs.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170

Left out link to 2013 version just in case, but maybe it's old enough we can remove it as well(?).
I considered replacing it with what's on downloads page (https://aka.ms/highdpimfc2013x64enu), but it seemed to provide an older version, so maybe it's better to not change that.
