### PR TITLE
Fix weird IRC channels causing crashes due to bad cast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - Bugfix: Fix split focusing being broken in certain circumstances when the "Show input when it's empty" setting was disabled. (#3838, #3860)
 - Bugfix: Always refresh tab when a contained split's channel is set. (#3849)
 - Bugfix: Drop trailing whitespace from Twitch system messages. (#3888)
+- Bugfix: Fix crash related to logging IRC channels (#3918)
 - Dev: Remove official support for QMake. (#3839, #3883)
 - Dev: Rewrite LimitedQueue (#3798)
 - Dev: Overhaul highlight system by moving all checks into a Controller allowing for easier tests. (#3399, #3801, #3835)

--- a/src/common/Channel.cpp
+++ b/src/common/Channel.cpp
@@ -88,9 +88,12 @@ void Channel::addMessage(MessagePtr message,
         QString channelPlatform("other");
         if (this->type_ == Type::Irc)
         {
-            auto irc = static_cast<IrcChannel *>(this);
-            channelPlatform =
-                QString("irc-%1").arg(irc->server()->userFriendlyIdentifier());
+            auto *irc = dynamic_cast<IrcChannel *>(this);
+            if (irc != nullptr)
+            {
+                channelPlatform = QString("irc-%1").arg(
+                    irc->server()->userFriendlyIdentifier());
+            }
         }
         else if (this->isTwitchChannel())
         {


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
it used to read garbage from Channel data, it doesn't anymore

test:
```
# pacman -S libfaketime

$ LD_PRELOAD=/usr/lib/faketime/libfaketimeMT.so.1 FAKETIME='@2022-08-10 23:59:50' path/to/build/bin/chatterino
```