### PR TITLE
fix: disable `autoInvoke` for emote settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 - Minor: Warn when parsing an environment variable fails. (#3904)
 - Minor: Load missing messages from Recent Messages API upon reconnecting (#3878, #3932)
 - Minor: Reduced image memory usage when running Chatterino for a long time. (#3915)
-- Minor: Add settings to toggle BTTV/FFZ global/channel emotes (#3935)
+- Minor: Add settings to toggle BTTV/FFZ global/channel emotes (#3935, #3990)
 - Minor: Add AutoMod message flag filter. (#3938)
 - Minor: Added whitespace trim to username field in nicknames (#3946)
 - Minor: Added `Go to message` context menu action to search popup, mentions, usercard and reply threads. (#3953)

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -179,18 +179,26 @@ int Application::run(QApplication &qtApp)
         this->windows->forceLayoutChannelViews();
     });
 
-    getSettings()->enableBTTVGlobalEmotes.connect([this] {
-        this->twitch->reloadBTTVGlobalEmotes();
-    });
-    getSettings()->enableBTTVChannelEmotes.connect([this] {
-        this->twitch->reloadAllBTTVChannelEmotes();
-    });
-    getSettings()->enableFFZGlobalEmotes.connect([this] {
-        this->twitch->reloadFFZGlobalEmotes();
-    });
-    getSettings()->enableFFZChannelEmotes.connect([this] {
-        this->twitch->reloadAllFFZChannelEmotes();
-    });
+    getSettings()->enableBTTVGlobalEmotes.connect(
+        [this] {
+            this->twitch->reloadBTTVGlobalEmotes();
+        },
+        false);
+    getSettings()->enableBTTVChannelEmotes.connect(
+        [this] {
+            this->twitch->reloadAllBTTVChannelEmotes();
+        },
+        false);
+    getSettings()->enableFFZGlobalEmotes.connect(
+        [this] {
+            this->twitch->reloadFFZGlobalEmotes();
+        },
+        false);
+    getSettings()->enableFFZChannelEmotes.connect(
+        [this] {
+            this->twitch->reloadAllFFZChannelEmotes();
+        },
+        false);
 
     return qtApp.exec();
 }


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Disabled `autoInvoke` because when this is first invoked, the room-id's aren't loaded yet - resulting in an error message (first introduced in #3935). 