### PR TITLE
Reduce GIF frame window from 30ms to 20ms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Minor: Added `/copy` command. Usage: `/copy <text>`. Copies provided text to clipboard - can be useful with custom commands. (#3763)
 - Minor: Removed total views from the usercard, as Twitch no longer updates the number. (#3792)
 - Minor: Add Quick Switcher item to open a channel in a new popup window. (#3828)
+- Minor: Reduced GIF frame window from 30ms to 20ms, causing fewer frame skips in animated emotes. (#3886)
 - Bugfix: Fix crash that can occur when closing and quickly reopening a split, then running a command. (#3852)
 - Bugfix: Connection to Twitch PubSub now recovers more reliably. (#3643, #3716)
 - Bugfix: Fix crash that can occur when changing channels. (#3799)

--- a/src/singletons/helper/GifTimer.cpp
+++ b/src/singletons/helper/GifTimer.cpp
@@ -8,7 +8,7 @@ namespace chatterino {
 
 void GIFTimer::initialize()
 {
-    this->timer.setInterval(30);
+    this->timer.setInterval(gifFrameLength);
 
     getSettings()->animateEmotes.connect([this](bool enabled, auto) {
         if (enabled)

--- a/src/singletons/helper/GifTimer.hpp
+++ b/src/singletons/helper/GifTimer.hpp
@@ -5,7 +5,7 @@
 
 namespace chatterino {
 
-constexpr long unsigned gifFrameLength = 33;
+constexpr long unsigned gifFrameLength = 20;
 
 class GIFTimer
 {


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Currently the check for the next animated frame is every 30ms which happens to be too slow for the gif standard, the maximum speed of a gif is 20ms per frame.

An edge case would be when a gif only has 2 frames
| Frame Number | Frame delay|
|:-:|:-:|
| 1 | 20ms | 
| 2 | 20ms |

The total frame duration is 40ms

In the current implementation, if we start at a 0 offset

| Offset | Offset mod 40 | Time Passed| Frame Displayed |
|:-:|:-:|:-:|:-:|
| 0 | 0 | 0ms | 1 |
| 33 | 33 | 30ms | 2 |
| 66 | 26 | 60ms | 2 |
| 99 | 19 | 90ms | 1 |
| 132 | 12 | 120ms | 1 |

As you can see the frames are duplicated when they shouldn't be. 

Its like a train station with trains ever 30ms and we are only ready to board every 20ms, and since we are impatient we miss our train. 

Perhaps a smarter way of detecting which frame to select is a more performant approach however I haven't thought of how to do that. Or we could just say that 30ms is the min frame timing instead of 20ms

fixes https://github.com/SevenTV/chatterino7/issues/85
