### PR TITLE
Migrate /color command to Helix API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Minor: Added whitespace trim to username field in nicknames (#3946)
 - Minor: Added `Go to message` context menu action to search popup, mentions, usercard and reply threads. (#3953)
 - Minor: Added link back to original message that was deleted. (#3953)
+- Minor: Migrate /color command to Helix API. (#3988)
 - Bugfix: Fix crash that can occur when closing and quickly reopening a split, then running a command. (#3852)
 - Bugfix: Connection to Twitch PubSub now recovers more reliably. (#3643, #3716)
 - Bugfix: Fix crash that can occur when changing channels. (#3799)

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -1238,8 +1238,8 @@ void CommandController::initialize(Settings &, Paths &paths)
                 {
                     case HelixUpdateUserChatColorError::UserMissingScope: {
                         errorMessage +=
-                            "Missing required scope. Reauthenticate with your "
-                            "user and try again.";
+                            "Missing required scope. Re-login with your "
+                            "account and try again.";
                     }
                     break;
 

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -1208,14 +1208,6 @@ void CommandController::initialize(Settings &, Paths &paths)
             return "";
         }
 
-        // Colors retreived from https://dev.twitch.tv/docs/api/reference#update-user-chat-color 2022-09-11
-        const QStringList validColors{
-            "blue",      "blue_violet",  "cadet_blue",   "chocolate",
-            "coral",     "dodger_blue",  "firebrick",    "golden_rod",
-            "green",     "hot_pink",     "orange_red",   "red",
-            "sea_green", "spring_green", "yellow_green",
-        };
-
         auto colorString = words.value(1);
 
         if (colorString.isEmpty())
@@ -1224,7 +1216,7 @@ void CommandController::initialize(Settings &, Paths &paths)
                 QString("Usage: /color <color> - Color must be one of Twitch's "
                         "supported colors (%1) or a hex code (#000000) if you "
                         "have Turbo or Prime.")
-                    .arg(validColors.join(", "))));
+                    .arg(VALID_HELIX_COLORS.join(", "))));
             return "";
         }
 
@@ -1238,7 +1230,7 @@ void CommandController::initialize(Settings &, Paths &paths)
                         .arg(colorString);
                 channel->addMessage(makeSystemMessage(successMessage));
             },
-            [colorString, channel, validColors](auto error, auto message) {
+            [colorString, channel](auto error, auto message) {
                 QString errorMessage =
                     QString("Failed to change color to %1 - ").arg(colorString);
 
@@ -1256,7 +1248,7 @@ void CommandController::initialize(Settings &, Paths &paths)
                                                 "supported colors (%1) or a "
                                                 "hex code (#000000) if you "
                                                 "have Turbo or Prime.")
-                                            .arg(validColors.join(", "));
+                                            .arg(VALID_HELIX_COLORS.join(", "));
                     }
                     break;
 

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -1238,7 +1238,7 @@ void CommandController::initialize(Settings &, Paths &paths)
                         .arg(colorString);
                 channel->addMessage(makeSystemMessage(successMessage));
             },
-            [colorString, channel](auto error, auto message) {
+            [colorString, channel, validColors](auto error, auto message) {
                 QString errorMessage =
                     QString("Failed to change color to %1 - ").arg(colorString);
 
@@ -1248,6 +1248,15 @@ void CommandController::initialize(Settings &, Paths &paths)
                         errorMessage +=
                             "missing required scope. Reauthenticate with your "
                             "user and try again.";
+                    }
+                    break;
+
+                    case HelixUpdateUserChatColorError::InvalidColor: {
+                        errorMessage += QString("color must be one of Twitch's "
+                                                "supported colors (%1) or a "
+                                                "hex code (#000000) if you "
+                                                "have Turbo or Prime.")
+                                            .arg(validColors.join(", "));
                     }
                     break;
 

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -1223,7 +1223,7 @@ void CommandController::initialize(Settings &, Paths &paths)
             channel->addMessage(makeSystemMessage(
                 QString("Usage: /color <color> - Color must be one of Twitch's "
                         "supported colors (%1) or a hex code (#000000) if you "
-                        "have Turbo.")
+                        "have Turbo or Prime.")
                     .arg(validColors.join(", "))));
             return "";
         }
