### PR TITLE
feat: add settings to toggle BTTV/FFZ global/channel emotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Minor: Add Quick Switcher item to open a channel in a new popup window. (#3828)
 - Minor: Warn when parsing an environment variable fails. (#3904)
 - Minor: Load missing messages from Recent Messages API upon reconnecting (#3878, #3932)
+- Minor: Add settings to toggle BTTV/FFZ global/channel emotes (#3935)
 - Bugfix: Fix crash that can occur when closing and quickly reopening a split, then running a command. (#3852)
 - Bugfix: Connection to Twitch PubSub now recovers more reliably. (#3643, #3716)
 - Bugfix: Fix crash that can occur when changing channels. (#3799)

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -179,6 +179,19 @@ int Application::run(QApplication &qtApp)
         this->windows->forceLayoutChannelViews();
     });
 
+    getSettings()->bttvGlobalEmotes.connect([this] {
+        this->twitch->reloadBttvGlobalEmotes();
+    });
+    getSettings()->bttvChannelEmotes.connect([this] {
+        this->twitch->reloadAllBttvChannelEmotes();
+    });
+    getSettings()->ffzGlobalEmotes.connect([this] {
+        this->twitch->reloadFfzGlobalEmotes();
+    });
+    getSettings()->ffzChannelEmotes.connect([this] {
+        this->twitch->reloadAllFfzChannelEmotes();
+    });
+
     return qtApp.exec();
 }
 

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -179,16 +179,16 @@ int Application::run(QApplication &qtApp)
         this->windows->forceLayoutChannelViews();
     });
 
-    getSettings()->bttvGlobalEmotes.connect([this] {
+    getSettings()->enableBTTVGlobalEmotes.connect([this] {
         this->twitch->reloadBTTVGlobalEmotes();
     });
-    getSettings()->bttvChannelEmotes.connect([this] {
+    getSettings()->enableBTTVChannelEmotes.connect([this] {
         this->twitch->reloadAllBTTVChannelEmotes();
     });
-    getSettings()->ffzGlobalEmotes.connect([this] {
+    getSettings()->enableFFZGlobalEmotes.connect([this] {
         this->twitch->reloadFFZGlobalEmotes();
     });
-    getSettings()->ffzChannelEmotes.connect([this] {
+    getSettings()->enableFFZChannelEmotes.connect([this] {
         this->twitch->reloadAllFFZChannelEmotes();
     });
 

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -180,16 +180,16 @@ int Application::run(QApplication &qtApp)
     });
 
     getSettings()->bttvGlobalEmotes.connect([this] {
-        this->twitch->reloadBttvGlobalEmotes();
+        this->twitch->reloadBTTVGlobalEmotes();
     });
     getSettings()->bttvChannelEmotes.connect([this] {
-        this->twitch->reloadAllBttvChannelEmotes();
+        this->twitch->reloadAllBTTVChannelEmotes();
     });
     getSettings()->ffzGlobalEmotes.connect([this] {
-        this->twitch->reloadFfzGlobalEmotes();
+        this->twitch->reloadFFZGlobalEmotes();
     });
     getSettings()->ffzChannelEmotes.connect([this] {
-        this->twitch->reloadAllFfzChannelEmotes();
+        this->twitch->reloadAllFFZChannelEmotes();
     });
 
     return qtApp.exec();

--- a/src/messages/Emote.hpp
+++ b/src/messages/Emote.hpp
@@ -34,6 +34,9 @@ using EmoteIdMap = std::unordered_map<EmoteId, EmotePtr>;
 using WeakEmoteMap = std::unordered_map<EmoteName, std::weak_ptr<const Emote>>;
 using WeakEmoteIdMap = std::unordered_map<EmoteId, std::weak_ptr<const Emote>>;
 
+static const std::shared_ptr<const EmoteMap> EMPTY_EMOTE_MAP = std::make_shared<
+    const EmoteMap>();  // NOLINT(cert-err58-cpp) -- assume this doesn't throw an exception
+
 EmotePtr cachedOrMakeEmotePtr(Emote &&emote, const EmoteMap &cache);
 EmotePtr cachedOrMakeEmotePtr(
     Emote &&emote,

--- a/src/providers/bttv/BttvEmotes.cpp
+++ b/src/providers/bttv/BttvEmotes.cpp
@@ -142,7 +142,7 @@ boost::optional<EmotePtr> BttvEmotes::emote(const EmoteName &name) const
 
 void BttvEmotes::loadEmotes()
 {
-    if (!Settings::instance().bttvGlobalEmotes)
+    if (!Settings::instance().enableBTTVGlobalEmotes)
     {
         this->global_.set(EMPTY_EMOTE_MAP);
         return;

--- a/src/providers/bttv/BttvEmotes.cpp
+++ b/src/providers/bttv/BttvEmotes.cpp
@@ -11,6 +11,7 @@
 #include "messages/ImageSet.hpp"
 #include "messages/MessageBuilder.hpp"
 #include "providers/twitch/TwitchChannel.hpp"
+#include "singletons/Settings.hpp"
 
 namespace chatterino {
 namespace {
@@ -141,6 +142,12 @@ boost::optional<EmotePtr> BttvEmotes::emote(const EmoteName &name) const
 
 void BttvEmotes::loadEmotes()
 {
+    if (!Settings::instance().bttvGlobalEmotes)
+    {
+        this->global_.set(EMPTY_EMOTE_MAP);
+        return;
+    }
+
     NetworkRequest(QString(globalEmoteApiUrl))
         .timeout(30000)
         .onSuccess([this](auto result) -> Outcome {

--- a/src/providers/ffz/FfzEmotes.cpp
+++ b/src/providers/ffz/FfzEmotes.cpp
@@ -182,7 +182,7 @@ boost::optional<EmotePtr> FfzEmotes::emote(const EmoteName &name) const
 
 void FfzEmotes::loadEmotes()
 {
-    if (!Settings::instance().ffzGlobalEmotes)
+    if (!Settings::instance().enableFFZGlobalEmotes)
     {
         this->global_.set(EMPTY_EMOTE_MAP);
         return;

--- a/src/providers/ffz/FfzEmotes.cpp
+++ b/src/providers/ffz/FfzEmotes.cpp
@@ -9,6 +9,7 @@
 #include "messages/Image.hpp"
 #include "messages/MessageBuilder.hpp"
 #include "providers/twitch/TwitchChannel.hpp"
+#include "singletons/Settings.hpp"
 
 namespace chatterino {
 namespace {
@@ -181,6 +182,12 @@ boost::optional<EmotePtr> FfzEmotes::emote(const EmoteName &name) const
 
 void FfzEmotes::loadEmotes()
 {
+    if (!Settings::instance().ffzGlobalEmotes)
+    {
+        this->global_.set(EMPTY_EMOTE_MAP);
+        return;
+    }
+
     QString url("https://api.frankerfacez.com/v1/set/global");
 
     NetworkRequest(url)

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -197,7 +197,7 @@ void TwitchChannel::setLocalizedName(const QString &name)
 
 void TwitchChannel::refreshBTTVChannelEmotes(bool manualRefresh)
 {
-    if (!Settings::instance().bttvChannelEmotes)
+    if (!Settings::instance().enableBTTVChannelEmotes)
     {
         this->bttvEmotes_.set(EMPTY_EMOTE_MAP);
         return;
@@ -215,7 +215,7 @@ void TwitchChannel::refreshBTTVChannelEmotes(bool manualRefresh)
 
 void TwitchChannel::refreshFFZChannelEmotes(bool manualRefresh)
 {
-    if (!Settings::instance().ffzChannelEmotes)
+    if (!Settings::instance().enableFFZChannelEmotes)
     {
         this->ffzEmotes_.set(EMPTY_EMOTE_MAP);
         return;

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -197,6 +197,12 @@ void TwitchChannel::setLocalizedName(const QString &name)
 
 void TwitchChannel::refreshBTTVChannelEmotes(bool manualRefresh)
 {
+    if (!Settings::instance().bttvChannelEmotes)
+    {
+        this->bttvEmotes_.set(EMPTY_EMOTE_MAP);
+        return;
+    }
+
     BttvEmotes::loadChannel(
         weakOf<Channel>(this), this->roomId(), this->getLocalizedName(),
         [this, weak = weakOf<Channel>(this)](auto &&emoteMap) {
@@ -209,6 +215,12 @@ void TwitchChannel::refreshBTTVChannelEmotes(bool manualRefresh)
 
 void TwitchChannel::refreshFFZChannelEmotes(bool manualRefresh)
 {
+    if (!Settings::instance().ffzChannelEmotes)
+    {
+        this->ffzEmotes_.set(EMPTY_EMOTE_MAP);
+        return;
+    }
+
     FfzEmotes::loadChannel(
         weakOf<Channel>(this), this->roomId(),
         [this, weak = weakOf<Channel>(this)](auto &&emoteMap) {

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -52,8 +52,8 @@ void TwitchIrcServer::initialize(Settings &settings, Paths &paths)
         });
     });
 
-    this->reloadBttvGlobalEmotes();
-    this->reloadFfzGlobalEmotes();
+    this->reloadBTTVGlobalEmotes();
+    this->reloadFFZGlobalEmotes();
 
     /* Refresh all twitch channel's live status in bulk every 30 seconds after starting chatterino */
     QObject::connect(&this->bulkLiveStatusTimer_, &QTimer::timeout, [=] {
@@ -468,12 +468,12 @@ const FfzEmotes &TwitchIrcServer::getFfzEmotes() const
     return this->ffz;
 }
 
-void TwitchIrcServer::reloadBttvGlobalEmotes()
+void TwitchIrcServer::reloadBTTVGlobalEmotes()
 {
     this->bttv.loadEmotes();
 }
 
-void TwitchIrcServer::reloadAllBttvChannelEmotes()
+void TwitchIrcServer::reloadAllBTTVChannelEmotes()
 {
     this->forEachChannel([](const auto &chan) {
         if (auto *channel = dynamic_cast<TwitchChannel *>(chan.get()))
@@ -483,12 +483,12 @@ void TwitchIrcServer::reloadAllBttvChannelEmotes()
     });
 }
 
-void TwitchIrcServer::reloadFfzGlobalEmotes()
+void TwitchIrcServer::reloadFFZGlobalEmotes()
 {
     this->ffz.loadEmotes();
 }
 
-void TwitchIrcServer::reloadAllFfzChannelEmotes()
+void TwitchIrcServer::reloadAllFFZChannelEmotes()
 {
     this->forEachChannel([](const auto &chan) {
         if (auto *channel = dynamic_cast<TwitchChannel *>(chan.get()))

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -52,8 +52,8 @@ void TwitchIrcServer::initialize(Settings &settings, Paths &paths)
         });
     });
 
-    this->bttv.loadEmotes();
-    this->ffz.loadEmotes();
+    this->reloadBttvGlobalEmotes();
+    this->reloadFfzGlobalEmotes();
 
     /* Refresh all twitch channel's live status in bulk every 30 seconds after starting chatterino */
     QObject::connect(&this->bulkLiveStatusTimer_, &QTimer::timeout, [=] {
@@ -468,4 +468,33 @@ const FfzEmotes &TwitchIrcServer::getFfzEmotes() const
     return this->ffz;
 }
 
+void TwitchIrcServer::reloadBttvGlobalEmotes()
+{
+    this->bttv.loadEmotes();
+}
+
+void TwitchIrcServer::reloadAllBttvChannelEmotes()
+{
+    this->forEachChannel([](const auto &chan) {
+        if (auto *channel = dynamic_cast<TwitchChannel *>(chan.get()))
+        {
+            channel->refreshBTTVChannelEmotes(false);
+        }
+    });
+}
+
+void TwitchIrcServer::reloadFfzGlobalEmotes()
+{
+    this->ffz.loadEmotes();
+}
+
+void TwitchIrcServer::reloadAllFfzChannelEmotes()
+{
+    this->forEachChannel([](const auto &chan) {
+        if (auto *channel = dynamic_cast<TwitchChannel *>(chan.get()))
+        {
+            channel->refreshFFZChannelEmotes(false);
+        }
+    });
+}
 }  // namespace chatterino

--- a/src/providers/twitch/TwitchIrcServer.hpp
+++ b/src/providers/twitch/TwitchIrcServer.hpp
@@ -33,6 +33,11 @@ public:
 
     void bulkRefreshLiveStatus();
 
+    void reloadBttvGlobalEmotes();
+    void reloadAllBttvChannelEmotes();
+    void reloadFfzGlobalEmotes();
+    void reloadAllFfzChannelEmotes();
+
     Atomic<QString> lastUserThatWhisperedMe;
 
     const ChannelPtr whispersChannel;

--- a/src/providers/twitch/TwitchIrcServer.hpp
+++ b/src/providers/twitch/TwitchIrcServer.hpp
@@ -33,10 +33,10 @@ public:
 
     void bulkRefreshLiveStatus();
 
-    void reloadBttvGlobalEmotes();
-    void reloadAllBttvChannelEmotes();
-    void reloadFfzGlobalEmotes();
-    void reloadAllFfzChannelEmotes();
+    void reloadBTTVGlobalEmotes();
+    void reloadAllBTTVChannelEmotes();
+    void reloadFFZGlobalEmotes();
+    void reloadAllFFZChannelEmotes();
 
     Atomic<QString> lastUserThatWhisperedMe;
 

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -201,10 +201,10 @@ public:
     BoolSetting removeSpacesBetweenEmotes = {
         "/emotes/removeSpacesBetweenEmotes", false};
 
-    BoolSetting bttvGlobalEmotes = {"/emotes/bttvGlobal", true};
-    BoolSetting bttvChannelEmotes = {"/emotes/bttvChannel", true};
-    BoolSetting ffzGlobalEmotes = {"/emotes/ffzGlobal", true};
-    BoolSetting ffzChannelEmotes = {"/emotes/ffzChannel", true};
+    BoolSetting enableBTTVGlobalEmotes = {"/emotes/bttv/global", true};
+    BoolSetting enableBTTVChannelEmotes = {"/emotes/bttv/channel", true};
+    BoolSetting enableFFZGlobalEmotes = {"/emotes/ffz/global", true};
+    BoolSetting enableFFZChannelEmotes = {"/emotes/ffz/channel", true};
 
     /// Links
     BoolSetting linksDoubleClickOnly = {"/links/doubleClickToOpen", false};

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -201,6 +201,11 @@ public:
     BoolSetting removeSpacesBetweenEmotes = {
         "/emotes/removeSpacesBetweenEmotes", false};
 
+    BoolSetting bttvGlobalEmotes = {"/emotes/bttvGlobal", true};
+    BoolSetting bttvChannelEmotes = {"/emotes/bttvChannel", true};
+    BoolSetting ffzGlobalEmotes = {"/emotes/ffzGlobal", true};
+    BoolSetting ffzChannelEmotes = {"/emotes/ffzChannel", true};
+
     /// Links
     BoolSetting linksDoubleClickOnly = {"/links/doubleClickToOpen", false};
     BoolSetting linkInfoTooltip = {"/links/linkInfoTooltip", false};

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -349,16 +349,28 @@ void EmotePopup::loadChannel(ChannelPtr channel)
         *globalChannel, *subChannel, this->channel_->getName());
 
     // global
-    addEmotes(*globalChannel, *getApp()->twitch->getBttvEmotes().emotes(),
-              "BetterTTV", MessageElementFlag::BttvEmote);
-    addEmotes(*globalChannel, *getApp()->twitch->getFfzEmotes().emotes(),
-              "FrankerFaceZ", MessageElementFlag::FfzEmote);
+    if (Settings::instance().bttvGlobalEmotes)
+    {
+        addEmotes(*globalChannel, *getApp()->twitch->getBttvEmotes().emotes(),
+                  "BetterTTV", MessageElementFlag::BttvEmote);
+    }
+    if (Settings::instance().ffzGlobalEmotes)
+    {
+        addEmotes(*globalChannel, *getApp()->twitch->getFfzEmotes().emotes(),
+                  "FrankerFaceZ", MessageElementFlag::FfzEmote);
+    }
 
     // channel
-    addEmotes(*channelChannel, *this->twitchChannel_->bttvEmotes(), "BetterTTV",
-              MessageElementFlag::BttvEmote);
-    addEmotes(*channelChannel, *this->twitchChannel_->ffzEmotes(),
-              "FrankerFaceZ", MessageElementFlag::FfzEmote);
+    if (Settings::instance().bttvChannelEmotes)
+    {
+        addEmotes(*channelChannel, *this->twitchChannel_->bttvEmotes(),
+                  "BetterTTV", MessageElementFlag::BttvEmote);
+    }
+    if (Settings::instance().ffzChannelEmotes)
+    {
+        addEmotes(*channelChannel, *this->twitchChannel_->ffzEmotes(),
+                  "FrankerFaceZ", MessageElementFlag::FfzEmote);
+    }
 
     this->globalEmotesView_->setChannel(globalChannel);
     this->subEmotesView_->setChannel(subChannel);

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -349,24 +349,24 @@ void EmotePopup::loadChannel(ChannelPtr channel)
         *globalChannel, *subChannel, this->channel_->getName());
 
     // global
-    if (Settings::instance().bttvGlobalEmotes)
+    if (Settings::instance().enableBTTVGlobalEmotes)
     {
         addEmotes(*globalChannel, *getApp()->twitch->getBttvEmotes().emotes(),
                   "BetterTTV", MessageElementFlag::BttvEmote);
     }
-    if (Settings::instance().ffzGlobalEmotes)
+    if (Settings::instance().enableFFZGlobalEmotes)
     {
         addEmotes(*globalChannel, *getApp()->twitch->getFfzEmotes().emotes(),
                   "FrankerFaceZ", MessageElementFlag::FfzEmote);
     }
 
     // channel
-    if (Settings::instance().bttvChannelEmotes)
+    if (Settings::instance().enableBTTVChannelEmotes)
     {
         addEmotes(*channelChannel, *this->twitchChannel_->bttvEmotes(),
                   "BetterTTV", MessageElementFlag::BttvEmote);
     }
-    if (Settings::instance().ffzChannelEmotes)
+    if (Settings::instance().enableFFZChannelEmotes)
     {
         addEmotes(*channelChannel, *this->twitchChannel_->ffzEmotes(),
                   "FrankerFaceZ", MessageElementFlag::FfzEmote);

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -346,10 +346,10 @@ void GeneralPage::initLayout(GeneralPageView &layout)
                            "Google",
                        },
                        s.emojiSet);
-    layout.addCheckbox("Show BTTV global emotes", s.bttvGlobalEmotes);
-    layout.addCheckbox("Show BTTV channel emotes", s.bttvChannelEmotes);
-    layout.addCheckbox("Show FFZ global emotes", s.ffzGlobalEmotes);
-    layout.addCheckbox("Show FFZ channel emotes", s.ffzChannelEmotes);
+    layout.addCheckbox("Show BTTV global emotes", s.enableBTTVGlobalEmotes);
+    layout.addCheckbox("Show BTTV channel emotes", s.enableBTTVChannelEmotes);
+    layout.addCheckbox("Show FFZ global emotes", s.enableFFZGlobalEmotes);
+    layout.addCheckbox("Show FFZ channel emotes", s.enableFFZChannelEmotes);
 
     layout.addTitle("Streamer Mode");
     layout.addDescription(

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -346,6 +346,10 @@ void GeneralPage::initLayout(GeneralPageView &layout)
                            "Google",
                        },
                        s.emojiSet);
+    layout.addCheckbox("Show BTTV global emotes", s.bttvGlobalEmotes);
+    layout.addCheckbox("Show BTTV channel emotes", s.bttvChannelEmotes);
+    layout.addCheckbox("Show FFZ global emotes", s.ffzGlobalEmotes);
+    layout.addCheckbox("Show FFZ channel emotes", s.ffzChannelEmotes);
 
     layout.addTitle("Streamer Mode");
     layout.addDescription(


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

In preparation to adding 7TV support, which users should be able to turn off, this PR adds settings to turn toggle BTTV/FFZ global/channel emotes.