### PR TITLE
Added opening a user's chat in a new tab/split/window with keybinds+click

### DIFF
--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -742,15 +742,7 @@ void CommandController::initialize(Settings &, Paths &paths)
             return "";
         }
 
-        auto *app = getApp();
-        Window &window = app->windows->createWindow(WindowType::Popup, true);
-
-        auto *split = new Split(static_cast<SplitContainer *>(
-            window.getNotebook().getOrAddSelectedPage()));
-
-        split->setChannel(app->twitch->getOrAddChannel(target));
-
-        window.getNotebook().getOrAddSelectedPage()->appendSplit(split);
+        getApp()->windows->openNewChannelWindow(target);
 
         return "";
     });

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -275,6 +275,22 @@ Window &WindowManager::createWindow(WindowType type, bool show)
     return *window;
 }
 
+Window &WindowManager::openNewChannelWindow(ChannelPtr channel)
+{
+    Window &window = this->createWindow(WindowType::Popup, true);
+    auto split =
+        window.getNotebook().getOrAddSelectedPage()->appendNewSplit(false);
+    split->setChannel(channel);
+    window.getNotebook().getOrAddSelectedPage()->refreshTab();
+    return window;
+}
+
+Window &WindowManager::openNewChannelWindow(QString channelName)
+{
+    return this->openNewChannelWindow(
+        getApp()->twitch->getOrAddChannel(channelName));
+}
+
 void WindowManager::select(Split *split)
 {
     this->selectSplit.invoke(split);

--- a/src/singletons/WindowManager.hpp
+++ b/src/singletons/WindowManager.hpp
@@ -59,6 +59,10 @@ public:
     Window &getSelectedWindow();
     Window &createWindow(WindowType type, bool show = true);
 
+    // Opens a channel in new popup window
+    Window &openNewChannelWindow(ChannelPtr channel);
+    Window &openNewChannelWindow(QString channelName);
+
     void select(Split *split);
     void select(SplitContainer *container);
 

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -295,14 +295,8 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically, QWidget *parent)
                         menu->addAction(
                             "Open channel in a new popup window", this,
                             [loginName] {
-                                auto app = getApp();
-                                auto &window = app->windows->createWindow(
-                                    WindowType::Popup, true);
-                                auto split = window.getNotebook()
-                                                 .getOrAddSelectedPage()
-                                                 ->appendNewSplit(false);
-                                split->setChannel(app->twitch->getOrAddChannel(
-                                    loginName.toLower()));
+                                getApp()->windows->openNewChannelWindow(
+                                    loginName);
                             });
 
                         menu->addAction(

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -2190,7 +2190,6 @@ void ChannelView::handleLinkClick(QMouseEvent *event, const Link &link,
             switch (event->modifiers())
             {
                 case Qt::ShiftModifier:
-                    // openChannelIn = FromTwitchLinkOpenChannelIn::
                     getApp()->windows->openNewChannelWindow(link.value);
                     break;
                 case Qt::ControlModifier:

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1718,6 +1718,22 @@ void ChannelView::mouseReleaseEvent(QMouseEvent *event)
             else if (hoverLayoutElement->getFlags().has(
                          MessageElementFlag::Username))
             {
+                if (event->modifiers() == Qt::ShiftModifier)
+                {
+                    this->openChannelIn.invoke(
+                        hoverLayoutElement->getLink().value,
+                        FromTwitchLinkOpenChannelIn::Tab);
+                    return;
+                }
+
+                if (event->modifiers() == Qt::AltModifier)
+                {
+                    this->openChannelIn.invoke(
+                        hoverLayoutElement->getLink().value,
+                        FromTwitchLinkOpenChannelIn::Split);
+                    return;
+                }
+
                 openTwitchUsercard(this->channel_->getName(),
                                    hoverLayoutElement->getLink().value);
                 return;

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1718,22 +1718,6 @@ void ChannelView::mouseReleaseEvent(QMouseEvent *event)
             else if (hoverLayoutElement->getFlags().has(
                          MessageElementFlag::Username))
             {
-                if (event->modifiers() == Qt::ShiftModifier)
-                {
-                    this->openChannelIn.invoke(
-                        hoverLayoutElement->getLink().value,
-                        FromTwitchLinkOpenChannelIn::Tab);
-                    return;
-                }
-
-                if (event->modifiers() == Qt::AltModifier)
-                {
-                    this->openChannelIn.invoke(
-                        hoverLayoutElement->getLink().value,
-                        FromTwitchLinkOpenChannelIn::Split);
-                    return;
-                }
-
                 openTwitchUsercard(this->channel_->getName(),
                                    hoverLayoutElement->getLink().value);
                 return;
@@ -2203,8 +2187,26 @@ void ChannelView::handleLinkClick(QMouseEvent *event, const Link &link,
     {
         case Link::UserWhisper:
         case Link::UserInfo: {
-            auto user = link.value;
-            this->showUserInfoPopup(user, layout->getMessage()->channelName);
+            switch (event->modifiers())
+            {
+                case Qt::ShiftModifier:
+                    // openChannelIn = FromTwitchLinkOpenChannelIn::
+                    getApp()->windows->openNewChannelWindow(link.value);
+                    break;
+                case Qt::ControlModifier:
+                    this->openChannelIn.invoke(
+                        link.value, FromTwitchLinkOpenChannelIn::Tab);
+                    break;
+                case Qt::AltModifier:
+                    this->openChannelIn.invoke(
+                        link.value, FromTwitchLinkOpenChannelIn::Split);
+                    break;
+                default:
+                    auto user = link.value;
+                    this->showUserInfoPopup(user,
+                                            layout->getMessage()->channelName);
+                    break;
+            }
         }
         break;
 

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -874,18 +874,11 @@ void Split::explainSplitting()
 
 void Split::popup()
 {
-    auto app = getApp();
-    Window &window = app->windows->createWindow(WindowType::Popup);
-
-    Split *split = new Split(static_cast<SplitContainer *>(
-        window.getNotebook().getOrAddSelectedPage()));
-
-    split->setChannel(this->getIndirectChannel());
+    Window &window = getApp()->windows->openNewChannelWindow(
+        this->getIndirectChannel().get());
+    Split *split = window.getNotebook().getOrAddSelectedPage()->getSplits()[0];
     split->setModerationMode(this->getModerationMode());
     split->setFilters(this->getFilters());
-
-    window.getNotebook().getOrAddSelectedPage()->appendSplit(split);
-    window.show();
 }
 
 void Split::clear()


### PR DESCRIPTION
- [ ] `CHANGELOG.md` was updated, if applicable

The following are the added keybinds for the modifiers required to be held when left clicking a username

<table>
<tr>
	<td>Modifier
	<td>Result
<tr>
	<td>SHIFT
	<td>Open chat in a new popup
<tr>
	<td>CTRL
	<td>Open chat in a new tab
<tr>
	<td>ALT
	<td>Open chat in a new split
</table>

Originally was for #2881 but after implementing this and re-reading the request I now realize that #3625 is what the user wanted. 

![image](https://user-images.githubusercontent.com/6964154/169895407-661c3f87-1c64-477f-acc6-8e3a778899bd.png)