### PR TITLE
Corrected the way we parse comma-separated "list tags" in PRIVMSGs

### DIFF
--- a/src/controllers/highlights/HighlightBadge.cpp
+++ b/src/controllers/highlights/HighlightBadge.cpp
@@ -88,8 +88,6 @@ bool HighlightBadge::compare(const QString &id, const Badge &badge) const
     if (this->hasVersions_)
     {
         auto parts = SharedMessageBuilder::slashKeyValue(id);
-        // zneix: I believe we don't need to check for whether parts.second is empty
-        // since there's a short-circuit after first comparison returns false
         return parts.first.compare(badge.key_, Qt::CaseInsensitive) == 0 &&
                parts.second.compare(badge.value_, Qt::CaseInsensitive) == 0;
     }

--- a/src/controllers/highlights/HighlightBadge.cpp
+++ b/src/controllers/highlights/HighlightBadge.cpp
@@ -1,5 +1,6 @@
 #include "HighlightBadge.hpp"
 
+#include "messages/SharedMessageBuilder.hpp"
 #include "singletons/Resources.hpp"
 
 namespace chatterino {
@@ -86,21 +87,14 @@ bool HighlightBadge::compare(const QString &id, const Badge &badge) const
 {
     if (this->hasVersions_)
     {
-        auto parts = id.split("/");
-        if (parts.size() == 2)
-        {
-            return parts.at(0).compare(badge.key_, Qt::CaseInsensitive) == 0 &&
-                   parts.at(1).compare(badge.value_, Qt::CaseInsensitive) == 0;
-        }
-        else
-        {
-            return parts.at(0).compare(badge.key_, Qt::CaseInsensitive) == 0;
-        }
+        auto parts = SharedMessageBuilder::slashKeyValue(id);
+        // zneix: I believe we don't need to check for whether parts.second is empty
+        // since there's a short-circuit after first comparison returns false
+        return parts.first.compare(badge.key_, Qt::CaseInsensitive) == 0 &&
+               parts.second.compare(badge.value_, Qt::CaseInsensitive) == 0;
     }
-    else
-    {
-        return id.compare(badge.key_, Qt::CaseInsensitive) == 0;
-    }
+
+    return id.compare(badge.key_, Qt::CaseInsensitive) == 0;
 }
 
 bool HighlightBadge::hasCustomSound() const

--- a/src/messages/Message.hpp
+++ b/src/messages/Message.hpp
@@ -2,6 +2,7 @@
 
 #include "common/FlagsEnum.hpp"
 #include "providers/twitch/TwitchBadge.hpp"
+#include "util/QStringHash.hpp"
 #include "widgets/helper/ScrollbarHighlight.hpp"
 
 #include <QTime>

--- a/src/messages/Message.hpp
+++ b/src/messages/Message.hpp
@@ -65,7 +65,7 @@ struct Message : boost::noncopyable {
     QColor usernameColor;
     QDateTime serverReceivedTime;
     std::vector<Badge> badges;
-    std::map<QString, QString> badgeInfos;
+    std::unordered_map<QString, QString> badgeInfos;
     std::shared_ptr<QColor> highlightColor;
     uint32_t count = 1;
     std::vector<std::unique_ptr<MessageElement>> elements;

--- a/src/messages/SharedMessageBuilder.cpp
+++ b/src/messages/SharedMessageBuilder.cpp
@@ -79,13 +79,13 @@ void SharedMessageBuilder::parse()
 // In that case, valid map content should be 'split by slash' only once:
 // {"foo": "bar/baz", "tri": "hard"}
 std::pair<QString, QString> SharedMessageBuilder::slashKeyValue(
-    const QString &keyValueString)
+    const QString &kvStr)
 {
     return {
         // part before first slash (index 0 of section)
-        keyValueString.section('/', 0, 0),
+        kvStr.section('/', 0, 0),
         // part after first slash (index 1 of section)
-        keyValueString.section('/', 1, -1),
+        kvStr.section('/', 1, -1),
     };
 }
 
@@ -106,7 +106,7 @@ std::vector<Badge> SharedMessageBuilder::parseBadgeTag(const QVariantMap &tags)
             continue;
         }
 
-        auto pair = this->slashKeyValue(badge);
+        auto pair = SharedMessageBuilder::slashKeyValue(badge);
         b.emplace_back(Badge{pair.first, pair.second});
     }
 

