### PR TITLE
Clear up Highlight sound settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unversioned
 
+- Minor: Cleared up highlight sound settings (#4194)
 - Bugfix: Fixed CTRL + C not working in reply thread popups. (#4209)
 - Bugfix: Fixed message input showing as red after removing a message that was more than 500 characters. (#4204)
 - Bugfix: Fixed unnecessary saving of windows layout. (#4201)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unversioned
 
 - Minor: Cleared up highlight sound settings (#4194)
+- Bugfix: Fixed highlight sounds not reloading on change properly. (#4194)
 - Bugfix: Fixed CTRL + C not working in reply thread popups. (#4209)
 - Bugfix: Fixed message input showing as red after removing a message that was more than 500 characters. (#4204)
 - Bugfix: Fixed unnecessary saving of windows layout. (#4201)

--- a/src/controllers/highlights/HighlightController.cpp
+++ b/src/controllers/highlights/HighlightController.cpp
@@ -284,15 +284,22 @@ namespace chatterino {
 
 void HighlightController::initialize(Settings &settings, Paths & /*paths*/)
 {
+    this->rebuildListener_.addSetting(settings.enableSelfHighlight);
+    this->rebuildListener_.addSetting(settings.enableSelfHighlightSound);
+    this->rebuildListener_.addSetting(settings.enableSelfHighlightTaskbar);
+    this->rebuildListener_.addSetting(settings.selfHighlightSoundUrl);
+    this->rebuildListener_.addSetting(settings.showSelfHighlightInMentions);
+
     this->rebuildListener_.addSetting(settings.enableWhisperHighlight);
     this->rebuildListener_.addSetting(settings.enableWhisperHighlightSound);
     this->rebuildListener_.addSetting(settings.enableWhisperHighlightTaskbar);
     this->rebuildListener_.addSetting(settings.whisperHighlightSoundUrl);
-    this->rebuildListener_.addSetting(settings.whisperHighlightColor);
-    this->rebuildListener_.addSetting(settings.enableSelfHighlight);
+
     this->rebuildListener_.addSetting(settings.enableSubHighlight);
     this->rebuildListener_.addSetting(settings.enableSubHighlightSound);
     this->rebuildListener_.addSetting(settings.enableSubHighlightTaskbar);
+    this->rebuildListener_.addSetting(settings.subHighlightSoundUrl);
+
     this->rebuildListener_.addSetting(settings.enableThreadHighlight);
     this->rebuildListener_.addSetting(settings.enableThreadHighlightSound);
     this->rebuildListener_.addSetting(settings.enableThreadHighlightTaskbar);

--- a/src/controllers/highlights/HighlightController.cpp
+++ b/src/controllers/highlights/HighlightController.cpp
@@ -50,8 +50,7 @@ void rebuildSubscriptionHighlights(Settings &settings,
     {
         auto highlightSound = settings.enableSubHighlightSound.getValue();
         auto highlightAlert = settings.enableSubHighlightTaskbar.getValue();
-        auto highlightSoundUrlValue =
-            settings.whisperHighlightSoundUrl.getValue();
+        auto highlightSoundUrlValue = settings.subHighlightSoundUrl.getValue();
         boost::optional<QUrl> highlightSoundUrl;
         if (!highlightSoundUrlValue.isEmpty())
         {

--- a/src/controllers/highlights/HighlightModel.cpp
+++ b/src/controllers/highlights/HighlightModel.cpp
@@ -140,10 +140,7 @@ void HighlightModel::afterInit()
     redeemedRow[Column::PlaySound]->setFlags({});
     redeemedRow[Column::UseRegex]->setFlags({});
     redeemedRow[Column::CaseSensitive]->setFlags({});
-
-    QUrl RedeemedSound =
-        QUrl(getSettings()->redeemedHighlightSoundUrl.getValue());
-    setFilePathItem(redeemedRow[Column::SoundPath], RedeemedSound, false);
+    redeemedRow[Column::SoundPath]->setFlags(Qt::NoItemFlags);
 
     auto RedeemedColor =
         ColorProvider::instance().color(ColorType::RedeemedHighlight);
@@ -169,11 +166,7 @@ void HighlightModel::afterInit()
     firstMessageRow[Column::PlaySound]->setFlags({});
     firstMessageRow[Column::UseRegex]->setFlags({});
     firstMessageRow[Column::CaseSensitive]->setFlags({});
-
-    QUrl FirstMessageSound =
-        QUrl(getSettings()->firstMessageHighlightSoundUrl.getValue());
-    setFilePathItem(firstMessageRow[Column::SoundPath], FirstMessageSound,
-                    false);
+    firstMessageRow[Column::SoundPath]->setFlags(Qt::NoItemFlags);
 
     auto FirstMessageColor =
         ColorProvider::instance().color(ColorType::FirstMessageHighlight);
@@ -200,11 +193,7 @@ void HighlightModel::afterInit()
     elevatedMessageRow[Column::PlaySound]->setFlags({});
     elevatedMessageRow[Column::UseRegex]->setFlags({});
     elevatedMessageRow[Column::CaseSensitive]->setFlags({});
-
-    QUrl elevatedMessageSound =
-        QUrl(getSettings()->elevatedMessageHighlightSoundUrl.getValue());
-    setFilePathItem(elevatedMessageRow[Column::SoundPath], elevatedMessageSound,
-                    false);
+    elevatedMessageRow[Column::SoundPath]->setFlags(Qt::NoItemFlags);
 
     auto elevatedMessageColor =
         ColorProvider::instance().color(ColorType::ElevatedMessageHighlight);
@@ -414,21 +403,6 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
                 else if (rowIndex == HighlightRowIndexes::SubRow)
                 {
                     getSettings()->subHighlightSoundUrl.setValue(
-                        value.toString());
-                }
-                else if (rowIndex == HighlightRowIndexes::RedeemedRow)
-                {
-                    getSettings()->redeemedHighlightSoundUrl.setValue(
-                        value.toString());
-                }
-                else if (rowIndex == HighlightRowIndexes::FirstMessageRow)
-                {
-                    getSettings()->firstMessageHighlightSoundUrl.setValue(
-                        value.toString());
-                }
-                if (rowIndex == HighlightRowIndexes::ElevatedMessageRow)
-                {
-                    getSettings()->elevatedMessageHighlightSoundUrl.setValue(
                         value.toString());
                 }
                 else if (rowIndex == HighlightRowIndexes::ThreadMessageRow)

--- a/src/controllers/highlights/HighlightModel.hpp
+++ b/src/controllers/highlights/HighlightModel.hpp
@@ -17,9 +17,9 @@ public:
         Pattern = 0,
         ShowInMentions = 1,
         FlashTaskbar = 2,
-        PlaySound = 3,
-        UseRegex = 4,
-        CaseSensitive = 5,
+        UseRegex = 3,
+        CaseSensitive = 4,
+        PlaySound = 5,
         SoundPath = 6,
         Color = 7,
         COUNT  // keep this as last member of enum

--- a/src/messages/SharedMessageBuilder.cpp
+++ b/src/messages/SharedMessageBuilder.cpp
@@ -22,11 +22,12 @@ namespace {
     QUrl getFallbackHighlightSound()
     {
         QString path = getSettings()->pathHighlightSound;
-        bool fileExists = QFileInfo::exists(path) && QFileInfo(path).isFile();
+        bool fileExists = !path.isEmpty() && QFileInfo::exists(path) &&
+                          QFileInfo(path).isFile();
 
-        // Use fallback sound when checkbox is not checked
-        // or custom file doesn't exist
-        if (getSettings()->customHighlightSound && fileExists)
+        // Use fallback sound when no custom sound is set
+        // or if the file doesn't exist.
+        if (fileExists)
         {
             return QUrl::fromLocalFile(path);
         }

--- a/src/messages/SharedMessageBuilder.cpp
+++ b/src/messages/SharedMessageBuilder.cpp
@@ -19,14 +19,16 @@ namespace chatterino {
 
 namespace {
 
+    /**
+     * Gets the default sound url if the user set one,
+     * or the chatterino default ping sound if no url is set.
+     */
     QUrl getFallbackHighlightSound()
     {
         QString path = getSettings()->pathHighlightSound;
         bool fileExists = !path.isEmpty() && QFileInfo::exists(path) &&
                           QFileInfo(path).isFile();
 
-        // Use fallback sound when no custom sound is set
-        // or if the file doesn't exist.
         if (fileExists)
         {
             return QUrl::fromLocalFile(path);

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -271,7 +271,6 @@ public:
 
     /// Highlighting
     //    BoolSetting enableHighlights = {"/highlighting/enabled", true};
-    //    BoolSetting customHighlightSound = {"/highlighting/useCustomSound", false};
 
     BoolSetting enableSelfHighlight = {
         "/highlighting/selfHighlight/nameIsHighlightKeyword", true};

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -271,7 +271,7 @@ public:
 
     /// Highlighting
     //    BoolSetting enableHighlights = {"/highlighting/enabled", true};
-    BoolSetting customHighlightSound = {"/highlighting/useCustomSound", false};
+    //    BoolSetting customHighlightSound = {"/highlighting/useCustomSound", false};
 
     BoolSetting enableSelfHighlight = {
         "/highlighting/selfHighlight/nameIsHighlightKeyword", true};

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -303,8 +303,8 @@ public:
     //        "/highlighting/redeemedHighlight/enableSound", false};
     //    BoolSetting enableRedeemedHighlightTaskbar = {
     //        "/highlighting/redeemedHighlight/enableTaskbarFlashing", false};
-    QStringSetting redeemedHighlightSoundUrl = {
-        "/highlighting/redeemedHighlightSoundUrl", ""};
+    //    QStringSetting redeemedHighlightSoundUrl = {
+    //        "/highlighting/redeemedHighlightSoundUrl", ""};
     QStringSetting redeemedHighlightColor = {
         "/highlighting/redeemedHighlightColor", ""};
 
@@ -314,8 +314,8 @@ public:
     //        "/highlighting/firstMessageHighlight/enableSound", false};
     //    BoolSetting enableFirstMessageHighlightTaskbar = {
     //        "/highlighting/firstMessageHighlight/enableTaskbarFlashing", false};
-    QStringSetting firstMessageHighlightSoundUrl = {
-        "/highlighting/firstMessageHighlightSoundUrl", ""};
+    //    QStringSetting firstMessageHighlightSoundUrl = {
+    //        "/highlighting/firstMessageHighlightSoundUrl", ""};
     QStringSetting firstMessageHighlightColor = {
         "/highlighting/firstMessageHighlightColor", ""};
 
@@ -325,8 +325,8 @@ public:
     //        "/highlighting/elevatedMessageHighlight/enableSound", false};
     //    BoolSetting enableElevatedMessageHighlightTaskbar = {
     //        "/highlighting/elevatedMessageHighlight/enableTaskbarFlashing", false};
-    QStringSetting elevatedMessageHighlightSoundUrl = {
-        "/highlighting/elevatedMessageHighlight/soundUrl", ""};
+    //    QStringSetting elevatedMessageHighlightSoundUrl = {
+    //        "/highlighting/elevatedMessageHighlight/soundUrl", ""};
     QStringSetting elevatedMessageHighlightColor = {
         "/highlighting/elevatedMessageHighlight/color", ""};
 

--- a/src/widgets/settingspages/HighlightingPage.cpp
+++ b/src/widgets/settingspages/HighlightingPage.cpp
@@ -17,14 +17,9 @@
 #include <QListWidget>
 #include <QPushButton>
 #include <QStandardItemModel>
-#include <QTableView>
 #include <QTabWidget>
-#include <QTextEdit>
+#include <QTableView>
 
-#define ENABLE_HIGHLIGHTS "Enable Highlighting"
-#define HIGHLIGHT_MSG "Highlight messages containing your name"
-#define PLAY_SOUND "Play sound when your name is mentioned"
-#define FLASH_TASKBAR "Flash taskbar when your name is mentioned"
 #define ALWAYS_PLAY "Play highlight sound even when Chatterino is focused"
 
 namespace chatterino {

--- a/src/widgets/settingspages/HighlightingPage.cpp
+++ b/src/widgets/settingspages/HighlightingPage.cpp
@@ -308,13 +308,6 @@ void HighlightingPage::openSoundDialog(const QModelIndex &clicked,
                                                tr("Audio Files (*.mp3 *.wav)"));
     view->getModel()->setData(clicked, fileUrl, Qt::UserRole);
     view->getModel()->setData(clicked, fileUrl.fileName(), Qt::DisplayRole);
-
-    // Enable custom sound check box if user set a sound
-    if (!fileUrl.isEmpty())
-    {
-        QModelIndex checkBox = clicked.siblingAtColumn(soundColumn);
-        view->getModel()->setData(checkBox, Qt::Checked, Qt::CheckStateRole);
-    }
 }
 
 void HighlightingPage::openColorDialog(const QModelIndex &clicked,

--- a/src/widgets/settingspages/HighlightingPage.cpp
+++ b/src/widgets/settingspages/HighlightingPage.cpp
@@ -7,6 +7,7 @@
 #include "controllers/highlights/UserHighlightModel.hpp"
 #include "singletons/Settings.hpp"
 #include "singletons/Theme.hpp"
+#include "util/Helpers.hpp"
 #include "util/LayoutCreator.hpp"
 #include "util/StandardItemHelper.hpp"
 #include "widgets/dialogs/BadgePickerDialog.hpp"
@@ -251,7 +252,8 @@ HighlightingPage::HighlightingPage()
                     auto url = QUrl::fromLocalFile(value);
                     return QString("Default sound: <a href=\"%1\"><span "
                                    "style=\"color: white\">%2</span></a>")
-                        .arg(url.toString(QUrl::FullyEncoded), url.fileName());
+                        .arg(url.toString(QUrl::FullyEncoded),
+                             shortenString(url.fileName(), 50));
                 },
                 getSettings()->pathHighlightSound));
             label->setToolTip(

--- a/src/widgets/settingspages/HighlightingPage.cpp
+++ b/src/widgets/settingspages/HighlightingPage.cpp
@@ -83,7 +83,7 @@ HighlightingPage::HighlightingPage()
                 // dpiChanged
                 QTimer::singleShot(1, [view] {
                     view->getTableView()->resizeColumnsToContents();
-                    view->getTableView()->setColumnWidth(0, 200);
+                    view->getTableView()->setColumnWidth(0, 400);
                 });
 
                 view->addButtonPressed.connect([] {

--- a/src/widgets/settingspages/HighlightingPage.cpp
+++ b/src/widgets/settingspages/HighlightingPage.cpp
@@ -367,7 +367,8 @@ void HighlightingPage::tableCellClicked(const QModelIndex &clicked,
                 (tab == HighlightTab::Messages &&
                  clicked.row() ==
                      HighlightModel::HighlightRowIndexes::WhisperRow);
-            if (clicked.column() == Column::SoundPath)
+            if (clicked.column() == Column::SoundPath &&
+                clicked.flags().testFlag(Qt::ItemIsEnabled))
             {
                 this->openSoundDialog(clicked, view, Column::SoundPath);
             }

--- a/src/widgets/settingspages/HighlightingPage.cpp
+++ b/src/widgets/settingspages/HighlightingPage.cpp
@@ -16,8 +16,8 @@
 #include <QHeaderView>
 #include <QPushButton>
 #include <QStandardItemModel>
-#include <QTabWidget>
 #include <QTableView>
+#include <QTabWidget>
 
 #define ALWAYS_PLAY "Play highlight sound even when Chatterino is focused"
 

--- a/src/widgets/settingspages/HighlightingPage.cpp
+++ b/src/widgets/settingspages/HighlightingPage.cpp
@@ -260,9 +260,8 @@ HighlightingPage::HighlightingPage()
                 "sound enabled and don't have a custom sound set.");
             customSound->setStretchFactor(label.getElement(), 1);
 
+            auto clearSound = customSound.emplace<QPushButton>("Clear");
             auto selectFile = customSound.emplace<QPushButton>("Change...");
-            auto clearSound = customSound.emplace<QPushButton>(
-                QIcon(":/buttons/cancel.svg"), "Clear");
 
             QObject::connect(selectFile.getElement(), &QPushButton::clicked,
                              this, [=]() mutable {
@@ -276,6 +275,19 @@ HighlightingPage::HighlightingPage()
                              this, [=]() mutable {
                                  getSettings()->pathHighlightSound = QString();
                              });
+
+            getSettings()->pathHighlightSound.connect(
+                [clearSound = clearSound.getElement()](const auto &value) {
+                    if (value.isEmpty())
+                    {
+                        clearSound->hide();
+                    }
+                    else
+                    {
+                        clearSound->show();
+                    }
+                },
+                this->managedConnections_);
         }
 
         layout.append(createCheckBox(ALWAYS_PLAY,

--- a/src/widgets/settingspages/HighlightingPage.cpp
+++ b/src/widgets/settingspages/HighlightingPage.cpp
@@ -14,7 +14,6 @@
 
 #include <QFileDialog>
 #include <QHeaderView>
-#include <QListWidget>
 #include <QPushButton>
 #include <QStandardItemModel>
 #include <QTabWidget>

--- a/src/widgets/settingspages/HighlightingPage.cpp
+++ b/src/widgets/settingspages/HighlightingPage.cpp
@@ -244,15 +244,24 @@ HighlightingPage::HighlightingPage()
         {
             auto label = customSound.append(this->createLabel<QString>(
                 [](const auto &value) {
-                    return QString("Default sound: %1")
-                        .arg(value.isEmpty()
-                                 ? "Chatterino Ping"
-                                 : QUrl::fromLocalFile(value).fileName());
+                    if (value.isEmpty())
+                    {
+                        return QString("Default sound: Chatterino Ping");
+                    }
+
+                    auto url = QUrl::fromLocalFile(value);
+                    return QString("Default sound: <a href=\"%1\"><span "
+                                   "style=\"color: white\">%2</span></a>")
+                        .arg(url.toString(QUrl::FullyEncoded), url.fileName());
                 },
                 getSettings()->pathHighlightSound));
             label->setToolTip(
                 "This sound will play for all highlight phrases that have "
                 "sound enabled and don't have a custom sound set.");
+            label->setTextFormat(Qt::RichText);
+            label->setTextInteractionFlags(Qt::TextBrowserInteraction |
+                                           Qt::LinksAccessibleByKeyboard);
+            label->setOpenExternalLinks(true);
             customSound->setStretchFactor(label.getElement(), 1);
 
             auto clearSound = customSound.emplace<QPushButton>("Clear");

--- a/src/widgets/settingspages/SettingsPage.hpp
+++ b/src/widgets/settingspages/SettingsPage.hpp
@@ -66,6 +66,20 @@ public:
     QLineEdit *createLineEdit(pajlada::Settings::Setting<QString> &setting);
     QSpinBox *createSpinBox(pajlada::Settings::Setting<int> &setting,
                             int min = 0, int max = 2500);
+    template <typename T>
+    SLabel *createLabel(const std::function<QString(const T &)> &makeText,
+                        pajlada::Settings::Setting<T> &setting)
+    {
+        auto *label = new SLabel();
+
+        setting.connect(
+            [label, makeText](const T &value, auto) {
+                label->setText(makeText(value));
+            },
+            this->managedConnections_);
+
+        return label;
+    }
 
     virtual void onShow()
     {


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

As discussed in #1540, this clears up the highlight settings for sounds:

![](https://user-images.githubusercontent.com/19953266/204150044-88775fe6-e4f9-4493-9863-9010ecdfebc6.png)

<details><summary>Without custom default sound</summary>

![firefox_2022-11-27_18-14-59](https://user-images.githubusercontent.com/19953266/204150063-ad725c5b-a368-4b73-af2e-07318b00b381.png)
</details>

Closes #1540.
