### PR TITLE
Fix FreeBSD Cirrus CI build

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,7 +3,7 @@ freebsd_instance:
 
 task:
   install_script:
-  - pkg install -y boost-libs git qt5-buildtools qt5-concurrent qt5-core qt5-multimedia qt5-svg qtkeychain qt5-qmake cmake qt5-linguist
+  - pkg install -y boost-libs git qt5-buildtools qt5-concurrent qt5-core qt5-multimedia qt5-svg qtkeychain-qt5 qt5-qmake cmake qt5-linguist
   script: |
     git submodule init
     git submodule update


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

It's now available in two flavours: qtkeychain-qt5 and qtkeychain-qt6

We change our dependency from qtkeychain to qtkeychain-qt5 to keep things working


![image](https://user-images.githubusercontent.com/962989/195982101-31d10125-3255-48ae-9d4d-8c6ddbf8474a.png)


<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
