### PR TITLE
fix: retain text from input when replying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Minor: Added whitespace trim to username field in nicknames (#3946)
 - Minor: Added `Go to message` context menu action to search popup, mentions, usercard and reply threads. (#3953)
 - Minor: Added link back to original message that was deleted. (#3953)
+- Minor: Input text is retained when replying to a message. (#3989)
 - Bugfix: Fix crash that can occur when closing and quickly reopening a split, then running a command. (#3852)
 - Bugfix: Connection to Twitch PubSub now recovers more reliably. (#3643, #3716)
 - Bugfix: Fix crash that can occur when changing channels. (#3799)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unversioned
 
-- Major: Added support for Twitch's Chat Replies. [Wiki Page](https://wiki.chatterino.com/Features/#message-replies) (#3722)
+- Major: Added support for Twitch's Chat Replies. [Wiki Page](https://wiki.chatterino.com/Features/#message-replies) (#3722, #3989)
 - Major: Added multi-channel searching to search dialog via keyboard shortcut. (Ctrl+Shift+F by default) (#3694, #3875)
 - Minor: Added option to display tabs on the right and bottom. (#3847)
 - Minor: Added `is:first-msg` search option. (#3700)
@@ -34,7 +34,6 @@
 - Minor: Added whitespace trim to username field in nicknames (#3946)
 - Minor: Added `Go to message` context menu action to search popup, mentions, usercard and reply threads. (#3953)
 - Minor: Added link back to original message that was deleted. (#3953)
-- Minor: Input text is retained when replying to a message. (#3989)
 - Bugfix: Fix crash that can occur when closing and quickly reopening a split, then running a command. (#3852)
 - Bugfix: Connection to Twitch PubSub now recovers more reliably. (#3643, #3716)
 - Bugfix: Fix crash that can occur when changing channels. (#3799)

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -978,9 +978,13 @@ void SplitInput::setReply(std::shared_ptr<MessageThread> reply,
     if (this->enableInlineReplying_)
     {
         // Only enable reply label if inline replying
-        this->ui_.textEdit->setPlainText(
-            "@" + this->replyThread_->root()->displayName + " ");
-        this->ui_.textEdit->moveCursor(QTextCursor::EndOfBlock);
+        auto replyPrefix = "@" + this->replyThread_->root()->displayName + " ";
+        auto plainText = this->ui_.textEdit->toPlainText().trimmed();
+        if (!plainText.startsWith(replyPrefix))
+        {
+            this->ui_.textEdit->setPlainText(replyPrefix + plainText + " ");
+            this->ui_.textEdit->moveCursor(QTextCursor::EndOfBlock);
+        }
         this->ui_.replyLabel->setText("Replying to @" +
                                       this->replyThread_->root()->displayName);
     }


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

When clicking `Reply to message` the input text is replaced with `@{displayName} `, this PR attempts to retain any input that was typed before (i.e. the text is replaced with `@{displayName} {input} `).
