### PR TITLE
Fix crash when closing and quickly opening a split, then running `/clearmessages`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Minor: Added `/copy` command. Usage: `/copy <text>`. Copies provided text to clipboard - can be useful with custom commands. (#3763)
 - Minor: Removed total views from the usercard, as Twitch no longer updates the number. (#3792)
 - Minor: Add Quick Switcher item to open a channel in a new popup window. (#3828)
+- Bugfix: Fix crash that can occur when closing and quickly reopening a split, then running a command. (#3852)
 - Bugfix: Connection to Twitch PubSub now recovers more reliably. (#3643, #3716)
 - Bugfix: Fix crash that can occur when changing channels. (#3799)
 - Bugfix: Fixed viewers list search not working when used before loading finishes. (#3774)

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -932,7 +932,11 @@ void CommandController::initialize(Settings &, Paths &paths)
         auto *currentPage = dynamic_cast<SplitContainer *>(
             getApp()->windows->getMainWindow().getNotebook().getSelectedPage());
 
-        currentPage->getSelectedSplit()->getChannelView().clearMessages();
+        if (auto split = currentPage->getSelectedSplit())
+        {
+            split->getChannelView().clearMessages();
+        }
+
         return "";
     });
 

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -408,12 +408,13 @@ void Window::addShortcuts()
              {
                  splitContainer = this->notebook_->getOrAddSelectedPage();
              }
-             this->notebook_->select(splitContainer);
              Split *split = new Split(splitContainer);
              split->setChannel(
                  getApp()->twitch->getOrAddChannel(si.channelName));
              split->setFilters(si.filters);
              splitContainer->appendSplit(split);
+             splitContainer->setSelected(split);
+             this->notebook_->select(splitContainer);
              return "";
          }},
         {"toggleLocalR9K",


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

When restoring a split, the split would be appended to the split container but would not be selected. When accessing the selected split upon running the `/clearmessages` command as shown in the bug report, `nullptr` would be returned resulting in a segfault.

This PR fixes the underlying issue of the split not being selected and also adds a check for `nullptr`.

Fixes #3846