### PR TITLE
Switch to ncipollo/release-action for generating our Nightly releases

### DIFF
--- a/.CI/CreateUbuntuDeb.sh
+++ b/.CI/CreateUbuntuDeb.sh
@@ -6,8 +6,13 @@ if [ ! -f ./bin/chatterino ] || [ ! -x ./bin/chatterino ]; then
     exit 1
 fi
 
-chatterino_version=$(git describe | cut -c 2-)
-echo "Found Chatterino version $chatterino_version via git"
+chatterino_version=$(git describe 2>/dev/null | cut -c 2-) || true
+if [ -z "$chatterino_version" ]; then
+    echo "Falling back to setting the version to 'dev'"
+    chatterino_version="dev"
+else
+    echo "Found Chatterino version $chatterino_version via git"
+fi
 
 rm -vrf "./package" || true  # delete any old packaging dir
 

--- a/.CI/CreateUbuntuDeb.sh
+++ b/.CI/CreateUbuntuDeb.sh
@@ -8,8 +8,8 @@ fi
 
 chatterino_version=$(git describe 2>/dev/null | cut -c 2-) || true
 if [ -z "$chatterino_version" ]; then
-    echo "Falling back to setting the version to 'dev'"
-    chatterino_version="dev"
+    chatterino_version="0.0.0-dev"
+    echo "Falling back to setting the version to '$chatterino_version'"
 else
     echo "Found Chatterino version $chatterino_version via git"
 fi

--- a/.CI/CreateUbuntuDeb.sh
+++ b/.CI/CreateUbuntuDeb.sh
@@ -37,4 +37,4 @@ DESTDIR="$packaging_dir" make INSTALL_ROOT="$packaging_dir" -j"$(nproc)" install
 echo ""
 
 echo "Building package..."
-dpkg-deb --build "$packaging_dir" "Chatterino.deb"
+dpkg-deb --build "$packaging_dir" "Chatterino-x86_64.deb"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -229,83 +229,34 @@ jobs:
     if: (github.event_name == 'push' && github.ref == 'refs/heads/master')
 
     steps:
-      - name: Create release
-        id: create_release
-        uses: pajlada/create-release@v2.0.4
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: nightly-build
-          backup_tag_name: backup-nightly-build
-          release_name: Nightly Release
-          body: |
-              Nightly Build
-          prerelease: true
-
       - uses: actions/download-artifact@v3
         with:
           name: chatterino-windows-x86-64-5.15.2.zip
-          path: windows/
+          path: release-artifacts/
 
       - uses: actions/download-artifact@v3
         with:
           name: Chatterino-x86_64-5.15.2.AppImage
-          path: linux/
+          path: release-artifacts/
 
       - uses: actions/download-artifact@v3
         with:
           name: Chatterino-5.15.2.deb
-          path: ubuntu/
+          path: release-artifacts/
 
       - uses: actions/download-artifact@v3
         with:
           name: chatterino-osx-5.15.2.dmg
-          path: macos/
+          path: release-artifacts/
 
-      # TODO: Extract dmg and appimage
-
-      # - name: Read upload URL into output
-      #   id: upload_url
-      #   run: |
-      #     echo "::set-output name=upload_url::$(cat release-upload-url.txt/release-upload-url.txt)"
-
-      - name: Upload release asset (Windows)
-        uses: actions/upload-release-asset@v1.0.2
+      - name: Create release
+        uses: ncipollo/release-action@v1.11.1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./windows/chatterino-windows-x86-64.zip
-          asset_name: chatterino-windows-x86-64.zip
-          asset_content_type: application/zip
-
-      - name: Upload release asset (Ubuntu)
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./linux/Chatterino-x86_64.AppImage
-          asset_name: Chatterino-x86_64.AppImage
-          asset_content_type: application/x-executable
-
-      - name: Upload release asset (Ubuntu .deb)
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./ubuntu/Chatterino.deb
-          asset_name: Chatterino-x86_64.deb
-          asset_content_type: application/vnd.debian.binary-package
-
-      - name: Upload release asset (MacOS)
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./macos/chatterino-osx.dmg
-          asset_name: chatterino-osx.dmg
-          asset_content_type: application/x-bzip2
-
+          removeArtifacts: true
+          allowUpdates: true
+          artifactErrorsFailBuild: true
+          artifacts: "release-artifacts/*"
+          generateReleaseNotes: true
+          name: Nightly Release
+          tag: nightly-build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -164,26 +164,12 @@ jobs:
             sh ./../.CI/CreateAppImage.sh
         shell: bash
 
