### PR TITLE
Fix crash happening when QuickSwitcher is used with popout window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unversioned
 
-- Bugfix: Fixed crash happening when QuickSwitcher is used with popout window. (#4187)
+- Bugfix: Fixed crash happening when QuickSwitcher is used with a popout window. (#4187)
 - Bugfix: Fixed being unable to see the usercard of VIPs who have Asian language display names. (#4174)
 - Bugfix: Fixed the wrong right-click menu showing in the chat input box. (#4177)
 - Bugfix: Fixed popup windows not appearing/minimizing correctly on the Windows taskbar. (#4181)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unversioned
 
+- Bugfix: Fixed crash happening when QuickSwitcher is used with popout window. (#4187)
 - Bugfix: Fixed being unable to see the usercard of VIPs who have Asian language display names. (#4174)
 - Bugfix: Fixed the wrong right-click menu showing in the chat input box. (#4177)
 - Bugfix: Fixed popup windows not appearing/minimizing correctly on the Windows taskbar. (#4181)

--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -156,54 +156,58 @@ int Notebook::indexOf(QWidget *page) const
 
 void Notebook::select(QWidget *page, bool focusPage)
 {
+    if (!page)
+    {
+        return;
+    }
+
     if (page == this->selectedPage_)
     {
         return;
     }
 
-    if (page != nullptr)
+    auto *item = this->findItem(page);
+    if (!item)
     {
-        page->setHidden(false);
+        return;
+    }
 
-        assert(this->containsPage(page));
-        Item &item = this->findItem(page);
+    page->show();
 
-        item.tab->setSelected(true);
-        item.tab->raise();
+    item->tab->setSelected(true);
+    item->tab->raise();
 
-        if (focusPage)
+    if (focusPage)
+    {
+        if (item->selectedWidget == nullptr)
         {
-            if (item.selectedWidget == nullptr)
+            item->page->setFocus();
+        }
+        else
+        {
+            if (containsChild(page, item->selectedWidget))
             {
-                item.page->setFocus();
+                item->selectedWidget->setFocus(Qt::MouseFocusReason);
             }
             else
             {
-                if (containsChild(page, item.selectedWidget))
-                {
-                    item.selectedWidget->setFocus(Qt::MouseFocusReason);
-                }
-                else
-                {
-                    qCDebug(chatterinoWidget) << "Notebook: selected child of "
-                                                 "page doesn't exist anymore";
-                }
+                qCDebug(chatterinoWidget) << "Notebook: selected child of "
+                                             "page doesn't exist anymore";
             }
         }
     }
 
     if (this->selectedPage_ != nullptr)
     {
-        this->selectedPage_->setHidden(true);
+        this->selectedPage_->hide();
 
-        Item &item = this->findItem(selectedPage_);
-        item.tab->setSelected(false);
-
-        //        for (auto split : this->selectedPage->getSplits()) {
-        //            split->updateLastReadMessage();
-        //        }
-
-        item.selectedWidget = this->selectedPage_->focusWidget();
+        auto *item = this->findItem(selectedPage_);
+        if (!item)
+        {
+            return;
+        }
+        item->tab->setSelected(false);
+        item->selectedWidget = this->selectedPage_->focusWidget();
     }
 
     this->selectedPage_ = page;
@@ -219,14 +223,17 @@ bool Notebook::containsPage(QWidget *page)
                        });
 }
 
-Notebook::Item &Notebook::findItem(QWidget *page)
+Notebook::Item *Notebook::findItem(QWidget *page)
 {
     auto it = std::find_if(this->items_.begin(), this->items_.end(),
                            [page](const auto &item) {
                                return page == item.page;
                            });
-    assert(it != this->items_.end());
-    return *it;
+    if (it != this->items_.end())
+    {
+        return &(*it);
+    }
+    return nullptr;
 }
 
 bool Notebook::containsChild(const QObject *obj, const QObject *child)

--- a/src/widgets/Notebook.hpp
+++ b/src/widgets/Notebook.hpp
@@ -90,7 +90,7 @@ private:
     void resizeAddButton();
 
     bool containsPage(QWidget *page);
-    Item &findItem(QWidget *page);
+    Item *findItem(QWidget *page);
 
     static bool containsChild(const QObject *obj, const QObject *child);
     NotebookTab *getTabFromPage(QWidget *page);


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

## Crash reproduce
- rename any tab in main window to something unique like "asd"
- popout window (ctrl+n), can be any chat or empty tab
- open quick switch (ctrl+k) and search for "asd"
- click it to select and crash

## Why
QuickSwitcher has 2 types of search result: split (specific channel) or container (whole notebook page), tab rename above was used as simply way for container result which is focus of this crash.
Clicking on result invokes  `selectSplitContainer` signal:
https://github.com/Chatterino/chatterino2/blob/9d1b8b0a93a5d8df10ea6ea55159efbbe3bd65e1/src/singletons/WindowManager.cpp#L326
with callback declared here:
https://github.com/Chatterino/chatterino2/blob/9d1b8b0a93a5d8df10ea6ea55159efbbe3bd65e1/src/widgets/Notebook.cpp#L1071
Each poped out window adds own callback, so clicking on result in Quick Switcher fires selection in each window (even tho it doesnt actually work for now).
Crash is happening because `Notebook::select` called from handler, didn't check if passed page (aka splitContainer) is actually found in Notebook of given window.

## Fix in this PR
- `Notebook::findItem` will now return nullptr when requested page was not found, so `Notebook::select` can safely abort
- removed asserts since notebook select is now allowed to fail
- moved `page` null check earlier
- changed `setHidden(bool)` to equivalent `show()`, and call it only after page was found
