### PR TITLE
Add missing boost-circular-buffer dependency to vcpkg

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -10,6 +10,7 @@
     "boost-interprocess",
     "boost-random",
     "boost-variant",
+    "boost-circular-buffer",
     "gtest",
     "openssl",
     "qt5-multimedia",


### PR DESCRIPTION
Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable

# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
