### PR TITLE
Fix Reply Text Showing In Reply Thread Popup

### DIFF
--- a/src/messages/layouts/MessageLayout.cpp
+++ b/src/messages/layouts/MessageLayout.cpp
@@ -134,30 +134,33 @@ void MessageLayout::actuallyLayout(int width, MessageElementFlags flags)
         messageFlags.unset(MessageFlag::Collapsed);
     }
 
+    bool hideModerated = getSettings()->hideModerated;
+    bool hideModerationActions = getSettings()->hideModerationActions;
+    bool hideSimilar = getSettings()->hideSimilar;
+    bool hideReplies = !flags.has(MessageElementFlag::RepliedMessage);
+
     this->container_->begin(width, this->scale_, messageFlags);
 
     for (const auto &element : this->message_->elements)
     {
-        if (getSettings()->hideModerated &&
-            this->message_->flags.has(MessageFlag::Disabled))
+        if (hideModerated && this->message_->flags.has(MessageFlag::Disabled))
         {
             continue;
         }
 
-        if (getSettings()->hideModerationActions &&
+        if (hideModerationActions &&
             (this->message_->flags.has(MessageFlag::Timeout) ||
              this->message_->flags.has(MessageFlag::Untimeout)))
         {
             continue;
         }
 
-        if (getSettings()->hideSimilar &&
-            this->message_->flags.has(MessageFlag::Similar))
+        if (hideSimilar && this->message_->flags.has(MessageFlag::Similar))
         {
             continue;
         }
 
-        if (!this->renderReplies_ &&
+        if (hideReplies &&
             element->getFlags().has(MessageElementFlag::RepliedMessage))
         {
             continue;
@@ -453,11 +456,6 @@ bool MessageLayout::isReplyable() const
     }
 
     return true;
-}
-
-void MessageLayout::setRenderReplies(bool render)
-{
-    this->renderReplies_ = render;
 }
 
 }  // namespace chatterino

--- a/src/messages/layouts/MessageLayout.hpp
+++ b/src/messages/layouts/MessageLayout.hpp
@@ -65,7 +65,6 @@ public:
     // Misc
     bool isDisabled() const;
     bool isReplyable() const;
-    void setRenderReplies(bool render);
 
 private:
     // variables
@@ -73,7 +72,6 @@ private:
     std::shared_ptr<MessageLayoutContainer> container_;
     std::shared_ptr<QPixmap> buffer_{};
     bool bufferValid_ = false;
-    bool renderReplies_ = true;
 
     int height_ = 0;
 


### PR DESCRIPTION
Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable

There have been so many changes to the reply thread changelog entry (and this is a bugfix to a bugfix) that I really don't care if we don't add this PR to the changelog.

# Description

#4092 Introduced the following bug: 
<img width="514" alt="image" src="https://user-images.githubusercontent.com/24928223/199611060-df3e21c1-ac66-47d1-a5d0-d2032822632e.png">
The reply text is improperly rendered in the reply thread popup.

This PR fixes the bug. The bug itself is my fault because, during the (extensive) changes made to my original reply threads PR, I changed around how hiding the reply message elements worked. This change eliminates the `setRenderReplies` method which became unused at some point.

Also: sorry for the unrelated change of extracting the accessing of setting values. I just couldn't leave the repeated calls that could easily be reused.
