### PR TITLE
Add Basic Elevated Message support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Major: Added support for Twitch's Chat Replies. [Wiki Page](https://wiki.chatterino.com/Features/#message-replies) (#3722, #3989)
 - Major: Added multi-channel searching to search dialog via keyboard shortcut. (Ctrl+Shift+F by default) (#3694, #3875)
+- Minor: Added highlights for `Elevated Messages`. (#4016)
 - Minor: Removed total views from the usercard, as Twitch no longer updates the number. (#3792)
 - Minor: Load missing messages from Recent Messages API upon reconnecting (#3878, #3932)
 - Minor: Reduced image memory usage when running Chatterino for a long time. (#3915)

--- a/src/controllers/highlights/HighlightModel.cpp
+++ b/src/controllers/highlights/HighlightModel.cpp
@@ -201,14 +201,14 @@ void HighlightModel::afterInit()
     elevatedMessageRow[Column::UseRegex]->setFlags({});
     elevatedMessageRow[Column::CaseSensitive]->setFlags({});
 
-    QUrl ElevatedMessageSound =
+    QUrl elevatedMessageSound =
         QUrl(getSettings()->elevatedMessageHighlightSoundUrl.getValue());
-    setFilePathItem(elevatedMessageRow[Column::SoundPath], ElevatedMessageSound,
+    setFilePathItem(elevatedMessageRow[Column::SoundPath], elevatedMessageSound,
                     false);
 
-    auto ElevatedMessageColor =
+    auto elevatedMessageColor =
         ColorProvider::instance().color(ColorType::ElevatedMessageHighlight);
-    setColorItem(elevatedMessageRow[Column::Color], *ElevatedMessageColor,
+    setColorItem(elevatedMessageRow[Column::Color], *elevatedMessageColor,
                  false);
 
     this->insertCustomRow(elevatedMessageRow,

--- a/src/controllers/highlights/HighlightModel.cpp
+++ b/src/controllers/highlights/HighlightModel.cpp
@@ -181,6 +181,38 @@ void HighlightModel::afterInit()
 
     this->insertCustomRow(firstMessageRow,
                           HighlightRowIndexes::FirstMessageRow);
+
+    // Highlight settings for elevated messages
+    std::vector<QStandardItem *> elevatedMessageRow = this->createRow();
+    setBoolItem(elevatedMessageRow[Column::Pattern],
+                getSettings()->enableElevatedMessageHighlight.getValue(), true,
+                false);
+    elevatedMessageRow[Column::Pattern]->setData("Elevated Messages",
+                                                 Qt::DisplayRole);
+    elevatedMessageRow[Column::ShowInMentions]->setFlags({});
+    //    setBoolItem(elevatedMessageRow[Column::FlashTaskbar],
+    //                getSettings()->enableElevatedMessageHighlightTaskbar.getValue(),
+    //                true, false);
+    //    setBoolItem(elevatedMessageRow[Column::PlaySound],
+    //                getSettings()->enableElevatedMessageHighlightSound.getValue(),
+    //                true, false);
+    elevatedMessageRow[Column::FlashTaskbar]->setFlags({});
+    elevatedMessageRow[Column::PlaySound]->setFlags({});
+    elevatedMessageRow[Column::UseRegex]->setFlags({});
+    elevatedMessageRow[Column::CaseSensitive]->setFlags({});
+
+    QUrl ElevatedMessageSound =
+        QUrl(getSettings()->elevatedMessageHighlightSoundUrl.getValue());
+    setFilePathItem(elevatedMessageRow[Column::SoundPath], ElevatedMessageSound,
+                    false);
+
+    auto ElevatedMessageColor =
+        ColorProvider::instance().color(ColorType::ElevatedMessageHighlight);
+    setColorItem(elevatedMessageRow[Column::Color], *ElevatedMessageColor,
+                 false);
+
+    this->insertCustomRow(elevatedMessageRow,
+                          HighlightRowIndexes::ElevatedMessageRow);
 }
 
 void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
@@ -213,6 +245,11 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
                 else if (rowIndex == HighlightRowIndexes::FirstMessageRow)
                 {
                     getSettings()->enableFirstMessageHighlight.setValue(
+                        value.toBool());
+                }
+                else if (rowIndex == HighlightRowIndexes::ElevatedMessageRow)
+                {
+                    getSettings()->enableElevatedMessageHighlight.setValue(
                         value.toBool());
                 }
             }
@@ -257,6 +294,12 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
                     // getSettings()->enableFirstMessageHighlightTaskbar.setValue(
                     //     value.toBool());
                 }
+                else if (rowIndex == HighlightRowIndexes::ElevatedMessageRow)
+                {
+                    // getSettings()
+                    //     ->enableElevatedMessageHighlightTaskbar.setvalue(
+                    //         value.toBool());
+                }
             }
         }
         break;
@@ -286,6 +329,11 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
                 else if (rowIndex == HighlightRowIndexes::FirstMessageRow)
                 {
                     // getSettings()->enableFirstMessageHighlightSound.setValue(
+                    //     value.toBool());
+                }
+                else if (rowIndex == HighlightRowIndexes::ElevatedMessageRow)
+                {
+                    // getSettings()->enableElevatedMessageHighlightSound.setValue(
                     //     value.toBool());
                 }
             }
@@ -328,6 +376,11 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
                     getSettings()->firstMessageHighlightSoundUrl.setValue(
                         value.toString());
                 }
+                if (rowIndex == HighlightRowIndexes::ElevatedMessageRow)
+                {
+                    getSettings()->elevatedMessageHighlightSoundUrl.setValue(
+                        value.toString());
+                }
             }
         }
         break;
