### PR TITLE
Add icon in the CMake macOS bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Bugfix: Fixed automod queue pubsub topic persisting after user change. (#3718)
 - Bugfix: Fixed viewer list not closing after pressing escape key. (#3734)
 - Bugfix: Fixed links with no thumbnail having previous link's thumbnail. (#3720)
+- Bugfix: Add icon in the CMake macOS bundle. (#3832)
 - Dev: Rewrite LimitedQueue (#3798)
 - Dev: Overhaul highlight system by moving all checks into a Controller allowing for easier tests. (#3399, #3801)
 - Dev: Use Game Name returned by Get Streams instead of querying it from the Get Games API. (#3662)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -553,7 +553,11 @@ else()
 endif()
 
 if (BUILD_APP)
-    add_executable(${EXECUTABLE_PROJECT} main.cpp)
+    if (APPLE)
+        add_executable(${EXECUTABLE_PROJECT} ${MACOS_BUNDLE_ICON_FILE} main.cpp)
+    else()
+        add_executable(${EXECUTABLE_PROJECT} main.cpp)
+    endif()
     add_sanitizers(${EXECUTABLE_PROJECT})
 
     target_include_directories(${EXECUTABLE_PROJECT} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

macOS CMake build doesn't include bundle icon

[felanbird]: Fixes #3210
