### PR TITLE
Fix crash when adding recent messages to empty Channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 - Minor: Removed total views from the usercard, as Twitch no longer updates the number. (#3792)
 - Minor: Add Quick Switcher item to open a channel in a new popup window. (#3828)
 - Minor: Warn when parsing an environment variable fails. (#3904)
-- Minor: Load missing messages from Recent Messages API upon reconnecting (#3878)
+- Minor: Load missing messages from Recent Messages API upon reconnecting (#3878, #3932)
 - Bugfix: Fix crash that can occur when closing and quickly reopening a split, then running a command. (#3852)
 - Bugfix: Connection to Twitch PubSub now recovers more reliably. (#3643, #3716)
 - Bugfix: Fix crash that can occur when changing channels. (#3799)

--- a/src/common/Channel.cpp
+++ b/src/common/Channel.cpp
@@ -237,7 +237,20 @@ void Channel::addMessagesAtStart(const std::vector<MessagePtr> &_messages)
 
 void Channel::fillInMissingMessages(const std::vector<MessagePtr> &messages)
 {
+    if (messages.empty())
+    {
+        return;
+    }
+
     auto snapshot = this->getMessageSnapshot();
+    if (snapshot.size() == 0)
+    {
+        // There are no messages in this channel yet so we can just insert them
+        // at the front in order
+        this->messages_.pushFront(messages);
+        this->filledInMessages.invoke(messages);
+        return;
+    }
 
     std::unordered_set<QString> existingMessageIds;
     existingMessageIds.reserve(snapshot.size());


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

When loading recent messages upon reconnecting, we would blindly assume that the channel already had at least one message in it. However, in the case that it somehow doesn't, we would index out of bounds of our `snapshot` and crash. 

This PR adds checks for empty channels (and empty loaded recent messages).

Fixes #3930

(Note: I haven't verified this _actually_ fixes the crash because I can't reproduce it on my own. However, the stack trace provided by Felanbird strongly suggests this should fix the crash).