### PR TITLE
Update Windows build docs to rename the correct folder

### DIFF
--- a/BUILDING_ON_WINDOWS.md
+++ b/BUILDING_ON_WINDOWS.md
@@ -25,7 +25,7 @@ Notes:
      **Convenience link for Visual Studio 2022: [boost_1_79_0_b1-msvc-14.3-64.exe](https://sourceforge.net/projects/boost/files/boost-binaries/1.79.0_b1/boost_1_79_0_b1-msvc-14.3-64.exe/download)**
 
 2. When prompted where to install Boost, set the location to `C:\local\boost`.
-3. After the installation finishes, rename the `C:\local\boost\boost_1_79_0_b1_rc1` (or similar) directory to simply `lib` (`C:\local\boost\lib`).
+3. After the installation finishes, rename the `C:\local\boost\lib64-msvc-14.3` (or similar) directory to simply `lib` (`C:\local\boost\lib`).
 
 Note: This installation will take about 2.1 GB of disk space.
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

In #3390 we updated the build docs to support VS2022, but in Boost Step 3, the folder name was changed to the folder name that is already handled by Step 2.

See #3793 - While the user may have ran into more or less the same issue, they may have noticed the problem sooner if the Step 3 covered the correct `lib64-msvc-14.3` over Step 2 's `boost_1_79_0_b1_rc1`

This change reverts to the old variation of this line, but bumps it to `14.3`

