### PR TITLE
Fix channel-based popups rewriting messages to file log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@
 - Bugfix: Fixed non-global FrankerFaceZ emotes from being loaded as global emotes. (#3921)
 - Bugfix: Fixed trailing spaces from preventing Nicknames from working correctly. (#3946)
 - Bugfix: Fixed trailing spaces from preventing User Highlights from working correctly. (#4051)
+- Bugfix: Fixed channel-based popups from rewriting messages to file log (#4060)
 - Dev: Removed official support for QMake. (#3839, #3883)
 - Dev: Rewrote LimitedQueue (#3798)
 - Dev: Overhauled highlight system by moving all checks into a Controller allowing for easier tests. (#3399, #3801, #3835)

--- a/src/widgets/dialogs/ReplyThreadPopup.cpp
+++ b/src/widgets/dialogs/ReplyThreadPopup.cpp
@@ -130,12 +130,19 @@ void ReplyThreadPopup::addMessagesFromThread()
     this->ui_.threadView->setChannel(virtualChannel);
     this->ui_.threadView->setSourceChannel(sourceChannel);
 
-    virtualChannel->addMessage(this->thread_->root());
+    auto overrideFlags =
+        boost::optional<MessageFlags>(this->thread_->root()->flags);
+    overrideFlags->set(MessageFlag::DoNotLog);
+
+    virtualChannel->addMessage(this->thread_->root(), overrideFlags);
     for (const auto &msgRef : this->thread_->replies())
     {
         if (auto msg = msgRef.lock())
         {
-            virtualChannel->addMessage(msg);
+            auto overrideFlags = boost::optional<MessageFlags>(msg->flags);
+            overrideFlags->set(MessageFlag::DoNotLog);
+
+            virtualChannel->addMessage(msg, overrideFlags);
         }
     }
 
@@ -145,8 +152,12 @@ void ReplyThreadPopup::addMessagesFromThread()
                 [this, virtualChannel](MessagePtr &message, auto) {
                     if (message->replyThread == this->thread_)
                     {
+                        auto overrideFlags =
+                            boost::optional<MessageFlags>(message->flags);
+                        overrideFlags->set(MessageFlag::DoNotLog);
+
                         // same reply thread, add message
-                        virtualChannel->addMessage(message);
+                        virtualChannel->addMessage(message, overrideFlags);
                     }
                 }));
 }

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -105,9 +105,13 @@ namespace {
         for (size_t i = 0; i < snapshot.size(); i++)
         {
             MessagePtr message = snapshot[i];
+
+            auto overrideFlags = boost::optional<MessageFlags>(message->flags);
+            overrideFlags->set(MessageFlag::DoNotLog);
+
             if (checkMessageUserName(userName, message))
             {
-                channelPtr->addMessage(message);
+                channelPtr->addMessage(message, overrideFlags);
             }
         }
 

--- a/src/widgets/helper/SearchPopup.cpp
+++ b/src/widgets/helper/SearchPopup.cpp
@@ -46,7 +46,12 @@ ChannelPtr SearchPopup::filter(const QString &text, const QString &channelName,
 
         // If all predicates match, add the message to the channel
         if (accept)
-            channel->addMessage(message);
+        {
+            auto overrideFlags = boost::optional<MessageFlags>(message->flags);
+            overrideFlags->set(MessageFlag::DoNotLog);
+
+            channel->addMessage(message, overrideFlags);
+        }
     }
 
     return channel;


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Added needed `MessageFlag::DoNotLog` override flags to messages being added to `Channel`s for user info and reply thread popups to avoid those messages getting rewritten to the file log.

This was also happening to the search popups but was going to a separate logging folder "Other". This is because the proxy `Channel` made for the SearchPopup `ChanneView` is of type `None` which doesn't have an associated `platformName` logging channel/folder as opposed to these channel-based popups which are of type `Twitch`/`Irc` so it was just being sent to a default "Other" folder.

Closes #4046
