### PR TITLE
Moved highlight row index numbers to enum

### DIFF
--- a/src/controllers/highlights/HighlightModel.cpp
+++ b/src/controllers/highlights/HighlightModel.cpp
@@ -179,7 +179,8 @@ void HighlightModel::afterInit()
         ColorProvider::instance().color(ColorType::FirstMessageHighlight);
     setColorItem(firstMessageRow[Column::Color], *FirstMessageColor, false);
 
-    this->insertCustomRow(firstMessageRow, HighlightRowIndexes::FirstMessageRow);
+    this->insertCustomRow(firstMessageRow,
+                          HighlightRowIndexes::FirstMessageRow);
 }
 
 void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,

--- a/src/controllers/highlights/HighlightModel.cpp
+++ b/src/controllers/highlights/HighlightModel.cpp
@@ -74,7 +74,7 @@ void HighlightModel::afterInit()
     auto selfColor = ColorProvider::instance().color(ColorType::SelfHighlight);
     setColorItem(usernameRow[Column::Color], *selfColor, false);
 
-    this->insertCustomRow(usernameRow, {});
+    this->insertCustomRow(usernameRow, SELF_HIGHLIGHT_ROW);
 
     // Highlight settings for whispers
     std::vector<QStandardItem *> whisperRow = this->createRow();
@@ -121,7 +121,7 @@ void HighlightModel::afterInit()
     auto subColor = ColorProvider::instance().color(ColorType::Subscription);
     setColorItem(subRow[Column::Color], *subColor, false);
 
-    this->insertCustomRow(subRow, 2);
+    this->insertCustomRow(subRow, SUB_ROW);
 
     // Highlight settings for redeemed highlight messages
     std::vector<QStandardItem *> redeemedRow = this->createRow();
@@ -149,7 +149,7 @@ void HighlightModel::afterInit()
         ColorProvider::instance().color(ColorType::RedeemedHighlight);
     setColorItem(redeemedRow[Column::Color], *RedeemedColor, false);
 
-    this->insertCustomRow(redeemedRow, 3);
+    this->insertCustomRow(redeemedRow, REDEEMED_ROW);
 
     // Highlight settings for first messages
     std::vector<QStandardItem *> firstMessageRow = this->createRow();
@@ -179,7 +179,7 @@ void HighlightModel::afterInit()
         ColorProvider::instance().color(ColorType::FirstMessageHighlight);
     setColorItem(firstMessageRow[Column::Color], *FirstMessageColor, false);
 
-    this->insertCustomRow(firstMessageRow, 4);
+    this->insertCustomRow(firstMessageRow, FIRSTMESSAGE_ROW);
 }
 
 void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
