### PR TITLE
Migrate /clear command to Helix API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Minor: Added `Go to message` context menu action to search popup, mentions, usercard and reply threads. (#3953)
 - Minor: Added link back to original message that was deleted. (#3953)
 - Minor: Migrate /color command to Helix API. (#3988)
+- Minor: Migrate /clear command to Helix API. (#3994)
 - Bugfix: Fix crash that can occur when closing and quickly reopening a split, then running a command. (#3852)
 - Bugfix: Connection to Twitch PubSub now recovers more reliably. (#3643, #3716)
 - Bugfix: Fix crash that can occur when changing channels. (#3799)

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -1270,7 +1270,7 @@ void CommandController::initialize(Settings &, Paths &paths)
         return "";
     });
 
-    auto deleteMessagesLambda = [](auto channel, const QString &messageID) {
+    auto deleteMessages = [](auto channel, const QString &messageID) {
         const auto *commandName = messageID.isEmpty() ? "/clear" : "/delete";
         auto *twitchChannel = dynamic_cast<TwitchChannel *>(channel.get());
         if (twitchChannel == nullptr)
@@ -1351,10 +1351,9 @@ void CommandController::initialize(Settings &, Paths &paths)
     };
 
     this->registerCommand(
-        "/clear",
-        [deleteMessagesLambda](const QStringList &words, auto channel) {
+        "/clear", [deleteMessages](const QStringList &words, auto channel) {
             (void)words;  // unused
-            deleteMessagesLambda(channel, QString());
+            deleteMessages(channel, QString());
             return "";
         });
 }

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -1353,6 +1353,7 @@ void CommandController::initialize(Settings &, Paths &paths)
     this->registerCommand(
         "/clear",
         [deleteMessagesLambda](const QStringList &words, auto channel) {
+            (void)words;  // unused
             deleteMessagesLambda(channel, QString());
             return "";
         });

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -1353,8 +1353,7 @@ void CommandController::initialize(Settings &, Paths &paths)
     this->registerCommand(
         "/clear", [deleteMessages](const QStringList &words, auto channel) {
             (void)words;  // unused
-            deleteMessages(channel, QString());
-            return "";
+            return deleteMessages(channel, QString());
         });
 }
 

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -1270,7 +1270,7 @@ void CommandController::initialize(Settings &, Paths &paths)
         return "";
     });
 
-    auto deleteMessagesLambda = [](auto channel, QString messageID) {
+    auto deleteMessagesLambda = [](auto channel, const QString &messageID) {
         const auto *commandName = messageID.isEmpty() ? "/clear" : "/delete";
         auto *twitchChannel = dynamic_cast<TwitchChannel *>(channel.get());
         if (twitchChannel == nullptr)

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -1350,10 +1350,12 @@ void CommandController::initialize(Settings &, Paths &paths)
         return "";
     };
 
-    this->registerCommand("/clear", [deleteMessagesLambda](const QStringList &words, auto channel) {
-        deleteMessagesLambda(channel, QString());
-        return "";
-    });
+    this->registerCommand(
+        "/clear",
+        [deleteMessagesLambda](const QStringList &words, auto channel) {
+            deleteMessagesLambda(channel, QString());
+            return "";
+        });
 }
 
 void CommandController::save()

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -1271,7 +1271,7 @@ void CommandController::initialize(Settings &, Paths &paths)
     });
 
     auto deleteMessagesLambda = [](auto channel, QString messageID) {
-        auto commandName = messageID.isEmpty() ? "/clear" : "/delete";
+        const auto *commandName = messageID.isEmpty() ? "/clear" : "/delete";
         auto *twitchChannel = dynamic_cast<TwitchChannel *>(channel.get());
         if (twitchChannel == nullptr)
         {

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -1269,6 +1269,91 @@ void CommandController::initialize(Settings &, Paths &paths)
 
         return "";
     });
+
+    auto deleteMessagesLambda = [](auto channel, QString messageID) {
+        auto commandName = messageID.isEmpty() ? "/clear" : "/delete";
+        auto *twitchChannel = dynamic_cast<TwitchChannel *>(channel.get());
+        if (twitchChannel == nullptr)
+        {
+            channel->addMessage(makeSystemMessage(
+                QString("The %1 command only works in Twitch channels")
+                    .arg(commandName)));
+            return "";
+        }
+
+        auto user = getApp()->accounts->twitch.getCurrent();
+
+        // Avoid Helix calls without Client ID and/or OAuth Token
+        if (user->isAnon())
+        {
+            channel->addMessage(makeSystemMessage(
+                QString("You must be logged in to use the %1 command.")
+                    .arg(commandName)));
+            return "";
+        }
+
+        getHelix()->deleteChatMessages(
+            twitchChannel->roomId(), user->getUserId(), messageID,
+            []() {
+                // Success handling, we do nothing: IRC/pubsub-edge will dispatch the correct
+                // events to update state for us.
+            },
+            [channel, messageID](auto error, auto message) {
+                QString errorMessage =
+                    QString("Failed to delete chat messages - ");
+
+                switch (error)
+                {
+                    case HelixDeleteChatMessagesError::UserMissingScope: {
+                        errorMessage +=
+                            "Missing required scope. Re-login with your "
+                            "account and try again.";
+                    }
+                    break;
+
+                    case HelixDeleteChatMessagesError::UserNotAuthorized: {
+                        errorMessage +=
+                            "you don't have permission to perform that action.";
+                    }
+                    break;
+
+                    case HelixDeleteChatMessagesError::MessageUnavailable: {
+                        // Override default message prefix to match with IRC message format
+                        errorMessage =
+                            QString(
+                                "The message %1 does not exist, was deleted, "
+                                "or is too old to be deleted.")
+                                .arg(messageID);
+                    }
+                    break;
+
+                    case HelixDeleteChatMessagesError::UserNotAuthenticated: {
+                        errorMessage += "you need to re-authenticate.";
+                    }
+                    break;
+
+                    case HelixDeleteChatMessagesError::Forwarded: {
+                        errorMessage += message + ".";
+                    }
+                    break;
+
+                    case HelixDeleteChatMessagesError::Unknown:
+                    default: {
+                        errorMessage += "An unknown error has occurred.";
+                    }
+                    break;
+                }
+
+                channel->addMessage(makeSystemMessage(errorMessage));
+            });
+
+        return "";
+    };
+
+    this->registerCommand("/clear", [deleteMessagesLambda](const QStringList &words, auto channel) {
+        deleteMessagesLambda(channel, QString());
+        return "";
+    });
 }
 
 void CommandController::save()

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -864,7 +864,6 @@ void Helix::deleteChatMessages(
     this->makeRequest("moderation/chat", urlQuery)
         .type(NetworkRequestType::Delete)
         .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
-            auto obj = result.parseJson();
             if (result.status() != 204)
             {
                 qCWarning(chatterinoTwitch)

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -888,6 +888,15 @@ void Helix::deleteChatMessages(
                 }
                 break;
 
+                case 403: {
+                    // 403 endpoint means the user does not have permission to perform this action in that channel
+                    // Most likely to missing moderator permissions
+                    // Missing documentation issue: https://github.com/twitchdev/issues/issues/659
+                    // `message` value is well-formed so no need for a specific error type
+                    failureCallback(Error::Forwarded, message);
+                }
+                break;
+
                 case 401: {
                     if (message.startsWith("Missing scope",
                                            Qt::CaseInsensitive))

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -912,7 +912,7 @@ void Helix::deleteChatMessages(
             }
         })
         .execute();
-};
+}
 
 NetworkRequest Helix::makeRequest(QString url, QUrlQuery urlQuery)
 {

--- a/src/providers/twitch/api/Helix.hpp
+++ b/src/providers/twitch/api/Helix.hpp
@@ -329,6 +329,17 @@ enum class HelixUpdateUserChatColorError {
     Forwarded,
 };
 
+enum class HelixDeleteChatMessagesError {
+    Unknown,
+    UserMissingScope,
+    UserNotAuthenticated,
+    UserNotAuthorized,
+    MessageUnavailable,
+
+    // The error message is forwarded directly from the Twitch API
+    Forwarded,
+};
+
 class IHelix
 {
 public:
@@ -458,6 +469,13 @@ public:
         FailureCallback<HelixUpdateUserChatColorError, QString>
             failureCallback) = 0;
 
+    // https://dev.twitch.tv/docs/api/reference#delete-chat-messages
+    virtual void deleteChatMessages(
+        QString broadcasterID, QString moderatorID, QString messageID,
+        ResultCallback<> successCallback,
+        FailureCallback<HelixDeleteChatMessagesError, QString>
+            failureCallback) = 0;
+
     virtual void update(QString clientId, QString oauthToken) = 0;
 };
 
