### PR TITLE
Migrate viewer list to helix with timegate setting

### DIFF
--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -44,14 +44,6 @@ namespace {
 
 using namespace chatterino;
 
-bool areIRCCommandsStillAvailable()
-{
-    // 11th of February 2023, 06:00am UTC
-    const QDateTime migrationTime(QDate(2023, 2, 11), QTime(6, 0), Qt::UTC);
-    auto now = QDateTime::currentDateTimeUtc();
-    return now < migrationTime;
-}
-
 QString useIRCCommand(const QStringList &words)
 {
     // Reform the original command
@@ -191,7 +183,7 @@ bool useIrcForWhisperCommand()
     switch (getSettings()->helixTimegateWhisper.getValue())
     {
         case HelixTimegateOverride::Timegate: {
-            if (areIRCCommandsStillAvailable())
+            if (CommandController::areIRCCommandsStillAvailable())
             {
                 return true;
             }
@@ -542,6 +534,14 @@ const std::unordered_map<QString, VariableReplacer> COMMAND_VARS{
 }  // namespace
 
 namespace chatterino {
+
+bool CommandController::CommandController::areIRCCommandsStillAvailable()
+{
+    // 11th of February 2023, 06:00am UTC
+    const QDateTime migrationTime(QDate(2023, 2, 11), QTime(6, 0), Qt::UTC);
+    auto now = QDateTime::currentDateTimeUtc();
+    return now < migrationTime;
+}
 
 void CommandController::initialize(Settings &, Paths &paths)
 {
@@ -1068,7 +1068,7 @@ void CommandController::initialize(Settings &, Paths &paths)
             switch (getSettings()->helixTimegateModerators.getValue())
             {
                 case HelixTimegateOverride::Timegate: {
-                    if (areIRCCommandsStillAvailable())
+                    if (CommandController::areIRCCommandsStillAvailable())
                     {
                         return useIRCCommand(words);
                     }
@@ -2333,7 +2333,7 @@ void CommandController::initialize(Settings &, Paths &paths)
             switch (getSettings()->helixTimegateRaid.getValue())
             {
                 case HelixTimegateOverride::Timegate: {
-                    if (areIRCCommandsStillAvailable())
+                    if (CommandController::areIRCCommandsStillAvailable())
                     {
                         return useIRCCommand(words);
                     }
@@ -2456,7 +2456,7 @@ void CommandController::initialize(Settings &, Paths &paths)
             switch (getSettings()->helixTimegateRaid.getValue())
             {
                 case HelixTimegateOverride::Timegate: {
-                    if (areIRCCommandsStillAvailable())
+                    if (CommandController::areIRCCommandsStillAvailable())
                     {
                         return useIRCCommand(words);
                     }
@@ -3263,7 +3263,7 @@ void CommandController::initialize(Settings &, Paths &paths)
             switch (getSettings()->helixTimegateVIPs.getValue())
             {
                 case HelixTimegateOverride::Timegate: {
-                    if (areIRCCommandsStillAvailable())
+                    if (CommandController::areIRCCommandsStillAvailable())
                     {
                         return useIRCCommand(words);
                     }
@@ -3411,7 +3411,7 @@ void CommandController::initialize(Settings &, Paths &paths)
             switch (getSettings()->helixTimegateCommercial.getValue())
             {
                 case HelixTimegateOverride::Timegate: {
-                    if (areIRCCommandsStillAvailable())
+                    if (CommandController::areIRCCommandsStillAvailable())
                     {
                         return useIRCCommand(words);
                     }

--- a/src/controllers/commands/CommandController.hpp
+++ b/src/controllers/commands/CommandController.hpp
@@ -40,6 +40,8 @@ public:
         ChannelPtr channel, const Message *message = nullptr,
         std::unordered_map<QString, QString> context = {});
 
+    static bool areIRCCommandsStillAvailable();
+
 private:
     void load(Paths &paths);
 

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -447,6 +447,11 @@ public:
         HelixTimegateOverride::Timegate,
     };
 
+    EnumSetting<HelixTimegateOverride> helixTimegateViewerList = {
+        "/misc/twitch/helix-timegate/viwerlist",
+        HelixTimegateOverride::Timegate,
+    };
+
     EnumSetting<HelixTimegateOverride> helixTimegateCommercial = {
         "/misc/twitch/helix-timegate/commercial",
         HelixTimegateOverride::Timegate,

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -877,6 +877,19 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     helixTimegateModerators->setMinimumWidth(
         helixTimegateModerators->minimumSizeHint().width());
 
+
+    auto *helixTimegateViewerList =
+        layout.addDropdown<std::underlying_type<HelixTimegateOverride>::type>(
+            "Helix timegate viwer list behaviour",
+            // AlwaysUseIRC value is used to always use tmi endpoint
+            {"Timegate", "Always use tmi", "Always use Helix"},
+            s.helixTimegateViewerList,
+            helixTimegateGetValue,  //
+            helixTimegateSetValue,  //
+            false);
+    helixTimegateViewerList->setMinimumWidth(
+        helixTimegateViewerList->minimumSizeHint().width());
+
     layout.addStretch();
 
     // invisible element for width

--- a/src/widgets/splits/Split.hpp
+++ b/src/widgets/splits/Split.hpp
@@ -176,6 +176,10 @@ public slots:
     void openSubPage();
     void reloadChannelAndSubscriberEmotes();
     void reconnect();
+
+private slots:
+    void showViewerListTmi();
+    void showViewerListHelix();
 };
 
 }  // namespace chatterino


### PR DESCRIPTION
Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable

# Description

This uses the new helix endpoints for mods, vips, and chatters to get the viewer list via the helix api instead of the tmi endpoint which *may* go out of date whenever the irc commands are deprecated. It basically future proofs the viewer list so that if the tmi endpoint is ever randomly deprecated the user can change a setting and it will work for mods and the broadcaster. This is **opt in only** and will still use the tmi endpoint by default using the same time gate functionality as we use for the irc commands. The setting is located with the other time gate settings at the bottom of the general settings tab. I intentionally copied and pasted most of the `Split::showViewerList` function instead of making a better integrated function for both use cases so that whenever it is deprecated the transition to delete the old code will be as painless as possible.

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
