### PR TITLE
fix: `/watching` channel jumping around

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@
 - Bugfix: Fixed invalid/dangling completion when cycling through previous messages or replying (#4072)
 - Bugfix: Fixed incorrect .desktop icon path. (#4078)
 - Bugfix: Mark bad or invalid images as empty. (#4151)
+- Bugfix: Fixed `/watching` channel jumping around. (#4169)
 - Dev: Got rid of BaseTheme (#4132)
 - Dev: Removed official support for QMake. (#3839, #3883)
 - Dev: Rewrote LimitedQueue (#3798)

--- a/src/singletons/NativeMessaging.cpp
+++ b/src/singletons/NativeMessaging.cpp
@@ -239,8 +239,11 @@ void NativeMessagingServer::ReceiverThread::handleMessage(
             postToThread([=] {
                 if (!name.isEmpty())
                 {
-                    app->twitch->watchingChannel.reset(
-                        app->twitch->getOrAddChannel(name));
+                    auto channel = app->twitch->getOrAddChannel(name);
+                    if (app->twitch->watchingChannel.get() != channel)
+                    {
+                        app->twitch->watchingChannel.reset(channel);
+                    }
                 }
 
                 if (attach || attachFullscreen)


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

When the extension sends multiple messages with the same channel, Chatterino will always set the channel and thus dispatch a channel-changed signal (which causes a re-layout) even if the channel was already set.

Maybe this could be done in `IndirectChannel::reset` instead?

https://github.com/Chatterino/chatterino2/blob/3924861a3da6308cd8ee5e108c4c21884cfc81b3/src/common/Channel.cpp#L453-L459