### PR TITLE
Build GoogleTest & GoogleMock as submodules

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,8 +64,7 @@ jobs:
                 libxcb-image0 \
                 libxcb-keysyms1 \
                 libxcb-render-util0 \
-                libxcb-xinerama0 \
-                libgtest-dev
+                libxcb-xinerama0
 
       - name: Create build directory (Ubuntu)
         if: startsWith(matrix.os, 'ubuntu')

--- a/.gitmodules
+++ b/.gitmodules
@@ -32,3 +32,6 @@
 [submodule "lib/magic_enum"]
 	path = lib/magic_enum
 	url = https://github.com/Neargye/magic_enum
+[submodule "lib/googletest"]
+	path = lib/googletest
+	url = https://github.com/google/googletest.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,18 @@ find_package(RapidJSON REQUIRED)
 find_package(Websocketpp REQUIRED)
 
 if (BUILD_TESTS)
-    find_package(GTest REQUIRED)
+    add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/lib/googletest" "lib/googletest")
+
+    mark_as_advanced(
+        BUILD_GMOCK BUILD_GTEST BUILD_SHARED_LIBS
+        gmock_build_tests gtest_build_samples gtest_build_tests
+        gtest_disable_pthreads gtest_force_shared_crt gtest_hide_internal_symbols
+    )
+
+    set_target_properties(gtest PROPERTIES FOLDER lib)
+    set_target_properties(gtest_main PROPERTIES FOLDER lib)
+    set_target_properties(gmock PROPERTIES FOLDER lib)
+    set_target_properties(gmock_main PROPERTIES FOLDER lib)
 endif ()
 
 if (BUILD_BENCHMARKS)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,7 +25,7 @@ add_sanitizers(${PROJECT_NAME})
 
 target_link_libraries(${PROJECT_NAME} PRIVATE chatterino-lib)
 
-target_link_libraries(${PROJECT_NAME} PRIVATE ${GTEST_BOTH_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} PRIVATE gtest gmock)
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE
     CHATTERINO_TEST


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

We need GMock which is part of the same library, but there are no premade CMake constructs to include it unless we require CMake 3.20+, which we realistically cannot do.
Because of this, I've added the `googletest` submodule which contains both projects, and a few lines for building it if `BUILD_TESTS` is checked.

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
