### PR TITLE
Harden emote parsing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ option(USE_SYSTEM_QTKEYCHAIN "Use system QtKeychain library" OFF)
 option(BUILD_WITH_QTKEYCHAIN "Build Chatterino with support for your system key chain" ON)
 option(USE_PRECOMPILED_HEADERS "Use precompiled headers" ON)
 option(BUILD_WITH_QT6 "Use Qt6 instead of default Qt5" OFF)
+option(CHATTERINO_GENERATE_COVERAGE "Generate coverage files" OFF)
 
 option(USE_CONAN "Use conan" OFF)
 

--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -1,0 +1,719 @@
+# Copyright (c) 2012 - 2017, Lars Bilke
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+#    may be used to endorse or promote products derived from this software without
+#    specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# CHANGES:
+#
+# 2012-01-31, Lars Bilke
+# - Enable Code Coverage
+#
+# 2013-09-17, Joakim Söderberg
+# - Added support for Clang.
+# - Some additional usage instructions.
+#
+# 2016-02-03, Lars Bilke
+# - Refactored functions to use named parameters
+#
+# 2017-06-02, Lars Bilke
+# - Merged with modified version from github.com/ufz/ogs
+#
+# 2019-05-06, Anatolii Kurotych
+# - Remove unnecessary --coverage flag
+#
+# 2019-12-13, FeRD (Frank Dana)
+# - Deprecate COVERAGE_LCOVR_EXCLUDES and COVERAGE_GCOVR_EXCLUDES lists in favor
+#   of tool-agnostic COVERAGE_EXCLUDES variable, or EXCLUDE setup arguments.
+# - CMake 3.4+: All excludes can be specified relative to BASE_DIRECTORY
+# - All setup functions: accept BASE_DIRECTORY, EXCLUDE list
+# - Set lcov basedir with -b argument
+# - Add automatic --demangle-cpp in lcovr, if 'c++filt' is available (can be
+#   overridden with NO_DEMANGLE option in setup_target_for_coverage_lcovr().)
+# - Delete output dir, .info file on 'make clean'
+# - Remove Python detection, since version mismatches will break gcovr
+# - Minor cleanup (lowercase function names, update examples...)
+#
+# 2019-12-19, FeRD (Frank Dana)
+# - Rename Lcov outputs, make filtered file canonical, fix cleanup for targets
+#
+# 2020-01-19, Bob Apthorpe
+# - Added gfortran support
+#
+# 2020-02-17, FeRD (Frank Dana)
+# - Make all add_custom_target()s VERBATIM to auto-escape wildcard characters
+#   in EXCLUDEs, and remove manual escaping from gcovr targets
+#
+# 2021-01-19, Robin Mueller
+# - Add CODE_COVERAGE_VERBOSE option which will allow to print out commands which are run
+# - Added the option for users to set the GCOVR_ADDITIONAL_ARGS variable to supply additional
+#   flags to the gcovr command
+#
+# 2020-05-04, Mihchael Davis
+#     - Add -fprofile-abs-path to make gcno files contain absolute paths
+#     - Fix BASE_DIRECTORY not working when defined
+#     - Change BYPRODUCT from folder to index.html to stop ninja from complaining about double defines
+#
+# 2021-05-10, Martin Stump
+#     - Check if the generator is multi-config before warning about non-Debug builds
+#
+# 2022-02-22, Marko Wehle
+#     - Change gcovr output from -o <filename> for --xml <filename> and --html <filename> output respectively.
+#       This will allow for Multiple Output Formats at the same time by making use of GCOVR_ADDITIONAL_ARGS, e.g. GCOVR_ADDITIONAL_ARGS "--txt".
+#
+# USAGE:
+#
+# 1. Copy this file into your cmake modules path.
+#
+# 2. Add the following line to your CMakeLists.txt (best inside an if-condition
+#    using a CMake option() to enable it just optionally):
+#      include(CodeCoverage)
+#
+# 3. Append necessary compiler flags for all supported source files:
+#      append_coverage_compiler_flags()
+#    Or for specific target:
+#      append_coverage_compiler_flags_to_target(YOUR_TARGET_NAME)
+#
+# 3.a (OPTIONAL) Set appropriate optimization flags, e.g. -O0, -O1 or -Og
+#
+# 4. If you need to exclude additional directories from the report, specify them
+#    using full paths in the COVERAGE_EXCLUDES variable before calling
+#    setup_target_for_coverage_*().
+#    Example:
+#      set(COVERAGE_EXCLUDES
+#          '${PROJECT_SOURCE_DIR}/src/dir1/*'
+#          '/path/to/my/src/dir2/*')
+#    Or, use the EXCLUDE argument to setup_target_for_coverage_*().
+#    Example:
+#      setup_target_for_coverage_lcov(
+#          NAME coverage
+#          EXECUTABLE testrunner
+#          EXCLUDE "${PROJECT_SOURCE_DIR}/src/dir1/*" "/path/to/my/src/dir2/*")
+#
+# 4.a NOTE: With CMake 3.4+, COVERAGE_EXCLUDES or EXCLUDE can also be set
+#     relative to the BASE_DIRECTORY (default: PROJECT_SOURCE_DIR)
+#     Example:
+#       set(COVERAGE_EXCLUDES "dir1/*")
+#       setup_target_for_coverage_gcovr_html(
+#           NAME coverage
+#           EXECUTABLE testrunner
+#           BASE_DIRECTORY "${PROJECT_SOURCE_DIR}/src"
+#           EXCLUDE "dir2/*")
+#
+# 5. Use the functions described below to create a custom make target which
+#    runs your test executable and produces a code coverage report.
+#
+# 6. Build a Debug build:
+#      cmake -DCMAKE_BUILD_TYPE=Debug ..
+#      make
+#      make my_coverage_target
+#
+
+include(CMakeParseArguments)
+
+option(CODE_COVERAGE_VERBOSE "Verbose information" FALSE)
+
+# Check prereqs
+find_program( GCOV_PATH gcov )
+find_program( LCOV_PATH  NAMES lcov lcov.bat lcov.exe lcov.perl)
+find_program( FASTCOV_PATH NAMES fastcov fastcov.py )
+find_program( GENHTML_PATH NAMES genhtml genhtml.perl genhtml.bat )
+find_program( GCOVR_PATH gcovr PATHS ${CMAKE_SOURCE_DIR}/scripts/test)
+find_program( CPPFILT_PATH NAMES c++filt )
+
+if(NOT GCOV_PATH)
+    message(FATAL_ERROR "gcov not found! Aborting...")
+endif() # NOT GCOV_PATH
+
+get_property(LANGUAGES GLOBAL PROPERTY ENABLED_LANGUAGES)
+list(GET LANGUAGES 0 LANG)
+
+if("${CMAKE_${LANG}_COMPILER_ID}" MATCHES "(Apple)?[Cc]lang")
+    if("${CMAKE_${LANG}_COMPILER_VERSION}" VERSION_LESS 3)
+        message(FATAL_ERROR "Clang version must be 3.0.0 or greater! Aborting...")
+    endif()
+elseif(NOT CMAKE_COMPILER_IS_GNUCXX)
+    if("${CMAKE_Fortran_COMPILER_ID}" MATCHES "[Ff]lang")
+        # Do nothing; exit conditional without error if true
+    elseif("${CMAKE_Fortran_COMPILER_ID}" MATCHES "GNU")
+        # Do nothing; exit conditional without error if true
+    else()
+        message(FATAL_ERROR "Compiler is not GNU gcc! Aborting...")
+    endif()
+endif()
+
+set(COVERAGE_COMPILER_FLAGS "-g -fprofile-arcs -ftest-coverage"
+    CACHE INTERNAL "")
+if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
+    include(CheckCXXCompilerFlag)
+    check_cxx_compiler_flag(-fprofile-abs-path HAVE_fprofile_abs_path)
+    if(HAVE_fprofile_abs_path)
+        set(COVERAGE_COMPILER_FLAGS "${COVERAGE_COMPILER_FLAGS} -fprofile-abs-path")
+    endif()
+endif()
+
+set(CMAKE_Fortran_FLAGS_COVERAGE
+    ${COVERAGE_COMPILER_FLAGS}
+    CACHE STRING "Flags used by the Fortran compiler during coverage builds."
+    FORCE )
+set(CMAKE_CXX_FLAGS_COVERAGE
+    ${COVERAGE_COMPILER_FLAGS}
+    CACHE STRING "Flags used by the C++ compiler during coverage builds."
+    FORCE )
+set(CMAKE_C_FLAGS_COVERAGE
+    ${COVERAGE_COMPILER_FLAGS}
+    CACHE STRING "Flags used by the C compiler during coverage builds."
+    FORCE )
+set(CMAKE_EXE_LINKER_FLAGS_COVERAGE
+    ""
+    CACHE STRING "Flags used for linking binaries during coverage builds."
+    FORCE )
+set(CMAKE_SHARED_LINKER_FLAGS_COVERAGE
+    ""
+    CACHE STRING "Flags used by the shared libraries linker during coverage builds."
+    FORCE )
+mark_as_advanced(
+    CMAKE_Fortran_FLAGS_COVERAGE
+    CMAKE_CXX_FLAGS_COVERAGE
+    CMAKE_C_FLAGS_COVERAGE
+    CMAKE_EXE_LINKER_FLAGS_COVERAGE
+    CMAKE_SHARED_LINKER_FLAGS_COVERAGE )
+
+get_property(GENERATOR_IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if(NOT (CMAKE_BUILD_TYPE STREQUAL "Debug" OR GENERATOR_IS_MULTI_CONFIG))
+    message(WARNING "Code coverage results with an optimised (non-Debug) build may be misleading")
+endif() # NOT (CMAKE_BUILD_TYPE STREQUAL "Debug" OR GENERATOR_IS_MULTI_CONFIG)
+
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+    link_libraries(gcov)
+endif()
+
+# Defines a target for running and collection code coverage information
+# Builds dependencies, runs the given executable and outputs reports.
+# NOTE! The executable should always have a ZERO as exit code otherwise
+# the coverage generation will not complete.
+#
+# setup_target_for_coverage_lcov(
+#     NAME testrunner_coverage                    # New target name
+#     EXECUTABLE testrunner -j ${PROCESSOR_COUNT} # Executable in PROJECT_BINARY_DIR
+#     DEPENDENCIES testrunner                     # Dependencies to build first
+#     BASE_DIRECTORY "../"                        # Base directory for report
+#                                                 #  (defaults to PROJECT_SOURCE_DIR)
+#     EXCLUDE "src/dir1/*" "src/dir2/*"           # Patterns to exclude (can be relative
+#                                                 #  to BASE_DIRECTORY, with CMake 3.4+)
+#     NO_DEMANGLE                                 # Don't demangle C++ symbols
+#                                                 #  even if c++filt is found
+# )
+function(setup_target_for_coverage_lcov)
+
+    set(options NO_DEMANGLE)
+    set(oneValueArgs BASE_DIRECTORY NAME)
+    set(multiValueArgs EXCLUDE EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES LCOV_ARGS GENHTML_ARGS)
+    cmake_parse_arguments(Coverage "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if(NOT LCOV_PATH)
+        message(FATAL_ERROR "lcov not found! Aborting...")
+    endif() # NOT LCOV_PATH
+
+    if(NOT GENHTML_PATH)
+        message(FATAL_ERROR "genhtml not found! Aborting...")
+    endif() # NOT GENHTML_PATH
+
+    # Set base directory (as absolute path), or default to PROJECT_SOURCE_DIR
+    if(DEFINED Coverage_BASE_DIRECTORY)
+        get_filename_component(BASEDIR ${Coverage_BASE_DIRECTORY} ABSOLUTE)
+    else()
+        set(BASEDIR ${PROJECT_SOURCE_DIR})
+    endif()
+
+    # Collect excludes (CMake 3.4+: Also compute absolute paths)
+    set(LCOV_EXCLUDES "")
+    foreach(EXCLUDE ${Coverage_EXCLUDE} ${COVERAGE_EXCLUDES} ${COVERAGE_LCOV_EXCLUDES})
+        if(CMAKE_VERSION VERSION_GREATER 3.4)
+            get_filename_component(EXCLUDE ${EXCLUDE} ABSOLUTE BASE_DIR ${BASEDIR})
+        endif()
+        list(APPEND LCOV_EXCLUDES "${EXCLUDE}")
+    endforeach()
+    list(REMOVE_DUPLICATES LCOV_EXCLUDES)
+
+    # Conditional arguments
+    if(CPPFILT_PATH AND NOT ${Coverage_NO_DEMANGLE})
+      set(GENHTML_EXTRA_ARGS "--demangle-cpp")
+    endif()
+     
+    # Setting up commands which will be run to generate coverage data.
+    # Cleanup lcov
+    set(LCOV_CLEAN_CMD 
+        ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} -directory . 
+        -b ${BASEDIR} --zerocounters
+    )
+    # Create baseline to make sure untouched files show up in the report
+    set(LCOV_BASELINE_CMD 
+        ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} -c -i -d . -b 
+        ${BASEDIR} -o ${Coverage_NAME}.base
+    )
+    # Run tests
+    set(LCOV_EXEC_TESTS_CMD 
+        ${Coverage_EXECUTABLE} ${Coverage_EXECUTABLE_ARGS}
+    )    
+    # Capturing lcov counters and generating report
+    set(LCOV_CAPTURE_CMD 
+        ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} --directory . -b 
+        ${BASEDIR} --capture --output-file ${Coverage_NAME}.capture
+    )
+    # add baseline counters
+    set(LCOV_BASELINE_COUNT_CMD
+        ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} -a ${Coverage_NAME}.base 
+        -a ${Coverage_NAME}.capture --output-file ${Coverage_NAME}.total
+    ) 
+    # filter collected data to final coverage report
+    set(LCOV_FILTER_CMD 
+        ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} --remove 
+        ${Coverage_NAME}.total ${LCOV_EXCLUDES} --output-file ${Coverage_NAME}.info
+    )    
+    # Generate HTML output
+    set(LCOV_GEN_HTML_CMD
+        ${GENHTML_PATH} ${GENHTML_EXTRA_ARGS} ${Coverage_GENHTML_ARGS} -o 
+        ${Coverage_NAME} ${Coverage_NAME}.info
+    )
+    
+
+    if(CODE_COVERAGE_VERBOSE)
+        message(STATUS "Executed command report")
+        message(STATUS "Command to clean up lcov: ")
+        string(REPLACE ";" " " LCOV_CLEAN_CMD_SPACED "${LCOV_CLEAN_CMD}")
+        message(STATUS "${LCOV_CLEAN_CMD_SPACED}")
+
+        message(STATUS "Command to create baseline: ")
+        string(REPLACE ";" " " LCOV_BASELINE_CMD_SPACED "${LCOV_BASELINE_CMD}")
+        message(STATUS "${LCOV_BASELINE_CMD_SPACED}")
+
+        message(STATUS "Command to run the tests: ")
+        string(REPLACE ";" " " LCOV_EXEC_TESTS_CMD_SPACED "${LCOV_EXEC_TESTS_CMD}")
+        message(STATUS "${LCOV_EXEC_TESTS_CMD_SPACED}")
+
+        message(STATUS "Command to capture counters and generate report: ")
+        string(REPLACE ";" " " LCOV_CAPTURE_CMD_SPACED "${LCOV_CAPTURE_CMD}")
+        message(STATUS "${LCOV_CAPTURE_CMD_SPACED}")
+
+        message(STATUS "Command to add baseline counters: ")
+        string(REPLACE ";" " " LCOV_BASELINE_COUNT_CMD_SPACED "${LCOV_BASELINE_COUNT_CMD}")
+        message(STATUS "${LCOV_BASELINE_COUNT_CMD_SPACED}")
+
+        message(STATUS "Command to filter collected data: ")
+        string(REPLACE ";" " " LCOV_FILTER_CMD_SPACED "${LCOV_FILTER_CMD}")
+        message(STATUS "${LCOV_FILTER_CMD_SPACED}")
+
+        message(STATUS "Command to generate lcov HTML output: ")
+        string(REPLACE ";" " " LCOV_GEN_HTML_CMD_SPACED "${LCOV_GEN_HTML_CMD}")
+        message(STATUS "${LCOV_GEN_HTML_CMD_SPACED}")
+    endif()
+
+    # Setup target
+    add_custom_target(${Coverage_NAME}
+        COMMAND ${LCOV_CLEAN_CMD}
+        COMMAND ${LCOV_BASELINE_CMD} 
+        COMMAND ${LCOV_EXEC_TESTS_CMD}
+        COMMAND ${LCOV_CAPTURE_CMD}
+        COMMAND ${LCOV_BASELINE_COUNT_CMD}
+        COMMAND ${LCOV_FILTER_CMD} 
+        COMMAND ${LCOV_GEN_HTML_CMD}
+
+        # Set output files as GENERATED (will be removed on 'make clean')
+        BYPRODUCTS
+            ${Coverage_NAME}.base
+            ${Coverage_NAME}.capture
+            ${Coverage_NAME}.total
+            ${Coverage_NAME}.info
+            ${Coverage_NAME}/index.html
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+        DEPENDS ${Coverage_DEPENDENCIES}
+        VERBATIM # Protect arguments to commands
+        COMMENT "Resetting code coverage counters to zero.\nProcessing code coverage counters and generating report."
+    )
+
+    # Show where to find the lcov info report
+    add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
+        COMMAND ;
+        COMMENT "Lcov code coverage info report saved in ${Coverage_NAME}.info."
+    )
+
+    # Show info where to find the report
+    add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
+        COMMAND ;
+        COMMENT "Open ./${Coverage_NAME}/index.html in your browser to view the coverage report."
+    )
+
+endfunction() # setup_target_for_coverage_lcov
+
+# Defines a target for running and collection code coverage information
+# Builds dependencies, runs the given executable and outputs reports.
+# NOTE! The executable should always have a ZERO as exit code otherwise
+# the coverage generation will not complete.
+#
+# setup_target_for_coverage_gcovr_xml(
+#     NAME ctest_coverage                    # New target name
+#     EXECUTABLE ctest -j ${PROCESSOR_COUNT} # Executable in PROJECT_BINARY_DIR
+#     DEPENDENCIES executable_target         # Dependencies to build first
+#     BASE_DIRECTORY "../"                   # Base directory for report
+#                                            #  (defaults to PROJECT_SOURCE_DIR)
+#     EXCLUDE "src/dir1/*" "src/dir2/*"      # Patterns to exclude (can be relative
+#                                            #  to BASE_DIRECTORY, with CMake 3.4+)
+# )
+# The user can set the variable GCOVR_ADDITIONAL_ARGS to supply additional flags to the
+# GCVOR command.
+function(setup_target_for_coverage_gcovr_xml)
+
+    set(options NONE)
+    set(oneValueArgs BASE_DIRECTORY NAME)
+    set(multiValueArgs EXCLUDE EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES)
+    cmake_parse_arguments(Coverage "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if(NOT GCOVR_PATH)
+        message(FATAL_ERROR "gcovr not found! Aborting...")
+    endif() # NOT GCOVR_PATH
+
+    # Set base directory (as absolute path), or default to PROJECT_SOURCE_DIR
+    if(DEFINED Coverage_BASE_DIRECTORY)
+        get_filename_component(BASEDIR ${Coverage_BASE_DIRECTORY} ABSOLUTE)
+    else()
+        set(BASEDIR ${PROJECT_SOURCE_DIR})
+    endif()
+
+    # Collect excludes (CMake 3.4+: Also compute absolute paths)
+    set(GCOVR_EXCLUDES "")
+    foreach(EXCLUDE ${Coverage_EXCLUDE} ${COVERAGE_EXCLUDES} ${COVERAGE_GCOVR_EXCLUDES})
+        if(CMAKE_VERSION VERSION_GREATER 3.4)
+            get_filename_component(EXCLUDE ${EXCLUDE} ABSOLUTE BASE_DIR ${BASEDIR})
+        endif()
+        list(APPEND GCOVR_EXCLUDES "${EXCLUDE}")
+    endforeach()
+    list(REMOVE_DUPLICATES GCOVR_EXCLUDES)
+
+    # Combine excludes to several -e arguments
+    set(GCOVR_EXCLUDE_ARGS "")
+    foreach(EXCLUDE ${GCOVR_EXCLUDES})
+        list(APPEND GCOVR_EXCLUDE_ARGS "-e")
+        list(APPEND GCOVR_EXCLUDE_ARGS "${EXCLUDE}")
+    endforeach()
+    
+    # Set up commands which will be run to generate coverage data
+    # Run tests
+    set(GCOVR_XML_EXEC_TESTS_CMD
+        ${Coverage_EXECUTABLE} ${Coverage_EXECUTABLE_ARGS}
+    )
+    # Running gcovr
+    set(GCOVR_XML_CMD
+        ${GCOVR_PATH} --xml ${Coverage_NAME}.xml -r ${BASEDIR} ${GCOVR_ADDITIONAL_ARGS}
+        ${GCOVR_EXCLUDE_ARGS} --object-directory=${PROJECT_BINARY_DIR}
+    )
+    
+    if(CODE_COVERAGE_VERBOSE)
+        message(STATUS "Executed command report")
+
+        message(STATUS "Command to run tests: ")
+        string(REPLACE ";" " " GCOVR_XML_EXEC_TESTS_CMD_SPACED "${GCOVR_XML_EXEC_TESTS_CMD}")
+        message(STATUS "${GCOVR_XML_EXEC_TESTS_CMD_SPACED}")
+
+        message(STATUS "Command to generate gcovr XML coverage data: ")
+        string(REPLACE ";" " " GCOVR_XML_CMD_SPACED "${GCOVR_XML_CMD}")
+        message(STATUS "${GCOVR_XML_CMD_SPACED}")
+    endif()
+
+    add_custom_target(${Coverage_NAME}
+        COMMAND ${GCOVR_XML_EXEC_TESTS_CMD}
+        COMMAND ${GCOVR_XML_CMD}
+        
+        BYPRODUCTS ${Coverage_NAME}.xml
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+        DEPENDS ${Coverage_DEPENDENCIES}
+        VERBATIM # Protect arguments to commands
+        COMMENT "Running gcovr to produce Cobertura code coverage report."
+    )
+
+    # Show info where to find the report
+    add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
+        COMMAND ;
+        COMMENT "Cobertura code coverage report saved in ${Coverage_NAME}.xml."
+    )
+endfunction() # setup_target_for_coverage_gcovr_xml
+
+# Defines a target for running and collection code coverage information
+# Builds dependencies, runs the given executable and outputs reports.
+# NOTE! The executable should always have a ZERO as exit code otherwise
+# the coverage generation will not complete.
+#
+# setup_target_for_coverage_gcovr_html(
+#     NAME ctest_coverage                    # New target name
+#     EXECUTABLE ctest -j ${PROCESSOR_COUNT} # Executable in PROJECT_BINARY_DIR
+#     DEPENDENCIES executable_target         # Dependencies to build first
+#     BASE_DIRECTORY "../"                   # Base directory for report
+#                                            #  (defaults to PROJECT_SOURCE_DIR)
+#     EXCLUDE "src/dir1/*" "src/dir2/*"      # Patterns to exclude (can be relative
+#                                            #  to BASE_DIRECTORY, with CMake 3.4+)
+# )
+# The user can set the variable GCOVR_ADDITIONAL_ARGS to supply additional flags to the
+# GCVOR command.
+function(setup_target_for_coverage_gcovr_html)
+
+    set(options NONE)
+    set(oneValueArgs BASE_DIRECTORY NAME)
+    set(multiValueArgs EXCLUDE EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES)
+    cmake_parse_arguments(Coverage "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if(NOT GCOVR_PATH)
+        message(FATAL_ERROR "gcovr not found! Aborting...")
+    endif() # NOT GCOVR_PATH
+
+    # Set base directory (as absolute path), or default to PROJECT_SOURCE_DIR
+    if(DEFINED Coverage_BASE_DIRECTORY)
+        get_filename_component(BASEDIR ${Coverage_BASE_DIRECTORY} ABSOLUTE)
+    else()
+        set(BASEDIR ${PROJECT_SOURCE_DIR})
+    endif()
+
+    # Collect excludes (CMake 3.4+: Also compute absolute paths)
+    set(GCOVR_EXCLUDES "")
+    foreach(EXCLUDE ${Coverage_EXCLUDE} ${COVERAGE_EXCLUDES} ${COVERAGE_GCOVR_EXCLUDES})
+        if(CMAKE_VERSION VERSION_GREATER 3.4)
+            get_filename_component(EXCLUDE ${EXCLUDE} ABSOLUTE BASE_DIR ${BASEDIR})
+        endif()
+        list(APPEND GCOVR_EXCLUDES "${EXCLUDE}")
+    endforeach()
+    list(REMOVE_DUPLICATES GCOVR_EXCLUDES)
+
+    # Combine excludes to several -e arguments
+    set(GCOVR_EXCLUDE_ARGS "")
+    foreach(EXCLUDE ${GCOVR_EXCLUDES})
+        list(APPEND GCOVR_EXCLUDE_ARGS "-e")
+        list(APPEND GCOVR_EXCLUDE_ARGS "${EXCLUDE}")
+    endforeach()
+
+    # Set up commands which will be run to generate coverage data
+    # Run tests
+    set(GCOVR_HTML_EXEC_TESTS_CMD
+        ${Coverage_EXECUTABLE} ${Coverage_EXECUTABLE_ARGS}
+    )
+    # Create folder
+    set(GCOVR_HTML_FOLDER_CMD
+        ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/${Coverage_NAME}
+    )
+    # Running gcovr
+    set(GCOVR_HTML_CMD
+        ${GCOVR_PATH} --html ${Coverage_NAME}/index.html --html-details -r ${BASEDIR} ${GCOVR_ADDITIONAL_ARGS}
+        ${GCOVR_EXCLUDE_ARGS} --object-directory=${PROJECT_BINARY_DIR}
+    )
+
+    if(CODE_COVERAGE_VERBOSE)
+        message(STATUS "Executed command report")
+
+        message(STATUS "Command to run tests: ")
+        string(REPLACE ";" " " GCOVR_HTML_EXEC_TESTS_CMD_SPACED "${GCOVR_HTML_EXEC_TESTS_CMD}")
+        message(STATUS "${GCOVR_HTML_EXEC_TESTS_CMD_SPACED}")
+
+        message(STATUS "Command to create a folder: ")
+        string(REPLACE ";" " " GCOVR_HTML_FOLDER_CMD_SPACED "${GCOVR_HTML_FOLDER_CMD}")
+        message(STATUS "${GCOVR_HTML_FOLDER_CMD_SPACED}")
+
+        message(STATUS "Command to generate gcovr HTML coverage data: ")
+        string(REPLACE ";" " " GCOVR_HTML_CMD_SPACED "${GCOVR_HTML_CMD}")
+        message(STATUS "${GCOVR_HTML_CMD_SPACED}")
+    endif()
+
+    add_custom_target(${Coverage_NAME}
+        COMMAND ${GCOVR_HTML_EXEC_TESTS_CMD}
+        COMMAND ${GCOVR_HTML_FOLDER_CMD}
+        COMMAND ${GCOVR_HTML_CMD}
+
+        BYPRODUCTS ${PROJECT_BINARY_DIR}/${Coverage_NAME}/index.html  # report directory
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+        DEPENDS ${Coverage_DEPENDENCIES}
+        VERBATIM # Protect arguments to commands
+        COMMENT "Running gcovr to produce HTML code coverage report."
+    )
+
+    # Show info where to find the report
+    add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
+        COMMAND ;
+        COMMENT "Open ./${Coverage_NAME}/index.html in your browser to view the coverage report."
+    )
+
+endfunction() # setup_target_for_coverage_gcovr_html
+
+# Defines a target for running and collection code coverage information
+# Builds dependencies, runs the given executable and outputs reports.
+# NOTE! The executable should always have a ZERO as exit code otherwise
+# the coverage generation will not complete.
+#
+# setup_target_for_coverage_fastcov(
+#     NAME testrunner_coverage                    # New target name
+#     EXECUTABLE testrunner -j ${PROCESSOR_COUNT} # Executable in PROJECT_BINARY_DIR
+#     DEPENDENCIES testrunner                     # Dependencies to build first
+#     BASE_DIRECTORY "../"                        # Base directory for report
+#                                                 #  (defaults to PROJECT_SOURCE_DIR)
+#     EXCLUDE "src/dir1/" "src/dir2/"             # Patterns to exclude.
+#     NO_DEMANGLE                                 # Don't demangle C++ symbols
+#                                                 #  even if c++filt is found
+#     SKIP_HTML                                   # Don't create html report
+#     POST_CMD perl -i -pe s!${PROJECT_SOURCE_DIR}/!!g ctest_coverage.json  # E.g. for stripping source dir from file paths
+# )
+function(setup_target_for_coverage_fastcov)
+
+    set(options NO_DEMANGLE SKIP_HTML)
+    set(oneValueArgs BASE_DIRECTORY NAME)
+    set(multiValueArgs EXCLUDE EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES FASTCOV_ARGS GENHTML_ARGS POST_CMD)
+    cmake_parse_arguments(Coverage "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if(NOT FASTCOV_PATH)
+        message(FATAL_ERROR "fastcov not found! Aborting...")
+    endif()
+
+    if(NOT Coverage_SKIP_HTML AND NOT GENHTML_PATH)
+        message(FATAL_ERROR "genhtml not found! Aborting...")
+    endif()
+
+    # Set base directory (as absolute path), or default to PROJECT_SOURCE_DIR
+    if(Coverage_BASE_DIRECTORY)
+        get_filename_component(BASEDIR ${Coverage_BASE_DIRECTORY} ABSOLUTE)
+    else()
+        set(BASEDIR ${PROJECT_SOURCE_DIR})
+    endif()
+
+    # Collect excludes (Patterns, not paths, for fastcov)
+    set(FASTCOV_EXCLUDES "")
+    foreach(EXCLUDE ${Coverage_EXCLUDE} ${COVERAGE_EXCLUDES} ${COVERAGE_FASTCOV_EXCLUDES})
+        list(APPEND FASTCOV_EXCLUDES "${EXCLUDE}")
+    endforeach()
+    list(REMOVE_DUPLICATES FASTCOV_EXCLUDES)
+
+    # Conditional arguments
+    if(CPPFILT_PATH AND NOT ${Coverage_NO_DEMANGLE})
+        set(GENHTML_EXTRA_ARGS "--demangle-cpp")
+    endif()
+
+    # Set up commands which will be run to generate coverage data
+    set(FASTCOV_EXEC_TESTS_CMD ${Coverage_EXECUTABLE} ${Coverage_EXECUTABLE_ARGS})
+
+    set(FASTCOV_CAPTURE_CMD ${FASTCOV_PATH} ${Coverage_FASTCOV_ARGS} --gcov ${GCOV_PATH}
+        --search-directory ${BASEDIR}
+        --process-gcno
+        --output ${Coverage_NAME}.json
+        --exclude ${FASTCOV_EXCLUDES}
+        --exclude ${FASTCOV_EXCLUDES}
+    )
+    
+    set(FASTCOV_CONVERT_CMD ${FASTCOV_PATH}
+        -C ${Coverage_NAME}.json --lcov --output ${Coverage_NAME}.info
+    )
+
+    if(Coverage_SKIP_HTML)
+        set(FASTCOV_HTML_CMD ";")
+    else()
+        set(FASTCOV_HTML_CMD ${GENHTML_PATH} ${GENHTML_EXTRA_ARGS} ${Coverage_GENHTML_ARGS}
+            -o ${Coverage_NAME} ${Coverage_NAME}.info
+        )
+    endif()
+
+    set(FASTCOV_POST_CMD ";")
+    if(Coverage_POST_CMD)
+        set(FASTCOV_POST_CMD ${Coverage_POST_CMD})
+    endif()
+
+    if(CODE_COVERAGE_VERBOSE)
+        message(STATUS "Code coverage commands for target ${Coverage_NAME} (fastcov):")
+
+        message("   Running tests:")
+        string(REPLACE ";" " " FASTCOV_EXEC_TESTS_CMD_SPACED "${FASTCOV_EXEC_TESTS_CMD}")
+        message("     ${FASTCOV_EXEC_TESTS_CMD_SPACED}")
+
+        message("   Capturing fastcov counters and generating report:")
+        string(REPLACE ";" " " FASTCOV_CAPTURE_CMD_SPACED "${FASTCOV_CAPTURE_CMD}")
+        message("     ${FASTCOV_CAPTURE_CMD_SPACED}")
+
+        message("   Converting fastcov .json to lcov .info:")
+        string(REPLACE ";" " " FASTCOV_CONVERT_CMD_SPACED "${FASTCOV_CONVERT_CMD}")
+        message("     ${FASTCOV_CONVERT_CMD_SPACED}")
+
+        if(NOT Coverage_SKIP_HTML)
+            message("   Generating HTML report: ")
+            string(REPLACE ";" " " FASTCOV_HTML_CMD_SPACED "${FASTCOV_HTML_CMD}")
+            message("     ${FASTCOV_HTML_CMD_SPACED}")
+        endif()
+        if(Coverage_POST_CMD)
+            message("   Running post command: ")
+            string(REPLACE ";" " " FASTCOV_POST_CMD_SPACED "${FASTCOV_POST_CMD}")
+            message("     ${FASTCOV_POST_CMD_SPACED}")
+        endif()
+    endif()
+
+    # Setup target
+    add_custom_target(${Coverage_NAME}
+
+        # Cleanup fastcov
+        COMMAND ${FASTCOV_PATH} ${Coverage_FASTCOV_ARGS} --gcov ${GCOV_PATH}
+            --search-directory ${BASEDIR}
+            --zerocounters
+
+        COMMAND ${FASTCOV_EXEC_TESTS_CMD}
+        COMMAND ${FASTCOV_CAPTURE_CMD}
+        COMMAND ${FASTCOV_CONVERT_CMD}
+        COMMAND ${FASTCOV_HTML_CMD}
+        COMMAND ${FASTCOV_POST_CMD}
+
+        # Set output files as GENERATED (will be removed on 'make clean')
+        BYPRODUCTS
+             ${Coverage_NAME}.info
+             ${Coverage_NAME}.json
+             ${Coverage_NAME}/index.html  # report directory
+
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+        DEPENDS ${Coverage_DEPENDENCIES}
+        VERBATIM # Protect arguments to commands
+        COMMENT "Resetting code coverage counters to zero. Processing code coverage counters and generating report."
+    )
+
+    set(INFO_MSG "fastcov code coverage info report saved in ${Coverage_NAME}.info and ${Coverage_NAME}.json.")
+    if(NOT Coverage_SKIP_HTML)
+        string(APPEND INFO_MSG " Open ${PROJECT_BINARY_DIR}/${Coverage_NAME}/index.html in your browser to view the coverage report.")
+    endif()
+    # Show where to find the fastcov info report
+    add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E echo ${INFO_MSG}
+    )
+
+endfunction() # setup_target_for_coverage_fastcov
+
+function(append_coverage_compiler_flags)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${COVERAGE_COMPILER_FLAGS}" PARENT_SCOPE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COVERAGE_COMPILER_FLAGS}" PARENT_SCOPE)
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} ${COVERAGE_COMPILER_FLAGS}" PARENT_SCOPE)
+    message(STATUS "Appending code coverage compiler flags: ${COVERAGE_COMPILER_FLAGS}")
+endfunction() # append_coverage_compiler_flags
+
+# Setup coverage for specific library
+function(append_coverage_compiler_flags_to_target name)
+     separate_arguments(_flag_list NATIVE_COMMAND "${COVERAGE_COMPILER_FLAGS}")
+ target_compile_options(${name} PRIVATE ${_flag_list})
+endfunction()

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -216,6 +216,11 @@ int Application::run(QApplication &qtApp)
     return qtApp.exec();
 }
 
