### PR TITLE
Drop trailing whitespace from Twitch system messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - Bugfix: Adopt popup windows in order to force floating behavior on some window managers. (#3836)
 - Bugfix: Fix split focusing being broken in certain circumstances when the "Show input when it's empty" setting was disabled. (#3838, #3860)
 - Bugfix: Always refresh tab when a contained split's channel is set. (#3849)
+- Bugfix: Drop trailing whitespace from Twitch system messages. (#3888)
 - Dev: Remove official support for QMake. (#3839, #3883)
 - Dev: Rewrite LimitedQueue (#3798)
 - Dev: Overhaul highlight system by moving all checks into a Controller allowing for easier tests. (#3399, #3801, #3835)

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -185,7 +185,8 @@ MessageBuilder::MessageBuilder(SystemMessageTag, const QString &text,
 
     // check system message for links
     // (e.g. needed for sub ticket message in sub only mode)
-    const QStringList textFragments = text.split(QRegularExpression("\\s"));
+    const QStringList textFragments = text.split(QRegularExpression("\\s"),
+                                                 Qt::SkipEmptyParts);
     for (const auto &word : textFragments)
     {
         const auto linkString = this->matchLink(word);

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -12,6 +12,7 @@
 #include "singletons/Resources.hpp"
 #include "singletons/Theme.hpp"
 #include "util/FormatTime.hpp"
+#include "util/Qt.hpp"
 
 #include <QDateTime>
 

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -190,15 +190,14 @@ MessageBuilder::MessageBuilder(SystemMessageTag, const QString &text,
     for (const auto &word : textFragments)
     {
         const auto linkString = this->matchLink(word);
-        if (linkString.isEmpty())
-        {
-            this->emplace<TextElement>(word, MessageElementFlag::Text,
-                                       MessageColor::System);
-        }
-        else
+        if (!linkString.isEmpty())
         {
             this->addLink(word, linkString);
+            continue;
         }
+
+        this->emplace<TextElement>(word, MessageElementFlag::Text,
+                                   MessageColor::System);
     }
     this->message().flags.set(MessageFlag::System);
     this->message().flags.set(MessageFlag::DoNotTriggerNotification);

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -185,8 +185,8 @@ MessageBuilder::MessageBuilder(SystemMessageTag, const QString &text,
 
     // check system message for links
     // (e.g. needed for sub ticket message in sub only mode)
-    const QStringList textFragments = text.split(QRegularExpression("\\s"),
-                                                 Qt::SkipEmptyParts);
+    const QStringList textFragments =
+        text.split(QRegularExpression("\\s"), Qt::SkipEmptyParts);
     for (const auto &word : textFragments)
     {
         const auto linkString = this->matchLink(word);


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

This PR aims to fix #3692 where Twitch would add an extra `\s` to the end of anon sub messages, causing it to wrap an "empty" line in the gift message when hitting the window's width. By skipping empty words when splitting the message, no extra whitespace is added to system messages when the `TextElement`s are rejoined.