### PR TITLE
Removed total views from the usercard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 - Minor: Added `/requests` command. Usage: `/requests [channel]`. Opens the channel points requests queue for the provided channel or the current channel if no input is provided. (#3746)
 - Minor: Added ability to execute commands on chat messages using the message context menu. (#3738, #3765)
 - Minor: Added `/copy` command. Usage: `/copy <text>`. Copies provided text to clipboard - can be useful with custom commands. (#3763)
-- Minor: Removed total views from the usercard. (#3792)
+- Minor: Removed total views from the usercard, as Twitch no longer updates the number. (#3792)
 - Bugfix: Fixed viewers list search not working when used before loading finishes. (#3774)
 - Bugfix: Fixed live notifications for usernames containing uppercase characters. (#3646)
 - Bugfix: Fixed live notifications not getting updated for closed streams going offline. (#3678)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 - Minor: Added `/requests` command. Usage: `/requests [channel]`. Opens the channel points requests queue for the provided channel or the current channel if no input is provided. (#3746)
 - Minor: Added ability to execute commands on chat messages using the message context menu. (#3738, #3765)
 - Minor: Added `/copy` command. Usage: `/copy <text>`. Copies provided text to clipboard - can be useful with custom commands. (#3763)
-- Bugfix: Removed total views from the usercard.
+- Bugfix: Removed total views from the usercard. (#3792)
 - Bugfix: Fixed viewers list search not working when used before loading finishes. (#3774)
 - Bugfix: Fixed live notifications for usernames containing uppercase characters. (#3646)
 - Bugfix: Fixed live notifications not getting updated for closed streams going offline. (#3678)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Minor: Added `/requests` command. Usage: `/requests [channel]`. Opens the channel points requests queue for the provided channel or the current channel if no input is provided. (#3746)
 - Minor: Added ability to execute commands on chat messages using the message context menu. (#3738, #3765)
 - Minor: Added `/copy` command. Usage: `/copy <text>`. Copies provided text to clipboard - can be useful with custom commands. (#3763)
+- Bugfix: Removed total views from the usercard.
 - Bugfix: Fixed viewers list search not working when used before loading finishes. (#3774)
 - Bugfix: Fixed live notifications for usernames containing uppercase characters. (#3646)
 - Bugfix: Fixed live notifications not getting updated for closed streams going offline. (#3678)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 - Minor: Added `/requests` command. Usage: `/requests [channel]`. Opens the channel points requests queue for the provided channel or the current channel if no input is provided. (#3746)
 - Minor: Added ability to execute commands on chat messages using the message context menu. (#3738, #3765)
 - Minor: Added `/copy` command. Usage: `/copy <text>`. Copies provided text to clipboard - can be useful with custom commands. (#3763)
-- Bugfix: Removed total views from the usercard. (#3792)
+- Minor: Removed total views from the usercard. (#3792)
 - Bugfix: Fixed viewers list search not working when used before loading finishes. (#3774)
 - Bugfix: Fixed live notifications for usernames containing uppercase characters. (#3646)
 - Bugfix: Fixed live notifications not getting updated for closed streams going offline. (#3678)

--- a/src/providers/twitch/api/Helix.hpp
+++ b/src/providers/twitch/api/Helix.hpp
@@ -27,7 +27,6 @@ struct HelixUser {
     QString createdAt;
     QString description;
     QString profileImageUrl;
-    int viewCount;
 
     explicit HelixUser(QJsonObject jsonObject)
         : id(jsonObject.value("id").toString())
@@ -36,7 +35,6 @@ struct HelixUser {
         , createdAt(jsonObject.value("created_at").toString())
         , description(jsonObject.value("description").toString())
         , profileImageUrl(jsonObject.value("profile_image_url").toString())
-        , viewCount(jsonObject.value("view_count").toInt())
     {
     }
 };

--- a/src/providers/twitch/api/README.md
+++ b/src/providers/twitch/api/README.md
@@ -12,7 +12,7 @@ URL: https://dev.twitch.tv/docs/api/reference#get-users
 
 Used in:
 
-- `UserInfoPopup` to get ID, viewCount, displayName, createdAt of username we clicked
+- `UserInfoPopup` to get ID, displayName, createdAt of username we clicked
 - `CommandController` to power any commands that need to get a user ID
 - `Toasts` to get the profile picture of a streamer who just went live
 - `TwitchAccount` block and unblock features to translate user name to user ID

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -35,7 +35,6 @@
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 
-const QString TEXT_VIEWS("Views: %1");
 const QString TEXT_FOLLOWERS("Followers: %1");
 const QString TEXT_CREATED("Created: %1");
 const QString TEXT_TITLE("%1's Usercard - #%2");
@@ -358,8 +357,6 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically, QWidget *parent)
             }
 
             // items on the left
-            vbox.emplace<Label>(TEXT_VIEWS.arg(""))
-                .assign(&this->ui_.viewCountLabel);
             vbox.emplace<Label>(TEXT_FOLLOWERS.arg(""))
                 .assign(&this->ui_.followerCountLabel);
             vbox.emplace<Label>(TEXT_CREATED.arg(""))
@@ -780,7 +777,6 @@ void UserInfoPopup::updateUserData()
         // this can occur when the account doesn't exist.
         this->ui_.followerCountLabel->setText(
             TEXT_FOLLOWERS.arg(TEXT_UNAVAILABLE));
-        this->ui_.viewCountLabel->setText(TEXT_VIEWS.arg(TEXT_UNAVAILABLE));
         this->ui_.createdDateLabel->setText(TEXT_CREATED.arg(TEXT_UNAVAILABLE));
 
         this->ui_.nameLabel->setText(this->userName_);
@@ -817,8 +813,6 @@ void UserInfoPopup::updateUserData()
 
         this->setWindowTitle(TEXT_TITLE.arg(
             user.displayName, this->underlyingChannel_->getName()));
-        this->ui_.viewCountLabel->setText(
-            TEXT_VIEWS.arg(localizeNumbers(user.viewCount)));
         this->ui_.createdDateLabel->setText(
             TEXT_CREATED.arg(user.createdAt.section("T", 0, 0)));
         this->ui_.userIDLabel->setText(TEXT_USER_ID + user.id);

--- a/src/widgets/dialogs/UserInfoPopup.hpp
+++ b/src/widgets/dialogs/UserInfoPopup.hpp
@@ -76,7 +76,6 @@ private:
 
         Label *nameLabel = nullptr;
         Label *localizedNameLabel = nullptr;
-        Label *viewCountLabel = nullptr;
         Label *followerCountLabel = nullptr;
         Label *createdDateLabel = nullptr;
         Label *userIDLabel = nullptr;


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description
Twitch removed the 'total views' counter from the channel page, dashboard, and I am certain the number isn't being updated anymore. [Announcement of total views being deprecated](https://discuss.dev.twitch.tv/t/get-users-api-endpoint-view-count-deprecation/37777)
<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