@@ -361,6 +414,14 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
                         colorName);
                     const_cast<ColorProvider &>(ColorProvider::instance())
                         .updateColor(ColorType::FirstMessageHighlight,
+                                     QColor(colorName));
+                }
+                else if (rowIndex == HighlightRowIndexes::ElevatedMessageRow)
+                {
+                    getSettings()->elevatedMessageHighlightColor.setValue(
+                        colorName);
+                    const_cast<ColorProvider &>(ColorProvider::instance())
+                        .updateColor(ColorType::ElevatedMessageHighlight,
                                      QColor(colorName));
                 }
             }

--- a/src/controllers/highlights/HighlightModel.hpp
+++ b/src/controllers/highlights/HighlightModel.hpp
@@ -31,6 +31,7 @@ public:
         SubRow = 2,
         RedeemedRow = 3,
         FirstMessageRow = 4,
+        ElevatedMessageRow = 5,
     };
 
 protected:

--- a/src/controllers/highlights/HighlightPhrase.cpp
+++ b/src/controllers/highlights/HighlightPhrase.cpp
@@ -15,7 +15,7 @@ QColor HighlightPhrase::FALLBACK_REDEEMED_HIGHLIGHT_COLOR =
 QColor HighlightPhrase::FALLBACK_FIRST_MESSAGE_HIGHLIGHT_COLOR =
     QColor(72, 127, 63, 60);
 QColor HighlightPhrase::FALLBACK_ELEVATED_MESSAGE_HIGHLIGHT_COLOR =
-    QColor(255, 174, 66, 255);
+    QColor(255, 174, 66, 60);
 QColor HighlightPhrase::FALLBACK_SUB_COLOR = QColor(196, 102, 255, 100);
 
 bool HighlightPhrase::operator==(const HighlightPhrase &other) const

--- a/src/controllers/highlights/HighlightPhrase.cpp
+++ b/src/controllers/highlights/HighlightPhrase.cpp
@@ -14,6 +14,8 @@ QColor HighlightPhrase::FALLBACK_REDEEMED_HIGHLIGHT_COLOR =
     QColor(28, 126, 141, 60);
 QColor HighlightPhrase::FALLBACK_FIRST_MESSAGE_HIGHLIGHT_COLOR =
     QColor(72, 127, 63, 60);
