### PR TITLE
Migrate /mod command to Helix API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Minor: Added link back to original message that was deleted. (#3953)
 - Minor: Migrate /color command to Helix API. (#3988)
 - Minor: Migrate /clear command to Helix API. (#3994)
+- Minor: Migrate /mod command to Helix API. (#4000)
 - Bugfix: Fix crash that can occur when closing and quickly reopening a split, then running a command. (#3852)
 - Bugfix: Connection to Twitch PubSub now recovers more reliably. (#3643, #3716)
 - Bugfix: Fix crash that can occur when changing channels. (#3799)

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -1404,6 +1404,7 @@ void CommandController::initialize(Settings &, Paths &paths)
                         switch (error)
                         {
                             case Error::UserMissingScope: {
+                                // TODO(pajlada): Phrase MISSING_REQUIRED_SCOPE
                                 errorMessage += "Missing required scope. "
                                                 "Re-login with your "
                                                 "account and try again.";
@@ -1411,6 +1412,7 @@ void CommandController::initialize(Settings &, Paths &paths)
                             break;
 
                             case Error::UserNotAuthorized: {
+                                // TODO(pajlada): Phrase MISSING_PERMISSION
                                 errorMessage += "You don't have permission to "
                                                 "perform that action.";
                             }

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -1361,7 +1361,7 @@ void CommandController::initialize(Settings &, Paths &paths)
         {
             channel->addMessage(makeSystemMessage(
                 "Usage: \"/mod <username>\" - Grant moderator status to a "
-                "user. Use \"mods\" to list the moderators of this channel."));
+                "user. Use \"/mods\" to list the moderators of this channel."));
             return "";
         }
 

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -1399,31 +1399,31 @@ void CommandController::initialize(Settings &, Paths &paths)
                         QString errorMessage =
                             QString("Failed to add channel moderator - ");
 
+                        using Error = HelixAddChannelModeratorError;
+
                         switch (error)
                         {
-                            case HelixAddChannelModeratorError::
-                                UserMissingScope: {
+                            case Error::UserMissingScope: {
                                 errorMessage += "Missing required scope. "
                                                 "Re-login with your "
                                                 "account and try again.";
                             }
                             break;
 
-                            case HelixAddChannelModeratorError::
-                                UserNotAuthorized: {
+                            case Error::UserNotAuthorized: {
                                 errorMessage += "you don't have permission to "
                                                 "perform that action.";
                             }
                             break;
 
-                            case HelixAddChannelModeratorError::Ratelimited: {
+                            case Error::Ratelimited: {
                                 errorMessage +=
                                     "You are being ratelimited by Twitch. Try "
                                     "again in a few seconds.";
                             }
                             break;
 
-                            case HelixAddChannelModeratorError::TargetIsVIP: {
+                            case Error::TargetIsVIP: {
                                 errorMessage +=
                                     QString("%1 is currently a VIP, \"/unvip\" "
                                             "them and "
@@ -1442,12 +1442,12 @@ void CommandController::initialize(Settings &, Paths &paths)
                             }
                             break;
 
-                            case HelixAddChannelModeratorError::Forwarded: {
+                            case Error::Forwarded: {
                                 errorMessage += message;
                             }
                             break;
 
-                            case HelixAddChannelModeratorError::Unknown:
+                            case Error::Unknown:
                             default: {
                                 errorMessage +=
                                     "An unknown error has occurred.";

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -1377,7 +1377,7 @@ void CommandController::initialize(Settings &, Paths &paths)
         if (twitchChannel == nullptr)
         {
             channel->addMessage(makeSystemMessage(
-                "The /unmod command only works in Twitch channels"));
+                "The /mod command only works in Twitch channels"));
             return "";
         }
 

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -1377,7 +1377,7 @@ void CommandController::initialize(Settings &, Paths &paths)
         if (twitchChannel == nullptr)
         {
             channel->addMessage(makeSystemMessage(
-                "The /reply command only works in Twitch channels"));
+                "The /unmod command only works in Twitch channels"));
             return "";
         }
 

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -1432,8 +1432,7 @@ void CommandController::initialize(Settings &, Paths &paths)
                             }
                             break;
 
-                            case HelixAddChannelModeratorError::
-                                TargetAlreadyModded: {
+                            case Error::TargetAlreadyModded: {
                                 // Equivalent irc error
                                 errorMessage =
                                     QString("%1 is already a moderator of this "

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -1411,7 +1411,7 @@ void CommandController::initialize(Settings &, Paths &paths)
                             break;
 
                             case Error::UserNotAuthorized: {
-                                errorMessage += "you don't have permission to "
+                                errorMessage += "You don't have permission to "
                                                 "perform that action.";
                             }
                             break;

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -959,21 +959,18 @@ void Helix::addChannelModerator(
 
             switch (result.status())
             {
-                case 403: {
-                    // 403 endpoint means the user does not have permission to perform this action in that channel
-                    // Most likely to missing moderator permissions
-                    // Missing documentation issue: https://github.com/twitchdev/issues/issues/659
-                    // `message` value is well-formed so no need for a specific error type
-                    failureCallback(Error::Forwarded, message);
-                }
-                break;
-
                 case 401: {
                     if (message.startsWith("Missing scope",
                                            Qt::CaseInsensitive))
                     {
                         // Handle this error specifically because its API error is especially unfriendly
                         failureCallback(Error::UserMissingScope, message);
+                    }
+                    else if (message.compare("incorrect user authorization",
+                                             Qt::CaseInsensitive) == 0)
+                    {
+                        // This error is pretty ugly, but essentially means they're not authorized to mod people in this channel
+                        failureCallback(Error::UserNotAuthorized, message);
                     }
                     else
                     {
@@ -987,7 +984,7 @@ void Helix::addChannelModerator(
                                         Qt::CaseInsensitive) == 0)
                     {
                         // This error is particularly ugly, handle it separately
-                        failureCallback(Error::AlreadyModded, message);
+                        failureCallback(Error::TargetAlreadyModded, message);
                     }
                     else
                     {
@@ -998,8 +995,8 @@ void Helix::addChannelModerator(
                 break;
 
                 case 422: {
-                    // User is already a VIP
-                    failureCallback(Error::UserIsVIP, message);
+                    // Target is already a VIP
+                    failureCallback(Error::TargetIsVIP, message);
                 }
                 break;
 

--- a/src/providers/twitch/api/Helix.hpp
+++ b/src/providers/twitch/api/Helix.hpp
@@ -343,11 +343,10 @@ enum class HelixDeleteChatMessagesError {
 enum class HelixAddChannelModeratorError {
     Unknown,
     UserMissingScope,
-    UserNotAuthenticated,
     UserNotAuthorized,
-    UserIsVIP,
     Ratelimited,
-    AlreadyModded,
+    TargetAlreadyModded,
+    TargetIsVIP,
 
     // The error message is forwarded directly from the Twitch API
     Forwarded,

--- a/src/providers/twitch/api/Helix.hpp
+++ b/src/providers/twitch/api/Helix.hpp
@@ -340,6 +340,19 @@ enum class HelixDeleteChatMessagesError {
     Forwarded,
 };
 
+enum class HelixAddChannelModeratorError {
+    Unknown,
+    UserMissingScope,
+    UserNotAuthenticated,
+    UserNotAuthorized,
+    UserIsVIP,
+    Ratelimited,
+    AlreadyModded,
+
+    // The error message is forwarded directly from the Twitch API
+    Forwarded,
+};
+
 class IHelix
 {
 public:
@@ -476,6 +489,12 @@ public:
         FailureCallback<HelixDeleteChatMessagesError, QString>
             failureCallback) = 0;
 
+    // https://dev.twitch.tv/docs/api/reference#add-channel-moderator
+    virtual void addChannelModerator(
+        QString broadcasterID, QString userID, ResultCallback<> successCallback,
+        FailureCallback<HelixAddChannelModeratorError, QString>
+            failureCallback) = 0;
+
     virtual void update(QString clientId, QString oauthToken) = 0;
 };
 
@@ -603,6 +622,12 @@ public:
         QString broadcasterID, QString moderatorID, QString messageID,
         ResultCallback<> successCallback,
         FailureCallback<HelixDeleteChatMessagesError, QString> failureCallback)
+        final;
+
+    // https://dev.twitch.tv/docs/api/reference#add-channel-moderator
+    void addChannelModerator(
+        QString broadcasterID, QString userID, ResultCallback<> successCallback,
+        FailureCallback<HelixAddChannelModeratorError, QString> failureCallback)
         final;
 
     void update(QString clientId, QString oauthToken) final;

--- a/tests/src/HighlightController.cpp
+++ b/tests/src/HighlightController.cpp
@@ -225,6 +225,14 @@ public:
                       failureCallback)),
                 (override));
 
+    // The extra parenthesis around the failure callback is because its type contains a comma
+    MOCK_METHOD(void, addChannelModerator,
+                (QString broadcasterID, QString userID,
+                 ResultCallback<> successCallback,
+                 (FailureCallback<HelixAddChannelModeratorError, QString>
+                      failureCallback)),
+                (override));
+
     MOCK_METHOD(void, update, (QString clientId, QString oauthToken),
                 (override));
 };


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

- Fixes #3970 
- Adds support for `/mod` command on Helix API, including all edge cases that I could think of - including trying to mod people in other channels.
