### PR TITLE
Automatically place newlines at end of generated files

### DIFF
--- a/resources/_generate_resources.py
+++ b/resources/_generate_resources.py
@@ -4,7 +4,7 @@ resources_header = \
 
 resources_footer = \
 '''  </qresource>
-</RCC>'''
+</RCC>\n'''
 
 header_header = \
 '''#include <QPixmap>
@@ -22,7 +22,7 @@ public:
 header_footer = \
 '''};
 
-}  // namespace chatterino'''
+}  // namespace chatterino\n'''
 
 source_header = \
 '''#include "ResourcesAutogen.hpp"
@@ -36,4 +36,4 @@ Resources2::Resources2()
 source_footer = \
 '''}
 
-}  // namespace chatterino'''
+}  // namespace chatterino\n'''


### PR DESCRIPTION
# Description
The `resources/generate_resources.py` script would not place newlines at the end of the generated files. This adds the newlines to the generation.

## Pull request checklist:
I don't think that a changelog entry is necessary for this change.
- ~`CHANGELOG.md` was updated, if applicable~