### PR TITLE
Allow Commercial API endpoint to handle commercial lengths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@
 - Minor: Migrated /vips to Helix API. Chat command will continue to be used until February 11th 2023. (#4053)
 - Minor: Migrated /uniquechat and /r9kbeta to Helix API. (#4057)
 - Minor: Migrated /uniquechatoff and /r9kbetaoff to Helix API. (#4057)
-- Minor: Migrated /commercial to Helix API. (#4094)
+- Minor: Migrated /commercial to Helix API. (#4094, #4141)
 - Minor: Added stream titles to windows live toast notifications. (#1297)
 - Minor: Make menus and placeholders display appropriate custom key combos. (#4045)
 - Minor: Migrated /chatters to Helix API. (#4088, #4097, #4114)

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -2847,6 +2847,13 @@ void CommandController::initialize(Settings &, Paths &paths)
             }
             break;
 
+            case Error::MissingLengthParameter: {
+                errorMessage +=
+                    "Command must include a desired commercial break "
+                    "length that is greater than zero.";
+            }
+            break;
+
             case Error::Ratelimited: {
                 errorMessage += "You must wait until your cooldown period "
                                 "expires before you can run another "
@@ -3009,29 +3016,16 @@ void CommandController::initialize(Settings &, Paths &paths)
             auto broadcasterID = tc->roomId();
             auto length = words.at(1).toInt();
 
-            // We would prefer not to early out here and rather handle the API error
-            // like the rest of them, but the API doesn't give us a proper length error.
-            // Valid lengths can be found in the length body parameter description
-            // https://dev.twitch.tv/docs/api/reference#start-commercial
-            const QList<int> validLengths = {30, 60, 90, 120, 150, 180};
-            if (!validLengths.contains(length))
-            {
-                channel->addMessage(makeSystemMessage(
-                    "Invalid commercial duration length specified. Valid "
-                    "options "
-                    "are 30, 60, 90, 120, 150, and 180 seconds"));
-                return "";
-            }
-
             getHelix()->startCommercial(
                 broadcasterID, length,
                 [channel](auto response) {
                     channel->addMessage(makeSystemMessage(
-                        QString("Starting commercial break. Keep in mind you "
-                                "are still "
+                        QString("Starting %1 second long commercial break. "
+                                "Keep in mind you are still "
                                 "live and not all viewers will receive a "
                                 "commercial. "
-                                "You may run another commercial in %1 seconds.")
+                                "You may run another commercial in %2 seconds.")
+                            .arg(response.length)
                             .arg(response.retryAfter)));
                 },
                 [channel, formatStartCommercialError](auto error,

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -2398,6 +2398,11 @@ void Helix::startCommercial(
                         failureCallback(Error::BroadcasterNotStreaming,
                                         message);
                     }
+                    else if (message.startsWith("Missing required parameter",
+                                                Qt::CaseInsensitive))
+                    {
+                        failureCallback(Error::MissingLengthParameter, message);
+                    }
                     else
                     {
                         failureCallback(Error::Forwarded, message);

--- a/src/providers/twitch/api/Helix.hpp
+++ b/src/providers/twitch/api/Helix.hpp
@@ -620,6 +620,7 @@ enum class HelixStartCommercialError {
     TokenMustMatchBroadcaster,
     UserMissingScope,
     BroadcasterNotStreaming,
+    MissingLengthParameter,
     Ratelimited,
 
     // The error message is forwarded directly from the Twitch API


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Removed client side check for valid commercial lengths and instead let the commercial api endpoint to handle it. They actually do not throw an error back for an invalid length but instead find the closest appropriate length value and returns that length in the response. Sending `/commercial 0` does return an error though treating it as a missing required parameter which this is now being handled. 