### PR TITLE
refactor: Remove Leading Mention in Replies and Highlight Participated Threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unversioned
 
-- Major: Added support for Twitch's Chat Replies. [Wiki Page](https://wiki.chatterino.com/Features/#message-replies) (#3722, #3989, #4041)
+- Major: Added support for Twitch's Chat Replies. [Wiki Page](https://wiki.chatterino.com/Features/#message-replies) (
+  #3722, #3989, #4041, #4047)
 - Major: Added multi-channel searching to search dialog via keyboard shortcut. (Ctrl+Shift+F by default) (#3694, #3875)
 - Minor: Added highlights for `Elevated Messages`. (#4016)
 - Minor: Removed total views from the usercard, as Twitch no longer updates the number. (#3792)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## Unversioned
 
-- Major: Added support for Twitch's Chat Replies. [Wiki Page](https://wiki.chatterino.com/Features/#message-replies) (
-  #3722, #3989, #4041, #4047)
+- Major: Added support for Twitch's Chat Replies. [Wiki Page](https://wiki.chatterino.com/Features/#message-replies) (#3722, #3989, #4041, #4047)
 - Major: Added multi-channel searching to search dialog via keyboard shortcut. (Ctrl+Shift+F by default) (#3694, #3875)
 - Minor: Added highlights for `Elevated Messages`. (#4016)
 - Minor: Removed total views from the usercard, as Twitch no longer updates the number. (#3792)

--- a/src/controllers/highlights/HighlightController.cpp
+++ b/src/controllers/highlights/HighlightController.cpp
@@ -164,10 +164,8 @@ void rebuildReplyThreadHighlight(Settings &settings,
                         highlightInMentions,
                     };
                 }
-                else
-                {
-                    return boost::none;
-                }
+
+                return boost::none;
             }});
     }
 }

--- a/src/controllers/highlights/HighlightController.cpp
+++ b/src/controllers/highlights/HighlightController.cpp
@@ -193,7 +193,6 @@ void rebuildMessageHighlights(Settings &settings,
     {
         checks.emplace_back(highlightPhraseCheck(highlight));
     }
-    rebuildReplyThreadHighlight(settings, checks);
 }
 
 void rebuildUserHighlights(Settings &settings,
@@ -346,7 +345,7 @@ void HighlightController::rebuildChecks(Settings &settings)
     checks->clear();
 
     // CURRENT ORDER:
-    // Subscription -> Whisper -> User -> Message -> Badge
+    // Subscription -> Whisper -> User -> Message -> Reply Threads -> Badge
 
     rebuildSubscriptionHighlights(settings, *checks);
 
@@ -355,6 +354,8 @@ void HighlightController::rebuildChecks(Settings &settings)
     rebuildUserHighlights(settings, *checks);
 
     rebuildMessageHighlights(settings, *checks);
+
+    rebuildReplyThreadHighlight(settings, *checks);
 
     rebuildBadgeHighlights(settings, *checks);
 }