+IEmotes *Application::getEmotes()
+{
+    return this->emotes;
+}
+
 void Application::save()
 {
     for (auto &singleton : this->singletons_)

--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -24,6 +24,7 @@ class Logging;
 class Paths;
 class AccountManager;
 class Emotes;
+class IEmotes;
 class Settings;
 class Fonts;
 class Toasts;
@@ -41,7 +42,7 @@ public:
 
     virtual Theme *getThemes() = 0;
     virtual Fonts *getFonts() = 0;
-    virtual Emotes *getEmotes() = 0;
+    virtual IEmotes *getEmotes() = 0;
     virtual AccountController *getAccounts() = 0;
     virtual HotkeyController *getHotkeys() = 0;
     virtual WindowManager *getWindows() = 0;
@@ -99,10 +100,7 @@ public:
     {
         return this->fonts;
     }
-    Emotes *getEmotes() override
-    {
-        return this->emotes;
-    }
+    IEmotes *getEmotes() override;
     AccountController *getAccounts() override
     {
         return this->accounts;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -542,6 +542,21 @@ source_group(TREE ${CMAKE_SOURCE_DIR} FILES ${SOURCE_FILES})
 
 add_library(${LIBRARY_PROJECT} OBJECT ${SOURCE_FILES})
 
+if (CHATTERINO_GENERATE_COVERAGE)
+    include(CodeCoverage)
+    append_coverage_compiler_flags_to_target(${LIBRARY_PROJECT})
+    target_link_libraries(${LIBRARY_PROJECT} PUBLIC gcov)
+    message(STATUS "project source dir: ${PROJECT_SOURCE_DIR}/src")
+    setup_target_for_coverage_lcov(
+        NAME coverage
+        EXECUTABLE ./bin/chatterino-test
+        BASE_DIRECTORY ${PROJECT_SOURCE_DIR}/src
+        EXCLUDE "/usr/include/*"
+        EXCLUDE "build-*/*"
+        EXCLUDE "lib/*"
+        )
+endif ()
+
 target_link_libraries(${LIBRARY_PROJECT}
         PUBLIC
         Qt${MAJOR_QT_VERSION}::Core

--- a/src/common/SignalVector.hpp
+++ b/src/common/SignalVector.hpp
@@ -76,9 +76,13 @@ public:
         else
         {
             if (index == -1)
+            {
                 index = this->items_.size();
+            }
             else
+            {
                 assert(index >= 0 && index <= this->items_.size());
+            }
 
             this->items_.insert(this->items_.begin() + index, item);
         }

--- a/src/common/SignalVector.hpp
+++ b/src/common/SignalVector.hpp
@@ -41,7 +41,7 @@ public:
         this->itemCompare_ = std::move(compare);
     }
 
-    virtual bool isSorted() const
+    bool isSorted() const
     {
         return bool(this->itemCompare_);
     }

--- a/src/common/SignalVector.hpp
+++ b/src/common/SignalVector.hpp
@@ -38,7 +38,7 @@ public:
     SignalVector(std::function<bool(const T &, const T &)> &&compare)
         : SignalVector()
     {
-        itemCompare_ = std::move(compare);
+        this->itemCompare_ = std::move(compare);
     }
 
     virtual bool isSorted() const

--- a/src/providers/twitch/TwitchEmotes.cpp
+++ b/src/providers/twitch/TwitchEmotes.cpp
@@ -1,10 +1,7 @@
 #include "providers/twitch/TwitchEmotes.hpp"
 
-#include "common/NetworkRequest.hpp"
-#include "debug/Benchmark.hpp"
 #include "messages/Emote.hpp"
 #include "messages/Image.hpp"
-#include "util/RapidjsonHelpers.hpp"
 
 namespace chatterino {
 

--- a/src/providers/twitch/TwitchEmotes.cpp
+++ b/src/providers/twitch/TwitchEmotes.cpp
@@ -5,10 +5,6 @@
 
 namespace chatterino {
 
-TwitchEmotes::TwitchEmotes()
-{
-}
-
 QString TwitchEmotes::cleanUpEmoteCode(const QString &dirtyEmoteCode)
 {
     auto cleanCode = dirtyEmoteCode;

--- a/src/providers/twitch/TwitchEmotes.hpp
+++ b/src/providers/twitch/TwitchEmotes.hpp
@@ -33,7 +33,16 @@ struct CheerEmoteSet {
     std::vector<CheerEmote> cheerEmotes;
 };
 
-class TwitchEmotes
+class ITwitchEmotes
+{
+public:
+    virtual ~ITwitchEmotes() = default;
+
+    virtual EmotePtr getOrCreateEmote(const EmoteId &id,
+                                      const EmoteName &name) = 0;
+};
+
+class TwitchEmotes : public ITwitchEmotes
 {
 public:
     static QString cleanUpEmoteCode(const QString &dirtyEmoteCode);

--- a/src/providers/twitch/TwitchEmotes.hpp
+++ b/src/providers/twitch/TwitchEmotes.hpp
@@ -48,7 +48,8 @@ public:
     static QString cleanUpEmoteCode(const QString &dirtyEmoteCode);
     TwitchEmotes() = default;
 
-    EmotePtr getOrCreateEmote(const EmoteId &id, const EmoteName &name);
+    EmotePtr getOrCreateEmote(const EmoteId &id,
+                              const EmoteName &name) override;
 
 private:
     Url getEmoteLink(const EmoteId &id, const QString &emoteScale);

--- a/src/providers/twitch/TwitchEmotes.hpp
+++ b/src/providers/twitch/TwitchEmotes.hpp
@@ -46,7 +46,7 @@ class TwitchEmotes : public ITwitchEmotes
 {
 public:
     static QString cleanUpEmoteCode(const QString &dirtyEmoteCode);
-    TwitchEmotes();
+    TwitchEmotes() = default;
 
     EmotePtr getOrCreateEmote(const EmoteId &id, const EmoteName &name);
 

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -1016,6 +1016,9 @@ void TwitchMessageBuilder::appendTwitchEmote(
         if (from > to || to >= maxPositions)
         {
             // Emote coords are out of range
+            qCDebug(chatterinoTwitch)
+                << "Emote coords" << from << "-" << to << "are out of range ("
+                << maxPositions << ")";
             return;
         }
 
@@ -1024,6 +1027,9 @@ void TwitchMessageBuilder::appendTwitchEmote(
         if (start > end || start < 0 || end > this->originalMessage_.length())
         {
             // Emote coords are out of range from the modified character positions
+            qCDebug(chatterinoTwitch) << "Emote coords" << from << "-" << to
+                                      << "are out of range after offsets ("
+                                      << this->originalMessage_.length() << ")";
             return;
         }
 

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -163,16 +163,18 @@ namespace {
             }
 
             auto name = EmoteName{originalMessage.mid(start, end - start + 1)};
-            TwitchEmoteOccurrence emoteOccurence{
-                start, end,
+            TwitchEmoteOccurrence emoteOccurrence{
+                start,
+                end,
                 app->getEmotes()->getTwitchEmotes()->getOrCreateEmote(id, name),
-                name};
-            if (emoteOccurence.ptr == nullptr)
+                name,
+            };
+            if (emoteOccurrence.ptr == nullptr)
             {
                 qCDebug(chatterinoTwitch)
-                    << "nullptr" << emoteOccurence.name.string;
+                    << "nullptr" << emoteOccurrence.name.string;
             }
-            vec.push_back(std::move(emoteOccurence));
+            vec.push_back(std::move(emoteOccurrence));
         }
     }
 

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -108,7 +108,7 @@ namespace {
     }
 
     void appendTwitchEmoteOccurences(const QString &emote,
-                                     std::vector<TwitchEmoteOccurence> &vec,
+                                     std::vector<TwitchEmoteOccurrence> &vec,
                                      const std::vector<int> &correctPositions,
                                      const QString &originalMessage,
                                      int messageOffset)
@@ -163,7 +163,7 @@ namespace {
             }
 
             auto name = EmoteName{originalMessage.mid(start, end - start + 1)};
-            TwitchEmoteOccurence emoteOccurence{
+            TwitchEmoteOccurrence emoteOccurence{
                 start, end,
                 app->getEmotes()->getTwitchEmotes()->getOrCreateEmote(id, name),
                 name};
@@ -431,8 +431,8 @@ MessagePtr TwitchMessageBuilder::build()
 
 bool doesWordContainATwitchEmote(
     int cursor, const QString &word,
-    const std::vector<TwitchEmoteOccurence> &twitchEmotes,
-    std::vector<TwitchEmoteOccurence>::const_iterator &currentTwitchEmoteIt)
+    const std::vector<TwitchEmoteOccurrence> &twitchEmotes,
+    std::vector<TwitchEmoteOccurrence>::const_iterator &currentTwitchEmoteIt)
 {
     if (currentTwitchEmoteIt == twitchEmotes.end())
     {
@@ -456,7 +456,7 @@ bool doesWordContainATwitchEmote(
 
 void TwitchMessageBuilder::addWords(
     const QStringList &words,
-    const std::vector<TwitchEmoteOccurence> &twitchEmotes)
+    const std::vector<TwitchEmoteOccurrence> &twitchEmotes)
 {
     // cursor currently indicates what character index we're currently operating in the full list of words
     int cursor = 0;
@@ -814,7 +814,7 @@ void TwitchMessageBuilder::appendUsername()
 }
 
 void TwitchMessageBuilder::runIgnoreReplaces(
-    std::vector<TwitchEmoteOccurence> &twitchEmotes)
+    std::vector<TwitchEmoteOccurrence> &twitchEmotes)
 {
     auto phrases = getCSettings().ignoredMessages.readOnly();
     auto removeEmotesInRange = [](int pos, int len,
@@ -832,7 +832,7 @@ void TwitchMessageBuilder::runIgnoreReplaces(
                     << "remem nullptr" << (*copy).name.string;
             }
         }
-        std::vector<TwitchEmoteOccurence> v(it, twitchEmotes.end());
+        std::vector<TwitchEmoteOccurrence> v(it, twitchEmotes.end());
         twitchEmotes.erase(it, twitchEmotes.end());
         return v;
     };
@@ -870,7 +870,7 @@ void TwitchMessageBuilder::runIgnoreReplaces(
                         qCDebug(chatterinoTwitch)
                             << "emote null" << emote.first.string;
                     }
-                    twitchEmotes.push_back(TwitchEmoteOccurence{
+                    twitchEmotes.push_back(TwitchEmoteOccurrence{
                         startIndex + pos,
                         startIndex + pos + emote.first.string.length(),
                         emote.second,
@@ -1136,11 +1136,11 @@ std::unordered_map<QString, QString> TwitchMessageBuilder::parseBadgeInfoTag(
     return infoMap;
 }
 
-std::vector<TwitchEmoteOccurence> TwitchMessageBuilder::parseTwitchEmotes(
+std::vector<TwitchEmoteOccurrence> TwitchMessageBuilder::parseTwitchEmotes(
     const QVariantMap &tags, const QString &originalMessage, int messageOffset)
 {
     // Twitch emotes
-    std::vector<TwitchEmoteOccurence> twitchEmotes;
+    std::vector<TwitchEmoteOccurrence> twitchEmotes;
 
     auto emotesTag = tags.find("emotes");
 
@@ -1160,8 +1160,8 @@ std::vector<TwitchEmoteOccurence> TwitchMessageBuilder::parseTwitchEmotes(
     }
     for (const QString &emote : emoteString)
     {
-        appendTwitchEmoteOccurences(emote, twitchEmotes, correctPositions,
-                                    originalMessage, messageOffset);
+        appendTwitchEmoteOccurrences(emote, twitchEmotes, correctPositions,
+                                     originalMessage, messageOffset);
     }
 
     return twitchEmotes;

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -1010,13 +1010,20 @@ void TwitchMessageBuilder::appendTwitchEmote(
             return;
         }
 
-        auto start =
-            correctPositions[coords.at(0).toUInt() - this->messageOffset_];
-        auto end =
-            correctPositions[coords.at(1).toUInt() - this->messageOffset_];
-
-        if (start >= end || start < 0 || end > this->originalMessage_.length())
+        auto from = coords.at(0).toUInt() - this->messageOffset_;
+        auto to = coords.at(1).toUInt() - this->messageOffset_;
+        auto maxPositions = correctPositions.size();
+        if (from > to || to >= maxPositions)
         {
+            // Emote coords are out of range
+            return;
+        }
+
+        auto start = correctPositions[from];
+        auto end = correctPositions[to];
+        if (start > end || start < 0 || end > this->originalMessage_.length())
+        {
+            // Emote coords are out of range from the modified character positions
             return;
         }
 

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -128,11 +128,11 @@ namespace {
 
         auto id = EmoteId{parameters.at(0)};
 
-        auto occurences = parameters.at(1).split(',');
+        auto occurrences = parameters.at(1).split(',');
 
-        for (const QString &occurence : occurences)
+        for (const QString &occurrence : occurrences)
         {
-            auto coords = occurence.split('-');
+            auto coords = occurrence.split('-');
 
             if (coords.length() < 2)
             {

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -982,7 +982,7 @@ void TwitchMessageBuilder::runIgnoreReplaces(
 
 void TwitchMessageBuilder::appendTwitchEmote(
     const QString &emote, std::vector<TwitchEmoteOccurence> &vec,
-    std::vector<int> &correctPositions) const
+    const std::vector<int> &correctPositions) const
 {
     auto app = getApp();
     if (!emote.contains(':'))

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -982,7 +982,7 @@ void TwitchMessageBuilder::runIgnoreReplaces(
 
 void TwitchMessageBuilder::appendTwitchEmote(
     const QString &emote, std::vector<TwitchEmoteOccurence> &vec,
-    std::vector<int> &correctPositions)
+    std::vector<int> &correctPositions) const
 {
     auto app = getApp();
     if (!emote.contains(':'))

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -1089,7 +1089,7 @@ void TwitchMessageBuilder::appendTwitchEmoteOccurences(
 
     auto occurences = parameters.at(1).split(',');
 
-    for (QString occurence : occurences)
+    for (const QString &occurence : occurences)
     {
         auto coords = occurence.split('-');
 
@@ -1157,7 +1157,7 @@ std::vector<TwitchEmoteOccurence> TwitchMessageBuilder::parseTwitchEmotes(
             correctPositions.push_back(i);
         }
     }
-    for (QString emote : emoteString)
+    for (const QString &emote : emoteString)
     {
         TwitchMessageBuilder::appendTwitchEmoteOccurences(
             emote, twitchEmotes, correctPositions, originalMessage,

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -107,11 +107,11 @@ namespace {
         return usernameText;
     }
 
-    void appendTwitchEmoteOccurences(const QString &emote,
-                                     std::vector<TwitchEmoteOccurrence> &vec,
-                                     const std::vector<int> &correctPositions,
-                                     const QString &originalMessage,
-                                     int messageOffset)
+    void appendTwitchEmoteOccurrences(const QString &emote,
+                                      std::vector<TwitchEmoteOccurrence> &vec,
+                                      const std::vector<int> &correctPositions,
+                                      const QString &originalMessage,
+                                      int messageOffset)
     {
         auto *app = getIApp();
         if (!emote.contains(':'))

--- a/src/providers/twitch/TwitchMessageBuilder.hpp
+++ b/src/providers/twitch/TwitchMessageBuilder.hpp
@@ -25,6 +25,12 @@ struct TwitchEmoteOccurence {
     int end;
     EmotePtr ptr;
     EmoteName name;
+
+    bool operator==(const TwitchEmoteOccurence &other) const
+    {
+        return std::tie(this->start, this->end, this->ptr, this->name) ==
+               std::tie(other.start, other.end, other.ptr, other.name);
+    }
 };
 
 class TwitchMessageBuilder : public SharedMessageBuilder

--- a/src/providers/twitch/TwitchMessageBuilder.hpp
+++ b/src/providers/twitch/TwitchMessageBuilder.hpp
@@ -82,11 +82,6 @@ public:
     static std::unordered_map<QString, QString> parseBadgeInfoTag(
         const QVariantMap &tags);
 
-    static void appendTwitchEmoteOccurences(
-        const QString &emote, std::vector<TwitchEmoteOccurence> &vec,
-        const std::vector<int> &correctPositions,
-        const QString &originalMessage, int messageOffset);
-
     static std::vector<TwitchEmoteOccurence> parseTwitchEmotes(
         const QVariantMap &tags, const QString &originalMessage,
         int messageOffset);

--- a/src/providers/twitch/TwitchMessageBuilder.hpp
+++ b/src/providers/twitch/TwitchMessageBuilder.hpp
@@ -20,13 +20,13 @@ using EmotePtr = std::shared_ptr<const Emote>;
 class Channel;
 class TwitchChannel;
 
-struct TwitchEmoteOccurence {
+struct TwitchEmoteOccurrence {
     int start;
     int end;
     EmotePtr ptr;
     EmoteName name;
 
-    bool operator==(const TwitchEmoteOccurence &other) const
+    bool operator==(const TwitchEmoteOccurrence &other) const
     {
         return std::tie(this->start, this->end, this->ptr, this->name) ==
                std::tie(other.start, other.end, other.ptr, other.name);
@@ -82,7 +82,7 @@ public:
     static std::unordered_map<QString, QString> parseBadgeInfoTag(
         const QVariantMap &tags);
 
-    static std::vector<TwitchEmoteOccurence> parseTwitchEmotes(
+    static std::vector<TwitchEmoteOccurrence> parseTwitchEmotes(
         const QVariantMap &tags, const QString &originalMessage,
         int messageOffset);
 
@@ -93,13 +93,13 @@ private:
     void parseRoomID();
     void appendUsername();
 
-    void runIgnoreReplaces(std::vector<TwitchEmoteOccurence> &twitchEmotes);
+    void runIgnoreReplaces(std::vector<TwitchEmoteOccurrence> &twitchEmotes);
 
     boost::optional<EmotePtr> getTwitchBadge(const Badge &badge);
     Outcome tryAppendEmote(const EmoteName &name) override;
 
     void addWords(const QStringList &words,
-                  const std::vector<TwitchEmoteOccurence> &twitchEmotes);
+                  const std::vector<TwitchEmoteOccurrence> &twitchEmotes);
     void addTextOrEmoji(EmotePtr emote) override;
     void addTextOrEmoji(const QString &value) override;
 

--- a/src/providers/twitch/TwitchMessageBuilder.hpp
+++ b/src/providers/twitch/TwitchMessageBuilder.hpp
@@ -76,6 +76,15 @@ public:
     static std::unordered_map<QString, QString> parseBadgeInfoTag(
         const QVariantMap &tags);
 
+    static void appendTwitchEmoteOccurences(
+        const QString &emote, std::vector<TwitchEmoteOccurence> &vec,
+        const std::vector<int> &correctPositions,
+        const QString &originalMessage, int messageOffset);
+
+    static std::vector<TwitchEmoteOccurence> parseTwitchEmotes(
+        const QVariantMap &tags, const QString &originalMessage,
+        int messageOffset);
+
 private:
     void parseUsernameColor() override;
     void parseUsername() override;
@@ -86,9 +95,6 @@ private:
     void runIgnoreReplaces(std::vector<TwitchEmoteOccurence> &twitchEmotes);
 
     boost::optional<EmotePtr> getTwitchBadge(const Badge &badge);
-    void appendTwitchEmote(const QString &emote,
-                           std::vector<TwitchEmoteOccurence> &vec,
-                           const std::vector<int> &correctPositions) const;
     Outcome tryAppendEmote(const EmoteName &name) override;
 
     void addWords(const QStringList &words,

--- a/src/providers/twitch/TwitchMessageBuilder.hpp
+++ b/src/providers/twitch/TwitchMessageBuilder.hpp
@@ -88,7 +88,7 @@ private:
     boost::optional<EmotePtr> getTwitchBadge(const Badge &badge);
     void appendTwitchEmote(const QString &emote,
                            std::vector<TwitchEmoteOccurence> &vec,
-                           std::vector<int> &correctPositions) const;
+                           const std::vector<int> &correctPositions) const;
     Outcome tryAppendEmote(const EmoteName &name) override;
 
     void addWords(const QStringList &words,

--- a/src/providers/twitch/TwitchMessageBuilder.hpp
+++ b/src/providers/twitch/TwitchMessageBuilder.hpp
@@ -88,7 +88,7 @@ private:
     boost::optional<EmotePtr> getTwitchBadge(const Badge &badge);
     void appendTwitchEmote(const QString &emote,
                            std::vector<TwitchEmoteOccurence> &vec,
-                           std::vector<int> &correctPositions);
+                           std::vector<int> &correctPositions) const;
     Outcome tryAppendEmote(const EmoteName &name) override;
 
     void addWords(const QStringList &words,

--- a/src/singletons/Emotes.hpp
+++ b/src/singletons/Emotes.hpp
@@ -14,7 +14,15 @@ namespace chatterino {
 class Settings;
 class Paths;
 
-class Emotes final : public Singleton
+class IEmotes
+{
+public:
+    virtual ~IEmotes() = default;
+
+    virtual ITwitchEmotes *getTwitchEmotes() = 0;
+};
+
+class Emotes final : public IEmotes, public Singleton
 {
 public:
     Emotes();
@@ -22,6 +30,11 @@ public:
     virtual void initialize(Settings &settings, Paths &paths) override;
 
     bool isIgnoredEmote(const QString &emote);
+
+    ITwitchEmotes *getTwitchEmotes() final
+    {
+        return &this->twitch;
+    }
 
     TwitchEmotes twitch;
     Emojis emojis;

--- a/src/widgets/dialogs/switcher/QuickSwitcherModel.hpp
+++ b/src/widgets/dialogs/switcher/QuickSwitcherModel.hpp
@@ -7,4 +7,4 @@ namespace chatterino {
 
 using QuickSwitcherModel = GenericListModel;
 
-}
+}  // namespace chatterino

--- a/tests/src/HighlightController.cpp
+++ b/tests/src/HighlightController.cpp
@@ -27,7 +27,7 @@ public:
     {
         return nullptr;
     }
-    Emotes *getEmotes() override
+    IEmotes *getEmotes() override
     {
         return nullptr;
     }

--- a/tests/src/HighlightController.cpp
+++ b/tests/src/HighlightController.cpp
@@ -16,6 +16,8 @@
 using namespace chatterino;
 using ::testing::Exactly;
 
+namespace {
+
 class MockApplication : IApplication
 {
 public:
@@ -76,6 +78,8 @@ public:
     HighlightController highlights;
     // TODO: Figure this out
 };
+
+}  // namespace
 
 class MockHelix : public IHelix
 {

--- a/tests/src/TwitchMessageBuilder.cpp
+++ b/tests/src/TwitchMessageBuilder.cpp
@@ -16,6 +16,8 @@
 
 using namespace chatterino;
 
+namespace {
+
 class MockApplication : IApplication
 {
 public:
@@ -74,6 +76,8 @@ public:
 
     Emotes emotes;
 };
+
+}  // namespace
 
 TEST(TwitchMessageBuilder, CommaSeparatedListTagParsing)
 {

--- a/tests/src/TwitchMessageBuilder.cpp
+++ b/tests/src/TwitchMessageBuilder.cpp
@@ -1,8 +1,10 @@
 #include "providers/twitch/TwitchMessageBuilder.hpp"
 
+#include "Application.hpp"
 #include "common/Channel.hpp"
 #include "messages/MessageBuilder.hpp"
 #include "providers/twitch/TwitchBadge.hpp"
+#include "singletons/Emotes.hpp"
 
 #include "ircconnection.h"
 
@@ -13,6 +15,65 @@
 #include <vector>
 
 using namespace chatterino;
+
+class MockApplication : IApplication
+{
+public:
+    Theme *getThemes() override
+    {
+        return nullptr;
+    }
+    Fonts *getFonts() override
+    {
+        return nullptr;
+    }
+    IEmotes *getEmotes() override
+    {
+        return &this->emotes;
+    }
+    AccountController *getAccounts() override
+    {
+        return nullptr;
+    }
+    HotkeyController *getHotkeys() override
+    {
+        return nullptr;
+    }
+    WindowManager *getWindows() override
+    {
+        return nullptr;
+    }
+    Toasts *getToasts() override
+    {
+        return nullptr;
+    }
+    CommandController *getCommands() override
+    {
+        return nullptr;
+    }
+    NotificationController *getNotifications() override
+    {
+        return nullptr;
+    }
+    HighlightController *getHighlights() override
+    {
+        return nullptr;
+    }
+    TwitchIrcServer *getTwitch() override
+    {
+        return nullptr;
+    }
+    ChatterinoBadges *getChatterinoBadges() override
+    {
+        return nullptr;
+    }
+    FfzBadges *getFfzBadges() override
+    {
+        return nullptr;
+    }
+
+    Emotes emotes;
+};
 
 TEST(TwitchMessageBuilder, CommaSeparatedListTagParsing)
 {
@@ -126,5 +187,169 @@ TEST(TwitchMessageBuilder, BadgeInfoParsing)
             SharedMessageBuilder::parseBadgeTag(privmsg->tags());
         EXPECT_EQ(outputBadges, test.expectedBadges)
             << "Input for badges " << test.input.toStdString() << " failed";
+    }
+}
+
+TEST(TwitchMessageBuilder, ParseTwitchEmotes)
+{
+    auto mockApplication = std::make_unique<MockApplication>();
+    struct TestCase {
+        QByteArray input;
+        std::vector<TwitchEmoteOccurence> expectedTwitchEmotes;
+    };
+
+    auto *twitchEmotes = mockApplication->getEmotes()->getTwitchEmotes();
+
+    std::vector<TestCase> testCases{
+        {
+            R"(@badge-info=subscriber/17;badges=subscriber/12,no_audio/1;color=#EBA2C0;display-name=jammehcow;emote-only=1;emotes=25:0-4;first-msg=0;flags=;id=9c2dd916-5a6d-4c1f-9fe7-a081b62a9c6b;mod=0;returning-chatter=0;room-id=11148817;subscriber=1;tmi-sent-ts=1662201093248;turbo=0;user-id=82674227;user-type= :jammehcow!jammehcow@jammehcow.tmi.twitch.tv PRIVMSG #pajlada :Kappa)",
+            {
+                {{
+                    0,  // start
+                    4,  // end
+                    twitchEmotes->getOrCreateEmote(EmoteId{"25"},
+                                                   EmoteName{"Kappa"}),  // ptr
+                    EmoteName{"Kappa"},                                  // name
+                }},
+            },
+        },
+        {
+            R"(@badge-info=;badges=no_audio/1;color=#DAA520;display-name=Mm2PL;emote-only=1;emotes=1902:0-4;first-msg=0;flags=;id=9b1c3cb9-7817-47ea-add1-f9d4a9b4f846;mod=0;returning-chatter=0;room-id=11148817;subscriber=0;tmi-sent-ts=1662201095690;turbo=0;user-id=117691339;user-type= :mm2pl!mm2pl@mm2pl.tmi.twitch.tv PRIVMSG #pajlada :Keepo)",
+            {
+                {{
+                    0,  // start
+                    4,  // end
+                    twitchEmotes->getOrCreateEmote(EmoteId{"1902"},
+                                                   EmoteName{"Keepo"}),  // ptr
+                    EmoteName{"Keepo"},                                  // name
+                }},
+            },
+        },
+        {
+            R"(@badge-info=;badges=no_audio/1;color=#DAA520;display-name=Mm2PL;emote-only=1;emotes=25:0-4/1902:6-10/305954156:12-19;first-msg=0;flags=;id=7be87072-bf24-4fa3-b3df-0ea6fa5f1474;mod=0;returning-chatter=0;room-id=11148817;subscriber=0;tmi-sent-ts=1662201102276;turbo=0;user-id=117691339;user-type= :mm2pl!mm2pl@mm2pl.tmi.twitch.tv PRIVMSG #pajlada :Kappa Keepo PogChamp)",
+            {
+                {
+                    {
+                        0,  // start
+                        4,  // end
+                        twitchEmotes->getOrCreateEmote(
+                            EmoteId{"25"}, EmoteName{"Kappa"}),  // ptr
+                        EmoteName{"Kappa"},                      // name
+                    },
+                    {
+                        6,   // start
+                        10,  // end
+                        twitchEmotes->getOrCreateEmote(
+                            EmoteId{"1902"}, EmoteName{"Keepo"}),  // ptr
+                        EmoteName{"Keepo"},                        // name
+                    },
+                    {
+                        12,  // start
+                        19,  // end
+                        twitchEmotes->getOrCreateEmote(
+                            EmoteId{"305954156"},
+                            EmoteName{"PogChamp"}),  // ptr
+                        EmoteName{"PogChamp"},       // name
+                    },
+                },
+            },
+        },
+        {
+            R"(@badge-info=subscriber/80;badges=broadcaster/1,subscriber/3072,partner/1;color=#CC44FF;display-name=pajlada;emote-only=1;emotes=25:0-4,6-10;first-msg=0;flags=;id=f7516287-e5d1-43ca-974e-fe0cff84400b;mod=0;returning-chatter=0;room-id=11148817;subscriber=1;tmi-sent-ts=1662204375009;turbo=0;user-id=11148817;user-type= :pajlada!pajlada@pajlada.tmi.twitch.tv PRIVMSG #pajlada :Kappa Kappa)",
+            {
+                {
+                    {
+                        0,  // start
+                        4,  // end
+                        twitchEmotes->getOrCreateEmote(
+                            EmoteId{"25"}, EmoteName{"Kappa"}),  // ptr
+                        EmoteName{"Kappa"},                      // name
+                    },
+                    {
+                        6,   // start
+                        10,  // end
+                        twitchEmotes->getOrCreateEmote(
+                            EmoteId{"25"}, EmoteName{"Kappa"}),  // ptr
+                        EmoteName{"Kappa"},                      // name
+                    },
+                },
+            },
+        },
+        {
+            R"(@badge-info=subscriber/80;badges=broadcaster/1,subscriber/3072,partner/1;color=#CC44FF;display-name=pajlada;emotes=25:0-4,8-12;first-msg=0;flags=;id=44f85d39-b5fb-475d-8555-f4244f2f7e82;mod=0;returning-chatter=0;room-id=11148817;subscriber=1;tmi-sent-ts=1662204423418;turbo=0;user-id=11148817;user-type= :pajlada!pajlada@pajlada.tmi.twitch.tv PRIVMSG #pajlada :Kappa 😂 Kappa)",
+            {
+                {
+                    {
+                        0,  // start
+                        4,  // end
+                        twitchEmotes->getOrCreateEmote(
+                            EmoteId{"25"}, EmoteName{"Kappa"}),  // ptr
+                        EmoteName{"Kappa"},                      // name
+                    },
+                    {
+                        9,   // start - modified due to emoji
+                        13,  // end - modified due to emoji
+                        twitchEmotes->getOrCreateEmote(
+                            EmoteId{"25"}, EmoteName{"Kappa"}),  // ptr
+                        EmoteName{"Kappa"},                      // name
+                    },
+                },
+            },
+        },
+        {
+            // start out of range
+            R"(@emotes=84608:9-10 :test!test@test.tmi.twitch.tv PRIVMSG #pajlada :foo bar)",
+            {},
+        },
+        {
+            // one character emote
+            R"(@emotes=84608:0-0 :test!test@test.tmi.twitch.tv PRIVMSG #pajlada :foo bar)",
+            {
+                {
+                    0,  // start
+                    0,  // end
+                    twitchEmotes->getOrCreateEmote(EmoteId{"84608"},
+                                                   EmoteName{"f"}),  // ptr
+                    EmoteName{"f"},                                  // name
+                },
+            },
+        },
+        {
+            // two character emote
+            R"(@emotes=84609:0-1 :test!test@test.tmi.twitch.tv PRIVMSG #pajlada :foo bar)",
+            {
+                {
+                    0,  // start
+                    1,  // end
+                    twitchEmotes->getOrCreateEmote(EmoteId{"84609"},
+                                                   EmoteName{"fo"}),  // ptr
+                    EmoteName{"fo"},                                  // name
+                },
+            },
+        },
+        {
+            // end out of range
+            R"(@emotes=84608:0-15 :test!test@test.tmi.twitch.tv PRIVMSG #pajlada :foo bar)",
+            {},
+        },
+        {
+            // range bad (end character before start)
+            R"(@emotes=84608:15-2 :test!test@test.tmi.twitch.tv PRIVMSG #pajlada :foo bar)",
+            {},
+        },
+    };
+
+    for (const auto &test : testCases)
+    {
+        auto *privmsg = static_cast<Communi::IrcPrivateMessage *>(
+            Communi::IrcPrivateMessage::fromData(test.input, nullptr));
+        QString originalMessage = privmsg->content();
+
+        auto actualTwitchEmotes = TwitchMessageBuilder::parseTwitchEmotes(
+            privmsg->tags(), originalMessage);
+
+        EXPECT_EQ(actualTwitchEmotes, test.expectedTwitchEmotes)
+            << "Input for twitch emotes " << test.input.toStdString()
+            << " failed";
     }
 }

--- a/tests/src/TwitchMessageBuilder.cpp
+++ b/tests/src/TwitchMessageBuilder.cpp
@@ -122,6 +122,22 @@ TEST(TwitchMessageBuilder, CommaSeparatedListTagParsing)
     }
 }
 
+class TestTwitchMessageBuilder : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        this->mockApplication = std::make_unique<MockApplication>();
+    }
+
+    void TearDown() override
+    {
+        this->mockApplication.reset();
+    }
+
+    std::unique_ptr<MockApplication> mockApplication;
+};
+
 TEST(TwitchMessageBuilder, BadgeInfoParsing)
 {
     struct TestCase {
@@ -194,15 +210,14 @@ TEST(TwitchMessageBuilder, BadgeInfoParsing)
     }
 }
 
-TEST(TwitchMessageBuilder, ParseTwitchEmotes)
+TEST_F(TestTwitchMessageBuilder, ParseTwitchEmotes)
 {
-    auto mockApplication = std::make_unique<MockApplication>();
     struct TestCase {
         QByteArray input;
         std::vector<TwitchEmoteOccurrence> expectedTwitchEmotes;
     };
 
-    auto *twitchEmotes = mockApplication->getEmotes()->getTwitchEmotes();
+    auto *twitchEmotes = this->mockApplication->getEmotes()->getTwitchEmotes();
 
     std::vector<TestCase> testCases{
         {

--- a/tests/src/TwitchMessageBuilder.cpp
+++ b/tests/src/TwitchMessageBuilder.cpp
@@ -195,7 +195,7 @@ TEST(TwitchMessageBuilder, ParseTwitchEmotes)
     auto mockApplication = std::make_unique<MockApplication>();
     struct TestCase {
         QByteArray input;
-        std::vector<TwitchEmoteOccurence> expectedTwitchEmotes;
+        std::vector<TwitchEmoteOccurrence> expectedTwitchEmotes;
     };
 
     auto *twitchEmotes = mockApplication->getEmotes()->getTwitchEmotes();

--- a/tests/src/TwitchMessageBuilder.cpp
+++ b/tests/src/TwitchMessageBuilder.cpp
@@ -378,7 +378,7 @@ TEST_F(TestTwitchMessageBuilder, ParseTwitchEmotes)
         QString originalMessage = privmsg->content();
 
         auto actualTwitchEmotes = TwitchMessageBuilder::parseTwitchEmotes(
-            privmsg->tags(), originalMessage);
+            privmsg->tags(), originalMessage, 0);
 
         EXPECT_EQ(actualTwitchEmotes, test.expectedTwitchEmotes)
             << "Input for twitch emotes " << test.input.toStdString()

--- a/tests/src/TwitchMessageBuilder.cpp
+++ b/tests/src/TwitchMessageBuilder.cpp
@@ -377,6 +377,7 @@ TEST_F(TestTwitchMessageBuilder, ParseTwitchEmotes)
             Communi::IrcPrivateMessage::fromData(test.input, nullptr));
         QString originalMessage = privmsg->content();
 
+        // TODO: Add tests with replies
         auto actualTwitchEmotes = TwitchMessageBuilder::parseTwitchEmotes(
             privmsg->tags(), originalMessage, 0);
 

--- a/tests/src/TwitchMessageBuilder.cpp
+++ b/tests/src/TwitchMessageBuilder.cpp
@@ -202,6 +202,19 @@ TEST(TwitchMessageBuilder, ParseTwitchEmotes)
 
     std::vector<TestCase> testCases{
         {
+            // action /me message
+            R"(@badge-info=subscriber/80;badges=broadcaster/1,subscriber/3072,partner/1;color=#CC44FF;display-name=pajlada;emote-only=1;emotes=25:0-4;first-msg=0;flags=;id=90ef1e46-8baa-4bf2-9c54-272f39d6fa11;mod=0;returning-chatter=0;room-id=11148817;subscriber=1;tmi-sent-ts=1662206235860;turbo=0;user-id=11148817;user-type= :pajlada!pajlada@pajlada.tmi.twitch.tv PRIVMSG #pajlada :ACTION Kappa)",
+            {
+                {{
+                    0,  // start
+                    4,  // end
+                    twitchEmotes->getOrCreateEmote(EmoteId{"25"},
+                                                   EmoteName{"Kappa"}),  // ptr
+                    EmoteName{"Kappa"},                                  // name
+                }},
+            },
+        },
+        {
             R"(@badge-info=subscriber/17;badges=subscriber/12,no_audio/1;color=#EBA2C0;display-name=jammehcow;emote-only=1;emotes=25:0-4;first-msg=0;flags=;id=9c2dd916-5a6d-4c1f-9fe7-a081b62a9c6b;mod=0;returning-chatter=0;room-id=11148817;subscriber=1;tmi-sent-ts=1662201093248;turbo=0;user-id=82674227;user-type= :jammehcow!jammehcow@jammehcow.tmi.twitch.tv PRIVMSG #pajlada :Kappa)",
             {
                 {{


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Messages I tested with

#### START OUT OF RANGE
`/fakemsg @emotes=84608:9-10 :test!test@test.tmi.twitch.tv PRIVMSG #pajlada :foo bar`

#### SINGLE CHARACTER EMOTE
`/fakemsg @emotes=84608:0-0 :test!test@test.tmi.twitch.tv PRIVMSG #pajlada :foo bar`

#### TWO CHARACTER EMOTE
`/fakemsg @emotes=84608:0-1 :test!test@test.tmi.twitch.tv PRIVMSG #pajlada :foo bar`

#### END OUT OF RANGE
`/fakemsg @emotes=84608:0-15 :test!test@test.tmi.twitch.tv PRIVMSG #pajlada :foo bar`

#### RANGE BAD
`/fakemsg @emotes=84608:15-2 :test!test@test.tmi.twitch.tv PRIVMSG #pajlada :foo bar`

#### MESSAGE FROM KARL-POLICE
`/fakemsg @badge-info=;badges=glhf-pledge/1;client-nonce=5d2627b0cbe56fa05faf5420def4807d;color=#1E90FF;display-name=oldcoeur;emote-only=1;emotes=84608:0-7;first-msg=1;flags=;id=7412fea4-8683-4cc9-a506-4228127a5c2d;mod=0;room-id=62300805;subscriber=0;tmi-sent-ts=1623429859222;turbo=0;user-id=139147886;user-type= :oldcoeur!oldcoeur@oldcoeur.tmi.twitch.tv PRIVMSG #test :test`

To test with these messages, join #test and #pajlada

Fixes #3487

Not adding a changelog entry as it doesn't fix an actual user-discoverable bug

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
