### PR TITLE
fix: Mark Bad or Invalid Images as Empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@
 - Bugfix: Fixed channel-based popups from rewriting messages to file log (#4060)
 - Bugfix: Fixed invalid/dangling completion when cycling through previous messages or replying (#4072)
 - Bugfix: Fixed incorrect .desktop icon path. (#4078)
+- Bugfix: Mark bad or invalid images as empty. (#4151)
 - Dev: Got rid of BaseTheme (#4132)
 - Dev: Removed official support for QMake. (#3839, #3883)
 - Dev: Rewrote LimitedQueue (#3798)

--- a/src/messages/Image.cpp
+++ b/src/messages/Image.cpp
@@ -506,6 +506,7 @@ void Image::actuallyLoad()
                 double(Image::maxBytesRam))
             {
                 qCDebug(chatterinoImage) << "image too large in RAM";
+
                 shared->empty_ = true;
                 return Failure;
             }

--- a/src/messages/Image.cpp
+++ b/src/messages/Image.cpp
@@ -479,12 +479,14 @@ void Image::actuallyLoad()
             {
                 qCDebug(chatterinoImage)
                     << "Error: image cant be read " << shared->url().string;
+                shared->empty_ = true;
                 return Failure;
             }
 
             const auto size = reader.size();
             if (size.isEmpty())
             {
+                shared->empty_ = true;
                 return Failure;
             }
 
@@ -494,6 +496,7 @@ void Image::actuallyLoad()
                 qCDebug(chatterinoImage)
                     << "Error: image has less than 1 frame "
                     << shared->url().string << ": " << reader.errorString();
+                shared->empty_ = true;
                 return Failure;
             }
 
@@ -503,7 +506,7 @@ void Image::actuallyLoad()
                 double(Image::maxBytesRam))
             {
                 qCDebug(chatterinoImage) << "image too large in RAM";
-
+                shared->empty_ = true;
                 return Failure;
             }
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

While looking at #4145 I found that images that are rejected because they are too large or have an invalid format are never marked as empty. This PR fixes that. It also has the consequence that for emote-tooltips where the 3x variant is too large, the 2x or 1x variants eventually get shown.
