### PR TITLE
Fix rare reply mention crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unversioned
 
-- Major: Added support for Twitch's Chat Replies. [Wiki Page](https://wiki.chatterino.com/Features/#message-replies) (#3722, #3989, #4041, #4047)
+- Major: Added support for Twitch's Chat Replies. [Wiki Page](https://wiki.chatterino.com/Features/#message-replies) (#3722, #3989, #4041, #4047, #4055)
 - Major: Added multi-channel searching to search dialog via keyboard shortcut. (Ctrl+Shift+F by default) (#3694, #3875)
 - Minor: Added highlights for `Elevated Messages`. (#4016)
 - Minor: Removed total views from the usercard, as Twitch no longer updates the number. (#3792)

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -78,6 +78,13 @@ int stripLeadingReplyMention(const QVariantMap &tags, QString &content)
         it != tags.end())
     {
         auto displayName = it.value().toString();
+
+        if (content.length() <= 1 + displayName.length())
+        {
+            // The reply contains no content
+            return 0;
+        }
+
         if (content.startsWith('@') &&
             content.at(1 + displayName.length()) == ' ' &&
             content.indexOf(displayName, 1) == 1)


### PR DESCRIPTION
- Fix potential out-of-range access of at when stripping reply mention if the message contained nothing other than the username
- Update changelog entry

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Example crash scenario

Content: `@pajlada`
Tag `reply-parent-display-name`: `pajlada`

content.at(1+displayName.length()) would look for the character after the username `pajlada`, but since there was no more text it would throw an exception or something

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
