### PR TITLE
Filtering trailing/leading whitespace in username field in nicknames.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Minor: Reduced image memory usage when running Chatterino for a long time. (#3915)
 - Minor: Add settings to toggle BTTV/FFZ global/channel emotes (#3935)
 - Minor: Add AutoMod message flag filter. (#3938)
+- Minor: Added whitespace trim to username field in nicknames (#3946)
 - Bugfix: Fix crash that can occur when closing and quickly reopening a split, then running a command. (#3852)
 - Bugfix: Connection to Twitch PubSub now recovers more reliably. (#3643, #3716)
 - Bugfix: Fix crash that can occur when changing channels. (#3799)

--- a/src/controllers/nicknames/NicknamesModel.cpp
+++ b/src/controllers/nicknames/NicknamesModel.cpp
@@ -16,7 +16,7 @@ NicknamesModel::NicknamesModel(QObject *parent)
 Nickname NicknamesModel::getItemFromRow(std::vector<QStandardItem *> &row,
                                         const Nickname &original)
 {
-    return Nickname{row[0]->data(Qt::DisplayRole).toString(),
+    return Nickname{row[0]->data(Qt::DisplayRole).toString().trimmed(),
                     row[1]->data(Qt::DisplayRole).toString(),
                     row[2]->data(Qt::CheckStateRole).toBool(),
                     row[3]->data(Qt::CheckStateRole).toBool()};


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Fixed issue #3887. Added whitespace trim to nickname string in NicknamesModel.cpp