### PR TITLE
Added interface for highlights to Application

### DIFF
--- a/benchmarks/src/Highlights.cpp
+++ b/benchmarks/src/Highlights.cpp
@@ -2,6 +2,7 @@
 #include "BaseSettings.hpp"
 #include "common/Channel.hpp"
 #include "controllers/accounts/AccountController.hpp"
+#include "controllers/highlights/HighlightController.hpp"
 #include "controllers/highlights/HighlightPhrase.hpp"
 #include "messages/Message.hpp"
 #include "messages/SharedMessageBuilder.hpp"
@@ -83,6 +84,10 @@ public:
     {
         return nullptr;
     }
+    HighlightController *getHighlights() override
+    {
+        return &this->highlights;
+    }
     TwitchIrcServer *getTwitch() override
     {
         return nullptr;
@@ -97,6 +102,7 @@ public:
     }
 
     AccountController accounts;
+    HighlightController highlights;
     // TODO: Figure this out
 };
 

--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -46,6 +46,7 @@ public:
     virtual WindowManager *getWindows() = 0;
     virtual Toasts *getToasts() = 0;
     virtual CommandController *getCommands() = 0;
+    virtual HighlightController *getHighlights() = 0;
     virtual NotificationController *getNotifications() = 0;
     virtual TwitchIrcServer *getTwitch() = 0;
     virtual ChatterinoBadges *getChatterinoBadges() = 0;
@@ -123,6 +124,10 @@ public:
     NotificationController *getNotifications() override
     {
         return this->notifications;
+    }
+    HighlightController *getHighlights() override
+    {
+        return this->highlights;
     }
     TwitchIrcServer *getTwitch() override
     {

--- a/src/messages/SharedMessageBuilder.cpp
+++ b/src/messages/SharedMessageBuilder.cpp
@@ -155,7 +155,7 @@ void SharedMessageBuilder::parseHighlights()
     }
 
     auto badges = SharedMessageBuilder::parseBadgeTag(this->tags);
-    auto [highlighted, highlightResult] = getApp()->highlights->check(
+    auto [highlighted, highlightResult] = getIApp()->getHighlights()->check(
         this->args, badges, this->ircMessage->nick(), this->originalMessage_);
 
     if (!highlighted)

--- a/tests/src/HighlightController.cpp
+++ b/tests/src/HighlightController.cpp
@@ -54,6 +54,10 @@ public:
     {
         return nullptr;
     }
+    HighlightController *getHighlights() override
+    {
+        return &this->highlights;
+    }
     TwitchIrcServer *getTwitch() override
     {
         return nullptr;
@@ -68,6 +72,7 @@ public:
     }
 
     AccountController accounts;
+    HighlightController highlights;
     // TODO: Figure this out
 };
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Added `getHighlights()` method pointing to underlying `highlights` member.
Switched from `getApp()` to `getIApp()` in `SharedMessageBuilder` to advantage of newly added `getHighlights()` in benchmark code.
Updated benchmark and test code accordingly to "upstream" changes in the `Application` class.

This fixes crash in Highlights benchmark:
![proof of highlights working](https://cdn.zneix.eu/lEluA4v.png)
