### PR TITLE
fix: Limiting the height of a message that contains some RTL text causes a crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Major: Added support for Twitch's Chat Replies. [Wiki Page](https://wiki.chatterino.com/Features/#message-replies) (#3722, #3989, #4041, #4047, #4055, #4067, #4077, #3905, #4131)
 - Major: Added multi-channel searching to search dialog via keyboard shortcut. (Ctrl+Shift+F by default) (#3694, #3875)
 - Major: Added support for emotes, badges, and live emote updates from [7TV](https://7tv.app). [Wiki Page](https://wiki.chatterino.com/Third_party_services/#7tv) (#4002, #4062, #4090)
-- Major: Added support for Right-to-Left Languages (#3958, #4139)
+- Major: Added support for Right-to-Left Languages (#3958, #4139, #4168)
 - Minor: Added setting to keep more message history in splits. (#3811)
 - Minor: Added setting to keep more message history in usercards. (#3811)
 - Minor: Added ability to pin Usercards to stay open even if it loses focus. Only available if "Automatically close usercard when it loses focus" is enabled. (#3884)

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -264,7 +264,7 @@ void MessageLayoutContainer::reorderRTL(int firstTextIndex)
     int startIndex = static_cast<int>(this->lineStart_);
     int endIndex = static_cast<int>(this->elements_.size()) - 1;
 
-    if (firstTextIndex >= endIndex)
+    if (firstTextIndex >= endIndex || startIndex >= this->elements_.size())
     {
         return;
     }
@@ -449,7 +449,17 @@ void MessageLayoutContainer::end()
             QSize(this->dotdotdotWidth_, this->textLineHeight_),
             QColor("#00D80A"), FontStyle::ChatMediumBold, this->scale_);
 
-        // getApp()->themes->messages.textColors.system
+        if (this->first == FirstWord::RTL)
+        {
+            // Shift all elements in the next line to the left
+            for (int i = this->lines_.back().startIndex;
+                 i < this->elements_.size(); i++)
+            {
+                QPoint prevPos = this->elements_[i]->getRect().topLeft();
+                this->elements_[i]->setPosition(
+                    QPoint(prevPos.x() + this->dotdotdotWidth_, prevPos.y()));
+            }
+        }
         this->_addElement(element, true);
         this->isCollapsed_ = true;
     }

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -83,7 +83,7 @@ void MessageLayoutContainer::addElementNoLineBreak(
     this->_addElement(element);
 }
 
-bool MessageLayoutContainer::canAddElements()
+bool MessageLayoutContainer::canAddElements() const
 {
     return this->canAddMessages_;
 }
@@ -331,9 +331,12 @@ void MessageLayoutContainer::reorderRTL(int firstTextIndex)
         this->currentX_ = this->elements_[startIndex]->getRect().left();
     }
     // manually do the first call with -1 as previous index
-    this->_addElement(this->elements_[correctSequence[0]].get(), false, -1);
+    if (this->canAddElements())
+    {
+        this->_addElement(this->elements_[correctSequence[0]].get(), false, -1);
+    }
 
-    for (int i = 1; i < correctSequence.size(); i++)
+    for (int i = 1; i < correctSequence.size() && this->canAddElements(); i++)
     {
         this->_addElement(this->elements_[correctSequence[i]].get(), false,
                           correctSequence[i - 1]);

--- a/src/messages/layouts/MessageLayoutContainer.hpp
+++ b/src/messages/layouts/MessageLayoutContainer.hpp
@@ -58,7 +58,7 @@ struct MessageLayoutContainer {
     void end();
 
     void clear();
-    bool canAddElements();
+    bool canAddElements() const;
     void addElement(MessageLayoutElement *element);
     void addElementNoLineBreak(MessageLayoutElement *element);
     void breakLine();


### PR DESCRIPTION
Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable

# Description

This is an attempt at fixing the crash.

Currently, the ellipsis is misplaced (since it's not really added):
![](https://user-images.githubusercontent.com/19953266/202899938-bdf17244-044b-4126-bdbe-10b8f081e787.png)

It should be added at the first position (like it's done in browsers if the `direction` is `rtl`).

Fixes #4166. Thanks to @mohad12211 for making the ellipsis adding simple.

## Test Messages

### Ellipsis on the left

```
واحد اثنينواحد اثنينواحد اثنينواحد اثنينواحد اثنينواحد اثنينواحد اثنينواحد اثنينواحد اثنينواحد اثنينواحد اثنينواحد اثنينواحد اثنينواحد اثنينواحد اثنينواحد اثنينواحد اثنينواحد اثنينواحد اثنينواحد اثنينواحد اثنينواحد اثنينواحد اثنينواحد اثنينواحد اثنينواحد اثنينواحد اثنينواحد اثنينواحد اثنينواحد اثنينواحد اثنينواحد اثنينواحد اثنينواحد اثنينواحد اثنينواحد اثنينواحد اثنينواحد اثنينواحد اثنين 
```

```
واحد اثنين ثلاثه اربعه one two three four واحد اثنين ثلاثه اربعه one two three four واحد اثنين ثلاثه اربعه one two three four واحد اثنين ثلاثه اربعه one two three four واحد اثنين ثلاثه اربعه one two three four 
```

### Ellipsis on the right

```
one two three four واحد اثنين ثلاثه اربعه one two three four واحد اثنين ثلاثه اربعه one two three four واحد اثنين ثلاثه اربعه one two three four واحد اثنين ثلاثه اربعه one two three four واحد اثنين ثلاثه اربعه one two three four واحد اثنين ثلاثه اربعه 
```

```
one two three four one two three four one two three four one two three four one two three four one two three four one two three four one two three four one two three four one two three four one two three four one two three four one two three four 
```