### PR TITLE
fix: prevent system messages from being ignored in multi-channel search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unversioned
 
-- Major: Added multi-channel searching to search dialog via keyboard shortcut. (Ctrl+Shift+F by default) (#3694)
+- Major: Added multi-channel searching to search dialog via keyboard shortcut. (Ctrl+Shift+F by default) (#3694, #3875)
 - Minor: Added option to display tabs on the right and bottom. (#3847)
 - Minor: Added `is:first-msg` search option. (#3700)
 - Minor: Added quotation marks in the permitted/blocked Automod messages for clarity. (#3654)

--- a/src/widgets/helper/SearchPopup.cpp
+++ b/src/widgets/helper/SearchPopup.cpp
@@ -189,7 +189,7 @@ LimitedQueueSnapshot<MessagePtr> SearchPopup::buildSnapshot()
         std::unique(combinedSnapshot.begin(), combinedSnapshot.end(),
                     [](MessagePtr &a, MessagePtr &b) {
                         // nullptr check prevents system messages from being dropped
-                        return (a->id == nullptr) && a->id == b->id;
+                        return (a->id != nullptr) && a->id == b->id;
                     });
 
     combinedSnapshot.erase(uniqueIterator, combinedSnapshot.end());

--- a/src/widgets/helper/SearchPopup.cpp
+++ b/src/widgets/helper/SearchPopup.cpp
@@ -188,7 +188,7 @@ LimitedQueueSnapshot<MessagePtr> SearchPopup::buildSnapshot()
     auto uniqueIterator =
         std::unique(combinedSnapshot.begin(), combinedSnapshot.end(),
                     [](MessagePtr &a, MessagePtr &b) {
-                        return a->id == b->id;
+                        return (a->id == nullptr) && a->id == b->id;
                     });
 
     combinedSnapshot.erase(uniqueIterator, combinedSnapshot.end());

--- a/src/widgets/helper/SearchPopup.cpp
+++ b/src/widgets/helper/SearchPopup.cpp
@@ -188,6 +188,7 @@ LimitedQueueSnapshot<MessagePtr> SearchPopup::buildSnapshot()
     auto uniqueIterator =
         std::unique(combinedSnapshot.begin(), combinedSnapshot.end(),
                     [](MessagePtr &a, MessagePtr &b) {
+                        // nullptr check prevents system messages from being dropped
                         return (a->id == nullptr) && a->id == b->id;
                     });
 


### PR DESCRIPTION
Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable

# Description

This PR aims to fix #3870 where search predicates that act on system messages (ie. bans, timeouts) would not show system messages. This was caused by an oversight in the multi-channel search filtering logic that attempted to filter out duplicate messages (meant to catch the same channel in multiple splits) but ended up treating the ID-less system messages as duplicates.

*NOTE: it looks like the channel name isn't prepended to system messages, I'll create a separate fix for this*

Behaviour prior to fix (banned in 2 channels):
![image](https://user-images.githubusercontent.com/4962764/180627804-5c80de56-af3e-490a-8763-0eff1020d369.png)

Post-fix:
![image](https://user-images.githubusercontent.com/4962764/180627919-22d57598-9d8e-4ac0-bd62-a5ab92271ae7.png)
