### PR TITLE
Include more error messaging for failed image uploads

### DIFF
--- a/src/util/NuulsUploader.cpp
+++ b/src/util/NuulsUploader.cpp
@@ -204,9 +204,32 @@ void uploadImageToNuuls(RawImageData imageData, ChannelPtr channel,
             return Success;
         })
         .onError([channel](NetworkResult result) -> bool {
-            channel->addMessage(makeSystemMessage(
+            auto errorMessage =
                 QString("An error happened while uploading your image: %1")
-                    .arg(result.status())));
+                    .arg(result.status());
+
+            // Try to read more information from the result body
+            auto obj = result.parseJson();
+            if (!obj.isEmpty())
+            {
+                auto apiCode = obj.value("code");
+                if (!apiCode.isUndefined())
+                {
+                    auto codeString = apiCode.toVariant().toString();
+                    codeString.truncate(20);
+                    errorMessage += QString(" - code: %1").arg(codeString);
+                }
+
+                auto apiError = obj.value("error").toString();
+                if (!apiError.isEmpty())
+                {
+                    apiError.truncate(300);
+                    errorMessage +=
+                        QString(" - error: %1").arg(apiError.trimmed());
+                }
+            }
+
+            channel->addMessage(makeSystemMessage(errorMessage));
             uploadMutex.unlock();
             return true;
         })


### PR DESCRIPTION

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

`parseJson` will return an empty object if the body is not a valid JSON string.

We currently try to read:
`.error` as an error string, of which we include a maximum of 300 characters.
`.code` as any type of value, of which we include a maximum of 20 characters.

Fixes #4095

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