@@ -191,7 +191,7 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
         case Column::Pattern: {
             if (role == Qt::CheckStateRole)
             {
-                if (rowIndex == 0)
+                if (rowIndex == SELF_HIGHLIGHT_ROW)
                 {
                     getSettings()->enableSelfHighlight.setValue(value.toBool());
                 }
@@ -200,16 +200,16 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
                     getSettings()->enableWhisperHighlight.setValue(
                         value.toBool());
                 }
-                else if (rowIndex == 2)
+                else if (rowIndex == SUB_ROW)
                 {
                     getSettings()->enableSubHighlight.setValue(value.toBool());
                 }
-                else if (rowIndex == 3)
+                else if (rowIndex == REDEEMED_ROW)
                 {
                     getSettings()->enableRedeemedHighlight.setValue(
                         value.toBool());
                 }
-                else if (rowIndex == 4)
+                else if (rowIndex == FIRSTMESSAGE_ROW)
                 {
                     getSettings()->enableFirstMessageHighlight.setValue(
                         value.toBool());
@@ -220,7 +220,7 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
         case Column::ShowInMentions: {
             if (role == Qt::CheckStateRole)
             {
-                if (rowIndex == 0)
+                if (rowIndex == SELF_HIGHLIGHT_ROW)
                 {
                     getSettings()->showSelfHighlightInMentions.setValue(
                         value.toBool());
@@ -231,7 +231,7 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
         case Column::FlashTaskbar: {
             if (role == Qt::CheckStateRole)
             {
-                if (rowIndex == 0)
+                if (rowIndex == SELF_HIGHLIGHT_ROW)
                 {
                     getSettings()->enableSelfHighlightTaskbar.setValue(
                         value.toBool());
@@ -241,17 +241,17 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
                     getSettings()->enableWhisperHighlightTaskbar.setValue(
                         value.toBool());
                 }
-                else if (rowIndex == 2)
+                else if (rowIndex == SUB_ROW)
                 {
                     getSettings()->enableSubHighlightTaskbar.setValue(
                         value.toBool());
                 }
-                else if (rowIndex == 3)
+                else if (rowIndex == REDEEMED_ROW)
                 {
                     // getSettings()->enableRedeemedHighlightTaskbar.setValue(
                     //     value.toBool());
                 }
-                else if (rowIndex == 4)
+                else if (rowIndex == FIRSTMESSAGE_ROW)
                 {
                     // getSettings()->enableFirstMessageHighlightTaskbar.setValue(
                     //     value.toBool());
@@ -262,7 +262,7 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
         case Column::PlaySound: {
             if (role == Qt::CheckStateRole)
             {
-                if (rowIndex == 0)
+                if (rowIndex == SELF_HIGHLIGHT_ROW)
                 {
                     getSettings()->enableSelfHighlightSound.setValue(
                         value.toBool());
@@ -272,17 +272,17 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
                     getSettings()->enableWhisperHighlightSound.setValue(
                         value.toBool());
                 }
-                else if (rowIndex == 2)
+                else if (rowIndex == SUB_ROW)
                 {
                     getSettings()->enableSubHighlightSound.setValue(
                         value.toBool());
                 }
-                else if (rowIndex == 3)
+                else if (rowIndex == REDEEMED_ROW)
                 {
                     // getSettings()->enableRedeemedHighlightSound.setValue(
                     //     value.toBool());
                 }
-                else if (rowIndex == 4)
+                else if (rowIndex == FIRSTMESSAGE_ROW)
                 {
                     // getSettings()->enableFirstMessageHighlightSound.setValue(
                     //     value.toBool());
@@ -302,7 +302,7 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
             // Custom sound file
             if (role == Qt::UserRole)
             {
-                if (rowIndex == 0)
+                if (rowIndex == SELF_HIGHLIGHT_ROW)
                 {
                     getSettings()->selfHighlightSoundUrl.setValue(
                         value.toString());
@@ -312,17 +312,17 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
                     getSettings()->whisperHighlightSoundUrl.setValue(
                         value.toString());
                 }
-                else if (rowIndex == 2)
+                else if (rowIndex == SUB_ROW)
                 {
                     getSettings()->subHighlightSoundUrl.setValue(
                         value.toString());
                 }
-                else if (rowIndex == 3)
+                else if (rowIndex == REDEEMED_ROW)
                 {
                     getSettings()->redeemedHighlightSoundUrl.setValue(
                         value.toString());
                 }
-                else if (rowIndex == 4)
+                else if (rowIndex == FIRSTMESSAGE_ROW)
                 {
                     getSettings()->firstMessageHighlightSoundUrl.setValue(
                         value.toString());
@@ -335,7 +335,7 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
             if (role == Qt::DecorationRole)
             {
                 auto colorName = value.value<QColor>().name(QColor::HexArgb);
-                if (rowIndex == 0)
+                if (rowIndex == SELF_HIGHLIGHT_ROW)
                 {
                     getSettings()->selfHighlightColor.setValue(colorName);
                 }
@@ -343,18 +343,18 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
                 //                {
                 //                    getSettings()->whisperHighlightColor.setValue(colorName);
                 //                }
-                else if (rowIndex == 2)
+                else if (rowIndex == SUB_ROW)
                 {
                     getSettings()->subHighlightColor.setValue(colorName);
                 }
-                else if (rowIndex == 3)
+                else if (rowIndex == REDEEMED_ROW)
                 {
                     getSettings()->redeemedHighlightColor.setValue(colorName);
                     const_cast<ColorProvider &>(ColorProvider::instance())
                         .updateColor(ColorType::RedeemedHighlight,
                                      QColor(colorName));
                 }
-                else if (rowIndex == 4)
+                else if (rowIndex == FIRSTMESSAGE_ROW)
                 {
                     getSettings()->firstMessageHighlightColor.setValue(
                         colorName);

--- a/src/controllers/highlights/HighlightModel.cpp
+++ b/src/controllers/highlights/HighlightModel.cpp
@@ -74,7 +74,7 @@ void HighlightModel::afterInit()
     auto selfColor = ColorProvider::instance().color(ColorType::SelfHighlight);
     setColorItem(usernameRow[Column::Color], *selfColor, false);
 
-    this->insertCustomRow(usernameRow, SelfHighlightRow);
+    this->insertCustomRow(usernameRow, HighlightRowIndexes::SelfHighlightRow);
 
     // Highlight settings for whispers
     std::vector<QStandardItem *> whisperRow = this->createRow();
@@ -99,7 +99,7 @@ void HighlightModel::afterInit()
     //    setColorItem(whisperRow[Column::Color], *whisperColor, false);
     whisperRow[Column::Color]->setFlags(Qt::ItemFlag::NoItemFlags);
 
-    this->insertCustomRow(whisperRow, WhisperRow);
+    this->insertCustomRow(whisperRow, HighlightRowIndexes::WhisperRow);
 
     // Highlight settings for subscription messages
     std::vector<QStandardItem *> subRow = this->createRow();
@@ -121,7 +121,7 @@ void HighlightModel::afterInit()
     auto subColor = ColorProvider::instance().color(ColorType::Subscription);
     setColorItem(subRow[Column::Color], *subColor, false);
 
-    this->insertCustomRow(subRow, SubRow);
+    this->insertCustomRow(subRow, HighlightRowIndexes::SubRow);
 
     // Highlight settings for redeemed highlight messages
     std::vector<QStandardItem *> redeemedRow = this->createRow();
@@ -149,7 +149,7 @@ void HighlightModel::afterInit()
         ColorProvider::instance().color(ColorType::RedeemedHighlight);
     setColorItem(redeemedRow[Column::Color], *RedeemedColor, false);
 
-    this->insertCustomRow(redeemedRow, RedeemedRow);
+    this->insertCustomRow(redeemedRow, HighlightRowIndexes::RedeemedRow);
 
     // Highlight settings for first messages
     std::vector<QStandardItem *> firstMessageRow = this->createRow();
@@ -179,7 +179,7 @@ void HighlightModel::afterInit()
         ColorProvider::instance().color(ColorType::FirstMessageHighlight);
     setColorItem(firstMessageRow[Column::Color], *FirstMessageColor, false);
 
-    this->insertCustomRow(firstMessageRow, FirstMessageRow);
+    this->insertCustomRow(firstMessageRow, HighlightRowIndexes::FirstMessageRow);
 }
 
 void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
@@ -191,25 +191,25 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
         case Column::Pattern: {
             if (role == Qt::CheckStateRole)
             {
-                if (rowIndex == SelfHighlightRow)
+                if (rowIndex == HighlightRowIndexes::SelfHighlightRow)
                 {
                     getSettings()->enableSelfHighlight.setValue(value.toBool());
                 }
-                else if (rowIndex == WhisperRow)
+                else if (rowIndex == HighlightRowIndexes::WhisperRow)
                 {
                     getSettings()->enableWhisperHighlight.setValue(
                         value.toBool());
                 }
-                else if (rowIndex == SubRow)
+                else if (rowIndex == HighlightRowIndexes::SubRow)
                 {
                     getSettings()->enableSubHighlight.setValue(value.toBool());
                 }
-                else if (rowIndex == RedeemedRow)
+                else if (rowIndex == HighlightRowIndexes::RedeemedRow)
                 {
                     getSettings()->enableRedeemedHighlight.setValue(
                         value.toBool());
                 }
-                else if (rowIndex == FirstMessageRow)
+                else if (rowIndex == HighlightRowIndexes::FirstMessageRow)
                 {
                     getSettings()->enableFirstMessageHighlight.setValue(
                         value.toBool());
@@ -220,7 +220,7 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
         case Column::ShowInMentions: {
             if (role == Qt::CheckStateRole)
             {
-                if (rowIndex == SelfHighlightRow)
+                if (rowIndex == HighlightRowIndexes::SelfHighlightRow)
                 {
                     getSettings()->showSelfHighlightInMentions.setValue(
                         value.toBool());
@@ -231,27 +231,27 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
         case Column::FlashTaskbar: {
             if (role == Qt::CheckStateRole)
             {
-                if (rowIndex == SelfHighlightRow)
+                if (rowIndex == HighlightRowIndexes::SelfHighlightRow)
                 {
                     getSettings()->enableSelfHighlightTaskbar.setValue(
                         value.toBool());
                 }
-                else if (rowIndex == WhisperRow)
+                else if (rowIndex == HighlightRowIndexes::WhisperRow)
                 {
                     getSettings()->enableWhisperHighlightTaskbar.setValue(
                         value.toBool());
                 }
-                else if (rowIndex == SubRow)
+                else if (rowIndex == HighlightRowIndexes::SubRow)
                 {
                     getSettings()->enableSubHighlightTaskbar.setValue(
                         value.toBool());
                 }
-                else if (rowIndex == RedeemedRow)
+                else if (rowIndex == HighlightRowIndexes::RedeemedRow)
                 {
                     // getSettings()->enableRedeemedHighlightTaskbar.setValue(
                     //     value.toBool());
                 }
-                else if (rowIndex == FirstMessageRow)
+                else if (rowIndex == HighlightRowIndexes::FirstMessageRow)
                 {
                     // getSettings()->enableFirstMessageHighlightTaskbar.setValue(
                     //     value.toBool());
@@ -262,27 +262,27 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
         case Column::PlaySound: {
             if (role == Qt::CheckStateRole)
             {
-                if (rowIndex == SelfHighlightRow)
+                if (rowIndex == HighlightRowIndexes::SelfHighlightRow)
                 {
                     getSettings()->enableSelfHighlightSound.setValue(
                         value.toBool());
                 }
-                else if (rowIndex == WhisperRow)
+                else if (rowIndex == HighlightRowIndexes::WhisperRow)
                 {
                     getSettings()->enableWhisperHighlightSound.setValue(
                         value.toBool());
                 }
-                else if (rowIndex == SubRow)
+                else if (rowIndex == HighlightRowIndexes::SubRow)
                 {
                     getSettings()->enableSubHighlightSound.setValue(
                         value.toBool());
                 }
-                else if (rowIndex == RedeemedRow)
+                else if (rowIndex == HighlightRowIndexes::RedeemedRow)
                 {
                     // getSettings()->enableRedeemedHighlightSound.setValue(
                     //     value.toBool());
                 }
-                else if (rowIndex == FirstMessageRow)
+                else if (rowIndex == HighlightRowIndexes::FirstMessageRow)
                 {
                     // getSettings()->enableFirstMessageHighlightSound.setValue(
                     //     value.toBool());
@@ -302,27 +302,27 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
             // Custom sound file
             if (role == Qt::UserRole)
             {
-                if (rowIndex == SelfHighlightRow)
+                if (rowIndex == HighlightRowIndexes::SelfHighlightRow)
                 {
                     getSettings()->selfHighlightSoundUrl.setValue(
                         value.toString());
                 }
-                else if (rowIndex == WhisperRow)
+                else if (rowIndex == HighlightRowIndexes::WhisperRow)
                 {
                     getSettings()->whisperHighlightSoundUrl.setValue(
                         value.toString());
                 }
-                else if (rowIndex == SubRow)
+                else if (rowIndex == HighlightRowIndexes::SubRow)
                 {
                     getSettings()->subHighlightSoundUrl.setValue(
                         value.toString());
                 }
-                else if (rowIndex == RedeemedRow)
+                else if (rowIndex == HighlightRowIndexes::RedeemedRow)
                 {
                     getSettings()->redeemedHighlightSoundUrl.setValue(
                         value.toString());
                 }
-                else if (rowIndex == FirstMessageRow)
+                else if (rowIndex == HighlightRowIndexes::FirstMessageRow)
                 {
                     getSettings()->firstMessageHighlightSoundUrl.setValue(
                         value.toString());
@@ -335,26 +335,26 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
             if (role == Qt::DecorationRole)
             {
                 auto colorName = value.value<QColor>().name(QColor::HexArgb);
-                if (rowIndex == SelfHighlightRow)
+                if (rowIndex == HighlightRowIndexes::SelfHighlightRow)
                 {
                     getSettings()->selfHighlightColor.setValue(colorName);
                 }
-                //                else if (rowIndex == WhisperRow)
+                //                else if (rowIndex == HighlightRowIndexes::WhisperRow)
                 //                {
                 //                    getSettings()->whisperHighlightColor.setValue(colorName);
                 //                }
-                else if (rowIndex == SubRow)
+                else if (rowIndex == HighlightRowIndexes::SubRow)
                 {
                     getSettings()->subHighlightColor.setValue(colorName);
                 }
-                else if (rowIndex == RedeemedRow)
+                else if (rowIndex == HighlightRowIndexes::RedeemedRow)
                 {
                     getSettings()->redeemedHighlightColor.setValue(colorName);
                     const_cast<ColorProvider &>(ColorProvider::instance())
                         .updateColor(ColorType::RedeemedHighlight,
                                      QColor(colorName));
                 }
-                else if (rowIndex == FirstMessageRow)
+                else if (rowIndex == HighlightRowIndexes::FirstMessageRow)
                 {
                     getSettings()->firstMessageHighlightColor.setValue(
                         colorName);

--- a/src/controllers/highlights/HighlightModel.cpp
+++ b/src/controllers/highlights/HighlightModel.cpp
@@ -74,7 +74,7 @@ void HighlightModel::afterInit()
     auto selfColor = ColorProvider::instance().color(ColorType::SelfHighlight);
     setColorItem(usernameRow[Column::Color], *selfColor, false);
 
-    this->insertCustomRow(usernameRow, SELF_HIGHLIGHT_ROW);
+    this->insertCustomRow(usernameRow, SelfHighlightRow);
 
     // Highlight settings for whispers
     std::vector<QStandardItem *> whisperRow = this->createRow();
@@ -99,7 +99,7 @@ void HighlightModel::afterInit()
     //    setColorItem(whisperRow[Column::Color], *whisperColor, false);
     whisperRow[Column::Color]->setFlags(Qt::ItemFlag::NoItemFlags);
 
-    this->insertCustomRow(whisperRow, WHISPER_ROW);
+    this->insertCustomRow(whisperRow, WhisperRow);
 
     // Highlight settings for subscription messages
     std::vector<QStandardItem *> subRow = this->createRow();
@@ -121,7 +121,7 @@ void HighlightModel::afterInit()
     auto subColor = ColorProvider::instance().color(ColorType::Subscription);
     setColorItem(subRow[Column::Color], *subColor, false);
 
-    this->insertCustomRow(subRow, SUB_ROW);
+    this->insertCustomRow(subRow, SubRow);
 
     // Highlight settings for redeemed highlight messages
     std::vector<QStandardItem *> redeemedRow = this->createRow();
@@ -149,7 +149,7 @@ void HighlightModel::afterInit()
         ColorProvider::instance().color(ColorType::RedeemedHighlight);
     setColorItem(redeemedRow[Column::Color], *RedeemedColor, false);
 
-    this->insertCustomRow(redeemedRow, REDEEMED_ROW);
+    this->insertCustomRow(redeemedRow, RedeemedRow);
 
     // Highlight settings for first messages
     std::vector<QStandardItem *> firstMessageRow = this->createRow();
@@ -179,7 +179,7 @@ void HighlightModel::afterInit()
         ColorProvider::instance().color(ColorType::FirstMessageHighlight);
     setColorItem(firstMessageRow[Column::Color], *FirstMessageColor, false);
 
-    this->insertCustomRow(firstMessageRow, FIRSTMESSAGE_ROW);
+    this->insertCustomRow(firstMessageRow, FirstMessageRow);
 }
 
 void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
@@ -191,25 +191,25 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
         case Column::Pattern: {
             if (role == Qt::CheckStateRole)
             {
-                if (rowIndex == SELF_HIGHLIGHT_ROW)
+                if (rowIndex == SelfHighlightRow)
                 {
                     getSettings()->enableSelfHighlight.setValue(value.toBool());
                 }
-                else if (rowIndex == WHISPER_ROW)
+                else if (rowIndex == WhisperRow)
                 {
                     getSettings()->enableWhisperHighlight.setValue(
                         value.toBool());
                 }
-                else if (rowIndex == SUB_ROW)
+                else if (rowIndex == SubRow)
                 {
                     getSettings()->enableSubHighlight.setValue(value.toBool());
                 }
-                else if (rowIndex == REDEEMED_ROW)
+                else if (rowIndex == RedeemedRow)
                 {
                     getSettings()->enableRedeemedHighlight.setValue(
                         value.toBool());
                 }
-                else if (rowIndex == FIRSTMESSAGE_ROW)
+                else if (rowIndex == FirstMessageRow)
                 {
                     getSettings()->enableFirstMessageHighlight.setValue(
                         value.toBool());
@@ -220,7 +220,7 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
         case Column::ShowInMentions: {
             if (role == Qt::CheckStateRole)
             {
-                if (rowIndex == SELF_HIGHLIGHT_ROW)
+                if (rowIndex == SelfHighlightRow)
                 {
                     getSettings()->showSelfHighlightInMentions.setValue(
                         value.toBool());
@@ -231,27 +231,27 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
         case Column::FlashTaskbar: {
             if (role == Qt::CheckStateRole)
             {
-                if (rowIndex == SELF_HIGHLIGHT_ROW)
+                if (rowIndex == SelfHighlightRow)
                 {
                     getSettings()->enableSelfHighlightTaskbar.setValue(
                         value.toBool());
                 }
-                else if (rowIndex == WHISPER_ROW)
+                else if (rowIndex == WhisperRow)
                 {
                     getSettings()->enableWhisperHighlightTaskbar.setValue(
                         value.toBool());
                 }
-                else if (rowIndex == SUB_ROW)
+                else if (rowIndex == SubRow)
                 {
                     getSettings()->enableSubHighlightTaskbar.setValue(
                         value.toBool());
                 }
-                else if (rowIndex == REDEEMED_ROW)
+                else if (rowIndex == RedeemedRow)
                 {
                     // getSettings()->enableRedeemedHighlightTaskbar.setValue(
                     //     value.toBool());
                 }
-                else if (rowIndex == FIRSTMESSAGE_ROW)
+                else if (rowIndex == FirstMessageRow)
                 {
                     // getSettings()->enableFirstMessageHighlightTaskbar.setValue(
                     //     value.toBool());
@@ -262,27 +262,27 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
         case Column::PlaySound: {
             if (role == Qt::CheckStateRole)
             {
-                if (rowIndex == SELF_HIGHLIGHT_ROW)
+                if (rowIndex == SelfHighlightRow)
                 {
                     getSettings()->enableSelfHighlightSound.setValue(
                         value.toBool());
                 }
-                else if (rowIndex == WHISPER_ROW)
+                else if (rowIndex == WhisperRow)
                 {
                     getSettings()->enableWhisperHighlightSound.setValue(
                         value.toBool());
                 }
-                else if (rowIndex == SUB_ROW)
+                else if (rowIndex == SubRow)
                 {
                     getSettings()->enableSubHighlightSound.setValue(
                         value.toBool());
                 }
-                else if (rowIndex == REDEEMED_ROW)
+                else if (rowIndex == RedeemedRow)
                 {
                     // getSettings()->enableRedeemedHighlightSound.setValue(
                     //     value.toBool());
                 }
-                else if (rowIndex == FIRSTMESSAGE_ROW)
+                else if (rowIndex == FirstMessageRow)
                 {
                     // getSettings()->enableFirstMessageHighlightSound.setValue(
                     //     value.toBool());
@@ -302,27 +302,27 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
             // Custom sound file
             if (role == Qt::UserRole)
             {
-                if (rowIndex == SELF_HIGHLIGHT_ROW)
+                if (rowIndex == SelfHighlightRow)
                 {
                     getSettings()->selfHighlightSoundUrl.setValue(
                         value.toString());
                 }
-                else if (rowIndex == WHISPER_ROW)
+                else if (rowIndex == WhisperRow)
                 {
                     getSettings()->whisperHighlightSoundUrl.setValue(
                         value.toString());
                 }
-                else if (rowIndex == SUB_ROW)
+                else if (rowIndex == SubRow)
                 {
                     getSettings()->subHighlightSoundUrl.setValue(
                         value.toString());
                 }
-                else if (rowIndex == REDEEMED_ROW)
+                else if (rowIndex == RedeemedRow)
                 {
                     getSettings()->redeemedHighlightSoundUrl.setValue(
                         value.toString());
                 }
-                else if (rowIndex == FIRSTMESSAGE_ROW)
+                else if (rowIndex == FirstMessageRow)
                 {
                     getSettings()->firstMessageHighlightSoundUrl.setValue(
                         value.toString());
@@ -335,26 +335,26 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
             if (role == Qt::DecorationRole)
             {
                 auto colorName = value.value<QColor>().name(QColor::HexArgb);
-                if (rowIndex == SELF_HIGHLIGHT_ROW)
+                if (rowIndex == SelfHighlightRow)
                 {
                     getSettings()->selfHighlightColor.setValue(colorName);
                 }
-                //                else if (rowIndex == WHISPER_ROW)
+                //                else if (rowIndex == WhisperRow)
                 //                {
                 //                    getSettings()->whisperHighlightColor.setValue(colorName);
                 //                }
-                else if (rowIndex == SUB_ROW)
+                else if (rowIndex == SubRow)
                 {
                     getSettings()->subHighlightColor.setValue(colorName);
                 }
-                else if (rowIndex == REDEEMED_ROW)
+                else if (rowIndex == RedeemedRow)
                 {
                     getSettings()->redeemedHighlightColor.setValue(colorName);
                     const_cast<ColorProvider &>(ColorProvider::instance())
                         .updateColor(ColorType::RedeemedHighlight,
                                      QColor(colorName));
                 }
-                else if (rowIndex == FIRSTMESSAGE_ROW)
+                else if (rowIndex == FirstMessageRow)
                 {
                     getSettings()->firstMessageHighlightColor.setValue(
                         colorName);

--- a/src/controllers/highlights/HighlightModel.hpp
+++ b/src/controllers/highlights/HighlightModel.hpp
@@ -25,7 +25,11 @@ public:
         COUNT  // keep this as last member of enum
     };
 
+    constexpr static int SELF_HIGHLIGHT_ROW = 0;
     constexpr static int WHISPER_ROW = 1;
+    constexpr static int SUB_ROW = 2;
+    constexpr static int REDEEMED_ROW = 3;
+    constexpr static int FIRSTMESSAGE_ROW = 4;
 
 protected:
     // turn a vector item into a model row

--- a/src/controllers/highlights/HighlightModel.hpp
+++ b/src/controllers/highlights/HighlightModel.hpp
@@ -25,11 +25,13 @@ public:
         COUNT  // keep this as last member of enum
     };
 
-    constexpr static int SELF_HIGHLIGHT_ROW = 0;
-    constexpr static int WHISPER_ROW = 1;
-    constexpr static int SUB_ROW = 2;
-    constexpr static int REDEEMED_ROW = 3;
-    constexpr static int FIRSTMESSAGE_ROW = 4;
+    enum HighlightRowIndexes {
+        SelfHighlightRow = 0,
+        WhisperRow = 1,
+        SubRow = 2,
+        RedeemedRow = 3,
+        FirstMessageRow = 4,
+    };
 
 protected:
     // turn a vector item into a model row

--- a/src/widgets/settingspages/HighlightingPage.cpp
+++ b/src/widgets/settingspages/HighlightingPage.cpp
@@ -353,7 +353,7 @@ void HighlightingPage::tableCellClicked(const QModelIndex &clicked,
             using Column = HighlightModel::Column;
             bool restrictColorRow =
                 (tab == HighlightTab::Messages &&
-                 clicked.row() == HighlightModel::WHISPER_ROW);
+                 clicked.row() == HighlightModel::WhisperRow);
             if (clicked.column() == Column::SoundPath)
             {
                 this->openSoundDialog(clicked, view, Column::SoundPath);

--- a/src/widgets/settingspages/HighlightingPage.cpp
+++ b/src/widgets/settingspages/HighlightingPage.cpp
@@ -353,7 +353,8 @@ void HighlightingPage::tableCellClicked(const QModelIndex &clicked,
             using Column = HighlightModel::Column;
             bool restrictColorRow =
                 (tab == HighlightTab::Messages &&
-                 clicked.row() == HighlightModel::WhisperRow);
+                 clicked.row() ==
+                     HighlightModel::HighlightRowIndexes::WhisperRow);
             if (clicked.column() == Column::SoundPath)
             {
                 this->openSoundDialog(clicked, view, Column::SoundPath);


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Changes hardcoded index values for the message highlights to a value set in the header file. All indexes except for WHISPER_ROW were hardcoded