### PR TITLE
Fix tab wrapping with vertical tab layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,7 @@
 - Minor: Improved text selection to match Windows native behaviour. (#4127)
 - Minor: Add settings tooltips. (#3437)
 - Minor: Add setting to limit message input length. (#3418)
-- Minor: Improved look of tabs when using a layout other than top. (#3925)
+- Minor: Improved look of tabs when using a layout other than top. (#3925, #4152)
 - Bugfix: Fixed `Add new account` dialog causing main chatterino window to be non movable. (#4121)
 - Bugfix: Connection to Twitch PubSub now recovers more reliably. (#3643, #3716)
 - Bugfix: Fixed `Smooth scrolling on new messages` setting sometimes hiding messages. (#4028)

--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -617,7 +617,7 @@ void Notebook::performLayout(bool animated)
 
         // zneix: if we were to remove buttons when tabs are hidden
         // stuff below to "set page bounds" part should be in conditional statement
-        int tabsPerColumn = (this->height() - top) / tabHeight;
+        int tabsPerColumn = (this->height() - top) / (tabHeight + tabSpacer);
         if (tabsPerColumn == 0)  // window hasn't properly rendered yet
         {
             return;
@@ -719,7 +719,7 @@ void Notebook::performLayout(bool animated)
 
         // zneix: if we were to remove buttons when tabs are hidden
         // stuff below to "set page bounds" part should be in conditional statement
-        int tabsPerColumn = (this->height() - top) / tabHeight;
+        int tabsPerColumn = (this->height() - top) / (tabHeight + tabSpacer);
         if (tabsPerColumn == 0)  // window hasn't properly rendered yet
         {
             return;


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

#3925 had a slight error that I'm surprised I didn't manage to spot: when calculating the number of tabs per column when using a vertical tab layout, we would not account for the ~1 px space between tabs. This would lead to improper wrapping with many tabs (note cut off tab at the bottom):

<img width="501" alt="image" src="https://user-images.githubusercontent.com/24928223/201820998-a415c3e5-f091-40c8-90ff-ad65da743bea.png">

And with this fix:
<img width="501" alt="image" src="https://user-images.githubusercontent.com/24928223/201821041-4027dc5a-2e07-43ac-a331-fee50555f938.png">
