### PR TITLE
fix: Mentions of "You" in timeouts will link to your own user now instead of the user "You"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@
 - Bugfix: Always refresh tab when a contained split's channel is set. (#3849)
 - Bugfix: Drop trailing whitespace from Twitch system messages. (#3888)
 - Bugfix: Fix crash related to logging IRC channels (#3918)
-- Bugfix: Link to the current user when they're timed out (#3922)
+- Bugfix: Mentions of "You" in timeouts will link to your own user now instead of the user "You". (#3922)
 - Dev: Remove official support for QMake. (#3839, #3883)
 - Dev: Rewrite LimitedQueue (#3798)
 - Dev: Overhaul highlight system by moving all checks into a Controller allowing for easier tests. (#3399, #3801, #3835)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 - Bugfix: Always refresh tab when a contained split's channel is set. (#3849)
 - Bugfix: Drop trailing whitespace from Twitch system messages. (#3888)
 - Bugfix: Fix crash related to logging IRC channels (#3918)
+- Bugfix: Link to the current user when they're timed out (#3922)
 - Dev: Remove official support for QMake. (#3839, #3883)
 - Dev: Rewrite LimitedQueue (#3798)
 - Dev: Overhaul highlight system by moving all checks into a Controller allowing for easier tests. (#3399, #3801, #3835)

--- a/src/common/Channel.cpp
+++ b/src/common/Channel.cpp
@@ -168,8 +168,8 @@ void Channel::addOrReplaceTimeout(MessagePtr message)
 
             int count = s->count + 1;
 
-            MessageBuilder replacement(timeoutMessage, message->searchText,
-                                       count);
+            MessageBuilder replacement(timeoutMessage, message->timeoutUser,
+                                       message->searchText, count);
 
             replacement->timeoutUser = message->timeoutUser;
             replacement->count = count;

--- a/src/common/Channel.cpp
+++ b/src/common/Channel.cpp
@@ -169,7 +169,8 @@ void Channel::addOrReplaceTimeout(MessagePtr message)
             int count = s->count + 1;
 
             MessageBuilder replacement(timeoutMessage, message->timeoutUser,
-                                       message->searchText, count);
+                                       message->loginName, message->searchText,
+                                       count);
 
             replacement->timeoutUser = message->timeoutUser;
             replacement->count = count;

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -206,18 +206,19 @@ MessageBuilder::MessageBuilder(SystemMessageTag, const QString &text,
     this->message().searchText = text;
 }
 
-MessageBuilder::MessageBuilder(TimeoutMessageTag,
+MessageBuilder::MessageBuilder(TimeoutMessageTag, const QString &username,
                                const QString &systemMessageText, int times,
                                const QTime &time)
     : MessageBuilder()
 {
-    QString username = systemMessageText.split(" ").at(0);
-    QString remainder = systemMessageText.mid(username.length() + 1);
+    QString usernamePart = systemMessageText.split(" ").at(0);
+    QString remainder = systemMessageText.mid(usernamePart.length() + 1);
 
     QString text;
 
     this->emplace<TimestampElement>(time);
-    this->emplaceSystemTextAndUpdate(username, text)
+    this->emplaceSystemTextAndUpdate(
+            usernamePart, text)  // NOLINT(readability-suspicious-call-argument)
         ->setLink({Link::UserInfo, username});
     this->emplaceSystemTextAndUpdate(
         QString("%1 (%2 times)").arg(remainder.trimmed()).arg(times), text);
@@ -290,7 +291,9 @@ MessageBuilder::MessageBuilder(const BanAction &action, uint32_t count)
 
     if (action.target.id == current->getUserId())
     {
-        this->emplaceSystemTextAndUpdate("You were", text);
+        this->emplaceSystemTextAndUpdate("You", text)
+            ->setLink({Link::UserInfo, current->getUserName()});
+        this->emplaceSystemTextAndUpdate("were", text);
         if (action.isBan())
         {
             this->emplaceSystemTextAndUpdate("banned", text);

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -211,20 +211,20 @@ MessageBuilder::MessageBuilder(TimeoutMessageTag, const QString &username,
                                const QTime &time)
     : MessageBuilder()
 {
-    QString usernamePart = systemMessageText.split(" ").at(0);
-    QString remainder = systemMessageText.mid(usernamePart.length() + 1);
+    QString usernameText = systemMessageText.split(" ").at(0);
+    QString remainder = systemMessageText.mid(usernameText.length() + 1);
 
-    QString text;
+    QString messageText;
 
     this->emplace<TimestampElement>(time);
-    this->emplaceSystemTextAndUpdate(
-            usernamePart, text)  // NOLINT(readability-suspicious-call-argument)
+    this->emplaceSystemTextAndUpdate(usernameText, messageText)
         ->setLink({Link::UserInfo, username});
     this->emplaceSystemTextAndUpdate(
-        QString("%1 (%2 times)").arg(remainder.trimmed()).arg(times), text);
+        QString("%1 (%2 times)").arg(remainder.trimmed()).arg(times),
+        messageText);
 
-    this->message().messageText = text;
-    this->message().searchText = text;
+    this->message().messageText = messageText;
+    this->message().searchText = messageText;
 }
 
 MessageBuilder::MessageBuilder(TimeoutMessageTag, const QString &username,

--- a/src/messages/MessageBuilder.hpp
+++ b/src/messages/MessageBuilder.hpp
@@ -44,8 +44,9 @@ public:
     MessageBuilder();
     MessageBuilder(SystemMessageTag, const QString &text,
                    const QTime &time = QTime::currentTime());
-    MessageBuilder(TimeoutMessageTag, const QString &systemMessageText,
-                   int times, const QTime &time = QTime::currentTime());
+    MessageBuilder(TimeoutMessageTag, const QString &username,
+                   const QString &systemMessageText, int times,
+                   const QTime &time = QTime::currentTime());
     MessageBuilder(TimeoutMessageTag, const QString &username,
                    const QString &durationInSeconds, bool multipleTimes,
                    const QTime &time = QTime::currentTime());

--- a/src/messages/MessageBuilder.hpp
+++ b/src/messages/MessageBuilder.hpp
@@ -44,9 +44,9 @@ public:
     MessageBuilder();
     MessageBuilder(SystemMessageTag, const QString &text,
                    const QTime &time = QTime::currentTime());
-    MessageBuilder(TimeoutMessageTag, const QString &username,
-                   const QString &systemMessageText, int times,
-                   const QTime &time = QTime::currentTime());
+    MessageBuilder(TimeoutMessageTag, const QString &timeoutUser,
+                   const QString &sourceUser, const QString &systemMessageText,
+                   int times, const QTime &time = QTime::currentTime());
     MessageBuilder(TimeoutMessageTag, const QString &username,
                    const QString &durationInSeconds, bool multipleTimes,
                    const QTime &time = QTime::currentTime());


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

* When the current user is timed out once no link was added.
* When the current user is timed out again a link to the user `You` was added.
