### PR TITLE
Add missing 403 handling for /unban

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@
 - Minor: Migrated /vip command to Helix API. (#4010)
 - Minor: Migrated /unvip command to Helix API. (#4025)
 - Minor: Migrated /untimeout to Helix API. (#4026)
-- Minor: Migrated /unban to Helix API. (#4026)
+- Minor: Migrated /unban to Helix API. (#4026, #4050)
 - Minor: Migrated /subscribers to Helix API. (#4040)
 - Minor: Migrated /subscribersoff to Helix API. (#4040)
 - Minor: Migrated /slow to Helix API. (#4040)

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -1419,6 +1419,11 @@ void Helix::unbanUser(
                 }
                 break;
 
+                case 403: {
+                    failureCallback(Error::UserNotAuthorized, message);
+                }
+                break;
+
                 case 429: {
                     failureCallback(Error::Ratelimited, message);
                 }


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Clang-tidy had comments right near 401 so that's probably why we missed it

before:
![image](https://user-images.githubusercontent.com/41973452/194386845-4f57331f-e686-44c9-b156-bec61cad68cd.png)

after:
![image](https://user-images.githubusercontent.com/41973452/194386881-41e5f067-a599-4701-8288-3a4e0ef86b82.png)
