### PR TITLE
Fix recursive fetchChatters call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@
 - Minor: Migrated /uniquechatoff and /r9kbetaoff to Helix API. (#4057)
 - Minor: Added stream titles to windows live toast notifications. (#1297)
 - Minor: Make menus and placeholders display appropriate custom key combos. (#4045)
-- Minor: Migrated /chatters to Helix API. (#4088)
+- Minor: Migrated /chatters to Helix API. (#4088, #4097)
 - Minor: Add settings tooltips. (#3437)
 - Bugfix: Connection to Twitch PubSub now recovers more reliably. (#3643, #3716)
 - Bugfix: Fixed `Smooth scrolling on new messages` setting sometimes hiding messages. (#4028)


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Had a false sense of confidence that SURELY this call had been made, but the `hasModRights` check will return false for the first check. We should delay the initial call until the USERSTATE message has come in and we know whether they're a moderator or not

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
