### PR TITLE
Migrate /unmod command to Helix API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Minor: Added link back to original message that was deleted. (#3953)
 - Minor: Migrate /color command to Helix API. (#3988)
 - Minor: Migrate /clear command to Helix API. (#3994)
+- Minor: Migrate /unmod command to Helix API. (#4001)
 - Bugfix: Fix crash that can occur when closing and quickly reopening a split, then running a command. (#3852)
 - Bugfix: Connection to Twitch PubSub now recovers more reliably. (#3643, #3716)
 - Bugfix: Fix crash that can occur when changing channels. (#3799)

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -1515,6 +1515,7 @@ void CommandController::initialize(Settings &, Paths &paths)
                         switch (error)
                         {
                             case Error::UserMissingScope: {
+                                // TODO(pajlada): Phrase MISSING_REQUIRED_SCOPE
                                 errorMessage += "Missing required scope. "
                                                 "Re-login with your "
                                                 "account and try again.";
@@ -1522,6 +1523,7 @@ void CommandController::initialize(Settings &, Paths &paths)
                             break;
 
                             case Error::UserNotAuthorized: {
+                                // TODO(pajlada): Phrase MISSING_PERMISSION
                                 errorMessage += "You don't have permission to "
                                                 "perform that action.";
                             }

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -1355,6 +1355,120 @@ void CommandController::initialize(Settings &, Paths &paths)
             (void)words;  // unused
             return deleteMessages(channel, QString());
         });
+
+    this->registerCommand("/unmod", [](const QStringList &words, auto channel) {
+        if (words.size() < 2)
+        {
+            channel->addMessage(makeSystemMessage(
+                "Usage: \"/unmod <username>\" - Revoke moderator status from a "
+                "user. Use \"mods\" to list the moderators of this channel."));
+            return "";
+        }
+
+        auto currentUser = getApp()->accounts->twitch.getCurrent();
+        if (currentUser->isAnon())
+        {
+            channel->addMessage(
+                makeSystemMessage("You must be logged in to unmod someone!"));
+            return "";
+        }
+
+        auto *twitchChannel = dynamic_cast<TwitchChannel *>(channel.get());
+        if (twitchChannel == nullptr)
+        {
+            channel->addMessage(makeSystemMessage(
+                "The /unmod command only works in Twitch channels"));
+            return "";
+        }
+
+        if (twitchChannel->roomId() != currentUser->getUserId())
+        {
+            channel->addMessage(makeSystemMessage(
+                "You may only unmod people in your own channel."));
+            return "";
+        }
+
+        auto target = words.at(1);
+        stripChannelName(target);
+
+        getHelix()->getUserByName(
+            target,
+            [currentUser, channel](const HelixUser &targetUser) {
+                getHelix()->removeChannelModerator(
+                    currentUser->getUserId(), targetUser.id,
+                    [channel, targetUser] {
+                        channel->addMessage(makeSystemMessage(
+                            QString("You have removed %1 as a moderator of "
+                                    "this channel.")
+                                .arg(targetUser.displayName)));
+                    },
+                    [channel, targetUser](auto error, auto message) {
+                        QString errorMessage =
+                            QString("Failed to remove channel moderator - ");
+
+                        switch (error)
+                        {
+                            case HelixRemoveChannelModeratorError::
+                                UserMissingScope: {
+                                errorMessage += "Missing required scope. "
+                                                "Re-login with your "
+                                                "account and try again.";
+                            }
+                            break;
+
+                            case HelixRemoveChannelModeratorError::
+                                UserNotAuthorized: {
+                                errorMessage += "you don't have permission to "
+                                                "perform that action.";
+                            }
+                            break;
+
+                            case HelixRemoveChannelModeratorError::
+                                Ratelimited: {
+                                errorMessage +=
+                                    "You are being ratelimited by Twitch. Try "
+                                    "again in a few seconds.";
+                            }
+                            break;
+
+                            case HelixRemoveChannelModeratorError::NotModded: {
+                                // Equivalent irc error
+                                errorMessage +=
+                                    QString("%1 is not a moderator of this "
+                                            "channel.")
+                                        .arg(targetUser.displayName);
+                            }
+                            break;
+
+                            case HelixRemoveChannelModeratorError::
+                                UserNotAuthenticated: {
+                                errorMessage += "you need to re-authenticate.";
+                            }
+                            break;
+
+                            case HelixRemoveChannelModeratorError::Forwarded: {
+                                errorMessage += message;
+                            }
+                            break;
+
+                            case HelixRemoveChannelModeratorError::Unknown:
+                            default: {
+                                errorMessage +=
+                                    "An unknown error has occurred.";
+                            }
+                            break;
+                        }
+                        channel->addMessage(makeSystemMessage(errorMessage));
+                    });
+            },
+            [channel, target] {
+                // Equivalent error from IRC
+                channel->addMessage(makeSystemMessage(
+                    QString("Invalid username: %1").arg(target)));
+            });
+
+        return "";
+    });
 }
 
 void CommandController::save()

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -1424,18 +1424,12 @@ void CommandController::initialize(Settings &, Paths &paths)
                             }
                             break;
 
-                            case HelixRemoveChannelModeratorError::NotModded: {
+                            case HelixRemoveChannelModeratorError::TargetNotModded: {
                                 // Equivalent irc error
                                 errorMessage +=
                                     QString("%1 is not a moderator of this "
                                             "channel.")
                                         .arg(targetUser.displayName);
-                            }
-                            break;
-
-                            case HelixRemoveChannelModeratorError::
-                                UserNotAuthenticated: {
-                                errorMessage += "you need to re-authenticate.";
                             }
                             break;
 

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -1424,7 +1424,8 @@ void CommandController::initialize(Settings &, Paths &paths)
                             }
                             break;
 
-                            case HelixRemoveChannelModeratorError::TargetNotModded: {
+                            case HelixRemoveChannelModeratorError::
+                                TargetNotModded: {
                                 // Equivalent irc error
                                 errorMessage +=
                                     QString("%1 is not a moderator of this "

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -1411,7 +1411,7 @@ void CommandController::initialize(Settings &, Paths &paths)
                             break;
 
                             case Error::UserNotAuthorized: {
-                                errorMessage += "you don't have permission to "
+                                errorMessage += "You don't have permission to "
                                                 "perform that action.";
                             }
                             break;

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -1399,33 +1399,31 @@ void CommandController::initialize(Settings &, Paths &paths)
                         QString errorMessage =
                             QString("Failed to remove channel moderator - ");
 
+                        using Error = HelixRemoveChannelModeratorError;
+
                         switch (error)
                         {
-                            case HelixRemoveChannelModeratorError::
-                                UserMissingScope: {
+                            case Error::UserMissingScope: {
                                 errorMessage += "Missing required scope. "
                                                 "Re-login with your "
                                                 "account and try again.";
                             }
                             break;
 
-                            case HelixRemoveChannelModeratorError::
-                                UserNotAuthorized: {
+                            case Error::UserNotAuthorized: {
                                 errorMessage += "you don't have permission to "
                                                 "perform that action.";
                             }
                             break;
 
-                            case HelixRemoveChannelModeratorError::
-                                Ratelimited: {
+                            case Error::Ratelimited: {
                                 errorMessage +=
                                     "You are being ratelimited by Twitch. Try "
                                     "again in a few seconds.";
                             }
                             break;
 
-                            case HelixRemoveChannelModeratorError::
-                                TargetNotModded: {
+                            case Error::TargetNotModded: {
                                 // Equivalent irc error
                                 errorMessage +=
                                     QString("%1 is not a moderator of this "
@@ -1434,12 +1432,12 @@ void CommandController::initialize(Settings &, Paths &paths)
                             }
                             break;
 
-                            case HelixRemoveChannelModeratorError::Forwarded: {
+                            case Error::Forwarded: {
                                 errorMessage += message;
                             }
                             break;
 
-                            case HelixRemoveChannelModeratorError::Unknown:
+                            case Error::Unknown:
                             default: {
                                 errorMessage +=
                                     "An unknown error has occurred.";

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -964,7 +964,7 @@ void Helix::removeChannelModerator(
                                         Qt::CaseInsensitive) == 0)
                     {
                         // This error message is particularly ugly, so we handle it differently
-                        failureCallback(Error::NotModded, message);
+                        failureCallback(Error::TargetNotModded, message);
                     }
                     else
                     {
@@ -979,6 +979,11 @@ void Helix::removeChannelModerator(
                     {
                         // Handle this error specifically because its API error is especially unfriendly
                         failureCallback(Error::UserMissingScope, message);
+                    }
+                    else if (message.compare("incorrect user authorization",
+                                             Qt::CaseInsensitive) == 0)
+                    {
+                        failureCallback(Error::UserNotAuthorized, message);
                     }
                     else
                     {

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -953,7 +953,8 @@ void Helix::removeChannelModerator(
             switch (result.status())
             {
                 case 400: {
-                    if (message.compare("user is not a mod", Qt::CaseInsensitive) == 0)
+                    if (message.compare("user is not a mod",
+                                        Qt::CaseInsensitive) == 0)
                     {
                         // This error message is particularly ugly, so we handle it differently
                         failureCallback(Error::NotModded, message);

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -922,6 +922,80 @@ void Helix::deleteChatMessages(
         .execute();
 }
 
+void Helix::removeChannelModerator(
+    QString broadcasterID, QString userID, ResultCallback<> successCallback,
+    FailureCallback<HelixRemoveChannelModeratorError, QString> failureCallback)
+{
+    using Error = HelixRemoveChannelModeratorError;
+
+    QUrlQuery urlQuery;
+
+    urlQuery.addQueryItem("broadcaster_id", broadcasterID);
+    urlQuery.addQueryItem("user_id", userID);
+
+    this->makeRequest("moderation/moderators", urlQuery)
+        .type(NetworkRequestType::Delete)
+        .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
+            if (result.status() != 204)
+            {
+                qCWarning(chatterinoTwitch)
+                    << "Success result for unmodding user was"
+                    << result.status() << "but we only expected it to be 204";
+            }
+
+            successCallback();
+            return Success;
+        })
+        .onError([failureCallback](auto result) {
+            auto obj = result.parseJson();
+            auto message = obj.value("message").toString();
+
+            switch (result.status())
+            {
+                case 400: {
+                    if (message.compare("user is not a mod", Qt::CaseInsensitive) == 0)
+                    {
+                        // This error message is particularly ugly, so we handle it differently
+                        failureCallback(Error::NotModded, message);
+                    }
+                    else
+                    {
+                        failureCallback(Error::Forwarded, message);
+                    }
+                }
+                break;
+
+                case 401: {
+                    if (message.startsWith("Missing scope",
+                                           Qt::CaseInsensitive))
+                    {
+                        // Handle this error specifically because its API error is especially unfriendly
+                        failureCallback(Error::UserMissingScope, message);
+                    }
+                    else
+                    {
+                        failureCallback(Error::Forwarded, message);
+                    }
+                }
+                break;
+
+                case 429: {
+                    failureCallback(Error::Ratelimited, message);
+                }
+                break;
+
+                default: {
+                    qCDebug(chatterinoTwitch)
+                        << "Unhandled error unmodding user:" << result.status()
+                        << result.getData() << obj;
+                    failureCallback(Error::Unknown, message);
+                }
+                break;
+            }
+        })
+        .execute();
+}
+
 NetworkRequest Helix::makeRequest(QString url, QUrlQuery urlQuery)
 {
     assert(!url.startsWith("/"));

--- a/src/providers/twitch/api/Helix.hpp
+++ b/src/providers/twitch/api/Helix.hpp
@@ -340,6 +340,18 @@ enum class HelixDeleteChatMessagesError {
     Forwarded,
 };
 
+enum class HelixRemoveChannelModeratorError {
+    Unknown,
+    UserMissingScope,
+    UserNotAuthenticated,
+    UserNotAuthorized,
+    NotModded,
+    Ratelimited,
+
+    // The error message is forwarded directly from the Twitch API
+    Forwarded,
+};
+
 class IHelix
 {
 public:
@@ -476,6 +488,12 @@ public:
         FailureCallback<HelixDeleteChatMessagesError, QString>
             failureCallback) = 0;
 
+    // https://dev.twitch.tv/docs/api/reference#remove-channel-moderator
+    virtual void removeChannelModerator(
+        QString broadcasterID, QString userID, ResultCallback<> successCallback,
+        FailureCallback<HelixRemoveChannelModeratorError, QString>
+            failureCallback) = 0;
+
     virtual void update(QString clientId, QString oauthToken) = 0;
 };
 
@@ -604,6 +622,12 @@ public:
         ResultCallback<> successCallback,
         FailureCallback<HelixDeleteChatMessagesError, QString> failureCallback)
         final;
+
+    // https://dev.twitch.tv/docs/api/reference#remove-channel-moderator
+    void removeChannelModerator(
+        QString broadcasterID, QString userID, ResultCallback<> successCallback,
+        FailureCallback<HelixRemoveChannelModeratorError, QString>
+            failureCallback) final;
 
     void update(QString clientId, QString oauthToken) final;
 

--- a/src/providers/twitch/api/Helix.hpp
+++ b/src/providers/twitch/api/Helix.hpp
@@ -343,9 +343,8 @@ enum class HelixDeleteChatMessagesError {
 enum class HelixRemoveChannelModeratorError {
     Unknown,
     UserMissingScope,
-    UserNotAuthenticated,
     UserNotAuthorized,
-    NotModded,
+    TargetNotModded,
     Ratelimited,
 
     // The error message is forwarded directly from the Twitch API

--- a/tests/src/HighlightController.cpp
+++ b/tests/src/HighlightController.cpp
@@ -225,6 +225,15 @@ public:
                       failureCallback)),
                 (override));
 
+    // The extra parenthesis around the failure callback is because its type contains a comma
+    MOCK_METHOD(void, removeChannelModerator,
+                (QString broadcasterID, QString userID,
+                 ResultCallback<> successCallback,
+                 (FailureCallback<HelixRemoveChannelModeratorError, QString>
+                      failureCallback)),
+                (override));
+
+
     MOCK_METHOD(void, update, (QString clientId, QString oauthToken),
                 (override));
 };


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

- Adds `removeChannelModerator` to Helix API
- Adds support to send `/unmod` through Helix API

Tested locally, couldn't find any edge cases - let me know if I missed anything.

[felanbird]: Fixes #3972