### PR TITLE
perf: use constant time live channel lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 - Bugfix: Fixed viewer list not closing after pressing escape key. (#3734)
 - Bugfix: Fixed links with no thumbnail having previous link's thumbnail. (#3720)
 - Dev: Use Game Name returned by Get Streams instead of querying it from the Get Games API. (#3662)
-- Dev: Batch checking live status for all channels after startup. (#3757)
+- Dev: Batch checking live status for all channels after startup. (#3757, #3762)
 
 ## 2.3.5
 

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -346,8 +346,8 @@ void TwitchIrcServer::bulkRefreshLiveStatus()
             [this](std::vector<HelixStream> streams) {
                 for (const auto &stream : streams)
                 {
-                    auto chan = this->getChannelOrEmptyByID(stream.userId);
-                    if (chan->getType() != Channel::Type::Twitch)
+                    auto chan = getApp()->twitch->getChannelOrEmpty(stream.userLogin);
+                    if (chan->isEmpty())
                         continue;
 
                     auto twitchChan = dynamic_cast<TwitchChannel *>(chan.get());

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -346,7 +346,8 @@ void TwitchIrcServer::bulkRefreshLiveStatus()
             [this](std::vector<HelixStream> streams) {
                 for (const auto &stream : streams)
                 {
-                    auto chan = getApp()->twitch->getChannelOrEmpty(stream.userLogin);
+                    auto chan =
+                        getApp()->twitch->getChannelOrEmpty(stream.userLogin);
                     if (chan->isEmpty())
                         continue;
 

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -346,9 +346,8 @@ void TwitchIrcServer::bulkRefreshLiveStatus()
             [this](std::vector<HelixStream> streams) {
                 for (const auto &stream : streams)
                 {
-                    auto chan =
-                        getApp()->twitch->getChannelOrEmpty(stream.userLogin);
-                    if (chan->isEmpty())
+                    auto chan = this->getChannelOrEmpty(stream.userLogin);
+                    if (chan->getType() != Channel::Type::Twitch)
                         continue;
 
                     auto twitchChan = dynamic_cast<TwitchChannel *>(chan.get());


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description
Use O(1) getChannelOrEmpty instead of O(n) getChannelOrEmptyByID in bulkRefreshLiveStatus
