### PR TITLE
change unicode for better font support and fix some cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Major: Added support for Twitch's Chat Replies. [Wiki Page](https://wiki.chatterino.com/Features/#message-replies) (#3722, #3989, #4041, #4047, #4055, #4067, #4077, #3905)
 - Major: Added multi-channel searching to search dialog via keyboard shortcut. (Ctrl+Shift+F by default) (#3694, #3875)
 - Major: Added support for emotes and badges from [7TV](https://7tv.app). [Wiki Page](https://wiki.chatterino.com/Third_party_services/#7tv) (#4002, #4062)
-- Major: Added support for Right-to-Left Languages (#3958)
+- Major: Added support for Right-to-Left Languages (#3958, #4139)
 - Minor: Allow hiding moderation actions in streamer mode. (#3926)
 - Minor: Added highlights for `Elevated Messages`. (#4016)
 - Minor: Removed total views from the usercard, as Twitch no longer updates the number. (#3792)

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -278,12 +278,13 @@ void MessageLayoutContainer::reorderRTL(int firstTextIndex)
     // the second condition below covers the possible three cases:
     // 1 - if we are in RTL mode (first non-neutral word is RTL)
     // we render RTL, reversing LTR sequences,
-    // 2 - if we are in LTR mode (first non-neautral word is LTR or all wrods are neutral)
+    // 2 - if we are in LTR mode (first non-neautral word is LTR or all words are neutral)
     // we render LTR, reversing RTL sequences
     // 3 - neutral words follow previous words, we reverse a neutral word when the previous word was reversed
 
     // the first condition checks if a neutral word is treated as a RTL word
-    // this is used later to add an invisible Arabic letter to fix orentation
+    // this is used later to add U+202B (RTL embedding) character signal to
+    // fix punctuation marks and mixing embedding LTR in an RTL word
     // this can happen in two cases:
     // 1 - in RTL mode, the previous word should be RTL (i.e. not reversed)
     // 2 - in LTR mode, the previous word should be RTL (i.e. reversed)

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -278,7 +278,7 @@ void MessageLayoutContainer::reorderRTL(int firstTextIndex)
     // the second condition below covers the possible three cases:
     // 1 - if we are in RTL mode (first non-neutral word is RTL)
     // we render RTL, reversing LTR sequences,
-    // 2 - if we are in LTR mode (first non-neautral word is LTR or all words are neutral)
+    // 2 - if we are in LTR mode (first non-neutral word is LTR or all words are neutral)
     // we render LTR, reversing RTL sequences
     // 3 - neutral words follow previous words, we reverse a neutral word when the previous word was reversed
 

--- a/src/messages/layouts/MessageLayoutElement.cpp
+++ b/src/messages/layouts/MessageLayoutElement.cpp
@@ -14,8 +14,7 @@
 
 namespace {
 
-const QChar RTL_MARK(0x200F);
-
+const QChar RTL_EMBED(0x202B);
 }  // namespace
 
 namespace chatterino {
@@ -295,8 +294,7 @@ void TextLayoutElement::paint(QPainter &painter)
     QString text = this->getText();
     if (text.isRightToLeft() || this->reversedNeutral)
     {
-        text.prepend(RTL_MARK);
-        text.append(RTL_MARK);
+        text.prepend(RTL_EMBED);
     }
 
     painter.setPen(this->color_);


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

changed ``0x200F`` unicode to ``0x202B`` for better [font support](https://github.com/Chatterino/chatterino2/pull/3958#issuecomment-1310792964),

and cases like ``الStyles`` (it's broken even in twitch, ال should be on the right and Styles on the left)
![image](https://user-images.githubusercontent.com/85521119/201392974-9b2d7248-37a2-480f-872e-44b36e1c98b5.png)

it has a minor issue with something like ``سلام 1-2``

thanks to @mohad12211 for the hard work