--- a/src/messages/SharedMessageBuilder.cpp
+++ b/src/messages/SharedMessageBuilder.cpp
@@ -91,7 +91,7 @@ std::pair<QString, QString> SharedMessageBuilder::slashKeyValue(
 
 std::vector<Badge> SharedMessageBuilder::parseBadgeTag(const QVariantMap &tags)
 {
-    auto b = std::vector<Badge>();
+    std::vector<Badge> b;
 
     auto badgesIt = tags.constFind("badges");
     if (badgesIt == tags.end())

--- a/src/messages/SharedMessageBuilder.cpp
+++ b/src/messages/SharedMessageBuilder.cpp
@@ -340,7 +340,7 @@ void SharedMessageBuilder::parseHighlights()
     bool badgeHighlightSet = false;
     for (const HighlightBadge &highlight : *badgeHighlights)
     {
-        for (const auto &badge : badges)
+        for (const Badge &badge : badges)
         {
             if (!highlight.isMatch(badge))
             {

--- a/src/messages/SharedMessageBuilder.cpp
+++ b/src/messages/SharedMessageBuilder.cpp
@@ -8,6 +8,7 @@
 #include "singletons/Settings.hpp"
 #include "singletons/WindowManager.hpp"
 #include "util/Helpers.hpp"
+#include "util/QStringHash.hpp"
 #include "util/Qt.hpp"
 #include "util/StreamerMode.hpp"
 

--- a/src/messages/SharedMessageBuilder.cpp
+++ b/src/messages/SharedMessageBuilder.cpp
@@ -83,9 +83,9 @@ std::pair<QString, QString> SharedMessageBuilder::slashKeyValue(
 {
     return {
         // part before first slash (index 0 of section)
-        keyValueString.section('/', 0, 0, QString::SectionSkipEmpty),
+        keyValueString.section('/', 0, 0),
         // part after first slash (index 1 of section)
-        keyValueString.section('/', 1, -1, QString::SectionSkipEmpty),
+        keyValueString.section('/', 1, -1),
     };
 }
 

--- a/src/messages/SharedMessageBuilder.cpp
+++ b/src/messages/SharedMessageBuilder.cpp
@@ -4,7 +4,6 @@
 #include "common/QLogging.hpp"
 #include "controllers/ignores/IgnoreController.hpp"
 #include "controllers/ignores/IgnorePhrase.hpp"
-#include "messages/Message.hpp"
 #include "messages/MessageElement.hpp"
 #include "singletons/Settings.hpp"
 #include "singletons/WindowManager.hpp"

--- a/src/messages/SharedMessageBuilder.cpp
+++ b/src/messages/SharedMessageBuilder.cpp
@@ -4,11 +4,11 @@
 #include "common/QLogging.hpp"
 #include "controllers/ignores/IgnoreController.hpp"
 #include "controllers/ignores/IgnorePhrase.hpp"
+#include "messages/Message.hpp"
 #include "messages/MessageElement.hpp"
 #include "singletons/Settings.hpp"
 #include "singletons/WindowManager.hpp"
 #include "util/Helpers.hpp"
-#include "util/QStringHash.hpp"
 #include "util/Qt.hpp"
 #include "util/StreamerMode.hpp"
 

--- a/src/messages/SharedMessageBuilder.cpp
+++ b/src/messages/SharedMessageBuilder.cpp
@@ -95,7 +95,9 @@ std::vector<Badge> SharedMessageBuilder::parseBadgeTag(const QVariantMap &tags)
 
     auto badgesIt = tags.constFind("badges");
     if (badgesIt == tags.end())
+    {
         return b;
+    }
 
     auto badges = badgesIt.value().toString().split(',', Qt::SkipEmptyParts);
 

--- a/src/messages/SharedMessageBuilder.hpp
+++ b/src/messages/SharedMessageBuilder.hpp
@@ -43,7 +43,7 @@ protected:
     virtual void parseUsername();
 
     // Parses "badges" tag which contains a comma separated list of key-value elements
-    virtual std::vector<Badge> parseBadgeTag(const QVariantMap &tag);
+    virtual std::vector<Badge> parseBadgeTag(const QVariantMap &tags);
 
     virtual Outcome tryAppendEmote(const EmoteName &name)
     {

--- a/src/messages/SharedMessageBuilder.hpp
+++ b/src/messages/SharedMessageBuilder.hpp
@@ -33,6 +33,8 @@ public:
     virtual void triggerHighlights();
     virtual MessagePtr build() = 0;
 
+    static std::pair<QString, QString> slashKeyValue(const QString &str);
+
 protected:
     virtual void parse();
 
@@ -40,9 +42,8 @@ protected:
 
     virtual void parseUsername();
 
-    // Used for parsing PRIVMSG tags which contain a comma separated list of key-value elements
-    std::unordered_map<QString, QString> parseTagList(const QVariantMap &tags,
-                                                      const QString &key);
+    // Parses "badges" tag which contains a comma separated list of key-value elements
+    virtual std::vector<Badge> parseBadgeTag(const QVariantMap &tag);
 
     virtual Outcome tryAppendEmote(const EmoteName &name)
     {

--- a/src/messages/SharedMessageBuilder.hpp
+++ b/src/messages/SharedMessageBuilder.hpp
@@ -33,10 +33,10 @@ public:
     virtual void triggerHighlights();
     virtual MessagePtr build() = 0;
 
-    static std::pair<QString, QString> slashKeyValue(const QString &str);
+    static std::pair<QString, QString> slashKeyValue(const QString &kvStr);
 
     // Parses "badges" tag which contains a comma separated list of key-value elements
-    std::vector<Badge> parseBadgeTag(const QVariantMap &tags);
+    static std::vector<Badge> parseBadgeTag(const QVariantMap &tags);
 
 protected:
     virtual void parse();

--- a/src/messages/SharedMessageBuilder.hpp
+++ b/src/messages/SharedMessageBuilder.hpp
@@ -35,15 +35,15 @@ public:
 
     static std::pair<QString, QString> slashKeyValue(const QString &str);
 
+    // Parses "badges" tag which contains a comma separated list of key-value elements
+    std::vector<Badge> parseBadgeTag(const QVariantMap &tags);
+
 protected:
     virtual void parse();
 
     virtual void parseUsernameColor();
 
     virtual void parseUsername();
-
-    // Parses "badges" tag which contains a comma separated list of key-value elements
-    virtual std::vector<Badge> parseBadgeTag(const QVariantMap &tags);
 
     virtual Outcome tryAppendEmote(const EmoteName &name)
     {

--- a/src/messages/SharedMessageBuilder.hpp
+++ b/src/messages/SharedMessageBuilder.hpp
@@ -3,6 +3,7 @@
 #include "common/Aliases.hpp"
 #include "common/Outcome.hpp"
 #include "messages/MessageColor.hpp"
+#include "providers/twitch/TwitchBadge.hpp"
 
 #include <IrcMessage>
 #include <QColor>
@@ -38,6 +39,10 @@ protected:
     virtual void parseUsernameColor();
 
     virtual void parseUsername();
+
+    // Used for parsing PRIVMSG tags which contain a comma separated list of key-value elements
+    std::unordered_map<QString, QString> parseTagList(const QVariantMap &tags,
+                                                      const QString &key);
 
     virtual Outcome tryAppendEmote(const EmoteName &name)
     {

--- a/src/providers/twitch/TwitchBadge.cpp
+++ b/src/providers/twitch/TwitchBadge.cpp
@@ -33,4 +33,9 @@ Badge::Badge(QString key, QString value)
     }
 }
 
+bool Badge::operator==(const Badge &other) const
+{
+    return this->key_ == other.key_ && this->value_ == other.value_;
+}
+
 }  // namespace chatterino

--- a/src/providers/twitch/TwitchBadge.cpp
+++ b/src/providers/twitch/TwitchBadge.cpp
@@ -11,9 +11,9 @@ const QSet<QString> predictions{"predictions"};
 const QSet<QString> channelAuthority{"moderator", "vip", "broadcaster"};
 const QSet<QString> subBadges{"subscriber", "founder"};
 
-Badge::Badge(const std::pair<const QString, QString> keyValuePair)
-    : key_(std::move(keyValuePair.first))
-    , value_(std::move(keyValuePair.second))
+Badge::Badge(QString key, QString value)
+    : key_(std::move(key))
+    , value_(std::move(value))
 {
     if (globalAuthority.contains(this->key_))
     {

--- a/src/providers/twitch/TwitchBadge.cpp
+++ b/src/providers/twitch/TwitchBadge.cpp
@@ -11,9 +11,9 @@ const QSet<QString> predictions{"predictions"};
 const QSet<QString> channelAuthority{"moderator", "vip", "broadcaster"};
 const QSet<QString> subBadges{"subscriber", "founder"};
 
-Badge::Badge(QString key, QString value)
-    : key_(std::move(key))
-    , value_(std::move(value))
+Badge::Badge(const std::pair<const QString, QString> keyValuePair)
+    : key_(std::move(keyValuePair.first))
+    , value_(std::move(keyValuePair.second))
 {
     if (globalAuthority.contains(this->key_))
     {

--- a/src/providers/twitch/TwitchBadge.hpp
+++ b/src/providers/twitch/TwitchBadge.hpp
@@ -11,9 +11,8 @@ class Badge
 public:
     Badge(const std::pair<const QString, QString> keyValuePair);
 
-    QString key_;           // e.g. bits
-    QString value_;         // e.g. 100
-    QString extraValue_{};  // e.g. 5 (the number of months subscribed)
+    QString key_;    // e.g. bits
+    QString value_;  // e.g. 100
     MessageElementFlag flag_{
         MessageElementFlag::BadgeVanity};  // badge slot it takes up
 };

--- a/src/providers/twitch/TwitchBadge.hpp
+++ b/src/providers/twitch/TwitchBadge.hpp
@@ -9,7 +9,7 @@ namespace chatterino {
 class Badge
 {
 public:
-    Badge(QString key, QString value);
+    Badge(const std::pair<const QString, QString> keyValuePair);
 
     QString key_;           // e.g. bits
     QString value_;         // e.g. 100

--- a/src/providers/twitch/TwitchBadge.hpp
+++ b/src/providers/twitch/TwitchBadge.hpp
@@ -11,6 +11,8 @@ class Badge
 public:
     Badge(QString key, QString value);
 
+    bool operator==(const Badge &other) const;
+
     // Class members are fetched from both "badges" and "badge-info" tags
     // E.g.: "badges": "subscriber/18", "badge-info": "subscriber/22"
     QString key_;    // subscriber

--- a/src/providers/twitch/TwitchBadge.hpp
+++ b/src/providers/twitch/TwitchBadge.hpp
@@ -9,10 +9,13 @@ namespace chatterino {
 class Badge
 {
 public:
-    Badge(const std::pair<const QString, QString> keyValuePair);
+    Badge(QString key, QString value);
 
-    QString key_;    // e.g. bits
-    QString value_;  // e.g. 100
+    // Class members are fetched from both "badges" and "badge-info" tags
+    // E.g.: "badges": "subscriber/18", "badge-info": "subscriber/22"
+    QString key_;    // subscriber
+    QString value_;  // 18
+    //QString info_; // 22 (should be parsed separetly into an std::unordered_map)
     MessageElementFlag flag_{
         MessageElementFlag::BadgeVanity};  // badge slot it takes up
 };

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -998,7 +998,7 @@ std::unordered_map<QString, QString> TwitchMessageBuilder::parseBadgeInfoTag(
 
     for (const QString &badge : info)
     {
-        infoMap.emplace(this->slashKeyValue(badge));
+        infoMap.emplace(SharedMessageBuilder::slashKeyValue(badge));
     }
 
     return infoMap;
@@ -1011,7 +1011,7 @@ void TwitchMessageBuilder::appendTwitchBadges()
         return;
     }
 
-    auto badgeInfos = this->parseBadgeInfoTag(this->tags);
+    auto badgeInfos = TwitchMessageBuilder::parseBadgeInfoTag(this->tags);
     auto badges = this->parseBadgeTag(this->tags);
 
     for (const Badge &badge : badges)

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -994,11 +994,10 @@ void TwitchMessageBuilder::appendTwitchBadges()
 
     auto badgeInfos = this->parseTagList(this->tags, "badge-info");
     auto badgeMap = this->parseTagList(this->tags, "badges");
-
     std::vector<Badge> badgeVector;
-    for (const auto &badgeData : badgeMap)
+
+    for (const Badge &badge : badgeMap)
     {
-        Badge badge(badgeData);
         badgeVector.emplace_back(badge);
 
         auto badgeEmote = this->getTwitchBadge(badge);

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -985,6 +985,25 @@ boost::optional<EmotePtr> TwitchMessageBuilder::getTwitchBadge(
     return boost::none;
 }
 
+std::unordered_map<QString, QString> TwitchMessageBuilder::parseBadgeInfoTag(
+    const QVariantMap &tags)
+{
+    auto infoMap = std::unordered_map<QString, QString>();
+
+    auto infoIt = tags.constFind("badge-info");
+    if (infoIt == tags.end())
+        return infoMap;
+
+    auto badges = infoIt.value().toString().split(',', Qt::SkipEmptyParts);
+
+    for (const QString &badge : badges)
+    {
+        infoMap.emplace(this->slashKeyValue(badge));
+    }
+
+    return infoMap;
+}
+
 void TwitchMessageBuilder::appendTwitchBadges()
 {
     if (this->twitchChannel == nullptr)
@@ -992,14 +1011,11 @@ void TwitchMessageBuilder::appendTwitchBadges()
         return;
     }
 
-    auto badgeInfos = this->parseTagList(this->tags, "badge-info");
-    auto badgeMap = this->parseTagList(this->tags, "badges");
-    std::vector<Badge> badgeVector;
+    auto badgeInfos = this->parseBadgeInfoTag(this->tags);
+    auto badges = this->parseBadgeTag(this->tags);
 
-    for (const Badge &badge : badgeMap)
+    for (const Badge &badge : badges)
     {
-        badgeVector.emplace_back(badge);
-
         auto badgeEmote = this->getTwitchBadge(badge);
         if (!badgeEmote)
         {
@@ -1076,7 +1092,7 @@ void TwitchMessageBuilder::appendTwitchBadges()
             ->setTooltip(tooltip);
     }
 
-    this->message().badges = badgeVector;
+    this->message().badges = badges;
     this->message().badgeInfos = badgeInfos;
 }
 

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -1014,7 +1014,7 @@ void TwitchMessageBuilder::appendTwitchBadges()
     auto badgeInfos = TwitchMessageBuilder::parseBadgeInfoTag(this->tags);
     auto badges = this->parseBadgeTag(this->tags);
 
-    for (const Badge &badge : badges)
+    for (const auto &badge : badges)
     {
         auto badgeEmote = this->getTwitchBadge(badge);
         if (!badgeEmote)

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -988,15 +988,15 @@ boost::optional<EmotePtr> TwitchMessageBuilder::getTwitchBadge(
 std::unordered_map<QString, QString> TwitchMessageBuilder::parseBadgeInfoTag(
     const QVariantMap &tags)
 {
-    auto infoMap = std::unordered_map<QString, QString>();
+    std::unordered_map<QString, QString> infoMap;
 
     auto infoIt = tags.constFind("badge-info");
     if (infoIt == tags.end())
         return infoMap;
 
-    auto badges = infoIt.value().toString().split(',', Qt::SkipEmptyParts);
+    auto info = infoIt.value().toString().split(',', Qt::SkipEmptyParts);
 
-    for (const QString &badge : badges)
+    for (const QString &badge : info)
     {
         infoMap.emplace(this->slashKeyValue(badge));
     }

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -1078,9 +1078,9 @@ void TwitchMessageBuilder::appendTwitchBadges()
             {
                 auto predictionText =
                     badgeInfoIt->second
-                        .replace("\\s", " ")  // standard IRC escapes
-                        .replace("\\:", ";")
-                        .replace("\\\\", "\\")
+                        .replace(R"(\s)", " ")  // standard IRC escapes
+                        .replace(R"(\:)", ";")
+                        .replace(R"(\\)", R"(\)")
                         .replace("⸝", ",");  // twitch's comma escape
                 // Careful, the first character is RIGHT LOW PARAPHRASE BRACKET or U+2E1D, which just looks like a comma
 

--- a/src/providers/twitch/TwitchMessageBuilder.hpp
+++ b/src/providers/twitch/TwitchMessageBuilder.hpp
@@ -88,6 +88,9 @@ private:
     void addTextOrEmoji(EmotePtr emote) override;
     void addTextOrEmoji(const QString &value) override;
 
+    // Copied some common logic from SharedMessageBuilder::parseBadgeTag
+    std::unordered_map<QString, QString> parseBadgeInfoTag(
+        const QVariantMap &tag);
     void appendTwitchBadges();
     void appendChatterinoBadges();
     void appendFfzBadges();

--- a/src/providers/twitch/TwitchMessageBuilder.hpp
+++ b/src/providers/twitch/TwitchMessageBuilder.hpp
@@ -68,8 +68,8 @@ public:
                                          Channel *channel,
                                          MessageBuilder *builder);
 
-    // Copied some common logic from SharedMessageBuilder::parseBadgeTag
-    std::unordered_map<QString, QString> parseBadgeInfoTag(
+    // Shares some common logic from SharedMessageBuilder::parseBadgeTag
+    static std::unordered_map<QString, QString> parseBadgeInfoTag(
         const QVariantMap &tags);
 
 private:

--- a/src/providers/twitch/TwitchMessageBuilder.hpp
+++ b/src/providers/twitch/TwitchMessageBuilder.hpp
@@ -68,6 +68,10 @@ public:
                                          Channel *channel,
                                          MessageBuilder *builder);
 
+    // Copied some common logic from SharedMessageBuilder::parseBadgeTag
+    std::unordered_map<QString, QString> parseBadgeInfoTag(
+        const QVariantMap &tags);
+
 private:
     void parseUsernameColor() override;
     void parseUsername() override;
@@ -88,9 +92,6 @@ private:
     void addTextOrEmoji(EmotePtr emote) override;
     void addTextOrEmoji(const QString &value) override;
 
-    // Copied some common logic from SharedMessageBuilder::parseBadgeTag
-    std::unordered_map<QString, QString> parseBadgeInfoTag(
-        const QVariantMap &tag);
     void appendTwitchBadges();
     void appendChatterinoBadges();
     void appendFfzBadges();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ set(test_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/src/UtilTwitch.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/IrcHelpers.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/TwitchPubSubClient.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/TwitchMessageBuilder.cpp
     # Add your new file above this line!
     )
 

--- a/tests/src/TwitchMessageBuilder.cpp
+++ b/tests/src/TwitchMessageBuilder.cpp
@@ -114,19 +114,16 @@ TEST(TwitchMessageBuilder, BadgeInfoParsing)
 
     for (const auto &test : testCases)
     {
-        Channel chan("zneix", Channel::Type::Twitch);
-        Communi::IrcConnection ircConn(nullptr);
         auto privmsg =
-            Communi::IrcPrivateMessage::fromData(test.input, &ircConn);
+            Communi::IrcPrivateMessage::fromData(test.input, nullptr);
 
-        MessageParseArgs args;
-        TwitchMessageBuilder builder(&chan, privmsg, args, "", false);
-
-        auto outputBadgeInfo = builder.parseBadgeInfoTag(privmsg->tags());
+        auto outputBadgeInfo =
+            TwitchMessageBuilder::parseBadgeInfoTag(privmsg->tags());
         EXPECT_EQ(outputBadgeInfo, test.expectedBadgeInfo)
             << "Input for badgeInfo " << test.input.toStdString() << " failed";
 
-        auto outputBadges = builder.parseBadgeTag(privmsg->tags());
+        auto outputBadges =
+            SharedMessageBuilder::parseBadgeTag(privmsg->tags());
         EXPECT_EQ(outputBadges, test.expectedBadges)
             << "Input for badges " << test.input.toStdString() << " failed";
     }

--- a/tests/src/TwitchMessageBuilder.cpp
+++ b/tests/src/TwitchMessageBuilder.cpp
@@ -1,0 +1,133 @@
+#include "providers/twitch/TwitchMessageBuilder.hpp"
+
+#include "common/Channel.hpp"
+#include "messages/MessageBuilder.hpp"
+#include "providers/twitch/TwitchBadge.hpp"
+
+#include "ircconnection.h"
+
+#include <gtest/gtest.h>
+#include <QDebug>
+#include <QString>
+#include <unordered_map>
+#include <vector>
+
+using namespace chatterino;
+
+TEST(TwitchMessageBuilder, CommaSeparatedListTagParsing)
+{
+    struct TestCase {
+        QString input;
+        std::pair<QString, QString> expectedOutput;
+    };
+
+    std::vector<TestCase> testCases{
+        {
+            "broadcaster/1",
+            {"broadcaster", "1"},
+        },
+        {
+            "predictions/foo/bar/baz",
+            {"predictions", "foo/bar/baz"},
+        },
+        {
+            "test/",
+            {"test", ""},
+        },
+        {
+            "/",
+            {"", ""},
+        },
+        {
+            "/value",
+            {"", "value"},
+        },
+        {
+            "",
+            {"", ""},
+        },
+    };
+
+    for (const auto &test : testCases)
+    {
+        auto output = TwitchMessageBuilder::slashKeyValue(test.input);
+
+        EXPECT_EQ(output, test.expectedOutput)
+            << "Input " << test.input.toStdString() << " failed";
+    }
+}
+
+TEST(TwitchMessageBuilder, BadgeInfoParsing)
+{
+    struct TestCase {
+        QByteArray input;
+        std::unordered_map<QString, QString> expectedBadgeInfo;
+        std::vector<Badge> expectedBadges;
+    };
+
+    std::vector<TestCase> testCases{
+        {
+            R"(@badge-info=predictions/<<<<<<\sHEAD[15A⸝asdf/test;badges=predictions/pink-2;client-nonce=9dbb88e516edf4efb055c011f91ea0cf;color=#FF4500;display-name=もっと頑張って;emotes=;first-msg=0;flags=;id=feb00b12-4ec5-4f77-9160-667de463dab1;mod=0;room-id=99631238;subscriber=0;tmi-sent-ts=1653494874297;turbo=0;user-id=648946956;user-type= :zniksbot!zniksbot@zniksbot.tmi.twitch.tv PRIVMSG #zneix :-tags")",
+            {
+                {"predictions", R"(<<<<<<\sHEAD[15A⸝asdf/test)"},
+            },
+            {
+                Badge{"predictions", "pink-2"},
+            },
+        },
+        {
+            R"(@badge-info=predictions/<<<<<<\sHEAD[15A⸝asdf/test,founder/17;badges=predictions/pink-2,vip/1,founder/0,bits/1;client-nonce=9b836e232170a9df213aefdcb458b67e;color=#696969;display-name=NotKarar;emotes=;first-msg=0;flags=;id=e00881bd-5f21-4993-8bbd-1736cd13d42e;mod=0;room-id=99631238;subscriber=1;tmi-sent-ts=1653494879409;turbo=0;user-id=89954186;user-type= :notkarar!notkarar@notkarar.tmi.twitch.tv PRIVMSG #zneix :-tags)",
+            {
+                {"predictions", R"(<<<<<<\sHEAD[15A⸝asdf/test)"},
+                {"founder", "17"},
+            },
+            {
+                Badge{"predictions", "pink-2"},
+                Badge{"vip", "1"},
+                Badge{"founder", "0"},
+                Badge{"bits", "1"},
+            },
+        },
+        {
+            R"(@badge-info=predictions/foo/bar/baz;badges=predictions/blue-1,moderator/1,glhf-pledge/1;client-nonce=f73f16228e6e32f8e92b47ab8283b7e1;color=#1E90FF;display-name=zneixbot;emotes=30259:6-12;first-msg=0;flags=;id=9682a5f1-a0b0-45e2-be9f-8074b58c5f8f;mod=1;room-id=99631238;subscriber=0;tmi-sent-ts=1653573594035;turbo=0;user-id=463521670;user-type=mod :zneixbot!zneixbot@zneixbot.tmi.twitch.tv PRIVMSG #zneix :-tags HeyGuys)",
+            {
+                {"predictions", "foo/bar/baz"},
+            },
+            {
+                Badge{"predictions", "blue-1"},
+                Badge{"moderator", "1"},
+                Badge{"glhf-pledge", "1"},
+            },
+        },
+        {
+            R"(@badge-info=subscriber/22;badges=broadcaster/1,subscriber/18,glhf-pledge/1;color=#F97304;display-name=zneix;emotes=;first-msg=0;flags=;id=1d99f67f-a566-4416-a4e2-e85d7fce9223;mod=0;room-id=99631238;subscriber=1;tmi-sent-ts=1653612232758;turbo=0;user-id=99631238;user-type= :zneix!zneix@zneix.tmi.twitch.tv PRIVMSG #zneix :-tags)",
+            {
+                {"subscriber", "22"},
+            },
+            {
+                Badge{"broadcaster", "1"},
+                Badge{"subscriber", "18"},
+                Badge{"glhf-pledge", "1"},
+            },
+        },
+    };
+
+    for (const auto &test : testCases)
+    {
+        Channel chan("zneix", Channel::Type::Twitch);
+        Communi::IrcConnection ircConn(nullptr);
+        auto privmsg =
+            Communi::IrcPrivateMessage::fromData(test.input, &ircConn);
+
+        MessageParseArgs args;
+        TwitchMessageBuilder builder(&chan, privmsg, args, "", false);
+
+        auto outputBadgeInfo = builder.parseBadgeInfoTag(privmsg->tags());
+        EXPECT_EQ(outputBadgeInfo, test.expectedBadgeInfo)
+            << "Input for badgeInfo " << test.input.toStdString() << " failed";
+
+        auto outputBadges = builder.parseBadgeTag(privmsg->tags());
+        EXPECT_EQ(outputBadges, test.expectedBadges)
+            << "Input for badges " << test.input.toStdString() << " failed";
+    }
+}


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Add tests from:
https://paste.ivr.fi/raw/marehysiwo
https://paste.ivr.fi/raw/ocidamuxyq
https://paste.ivr.fi/raw/opeponetyg
https://paste.ivr.fi/raw/icejijiqaq

# Description

### Why was the logic change in parsing "badges" and "badge-info" made/needed:

tl;dr: we should split by slash only its occurrence instead of every occurrence.

It's been discovered that elements of the comma-separated list (taglist) in "badge-info" tag can have slashes in their values.
For example, "foo/bar/baz,tri/hard" can be a valid badge tag
In that case, valid map content should be:
	`{"foo": "bar/baz", "tri": "hard"}`
With old logic of just splitting elements of the taglist by (every) slash it would be instead:
	`{"foo": "bar" "baz", "tri": "hard"}`
Here, the "foo" element of the taglist would be considered invalid and skipped (because the amount of substrings after `QString::split` operation was not equal to 2).
Now, the lack of slash can indicate that the tag is invalid and should be skipped instead of checking for amount of substring being non-equal to 2.
And to ensure we parse taglist's elements properly, a [`QString::section`](https://doc.qt.io/qt-5/qstring.html#section) is used which can return a substring of elements before and after a specified occurrence of the delimeter, similarly to GNU Coreutils' cut command:
```sh
zneix@uds ~$ echo "foo/bar/baz" | cut -d/ -f1
foo
zneix@uds ~$ echo "foo/bar/baz" | cut -d/ -f2-
bar/baz
```

### Actual noticable differences

With old logic, some edge-cases were wrongly parsed, resulting in `badge-info` taglist values being skipped (fallback text is being used):
![old behaviour](https://cdn.zneix.eu/92Oo1I7.png)

New logic (element of `badge-info` is parsed correctly and used in the tooltip):
![new behaviour](https://cdn.zneix.eu/pKOghPa.png)

### Details about codebase changes:

In the process a lot of duplicate code was removed to have the logic responsible for this in one place only. For that to work, some type changes were required.
~~I've also decided in this scenario it's better to use `std::unordered_map` over `std::map` - perhaps it's convinient to use `QHash` at this point, but I'm not sure so I just left it as is.~~
nevermind, map/hash can't be used for badges - that breaks the order in which they're displayed (which btw, should follow the order in which badges came in to us from twitch).
Changed map for `badge-info` to an `std::unordered_map` though which seemed appropriate.

~~Changing the default constructor for `Badge` class in TwitchBadges.cpp made things easier to handle, making `SharedMessageBuilder::parseTagList` work for parsing both `badge-info` and `badges` tags in PRIVMSG messages, without having to duplicate the same function just for the sake of returning `std::vector<Badge>` instead of `std::(unordered_)map<QString, QString>`. This comes with a little compromise in TwitchMessageBuilder.cpp, where a helper vector is declared and set as `this->message().badges` - perhaps this can be mitigated somehow.~~
this isn't true anymore - while retaining badge order, it's less complex to parse `badges` and `badge-info` separetly.