### PR TITLE
Fix vcpkg manifest and finding RapidJSON and Websocketpp modules

### DIFF
--- a/cmake/FindRapidJSON.cmake
+++ b/cmake/FindRapidJSON.cmake
@@ -1,14 +1,14 @@
 include(FindPackageHandleStandardArgs)
 
-find_path(RapidJSON_INCLUDE_DIRS rapidjson/rapidjson.h HINTS ${CMAKE_SOURCE_DIR}/lib/rapidjson/include)
+find_path(RapidJSON_INCLUDE_DIR rapidjson/rapidjson.h HINTS ${CMAKE_SOURCE_DIR}/lib/rapidjson/include)
 
-find_package_handle_standard_args(RapidJSON DEFAULT_MSG RapidJSON_INCLUDE_DIRS)
+find_package_handle_standard_args(RapidJSON DEFAULT_MSG RapidJSON_INCLUDE_DIR)
 
 if (RapidJSON_FOUND)
     add_library(RapidJSON::RapidJSON INTERFACE IMPORTED)
     set_target_properties(RapidJSON::RapidJSON PROPERTIES
-            INTERFACE_INCLUDE_DIRECTORIES "${RapidJSON_INCLUDE_DIRS}"
+            INTERFACE_INCLUDE_DIRECTORIES "${RapidJSON_INCLUDE_DIR}"
             )
 endif ()
 
-mark_as_advanced(RapidJSON_INCLUDE_DIRS)
+mark_as_advanced(RapidJSON_INCLUDE_DIR)

--- a/cmake/FindWebsocketpp.cmake
+++ b/cmake/FindWebsocketpp.cmake
@@ -1,14 +1,14 @@
 include(FindPackageHandleStandardArgs)
 
-find_path(Websocketpp_INCLUDE_DIRS websocketpp/version.hpp HINTS ${CMAKE_SOURCE_DIR}/lib/websocketpp)
+find_path(Websocketpp_INCLUDE_DIR websocketpp/version.hpp HINTS ${CMAKE_SOURCE_DIR}/lib/websocketpp)
 
-find_package_handle_standard_args(Websocketpp DEFAULT_MSG Websocketpp_INCLUDE_DIRS)
+find_package_handle_standard_args(Websocketpp DEFAULT_MSG Websocketpp_INCLUDE_DIR)
 
 if (Websocketpp_FOUND)
     add_library(websocketpp::websocketpp INTERFACE IMPORTED)
     set_target_properties(websocketpp::websocketpp PROPERTIES
-            INTERFACE_INCLUDE_DIRECTORIES "${Websocketpp_INCLUDE_DIRS}"
+            INTERFACE_INCLUDE_DIRECTORIES "${Websocketpp_INCLUDE_DIR}"
             )
 endif ()
 
-mark_as_advanced(Websocketpp_INCLUDE_DIRS)
+mark_as_advanced(Websocketpp_INCLUDE_DIR)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,6 +5,7 @@
   "dependencies": [
     "benchmark",
     "boost-asio",
+    "boost-signals2",
     "boost-foreach",
     "boost-interprocess",
     "boost-random",
@@ -14,8 +15,10 @@
     "qt5-multimedia",
     "qt5-tools"
   ],
-  "builtin-baseline": "2ac61f87f69f0484b8044f95ab274038fbaf7bdd",
+  "builtin-baseline": "8da5d2b4503b3100b6b7bb26ffeeefd0e8a25799",
   "overrides": [
-    { "name": "openssl", "version-string": "1.1.1n" }
+    {
+      "name": "openssl", "version-string": "1.1.1n"
+    }
   ]
 }


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

PR fixes 2 problems found when testing recently merged vcpkg building, on clean VM run without global cache. #3634

- `FindRapidJSON.cmake` and `FindWebsocketpp.cmake` find modules were update to use `_INCLUDE_DIR` result variable instead of `_INCLUDE_DIRS`. [Cmake docs](https://cmake.org/cmake/help/latest/manual/cmake-developer.7.html#standard-variable-names) state singular form vars should be used as return values. This change fixes problem where only these 2 dependencies would not be found in hinted /lib folder with vcpkg toolchain. Issue was reproduced on Cmake 3.23.0 and 3.20.21032501-MSVC_2, so seems like some vcpkg specific. Other find modules already use that return var for `find_path()` so don't expect problems, but we gonna find out :D
- Added missing `boost-signals2` (introduced in recent pubsub rework)
- Updated `builtin-baseline` to todays commit 

suggest no changelog 