@@ -578,6 +596,13 @@ public:
     void updateUserChatColor(
         QString userID, QString color, ResultCallback<> successCallback,
         FailureCallback<HelixUpdateUserChatColorError, QString> failureCallback)
+        final;
+
+    // https://dev.twitch.tv/docs/api/reference#delete-chat-messages
+    void deleteChatMessages(
+        QString broadcasterID, QString moderatorID, QString messageID,
+        ResultCallback<> successCallback,
+        FailureCallback<HelixDeleteChatMessagesError, QString> failureCallback)
         final;
 
     void update(QString clientId, QString oauthToken) final;

--- a/tests/src/HighlightController.cpp
+++ b/tests/src/HighlightController.cpp
@@ -217,6 +217,14 @@ public:
                       failureCallback)),
                 (override));
 
+    // The extra parenthesis around the failure callback is because its type contains a comma
+    MOCK_METHOD(void, deleteChatMessages,
+                (QString broadcasterID, QString moderatorID, QString messageID,
+                 ResultCallback<> successCallback,
+                 (FailureCallback<HelixDeleteChatMessagesError, QString>
+                      failureCallback)),
+                (override));
+
     MOCK_METHOD(void, update, (QString clientId, QString oauthToken),
                 (override));
 };


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

- Closes #3962 

- Implemented a new Helix func `deleteChatMessages` - this can be used for both `/delete` and `/clear `commands as they call the same Twitch Helix endpoint under the hood.

- Adds command handler for `/clear`, defined as a lambda function as I will come back in a followup PR to hook up the same lambda to `/delete` too.
