### PR TITLE
Fix issue with VIPs who have Asian Language display names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ name: Build
 on:
   push:
     branches:
-      - master
+      - chore/user-logins-for-/vips
   pull_request:
   workflow_dispatch:
 
@@ -226,7 +226,7 @@ jobs:
   create-release:
     needs: build
     runs-on: ubuntu-latest
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/master')
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/chore/user-logins-for-/vips')
 
     steps:
       - uses: actions/download-artifact@v3
@@ -256,7 +256,7 @@ jobs:
           allowUpdates: true
           artifactErrorsFailBuild: true
           artifacts: "release-artifacts/*"
-          body: ${{ github.event.head_commit.message }}
+          body: "Use `userLogin` for /vips response"
           prerelease: true
           name: Nightly Release
-          tag: nightly-build
+          tag: nightly-build-vips

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ name: Build
 on:
   push:
     branches:
-      - chore/user-logins-for-/vips
+      - master
   pull_request:
   workflow_dispatch:
 
@@ -226,7 +226,7 @@ jobs:
   create-release:
     needs: build
     runs-on: ubuntu-latest
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/chore/user-logins-for-/vips')
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/master')
 
     steps:
       - uses: actions/download-artifact@v3
@@ -256,7 +256,7 @@ jobs:
           allowUpdates: true
           artifactErrorsFailBuild: true
           artifacts: "release-artifacts/*"
-          body: "Use `userLogin` for /vips response"
+          body: ${{ github.event.head_commit.message }}
           prerelease: true
           name: Nightly Release
-          tag: nightly-build-vips
+          tag: nightly-build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+- Bugfix: Fixed being unable to see the usercard of VIPs who have Asian language display names. (#4174)
+
 ## 2.4.0
 
 - Major: Added support for emotes, badges, and live emote updates from [7TV](https://7tv.app). [Wiki Page](https://wiki.chatterino.com/Third_party_services/#7tv) (#4002, #4062, #4090)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Bugfix: Fixed being unable to see the usercard of VIPs who have Asian language display names. (#4174)
 
-## 2.4.0
+## 2.4.0-beta
 
 - Major: Added support for emotes, badges, and live emote updates from [7TV](https://7tv.app). [Wiki Page](https://wiki.chatterino.com/Third_party_services/#7tv) (#4002, #4062, #4090)
 - Major: Added support for Right-to-Left Languages (#3958, #4139, #4168)

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -3003,7 +3003,7 @@ void CommandController::initialize(Settings &, Paths &paths)
 
                     for (const auto &vip : vipList)
                     {
-                        entries.append(vip.userName);
+                        entries.append(vip.userLogin);
                     }
 
                     entries.sort(Qt::CaseInsensitive);

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -3000,6 +3000,7 @@ void CommandController::initialize(Settings &, Paths &paths)
                     auto messagePrefix =
                         QString("The VIPs of this channel are");
 
+                    // TODO: sort results?
                     MessageBuilder builder;
                     TwitchMessageBuilder::listOfUsersSystemMessage(
                         messagePrefix, vipList, twitchChannel, &builder);

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -2999,18 +2999,10 @@ void CommandController::initialize(Settings &, Paths &paths)
 
                     auto messagePrefix =
                         QString("The VIPs of this channel are");
-                    auto entries = QStringList();
-
-                    for (const auto &vip : vipList)
-                    {
-                        entries.append(vip.userLogin);
-                    }
-
-                    entries.sort(Qt::CaseInsensitive);
 
                     MessageBuilder builder;
                     TwitchMessageBuilder::listOfUsersSystemMessage(
-                        messagePrefix, entries, twitchChannel, &builder);
+                        messagePrefix, vipList, twitchChannel, &builder);
 
                     channel->addMessage(builder.release());
                 },


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

In a previous life, the IRC `/vips` response returned the `loginName` of said VIPs. One day we woke up and Twitch suddenly started sending us the `displayName`'s of those VIPs.
The problem with this was the fact that display names containing Asian language characters are of no use to us in Chatterino, as Twitch has no way of looking up a user, by these names.

Due to the migration of the `/vips` command to the Helix API, this fix will only help broadcasters (after the Timegate), but I do think it's better for them to be able to use the usercard feature in Chatterino, from the VIPs response.
Also suggested as a fix in https://github.com/Chatterino/chatterino2/pull/4053#discussion_r990955144

Fixes #3524
