### PR TITLE
chore: migrate /vips command to Helix call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@
 - Minor: Migrated /ban to Helix API. (#4049)
 - Minor: Migrated /timeout to Helix API. (#4049)
 - Minor: Migrated /w to Helix API. Chat command will continue to be used until February 11th 2023. (#4052)
-- Minor: Migrated /vips to Helix API. (#4053)
+- Minor: Migrated /vips to Helix API. Chat command will continue to be used until February 11th 2023. (#4053)
 - Bugfix: Connection to Twitch PubSub now recovers more reliably. (#3643, #3716)
 - Bugfix: Fixed `Smooth scrolling on new messages` setting sometimes hiding messages. (#4028)
 - Bugfix: Fixed a crash that can occur when closing and quickly reopening a split, then running a command. (#3852)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 - Minor: Migrated /ban to Helix API. (#4049)
 - Minor: Migrated /timeout to Helix API. (#4049)
 - Minor: Migrated /w to Helix API. Chat command will continue to be used until February 11th 2023. (#4052)
+- Minor: Migrated /vips to Helix API. (#4053)
 - Bugfix: Connection to Twitch PubSub now recovers more reliably. (#3643, #3716)
 - Bugfix: Fixed `Smooth scrolling on new messages` setting sometimes hiding messages. (#4028)
 - Bugfix: Fixed a crash that can occur when closing and quickly reopening a split, then running a command. (#3852)

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -2938,12 +2938,11 @@ void CommandController::initialize(Settings &, Paths &paths)
         });
     }
 
-    auto formatVIPListError = [](const char *operation,
-                                 HelixListVIPsError error,
+    auto formatVIPListError = [](HelixListVIPsError error,
                                  const QString &message) -> QString {
         using Error = HelixListVIPsError;
 
-        QString errorMessage = QString("Failed to %1 user - ").arg(operation);
+        QString errorMessage = QString("Failed to list VIPs - ");
 
         switch (error)
         {
@@ -3052,7 +3051,7 @@ void CommandController::initialize(Settings &, Paths &paths)
                 channel->addMessage(builder.release());
             },
             [channel, formatVIPListError](auto error, auto message) {
-                auto errorMessage = formatVIPListError("vip", error, message);
+                auto errorMessage = formatVIPListError(error, message);
                 channel->addMessage(makeSystemMessage(errorMessage));
             });
 

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -2994,9 +2994,10 @@ void CommandController::initialize(Settings &, Paths &paths)
         if (currentUser->isAnon() ||
             currentUser->getUserId() != twitchChannel->roomId())
         {
-            channel->addMessage(
-                makeSystemMessage("You must be logged in as the broadcaster of "
-                                  "this channel to see the VIP list!"));
+            channel->addMessage(makeSystemMessage(
+                "Due to Twitch restrictions, this command can only be used by "
+                "the broadcaster. To see the list of VIPs you must use the "
+                "Twitch website."));
             return "";
         }
 

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -2980,8 +2980,9 @@ void CommandController::initialize(Settings &, Paths &paths)
         return errorMessage;
     };
 
-    this->registerCommand("/vips", [formatVIPListError](const QStringList &,
-                                                        auto channel) {
+    this->registerCommand("/vips", [formatVIPListError](
+                                       const QStringList & /*unused*/,
+                                       auto channel) {
         auto *twitchChannel = dynamic_cast<TwitchChannel *>(channel.get());
         if (twitchChannel == nullptr)
         {

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -3032,8 +3032,8 @@ void CommandController::initialize(Settings &, Paths &paths)
                 [channel, twitchChannel](const std::vector<HelixVip> &vipList) {
                     if (vipList.empty())
                     {
-                        makeSystemMessage(
-                            "This channel does not have any VIPs.");
+                        channel->addMessage(makeSystemMessage(
+                            "This channel does not have any VIPs."));
                         return;
                     }
 

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -3020,9 +3020,9 @@ void CommandController::initialize(Settings &, Paths &paths)
                 currentUser->getUserId() != twitchChannel->roomId())
             {
                 channel->addMessage(makeSystemMessage(
-                    "Due to Twitch restrictions, this command can only be used "
-                    "by "
-                    "the broadcaster. To see the list of VIPs you must use the "
+                    "Due to Twitch restrictions, "  //
+                    "this command can only be used by the broadcaster. "
+                    "To see the list of VIPs you must use the "
                     "Twitch website."));
                 return "";
             }

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -3028,7 +3028,11 @@ void CommandController::initialize(Settings &, Paths &paths)
         getHelix()->getChannelVIPs(
             twitchChannel->roomId(),
             [channel](const std::vector<HelixVip> &vipList) {
-                // TODO: handle 0 items
+                if (vipList.empty()) {
+                    makeSystemMessage("This channel does not have any VIPs.");
+                    return;
+                }
+
                 auto message = QString("The VIPs of this channel are ");
                 auto entries = QStringList();
 

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -2972,6 +2972,14 @@ void CommandController::initialize(Settings &, Paths &paths)
             }
             break;
 
+            case Error::UserNotBroadcaster: {
+                errorMessage += "Due to Twitch restrictions, "
+                                "this command can only be used by the broadcaster. "
+                                "To see the list of VIPs you must use the "
+                                "Twitch website.";
+            }
+            break;
+
             case Error::Unknown: {
                 errorMessage += "An unknown error has occurred.";
             }
@@ -3016,8 +3024,7 @@ void CommandController::initialize(Settings &, Paths &paths)
             }
 
             auto currentUser = getApp()->accounts->twitch.getCurrent();
-            if (currentUser->isAnon() ||
-                currentUser->getUserId() != twitchChannel->roomId())
+            if (currentUser->isAnon())
             {
                 channel->addMessage(makeSystemMessage(
                     "Due to Twitch restrictions, "  //

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -2981,8 +2981,31 @@ void CommandController::initialize(Settings &, Paths &paths)
     };
 
     this->registerCommand("/vips", [formatVIPListError](
-                                       const QStringList & /*unused*/,
-                                       auto channel) {
+                                       const QStringList & words,
+                                       auto channel) -> QString {
+        switch (getSettings()->helixTimegateVIPs.getValue())
+        {
+            case HelixTimegateOverride::Timegate: {
+                if (areIRCCommandsStillAvailable())
+                {
+                    return useIRCCommand(words);
+                }
+
+                // fall through to Helix logic
+            }
+            break;
+
+            case HelixTimegateOverride::AlwaysUseIRC: {
+                return useIRCCommand(words);
+            }
+            break;
+
+            case HelixTimegateOverride::AlwaysUseHelix: {
+                // do nothing and fall through to Helix logic
+            }
+            break;
+        }
+
         auto *twitchChannel = dynamic_cast<TwitchChannel *>(channel.get());
         if (twitchChannel == nullptr)
         {

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -2973,10 +2973,10 @@ void CommandController::initialize(Settings &, Paths &paths)
             break;
 
             case Error::UserNotBroadcaster: {
-                errorMessage += "Due to Twitch restrictions, "
-                                "this command can only be used by the broadcaster. "
-                                "To see the list of VIPs you must use the "
-                                "Twitch website.";
+                errorMessage +=
+                    "Due to Twitch restrictions, "
+                    "this command can only be used by the broadcaster. "
+                    "To see the list of VIPs you must use the Twitch website.";
             }
             break;
 

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -2936,6 +2936,85 @@ void CommandController::initialize(Settings &, Paths &paths)
             return runWhisperCommand(words, channel);
         });
     }
+
+    auto formatVIPListError =
+        [](const char *operation, HelixListVIPsError error,
+           const QString &message) -> QString {
+          using Error = HelixListVIPsError;
+
+          QString errorMessage = QString("Failed to %1 user - ").arg(operation);
+
+          switch (error)
+          {
+              case Error::Forwarded: {
+                  errorMessage += message;
+              }
+              break;
+
+              case Error::Ratelimited: {
+                  errorMessage += "You are being ratelimited by Twitch. Try "
+                                  "again in a few seconds.";
+              }
+              break;
+
+              case Error::UserMissingScope: {
+                  // TODO(pajlada): Phrase MISSING_REQUIRED_SCOPE
+                  errorMessage += "Missing required scope. "
+                                  "Re-login with your "
+                                  "account and try again.";
+              }
+              break;
+
+              case Error::UserNotAuthorized: {
+                  // TODO(pajlada): Phrase MISSING_PERMISSION
+                  errorMessage += "You don't have permission to "
+                                  "perform that action.";
+              }
+              break;
+
+              case Error::Unknown: {
+                  errorMessage += "An unknown error has occurred.";
+              }
+                  break;
+          }
+          return errorMessage;
+        };
+
+    this->registerCommand("/vips", [formatVIPListError](const QStringList &,
+                                                        auto channel) {
+        auto *twitchChannel = dynamic_cast<TwitchChannel *>(channel.get());
+        if (twitchChannel == nullptr)
+        {
+            channel->addMessage(makeSystemMessage(
+                "The /vips command only works in Twitch channels"));
+            return "";
+        }
+
+        auto currentUser = getApp()->accounts->twitch.getCurrent();
+        if (currentUser->isAnon() ||
+            currentUser->getUserId() != twitchChannel->roomId())
+        {
+            channel->addMessage(
+                makeSystemMessage("You must be logged in as the broadcaster of "
+                                  "this channel to see the VIP list!"));
+            return "";
+        }
+
+        getHelix()->getChannelVIPs(
+            twitchChannel->roomId(),
+            [channel](const std::vector<HelixVip> &vipList) {
+                // TODO: implement handler
+                channel->addMessage(
+                    makeSystemMessage(QString("TODO: better error message")));
+            },
+            [channel, formatVIPListError] (auto error, auto message) {
+                auto errorMessage = formatVIPListError(
+                    "vip", error, message);
+                channel->addMessage(makeSystemMessage(errorMessage));
+            });
+
+        return "";
+    });
 }
 
 void CommandController::save()

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -2937,48 +2937,48 @@ void CommandController::initialize(Settings &, Paths &paths)
         });
     }
 
-    auto formatVIPListError =
-        [](const char *operation, HelixListVIPsError error,
-           const QString &message) -> QString {
-          using Error = HelixListVIPsError;
+    auto formatVIPListError = [](const char *operation,
+                                 HelixListVIPsError error,
+                                 const QString &message) -> QString {
+        using Error = HelixListVIPsError;
 
-          QString errorMessage = QString("Failed to %1 user - ").arg(operation);
+        QString errorMessage = QString("Failed to %1 user - ").arg(operation);
 
-          switch (error)
-          {
-              case Error::Forwarded: {
-                  errorMessage += message;
-              }
-              break;
+        switch (error)
+        {
+            case Error::Forwarded: {
+                errorMessage += message;
+            }
+            break;
 
-              case Error::Ratelimited: {
-                  errorMessage += "You are being ratelimited by Twitch. Try "
-                                  "again in a few seconds.";
-              }
-              break;
+            case Error::Ratelimited: {
+                errorMessage += "You are being ratelimited by Twitch. Try "
+                                "again in a few seconds.";
+            }
+            break;
 
-              case Error::UserMissingScope: {
-                  // TODO(pajlada): Phrase MISSING_REQUIRED_SCOPE
-                  errorMessage += "Missing required scope. "
-                                  "Re-login with your "
-                                  "account and try again.";
-              }
-              break;
+            case Error::UserMissingScope: {
+                // TODO(pajlada): Phrase MISSING_REQUIRED_SCOPE
+                errorMessage += "Missing required scope. "
+                                "Re-login with your "
+                                "account and try again.";
+            }
+            break;
 
-              case Error::UserNotAuthorized: {
-                  // TODO(pajlada): Phrase MISSING_PERMISSION
-                  errorMessage += "You don't have permission to "
-                                  "perform that action.";
-              }
-              break;
+            case Error::UserNotAuthorized: {
+                // TODO(pajlada): Phrase MISSING_PERMISSION
+                errorMessage += "You don't have permission to "
+                                "perform that action.";
+            }
+            break;
 
-              case Error::Unknown: {
-                  errorMessage += "An unknown error has occurred.";
-              }
-                  break;
-          }
-          return errorMessage;
-        };
+            case Error::Unknown: {
+                errorMessage += "An unknown error has occurred.";
+            }
+            break;
+        }
+        return errorMessage;
+    };
 
     this->registerCommand("/vips", [formatVIPListError](const QStringList &,
                                                         auto channel) {
@@ -3008,9 +3008,8 @@ void CommandController::initialize(Settings &, Paths &paths)
                 channel->addMessage(
                     makeSystemMessage(QString("TODO: better error message")));
             },
-            [channel, formatVIPListError] (auto error, auto message) {
-                auto errorMessage = formatVIPListError(
-                    "vip", error, message);
+            [channel, formatVIPListError](auto error, auto message) {
+                auto errorMessage = formatVIPListError("vip", error, message);
                 channel->addMessage(makeSystemMessage(errorMessage));
             });
 

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -3005,9 +3005,18 @@ void CommandController::initialize(Settings &, Paths &paths)
         getHelix()->getChannelVIPs(
             twitchChannel->roomId(),
             [channel](const std::vector<HelixVip> &vipList) {
-                // TODO: implement handler
+                // TODO: handle 0 items
+                auto message = QString("The VIPs of this channel are ");
+                auto entries = QStringList();
+
+                // TODO: sort
+                for (const auto &vip : vipList)
+                {
+                    entries.append(vip.userName);
+                }
+
                 channel->addMessage(
-                    makeSystemMessage(QString("TODO: better error message")));
+                    makeSystemMessage(message.append(entries.join(", "))));
             },
             [channel, formatVIPListError](auto error, auto message) {
                 auto errorMessage = formatVIPListError("vip", error, message);

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -3036,7 +3036,6 @@ void CommandController::initialize(Settings &, Paths &paths)
                 auto messagePrefix = QString("The VIPs of this channel are");
                 auto entries = QStringList();
 
-                // TODO: sort
                 for (const auto &vip : vipList)
                 {
                     entries.append(vip.userName);

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -3042,6 +3042,8 @@ void CommandController::initialize(Settings &, Paths &paths)
                     entries.append(vip.userName);
                 }
 
+                entries.sort(Qt::CaseInsensitive);
+
                 channel->addMessage(
                     makeSystemMessage(message.append(entries.join(", "))));
             },

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -2018,6 +2018,16 @@ void Helix::getChannelVIPs(
                   << "Success result for banning a user was"
                   << result.status() << "but we expected it to be 200";
           }
+
+          auto response = result.parseJson();
+
+          std::vector<HelixVip> channelVips;
+          for (const auto &jsonStream : response.value("data").toArray())
+          {
+              channelVips.emplace_back(jsonStream.toObject());
+          }
+
+          successCallback(channelVips);
           return Success;
         })
         .onError([failureCallback](auto result) {

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -2008,7 +2008,7 @@ void Helix::getChannelVIPs(
     //   as the mod list can go over 100 (I assume, I see no limit)
     urlQuery.addQueryItem("first", "100");
 
-    this->makeRequest("channel/vips", urlQuery)
+    this->makeRequest("channels/vips", urlQuery)
         .type(NetworkRequestType::Get)
         .header("Content-Type", "application/json")
         .onSuccess([successCallback](auto result) -> Outcome {

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -2015,7 +2015,7 @@ void Helix::getChannelVIPs(
             if (result.status() != 200)
             {
                 qCWarning(chatterinoTwitch)
-                    << "Success result for banning a user was"
+                    << "Success result for getting VIPs was"
                     << result.status() << "but we expected it to be 200";
             }
 

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -2015,8 +2015,8 @@ void Helix::getChannelVIPs(
             if (result.status() != 200)
             {
                 qCWarning(chatterinoTwitch)
-                    << "Success result for getting VIPs was"
-                    << result.status() << "but we expected it to be 200";
+                    << "Success result for getting VIPs was" << result.status()
+                    << "but we expected it to be 200";
             }
 
             auto response = result.parseJson();

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -2053,7 +2053,7 @@ void Helix::getChannelVIPs(
                                  Qt::CaseInsensitive) == 0)
                     {
                         // Must be the broadcaster.
-                        failureCallback(Error::UserNotAuthorized, message);
+                        failureCallback(Error::UserNotBroadcaster, message);
                     }
                     else
                     {

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -2036,6 +2036,42 @@ void Helix::getChannelVIPs(
 
           switch (result.status())
           {
+              case 400: {
+                  failureCallback(Error::Forwarded, message);
+              }
+              break;
+
+              case 401: {
+                  if (message.startsWith("Missing scope",
+                                         Qt::CaseInsensitive))
+                  {
+                      failureCallback(Error::UserMissingScope, message);
+                  }
+                  else if (message.compare(
+                      "The ID in broadcaster_id must match the user "
+                      "ID found in the request's OAuth token.",
+                      Qt::CaseInsensitive) == 0)
+                  {
+                      // Must be the broadcaster.
+                      failureCallback(Error::UserNotAuthorized, message);
+                  }
+                  else
+                  {
+                      failureCallback(Error::Forwarded, message);
+                  }
+              }
+              break;
+
+              case 403: {
+                  failureCallback(Error::UserNotAuthorized, message);
+              }
+              break;
+
+              case 429: {
+                  failureCallback(Error::Ratelimited, message);
+              }
+              break;
+
               default: {
                   qCDebug(chatterinoTwitch)
                       << "Unhandled error listing VIPs:" << result.status()

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -2012,74 +2012,74 @@ void Helix::getChannelVIPs(
         .type(NetworkRequestType::Post)
         .header("Content-Type", "application/json")
         .onSuccess([successCallback](auto result) -> Outcome {
-          if (result.status() != 200)
-          {
-              qCWarning(chatterinoTwitch)
-                  << "Success result for banning a user was"
-                  << result.status() << "but we expected it to be 200";
-          }
+            if (result.status() != 200)
+            {
+                qCWarning(chatterinoTwitch)
+                    << "Success result for banning a user was"
+                    << result.status() << "but we expected it to be 200";
+            }
 
-          auto response = result.parseJson();
+            auto response = result.parseJson();
 
-          std::vector<HelixVip> channelVips;
-          for (const auto &jsonStream : response.value("data").toArray())
-          {
-              channelVips.emplace_back(jsonStream.toObject());
-          }
+            std::vector<HelixVip> channelVips;
+            for (const auto &jsonStream : response.value("data").toArray())
+            {
+                channelVips.emplace_back(jsonStream.toObject());
+            }
 
-          successCallback(channelVips);
-          return Success;
+            successCallback(channelVips);
+            return Success;
         })
         .onError([failureCallback](auto result) {
-          auto obj = result.parseJson();
-          auto message = obj.value("message").toString();
+            auto obj = result.parseJson();
+            auto message = obj.value("message").toString();
 
-          switch (result.status())
-          {
-              case 400: {
-                  failureCallback(Error::Forwarded, message);
-              }
-              break;
+            switch (result.status())
+            {
+                case 400: {
+                    failureCallback(Error::Forwarded, message);
+                }
+                break;
 
-              case 401: {
-                  if (message.startsWith("Missing scope",
-                                         Qt::CaseInsensitive))
-                  {
-                      failureCallback(Error::UserMissingScope, message);
-                  }
-                  else if (message.compare(
-                      "The ID in broadcaster_id must match the user "
-                      "ID found in the request's OAuth token.",
-                      Qt::CaseInsensitive) == 0)
-                  {
-                      // Must be the broadcaster.
-                      failureCallback(Error::UserNotAuthorized, message);
-                  }
-                  else
-                  {
-                      failureCallback(Error::Forwarded, message);
-                  }
-              }
-              break;
+                case 401: {
+                    if (message.startsWith("Missing scope",
+                                           Qt::CaseInsensitive))
+                    {
+                        failureCallback(Error::UserMissingScope, message);
+                    }
+                    else if (message.compare(
+                                 "The ID in broadcaster_id must match the user "
+                                 "ID found in the request's OAuth token.",
+                                 Qt::CaseInsensitive) == 0)
+                    {
+                        // Must be the broadcaster.
+                        failureCallback(Error::UserNotAuthorized, message);
+                    }
+                    else
+                    {
+                        failureCallback(Error::Forwarded, message);
+                    }
+                }
+                break;
 
-              case 403: {
-                  failureCallback(Error::UserNotAuthorized, message);
-              }
-              break;
+                case 403: {
+                    failureCallback(Error::UserNotAuthorized, message);
+                }
+                break;
 
-              case 429: {
-                  failureCallback(Error::Ratelimited, message);
-              }
-              break;
+                case 429: {
+                    failureCallback(Error::Ratelimited, message);
+                }
+                break;
 
-              default: {
-                  qCDebug(chatterinoTwitch)
-                      << "Unhandled error listing VIPs:" << result.status()
-                      << result.getData() << obj;
-                  failureCallback(Error::Unknown, message);
-              }
-              break;
-          }
+                default: {
+                    qCDebug(chatterinoTwitch)
+                        << "Unhandled error listing VIPs:" << result.status()
+                        << result.getData() << obj;
+                    failureCallback(Error::Unknown, message);
+                }
+                break;
+            }
         })
         .execute();
 }

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -2009,7 +2009,7 @@ void Helix::getChannelVIPs(
     urlQuery.addQueryItem("first", "100");
 
     this->makeRequest("channel/vips", urlQuery)
-        .type(NetworkRequestType::Post)
+        .type(NetworkRequestType::Get)
         .header("Content-Type", "application/json")
         .onSuccess([successCallback](auto result) -> Outcome {
             if (result.status() != 200)

--- a/src/providers/twitch/api/Helix.hpp
+++ b/src/providers/twitch/api/Helix.hpp
@@ -329,6 +329,23 @@ struct HelixChatSettings {
     }
 };
 
+struct HelixVip {
+    QString userId;
+    QString userName;
+    QString userLogin;
+
+    explicit HelixVip(const QJsonObject &jsonObject)
+        : userId(jsonObject.value("user_id").toString())
+        , userName(jsonObject.value("user_name").toString())
+        , userLogin(jsonObject.value("user_login").toString())
+    {
+    }
+};
+
+// TODO(jammehcow): when implementing mod list, just alias HelixVip to HelixMod
+//   as they share the same model.
+//   Alternatively, rename base struct to HelixUser or something and alias both
+
 enum class HelixAnnouncementColor {
     Blue,
     Green,

--- a/src/providers/twitch/api/Helix.hpp
+++ b/src/providers/twitch/api/Helix.hpp
@@ -519,6 +519,16 @@ enum class HelixWhisperError {  // /w
     Forwarded,
 };  // /w
 
+enum class HelixListVIPsError {  // /vips
+    Unknown,
+    UserMissingScope,
+    UserNotAuthorized,
+    Ratelimited,
+
+    // The error message is forwarded directly from the Twitch API
+    Forwarded,
+};  // /vips
+
 class IHelix
 {
 public:
@@ -772,6 +782,12 @@ public:
         QString fromUserID, QString toUserID, QString message,
         ResultCallback<> successCallback,
         FailureCallback<HelixWhisperError, QString> failureCallback) = 0;
+
+    // https://dev.twitch.tv/docs/api/reference#get-vips
+    virtual void getChannelVIPs(
+        QString broadcasterID,
+        ResultCallback<std::vector<HelixVip>> successCallback,
+        FailureCallback<HelixListVIPsError, QString> failureCallback) = 0;
 
     virtual void update(QString clientId, QString oauthToken) = 0;
 
@@ -1027,6 +1043,12 @@ public:
         QString fromUserID, QString toUserID, QString message,
         ResultCallback<> successCallback,
         FailureCallback<HelixWhisperError, QString> failureCallback) final;
+
+    // https://dev.twitch.tv/docs/api/reference#get-vips
+    void getChannelVIPs(
+        QString broadcasterID,
+        ResultCallback<std::vector<HelixVip>> successCallback,
+        FailureCallback<HelixListVIPsError, QString> failureCallback) final;
 
     void update(QString clientId, QString oauthToken) final;
 

--- a/src/providers/twitch/api/Helix.hpp
+++ b/src/providers/twitch/api/Helix.hpp
@@ -523,6 +523,7 @@ enum class HelixListVIPsError {  // /vips
     Unknown,
     UserMissingScope,
     UserNotAuthorized,
+    UserNotBroadcaster,
     Ratelimited,
 
     // The error message is forwarded directly from the Twitch API

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -432,6 +432,10 @@ public:
         "/misc/twitch/helix-timegate/whisper",
         HelixTimegateOverride::Timegate,
     };
+    EnumSetting<HelixTimegateOverride> helixTimegateVIPs = {
+        "/misc/twitch/helix-timegate/vips",
+        HelixTimegateOverride::Timegate,
+    };
 
     IntSetting emotesTooltipPreview = {"/misc/emotesTooltipPreview", 1};
     BoolSetting openLinksIncognito = {"/misc/openLinksIncognito", 0};

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -778,6 +778,17 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     helixTimegateWhisper->setMinimumWidth(
         helixTimegateWhisper->minimumSizeHint().width());
 
+    auto *helixTimegateVIPs =
+        layout.addDropdown<std::underlying_type<HelixTimegateOverride>::type>(
+            "Helix timegate /vips behaviour",
+            {"Timegate", "Always use IRC", "Always use Helix"},
+            s.helixTimegateVIPs,
+            helixTimegateGetValue,
+            helixTimegateSetValue,
+            false);
+    helixTimegateVIPs->setMinimumWidth(
+        helixTimegateVIPs->minimumSizeHint().width());
+
     layout.addStretch();
 
     // invisible element for width

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -782,9 +782,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         layout.addDropdown<std::underlying_type<HelixTimegateOverride>::type>(
             "Helix timegate /vips behaviour",
             {"Timegate", "Always use IRC", "Always use Helix"},
-            s.helixTimegateVIPs,
-            helixTimegateGetValue,
-            helixTimegateSetValue,
+            s.helixTimegateVIPs, helixTimegateGetValue, helixTimegateSetValue,
             false);
     helixTimegateVIPs->setMinimumWidth(
         helixTimegateVIPs->minimumSizeHint().width());

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -782,7 +782,9 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         layout.addDropdown<std::underlying_type<HelixTimegateOverride>::type>(
             "Helix timegate /vips behaviour",
             {"Timegate", "Always use IRC", "Always use Helix"},
-            s.helixTimegateVIPs, helixTimegateGetValue, helixTimegateSetValue,
+            s.helixTimegateVIPs,
+            helixTimegateGetValue,  //
+            helixTimegateSetValue,  //
             false);
     helixTimegateVIPs->setMinimumWidth(
         helixTimegateVIPs->minimumSizeHint().width());

--- a/tests/src/HighlightController.cpp
+++ b/tests/src/HighlightController.cpp
@@ -360,6 +360,15 @@ public:
                  (FailureCallback<HelixWhisperError, QString> failureCallback)),
                 (override));  // /w
 
+    // /vips
+    // The extra parenthesis around the failure callback is because its type contains a comma
+    MOCK_METHOD(
+        void, getChannelVIPs,
+        (QString broadcasterID,
+         ResultCallback<std::vector<HelixVip>> successCallback,
+         (FailureCallback<HelixListVIPsError, QString> failureCallback)),
+        (override));  // /vips
+
     MOCK_METHOD(void, update, (QString clientId, QString oauthToken),
                 (override));
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

This PR aims to migrate the IRC server-side handling of the `/vips` command to a client-side Helix API call as part of the IRC command migration initiative. This feature is now broadcaster-only so care needs to be taken on how that's presented to the user :( 

## TODO: 
 - [x] actually display the VIPs in output
 - [x] sort VIPs alphabetically
 - [x] ensure all API errors are handled (at least the ones we want to share with the user)
 - [x] handle `0` VIPs
 - [x] verify how we want to explain to the user that `/vips` is broadcaster-only
 - [x] timegating (ty felan)

Closes #3984 