### PR TITLE
Fix white border appearing around maximized window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Bugfix: Fixed being unable to see the usercard of VIPs who have Asian language display names. (#4174)
 - Bugfix: Fixed the wrong right-click menu showing in the chat input box. (#4177)
 - Bugfix: Fixed popup windows not appearing/minimizing correctly on the Windows taskbar. (#4181)
+- Bugfix: Fixed white border appearing around maximized window on Windows. (#4190)
 
 ## 2.4.0-beta
 

--- a/src/widgets/BaseWindow.cpp
+++ b/src/widgets/BaseWindow.cpp
@@ -823,7 +823,7 @@ bool BaseWindow::handleNCCALCSIZE(MSG *msg, long *result)
         if (msg->wParam == TRUE)
         {
             // remove 1 extra pixel on top of custom frame
-            auto *ncp = (reinterpret_cast<NCCALCSIZE_PARAMS *>(msg->lParam));
+            auto *ncp = reinterpret_cast<NCCALCSIZE_PARAMS *>(msg->lParam);
             if (ncp)
             {
                 ncp->lppos->flags |= SWP_NOREDRAW;

--- a/src/widgets/BaseWindow.cpp
+++ b/src/widgets/BaseWindow.cpp
@@ -793,8 +793,9 @@ bool BaseWindow::handleSHOWWINDOW(MSG *msg)
         {
             this->shown_ = true;
 
-            const MARGINS shadow = {8, 8, 8, 8};
-            DwmExtendFrameIntoClientArea(HWND(this->winId()), &shadow);
+            // disable OS window border
+            const MARGINS margins = {-1};
+            DwmExtendFrameIntoClientArea(HWND(this->winId()), &margins);
         }
         if (!this->initalBounds_.isNull())
         {
@@ -819,17 +820,15 @@ bool BaseWindow::handleNCCALCSIZE(MSG *msg, long *result)
 #ifdef USEWINSDK
     if (this->hasCustomWindowFrame())
     {
-        // int cx = GetSystemMetrics(SM_CXSIZEFRAME);
-        // int cy = GetSystemMetrics(SM_CYSIZEFRAME);
-
         if (msg->wParam == TRUE)
         {
-            NCCALCSIZE_PARAMS *ncp =
-                (reinterpret_cast<NCCALCSIZE_PARAMS *>(msg->lParam));
-            ncp->lppos->flags |= SWP_NOREDRAW;
-            RECT *clientRect = &ncp->rgrc[0];
-
-            clientRect->top -= 1;
+            // remove 1 extra pixel on top of custom frame
+            auto *ncp = (reinterpret_cast<NCCALCSIZE_PARAMS *>(msg->lParam));
+            if (ncp)
+            {
+                ncp->lppos->flags |= SWP_NOREDRAW;
+                ncp->rgrc[0].top -= 1;
+            }
         }
 
         *result = 0;


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description
changes:
- use `-1` margins passed to `DwmExtendFrameIntoClientArea` to effectively disable invisible window borders, which caused white border to appear around maximized windows (visible on 2nd monitor)
- tiny refactor of `WM_NCCALCSIZE` handling

fixes #2205

tested on:
- [x] ~~win7~~ custom frame is enabled from [win8 and later](https://github.com/Chatterino/chatterino2/blob/fe2a9ccbff8c4abad0b6df4a1bd279ad9fdf531a/src/widgets/BaseWindow.cpp#L293)
- [x] win10
- [x] win11