--- a/src/controllers/highlights/HighlightController.cpp
+++ b/src/controllers/highlights/HighlightController.cpp
@@ -213,7 +213,7 @@ void rebuildUserHighlights(Settings &settings,
                 (void)args;             // unused
                 (void)badges;           // unused
                 (void)originalMessage;  // unused
-                (void)flags;            //unused
+                (void)flags;            // unused
                 (void)self;             // unused
 
                 if (!highlight.isMatch(senderName))

--- a/src/controllers/highlights/HighlightController.cpp
+++ b/src/controllers/highlights/HighlightController.cpp
@@ -11,10 +11,12 @@ auto highlightPhraseCheck(const HighlightPhrase &highlight) -> HighlightCheck
     return HighlightCheck{
         [highlight](const auto &args, const auto &badges,
                     const auto &senderName, const auto &originalMessage,
+                    const auto &flags,
                     const auto self) -> boost::optional<HighlightResult> {
             (void)args;        // unused
             (void)badges;      // unused
             (void)senderName;  // unused
+            (void)flags;       // unused
 
             if (self)
             {
@@ -60,11 +62,12 @@ void rebuildSubscriptionHighlights(Settings &settings,
 
         checks.emplace_back(HighlightCheck{
             [=](const auto &args, const auto &badges, const auto &senderName,
-                const auto &originalMessage,
+                const auto &originalMessage, const auto &flags,
                 const auto self) -> boost::optional<HighlightResult> {
                 (void)badges;           // unused
                 (void)senderName;       // unused
                 (void)originalMessage;  // unused
+                (void)flags;            // unused
                 (void)self;             // unused
 
                 if (!args.isSubscriptionMessage)
@@ -105,11 +108,12 @@ void rebuildWhisperHighlights(Settings &settings,
 
         checks.emplace_back(HighlightCheck{
             [=](const auto &args, const auto &badges, const auto &senderName,
-                const auto &originalMessage,
+                const auto &originalMessage, const auto &flags,
                 const auto self) -> boost::optional<HighlightResult> {
                 (void)badges;           // unused
                 (void)senderName;       // unused
                 (void)originalMessage;  // unused
+                (void)flags;            // unused
                 (void)self;             // unused
 
                 if (!args.isReceivedWhisper)
@@ -124,6 +128,46 @@ void rebuildWhisperHighlights(Settings &settings,
                     ColorProvider::instance().color(ColorType::Whisper),
                     false,
                 };
+            }});
+    }
+}
+
+void rebuildReplyThreadHighlight(Settings &settings,
+                                 std::vector<HighlightCheck> &checks)
+{
+    if (settings.enableThreadHighlight)
+    {
+        auto highlightSound = settings.enableThreadHighlightSound.getValue();
+        auto highlightAlert = settings.enableThreadHighlightTaskbar.getValue();
+        auto highlightSoundUrlValue =
+            settings.threadHighlightSoundUrl.getValue();
+        boost::optional<QUrl> highlightSoundUrl;
+        if (!highlightSoundUrlValue.isEmpty())
+        {
+            highlightSoundUrl = highlightSoundUrlValue;
+        }
+        auto highlightInMentions =
+            settings.showThreadHighlightInMentions.getValue();
+        checks.emplace_back(HighlightCheck{
+            [=](const auto & /*args*/, const auto & /*badges*/,
+                const auto & /*senderName*/, const auto & /*originalMessage*/,
+                const auto &flags,
+                const auto self) -> boost::optional<HighlightResult> {
+                if (flags.has(MessageFlag::ParticipatedThread) && !self)
+                {
+                    return HighlightResult{
+                        highlightAlert,
+                        highlightSound,
+                        highlightSoundUrl,
+                        ColorProvider::instance().color(
+                            ColorType::ThreadMessageHighlight),
+                        highlightInMentions,
+                    };
+                }
+                else
+                {
+                    return boost::none;
+                }
             }});
     }
 }
@@ -151,6 +195,7 @@ void rebuildMessageHighlights(Settings &settings,
     {
         checks.emplace_back(highlightPhraseCheck(highlight));
     }
+    rebuildReplyThreadHighlight(settings, checks);
 }
 
 void rebuildUserHighlights(Settings &settings,
@@ -163,10 +208,12 @@ void rebuildUserHighlights(Settings &settings,
         checks.emplace_back(HighlightCheck{
             [highlight](const auto &args, const auto &badges,
                         const auto &senderName, const auto &originalMessage,
+                        const auto &flags,
                         const auto self) -> boost::optional<HighlightResult> {
                 (void)args;             // unused
                 (void)badges;           // unused
                 (void)originalMessage;  // unused
+                (void)flags;            //unused
                 (void)self;             // unused
 
                 if (!highlight.isMatch(senderName))
@@ -201,10 +248,12 @@ void rebuildBadgeHighlights(Settings &settings,
         checks.emplace_back(HighlightCheck{
             [highlight](const auto &args, const auto &badges,
                         const auto &senderName, const auto &originalMessage,
+                        const auto &flags,
                         const auto self) -> boost::optional<HighlightResult> {
                 (void)args;             // unused
                 (void)senderName;       // unused
                 (void)originalMessage;  // unused
+                (void)flags;            // unused
                 (void)self;             // unused
 
                 for (const Badge &badge : badges)
@@ -247,6 +296,11 @@ void HighlightController::initialize(Settings &settings, Paths & /*paths*/)
     this->rebuildListener_.addSetting(settings.enableSubHighlight);
     this->rebuildListener_.addSetting(settings.enableSubHighlightSound);
     this->rebuildListener_.addSetting(settings.enableSubHighlightTaskbar);
+    this->rebuildListener_.addSetting(settings.enableThreadHighlight);
+    this->rebuildListener_.addSetting(settings.enableThreadHighlightSound);
+    this->rebuildListener_.addSetting(settings.enableThreadHighlightTaskbar);
+    this->rebuildListener_.addSetting(settings.threadHighlightSoundUrl);
+    this->rebuildListener_.addSetting(settings.showThreadHighlightInMentions);
 
     this->rebuildListener_.setCB([this, &settings] {
         qCDebug(chatterinoHighlights)
@@ -309,7 +363,8 @@ void HighlightController::rebuildChecks(Settings &settings)
 
 std::pair<bool, HighlightResult> HighlightController::check(
     const MessageParseArgs &args, const std::vector<Badge> &badges,
-    const QString &senderName, const QString &originalMessage) const
+    const QString &senderName, const QString &originalMessage,
+    const MessageFlags &messageFlags) const
 {
     bool highlighted = false;
     auto result = HighlightResult::emptyResult();
@@ -322,8 +377,8 @@ std::pair<bool, HighlightResult> HighlightController::check(
 
     for (const auto &check : *checks)
     {
-        if (auto checkResult =
-                check.cb(args, badges, senderName, originalMessage, self);
+        if (auto checkResult = check.cb(args, badges, senderName,
+                                        originalMessage, messageFlags, self);
             checkResult)
         {
             highlighted = true;

--- a/src/controllers/highlights/HighlightController.hpp
+++ b/src/controllers/highlights/HighlightController.hpp
@@ -142,7 +142,8 @@ struct HighlightResult {
 struct HighlightCheck {
     using Checker = std::function<boost::optional<HighlightResult>(
         const MessageParseArgs &args, const std::vector<Badge> &badges,
-        const QString &senderName, const QString &originalMessage, bool self)>;
+        const QString &senderName, const QString &originalMessage,
+        const MessageFlags &messageFlags, bool self)>;
     Checker cb;
 };
 
@@ -156,7 +157,8 @@ public:
      **/
     [[nodiscard]] std::pair<bool, HighlightResult> check(
         const MessageParseArgs &args, const std::vector<Badge> &badges,
-        const QString &senderName, const QString &originalMessage) const;
+        const QString &senderName, const QString &originalMessage,
+        const MessageFlags &messageFlags) const;
 
 private:
     /**

--- a/src/controllers/highlights/HighlightModel.cpp
+++ b/src/controllers/highlights/HighlightModel.cpp
@@ -213,6 +213,36 @@ void HighlightModel::afterInit()
 
     this->insertCustomRow(elevatedMessageRow,
                           HighlightRowIndexes::ElevatedMessageRow);
+
+    // Highlight settings for reply threads
+    std::vector<QStandardItem *> threadMessageRow = this->createRow();
+    setBoolItem(threadMessageRow[Column::Pattern],
+                getSettings()->enableThreadHighlight.getValue(), true, false);
+    threadMessageRow[Column::Pattern]->setData("Participated Reply Threads",
+                                               Qt::DisplayRole);
+    setBoolItem(threadMessageRow[Column::ShowInMentions],
+                getSettings()->showThreadHighlightInMentions.getValue(), true,
+                false);
+    setBoolItem(threadMessageRow[Column::FlashTaskbar],
+                getSettings()->enableThreadHighlightTaskbar.getValue(), true,
+                false);
+    setBoolItem(threadMessageRow[Column::PlaySound],
+                getSettings()->enableThreadHighlightSound.getValue(), true,
+                false);
+    threadMessageRow[Column::UseRegex]->setFlags({});
+    threadMessageRow[Column::CaseSensitive]->setFlags({});
+
+    QUrl threadMessageSound =
+        QUrl(getSettings()->threadHighlightSoundUrl.getValue());
+    setFilePathItem(threadMessageRow[Column::SoundPath], threadMessageSound,
+                    false);
+
+    auto threadMessageColor =
+        ColorProvider::instance().color(ColorType::ThreadMessageHighlight);
+    setColorItem(threadMessageRow[Column::Color], *threadMessageColor, false);
+
+    this->insertCustomRow(threadMessageRow,
+                          HighlightRowIndexes::ThreadMessageRow);
 }
 
 void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
@@ -252,6 +282,11 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
                     getSettings()->enableElevatedMessageHighlight.setValue(
                         value.toBool());
                 }
+                else if (rowIndex == HighlightRowIndexes::ThreadMessageRow)
+                {
+                    getSettings()->enableThreadHighlight.setValue(
+                        value.toBool());
+                }
             }
         }
         break;
@@ -261,6 +296,11 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
                 if (rowIndex == HighlightRowIndexes::SelfHighlightRow)
                 {
                     getSettings()->showSelfHighlightInMentions.setValue(
+                        value.toBool());
+                }
+                else if (rowIndex == HighlightRowIndexes::ThreadMessageRow)
+                {
+                    getSettings()->showThreadHighlightInMentions.setValue(
                         value.toBool());
                 }
             }
@@ -300,6 +340,11 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
                     //     ->enableElevatedMessageHighlightTaskbar.setvalue(
                     //         value.toBool());
                 }
+                else if (rowIndex == HighlightRowIndexes::ThreadMessageRow)
+                {
+                    getSettings()->enableThreadHighlightTaskbar.setValue(
+                        value.toBool());
+                }
             }
         }
         break;
@@ -335,6 +380,11 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
                 {
                     // getSettings()->enableElevatedMessageHighlightSound.setValue(
                     //     value.toBool());
+                }
+                else if (rowIndex == HighlightRowIndexes::ThreadMessageRow)
+                {
+                    getSettings()->enableThreadHighlightSound.setValue(
+                        value.toBool());
                 }
             }
         }
@@ -381,6 +431,11 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
                     getSettings()->elevatedMessageHighlightSoundUrl.setValue(
                         value.toString());
                 }
+                else if (rowIndex == HighlightRowIndexes::ThreadMessageRow)
+                {
+                    getSettings()->threadHighlightSoundUrl.setValue(
+                        value.toString());
+                }
             }
         }
         break;
@@ -422,6 +477,13 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
                         colorName);
                     const_cast<ColorProvider &>(ColorProvider::instance())
                         .updateColor(ColorType::ElevatedMessageHighlight,
+                                     QColor(colorName));
+                }
+                else if (rowIndex == HighlightRowIndexes::ThreadMessageRow)
+                {
+                    getSettings()->threadHighlightColor.setValue(colorName);
+                    const_cast<ColorProvider &>(ColorProvider::instance())
+                        .updateColor(ColorType::ThreadMessageHighlight,
                                      QColor(colorName));
                 }
             }

--- a/src/controllers/highlights/HighlightModel.hpp
+++ b/src/controllers/highlights/HighlightModel.hpp
@@ -32,6 +32,7 @@ public:
         RedeemedRow = 3,
         FirstMessageRow = 4,
         ElevatedMessageRow = 5,
+        ThreadMessageRow = 6,
     };
 
 protected:

--- a/src/controllers/highlights/HighlightPhrase.cpp
+++ b/src/controllers/highlights/HighlightPhrase.cpp
@@ -16,6 +16,8 @@ QColor HighlightPhrase::FALLBACK_FIRST_MESSAGE_HIGHLIGHT_COLOR =
     QColor(72, 127, 63, 60);
 QColor HighlightPhrase::FALLBACK_ELEVATED_MESSAGE_HIGHLIGHT_COLOR =
     QColor(255, 174, 66, 60);
+QColor HighlightPhrase::FALLBACK_THREAD_HIGHLIGHT_COLOR =
+    QColor(143, 48, 24, 60);
 QColor HighlightPhrase::FALLBACK_SUB_COLOR = QColor(196, 102, 255, 100);
 
 bool HighlightPhrase::operator==(const HighlightPhrase &other) const

--- a/src/controllers/highlights/HighlightPhrase.hpp
+++ b/src/controllers/highlights/HighlightPhrase.hpp
@@ -84,6 +84,7 @@ public:
     static QColor FALLBACK_SUB_COLOR;
     static QColor FALLBACK_FIRST_MESSAGE_HIGHLIGHT_COLOR;
     static QColor FALLBACK_ELEVATED_MESSAGE_HIGHLIGHT_COLOR;
+    static QColor FALLBACK_THREAD_HIGHLIGHT_COLOR;
 
 private:
     QString pattern_;

--- a/src/messages/Message.hpp
+++ b/src/messages/Message.hpp
@@ -43,6 +43,7 @@ enum class MessageFlag : int64_t {
     FirstMessage = (1LL << 23),
     ReplyMessage = (1LL << 24),
     ElevatedMessage = (1LL << 25),
+    ParticipatedThread = (1LL << 26),
 };
 using MessageFlags = FlagsEnum<MessageFlag>;
 

--- a/src/messages/MessageThread.cpp
+++ b/src/messages/MessageThread.cpp
@@ -58,4 +58,14 @@ size_t MessageThread::liveCount(
     return count;
 }
 
+bool MessageThread::participated() const
+{
+    return this->participated_;
+}
+
+void MessageThread::markParticipated()
+{
+    this->participated_ = true;
+}
+
 }  // namespace chatterino

--- a/src/messages/MessageThread.hpp
+++ b/src/messages/MessageThread.hpp
@@ -23,6 +23,10 @@ public:
     /// Returns the number of live reply references
     size_t liveCount(const std::shared_ptr<const Message> &exclude) const;
 
+    bool participated() const;
+
+    void markParticipated();
+
     const QString &rootId() const
     {
         return rootMessageId_;
@@ -42,6 +46,7 @@ private:
     const QString rootMessageId_;
     const std::shared_ptr<const Message> rootMessage_;
     std::vector<std::weak_ptr<const Message>> replies_;
+    bool participated_ = false;
 };
 
 }  // namespace chatterino

--- a/src/messages/SharedMessageBuilder.cpp
+++ b/src/messages/SharedMessageBuilder.cpp
@@ -149,7 +149,8 @@ void SharedMessageBuilder::parseHighlights()
 
     auto badges = SharedMessageBuilder::parseBadgeTag(this->tags);
     auto [highlighted, highlightResult] = getIApp()->getHighlights()->check(
-        this->args, badges, this->ircMessage->nick(), this->originalMessage_);
+        this->args, badges, this->ircMessage->nick(), this->originalMessage_,
+        this->message().flags);
 
     if (!highlighted)
     {

--- a/src/providers/colors/ColorProvider.cpp
+++ b/src/providers/colors/ColorProvider.cpp
@@ -147,6 +147,20 @@ void ColorProvider::initTypeColorMap()
              std::make_shared<QColor>(
                  HighlightPhrase::FALLBACK_ELEVATED_MESSAGE_HIGHLIGHT_COLOR)});
     }
+
+    customColor = getSettings()->threadHighlightColor;
+    if (QColor(customColor).isValid())
+    {
+        this->typeColorMap_.insert({ColorType::ThreadMessageHighlight,
+                                    std::make_shared<QColor>(customColor)});
+    }
+    else
+    {
+        this->typeColorMap_.insert(
+            {ColorType::ThreadMessageHighlight,
+             std::make_shared<QColor>(
+                 HighlightPhrase::FALLBACK_THREAD_HIGHLIGHT_COLOR)});
+    }
 }
 
 void ColorProvider::initDefaultColors()

--- a/src/providers/colors/ColorProvider.hpp
+++ b/src/providers/colors/ColorProvider.hpp
@@ -14,7 +14,7 @@ enum class ColorType {
     RedeemedHighlight,
     FirstMessageHighlight,
     ElevatedMessageHighlight,
-    ThreadMessageHighlight
+    ThreadMessageHighlight,
 };
 
 class ColorProvider

--- a/src/providers/colors/ColorProvider.hpp
+++ b/src/providers/colors/ColorProvider.hpp
@@ -14,6 +14,7 @@ enum class ColorType {
     RedeemedHighlight,
     FirstMessageHighlight,
     ElevatedMessageHighlight,
+    ThreadMessageHighlight
 };
 
 class ColorProvider

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -502,7 +502,8 @@ void IrcMessageHandler::updateReplyParticipatedStatus(
     TwitchMessageBuilder &builder, std::shared_ptr<MessageThread> &thread,
     bool isNew)
 {
-    auto &currentLogin = getApp()->accounts->twitch.getCurrent()->getUserName();
+    const auto &currentLogin =
+        getApp()->accounts->twitch.getCurrent()->getUserName();
     if (thread->participated())
     {
         builder.message().flags.set(MessageFlag::ParticipatedThread);
@@ -511,7 +512,7 @@ void IrcMessageHandler::updateReplyParticipatedStatus(
 
     if (isNew)
     {
-        if (const auto it = tags.find("reply-parent-user-name");
+        if (const auto it = tags.find("reply-parent-user-login");
             it != tags.end())
         {
             auto name = it.value().toString();

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -476,6 +476,11 @@ void IrcMessageHandler::addMessage(Communi::IrcMessage *_message,
 int IrcMessageHandler::stripLeadingReplyMention(const QVariantMap &tags,
                                                 QString &content)
 {
+    if (!getSettings()->stripReplyMention)
+    {
+        return 0;
+    }
+
     if (const auto it = tags.find("reply-parent-display-name");
         it != tags.end())
     {

--- a/src/providers/twitch/IrcMessageHandler.hpp
+++ b/src/providers/twitch/IrcMessageHandler.hpp
@@ -71,13 +71,6 @@ private:
     void populateReply(TwitchChannel *channel, Communi::IrcMessage *message,
                        const std::vector<MessagePtr> &otherLoaded,
                        TwitchMessageBuilder &builder);
-
-    static int stripLeadingReplyMention(const QVariantMap &tags,
-                                        QString &content);
-    static void updateReplyParticipatedStatus(
-        const QVariantMap &tags, const QString &senderLogin,
-        TwitchMessageBuilder &builder, std::shared_ptr<MessageThread> &thread,
-        bool isNew);
 };
 
 }  // namespace chatterino

--- a/src/providers/twitch/IrcMessageHandler.hpp
+++ b/src/providers/twitch/IrcMessageHandler.hpp
@@ -71,6 +71,14 @@ private:
     void populateReply(TwitchChannel *channel, Communi::IrcMessage *message,
                        const std::vector<MessagePtr> &otherLoaded,
                        TwitchMessageBuilder &builder);
+
+    static int stripLeadingReplyMention(const QVariantMap &tags,
+                                        QString &content);
+    void updateReplyParticipatedStatus(const QVariantMap &tags,
+                                       const QString &senderLogin,
+                                       TwitchMessageBuilder &builder,
+                                       std::shared_ptr<MessageThread> &thread,
+                                       bool isNew);
 };
 
 }  // namespace chatterino

--- a/src/providers/twitch/IrcMessageHandler.hpp
+++ b/src/providers/twitch/IrcMessageHandler.hpp
@@ -74,11 +74,10 @@ private:
 
     static int stripLeadingReplyMention(const QVariantMap &tags,
                                         QString &content);
-    void updateReplyParticipatedStatus(const QVariantMap &tags,
-                                       const QString &senderLogin,
-                                       TwitchMessageBuilder &builder,
-                                       std::shared_ptr<MessageThread> &thread,
-                                       bool isNew);
+    static void updateReplyParticipatedStatus(
+        const QVariantMap &tags, const QString &senderLogin,
+        TwitchMessageBuilder &builder, std::shared_ptr<MessageThread> &thread,
+        bool isNew);
 };
 
 }  // namespace chatterino

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -999,8 +999,10 @@ void TwitchMessageBuilder::appendTwitchEmote(
             return;
         }
 
-        auto start = correctPositions[coords.at(0).toUInt()];
-        auto end = correctPositions[coords.at(1).toUInt()];
+        auto start =
+            correctPositions[coords.at(0).toUInt() - this->messageOffset_];
+        auto end =
+            correctPositions[coords.at(1).toUInt() - this->messageOffset_];
 
         if (start >= end || start < 0 || end > this->originalMessage_.length())
         {
@@ -1587,6 +1589,11 @@ void TwitchMessageBuilder::listOfUsersSystemMessage(QString prefix,
 void TwitchMessageBuilder::setThread(std::shared_ptr<MessageThread> thread)
 {
     this->thread_ = std::move(thread);
+}
+
+void TwitchMessageBuilder::setMessageOffset(int offset)
+{
+    this->messageOffset_ = offset;
 }
 
 }  // namespace chatterino

--- a/src/providers/twitch/TwitchMessageBuilder.hpp
+++ b/src/providers/twitch/TwitchMessageBuilder.hpp
@@ -47,6 +47,7 @@ public:
     MessagePtr build() override;
 
     void setThread(std::shared_ptr<MessageThread> thread);
+    void setMessageOffset(int offset);
 
     static void appendChannelPointRewardMessage(
         const ChannelPointReward &reward, MessageBuilder *builder, bool isMod,
@@ -109,6 +110,7 @@ private:
     bool bitsStacked = false;
     bool historicalMessage_ = false;
     std::shared_ptr<MessageThread> thread_;
+    int messageOffset_ = 0;
 
     QString userId_;
     bool senderIsBroadcaster{};

--- a/src/providers/twitch/TwitchMessageBuilder.hpp
+++ b/src/providers/twitch/TwitchMessageBuilder.hpp
@@ -110,6 +110,17 @@ private:
     bool bitsStacked = false;
     bool historicalMessage_ = false;
     std::shared_ptr<MessageThread> thread_;
+
+    /**
+     * Starting offset to be used on index-based operations on `originalMessage_`.
+     *
+     * For example:
+     * originalMessage_ = "there"
+     * messageOffset_ = 4
+     * (the irc message is "hey there")
+     *
+     * then the index 6 would resolve to 6 - 4 = 2 => 'e'
+     */
     int messageOffset_ = 0;
 
     QString userId_;

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -118,6 +118,7 @@ public:
     //    BoolSetting collapseLongMessages =
     //    {"/appearance/messages/collapseLongMessages", false};
     BoolSetting showReplyButton = {"/appearance/showReplyButton", false};
+    BoolSetting stripReplyMention = {"/appearance/stripReplyMention", true};
     IntSetting collpseMessagesMinLines = {
         "/appearance/messages/collapseMessagesMinLines", 0};
     BoolSetting alternateMessages = {

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -327,6 +327,19 @@ public:
                                            ""};
     QStringSetting subHighlightColor = {"/highlighting/subHighlightColor", ""};
 
+    BoolSetting enableThreadHighlight = {
+        "/highlighting/thread/nameIsHighlightKeyword", true};
+    BoolSetting showThreadHighlightInMentions = {
+        "/highlighting/thread/showSelfHighlightInMentions", true};
+    BoolSetting enableThreadHighlightSound = {
+        "/highlighting/thread/enableSound", true};
+    BoolSetting enableThreadHighlightTaskbar = {
+        "/highlighting/thread/enableTaskbarFlashing", true};
+    QStringSetting threadHighlightSoundUrl = {
+        "/highlighting/threadHighlightSoundUrl", ""};
+    QStringSetting threadHighlightColor = {"/highlighting/threadHighlightColor",
+                                           ""};
+
     QStringSetting highlightColor = {"/highlighting/color", ""};
 
     BoolSetting longAlerts = {"/highlighting/alerts", false};

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -719,6 +719,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     layout.addCheckbox("Combine multiple bit tips into one", s.stackBits);
     layout.addCheckbox("Messages in /mentions highlights tab",
                        s.highlightMentions);
+    layout.addCheckbox("Strip leading mention in replies", s.stripReplyMention);
 
     // Helix timegate settings
     auto helixTimegateGetValue = [](auto val) {

--- a/tests/src/HighlightController.cpp
+++ b/tests/src/HighlightController.cpp
@@ -485,6 +485,7 @@ struct TestCase {
         std::vector<Badge> badges;
         QString senderName;
         QString originalMessage;
+        MessageFlags flags;
     } input;
 
     struct {
@@ -727,8 +728,9 @@ TEST_F(HighlightControllerTest, A)
 
     for (const auto &[input, expected] : tests)
     {
-        auto [isMatch, matchResult] = this->controller->check(
-            input.args, input.badges, input.senderName, input.originalMessage);
+        auto [isMatch, matchResult] =
+            this->controller->check(input.args, input.badges, input.senderName,
+                                    input.originalMessage, input.flags);
 
         EXPECT_EQ(isMatch, expected.state)
             << qUtf8Printable(input.senderName) << ": "


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

This PR removes the leading mention in a reply message ~~(currently without a setting)~~.
This aligns Chatterino's reply threads more with the way Twitch displays them in web-chat (See #4044).

As this removes highlights on reply threads, I've added a new highlight that will be active on all threads a user participated in (maybe this should be in another PR?).

![](https://user-images.githubusercontent.com/19953266/194106535-43529afc-1871-4d5c-9692-ad0ab0592a39.png)
Left: new, right: old.

Closes #4044.

