### PR TITLE
Bump Qt 5.12.10 to 5.12.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,3 @@
----
 name: Build
 
 on:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - master
-      - **-ci
+      - zneix/chore/experiment*
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,9 @@ on:
   push:
     branches:
       - master
+      - *-ci
   pull_request:
+  workflow_dispatch:
 
 concurrency: 
   group: build-${{ github.ref }}
@@ -47,10 +49,6 @@ jobs:
           key: ${{ runner.os }}-QtCache-${{ matrix.qt-version }}
 
       # LINUX
-      - name: Install p7zip (Ubuntu)
-        if: startsWith(matrix.os, 'ubuntu')
-        run: sudo apt-get update && sudo apt-get -y install p7zip-full
-
       - name: Install Qt
         uses: jurplel/install-qt-action@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - zneix/chore/experiment*
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        qt-version: [5.15.2, 5.12.10]
+        qt-version: [5.15.2, 5.12.12]
         build-system: [qmake, cmake]
         pch: [true]
         include:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,11 @@
+---
 name: Build
 
 on:
   push:
     branches:
       - master
-      - *-ci
+      - **-ci
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,8 @@ name: Test
 
 on:
   pull_request:
+  push:
+    - 'zneix/chore/experiment*'
 
 env:
   TWITCH_PUBSUB_SERVER_IMAGE: ghcr.io/chatterino/twitch-pubsub-server-test:v1.0.3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,7 @@ name: Test
 
 on:
   pull_request:
-  push:
-    branches:
-      - zneix/chore/experiment*
+  workflow_dispatch:
 
 env:
   TWITCH_PUBSUB_SERVER_IMAGE: ghcr.io/chatterino/twitch-pubsub-server-test:v1.0.3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
+        qt-version: [5.15.2]
       fail-fast: false
 
     steps:
@@ -28,20 +29,16 @@ jobs:
         id: cache-qt
         uses: actions/cache@v3
         with:
-          path: ../Qt
-          key: ${{ runner.os }}-QtCache-20201005
+          path: "${{ github.workspace }}/qt/"
+          key: ${{ runner.os }}-QtCache-${{ matrix.qt-version }}
 
       # LINUX
-      - name: Install p7zip (Ubuntu)
-        if: startsWith(matrix.os, 'ubuntu')
-        run: sudo apt-get update && sudo apt-get -y install p7zip-full
-
       - name: Install Qt
         uses: jurplel/install-qt-action@v2
         with:
-          aqtversion: '==1.1.1'
           cached: ${{ steps.cache-qt.outputs.cache-hit }}
-          extra: --external 7z
+          version: ${{ matrix.qt-version }}
+          dir: "${{ github.workspace }}/qt/"
 
       # LINUX
       - name: Install dependencies (Ubuntu)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,8 @@ name: Test
 on:
   pull_request:
   push:
-    - 'zneix/chore/experiment*'
+    branches:
+      - zneix/chore/experiment*
 
 env:
   TWITCH_PUBSUB_SERVER_IMAGE: ghcr.io/chatterino/twitch-pubsub-server-test:v1.0.3


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

- Attempt to fix caching in test workflow, Acomplishes similar thing as #3586 and #3587
- Try to bump qt 5.12 version and see if it breaks
- Experiment with `workflow_dispatch` which allows us to manually trigger an action, see https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow and https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch - however for this to work, it needs to be in the default branch.

Requires admin merge + required workflow update.
