### PR TITLE
Batch checking live status for all channels after startup.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Bugfix: Fixed automod queue pubsub topic persisting after user change. (#3718)
 - Bugfix: Fixed viewer list not closing after pressing escape key. (#3734)
 - Dev: Use Game Name returned by Get Streams instead of querying it from the Get Games API. (#3662)
+- Dev: Batch checking live status for all channels after startup. (#3757)
 
 ## 2.3.5
 

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -188,11 +188,6 @@ TwitchChannel::TwitchChannel(const QString &name)
     });
     this->chattersListTimer_.start(5 * 60 * 1000);
 
-    QObject::connect(&this->liveStatusTimer_, &QTimer::timeout, [=] {
-        this->refreshLiveStatus();
-    });
-    this->liveStatusTimer_.start(60 * 1000);
-
     // debugging
 #if 0
     for (int i = 0; i < 1000; i++) {

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -193,7 +193,6 @@ private:
     // --
     QString lastSentMessage_;
     QObject lifetimeGuard_;
-    QTimer liveStatusTimer_;
     QTimer chattersListTimer_;
     QElapsedTimer titleRefreshedTimer_;
     QElapsedTimer clipCreationTimer_;

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -342,7 +342,7 @@ void TwitchIrcServer::bulkRefreshLiveStatus()
     for (const auto &batch : getChannelsInBatches(userIDs))
     {
         getHelix()->fetchStreams(
-            userIDs, QStringList(),
+            batch, QStringList(),
             [this](std::vector<HelixStream> streams) {
                 for (const auto &stream : streams)
                 {

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -332,17 +332,17 @@ namespace {
 
 void TwitchIrcServer::bulkRefreshLiveStatus()
 {
-    QStringList userIds;
-    this->forEachChannel([&userIds](ChannelPtr chan) {
+    QStringList userIDs;
+    this->forEachChannel([&userIDs](ChannelPtr chan) {
         auto twitchChan = dynamic_cast<TwitchChannel *>(chan.get());
         if (!twitchChan->roomId().isEmpty())
-            userIds.push_back(twitchChan->roomId());
+            userIDs.push_back(twitchChan->roomId());
     });
 
-    for (const auto &batch : getChannelsInBatches(userIds))
+    for (const auto &batch : getChannelsInBatches(userIDs))
     {
         getHelix()->fetchStreams(
-            userIds, QStringList(),
+            userIDs, QStringList(),
             [this](std::vector<HelixStream> streams) {
                 for (const auto &stream : streams)
                 {

--- a/src/providers/twitch/TwitchIrcServer.hpp
+++ b/src/providers/twitch/TwitchIrcServer.hpp
@@ -31,6 +31,8 @@ public:
 
     std::shared_ptr<Channel> getChannelOrEmptyByID(const QString &channelID);
 
+    void bulkRefreshLiveStatus();
+
     Atomic<QString> lastUserThatWhisperedMe;
 
     const ChannelPtr whispersChannel;
@@ -74,6 +76,7 @@ private:
 
     BttvEmotes bttv;
     FfzEmotes ffz;
+    QTimer bulkLiveStatusTimer_;
 
     pajlada::Signals::SignalHolder signalHolder_;
 };


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description
On startup, each channel currently individually make an api call to update its own live status on `roomId` change, this behavior will be unchanged.

Instead of having a timer for each individual channel to call to refresh its own live status, we will have a single timer in `TwitchIrcServer` that will update the live status of every channel at once in a single api call. Currently I have this set on a 30 second interval. This will be updated faster than the current 60 second interval, but since we are only making a single api call it will still result in an overall performance gain.

Similar logic for `NotificationController::fetchFakeChannels()` mentioned in the connected issue was already done in PR #3442 

Closes #3009 