+QColor HighlightPhrase::FALLBACK_ELEVATED_MESSAGE_HIGHLIGHT_COLOR =
+    QColor(255, 174, 66, 255);
 QColor HighlightPhrase::FALLBACK_SUB_COLOR = QColor(196, 102, 255, 100);
 
 bool HighlightPhrase::operator==(const HighlightPhrase &other) const

--- a/src/controllers/highlights/HighlightPhrase.hpp
+++ b/src/controllers/highlights/HighlightPhrase.hpp
@@ -83,6 +83,7 @@ public:
     static QColor FALLBACK_REDEEMED_HIGHLIGHT_COLOR;
     static QColor FALLBACK_SUB_COLOR;
     static QColor FALLBACK_FIRST_MESSAGE_HIGHLIGHT_COLOR;
+    static QColor FALLBACK_ELEVATED_MESSAGE_HIGHLIGHT_COLOR;
 
 private:
     QString pattern_;

--- a/src/messages/Message.cpp
+++ b/src/messages/Message.cpp
@@ -48,6 +48,13 @@ SBHighlight Message::getScrollBarHighlight() const
             ColorProvider::instance().color(ColorType::FirstMessageHighlight),
             SBHighlight::Default, false, true);
     }
+    else if (this->flags.has(MessageFlag::ElevatedMessage))
+    {
+        return SBHighlight(ColorProvider::instance().color(
+                               ColorType::ElevatedMessageHighlight),
+                           SBHighlight::Default, false, true);
+    }
+
     return SBHighlight();
 }
 

--- a/src/messages/Message.cpp
+++ b/src/messages/Message.cpp
@@ -42,17 +42,17 @@ SBHighlight Message::getScrollBarHighlight() const
             ColorProvider::instance().color(ColorType::RedeemedHighlight),
             SBHighlight::Default, true);
     }
-    else if (this->flags.has(MessageFlag::FirstMessage))
-    {
-        return SBHighlight(
-            ColorProvider::instance().color(ColorType::FirstMessageHighlight),
-            SBHighlight::Default, false, true);
-    }
     else if (this->flags.has(MessageFlag::ElevatedMessage))
     {
         return SBHighlight(ColorProvider::instance().color(
                                ColorType::ElevatedMessageHighlight),
                            SBHighlight::Default, false, false, true);
+    }
+    else if (this->flags.has(MessageFlag::FirstMessage))
+    {
+        return SBHighlight(
+            ColorProvider::instance().color(ColorType::FirstMessageHighlight),
+            SBHighlight::Default, false, true);
     }
 
     return SBHighlight();

--- a/src/messages/Message.cpp
+++ b/src/messages/Message.cpp
@@ -52,7 +52,7 @@ SBHighlight Message::getScrollBarHighlight() const
     {
         return SBHighlight(ColorProvider::instance().color(
                                ColorType::ElevatedMessageHighlight),
-                           SBHighlight::Default, false, true);
+                           SBHighlight::Default, false, false, true);
     }
 
     return SBHighlight();

--- a/src/messages/Message.hpp
+++ b/src/messages/Message.hpp
@@ -42,6 +42,7 @@ enum class MessageFlag : uint32_t {
     ShowInMentions = (1 << 22),
     FirstMessage = (1 << 23),
     ReplyMessage = (1 << 24),
+    ElevatedMessage = (1 << 25),
 };
 using MessageFlags = FlagsEnum<MessageFlag>;
 

--- a/src/messages/layouts/MessageLayout.cpp
+++ b/src/messages/layouts/MessageLayout.cpp
@@ -310,8 +310,16 @@ void MessageLayout::updateBuffer(QPixmap *buffer, int /*messageIndex*/,
         }
     }();
 
