### PR TITLE
fix: Invalid/Dangling completion after updating input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,7 +96,7 @@
 - Bugfix: Fixed trailing spaces from preventing Nicknames from working correctly. (#3946)
 - Bugfix: Fixed trailing spaces from preventing User Highlights from working correctly. (#4051)
 - Bugfix: Fixed channel-based popups from rewriting messages to file log (#4060)
-- Bugfix: Fixed invalid completion when changing to previous message (#4072)
+- Bugfix: Fixed invalid/dangling completion when cycling through previous messages or replying (#4072)
 - Dev: Removed official support for QMake. (#3839, #3883)
 - Dev: Rewrote LimitedQueue (#3798)
 - Dev: Overhauled highlight system by moving all checks into a Controller allowing for easier tests. (#3399, #3801, #3835)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@
 - Bugfix: Fixed trailing spaces from preventing Nicknames from working correctly. (#3946)
 - Bugfix: Fixed trailing spaces from preventing User Highlights from working correctly. (#4051)
 - Bugfix: Fixed channel-based popups from rewriting messages to file log (#4060)
+- Bugfix: Fixed invalid completion when changing to previous message (#4072)
 - Dev: Removed official support for QMake. (#3839, #3883)
 - Dev: Rewrote LimitedQueue (#3798)
 - Dev: Overhauled highlight system by moving all checks into a Controller allowing for easier tests. (#3399, #3801, #3835)

--- a/src/widgets/helper/ResizingTextEdit.cpp
+++ b/src/widgets/helper/ResizingTextEdit.cpp
@@ -246,6 +246,11 @@ void ResizingTextEdit::setCompleter(QCompleter *c)
                      this, &ResizingTextEdit::insertCompletion);
 }
 
+void ResizingTextEdit::resetCompletion()
+{
+    this->completionInProgress_ = false;
+}
+
 void ResizingTextEdit::insertCompletion(const QString &completion)
 {
     if (this->completer_->widget() != this)

--- a/src/widgets/helper/ResizingTextEdit.hpp
+++ b/src/widgets/helper/ResizingTextEdit.hpp
@@ -24,6 +24,11 @@ public:
 
     void setCompleter(QCompleter *c);
     QCompleter *getCompleter() const;
+    /**
+     * Resets a completion for this text if one was is progress.
+     * See `completionInProgress_`.
+     */
+    void resetCompletion();
 
 protected:
     int heightForWidth(int) const override;
@@ -41,6 +46,24 @@ private:
     QString textUnderCursor(bool *hadSpace = nullptr) const;
 
     QCompleter *completer_ = nullptr;
+    /**
+     * This is true if a completion was done but the user didn't type yet,
+     * and might want to press `Tab` again to get the next completion
+     * on the original text.
+     *
+     * For example:
+     *
+     * input: "pog"
+     * `Tab` pressed:
+     *   - complete to "PogBones"
+     *   - retain "pog" for next completion
+     *   - set `completionInProgress_ = true`
+     * `Tab` pressed again:
+     *   - complete ["pog"] to "PogChamp"
+     *
+     * [other key] pressed - updating the input text:
+     *   - set `completionInProgress_ = false`
+     */
     bool completionInProgress_ = false;
 
     bool eventFilter(QObject *obj, QEvent *event) override;

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -990,6 +990,7 @@ void SplitInput::setReply(std::shared_ptr<MessageThread> reply,
             }
             this->ui_.textEdit->setPlainText(replyPrefix + plainText + " ");
             this->ui_.textEdit->moveCursor(QTextCursor::EndOfBlock);
+            this->ui_.textEdit->resetCompletion();
         }
         this->ui_.replyLabel->setText("Replying to @" +
                                       this->replyThread_->root()->displayName);

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -464,6 +464,7 @@ void SplitInput::addShortcuts()
                  this->prevIndex_--;
                  this->ui_.textEdit->setPlainText(
                      this->prevMsg_.at(this->prevIndex_));
+                 this->ui_.textEdit->resetCompletion();
 
                  QTextCursor cursor = this->ui_.textEdit->textCursor();
                  cursor.movePosition(QTextCursor::End);
@@ -487,6 +488,7 @@ void SplitInput::addShortcuts()
                  this->prevIndex_++;
                  this->ui_.textEdit->setPlainText(
                      this->prevMsg_.at(this->prevIndex_));
+                 this->ui_.textEdit->resetCompletion();
              }
              else
              {
@@ -496,6 +498,7 @@ void SplitInput::addShortcuts()
                      // If user has just come from a message history
                      // Then simply get currMsg_.
                      this->ui_.textEdit->setPlainText(this->currMsg_);
+                     this->ui_.textEdit->resetCompletion();
                  }
                  else if (message != this->currMsg_)
                  {


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

### How to reproduce

**Cycling through messages:**

* Send `foo`
* Type `PogCham`
* Press `Tab` (to complete the emote)
* Go to the previous message (`Up` by default)
* Press `Tab` _This will complete `foo` to `PogChamp`._

**Replying:**

* Type `PogCham foo`
* Move cursor behind `PogCham`
* Press `Tab` (to complete the emote)
* Right click any message and select `Reply to message`
* Press `Tab` _This will complete `foo` to `PogChamp`._

This only happens when cycling through messages and replying. It doesn't happen in other places calling `setPlainText`.
