### PR TITLE
Pin QtKeychain's branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -23,6 +23,7 @@
 [submodule "lib/qtkeychain"]
 	path = lib/qtkeychain
 	url = https://github.com/Chatterino/qtkeychain
+	branch = chatterino-cmake
 [submodule "lib/websocketpp"]
 	path = lib/websocketpp
 	url = https://github.com/zaphoyd/websocketpp


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Ensures that dependabot won't try to use master nor not go off if `chatterino-cmake` gets an update, but `master` on chatterino/qtkeychain doesn't.

This also pulls all submodule changes from upstream, decided to do it here instead of in #4064.

I've also cleaned up some stuff on the fork - 1 of 2 changes we've had on our fork has been introduced to upstream, so I rebased, merged and re-added the other change that we need.