-    if (this->message_->flags.has(MessageFlag::FirstMessage) &&
-        getSettings()->enableFirstMessageHighlight.getValue())
+    if (this->message_->flags.has(MessageFlag::ElevatedMessage) &&
+        getSettings()->enableElevatedMessageHighlight.getValue())
+    {
+        backgroundColor = blendColors(backgroundColor,
+                                      *ColorProvider::instance().color(
+                                          ColorType::ElevatedMessageHighlight));
+    }
+
+    else if (this->message_->flags.has(MessageFlag::FirstMessage) &&
+             getSettings()->enableFirstMessageHighlight.getValue())
     {
         backgroundColor = blendColors(
             backgroundColor,

--- a/src/providers/colors/ColorProvider.cpp
+++ b/src/providers/colors/ColorProvider.cpp
@@ -133,6 +133,20 @@ void ColorProvider::initTypeColorMap()
              std::make_shared<QColor>(
                  HighlightPhrase::FALLBACK_FIRST_MESSAGE_HIGHLIGHT_COLOR)});
     }
+
+    customColor = getSettings()->elevatedMessageHighlightColor;
+    if (QColor(customColor).isValid())
+    {
+        this->typeColorMap_.insert({ColorType::ElevatedMessageHighlight,
+                                    std::make_shared<QColor>(customColor)});
+    }
+    else
+    {
+        this->typeColorMap_.insert(
+            {ColorType::ElevatedMessageHighlight,
+             std::make_shared<QColor>(
+                 HighlightPhrase::FALLBACK_ELEVATED_MESSAGE_HIGHLIGHT_COLOR)});
+    }
 }
 
 void ColorProvider::initDefaultColors()

--- a/src/providers/colors/ColorProvider.hpp
+++ b/src/providers/colors/ColorProvider.hpp
@@ -13,6 +13,7 @@ enum class ColorType {
     Whisper,
     RedeemedHighlight,
     FirstMessageHighlight,
+    ElevatedMessageHighlight,
 };
 
 class ColorProvider

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -198,6 +198,11 @@ MessagePtr TwitchMessageBuilder::build()
         this->message().flags.set(MessageFlag::FirstMessage);
     }
 
+    if (this->tags.contains("pinned-chat-paid-amount"))
+    {
+        this->message().flags.set(MessageFlag::ElevatedMessage);
+    }
+
     // reply threads
     if (this->thread_)
     {

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -292,6 +292,17 @@ public:
     QStringSetting firstMessageHighlightColor = {
         "/highlighting/firstMessageHighlightColor", ""};
 
+    BoolSetting enableElevatedMessageHighlight = {
+        "/highlighting/elevatedMessageHighlight/highlighted", true};
+    //    BoolSetting enableElevatedMessageHighlightSound = {
+    //        "/highlighting/elevatedMessageHighlight/enableSound", false};
+    //    BoolSetting enableElevatedMessageHighlightTaskbar = {
+    //        "/highlighting/elevatedMessageHighlight/enableTaskbarFlashing", false};
+    QStringSetting elevatedMessageHighlightSoundUrl = {
+        "/highlighting/elevatedMessageHighlightSoundUrl", ""};
+    QStringSetting elevatedMessageHighlightColor = {
+        "/highlighting/elevatedMessageHighlightColor", ""};
+
     BoolSetting enableSubHighlight = {
         "/highlighting/subHighlight/subsHighlighted", true};
     BoolSetting enableSubHighlightSound = {

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -299,9 +299,9 @@ public:
     //    BoolSetting enableElevatedMessageHighlightTaskbar = {
     //        "/highlighting/elevatedMessageHighlight/enableTaskbarFlashing", false};
     QStringSetting elevatedMessageHighlightSoundUrl = {
-        "/highlighting/elevatedMessageHighlightSoundUrl", ""};
+        "/highlighting/elevatedMessageHighlight/SoundUrl", ""};
     QStringSetting elevatedMessageHighlightColor = {
-        "/highlighting/elevatedMessageHighlightColor", ""};
+        "/highlighting/elevatedMessageHighlight/Color", ""};
 
     BoolSetting enableSubHighlight = {
         "/highlighting/subHighlight/subsHighlighted", true};

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -299,9 +299,9 @@ public:
     //    BoolSetting enableElevatedMessageHighlightTaskbar = {
     //        "/highlighting/elevatedMessageHighlight/enableTaskbarFlashing", false};
     QStringSetting elevatedMessageHighlightSoundUrl = {
-        "/highlighting/elevatedMessageHighlight/SoundUrl", ""};
+        "/highlighting/elevatedMessageHighlight/soundUrl", ""};
     QStringSetting elevatedMessageHighlightColor = {
-        "/highlighting/elevatedMessageHighlight/Color", ""};
+        "/highlighting/elevatedMessageHighlight/color", ""};
 
     BoolSetting enableSubHighlight = {
         "/highlighting/subHighlight/subsHighlighted", true};

