### PR TITLE
chore(msvc): replace /W3 with /W4

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -783,6 +783,9 @@ endif ()
 
 # Configure compiler warnings
 if (MSVC)
+    # Someone adds /W3 before we add /W4.
+    # This makes sure, only /W4 is specified.
+    string(REPLACE "/W3" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
     # 4714 - function marked as __forceinline not inlined
     # 4996 - occurs when the compiler encounters a function or variable that is marked as deprecated.
     #        These functions may have a different preferred name, may be insecure or have


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

If you looked through the build logs in CI, you might have noticed a warning on almost all files from `cl`: `Command line warning D9025 : overriding '/W3' with '/W4'`. This is because some project (I suspect websocketpp) is adding `/W3` to `CMAKE_CXX_FLAGS`.

We're doing the same fix here that [googletest does](https://github.com/google/googletest/blob/9c332145b71c36a5bad9688312c79184f98601ff/googletest/cmake/internal_utils.cmake#L49-L51) (just with `CMAKE_CXX_FLAGS`, as that's enough).
