### PR TITLE
Migrate `/w` to Helix API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 - Minor: Migrated /raid command to Helix API. Chat command will continue to be used until February 11th 2023. (#4029)
 - Minor: Migrated /ban to Helix API. (#4049)
 - Minor: Migrated /timeout to Helix API. (#4049)
+- Minor: Migrated /w to Helix API. Chat command will continue to be used until February 11th 2023. (#4052)
 - Bugfix: Connection to Twitch PubSub now recovers more reliably. (#3643, #3716)
 - Bugfix: Fixed `Smooth scrolling on new messages` setting sometimes hiding messages. (#4028)
 - Bugfix: Fixed a crash that can occur when closing and quickly reopening a split, then running a command. (#3852)

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -2679,8 +2679,7 @@ void CommandController::initialize(Settings &, Paths &paths)
         return "";
     });
 
-    auto runWhisperCommand = [](const QStringList &words,
-                                auto channel) -> QString {
+    auto runWhisperCommand = [](auto words, auto channel) -> QString {
         auto useIrc = []() {
             switch (getSettings()->helixTimegateWhisper.getValue())
             {

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -2757,11 +2757,12 @@ void CommandController::initialize(Settings &, Paths &paths)
                         switch (error)
                         {
                             case Error::NoVerifiedPhone: {
-                                errorMessage += "You need a verified phone "
-                                                "number to send whispers. "
-                                                "You can add a number on "
-                                                "https://www.twitch.tv/"
-                                                "settings/security";
+                                errorMessage +=
+                                    "Due to Twitch restrictions, you are now "
+                                    "required to have a verified phone number "
+                                    "to send whispers. You can add a phone "
+                                    "number in Twitch settings. "
+                                    "https://www.twitch.tv/settings/security";
                             };
                             break;
 
@@ -2784,7 +2785,7 @@ void CommandController::initialize(Settings &, Paths &paths)
 
                             case Error::Ratelimited: {
                                 errorMessage +=
-                                    "You may whisper to a maximum of 40 "
+                                    "You may only whisper a maximum of 40 "
                                     "unique recipients per day. Within the "
                                     "per day limit, you may whisper a "
                                     "maximum of 3 whispers per second and "

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -2735,7 +2735,7 @@ void CommandController::initialize(Settings &, Paths &paths)
             else
             {
                 channel->addMessage(makeSystemMessage(
-                    "You can only send whispers from twitch channels."));
+                    "You can only send whispers from Twitch channels."));
             }
             return "";
         }

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -911,8 +911,20 @@ std::vector<MessagePtr> IrcMessageHandler::parseNoticeMessage(
     // default case
     std::vector<MessagePtr> builtMessages;
 
-    builtMessages.emplace_back(makeSystemMessage(
-        message->content(), calculateMessageTime(message).time()));
+    auto content = message->content();
+    if (content.startsWith(
+            "Your settings prevent you from sending this whisper",
+            Qt::CaseInsensitive) &&
+        getSettings()->helixTimegateWhisper.getValue() ==
+            HelixTimegateOverride::Timegate)
+    {
+        content =
+            content +
+            " Consider setting the \"Helix timegate /w "
+            "behaviour\" to \"Always use Helix\" in your Chatterino settings.";
+    }
+    builtMessages.emplace_back(
+        makeSystemMessage(content, calculateMessageTime(message).time()));
 
     return builtMessages;
 }

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -1812,6 +1812,113 @@ void Helix::banUser(QString broadcasterID, QString moderatorID, QString userID,
         .execute();
 }
 
+// Ban/timeout a user
+// https://dev.twitch.tv/docs/api/reference#ban-user
+void Helix::sendWhisper(
+    QString fromUserID, QString toUserID, QString message,
+    ResultCallback<> successCallback,
+    FailureCallback<HelixWhisperError, QString> failureCallback)
+{
+    using Error = HelixWhisperError;
+
+    QUrlQuery urlQuery;
+
+    urlQuery.addQueryItem("from_user_id", fromUserID);
+    urlQuery.addQueryItem("to_user_id", toUserID);
+
+    QJsonObject payload;
+    payload["message"] = message;
+
+    this->makeRequest("whispers", urlQuery)
+        .type(NetworkRequestType::Post)
+        .header("Content-Type", "application/json")
+        .payload(QJsonDocument(payload).toJson(QJsonDocument::Compact))
+        .onSuccess([successCallback](auto result) -> Outcome {
+            if (result.status() != 204)
+            {
+                qCWarning(chatterinoTwitch)
+                    << "Success result for sending a whisper was"
+                    << result.status() << "but we expected it to be 204";
+            }
+            // we don't care about the response
+            successCallback();
+            return Success;
+        })
+        .onError([failureCallback](auto result) {
+            auto obj = result.parseJson();
+            auto message = obj.value("message").toString();
+
+            switch (result.status())
+            {
+                case 400: {
+                    if (message.startsWith("A user cannot whisper themself",
+                                           Qt::CaseInsensitive))
+                    {
+                        failureCallback(Error::WhisperSelf, message);
+                    }
+                    else
+                    {
+                        failureCallback(Error::Forwarded, message);
+                    }
+                }
+                break;
+
+                case 401: {
+                    if (message.startsWith("Missing scope",
+                                           Qt::CaseInsensitive))
+                    {
+                        // Handle this error specifically because its API error is especially unfriendly
+                        failureCallback(Error::UserMissingScope, message);
+                    }
+                    else if (message.startsWith("the sender does not have a "
+                                                "verified phone number",
+                                                Qt::CaseInsensitive))
+                    {
+                        failureCallback(Error::NoVerifiedPhone, message);
+                    }
+                    else
+                    {
+                        failureCallback(Error::Forwarded, message);
+                    }
+                }
+                break;
+
+                case 403: {
+                    if (message.startsWith("The recipient's settings prevent "
+                                           "this sender from whispering them",
+                                           Qt::CaseInsensitive))
+                    {
+                        failureCallback(Error::RecipientBlockedUser, message);
+                    }
+                    else
+                    {
+                        failureCallback(Error::UserNotAuthorized, message);
+                    }
+                }
+                break;
+
+                case 404: {
+                    failureCallback(Error::Forwarded, message);
+                }
+                break;
+
+                case 429: {
+                    failureCallback(Error::Ratelimited, message);
+                }
+                break;
+
+                default: {
+                    qCDebug(chatterinoTwitch)
+                        << "Unhandled error banning user:" << result.status()
+                        << result.getData() << obj;
+                    failureCallback(Error::Unknown, message);
+                }
+                break;
+            }
+        })
+        .execute();
+}
+
 NetworkRequest Helix::makeRequest(QString url, QUrlQuery urlQuery)
 {
     assert(!url.startsWith("/"));

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -1812,8 +1812,7 @@ void Helix::banUser(QString broadcasterID, QString moderatorID, QString userID,
         .execute();
 }
 
-// Ban/timeout a user
-// https://dev.twitch.tv/docs/api/reference#ban-user
+// https://dev.twitch.tv/docs/api/reference#send-whisper
 void Helix::sendWhisper(
     QString fromUserID, QString toUserID, QString message,
     ResultCallback<> successCallback,

--- a/src/providers/twitch/api/Helix.hpp
+++ b/src/providers/twitch/api/Helix.hpp
@@ -478,6 +478,19 @@ enum class HelixBanUserError {  // /timeout, /ban
     Forwarded,
 };  // /timeout, /ban
 
+enum class HelixWhisperError {  // /w
+    Unknown,
+    UserMissingScope,
+    UserNotAuthorized,
+    Ratelimited,
+    NoVerifiedPhone,
+    RecipientBlockedUser,
+    WhisperSelf,
+
+    // The error message is forwarded directly from the Twitch API
+    Forwarded,
+};  // /w
+
 class IHelix
 {
 public:
@@ -718,6 +731,13 @@ public:
         boost::optional<int> duration, QString reason,
         ResultCallback<> successCallback,
         FailureCallback<HelixBanUserError, QString> failureCallback) = 0;
+
+    // Send a whisper
+    // https://dev.twitch.tv/docs/api/reference#send-whisper
+    virtual void sendWhisper(
+        QString fromUserID, QString toUserID, QString message,
+        ResultCallback<> successCallback,
+        FailureCallback<HelixWhisperError, QString> failureCallback) = 0;
 
     virtual void update(QString clientId, QString oauthToken) = 0;
 
@@ -960,6 +980,13 @@ public:
         boost::optional<int> duration, QString reason,
         ResultCallback<> successCallback,
         FailureCallback<HelixBanUserError, QString> failureCallback) final;
+
+    // Send a whisper
+    // https://dev.twitch.tv/docs/api/reference#send-whisper
+    void sendWhisper(
+        QString fromUserID, QString toUserID, QString message,
+        ResultCallback<> successCallback,
+        FailureCallback<HelixWhisperError, QString> failureCallback) final;
 
     void update(QString clientId, QString oauthToken) final;
 

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -414,6 +414,10 @@ public:
         "/misc/twitch/helix-timegate/raid",
         HelixTimegateOverride::Timegate,
     };
+    EnumSetting<HelixTimegateOverride> helixTimegateWhisper = {
+        "/misc/twitch/helix-timegate/whisper",
+        HelixTimegateOverride::Timegate,
+    };
 
     IntSetting emotesTooltipPreview = {"/misc/emotesTooltipPreview", 1};
     BoolSetting openLinksIncognito = {"/misc/openLinksIncognito", 0};

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -766,6 +766,17 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     helixTimegateRaid->setMinimumWidth(
         helixTimegateRaid->minimumSizeHint().width());
 
+    auto *helixTimegateWhisper =
+        layout.addDropdown<std::underlying_type<HelixTimegateOverride>::type>(
+            "Helix timegate /w behaviour",
+            {"Timegate", "Always use IRC", "Always use Helix"},
+            s.helixTimegateWhisper,
+            helixTimegateGetValue,  //
+            helixTimegateSetValue,  //
+            false);
+    helixTimegateWhisper->setMinimumWidth(
+        helixTimegateWhisper->minimumSizeHint().width());
+
     layout.addStretch();
 
     // invisible element for width

--- a/tests/src/HighlightController.cpp
+++ b/tests/src/HighlightController.cpp
@@ -345,6 +345,14 @@ public:
                  (FailureCallback<HelixBanUserError, QString> failureCallback)),
                 (override));  // /timeout, /ban
 
+    // /w
+    // The extra parenthesis around the failure callback is because its type contains a comma
+    MOCK_METHOD(void, sendWhisper,
+                (QString fromUserID, QString toUserID, QString message,
+                 ResultCallback<> successCallback,
+                 (FailureCallback<HelixWhisperError, QString> failureCallback)),
+                (override));  // /w
+
     MOCK_METHOD(void, update, (QString clientId, QString oauthToken),
                 (override));
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

This migrates _both_ `/w` and `.w` to the Helix API since `.w` wasn't sent directly to IRC.

Closes #3986.
Also some parts of #1163 will be fixed.