### PR TITLE
chore: fix debug text on non-204 add mod success

### DIFF
--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -947,7 +947,7 @@ void Helix::addChannelModerator(
             if (result.status() != 204)
             {
                 qCWarning(chatterinoTwitch)
-                    << "Success result for deleting chat messages was"
+                    << "Success result for adding a moderator was"
                     << result.status() << "but we only expected it to be 204";
             }
 


### PR DESCRIPTION
Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable

# Description

Updates debug text on addChannelModerator success without status 204
