### PR TITLE
Faster startup

### DIFF
--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -918,6 +918,10 @@ void TwitchChannel::fetchDisplayName()
             }
             channel->addRecentChatter(channel->getDisplayName());
             channel->displayNameChanged.invoke();
+            if (channel->roomId().isEmpty())
+            {
+                channel->setRoomId(user.id);
+            }
         },
         [] {});
 }


### PR DESCRIPTION


Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable

# Description

Since on startup the stream id is found as each TwitchChannel needs to ask for their display name to id conversion. Thus instead of waiting for the roomid over IRC we can get from the api. This speeds up loading a lot (1sec now instead of maybe 10-20sec) and gets rid of cases were sometimes channels fail to load for me.

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
