### PR TITLE
Add the ability to skip generation of git and date data

### DIFF
--- a/cmake/GIT.cmake
+++ b/cmake/GIT.cmake
@@ -19,6 +19,10 @@ set(GIT_COMMIT "GIT-REPOSITORY-NOT-FOUND")
 set(GIT_RELEASE "${PROJECT_VERSION}")
 set(GIT_MODIFIED 0)
 
+if (DEFINED ENV{CHATTERINO_SKIP_GIT_GEN})
+    return()
+endif ()
+
 if (GIT_EXECUTABLE)
     execute_process(
             COMMAND ${GIT_EXECUTABLE} rev-parse --is-inside-work-tree

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -622,7 +622,11 @@ set_target_properties(${LIBRARY_PROJECT}
 # compilation in CMake is a more involved, as documented in https://stackoverflow.com/q/24292898.
 # For CI runs, however, the date of build file generation should be consistent with the date of
 # compilation so this approximation is "good enough" for our purpose.
-string(TIMESTAMP cmake_gen_date "%Y-%m-%d")
+if (DEFINED ENV{CHATTERINO_SKIP_DATE_GEN})
+    set(cmake_gen_date "1970-01-01")
+else ()
+    string(TIMESTAMP cmake_gen_date "%Y-%m-%d")
+endif ()
 
 target_compile_definitions(${LIBRARY_PROJECT} PUBLIC
     CHATTERINO


### PR DESCRIPTION

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

This can be done by setting the `CHATTERINO_SKIP_DATE_GEN` and `CHATTERINO_SKIP_GIT_GEN` environment variables

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
