### PR TITLE
fix: don't ignore `mousePressEvent` in `SplitInput`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+- Bugfix: Show correct context menu in split input (#4177)
+
 ## 2.4.0
 
 - Major: Added support for emotes, badges, and live emote updates from [7TV](https://7tv.app). [Wiki Page](https://wiki.chatterino.com/Third_party_services/#7tv) (#4002, #4062, #4090)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unversioned
 
-- Bugfix: Show correct context menu in split input (#4177)
+- Bugfix: Fixed the wrong right-click menu showing in the chat input box. (#4177)
 
 ## 2.4.0
 

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -648,6 +648,16 @@ void SplitInput::installKeyPressedEvent()
     });
 }
 
+void SplitInput::mousePressEvent(QMouseEvent *event)
+{
+    if (this->hidden)
+    {
+        BaseWidget::mousePressEvent(event);
+    }
+    // else, don't call QWidget::mousePressEvent,
+    // which will call event->ignore()
+}
+
 void SplitInput::onTextChanged()
 {
     this->updateCompletionPopup();

--- a/src/widgets/splits/SplitInput.hpp
+++ b/src/widgets/splits/SplitInput.hpp
@@ -87,6 +87,8 @@ protected:
     void paintEvent(QPaintEvent * /*event*/) override;
     void resizeEvent(QResizeEvent * /*event*/) override;
 
+    void mousePressEvent(QMouseEvent *event) override;
+
     virtual void giveFocus(Qt::FocusReason reason);
 
     QString handleSendMessage(std::vector<QString> &arguments);


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

By default, a `QWidget` will [ignore the `mousePressEvent`](https://github.com/qt/qtbase/blob/5.12.12/src/widgets/kernel/qwidget.cpp#L9539-L9554). Before #3838, `SplitInput` had a handler for this event and thus didn't ignore the event. But the PR [removed the event handler](https://github.com/Chatterino/chatterino2/pull/3838/files#diff-28a2425a552a515ae2556b51b50f4e3102c012c67dfa291cd13b52e1406e2417).

This PR adds the handler back, and only calls the parent handler if the input is hidden. This has the effect that the context menu of the `ResizingTextEdit` is shown again, so that's what I mentioned in the changelog.

Fixes #3844.
