### PR TITLE
Fix uninitialized read in `ChannelView`'s `highlightedMessage_`

### DIFF
--- a/src/widgets/helper/ChannelView.hpp
+++ b/src/widgets/helper/ChannelView.hpp
@@ -301,7 +301,7 @@ private:
     QTimer scrollTimer_;
 
     // We're only interested in the pointer, not the contents
-    MessageLayout *highlightedMessage_;
+    MessageLayout *highlightedMessage_ = nullptr;
     QVariantAnimation highlightAnimation_;
     void setupHighlightAnimationColors();
 


### PR DESCRIPTION

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

```
==38498== Conditional jump or move depends on uninitialised value(s)
==38498==    at 0x6F966C: chatterino::ChannelView::drawMessages(QPainter&) (ChannelView.cpp:1262)
==38498==    by 0x6F9206: chatterino::ChannelView::paintEvent(QPaintEvent*) (ChannelView.cpp:1215)
==38498==    by 0x4B8C3C3: QWidget::event(QEvent*) (qwidget.cpp:8824)
==38498==    by 0x4B55B1B: QApplicationPrivate::notify_helper(QObject*, QEvent*) (qapplication.cpp:3637)
==38498==    by 0x5B85F97: QCoreApplication::notifyInternal2(QObject*, QEvent*) (qcoreapplication.cpp:1064)
==38498==    by 0x4B8034A: QWidgetPrivate::sendPaintEvent(QRegion const&) (qwidget.cpp:5477)
==38498==    by 0x4B816A5: QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) (qwidget.cpp:5427)
==38498==    by 0x4B820AD: QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) (qwidget.cpp:5608)
==38498==    by 0x4B80BFA: QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) (qwidget.cpp:5468)
==38498==    by 0x4B820AD: QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) (qwidget.cpp:5608)
==38498==    by 0x4B81F0B: QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) (qwidget.cpp:5594)
==38498==    by 0x4B81F0B: QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) (qwidget.cpp:5594)
==38498==
```

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
