### PR TITLE
Migrated `getSubage` to v2 version of the API

### DIFF
--- a/src/providers/IvrApi.cpp
+++ b/src/providers/IvrApi.cpp
@@ -40,7 +40,7 @@ void IvrApi::getBulkEmoteSets(QString emoteSetList,
     QUrlQuery urlQuery;
     urlQuery.addQueryItem("set_id", emoteSetList);
 
-    this->makeRequest("v2/twitch/emotes/sets", urlQuery)
+    this->makeRequest("twitch/emotes/sets", urlQuery)
         .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
             auto root = result.parseJsonArray();
 
@@ -61,7 +61,7 @@ NetworkRequest IvrApi::makeRequest(QString url, QUrlQuery urlQuery)
 {
     assert(!url.startsWith("/"));
 
-    const QString baseUrl("https://api.ivr.fi/");
+    const QString baseUrl("https://api.ivr.fi/v2/");
     QUrl fullUrl(baseUrl + url);
     fullUrl.setQuery(urlQuery);
 

--- a/src/providers/IvrApi.hpp
+++ b/src/providers/IvrApi.hpp
@@ -21,9 +21,9 @@ struct IvrSubage {
     const int totalSubMonths;
     const QString followingSince;
 
-    IvrSubage(QJsonObject root)
-        : isSubHidden(root.value("hidden").toBool())
-        , isSubbed(root.value("subscribed").toBool())
+    IvrSubage(const QJsonObject &root)
+        : isSubHidden(root.value("statusHidden").toBool())
+        , isSubbed(!root.value("meta").isNull())
         , subTier(root.value("meta").toObject().value("tier").toString())
         , totalSubMonths(
               root.value("cumulative").toObject().value("months").toInt())
@@ -40,7 +40,7 @@ struct IvrEmoteSet {
     const QString tier;
     const QJsonArray emotes;
 
-    IvrEmoteSet(QJsonObject root)
+    IvrEmoteSet(const QJsonObject &root)
         : setId(root.value("setID").toString())
         , displayName(root.value("channelName").toString())
         , login(root.value("channelLogin").toString())
@@ -60,7 +60,7 @@ struct IvrEmote {
     const QString emoteType;
     const QString imageType;
 
-    explicit IvrEmote(QJsonObject root)
+    explicit IvrEmote(const QJsonObject &root)
         : code(root.value("code").toString())
         , id(root.value("id").toString())
         , setId(root.value("setID").toString())

--- a/src/providers/IvrApi.hpp
+++ b/src/providers/IvrApi.hpp
@@ -76,7 +76,7 @@ struct IvrEmote {
 class IvrApi final : boost::noncopyable
 {
 public:
-    // https://api.ivr.fi/docs#tag/Twitch/paths/~1twitch~1subage~1{username}~1{channel}/get
+    // https://api.ivr.fi/v2/docs/static/index.html#/Twitch/get_twitch_subage__user___channel_
     void getSubage(QString userName, QString channelName,
                    ResultCallback<IvrSubage> resultCallback,
                    IvrFailureCallback failureCallback);


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

- Migrated `IvrApi::getSubage` function to use v2 version of its API.
- Updated link to the endpoint's documentation.
- Since this was the last endpoint from this provider to use a v1 route, base url for the API and its usages have been updated accordingly.
- Also applied some copying removal (not sure if it's correct though, pls correct me if that's a bad move).