@@ -1255,7 +1255,7 @@ void CommandController::initialize(Settings &, Paths &paths)
                         errorMessage += QString("color must be one of Twitch's "
                                                 "supported colors (%1) or a "
                                                 "hex code (#000000) if you "
-                                                "have Turbo.")
+                                                "have Turbo or Prime.")
                                             .arg(validColors.join(", "));
                     }
                     break;

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -1208,8 +1208,6 @@ void CommandController::initialize(Settings &, Paths &paths)
             return "";
         }
 
-        auto rawColorString = words.value(1);
-
         // Colors retreived from https://dev.twitch.tv/docs/api/reference#update-user-chat-color 2022-09-11
         const QStringList validColors{
             "blue",      "blue_violet",  "cadet_blue",   "chocolate",
@@ -1218,7 +1216,9 @@ void CommandController::initialize(Settings &, Paths &paths)
             "sea_green", "spring_green", "yellow_green",
         };
 
-        if (rawColorString.isEmpty())
+        auto colorString = words.value(1);
+
+        if (colorString.isEmpty())
         {
             channel->addMessage(makeSystemMessage(
                 QString("Usage: /color <color> - Color must be one of Twitch's "
@@ -1228,18 +1228,19 @@ void CommandController::initialize(Settings &, Paths &paths)
             return "";
         }
 
+        cleanHelixColorName(colorString);
+
         getHelix()->updateUserChatColor(
-            user->getUserId(), rawColorString,
-            [rawColorString, channel] {
+            user->getUserId(), colorString,
+            [colorString, channel] {
                 QString successMessage =
                     QString("Your color has been changed to %1.")
-                        .arg(rawColorString);
+                        .arg(colorString);
                 channel->addMessage(makeSystemMessage(successMessage));
             },
-            [rawColorString, channel](auto error, auto message) {
+            [colorString, channel](auto error, auto message) {
                 QString errorMessage =
-                    QString("Failed to change color to %1 - ")
-                        .arg(rawColorString);
+                    QString("Failed to change color to %1 - ").arg(colorString);
 
                 switch (error)
                 {

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -1223,7 +1223,7 @@ void CommandController::initialize(Settings &, Paths &paths)
             channel->addMessage(makeSystemMessage(
                 QString("Usage: /color <color> - Color must be one of Twitch's "
                         "supported colors (%1) or a hex code (#000000) if you "
-                        "have Turbo or Prime.")
+                        "have Turbo.")
                     .arg(validColors.join(", "))));
             return "";
         }
@@ -1255,7 +1255,7 @@ void CommandController::initialize(Settings &, Paths &paths)
                         errorMessage += QString("color must be one of Twitch's "
                                                 "supported colors (%1) or a "
                                                 "hex code (#000000) if you "
-                                                "have Turbo or Prime.")
+                                                "have Turbo.")
                                             .arg(validColors.join(", "));
                     }
                     break;

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -1238,13 +1238,13 @@ void CommandController::initialize(Settings &, Paths &paths)
                 {
                     case HelixUpdateUserChatColorError::UserMissingScope: {
                         errorMessage +=
-                            "missing required scope. Reauthenticate with your "
+                            "Missing required scope. Reauthenticate with your "
                             "user and try again.";
                     }
                     break;
 
                     case HelixUpdateUserChatColorError::InvalidColor: {
-                        errorMessage += QString("color must be one of Twitch's "
+                        errorMessage += QString("Color must be one of Twitch's "
                                                 "supported colors (%1) or a "
                                                 "hex code (#000000) if you "
                                                 "have Turbo or Prime.")
@@ -1259,7 +1259,7 @@ void CommandController::initialize(Settings &, Paths &paths)
 
                     case HelixUpdateUserChatColorError::Unknown:
                     default: {
-                        errorMessage += "an unknown error has occurred.";
+                        errorMessage += "An unknown error has occurred.";
                     }
                     break;
                 }

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -804,7 +804,16 @@ void Helix::updateUserChatColor(
             switch (result.status())
             {
                 case 400: {
-                    failureCallback(Error::Forwarded, message);
+                    if (message.startsWith("invalid color",
+                                           Qt::CaseInsensitive))
+                    {
+                        // Handle this error specifically since it allows us to list out the available colors
+                        failureCallback(Error::InvalidColor, message);
+                    }
+                    else
+                    {
+                        failureCallback(Error::Forwarded, message);
+                    }
                 }
                 break;
 

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -770,6 +770,70 @@ void Helix::getChannelEmotes(
         .execute();
 }
 
+void Helix::updateUserChatColor(
+    QString userID, QString color, ResultCallback<> successCallback,
+    FailureCallback<HelixUpdateUserChatColorError, QString> failureCallback)
+{
+    using Error = HelixUpdateUserChatColorError;
+
+    QJsonObject payload;
+
+    payload.insert("user_id", QJsonValue(userID));
+    payload.insert("color", QJsonValue(color));
+
+    this->makeRequest("chat/color", QUrlQuery())
+        .type(NetworkRequestType::Put)
+        .header("Content-Type", "application/json")
+        .payload(QJsonDocument(payload).toJson(QJsonDocument::Compact))
+        .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
+            auto obj = result.parseJson();
+            if (result.status() != 204)
+            {
+                qCWarning(chatterinoTwitch)
+                    << "Success result for updating chat color was"
+                    << result.status() << "but we only expected it to be 204";
+            }
+
+            successCallback();
+            return Success;
+        })
+        .onError([failureCallback](auto result) {
+            auto obj = result.parseJson();
+            auto message = obj.value("message").toString();
+
+            switch (result.status())
+            {
+                case 400: {
+                    failureCallback(Error::Forwarded, message);
+                }
+                break;
+
+                case 401: {
+                    if (message.startsWith("Missing scope",
+                                           Qt::CaseInsensitive))
+                    {
+                        // Handle this error specifically because its API error is especially unfriendly
+                        failureCallback(Error::UserMissingScope, message);
+                    }
+                    else
+                    {
+                        failureCallback(Error::Forwarded, message);
+                    }
+                }
+                break;
+
+                default: {
+                    qCDebug(chatterinoTwitch)
+                        << "Unhandled error changing user color:"
+                        << result.status() << result.getData() << obj;
+                    failureCallback(Error::Unknown, message);
+                }
+                break;
+            }
+        })
+        .execute();
+};
+
 NetworkRequest Helix::makeRequest(QString url, QUrlQuery urlQuery)
 {
     assert(!url.startsWith("/"));

--- a/src/providers/twitch/api/Helix.hpp
+++ b/src/providers/twitch/api/Helix.hpp
@@ -323,6 +323,7 @@ enum class HelixAutoModMessageError {
 enum class HelixUpdateUserChatColorError {
     Unknown,
     UserMissingScope,
+    InvalidColor,
 
     // The error message is forwarded directly from the Twitch API
     Forwarded,

--- a/src/providers/twitch/api/Helix.hpp
+++ b/src/providers/twitch/api/Helix.hpp
@@ -320,9 +320,20 @@ enum class HelixAutoModMessageError {
     MessageNotFound,
 };
 
+enum class HelixUpdateUserChatColorError {
+    Unknown,
+    UserMissingScope,
+
+    // The error message is forwarded directly from the Twitch API
+    Forwarded,
+};
+
 class IHelix
 {
 public:
+    template <typename... T>
+    using FailureCallback = std::function<void(T...)>;
+
     // https://dev.twitch.tv/docs/api/reference#get-users
     virtual void fetchUsers(
         QStringList userIds, QStringList userLogins,
@@ -440,6 +451,12 @@ public:
         ResultCallback<std::vector<HelixChannelEmote>> successCallback,
         HelixFailureCallback failureCallback) = 0;
 
+    // https://dev.twitch.tv/docs/api/reference#update-user-chat-color
+    virtual void updateUserChatColor(
+        QString userID, QString color, ResultCallback<> successCallback,
+        FailureCallback<HelixUpdateUserChatColorError, QString>
+            failureCallback) = 0;
+
     virtual void update(QString clientId, QString oauthToken) = 0;
 };
 
@@ -555,6 +572,12 @@ public:
         QString broadcasterId,
         ResultCallback<std::vector<HelixChannelEmote>> successCallback,
         HelixFailureCallback failureCallback) final;
+
+    // https://dev.twitch.tv/docs/api/reference#update-user-chat-color
+    void updateUserChatColor(
+        QString userID, QString color, ResultCallback<> successCallback,
+        FailureCallback<HelixUpdateUserChatColorError, QString> failureCallback)
+        final;
 
     void update(QString clientId, QString oauthToken) final;
 

--- a/src/providers/twitch/api/README.md
+++ b/src/providers/twitch/api/README.md
@@ -6,6 +6,18 @@ this folder describes what sort of API requests we do, what permissions are requ
 
 Full Helix API reference: https://dev.twitch.tv/docs/api/reference
 
+### Adding support for a new endpoint
+
+If you're adding support for a new endpoint, these are the things you should know.
+
+1. Add a virtual function in the `IHelix` class. Naming should reflect the API name as best as possible.
+1. Override the virtual function in the `Helix` class.
+1. Mock the function in the `MockHelix` class in the `tests/src/HighlightController.cpp` file.
+1. (Optional) Make a new error enum for the failure callback.
+
+For a simple example, see the `updateUserChatColor` function and its error enum `HelixUpdateUserChatColorError`.
+The API is used in the "/color" command in [CommandController.cpp](../../../controllers/commands/CommandController.cpp)
+
 ### Get Users
 
 URL: https://dev.twitch.tv/docs/api/reference#get-users

--- a/src/util/Twitch.cpp
+++ b/src/util/Twitch.cpp
@@ -13,6 +13,7 @@ namespace {
 
     const auto TWITCH_USER_LOGIN_PATTERN = R"(^[a-z0-9]\w{0,24}$)";
 
+    // Remember to keep VALID_HELIX_COLORS up-to-date if a new color is implemented to keep naming for users consistent
     const std::unordered_map<QString, QString> HELIX_COLOR_REPLACEMENTS{
         {"blueviolet", "blue_violet"},   {"cadetblue", "cadet_blue"},
         {"dodgerblue", "dodger_blue"},   {"goldenrod", "golden_rod"},
@@ -22,6 +23,14 @@ namespace {
     };
 
 }  // namespace
+
+// Colors retreived from https://dev.twitch.tv/docs/api/reference#update-user-chat-color 2022-09-11
+// Remember to keep HELIX_COLOR_REPLACEMENTS up-to-date if a new color is implemented to keep naming for users consistent
+extern const QStringList VALID_HELIX_COLORS{
+    "blue",        "blue_violet", "cadet_blue", "chocolate",    "coral",
+    "dodger_blue", "firebrick",   "golden_rod", "green",        "hot_pink",
+    "orange_red",  "red",         "sea_green",  "spring_green", "yellow_green",
+};
 
 void openTwitchUsercard(QString channel, QString username)
 {

--- a/src/util/Twitch.cpp
+++ b/src/util/Twitch.cpp
@@ -3,11 +3,21 @@
 #include <QDesktopServices>
 #include <QUrl>
 
+#include <unordered_map>
+
 namespace chatterino {
 
 namespace {
 
     const auto TWITCH_USER_LOGIN_PATTERN = R"(^[a-z0-9]\w{0,24}$)";
+
+    const std::unordered_map<QString, QString> HELIX_COLOR_REPLACEMENTS{
+        {"blueviolet", "blue_violet"},   {"cadetblue", "cadet_blue"},
+        {"dodgerblue", "dodger_blue"},   {"goldenrod", "golden_rod"},
+        {"hotpink", "hot_pink"},         {"orangered", "orange_red"},
+        {"seagreen", "sea_green"},       {"springgreen", "spring_green"},
+        {"yellowgreen", "yellow_green"},
+    };
 
 }  // namespace
 
@@ -55,6 +65,19 @@ QRegularExpression twitchUserLoginRegexp()
     static QRegularExpression re(TWITCH_USER_LOGIN_PATTERN);
 
     return re;
+}
+
+void cleanHelixColorName(QString &color)
+{
+    color = color.toLower();
+    auto it = HELIX_COLOR_REPLACEMENTS.find(color);
+
+    if (it == HELIX_COLOR_REPLACEMENTS.end())
+    {
+        return;
+    }
+
+    color = it->second;
 }
 
 }  // namespace chatterino

--- a/src/util/Twitch.cpp
+++ b/src/util/Twitch.cpp
@@ -1,5 +1,7 @@
 #include "util/Twitch.hpp"
 
+#include "util/QStringHash.hpp"
+
 #include <QDesktopServices>
 #include <QUrl>
 

--- a/src/util/Twitch.hpp
+++ b/src/util/Twitch.hpp
@@ -2,8 +2,11 @@
 
 #include <QRegularExpression>
 #include <QString>
+#include <QStringList>
 
 namespace chatterino {
+
+extern const QStringList VALID_HELIX_COLORS;
 
 void openTwitchUsercard(const QString channel, const QString username);
 

--- a/src/util/Twitch.hpp
+++ b/src/util/Twitch.hpp
@@ -25,4 +25,9 @@ QRegularExpression twitchUserLoginRegexp();
 // Must not start with an underscore
 QRegularExpression twitchUserNameRegexp();
 
+// Cleans up a color name input for use in the Helix API
+// Will help massage color names like BlueViolet to the helix-acceptible blue_violet
+// Will also lowercase the color
+void cleanHelixColorName(QString &color);
+
 }  // namespace chatterino

--- a/tests/src/HighlightController.cpp
+++ b/tests/src/HighlightController.cpp
@@ -209,6 +209,14 @@ public:
                  HelixFailureCallback failureCallback),
                 (override));
 
+    // The extra parenthesis around the failure callback is because its type contains a comma
+    MOCK_METHOD(void, updateUserChatColor,
+                (QString userID, QString color,
+                 ResultCallback<> successCallback,
+                 (FailureCallback<HelixUpdateUserChatColorError, QString>
+                      failureCallback)),
+                (override));
+
     MOCK_METHOD(void, update, (QString clientId, QString oauthToken),
                 (override));
 };

--- a/tests/src/UtilTwitch.cpp
+++ b/tests/src/UtilTwitch.cpp
@@ -264,3 +264,39 @@ TEST(UtilTwitch, UserNameRegexp)
             << qUtf8Printable(inputUserLogin) << " did not match as expected";
     }
 }
+
+TEST(UtilTwitch, CleanHelixColor)
+{
+    struct TestCase {
+        QString inputColor;
+        QString expectedColor;
+    };
+
+    std::vector<TestCase> tests{
+        {"foo", "foo"},
+        {"BlueViolet", "blue_violet"},
+        {"blueviolet", "blue_violet"},
+        {"DODGERBLUE", "dodger_blue"},
+        {"blUEviolet", "blue_violet"},
+        {"caDEtblue", "cadet_blue"},
+        {"doDGerblue", "dodger_blue"},
+        {"goLDenrod", "golden_rod"},
+        {"hoTPink", "hot_pink"},
+        {"orANgered", "orange_red"},
+        {"seAGreen", "sea_green"},
+        {"spRInggreen", "spring_green"},
+        {"yeLLowgreen", "yellow_green"},
+        {"xDxD", "xdxd"},
+    };
+
+    for (const auto &[inputColor, expectedColor] : tests)
+    {
+        QString actualColor = inputColor;
+        cleanHelixColorName(actualColor);
+
+        EXPECT_EQ(actualColor, expectedColor)
+            << qUtf8Printable(inputColor) << " cleaned up to "
+            << qUtf8Printable(actualColor) << " instead of "
+            << qUtf8Printable(expectedColor);
+    }
+}


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

This PR migrates the `/color` chat command to use the Helix API.
This migration does not necessitate any time-gating as the functionality is essentially the same except:
 - ~~The pre-defined colors have changed names~~ This is no longer a concern to users as we accept both the old and new names. We will, however, only show the new names to users.
 - The user has to re-authenticate to get the required scope on their token.
 
In addition to migrate the command, I've also added some documentation for how to add support for new Helix endpoints in the `/providers/twitch/api/README.md` file

Fixes #3963

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
