### PR TITLE
Improve Appearance of Reply Curve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unversioned
 
-- Major: Added support for Twitch's Chat Replies. [Wiki Page](https://wiki.chatterino.com/Features/#message-replies) (#3722, #3989, #4041, #4047, #4055, #4067)
+- Major: Added support for Twitch's Chat Replies. [Wiki Page](https://wiki.chatterino.com/Features/#message-replies) (#3722, #3989, #4041, #4047, #4055, #4067, #4077)
 - Major: Added multi-channel searching to search dialog via keyboard shortcut. (Ctrl+Shift+F by default) (#3694, #3875)
 - Major: Added support for emotes and badges from [7TV](https://7tv.app). [Wiki Page](https://wiki.chatterino.com/Third_party_services/#7tv) (#4002, #4062)
 - Minor: Added highlights for `Elevated Messages`. (#4016)

--- a/src/messages/MessageElement.cpp
+++ b/src/messages/MessageElement.cpp
@@ -684,10 +684,10 @@ ReplyCurveElement::ReplyCurveElement()
 void ReplyCurveElement::addToContainer(MessageLayoutContainer &container,
                                        MessageElementFlags flags)
 {
-    static const int width = 18;
-    static const float thickness = 1.5;
-    static const int radius = 6;
-    static const int margin = 2;
+    static const int width = 18;         // Overall width
+    static const float thickness = 1.5;  // Pen width
+    static const int radius = 6;         // Radius of the top left corner
+    static const int margin = 2;         // Top/Left/Bottom margin
 
     if (flags.hasAny(this->getFlags()))
     {

--- a/src/messages/MessageElement.cpp
+++ b/src/messages/MessageElement.cpp
@@ -678,21 +678,23 @@ void ScalingImageElement::addToContainer(MessageLayoutContainer &container,
 
 ReplyCurveElement::ReplyCurveElement()
     : MessageElement(MessageElementFlag::RepliedMessage)
-    // these values nicely align with a single badge
-    , neededMargin_(3)
-    , size_(18, 14)
 {
 }
 
 void ReplyCurveElement::addToContainer(MessageLayoutContainer &container,
                                        MessageElementFlags flags)
 {
+    static const int width = 18;
+    static const float thickness = 1.5;
+    static const int radius = 6;
+    static const int margin = 2;
+
     if (flags.hasAny(this->getFlags()))
     {
-        QSize boxSize = this->size_ * container.getScale();
-        container.addElement(new ReplyCurveLayoutElement(
-            *this, boxSize, 1.5 * container.getScale(),
-            this->neededMargin_ * container.getScale()));
+        float scale = container.getScale();
+        container.addElement(
+            new ReplyCurveLayoutElement(*this, width * scale, thickness * scale,
+                                        radius * scale, margin * scale));
     }
 }
 

--- a/src/messages/MessageElement.hpp
+++ b/src/messages/MessageElement.hpp
@@ -429,10 +429,6 @@ public:
 
     void addToContainer(MessageLayoutContainer &container,
                         MessageElementFlags flags) override;
-
-private:
-    int neededMargin_;
-    QSize size_;
 };
 
 }  // namespace chatterino

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -133,21 +133,20 @@ void MessageLayoutContainer::_addElement(MessageLayoutElement *element,
         this->currentY_ = int(this->margin.top * this->scale_);
     }
 
-    int newLineHeight = element->getRect().height();
+    int elementLineHeight = element->getRect().height();
 
     // compact emote offset
     bool isCompactEmote =
-        getSettings()->compactEmotes &&
         !this->flags_.has(MessageFlag::DisableCompactEmotes) &&
         element->getCreator().getFlags().has(MessageElementFlag::EmoteImages);
 
     if (isCompactEmote)
     {
-        newLineHeight -= COMPACT_EMOTES_OFFSET * this->scale_;
+        elementLineHeight -= COMPACT_EMOTES_OFFSET * this->scale_;
     }
 
     // update line height
-    this->lineHeight_ = std::max(this->lineHeight_, newLineHeight);
+    this->lineHeight_ = std::max(this->lineHeight_, elementLineHeight);
 
     auto xOffset = 0;
     bool isZeroWidthEmote = element->getCreator().getFlags().has(
@@ -218,7 +217,6 @@ void MessageLayoutContainer::breakLine()
         MessageLayoutElement *element = this->elements_.at(i).get();
 
         bool isCompactEmote =
-            getSettings()->compactEmotes &&
             !this->flags_.has(MessageFlag::DisableCompactEmotes) &&
             element->getCreator().getFlags().has(
                 MessageElementFlag::EmoteImages);
@@ -227,15 +225,6 @@ void MessageLayoutContainer::breakLine()
         if (isCompactEmote)
         {
             yExtra = (COMPACT_EMOTES_OFFSET / 2) * this->scale_;
-        }
-
-        //        if (element->getCreator().getFlags() &
-        //        MessageElementFlag::Badges)
-        //        {
-        if (element->getRect().height() < this->textLineHeight_)
-        {
-            // yExtra -= (this->textLineHeight_ - element->getRect().height()) /
-            // 2;
         }
 
         element->setPosition(

--- a/src/messages/layouts/MessageLayoutElement.hpp
+++ b/src/messages/layouts/MessageLayoutElement.hpp
@@ -164,7 +164,7 @@ class ReplyCurveLayoutElement : public MessageLayoutElement
 {
 public:
     ReplyCurveLayoutElement(MessageElement &creator, int width, float thickness,
-                            float radius, float lMargin);
+                            float radius, float neededMargin);
 
 protected:
     void paint(QPainter &painter) override;

--- a/src/messages/layouts/MessageLayoutElement.hpp
+++ b/src/messages/layouts/MessageLayoutElement.hpp
@@ -163,8 +163,8 @@ private:
 class ReplyCurveLayoutElement : public MessageLayoutElement
 {
 public:
-    ReplyCurveLayoutElement(MessageElement &creator, const QSize &size,
-                            float thickness, float lMargin);
+    ReplyCurveLayoutElement(MessageElement &creator, int width, float thickness,
+                            float radius, float lMargin);
 
 protected:
     void paint(QPainter &painter) override;
@@ -177,6 +177,7 @@ protected:
 
 private:
     const QPen pen_;
+    const float radius_;
     const float neededMargin_;
 };
 

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -100,7 +100,6 @@ public:
                                      false};
     BoolSetting separateMessages = {"/appearance/messages/separateMessages",
                                     false};
-    BoolSetting compactEmotes = {"/appearance/messages/compactEmotes", true};
     BoolSetting hideModerated = {"/appearance/messages/hideModerated", false};
     BoolSetting hideModerationActions = {
         "/appearance/messages/hideModerationActions", false};


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description
Improves the overall appearance of the reply curve. Related: #4009

Curve drawing parameters are defined here and can be tuned if people feel that some other value set would look better:
https://github.com/dnsge/chatterino2/blob/cf1c994cb4c5bae40c27af172e233965e84ca016/src/messages/MessageElement.cpp#L687-L690

New Appearance:
<img width="383" alt="Screen Shot 2022-11-01 at 11 00 49 PM" src="https://user-images.githubusercontent.com/24928223/199386807-32697d9b-d756-4446-ab7f-a8489e6c3ce7.png">

The vertical expanding nature of the reply curve has been removed from this PR. I will create another PR for the logic.

# ~Description~ Outdated

Improves the overall appearance of the reply curve. Related: #4009

1. Uses linear horizontal and vertical parts with a curve in the top left (much like discord)
2. Fully extends downwards to the element below

<img width="449" alt="Screen Shot 2022-10-21 at 9 13 38 PM" src="https://user-images.githubusercontent.com/24928223/197309935-38a16207-e1ea-4e4b-a124-01c658c373ef.png">

The vertical growth works as follows:
1. All elements are laid out, as usual, line by line
2. We iterate through every `MessageLayoutElement` and find every instance of `VerticalExpandingMessageLayoutElement`
3. For each `VerticalExpandingMessageLayoutElement`, if there is a line below it, we find the top of the elements directly beneath it
4. We then increase the size of the current element to touch the element(s) beneath it
 
This screenshot + drawing sort of show the process:
<img width="539" alt="Screen Shot 2022-10-21 at 9 17 18 PM" src="https://user-images.githubusercontent.com/24928223/197310394-8e929abc-5f4c-413e-9e46-edcb8a577d4a.png">

We identify the elements that are below the reply curve element and consider their bounding boxes. In this example, we don't need to worry about the two badges because they aren't directly below the reply curve. We then grow the bottom of the reply curve to meet the top of the timestamp.

The top of our reply curve remains unmoved; when we constructed the reply curve element, we gave it a zero height and told the `MessageLayoutContainer` to center it vertically in the line (new to this PR).

If we manually increase the width of the reply curve, we can see how the curve chooses the tallest element beneath it:
<img width="419" alt="Screen Shot 2022-10-21 at 8 37 53 PM" src="https://user-images.githubusercontent.com/24928223/197310543-f14b30a3-df23-4b87-b580-d81dae4e658b.png">