--- a/src/util/SampleData.cpp
+++ b/src/util/SampleData.cpp
@@ -106,6 +106,9 @@ const QStringList &getSampleMiscMessages()
 
         // mod announcement
         R"(@badge-info=subscriber/47;badges=broadcaster/1,subscriber/3012,twitchconAmsterdam2020/1;color=#FF0000;display-name=Supinic;emotes=;flags=;id=8c26e1ab-b50c-4d9d-bc11-3fd57a941d90;login=supinic;mod=0;msg-id=announcement;msg-param-color=PRIMARY;room-id=31400525;subscriber=1;system-msg=;tmi-sent-ts=1648762219962;user-id=31400525;user-type= :tmi.twitch.tv USERNOTICE #supinic :mm test lol)",
+
+        // Elevated Message (Paid option for keeping a message in chat longer)
+        R"(@badge-info=subscriber/3;badges=subscriber/0,bits-charity/1;color=#0000FF;display-name=SnoopyTheBot;emotes=;first-msg=0;flags=;id=8779a9e5-cf1b-47b3-b9fe-67a5b1b605f6;mod=0;pinned-chat-paid-amount=500;pinned-chat-paid-canonical-amount=5;pinned-chat-paid-currency=USD;pinned-chat-paid-exponent=2;returning-chatter=0;room-id=36340781;subscriber=1;tmi-sent-ts=1664505974154;turbo=0;user-id=136881249;user-type= :snoopythebot!snoopythebot@snoopythebot.tmi.twitch.tv PRIVMSG #tarik :-$5)",
     };
     return list;
 }

--- a/src/util/SampleData.cpp
+++ b/src/util/SampleData.cpp
@@ -108,7 +108,7 @@ const QStringList &getSampleMiscMessages()
         R"(@badge-info=subscriber/47;badges=broadcaster/1,subscriber/3012,twitchconAmsterdam2020/1;color=#FF0000;display-name=Supinic;emotes=;flags=;id=8c26e1ab-b50c-4d9d-bc11-3fd57a941d90;login=supinic;mod=0;msg-id=announcement;msg-param-color=PRIMARY;room-id=31400525;subscriber=1;system-msg=;tmi-sent-ts=1648762219962;user-id=31400525;user-type= :tmi.twitch.tv USERNOTICE #supinic :mm test lol)",
 
         // Elevated Message (Paid option for keeping a message in chat longer)
-        R"(@badge-info=subscriber/3;badges=subscriber/0,bits-charity/1;color=#0000FF;display-name=SnoopyTheBot;emotes=;first-msg=0;flags=;id=8779a9e5-cf1b-47b3-b9fe-67a5b1b605f6;mod=0;pinned-chat-paid-amount=500;pinned-chat-paid-canonical-amount=5;pinned-chat-paid-currency=USD;pinned-chat-paid-exponent=2;returning-chatter=0;room-id=36340781;subscriber=1;tmi-sent-ts=1664505974154;turbo=0;user-id=136881249;user-type= :snoopythebot!snoopythebot@snoopythebot.tmi.twitch.tv PRIVMSG #tarik :-$5)",
+        R"(@badge-info=subscriber/3;badges=subscriber/0,bits-charity/1;color=#0000FF;display-name=SnoopyTheBot;emotes=;first-msg=0;flags=;id=8779a9e5-cf1b-47b3-b9fe-67a5b1b605f6;mod=0;pinned-chat-paid-amount=500;pinned-chat-paid-canonical-amount=5;pinned-chat-paid-currency=USD;pinned-chat-paid-exponent=2;returning-chatter=0;room-id=36340781;subscriber=1;tmi-sent-ts=1664505974154;turbo=0;user-id=136881249;user-type= :snoopythebot!snoopythebot@snoopythebot.tmi.twitch.tv PRIVMSG #pajlada :-$5)",
     };
     return list;
 }

