### PR TITLE
Add `is:elevated-msg` search predicate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Minor: Added `Go to message` context menu action to search popup, mentions, usercard and reply threads. (#3953)
 - Minor: Clicking `A message from x was deleted` messages will now jump to the message in question. (#3953)
 - Minor: Added `is:first-msg` search option. (#3700)
+- Minor: Added `is:elevated-msg` search option. (#4018)
 - Minor: Added AutoMod message flag filter. (#3938)
 - Minor: Added chatter count for each category in viewer list. (#3683, #3719)
 - Minor: Added option to open a user's chat in a new tab from the usercard profile picture context menu. (#3625)

--- a/src/messages/search/MessageFlagsPredicate.cpp
+++ b/src/messages/search/MessageFlagsPredicate.cpp
@@ -34,6 +34,10 @@ MessageFlagsPredicate::MessageFlagsPredicate(const QString &flags)
         {
             this->flags_.set(MessageFlag::FirstMessage);
         }
+        else if (flag == "elevated-msg")
+        {
+            this->flags_.set(MessageFlag::ElevatedMessage);
+        }
     }
 }
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Added the `is:elevated-msg` search predicate.

Relies on #4016
