### PR TITLE
Remove comment suggesting `Build Qt` is a Linux only build step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,6 @@ jobs:
           path: "${{ github.workspace }}/qt/"
           key: ${{ runner.os }}-QtCache-${{ matrix.qt-version }}
 
-      # LINUX
       - name: Install Qt
         uses: jurplel/install-qt-action@v2
         with:


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

This can just be slapped in on Sunday or whenever the last weekend commit is pushed, no need to block other PRs with a comment removal.

<!-- [no ci] (I couldn't remember if it worked in PR body, looks like it doesn't) -->