### PR TITLE
fix: Show Emoji Completion in IRC Channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 - Bugfix: Fixed an issue where Anonymous gift messages appeared larger than normal gift messages. (#3888)
 - Bugfix: Fixed crash related to logging IRC channels (#3918)
 - Bugfix: Mentions of "You" in timeouts will link to your own user now instead of the user "You". (#3922)
+- Bugfix: Fixed emoji popup not being shown in IRC channels (#4021)
 - Dev: Removed official support for QMake. (#3839, #3883)
 - Dev: Rewrote LimitedQueue (#3798)
 - Dev: Overhauled highlight system by moving all checks into a Controller allowing for easier tests. (#3399, #3801, #3835)

--- a/src/widgets/splits/InputCompletionPopup.cpp
+++ b/src/widgets/splits/InputCompletionPopup.cpp
@@ -110,9 +110,9 @@ void InputCompletionPopup::updateEmotes(const QString &text, ChannelPtr channel)
             addEmotes(emotes, *bttvG, text, "Global BetterTTV");
         if (auto ffzG = getApp()->twitch->getFfzEmotes().emotes())
             addEmotes(emotes, *ffzG, text, "Global FrankerFaceZ");
-
-        addEmojis(emotes, getApp()->emotes->emojis.emojis, text);
     }
+
+    addEmojis(emotes, getApp()->emotes->emojis.emojis, text);
 
     // if there is an exact match, put that emote first
     for (size_t i = 1; i < emotes.size(); i++)

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -661,8 +661,7 @@ void SplitInput::updateCompletionPopup()
 {
     auto channel = this->split_->getChannel().get();
     auto tc = dynamic_cast<TwitchChannel *>(channel);
-    bool showEmoteCompletion =
-        channel->isTwitchChannel() && getSettings()->emoteCompletionWithColon;
+    bool showEmoteCompletion = getSettings()->emoteCompletionWithColon;
     bool showUsernameCompletion =
         tc && getSettings()->showUsernameCompletionMenu;
     if (!showEmoteCompletion && !showUsernameCompletion)


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

The emote completion popup wasn't shown in irc channels and it had no emojis added. Note that emojis in sent message use the system's emojis (see #4020).

Fixes #3550.
