### PR TITLE
Add `flags.elevated_message` filter variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@
 - Minor: Fixed `/streamlink` command not stripping leading @'s or #'s (#3215)
 - Minor: Strip leading @ and trailing , from username in `/popout` command. (#3217)
 - Minor: Added `flags.reward_message` filter variable (#3231)
+- Minor: Added `flags.elevated_message` filter variable. (#4017)
 - Minor: Added chatter count to viewer list popout (#3261)
 - Minor: Ignore out of bounds check for tiling wms (#3270)
 - Minor: Add clear cache button to cache settings section (#3277)

--- a/src/controllers/filters/parser/FilterParser.cpp
+++ b/src/controllers/filters/parser/FilterParser.cpp
@@ -29,6 +29,7 @@ ContextMap buildContextMap(const MessagePtr &m, chatterino::Channel *channel)
      * flags.system_message
      * flags.reward_message
      * flags.first_message
+     * flags.elevated_message
      * flags.whisper
      * flags.reply
      * flags.automod
@@ -83,6 +84,7 @@ ContextMap buildContextMap(const MessagePtr &m, chatterino::Channel *channel)
         {"flags.reward_message",
          m->flags.has(MessageFlag::RedeemedChannelPointReward)},
         {"flags.first_message", m->flags.has(MessageFlag::FirstMessage)},
+        {"flags.elevated_message", m->flags.has(MessageFlag::ElevatedMessage)},
         {"flags.whisper", m->flags.has(MessageFlag::Whisper)},
         {"flags.reply", m->flags.has(MessageFlag::ReplyMessage)},
         {"flags.automod", m->flags.has(MessageFlag::AutoMod)},

--- a/src/controllers/filters/parser/Tokenizer.hpp
+++ b/src/controllers/filters/parser/Tokenizer.hpp
@@ -24,6 +24,7 @@ static const QMap<QString, QString> validIdentifiersMap = {
     {"flags.system_message", "system message?"},
     {"flags.reward_message", "channel point reward message?"},
     {"flags.first_message", "first message?"},
+    {"flags.elevated_message", "elevated message?"},
     {"flags.whisper", "whisper message?"},
     {"flags.reply", "reply message?"},
     {"flags.automod", "automod message?"},


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Added the `flags.elevated_message` filter variable

Relies on #4016