### PR TITLE
Fix crashes that can occur when selecting/copying text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@
 - Bugfix: Display sent IRC messages like received ones (#4027)
 - Bugfix: Fixed non-global FrankerFaceZ emotes from being loaded as global emotes. (#3921)
 - Bugfix: Fixed trailing spaces from preventing Nicknames from working correctly. (#3946)
+- Bugfix: Fixed crashes that can occur when selecting/copying messages and they are removed. (#4153)
 - Bugfix: Fixed trailing spaces from preventing User Highlights from working correctly. (#4051)
 - Bugfix: Fixed channel-based popups from rewriting messages to file log (#4060)
 - Bugfix: Fixed invalid/dangling completion when cycling through previous messages or replying (#4072)

--- a/src/messages/Selection.hpp
+++ b/src/messages/Selection.hpp
@@ -1,25 +1,21 @@
 #pragma once
 
+#include <cstdint>
 #include <tuple>
 #include <utility>
 
 namespace chatterino {
 
 struct SelectionItem {
-    int messageIndex;
-    int charIndex;
+    uint32_t messageIndex{0};
+    uint32_t charIndex{0};
 
-    SelectionItem()
+    SelectionItem() = default;
+
+    SelectionItem(uint32_t _messageIndex, uint32_t _charIndex)
+        : messageIndex(_messageIndex)
+        , charIndex(_charIndex)
     {
-        this->messageIndex = 0;
-        this->charIndex = 0;
-    }
-
-    SelectionItem(int _messageIndex, int _charIndex)
-    {
-        this->messageIndex = _messageIndex;
-
-        this->charIndex = _charIndex;
     }
 
     bool operator<(const SelectionItem &b) const
@@ -78,11 +74,11 @@ struct Selection {
 };
 
 struct DoubleClickSelection {
-    int originalStart = 0;
-    int originalEnd = 0;
-    int origMessageIndex;
-    bool selectingLeft = false;
-    bool selectingRight = false;
+    uint32_t originalStart{0};
+    uint32_t originalEnd{0};
+    uint32_t origMessageIndex{0};
+    bool selectingLeft{false};
+    bool selectingRight{false};
     SelectionItem origStartItem;
     SelectionItem origEndItem;
 };

--- a/src/messages/layouts/MessageLayout.cpp
+++ b/src/messages/layouts/MessageLayout.cpp
@@ -442,7 +442,7 @@ int MessageLayout::getSelectionIndex(QPoint position)
     return this->container_->getSelectionIndex(position);
 }
 
-void MessageLayout::addSelectionText(QString &str, int from, int to,
+void MessageLayout::addSelectionText(QString &str, uint32_t from, uint32_t to,
                                      CopyMode copymode)
 {
     this->container_->addSelectionText(str, from, to, copymode);

--- a/src/messages/layouts/MessageLayout.hpp
+++ b/src/messages/layouts/MessageLayout.hpp
@@ -59,7 +59,8 @@ public:
     int getLastCharacterIndex() const;
     int getFirstMessageCharacterIndex() const;
     int getSelectionIndex(QPoint position);
-    void addSelectionText(QString &str, int from = 0, int to = INT_MAX,
+    void addSelectionText(QString &str, uint32_t from = 0,
+                          uint32_t to = UINT32_MAX,
                           CopyMode copymode = CopyMode::Everything);
 
     // Misc

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -798,10 +798,10 @@ int MessageLayoutContainer::getFirstMessageCharacterIndex() const
     return index;
 }
 
-void MessageLayoutContainer::addSelectionText(QString &str, int from, int to,
-                                              CopyMode copymode)
+void MessageLayoutContainer::addSelectionText(QString &str, uint32_t from,
+                                              uint32_t to, CopyMode copymode)
 {
-    int index = 0;
+    uint32_t index = 0;
     bool first = true;
 
     for (auto &element : this->elements_)
@@ -819,7 +819,9 @@ void MessageLayoutContainer::addSelectionText(QString &str, int from, int to,
             if (element->getCreator().getFlags().hasAny(
                     {MessageElementFlag::Timestamp,
                      MessageElementFlag::Username, MessageElementFlag::Badges}))
+            {
                 continue;
+            }
         }
 
         auto indexCount = element->getSelectionIndexCount();

--- a/src/messages/layouts/MessageLayoutContainer.hpp
+++ b/src/messages/layouts/MessageLayoutContainer.hpp
@@ -81,7 +81,8 @@ struct MessageLayoutContainer {
     int getSelectionIndex(QPoint point);
     int getLastCharacterIndex() const;
     int getFirstMessageCharacterIndex() const;
-    void addSelectionText(QString &str, int from, int to, CopyMode copymode);
+    void addSelectionText(QString &str, uint32_t from, uint32_t to,
+                          CopyMode copymode);
 
     bool isCollapsed();
 

--- a/src/messages/layouts/MessageLayoutElement.cpp
+++ b/src/messages/layouts/MessageLayoutElement.cpp
@@ -108,8 +108,8 @@ ImageLayoutElement::ImageLayoutElement(MessageElement &creator, ImagePtr image,
     this->trailingSpace = creator.hasTrailingSpace();
 }
 
-void ImageLayoutElement::addCopyTextToString(QString &str, int from,
-                                             int to) const
+void ImageLayoutElement::addCopyTextToString(QString &str, uint32_t from,
+                                             uint32_t to) const
 {
     const auto *emoteElement =
         dynamic_cast<EmoteElement *>(&this->getCreator());
@@ -272,8 +272,8 @@ void TextLayoutElement::listenToLinkChanges()
         });
 }
 
-void TextLayoutElement::addCopyTextToString(QString &str, int from,
-                                            int to) const
+void TextLayoutElement::addCopyTextToString(QString &str, uint32_t from,
+                                            uint32_t to) const
 {
     str += this->getText().mid(from, to - from);
 
@@ -387,8 +387,8 @@ TextIconLayoutElement::TextIconLayoutElement(MessageElement &creator,
 {
 }
 
-void TextIconLayoutElement::addCopyTextToString(QString &str, int from,
-                                                int to) const
+void TextIconLayoutElement::addCopyTextToString(QString &str, uint32_t from,
+                                                uint32_t to) const
 {
 }
 
@@ -513,14 +513,12 @@ int ReplyCurveLayoutElement::getXFromIndex(int index)
     {
         return this->getRect().left();
     }
-    else
-    {
-        return this->getRect().right();
-    }
+
+    return this->getRect().right();
 }
 
-void ReplyCurveLayoutElement::addCopyTextToString(QString &str, int from,
-                                                  int to) const
+void ReplyCurveLayoutElement::addCopyTextToString(QString &str, uint32_t from,
+                                                  uint32_t to) const
 {
 }
 

--- a/src/messages/layouts/MessageLayoutElement.hpp
+++ b/src/messages/layouts/MessageLayoutElement.hpp
@@ -1,18 +1,19 @@
 #pragma once
 
-#include <QPen>
-#include <QPoint>
-#include <QRect>
-#include <QString>
-#include <boost/noncopyable.hpp>
-#include <climits>
-
 #include "common/FlagsEnum.hpp"
 #include "messages/Link.hpp"
 #include "messages/MessageColor.hpp"
 #include "messages/MessageElement.hpp"
 
+#include <QPen>
+#include <QPoint>
+#include <QRect>
+#include <QString>
+#include <boost/noncopyable.hpp>
 #include <pajlada/signals/signalholder.hpp>
+
+#include <climits>
+#include <cstdint>
 
 class QPainter;
 
@@ -41,8 +42,8 @@ public:
     MessageLayoutElement *setLink(const Link &link_);
     MessageLayoutElement *setText(const QString &text_);
 
-    virtual void addCopyTextToString(QString &str, int from = 0,
-                                     int to = INT_MAX) const = 0;
+    virtual void addCopyTextToString(QString &str, uint32_t from = 0,
+                                     uint32_t to = UINT32_MAX) const = 0;
     virtual int getSelectionIndexCount() const = 0;
     virtual void paint(QPainter &painter) = 0;
     virtual void paintAnimated(QPainter &painter, int yOffset) = 0;
@@ -72,8 +73,8 @@ public:
                        const QSize &size);
 
 protected:
-    void addCopyTextToString(QString &str, int from = 0,
-                             int to = INT_MAX) const override;
+    void addCopyTextToString(QString &str, uint32_t from = 0,
+                             uint32_t to = UINT32_MAX) const override;
     int getSelectionIndexCount() const override;
     void paint(QPainter &painter) override;
     void paintAnimated(QPainter &painter, int yOffset) override;
@@ -124,8 +125,8 @@ public:
     void listenToLinkChanges();
 
 protected:
-    void addCopyTextToString(QString &str, int from = 0,
-                             int to = INT_MAX) const override;
+    void addCopyTextToString(QString &str, uint32_t from = 0,
+                             uint32_t to = UINT32_MAX) const override;
     int getSelectionIndexCount() const override;
     void paint(QPainter &painter) override;
     void paintAnimated(QPainter &painter, int yOffset) override;
@@ -148,8 +149,8 @@ public:
                           const QString &line2, float scale, const QSize &size);
 
 protected:
-    void addCopyTextToString(QString &str, int from = 0,
-                             int to = INT_MAX) const override;
+    void addCopyTextToString(QString &str, uint32_t from = 0,
+                             uint32_t to = UINT32_MAX) const override;
     int getSelectionIndexCount() const override;
     void paint(QPainter &painter) override;
     void paintAnimated(QPainter &painter, int yOffset) override;
@@ -173,8 +174,8 @@ protected:
     void paintAnimated(QPainter &painter, int yOffset) override;
     int getMouseOverIndex(const QPoint &abs) const override;
     int getXFromIndex(int index) override;
-    void addCopyTextToString(QString &str, int from = 0,
-                             int to = INT_MAX) const override;
+    void addCopyTextToString(QString &str, uint32_t from = 0,
+                             uint32_t to = UINT32_MAX) const override;
     int getSelectionIndexCount() const override;
 
 private:

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -550,23 +550,26 @@ QString ChannelView::getSelectedText()
     LimitedQueueSnapshot<MessageLayoutPtr> &messagesSnapshot =
         this->getMessagesSnapshot();
 
-    Selection _selection = this->selection_;
+    Selection selection = this->selection_;
 
-    if (_selection.isEmpty())
+    if (selection.isEmpty())
     {
         return result;
     }
 
-    for (int msg = _selection.selectionMin.messageIndex;
-         msg <= _selection.selectionMax.messageIndex; msg++)
+    const auto numMessages = messagesSnapshot.size();
+    const auto indexStart = selection.selectionMin.messageIndex;
+    const auto indexEnd = selection.selectionMax.messageIndex;
+
+    for (auto msg = indexStart; msg <= indexEnd; msg++)
     {
         MessageLayoutPtr layout = messagesSnapshot[msg];
-        int from = msg == _selection.selectionMin.messageIndex
-                       ? _selection.selectionMin.charIndex
-                       : 0;
-        int to = msg == _selection.selectionMax.messageIndex
-                     ? _selection.selectionMax.charIndex
-                     : layout->getLastCharacterIndex() + 1;
+        auto from = msg == selection.selectionMin.messageIndex
+                        ? selection.selectionMin.charIndex
+                        : 0;
+        auto to = msg == selection.selectionMax.messageIndex
+                      ? selection.selectionMax.charIndex
+                      : layout->getLastCharacterIndex() + 1;
 
         layout->addSelectionText(result, from, to);
     }

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -561,6 +561,12 @@ QString ChannelView::getSelectedText()
     const auto indexStart = selection.selectionMin.messageIndex;
     const auto indexEnd = selection.selectionMax.messageIndex;
 
+    if (indexEnd > numMessages || indexStart > numMessages)
+    {
+        // One of our messages is out of bounds
+        return result;
+    }
+
     for (auto msg = indexStart; msg <= indexEnd; msg++)
     {
         MessageLayoutPtr layout = messagesSnapshot[msg];


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

- Change types of selection indices to unsigned
- Ensure selection indices are within range before attempting to get the selected text
- Add changelog entry

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
