### PR TITLE
Disable submodule-build of QtKeychain

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,9 +20,6 @@
 [submodule "lib/rapidjson"]
 	path = lib/rapidjson
 	url = https://github.com/Tencent/rapidjson
-[submodule "lib/qtkeychain"]
-	path = lib/qtkeychain
-	url = https://github.com/frankosterfeld/qtkeychain
 [submodule "lib/websocketpp"]
 	path = lib/websocketpp
 	url = https://github.com/zaphoyd/websocketpp

--- a/.gitmodules
+++ b/.gitmodules
@@ -22,7 +22,7 @@
 	url = https://github.com/Tencent/rapidjson
 [submodule "lib/qtkeychain"]
 	path = lib/qtkeychain
-	url = https://github.com/Chatterino/qtkeychain
+	url = https://github.com/frankosterfeld/qtkeychain
 [submodule "lib/websocketpp"]
 	path = lib/websocketpp
 	url = https://github.com/zaphoyd/websocketpp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,7 +108,7 @@
 - Dev: Batched checking live status for all channels after startup. (#3757, #3762, #3767)
 - Dev: Moved most command context into the command controller. (#3824)
 - Dev: Error NetworkResults now include the body data. (#3987)
-- Dev: Use QtKeychain upstream repository instead of our own fork. We needed some quirky changes to the repository to support our qmake build, however this is no longer the case. (#3877)
+- Dev: Disable submodule-built version of QtKeychain. (#3877)
 
 ## 2.3.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@
 - Dev: Batched checking live status for all channels after startup. (#3757, #3762, #3767)
 - Dev: Moved most command context into the command controller. (#3824)
 - Dev: Error NetworkResults now include the body data. (#3987)
+- Dev: Use QtKeychain upstream repository instead of our own fork. We needed some quirky changes to the repository to support our qmake build, however this is no longer the case. (#3877)
 
 ## 2.3.5
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,13 +93,11 @@ if (BUILD_WITH_QTKEYCHAIN)
     else()
         FetchContent_Declare(
             QtKeychain
-            GIT_REPOSITORY  https://github.com/frankosterfeld/qtkeychain.git
-            GIT_TAG         67fb08e89194ed3a6cd2b2e4ae24509ea4714fa1
+
+            SOURCE_DIR      ${CMAKE_SOURCE_DIR}/lib/qtkeychain
             )
 
-
         FetchContent_MakeAvailable(QtKeychain)
-
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.8)
 cmake_policy(SET CMP0087 NEW)
 include(FeatureSummary)
-include(FetchContent)
 
 list(APPEND CMAKE_MODULE_PATH
     "${CMAKE_SOURCE_DIR}/cmake"
@@ -15,13 +14,9 @@ option(BUILD_TESTS "Build the tests for Chatterino" OFF)
 option(BUILD_BENCHMARKS "Build the benchmarks for Chatterino" OFF)
 option(USE_SYSTEM_PAJLADA_SETTINGS "Use system pajlada settings library" OFF)
 option(USE_SYSTEM_LIBCOMMUNI "Use system communi library" OFF)
-option(USE_SYSTEM_QTKEYCHAIN "Use system QtKeychain library" OFF)
-option(BUILD_WITH_QTKEYCHAIN "Build Chatterino with support for your system key chain" ON)
+option(C2_USE_QTKEYCHAIN "Build Chatterino with support for your system key chain" ON)
 option(USE_PRECOMPILED_HEADERS "Use precompiled headers" ON)
 option(BUILD_WITH_QT6 "Use Qt6 instead of default Qt5" OFF)
-option(C2_BUILD_SHARED_LIBS "Try to build and use shared libraries where possible" OFF)
-
-set(BUILD_SHARED_LIBS ${C2_BUILD_SHARED_LIBS})
 
 option(USE_CONAN "Use conan" OFF)
 
@@ -86,19 +81,8 @@ else()
 endif()
 
 
-if (BUILD_WITH_QTKEYCHAIN)
-    # Link QtKeychain statically
-    if (USE_SYSTEM_QTKEYCHAIN)
-        find_package(Qt${MAJOR_QT_VERSION}Keychain REQUIRED)
-    else()
-        FetchContent_Declare(
-            QtKeychain
-
-            SOURCE_DIR      ${CMAKE_SOURCE_DIR}/lib/qtkeychain
-            )
-
-        FetchContent_MakeAvailable(QtKeychain)
-    endif()
+if (C2_USE_QTKEYCHAIN)
+    find_package(Qt${MAJOR_QT_VERSION}Keychain)
 endif()
 
 find_package(RapidJSON REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.8)
 cmake_policy(SET CMP0087 NEW)
 include(FeatureSummary)
+include(FetchContent)
 
 list(APPEND CMAKE_MODULE_PATH
     "${CMAKE_SOURCE_DIR}/cmake"
@@ -18,6 +19,9 @@ option(USE_SYSTEM_QTKEYCHAIN "Use system QtKeychain library" OFF)
 option(BUILD_WITH_QTKEYCHAIN "Build Chatterino with support for your system key chain" ON)
 option(USE_PRECOMPILED_HEADERS "Use precompiled headers" ON)
 option(BUILD_WITH_QT6 "Use Qt6 instead of default Qt5" OFF)
+option(C2_BUILD_SHARED_LIBS "Try to build and use shared libraries where possible" OFF)
+
+set(BUILD_SHARED_LIBS ${C2_BUILD_SHARED_LIBS})
 
 option(USE_CONAN "Use conan" OFF)
 
@@ -81,21 +85,21 @@ else()
     add_subdirectory("${LIBCOMMUNI_ROOT_LIB_FOLDER}" EXCLUDE_FROM_ALL)
 endif()
 
+
 if (BUILD_WITH_QTKEYCHAIN)
     # Link QtKeychain statically
-    option(QTKEYCHAIN_STATIC "" ON)
     if (USE_SYSTEM_QTKEYCHAIN)
         find_package(Qt${MAJOR_QT_VERSION}Keychain REQUIRED)
     else()
-        set(QTKEYCHAIN_ROOT_LIB_FOLDER "${CMAKE_SOURCE_DIR}/lib/qtkeychain")
-        if (NOT EXISTS "${QTKEYCHAIN_ROOT_LIB_FOLDER}/CMakeLists.txt")
-            message(FATAL_ERROR "Submodules probably not loaded, unable to find lib/qtkeychain/CMakeLists.txt")
-        endif()
+        FetchContent_Declare(
+            QtKeychain
+            GIT_REPOSITORY  https://github.com/frankosterfeld/qtkeychain.git
+            GIT_TAG         67fb08e89194ed3a6cd2b2e4ae24509ea4714fa1
+            )
 
-        add_subdirectory("${QTKEYCHAIN_ROOT_LIB_FOLDER}" EXCLUDE_FROM_ALL)
-        if (NOT TARGET qt${MAJOR_QT_VERSION}keychain)
-            message(FATAL_ERROR "qt${MAJOR_QT_VERSION}keychain target was not created :@")
-        endif()
+
+        FetchContent_MakeAvailable(QtKeychain)
+
     endif()
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -562,19 +562,20 @@ target_link_libraries(${LIBRARY_PROJECT}
         LRUCache
         MagicEnum
         )
-if (BUILD_WITH_QTKEYCHAIN)
-    target_link_libraries(${LIBRARY_PROJECT} PUBLIC qt5keychain)
-    # SOURCE_DIR contains the keychain.h file
-    # BINARY_DIR contains the qkeychain_export.h file
-    target_include_directories(${LIBRARY_PROJECT} PUBLIC
-        ${qtkeychain_SOURCE_DIR}
-        ${qtkeychain_BINARY_DIR})
-else()
+
+if (C2_USE_QTKEYCHAIN AND Qt${MAJOR_QT_VERSION}Keychain_FOUND)
+    target_link_libraries(${LIBRARY_PROJECT}
+        PUBLIC
+        qt${MAJOR_QT_VERSION}keychain)
+else ()
+    if (C2_USE_QTKEYCHAIN)
+        message(WARNING "QtKeychain not found, building without system keychain support")
+    endif ()
     target_compile_definitions(${LIBRARY_PROJECT}
         PUBLIC
         NO_QTKEYCHAIN
         )
-endif()
+endif ()
 
 if (BUILD_APP)
     if (APPLE)
@@ -675,11 +676,6 @@ target_compile_definitions(${LIBRARY_PROJECT} PUBLIC
 if (GIT_MODIFIED)
     target_compile_definitions(${LIBRARY_PROJECT} PUBLIC
         CHATTERINO_GIT_MODIFIED
-        )
-endif ()
-if (USE_SYSTEM_QTKEYCHAIN)
-    target_compile_definitions(${LIBRARY_PROJECT} PUBLIC
-        SYSTEM_QTKEYCHAIN
         )
 endif ()
 if (WIN32)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -679,7 +679,7 @@ if (GIT_MODIFIED)
 endif ()
 if (USE_SYSTEM_QTKEYCHAIN)
     target_compile_definitions(${LIBRARY_PROJECT} PUBLIC
-        CMAKE_BUILD
+        SYSTEM_QTKEYCHAIN
         )
 endif ()
 if (WIN32)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -563,10 +563,12 @@ target_link_libraries(${LIBRARY_PROJECT}
         MagicEnum
         )
 if (BUILD_WITH_QTKEYCHAIN)
-    target_link_libraries(${LIBRARY_PROJECT}
-            PUBLIC
-            qt${MAJOR_QT_VERSION}keychain
-            )
+    target_link_libraries(${LIBRARY_PROJECT} PUBLIC qt5keychain)
+    # SOURCE_DIR contains the keychain.h file
+    # BINARY_DIR contains the qkeychain_export.h file
+    target_include_directories(${LIBRARY_PROJECT} PUBLIC
+        ${qtkeychain_SOURCE_DIR}
+        ${qtkeychain_BINARY_DIR})
 else()
     target_compile_definitions(${LIBRARY_PROJECT}
         PUBLIC

--- a/src/common/Credentials.cpp
+++ b/src/common/Credentials.cpp
@@ -10,10 +10,11 @@
 #include <QJsonObject>
 
 #ifndef NO_QTKEYCHAIN
-#    ifdef SYSTEM_QTKEYCHAIN
+#    if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 #        include <qt5keychain/keychain.h>
 #    else
-#        include <keychain.h>
+// Untested
+#        include <qt6keychain/keychain.h>
 #    endif
 #endif
 #include <QSaveFile>

--- a/src/common/Credentials.cpp
+++ b/src/common/Credentials.cpp
@@ -10,10 +10,10 @@
 #include <QJsonObject>
 
 #ifndef NO_QTKEYCHAIN
-#    ifdef CMAKE_BUILD
-#        include "qt5keychain/keychain.h"
+#    ifdef SYSTEM_QTKEYCHAIN
+#        include <qt5keychain/keychain.h>
 #    else
-#        include "keychain.h"
+#        include <keychain.h>
 #    endif
 #endif
 #include <QSaveFile>


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

The original reason for using the fork was to support our qmake build method. The changes we had made specifically were:
 - Updated the .pri file to point to the right mac/apple-specific file (since added upstream)
 - Added #undef singals in libsecret.cpp to fix compilation. (no longer necessary since we build with cmake now)

However, it's not as easy as just swapping to upstream - the way the library is built makes it difficult to include as part of our build process. Because of this, we now use `FetchContent` to ensure the build happens completely separately, and it also provides us with proper build/source directories we can use to find the include files.

~**The PR currently fetches the project from the internet, however once the build is stable the submodule will be updated and we'll just point to the local directory instead.**~

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
