### PR TITLE
fix: don't parent popup windows on Windows OS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Bugfix: Fixed being unable to see the usercard of VIPs who have Asian language display names. (#4174)
 - Bugfix: Fixed the wrong right-click menu showing in the chat input box. (#4177)
-- Bugfix: Do not parent popup windows on Windows OS. (#4181)
+- Bugfix: Fixed popup windows not appearing/minimizing correctly on the Windows taskbar. (#4181)
 
 ## 2.4.0-beta
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bugfix: Fixed being unable to see the usercard of VIPs who have Asian language display names. (#4174)
 - Bugfix: Fixed the wrong right-click menu showing in the chat input box. (#4177)
+- Bugfix: Do not parent popup windows on Windows OS. (#4181)
 
 ## 2.4.0-beta
 

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -262,12 +262,18 @@ Window &WindowManager::createWindow(WindowType type, bool show, QWidget *parent)
             return parent;
         }
 
+        // FIXME: On Windows, parenting popup windows causes unwanted behavior (see
+        //        https://github.com/Chatterino/chatterino2/issues/4179 for discussion). Ideally, we
+        //        would use a different solution rather than relying on OS-specific code but this is
+        //        the low-effort fix for now.
+#ifndef Q_OS_WIN
         if (type == WindowType::Popup)
         {
             // On some window managers, popup windows require a parent to behave correctly. See
             // https://github.com/Chatterino/chatterino2/pull/1843 for additional context.
             return &(this->getMainWindow());
         }
+#endif
 
         // If no parent is set and something other than a popup window is being created, we fall
         // back to the default behavior of no parent.


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Motivated by #4179, attempts to fix #3863 and fix #4180.

Need someone to test this as I don't have access to a Windows machine. This is not an ideal fix in my opinion. It would have been better if it was possible to parent windows on Windows and have them show up in the task bar regardless. However, I was not able to figure out how to do that or whether it is possible at all. Thus, aiming for this bandaid solution for now.
