### PR TITLE
ref: unify Split popup logic

### DIFF
--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -887,7 +887,7 @@ void CommandController::initialize(Settings &, Paths &paths)
     });
 
     this->registerCommand("/popup", [](const QStringList &words,
-                                       ChannelPtr channel) {
+                                       ChannelPtr sourceChannel) {
         static const auto *usageMessage =
             "Usage: /popup [channel]. Open specified Twitch channel in "
             "a new window. If no channel argument is specified, open "
@@ -896,6 +896,7 @@ void CommandController::initialize(Settings &, Paths &paths)
         QString target(words.value(1));
         stripChannelName(target);
 
+        // Popup the current split
         if (target.isEmpty())
         {
             auto *currentPage =
@@ -914,19 +915,14 @@ void CommandController::initialize(Settings &, Paths &paths)
                 }
             }
 
-            channel->addMessage(makeSystemMessage(usageMessage));
+            sourceChannel->addMessage(makeSystemMessage(usageMessage));
             return "";
         }
 
+        // Open channel passed as argument in a popup
         auto *app = getApp();
-        Window &window = app->windows->createWindow(WindowType::Popup, true);
-
-        auto *split = new Split(static_cast<SplitContainer *>(
-            window.getNotebook().getOrAddSelectedPage()));
-
-        split->setChannel(app->twitch->getOrAddChannel(target));
-
-        window.getNotebook().getOrAddSelectedPage()->appendSplit(split);
+        auto targetChannel = app->twitch->getOrAddChannel(target);
+        app->windows->openInPopup(targetChannel);
 
         return "";
     });

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -295,6 +295,16 @@ Window &WindowManager::createWindow(WindowType type, bool show, QWidget *parent)
     return *window;
 }
 
+Window &WindowManager::openInPopup(ChannelPtr channel)
+{
+    auto &popup = this->createWindow(WindowType::Popup, true);
+    auto *split =
+        popup.getNotebook().getOrAddSelectedPage()->appendNewSplit(false);
+    split->setChannel(channel);
+
+    return popup;
+}
+
 void WindowManager::select(Split *split)
 {
     this->selectSplit.invoke(split);

--- a/src/singletons/WindowManager.hpp
+++ b/src/singletons/WindowManager.hpp
@@ -60,6 +60,10 @@ public:
     Window &createWindow(WindowType type, bool show = true,
                          QWidget *parent = nullptr);
 
+    // Use this method if you want to open a "new" channel in a popup. If you want to popup an
+    // existing Split or SplitContainer, consider using Split::popup() or SplitContainer::popup().
+    Window &openInPopup(ChannelPtr channel);
+
     void select(Split *split);
     void select(SplitContainer *container);
 

--- a/src/widgets/dialogs/switcher/NewPopupItem.cpp
+++ b/src/widgets/dialogs/switcher/NewPopupItem.cpp
@@ -22,10 +22,8 @@ NewPopupItem::NewPopupItem(const QString &channelName)
 void NewPopupItem::action()
 {
     auto *app = getApp();
-    auto &popup = app->windows->createWindow(WindowType::Popup, true);
-    auto *split =
-        popup.getNotebook().getOrAddSelectedPage()->appendNewSplit(false);
-    split->setChannel(app->twitch->getOrAddChannel(this->channelName_));
+    auto channel = app->twitch->getOrAddChannel(this->channelName_);
+    app->windows->openInPopup(channel);
 }
 
 void NewPopupItem::paint(QPainter *painter, const QRect &rect) const


### PR DESCRIPTION
Pull request checklist:

- [x] ~~`CHANGELOG.md` was updated, if applicable~~ (n/a in my opinion)

# Description

This PR unifies the two places in the code where a "new" channel was opened in a popup (opposed to opening an existing Split/SplitContainer in a popup) by introducing the method `WindowManager::openInPopup(ChannelPtr)`.
