### PR TITLE
Ignore cert-err58-cpp clang-tidy warning

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -27,6 +27,7 @@ Checks: '-*,
     -readability-identifier-length,
     -readability-function-cognitive-complexity,
     -bugprone-easily-swappable-parameters,
+    -cert-err58-cpp,
     '
 CheckOptions:
   - key:             readability-identifier-naming.ClassCase


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Clang-tidy warning can be found here:
https://releases.llvm.org/10.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/cert-err58-cpp.html

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
