### PR TITLE
Enable Helix timegating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@
 - Minor: Migrated /unvip command to Helix API. (#4025)
 - Minor: Migrated /untimeout to Helix API. (#4026)
 - Minor: Migrated /unban to Helix API. (#4026)
-- Minor: Migrated /raid command to Helix API. (#4029)
+- Minor: Migrated /raid command to Helix API. Chat command will continue to be used until February 11th 2023. (#4029)
 - Bugfix: Connection to Twitch PubSub now recovers more reliably. (#3643, #3716)
 - Bugfix: Fixed `Smooth scrolling on new messages` setting sometimes hiding messages. (#4028)
 - Bugfix: Fixed a crash that can occur when closing and quickly reopening a split, then running a command. (#3852)

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -43,8 +43,10 @@ using namespace chatterino;
 
 bool areIRCCommandsStillAvailable()
 {
-    // TODO: time-gate
-    return true;
+    // 11th of February 2023, 06:00am UTC
+    const QDateTime migrationTime(QDate(2023, 2, 11), QTime(6, 0), Qt::UTC);
+    auto now = QDateTime::currentDateTimeUtc();
+    return now < migrationTime;
 }
 
 QString useIRCCommand(const QStringList &words)


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

For commands affected by the timegating, they will continue to use their IRC command equivalent until **the 11th of February, 2023**.
This is one week before the actual migration is supposed to start. The wording of the date is shaky, so we start a bit before to be sure.
Any highly affected commands will have a temporary setting at the bottom of the General settings page to override the timegating functionality.

Any commands that are affected will also have their changelog entry updated to notify of the timegating.

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