-      - name: Package - .deb (Ubuntu)
-        if: startsWith(matrix.os, 'ubuntu')
-        run: |
-            cd build
-            sh ./../.CI/CreateUbuntuDeb.sh
-        shell: bash
-
       - name: Upload artifact - AppImage (Ubuntu)
         if: startsWith(matrix.os, 'ubuntu')
         uses: actions/upload-artifact@v3
         with:
           name: Chatterino-x86_64-${{ matrix.qt-version }}.AppImage
           path: build/Chatterino-x86_64.AppImage
-
-      - name: Upload artifact - .deb (Ubuntu)
-        if: startsWith(matrix.os, 'ubuntu')
-        uses: actions/upload-artifact@v3
-        with:
-          name: Chatterino-${{ matrix.qt-version }}.deb
-          path: build/Chatterino.deb
 
       # MACOS
       - name: Install dependencies (MacOS)
@@ -237,11 +223,6 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: Chatterino-x86_64-5.15.2.AppImage
-          path: release-artifacts/
-
-      - uses: actions/download-artifact@v3
-        with:
-          name: Chatterino-5.15.2.deb
           path: release-artifacts/
 
       - uses: actions/download-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -164,12 +164,26 @@ jobs:
             sh ./../.CI/CreateAppImage.sh
         shell: bash
 
+      - name: Package - .deb (Ubuntu)
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+            cd build
+            sh ./../.CI/CreateUbuntuDeb.sh
+        shell: bash
+
       - name: Upload artifact - AppImage (Ubuntu)
         if: startsWith(matrix.os, 'ubuntu')
         uses: actions/upload-artifact@v3
         with:
           name: Chatterino-x86_64-${{ matrix.qt-version }}.AppImage
           path: build/Chatterino-x86_64.AppImage
+
+      - name: Upload artifact - .deb (Ubuntu)
+        if: startsWith(matrix.os, 'ubuntu')
+        uses: actions/upload-artifact@v3
+        with:
+          name: Chatterino-${{ matrix.qt-version }}.deb
+          path: build/Chatterino.deb
 
       # MACOS
       - name: Install dependencies (MacOS)
@@ -223,6 +237,11 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: Chatterino-x86_64-5.15.2.AppImage
+          path: release-artifacts/
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: Chatterino-5.15.2.deb
           path: release-artifacts/
 
       - uses: actions/download-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -251,7 +251,6 @@ jobs:
 
       - name: Create release
         uses: ncipollo/release-action@v1.11.1
-        env:
         with:
           removeArtifacts: true
           allowUpdates: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -257,5 +257,6 @@ jobs:
           artifactErrorsFailBuild: true
           artifacts: "release-artifacts/*"
           generateReleaseNotes: true
+          prerelease: true
           name: Nightly Release
           tag: nightly-build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,7 +183,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: Chatterino-${{ matrix.qt-version }}.deb
-          path: build/Chatterino.deb
+          path: build/Chatterino-x86_64.deb
 
       # MACOS
       - name: Install dependencies (MacOS)


### PR DESCRIPTION

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Test release can be found here: https://github.com/pajlada/chatterino2/releases/tag/nightly-build

I also made the deb-creation script fall back to version `0.0.0-dev` in case no git tag was found - useful for forks that have no tags

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
