### PR TITLE
Corrected determination of search popup's title

### DIFF
--- a/src/widgets/helper/SearchPopup.cpp
+++ b/src/widgets/helper/SearchPopup.cpp
@@ -109,17 +109,17 @@ void SearchPopup::updateWindowTitle()
 {
     QString historyName;
 
-    if (this->channelName_ == "/whispers")
+    if (this->searchChannels_.size() > 1)
     {
-        historyName = "whispers";
+        historyName = "multiple channels'";
     }
     else if (this->channelName_ == "/mentions")
     {
         historyName = "mentions";
     }
-    else if (this->searchChannels_.size() > 1)
+    else if (this->channelName_ == "/whispers")
     {
-        historyName = "multiple channels'";
+        historyName = "whispers";
     }
     else if (this->channelName_.isEmpty())
     {


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

In a case where `#/mentions` or `#/whispers` would be your first split in your first tab, the title determination would take that first channel's name due to the higher priority in if-else chain.
