### PR TITLE
Fix users being assigned duplicate FrankerFaceZ badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@
 - Bugfix: Fixed existing emote popups not being raised from behind other windows when refocusing them on macOS (#3713)
 - Bugfix: Fixed automod queue pubsub topic persisting after user change. (#3718)
 - Bugfix: Fixed viewer list not closing after pressing escape key. (#3734)
+- Bugfix: Fixed users being assigned duplicate FrankerFaceZ badges. (#4155)
 - Bugfix: Fixed links with no thumbnail having previous link's thumbnail. (#3720)
 - Bugfix: Fixed message only showing a maximum of one global FrankerFaceZ badge even if the user has multiple. (#3818)
 - Bugfix: Added an icon in the CMake macOS bundle. (#3832)

--- a/src/providers/ffz/FfzBadges.cpp
+++ b/src/providers/ffz/FfzBadges.cpp
@@ -92,12 +92,12 @@ void FfzBadges::load()
                     auto userIDString = QString::number(user.toInt());
 
                     auto [userBadges, created] = this->userBadges.emplace(
-                        std::make_pair<QString, std::vector<int>>(
+                        std::make_pair<QString, std::unordered_set<int>>(
                             std::move(userIDString), {badgeID}));
                     if (!created)
                     {
                         // User already had a badge assigned
-                        userBadges->second.push_back(badgeID);
+                        userBadges->second.emplace(badgeID);
                     }
                 }
             }

--- a/src/providers/ffz/FfzBadges.cpp
+++ b/src/providers/ffz/FfzBadges.cpp
@@ -92,7 +92,7 @@ void FfzBadges::load()
                     auto userIDString = QString::number(user.toInt());
 
                     auto [userBadges, created] = this->userBadges.emplace(
-                        std::make_pair<QString, std::unordered_set<int>>(
+                        std::make_pair<QString, std::set<int>>(
                             std::move(userIDString), {badgeID}));
                     if (!created)
                     {

--- a/src/providers/ffz/FfzBadges.hpp
+++ b/src/providers/ffz/FfzBadges.hpp
@@ -10,9 +10,9 @@
 
 #include <map>
 #include <memory>
+#include <set>
 #include <shared_mutex>
 #include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
 namespace chatterino {
@@ -41,7 +41,7 @@ private:
     std::shared_mutex mutex_;
 
     // userBadges points a user ID to the list of badges they have
-    std::unordered_map<QString, std::unordered_set<int>> userBadges;
+    std::unordered_map<QString, std::set<int>> userBadges;
 
     // badges points a badge ID to the information about the badge
     std::unordered_map<int, Badge> badges;

--- a/src/providers/ffz/FfzBadges.hpp
+++ b/src/providers/ffz/FfzBadges.hpp
@@ -1,19 +1,19 @@
 #pragma once
 
-#include <boost/optional.hpp>
-#include <common/Singleton.hpp>
-
 #include "common/Aliases.hpp"
 #include "common/UniqueAccess.hpp"
 #include "util/QStringHash.hpp"
+
+#include <QColor>
+#include <boost/optional.hpp>
+#include <common/Singleton.hpp>
 
 #include <map>
 #include <memory>
 #include <shared_mutex>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
-
-#include <QColor>
 
 namespace chatterino {
 
@@ -41,7 +41,7 @@ private:
     std::shared_mutex mutex_;
 
     // userBadges points a user ID to the list of badges they have
-    std::unordered_map<QString, std::vector<int>> userBadges;
+    std::unordered_map<QString, std::unordered_set<int>> userBadges;
 
     // badges points a badge ID to the information about the badge
     std::unordered_map<int, Badge> badges;


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

- Ensure users cannot have the same FrankerFaceZ badge more than once
- Add changelog entry

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
