### PR TITLE
Updated Building On Windows OpenSSL information

### DIFF
--- a/BUILDING_ON_WINDOWS.md
+++ b/BUILDING_ON_WINDOWS.md
@@ -47,7 +47,7 @@ Note: This installation will take about 2.1 GB of disk space.
 6. Add `C:\local\bin` to your path folder ([Follow the guide here if you don't know how to do it](https://www.computerhope.com/issues/ch000549.htm#windows10))
 
 **If the download links above do not work, try downloading similar 1.1.x & 1.0.x versions [here](https://slproweb.com/products/Win32OpenSSL.html). Note: Don't download the "light" installers, they do not have the required files.**
-
+[Screenshot Slproweb layout](https://user-images.githubusercontent.com/41973452/175827529-97802939-5549-4ab1-95c4-d39f012d06e9.png)
 Note: This installation will take about 200 MB of disk space.
 
 ## Qt

--- a/BUILDING_ON_WINDOWS.md
+++ b/BUILDING_ON_WINDOWS.md
@@ -33,7 +33,7 @@ Note: This installation will take about 2.1 GB of disk space.
 
 ### For our websocket library, we need OpenSSL 1.1
 
-1. Download OpenSSL for windows, version `1.1.1o`: **[Download](https://slproweb.com/download/Win64OpenSSL-1_1_1o.exe)**
+1. Download OpenSSL for windows, version `1.1.1p`: **[Download](https://slproweb.com/download/Win64OpenSSL-1_1_1p.exe)**
 2. When prompted, install OpenSSL to `C:\local\openssl`
 3. When prompted, copy the OpenSSL DLLs to "The OpenSSL binaries (/bin) directory".
 

--- a/BUILDING_ON_WINDOWS.md
+++ b/BUILDING_ON_WINDOWS.md
@@ -47,7 +47,7 @@ Note: This installation will take about 2.1 GB of disk space.
 6. Add `C:\local\bin` to your path folder ([Follow the guide here if you don't know how to do it](https://www.computerhope.com/issues/ch000549.htm#windows10))
 
 **If the 1.1.x download link above does not work, try downloading the similar 1.1.x version found [here](https://slproweb.com/products/Win32OpenSSL.html). Note: Don't download the "light" installer, it does not have the required files.**
-[Screenshot Slproweb layout](https://user-images.githubusercontent.com/41973452/175827529-97802939-5549-4ab1-95c4-d39f012d06e9.png)
+![Screenshot Slproweb layout](https://user-images.githubusercontent.com/41973452/175827529-97802939-5549-4ab1-95c4-d39f012d06e9.png)
 
 Note: This installation will take about 200 MB of disk space.
 

--- a/BUILDING_ON_WINDOWS.md
+++ b/BUILDING_ON_WINDOWS.md
@@ -46,8 +46,9 @@ Note: This installation will take about 2.1 GB of disk space.
 5. Then copy the OpenSSL 1.1 files from its `\bin` folder to `C:\local\bin` (Overwrite any duplicate files)
 6. Add `C:\local\bin` to your path folder ([Follow the guide here if you don't know how to do it](https://www.computerhope.com/issues/ch000549.htm#windows10))
 
-**If the download links above do not work, try downloading similar 1.1.x & 1.0.x versions [here](https://slproweb.com/products/Win32OpenSSL.html). Note: Don't download the "light" installers, they do not have the required files.**
+**If the 1.1.x download link above does not work, try downloading the similar 1.1.x version found [here](https://slproweb.com/products/Win32OpenSSL.html). Note: Don't download the "light" installer, it does not have the required files.**
 [Screenshot Slproweb layout](https://user-images.githubusercontent.com/41973452/175827529-97802939-5549-4ab1-95c4-d39f012d06e9.png)
+
 Note: This installation will take about 200 MB of disk space.
 
 ## Qt


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

To combat the ever updating versions of OpenSSL, I've gone ahead and done the following:

- Added a screenshot to show exactly what area of `slproweb` to find the newest version 

- Updated the additional help to remove suggestions that a newer version of `1.0.2_` can be found on `slproweb` - they no longer support said versions [see #3622]
	- I'm aware it was discussed in that PR that looking into whether or not we still need the section for `1.0.2_`, but either way the paragraph will need to be updated. 
	In it's current state if the archive link dies, we would like to know about it and it will give us (if needed) the push to have somebody actually look into it.

- Bumped the courtesy link to version `p` [mainly to match the screenshot I've added]