### PR TITLE
Remove unused mutex from Emotes

### DIFF
--- a/src/providers/twitch/TwitchEmotes.hpp
+++ b/src/providers/twitch/TwitchEmotes.hpp
@@ -45,8 +45,6 @@ private:
     Url getEmoteLink(const EmoteId &id, const QString &emoteScale);
     UniqueAccess<std::unordered_map<EmoteId, std::weak_ptr<Emote>>>
         twitchEmotesCache_;
-
-    std::mutex mutex_;
 };
 
 }  // namespace chatterino


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

The mutex was initially used to limit access to the twitchEmotesCache_ member
but it's no longer necessary since it's been made a UniqueAccess type

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
