### PR TITLE
Added minimal supported macOS version to CI builds.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,6 +197,7 @@ jobs:
             cd build
             cmake \
                 -DCMAKE_BUILD_TYPE=Release \
+                -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 \
                 -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl \
                 -DUSE_PRECOMPILED_HEADERS=${{ matrix.pch }} \
                 ..


### PR DESCRIPTION
Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable

# Description

Recently, nightly builds stopped working on macOS with outdated versions (I guess this is caused by the `macos-latest` being `macos-11.0`).

<details><summary>Popup</summary>
<img width="420" alt="image" src="https://user-images.githubusercontent.com/4051126/184540749-785228d6-12fd-4ae0-8b69-c328c109898e.png">
</details>

That makes me sad.
Let's support macOS Catalina for a while.