### PR TITLE
deps[conan]: update openssl and boost on Windows

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,6 +1,6 @@
 [requires]
-openssl/1.1.1m
-boost/1.78.0
+openssl/1.1.1s
+boost/1.80.0
 
 [generators]
 cmake


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

#4098 updated the convenience link for OpenSSL, so here we'll try the new versions in CI.

A note on boost: This updates boost on Windows to 1.80, but it should be noted, that the Ubuntu-CI is still on [1.74](https://packages.ubuntu.com/jammy/libboost-dev), macOS should be on 1.80.
