### PR TITLE
Migrate /mods command to helix API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 - Minor: Added stream titles to windows live toast notifications. (#1297)
 - Minor: Make menus and placeholders display appropriate custom key combos. (#4045)
 - Minor: Migrated /chatters to Helix API. (#4088, #4097)
+- Minor: Migrated /mods to Helix API. (#4103)
 - Minor: Add settings tooltips. (#3437)
 - Bugfix: Connection to Twitch PubSub now recovers more reliably. (#3643, #3716)
 - Bugfix: Fixed `Smooth scrolling on new messages` setting sometimes hiding messages. (#4028)

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -1009,16 +1009,17 @@ void CommandController::initialize(Settings &, Paths &paths)
                 twitchChannel->roomId(),
                 [channel, twitchChannel](auto result) {
                     QStringList list;
-                    for (auto it = result.begin(); it != result.end();it++)
+                    for (auto it = result.begin(); it != result.end(); it++)
                     {
                         list << it->userName;
                     }
-                    
+
                     list.sort(Qt::CaseInsensitive);
 
                     MessageBuilder builder;
                     TwitchMessageBuilder::listOfUsersSystemMessage(
-                        "The moderators of this channel are ", list, twitchChannel, &builder);
+                        "The moderators of this channel are ", list,
+                        twitchChannel, &builder);
                     channel->addMessage(builder.release());
                 },
                 [channel, formatModsError](auto error, auto message) {

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -1006,7 +1006,7 @@ void CommandController::initialize(Settings &, Paths &paths)
             }
 
             getHelix()->getModerators(
-                twitchChannel->roomId(),
+                twitchChannel->roomId(), 500,
                 [channel, twitchChannel](auto result) {
                     QStringList list;
                     for (auto it = result.begin(); it != result.end(); it++)

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -972,7 +972,6 @@ void CommandController::initialize(Settings &, Paths &paths)
             return errorMessage;
         };
 
-
         auto twitchChannel = dynamic_cast<TwitchChannel *>(channel.get());
 
         if (twitchChannel == nullptr)
@@ -988,18 +987,21 @@ void CommandController::initialize(Settings &, Paths &paths)
                 auto message = QString("The moderators of this channel are ");
                 auto listSize = result.size();
                 int i = 0;
-                for (auto it = result.begin(); it != result.end();it++)
+                for (auto it = result.begin(); it != result.end(); it++)
                 {
                     auto mod = *it;
                     message = message + mod.userName;
 
                     if (listSize > 2 && i < listSize - 2)
                     {
-                        message = message +  QString(", ");
-                    } else if (listSize > 2 && i == listSize - 1)
+                        message = message + QString(", ");
+                    }
+                    else if (listSize > 2 && i == listSize - 1)
                     {
                         message = message + QString(", and ");
-                    } else if (listSize == 2 && i == 1) {
+                    }
+                    else if (listSize == 2 && i == 1)
+                    {
                         message = message + QString(" and ");
                     }
 
@@ -1011,8 +1013,7 @@ void CommandController::initialize(Settings &, Paths &paths)
             [channel, formatError](auto error, auto message) {
                 auto errorMessage = formatError(error, message);
                 channel->addMessage(makeSystemMessage(errorMessage));
-            }
-        );
+            });
         return "";
     });
 

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -1008,17 +1008,11 @@ void CommandController::initialize(Settings &, Paths &paths)
             getHelix()->getModerators(
                 twitchChannel->roomId(), 500,
                 [channel, twitchChannel](auto result) {
-                    QStringList list;
-                    for (auto it = result.begin(); it != result.end(); it++)
-                    {
-                        list << it->userName;
-                    }
-
-                    list.sort(Qt::CaseInsensitive);
+                    // TODO: sort results?
 
                     MessageBuilder builder;
                     TwitchMessageBuilder::listOfUsersSystemMessage(
-                        "The moderators of this channel are", list,
+                        "The moderators of this channel are", result,
                         twitchChannel, &builder);
                     channel->addMessage(builder.release());
                 },

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -959,9 +959,9 @@ void CommandController::initialize(Settings &, Paths &paths)
 
             case Error::UserNotAuthorized: {
                 errorMessage +=
-                    "Due to Twitch restrictions, this command can only be "
-                    "used by moderators. To see the list of mods you must "
-                    "use the Twitch website.";
+                    "Due to Twitch restrictions, "
+                    "this command can only be used by the broadcaster. "
+                    "To see the list of mods you must use the Twitch website.";
             }
             break;
 

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -1007,33 +1007,19 @@ void CommandController::initialize(Settings &, Paths &paths)
 
             getHelix()->getModerators(
                 twitchChannel->roomId(),
-                [channel](auto result) {
-                    auto message =
-                        QString("The moderators of this channel are ");
-                    auto listSize = result.size();
-                    int i = 0;
-                    for (auto it = result.begin(); it != result.end(); it++)
+                [channel, twitchChannel](auto result) {
+                    QStringList list;
+                    for (auto it = result.begin(); it != result.end();it++)
                     {
-                        auto mod = *it;
-                        message = message + mod.userName;
-
-                        if (listSize > 2 && i < listSize - 2)
-                        {
-                            message = message + QString(", ");
-                        }
-                        else if (listSize > 2 && i == listSize - 1)
-                        {
-                            message = message + QString(", and ");
-                        }
-                        else if (listSize == 2 && i == 1)
-                        {
-                            message = message + QString(" and ");
-                        }
-
-                        i++;
+                        list << it->userName;
                     }
+                    
+                    list.sort(Qt::CaseInsensitive);
 
-                    channel->addMessage(makeSystemMessage(message));
+                    MessageBuilder builder;
+                    TwitchMessageBuilder::listOfUsersSystemMessage(
+                        "The moderators of this channel are ", list, twitchChannel, &builder);
+                    channel->addMessage(builder.release());
                 },
                 [channel, formatModsError](auto error, auto message) {
                     auto errorMessage = formatModsError(error, message);

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -1018,7 +1018,7 @@ void CommandController::initialize(Settings &, Paths &paths)
 
                     MessageBuilder builder;
                     TwitchMessageBuilder::listOfUsersSystemMessage(
-                        "The moderators of this channel are ", list,
+                        "The moderators of this channel are", list,
                         twitchChannel, &builder);
                     channel->addMessage(builder.release());
                 },

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -959,8 +959,9 @@ void CommandController::initialize(Settings &, Paths &paths)
                 break;
 
                 case Error::UserNotAuthorized: {
-                    errorMessage += "You must have moderator permissions to "
-                                    "use this command.";
+                    errorMessage += "Due to Twitch restrictions, this command can only be "
+                        "used by moderators. To see the list of mods you must "
+                        "use the Twitch website.";
                 }
                 break;
 

--- a/src/providers/twitch/TwitchMessageBuilder.hpp
+++ b/src/providers/twitch/TwitchMessageBuilder.hpp
@@ -7,6 +7,7 @@
 #include "providers/twitch/ChannelPointReward.hpp"
 #include "providers/twitch/PubSubActions.hpp"
 #include "providers/twitch/TwitchBadge.hpp"
+#include "providers/twitch/api/Helix.hpp"
 
 #include <IrcMessage>
 #include <QString>

--- a/src/providers/twitch/TwitchMessageBuilder.hpp
+++ b/src/providers/twitch/TwitchMessageBuilder.hpp
@@ -71,6 +71,9 @@ public:
     static void listOfUsersSystemMessage(QString prefix, QStringList users,
                                          Channel *channel,
                                          MessageBuilder *builder);
+    static void listOfUsersSystemMessage(
+        QString prefix, const std::vector<HelixModerator> &users,
+        Channel *channel, MessageBuilder *builder);
 
     // Shares some common logic from SharedMessageBuilder::parseBadgeTag
     static std::unordered_map<QString, QString> parseBadgeInfoTag(

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -6,6 +6,14 @@
 #include <QJsonDocument>
 #include <magic_enum.hpp>
 
+namespace {
+
+using namespace chatterino;
+
+static constexpr auto NUM_MODERATORS_TO_FETCH_PER_REQUEST = 100;
+
+}  // namespace
+
 namespace chatterino {
 
 static IHelix *instance = nullptr;
@@ -1883,7 +1891,7 @@ void Helix::onFetchModeratorsSuccess(
     }
 
     this->fetchModerators(
-        broadcasterID, moderators.cursor,
+        broadcasterID, NUM_MODERATORS_TO_FETCH_PER_REQUEST, moderators.cursor,
         [=](auto moderators) {
             this->onFetchModeratorsSuccess(
                 finalModerators, broadcasterID, maxModeratorsToFetch,
@@ -1894,7 +1902,7 @@ void Helix::onFetchModeratorsSuccess(
 
 // https://dev.twitch.tv/docs/api/reference#get-moderators
 void Helix::fetchModerators(
-    QString broadcasterID, QString after,
+    QString broadcasterID, int first, QString after,
     ResultCallback<HelixModerators> successCallback,
     FailureCallback<HelixGetModeratorsError, QString> failureCallback)
 {
@@ -1903,6 +1911,7 @@ void Helix::fetchModerators(
     QUrlQuery urlQuery;
 
     urlQuery.addQueryItem("broadcaster_id", broadcasterID);
+    urlQuery.addQueryItem("first", QString::number(first));
 
     if (!after.isEmpty())
     {
@@ -2224,7 +2233,7 @@ void Helix::getModerators(
 
     // Initiate the recursive calls
     this->fetchModerators(
-        broadcasterID, "",
+        broadcasterID, NUM_MODERATORS_TO_FETCH_PER_REQUEST, "",
         [=](auto moderators) {
             this->onFetchModeratorsSuccess(
                 finalModerators, broadcasterID, maxModeratorsToFetch,

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -1861,7 +1861,7 @@ void Helix::fetchChatters(
 
 void Helix::onFetchModeratorsSuccess(
     std::shared_ptr<std::vector<HelixModerator>> finalModerators,
-    QString broadcasterID,
+    QString broadcasterID, int maxModeratorsToFetch,
     ResultCallback<std::vector<HelixModerator>> successCallback,
     FailureCallback<HelixGetModeratorsError, QString> failureCallback,
     HelixModerators moderators)
@@ -1874,7 +1874,8 @@ void Helix::onFetchModeratorsSuccess(
                       finalModerators->push_back(mod);
                   });
 
-    if (moderators.cursor.isEmpty())
+    if (moderators.cursor.isEmpty() ||
+        finalModerators->size() >= maxModeratorsToFetch)
     {
         // Done paginating
         successCallback(*finalModerators);
@@ -1884,9 +1885,9 @@ void Helix::onFetchModeratorsSuccess(
     this->fetchModerators(
         broadcasterID, moderators.cursor,
         [=](auto moderators) {
-            this->onFetchModeratorsSuccess(finalModerators, broadcasterID,
-                                           successCallback, failureCallback,
-                                           moderators);
+            this->onFetchModeratorsSuccess(
+                finalModerators, broadcasterID, maxModeratorsToFetch,
+                successCallback, failureCallback, moderators);
         },
         failureCallback);
 }
@@ -2215,7 +2216,7 @@ void Helix::getChatters(
 
 // https://dev.twitch.tv/docs/api/reference#get-moderators
 void Helix::getModerators(
-    QString broadcasterID,
+    QString broadcasterID, int maxModeratorsToFetch,
     ResultCallback<std::vector<HelixModerator>> successCallback,
     FailureCallback<HelixGetModeratorsError, QString> failureCallback)
 {
@@ -2225,9 +2226,9 @@ void Helix::getModerators(
     this->fetchModerators(
         broadcasterID, "",
         [=](auto moderators) {
-            this->onFetchModeratorsSuccess(finalModerators, broadcasterID,
-                                           successCallback, failureCallback,
-                                           moderators);
+            this->onFetchModeratorsSuccess(
+                finalModerators, broadcasterID, maxModeratorsToFetch,
+                successCallback, failureCallback, moderators);
         },
         failureCallback);
 }

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -2189,17 +2189,17 @@ void Helix::getModerators(
 {
     auto finalModerators = std::make_shared<std::vector<HelixModerator>>();
 
-    auto fetchSuccess = [this, broadcasterID,
-                         finalModerators, successCallback,
+    auto fetchSuccess = [this, broadcasterID, finalModerators, successCallback,
                          failureCallback](auto fs) {
         return [=](auto moderators) {
             qCDebug(chatterinoTwitch)
                 << "Fetched " << moderators.moderators.size() << " moderators";
-            
-            std::for_each(moderators.moderators.begin(), moderators.moderators.end(), [finalModerators](auto mod)
-            {
-                finalModerators->push_back(mod);
-            });
+
+            std::for_each(moderators.moderators.begin(),
+                          moderators.moderators.end(),
+                          [finalModerators](auto mod) {
+                              finalModerators->push_back(mod);
+                          });
 
             if (moderators.cursor.isEmpty())
             {
@@ -2209,12 +2209,13 @@ void Helix::getModerators(
             }
 
             this->fetchModerators(broadcasterID, moderators.cursor, fs,
-                                failureCallback);
+                                  failureCallback);
         };
     };
 
     // Initiate the recursive calls
-    this->fetchModerators(broadcasterID, "", fetchSuccess(fetchSuccess), failureCallback);
+    this->fetchModerators(broadcasterID, "", fetchSuccess(fetchSuccess),
+                          failureCallback);
 }
 
 // List the VIPs of a channel

--- a/src/providers/twitch/api/Helix.hpp
+++ b/src/providers/twitch/api/Helix.hpp
@@ -1166,6 +1166,14 @@ protected:
         ResultCallback<HelixChatters> successCallback,
         FailureCallback<HelixGetChattersError, QString> failureCallback);
 
+    // Recursive boy
+    void onFetchModeratorsSuccess(
+        std::shared_ptr<std::vector<HelixModerator>> finalModerators,
+        QString broadcasterID,
+        ResultCallback<std::vector<HelixModerator>> successCallback,
+        FailureCallback<HelixGetModeratorsError, QString> failureCallback,
+        HelixModerators moderators);
+
     // Get moderator list - This method is what actually runs the API request
     // https://dev.twitch.tv/docs/api/reference#get-moderators
     void fetchModerators(

--- a/src/providers/twitch/api/Helix.hpp
+++ b/src/providers/twitch/api/Helix.hpp
@@ -1138,7 +1138,8 @@ public:
     void getModerators(
         QString broadcasterID,
         ResultCallback<std::vector<HelixModerator>> successCallback,
-        FailureCallback<HelixGetModeratorsError, QString> failureCallback) final;
+        FailureCallback<HelixGetModeratorsError, QString> failureCallback)
+        final;
 
     // https://dev.twitch.tv/docs/api/reference#get-vips
     void getChannelVIPs(

--- a/src/providers/twitch/api/Helix.hpp
+++ b/src/providers/twitch/api/Helix.hpp
@@ -1132,7 +1132,7 @@ public:
         ResultCallback<HelixChatters> successCallback,
         FailureCallback<HelixGetChattersError, QString> failureCallback) final;
 
-    // Get Chatters from the `broadcasterID` channel
+    // Get moderators from the `broadcasterID` channel
     // This will follow the returned cursor
     // https://dev.twitch.tv/docs/api/reference#get-moderators
     void getModerators(

--- a/src/providers/twitch/api/Helix.hpp
+++ b/src/providers/twitch/api/Helix.hpp
@@ -332,8 +332,13 @@ struct HelixChatSettings {
 };
 
 struct HelixVip {
+    // Twitch ID of the user
     QString userId;
+
+    // Display name of the user
     QString userName;
+
+    // Login name of the user
     QString userLogin;
 
     explicit HelixVip(const QJsonObject &jsonObject)

--- a/src/providers/twitch/api/Helix.hpp
+++ b/src/providers/twitch/api/Helix.hpp
@@ -859,7 +859,7 @@ public:
     // This will follow the returned cursor
     // https://dev.twitch.tv/docs/api/reference#get-moderators
     virtual void getModerators(
-        QString broadcasterID,
+        QString broadcasterID, int maxModeratorsToFetch,
         ResultCallback<std::vector<HelixModerator>> successCallback,
         FailureCallback<HelixGetModeratorsError, QString> failureCallback) = 0;
 
@@ -1136,7 +1136,7 @@ public:
     // This will follow the returned cursor
     // https://dev.twitch.tv/docs/api/reference#get-moderators
     void getModerators(
-        QString broadcasterID,
+        QString broadcasterID, int maxModeratorsToFetch,
         ResultCallback<std::vector<HelixModerator>> successCallback,
         FailureCallback<HelixGetModeratorsError, QString> failureCallback)
         final;
@@ -1169,7 +1169,7 @@ protected:
     // Recursive boy
     void onFetchModeratorsSuccess(
         std::shared_ptr<std::vector<HelixModerator>> finalModerators,
-        QString broadcasterID,
+        QString broadcasterID, int maxModeratorsToFetch,
         ResultCallback<std::vector<HelixModerator>> successCallback,
         FailureCallback<HelixGetModeratorsError, QString> failureCallback,
         HelixModerators moderators);

--- a/src/providers/twitch/api/Helix.hpp
+++ b/src/providers/twitch/api/Helix.hpp
@@ -367,9 +367,29 @@ struct HelixChatters {
     }
 };
 
-// TODO(jammehcow): when implementing mod list, just alias HelixVip to HelixMod
-//   as they share the same model.
-//   Alternatively, rename base struct to HelixUser or something and alias both
+using HelixModerator = HelixVip;
+
+struct HelixModerators {
+    std::vector<HelixModerator> moderators;
+    QString cursor;
+
+    HelixModerators() = default;
+
+    explicit HelixModerators(const QJsonObject &jsonObject)
+        : cursor(jsonObject.value("pagination")
+                     .toObject()
+                     .value("cursor")
+                     .toString())
+    {
+        const auto &data = jsonObject.value("data").toArray();
+        for (const auto &mod : data)
+        {
+            HelixModerator moderator(mod.toObject());
+
+            this->moderators.push_back(moderator);
+        }
+    }
+};
 
 enum class HelixAnnouncementColor {
     Blue,
@@ -545,6 +565,15 @@ enum class HelixWhisperError {  // /w
 };  // /w
 
 enum class HelixGetChattersError {
+    Unknown,
+    UserMissingScope,
+    UserNotAuthorized,
+
+    // The error message is forwarded directly from the Twitch API
+    Forwarded,
+};
+
+enum class HelixGetModeratorsError {
     Unknown,
     UserMissingScope,
     UserNotAuthorized,
@@ -826,6 +855,14 @@ public:
         ResultCallback<HelixChatters> successCallback,
         FailureCallback<HelixGetChattersError, QString> failureCallback) = 0;
 
+    // Get moderators from the `broadcasterID` channel
+    // This will follow the returned cursor
+    // https://dev.twitch.tv/docs/api/reference#get-moderators
+    virtual void getModerators(
+        QString broadcasterID,
+        ResultCallback<std::vector<HelixModerator>> successCallback,
+        FailureCallback<HelixGetModeratorsError, QString> failureCallback) = 0;
+
     // https://dev.twitch.tv/docs/api/reference#get-vips
     virtual void getChannelVIPs(
         QString broadcasterID,
@@ -1095,6 +1132,14 @@ public:
         ResultCallback<HelixChatters> successCallback,
         FailureCallback<HelixGetChattersError, QString> failureCallback) final;
 
+    // Get Chatters from the `broadcasterID` channel
+    // This will follow the returned cursor
+    // https://dev.twitch.tv/docs/api/reference#get-moderators
+    void getModerators(
+        QString broadcasterID,
+        ResultCallback<std::vector<HelixModerator>> successCallback,
+        FailureCallback<HelixGetModeratorsError, QString> failureCallback) final;
+
     // https://dev.twitch.tv/docs/api/reference#get-vips
     void getChannelVIPs(
         QString broadcasterID,
@@ -1119,6 +1164,13 @@ protected:
         QString broadcasterID, QString moderatorID, int first, QString after,
         ResultCallback<HelixChatters> successCallback,
         FailureCallback<HelixGetChattersError, QString> failureCallback);
+
+    // Get moderator list - This method is what actually runs the API request
+    // https://dev.twitch.tv/docs/api/reference#get-moderators
+    void fetchModerators(
+        QString broadcasterID, QString after,
+        ResultCallback<HelixModerators> successCallback,
+        FailureCallback<HelixGetModeratorsError, QString> failureCallback);
 
 private:
     NetworkRequest makeRequest(QString url, QUrlQuery urlQuery);

--- a/src/providers/twitch/api/Helix.hpp
+++ b/src/providers/twitch/api/Helix.hpp
@@ -1177,7 +1177,7 @@ protected:
     // Get moderator list - This method is what actually runs the API request
     // https://dev.twitch.tv/docs/api/reference#get-moderators
     void fetchModerators(
-        QString broadcasterID, QString after,
+        QString broadcasterID, int first, QString after,
         ResultCallback<HelixModerators> successCallback,
         FailureCallback<HelixGetModeratorsError, QString> failureCallback);
 

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -442,6 +442,10 @@ public:
         "/misc/twitch/helix-timegate/vips",
         HelixTimegateOverride::Timegate,
     };
+    EnumSetting<HelixTimegateOverride> helixTimegateModerators = {
+        "/misc/twitch/helix-timegate/moderaters",
+        HelixTimegateOverride::Timegate,
+    };
 
     IntSetting emotesTooltipPreview = {"/misc/emotesTooltipPreview", 1};
     BoolSetting openLinksIncognito = {"/misc/openLinksIncognito", 0};

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -443,7 +443,7 @@ public:
         HelixTimegateOverride::Timegate,
     };
     EnumSetting<HelixTimegateOverride> helixTimegateModerators = {
-        "/misc/twitch/helix-timegate/moderaters",
+        "/misc/twitch/helix-timegate/moderators",
         HelixTimegateOverride::Timegate,
     };
 

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -855,6 +855,17 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     helixTimegateVIPs->setMinimumWidth(
         helixTimegateVIPs->minimumSizeHint().width());
 
+    auto *helixTimegateModerators =
+        layout.addDropdown<std::underlying_type<HelixTimegateOverride>::type>(
+            "Helix timegate /mods behaviour",
+            {"Timegate", "Always use IRC", "Always use Helix"},
+            s.helixTimegateModerators,
+            helixTimegateGetValue,  //
+            helixTimegateSetValue,  //
+            false);
+    helixTimegateModerators->setMinimumWidth(
+        helixTimegateModerators->minimumSizeHint().width());
+
     layout.addStretch();
 
     // invisible element for width

--- a/tests/src/HighlightController.cpp
+++ b/tests/src/HighlightController.cpp
@@ -378,6 +378,15 @@ public:
          (FailureCallback<HelixListVIPsError, QString> failureCallback)),
         (override));  // /vips
 
+    // /mods
+    // The extra parenthesis around the failure callback is because its type contains a comma
+    MOCK_METHOD(
+        void, getModerators,
+        (QString broadcasterID,
+         ResultCallback<std::vector<HelixModerator>> successCallback,
+         (FailureCallback<HelixGetModeratorsError, QString> failureCallback)),
+        (override));  // /mods
+
     MOCK_METHOD(void, update, (QString clientId, QString oauthToken),
                 (override));
 

--- a/tests/src/HighlightController.cpp
+++ b/tests/src/HighlightController.cpp
@@ -382,7 +382,7 @@ public:
     // The extra parenthesis around the failure callback is because its type contains a comma
     MOCK_METHOD(
         void, getModerators,
-        (QString broadcasterID,
+        (QString broadcasterID, int maxModeratorsToFetch,
          ResultCallback<std::vector<HelixModerator>> successCallback,
          (FailureCallback<HelixGetModeratorsError, QString> failureCallback)),
         (override));  // /mods


### PR DESCRIPTION
Pull request checklist:

closes #3971 

- [x] `CHANGELOG.md` was updated, if applicable

# Description
Modeled after the /chatters migration PR #4088.

/mods command no longer uses the irc command and now makes a helix api request.
mod list is paginated just like chatter list.

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
