### PR TITLE
fix neutral elements order in multiple lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,14 @@
 - Bugfix: Fixed crash happening when QuickSwitcher is used with a popout window. (#4187)
 - Bugfix: Fixed low contrast of text in settings tooltips. (#4188)
 - Bugfix: Fixed being unable to see the usercard of VIPs who have Asian language display names. (#4174)
+- Bugfix: Fixed messages where Right-to-Left order is mixed in multiple lines. (#4173)
 - Bugfix: Fixed the wrong right-click menu showing in the chat input box. (#4177)
 - Bugfix: Fixed popup windows not appearing/minimizing correctly on the Windows taskbar. (#4181)
 
 ## 2.4.0-beta
 
 - Major: Added support for emotes, badges, and live emote updates from [7TV](https://7tv.app). [Wiki Page](https://wiki.chatterino.com/Third_party_services/#7tv) (#4002, #4062, #4090)
-- Major: Added support for Right-to-Left Languages (#3958, #4139, #4168, #4173)
+- Major: Added support for Right-to-Left Languages (#3958, #4139, #4168)
 - Major: Added support for Twitch's Chat Replies. [Wiki Page](https://wiki.chatterino.com/Features/#message-replies) (#3722, #3989, #4041, #4047, #4055, #4067, #4077, #3905, #4131)
 - Major: Added multi-channel searching to search dialog via keyboard shortcut. (Ctrl+Shift+F by default) (#3694, #3875)
 - Minor: Added setting to keep more message history in splits. (#3811)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## 2.4.0
 
 - Major: Added support for emotes, badges, and live emote updates from [7TV](https://7tv.app). [Wiki Page](https://wiki.chatterino.com/Third_party_services/#7tv) (#4002, #4062, #4090)
-- Major: Added support for Right-to-Left Languages (#3958, #4139, #4168)
+- Major: Added support for Right-to-Left Languages (#3958, #4139, #4168, #4173)
 - Major: Added support for Twitch's Chat Replies. [Wiki Page](https://wiki.chatterino.com/Features/#message-replies) (#3722, #3989, #4041, #4047, #4055, #4067, #4077, #3905, #4131)
 - Major: Added multi-channel searching to search dialog via keyboard shortcut. (Ctrl+Shift+F by default) (#3694, #3875)
 - Minor: Added setting to keep more message history in splits. (#3811)

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -299,7 +299,8 @@ void MessageLayoutContainer::reorderRTL(int firstTextIndex)
         if (((this->elements_[i]->getText().isRightToLeft() !=
               (this->first == FirstWord::RTL)) &&
              !isNeutral(this->elements_[i]->getText())) ||
-            (isNeutral(this->elements_[i]->getText()) && this->wasPrevReversed_))
+            (isNeutral(this->elements_[i]->getText()) &&
+             this->wasPrevReversed_))
         {
             swappedSequence.push(i);
             this->wasPrevReversed_ = true;

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -48,6 +48,7 @@ void MessageLayoutContainer::begin(int width, float scale, MessageFlags flags)
     this->dotdotdotWidth_ = mediumFontMetrics.horizontalAdvance("...");
     this->canAddMessages_ = true;
     this->isCollapsed_ = false;
+    this->wasPrevReversed_ = false;
 }
 
 void MessageLayoutContainer::clear()
@@ -272,7 +273,6 @@ void MessageLayoutContainer::reorderRTL(int firstTextIndex)
 
     std::vector<int> correctSequence;
     std::stack<int> swappedSequence;
-    bool wasPrevReversed = false;
 
     // we reverse a sequence of words if it's opposite to the text direction
     // the second condition below covers the possible three cases:
@@ -291,18 +291,18 @@ void MessageLayoutContainer::reorderRTL(int firstTextIndex)
     for (int i = startIndex; i <= endIndex; i++)
     {
         if (isNeutral(this->elements_[i]->getText()) &&
-            ((this->first == FirstWord::RTL && !wasPrevReversed) ||
-             (this->first == FirstWord::LTR && wasPrevReversed)))
+            ((this->first == FirstWord::RTL && !this->wasPrevReversed_) ||
+             (this->first == FirstWord::LTR && this->wasPrevReversed_)))
         {
             this->elements_[i]->reversedNeutral = true;
         }
         if (((this->elements_[i]->getText().isRightToLeft() !=
               (this->first == FirstWord::RTL)) &&
              !isNeutral(this->elements_[i]->getText())) ||
-            (isNeutral(this->elements_[i]->getText()) && wasPrevReversed))
+            (isNeutral(this->elements_[i]->getText()) && this->wasPrevReversed_))
         {
             swappedSequence.push(i);
-            wasPrevReversed = true;
+            this->wasPrevReversed_ = true;
         }
         else
         {
@@ -312,7 +312,7 @@ void MessageLayoutContainer::reorderRTL(int firstTextIndex)
                 swappedSequence.pop();
             }
             correctSequence.push_back(i);
-            wasPrevReversed = false;
+            this->wasPrevReversed_ = false;
         }
     }
     while (!swappedSequence.empty())

--- a/src/messages/layouts/MessageLayoutContainer.hpp
+++ b/src/messages/layouts/MessageLayoutContainer.hpp
@@ -128,6 +128,7 @@ private:
     int dotdotdotWidth_ = 0;
     bool canAddMessages_ = true;
     bool isCollapsed_ = false;
+    bool wasPrevReversed_ = false;
 
     std::vector<std::unique_ptr<MessageLayoutElement>> elements_;
     std::vector<Line> lines_;


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

If a text has RTL, and some line starts with neutral words (like emotes), it won't follow previous words (whether the previous was reversed or not) and that will result in wrong ordering across multiple lines.

before (wrong): 
![image](https://user-images.githubusercontent.com/51754973/202928254-1985c84d-aa3c-4d21-8b8d-655c4a0e7d5f.png)

after (correct): 
![image](https://user-images.githubusercontent.com/51754973/202928258-b54c979b-959e-4803-b925-7e8c99f3b0c4.png)

Test String: 
`واحد اثنين one two Kappa KKona three four `