--- a/src/widgets/Scrollbar.cpp
+++ b/src/widgets/Scrollbar.cpp
@@ -257,6 +257,8 @@ void Scrollbar::paintEvent(QPaintEvent *)
     bool enableRedeemedHighlights = getSettings()->enableRedeemedHighlight;
     bool enableFirstMessageHighlights =
         getSettings()->enableFirstMessageHighlight;
+    bool enableElevatedMessageHighlights =
+        getSettings()->enableElevatedMessageHighlight;
 
     //    painter.fillRect(QRect(xOffset, 0, width(), this->buttonHeight),
     //                     this->themeManager->ScrollbarArrow);
@@ -309,6 +311,12 @@ void Scrollbar::paintEvent(QPaintEvent *)
 
         if (highlight.isFirstMessageHighlight() &&
             !enableFirstMessageHighlights)
+        {
+            continue;
+        }
+
+        if (highlight.isElevatedMessageHighlight() &&
+            !enableElevatedMessageHighlights)
         {
             continue;
         }

--- a/src/widgets/helper/ScrollbarHighlight.cpp
+++ b/src/widgets/helper/ScrollbarHighlight.cpp
@@ -14,11 +14,13 @@ ScrollbarHighlight::ScrollbarHighlight()
 
 ScrollbarHighlight::ScrollbarHighlight(const std::shared_ptr<QColor> color,
                                        Style style, bool isRedeemedHighlight,
-                                       bool isFirstMessageHighlight)
+                                       bool isFirstMessageHighlight,
+                                       bool isElevatedMessageHighlight)
     : color_(color)
     , style_(style)
     , isRedeemedHighlight_(isRedeemedHighlight)
     , isFirstMessageHighlight_(isFirstMessageHighlight)
+    , isElevatedMessageHighlight_(isElevatedMessageHighlight)
 {
 }
 
@@ -40,6 +42,11 @@ bool ScrollbarHighlight::isRedeemedHighlight() const
 bool ScrollbarHighlight::isFirstMessageHighlight() const
 {
     return this->isFirstMessageHighlight_;
+}
+
+bool ScrollbarHighlight::isElevatedMessageHighlight() const
+{
+    return this->isElevatedMessageHighlight_;
 }
 
 bool ScrollbarHighlight::isNull() const

--- a/src/widgets/helper/ScrollbarHighlight.hpp
+++ b/src/widgets/helper/ScrollbarHighlight.hpp
@@ -22,12 +22,14 @@ public:
 
     ScrollbarHighlight(const std::shared_ptr<QColor> color,
                        Style style = Default, bool isRedeemedHighlight = false,
-                       bool isFirstMessageHighlight = false);
+                       bool isFirstMessageHighlight = false,
+                       bool isElevatedMessageHighlight = false);
 
     QColor getColor() const;
     Style getStyle() const;
     bool isRedeemedHighlight() const;
     bool isFirstMessageHighlight() const;
+    bool isElevatedMessageHighlight() const;
     bool isNull() const;
 
 private:
@@ -35,6 +37,7 @@ private:
     Style style_;
     bool isRedeemedHighlight_;
     bool isFirstMessageHighlight_;
+    bool isElevatedMessageHighlight_;
 };
 
 }  // namespace chatterino


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Added Basic Elevated Message Support via the existing standard of First Messages.

While this approach obviously is missing the main concept of this feature which is the "pinned message", it allows for users to not be left out of the loop, and allows moderators to properly moderate said messages. 
`(e.g. A message that might have gotten past if it was a normal message may gain additional scrutiny if it is an Elevated Message)`

TODO: 
- [x] Figure out what I missed which is preventing `enableElevatedMessageHighlight` from disabling the scrollbar highlights. (currently `enableFirstMessageHighlight` is doing both)
<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
