### PR TITLE
Fix low contrast of text in settings tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unversioned
 
+- Bugfix: Fixed low contrast of text in settings tooltips. (#4188)
 - Bugfix: Fixed being unable to see the usercard of VIPs who have Asian language display names. (#4174)
 - Bugfix: Fixed the wrong right-click menu showing in the chat input box. (#4177)
 - Bugfix: Fixed popup windows not appearing/minimizing correctly on the Windows taskbar. (#4181)

--- a/resources/qss/settings.qss
+++ b/resources/qss/settings.qss
@@ -34,6 +34,13 @@ chatterino--SettingsPage #generalSettingsScrollContent {
     background: #222;
 }
 
+chatterino--SettingsPage QToolTip {
+    padding: 2px;
+    background-color: #333333;
+    border: 1px solid #545454;
+    color: white;
+}
+
 chatterino--PageHeader {
     margin-bottom: 12px;
 }

--- a/src/widgets/settingspages/GeneralPageView.cpp
+++ b/src/widgets/settingspages/GeneralPageView.cpp
@@ -18,14 +18,6 @@ const auto MAX_TOOLTIP_LINE_LENGTH_PATTERN =
     QStringLiteral(R"(.{%1}\S*\K(\s+))").arg(MAX_TOOLTIP_LINE_LENGTH);
 const QRegularExpression MAX_TOOLTIP_LINE_LENGTH_REGEX(
     MAX_TOOLTIP_LINE_LENGTH_PATTERN);
-
-const auto TOOLTIP_STYLE_SHEET = QStringLiteral(R"(QToolTip {
-padding: 2px;
-background-color: #333333;
-border: 1px solid #545454;
-}
-)");
-
 }  // namespace
 
 namespace chatterino {
@@ -409,7 +401,6 @@ void GeneralPageView::addToolTip(QWidget &widget, QString text) const
     }
 
     widget.setToolTip(text);
-    widget.setStyleSheet(TOOLTIP_STYLE_SHEET);
 }
 
 }  // namespace chatterino


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description
- text color in settings tooltip changed to white
> In memory of @BlackJuvenile who first PRed this change 2 days ago, but sadly didn't make it till merge, your great input wont be forgotten 🕯
- tooltip style moved to general qss, now apply for whole settings window

| Before  | After |
| ------------- | ------------- |
|![before](https://user-images.githubusercontent.com/28986062/203668547-76ff2e77-8844-4a1b-be4a-9118cc049eb9.png)  |![after](https://user-images.githubusercontent.com/28986062/203668583-448c2062-a79f-4a8a-a2c6-9cc30bbc54c6.png) |