### PR TITLE
Fix windows toast notifications opening as http

### DIFF
--- a/src/singletons/Toasts.cpp
+++ b/src/singletons/Toasts.cpp
@@ -129,7 +129,7 @@ public:
             case ToastReaction::OpenInBrowser:
                 if (platform_ == Platform::Twitch)
                 {
-                    link = "http://www.twitch.tv/" + channelName_;
+                    link = "https://www.twitch.tv/" + channelName_;
                 }
                 QDesktopServices::openUrl(QUrl(link));
                 break;


### PR DESCRIPTION
gotta give the users them SECURE links

Fixes #4004