### PR TITLE
fix: prevent unnecessary layout saves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+- Bugfix: Fixed unnecessary saving of windows layout. (#4201)
+
 ## 2.4.0
 
 - Major: Added support for emotes, badges, and live emote updates from [7TV](https://7tv.app). [Wiki Page](https://wiki.chatterino.com/Third_party_services/#7tv) (#4002, #4062, #4090)

--- a/src/widgets/AccountSwitchPopup.cpp
+++ b/src/widgets/AccountSwitchPopup.cpp
@@ -11,7 +11,9 @@
 namespace chatterino {
 
 AccountSwitchPopup::AccountSwitchPopup(QWidget *parent)
-    : BaseWindow({BaseWindow::TopMost, BaseWindow::Frameless}, parent)
+    : BaseWindow({BaseWindow::TopMost, BaseWindow::Frameless,
+                  BaseWindow::DisableLayoutSave},
+                 parent)
 {
 #ifdef Q_OS_LINUX
     this->setWindowFlag(Qt::Popup);

--- a/src/widgets/BaseWindow.cpp
+++ b/src/widgets/BaseWindow.cpp
@@ -540,7 +540,11 @@ void BaseWindow::resizeEvent(QResizeEvent *)
 {
     // Queue up save because: Window resized
 #ifdef CHATTERINO
-    getApp()->windows->queueSave();
+    if (!flags_.has(DisableLayoutSave))
+    {
+        getApp()->windows->queueSave();
+    }
+    
 #endif
 
     //this->moveIntoDesktopRect(this);
@@ -572,7 +576,10 @@ void BaseWindow::moveEvent(QMoveEvent *event)
 {
     // Queue up save because: Window position changed
 #ifdef CHATTERINO
-    getApp()->windows->queueSave();
+    if (!flags_.has(DisableLayoutSave))
+    {
+        getApp()->windows->queueSave();
+    }    
 #endif
 
     BaseWidget::moveEvent(event);

--- a/src/widgets/BaseWindow.cpp
+++ b/src/widgets/BaseWindow.cpp
@@ -544,7 +544,7 @@ void BaseWindow::resizeEvent(QResizeEvent *)
     {
         getApp()->windows->queueSave();
     }
-    
+
 #endif
 
     //this->moveIntoDesktopRect(this);
@@ -579,7 +579,7 @@ void BaseWindow::moveEvent(QMoveEvent *event)
     if (!flags_.has(DisableLayoutSave))
     {
         getApp()->windows->queueSave();
-    }    
+    }
 #endif
 
     BaseWidget::moveEvent(event);

--- a/src/widgets/BaseWindow.hpp
+++ b/src/widgets/BaseWindow.hpp
@@ -32,6 +32,7 @@ public:
         FramelessDraggable = 16,
         DontFocus = 32,
         Dialog = 64,
+        DisableLayoutSave = 128,
     };
 
     enum ActionOnFocusLoss { Nothing, Delete, Close, Hide };

--- a/src/widgets/DraggablePopup.cpp
+++ b/src/widgets/DraggablePopup.cpp
@@ -23,8 +23,11 @@ namespace {
 }  // namespace
 
 DraggablePopup::DraggablePopup(bool closeAutomatically, QWidget *parent)
-    : BaseWindow(closeAutomatically ? popupFlagsCloseAutomatically : popupFlags,
-                 parent)
+    : BaseWindow(
+          closeAutomatically
+              ? popupFlagsCloseAutomatically | BaseWindow::DisableLayoutSave
+              : popupFlags | BaseWindow::DisableLayoutSave,
+          parent)
     , lifetimeHack_(std::make_shared<bool>(false))
     , dragTimer_(this)
 

--- a/src/widgets/FramelessEmbedWindow.cpp
+++ b/src/widgets/FramelessEmbedWindow.cpp
@@ -17,7 +17,7 @@
 namespace chatterino {
 
 FramelessEmbedWindow::FramelessEmbedWindow()
-    : BaseWindow(BaseWindow::Frameless)
+    : BaseWindow({BaseWindow::Frameless, BaseWindow::DisableLayoutSave})
 {
     this->split_ = new Split((QWidget *)nullptr);
     auto layout = new QHBoxLayout;

--- a/src/widgets/TooltipWidget.cpp
+++ b/src/widgets/TooltipWidget.cpp
@@ -22,7 +22,9 @@ TooltipWidget *TooltipWidget::instance()
 }
 
 TooltipWidget::TooltipWidget(BaseWidget *parent)
-    : BaseWindow({BaseWindow::TopMost, BaseWindow::DontFocus}, parent)
+    : BaseWindow({BaseWindow::TopMost, BaseWindow::DontFocus,
+                  BaseWindow::DisableLayoutSave},
+                 parent)
     , displayImage_(new QLabel())
     , displayText_(new QLabel())
 {

--- a/src/widgets/TooltipWidget.cpp
+++ b/src/widgets/TooltipWidget.cpp
@@ -116,4 +116,14 @@ void TooltipWidget::leaveEvent(QEvent *)
     // clear parents event
 }
 
+void TooltipWidget::moveEvent(QMoveEvent *)
+{
+    // clear parents event
+}
+
+void TooltipWidget::resizeEvent(QResizeEvent *)
+{
+    // clear parents event
+}
+
 }  // namespace chatterino

--- a/src/widgets/TooltipWidget.cpp
+++ b/src/widgets/TooltipWidget.cpp
@@ -116,14 +116,4 @@ void TooltipWidget::leaveEvent(QEvent *)
     // clear parents event
 }
 
-void TooltipWidget::moveEvent(QMoveEvent *)
-{
-    // clear parents event
-}
-
-void TooltipWidget::resizeEvent(QResizeEvent *)
-{
-    // clear parents event
-}
-
 }  // namespace chatterino

--- a/src/widgets/TooltipWidget.hpp
+++ b/src/widgets/TooltipWidget.hpp
@@ -30,6 +30,8 @@ public:
 protected:
     void changeEvent(QEvent *) override;
     void leaveEvent(QEvent *) override;
+    void moveEvent(QMoveEvent *) override;
+    void resizeEvent(QResizeEvent *) override;
     void themeChangedEvent() override;
     void scaleChangedEvent(float) override;
     void paintEvent(QPaintEvent *) override;

--- a/src/widgets/TooltipWidget.hpp
+++ b/src/widgets/TooltipWidget.hpp
@@ -30,8 +30,6 @@ public:
 protected:
     void changeEvent(QEvent *) override;
     void leaveEvent(QEvent *) override;
-    void moveEvent(QMoveEvent *) override;
-    void resizeEvent(QResizeEvent *) override;
     void themeChangedEvent() override;
     void scaleChangedEvent(float) override;
     void paintEvent(QPaintEvent *) override;

--- a/src/widgets/dialogs/ColorPickerDialog.cpp
+++ b/src/widgets/dialogs/ColorPickerDialog.cpp
@@ -9,7 +9,8 @@
 namespace chatterino {
 
 ColorPickerDialog::ColorPickerDialog(const QColor &initial, QWidget *parent)
-    : BasePopup(BaseWindow::EnableCustomFrame, parent)
+    : BasePopup({BaseWindow::EnableCustomFrame, BaseWindow::DisableLayoutSave},
+                parent)
     , color_()
     , dialogConfirmed_(false)
 {

--- a/src/widgets/dialogs/NotificationPopup.cpp
+++ b/src/widgets/dialogs/NotificationPopup.cpp
@@ -12,7 +12,7 @@
 namespace chatterino {
 
 NotificationPopup::NotificationPopup()
-    : BaseWindow(BaseWindow::Frameless)
+    : BaseWindow({BaseWindow::Frameless, BaseWindow::DisableLayoutSave})
     , channel_(std::make_shared<Channel>("notifications", Channel::Type::None))
 
 {

--- a/src/widgets/dialogs/QualityPopup.cpp
+++ b/src/widgets/dialogs/QualityPopup.cpp
@@ -9,7 +9,7 @@
 namespace chatterino {
 
 QualityPopup::QualityPopup(const QString &channelURL, QStringList options)
-    : BasePopup({},
+    : BasePopup({BaseWindow::DisableLayoutSave},
                 static_cast<QWidget *>(&(getApp()->windows->getMainWindow())))
     , channelURL_(channelURL)
 {

--- a/src/widgets/dialogs/SelectChannelDialog.cpp
+++ b/src/widgets/dialogs/SelectChannelDialog.cpp
@@ -28,9 +28,9 @@
 namespace chatterino {
 
 SelectChannelDialog::SelectChannelDialog(QWidget *parent)
-    : BaseWindow(
-          {BaseWindow::Flags::EnableCustomFrame, BaseWindow::Flags::Dialog},
-          parent)
+    : BaseWindow({BaseWindow::Flags::EnableCustomFrame,
+                  BaseWindow::Flags::Dialog, BaseWindow::DisableLayoutSave},
+                 parent)
     , selectedChannel_(Channel::getEmpty())
 {
     this->setWindowTitle("Select a channel to join");

--- a/src/widgets/dialogs/SettingsDialog.cpp
+++ b/src/widgets/dialogs/SettingsDialog.cpp
@@ -26,9 +26,9 @@
 namespace chatterino {
 
 SettingsDialog::SettingsDialog(QWidget *parent)
-    : BaseWindow(
-          {BaseWindow::Flags::DisableCustomScaling, BaseWindow::Flags::Dialog},
-          parent)
+    : BaseWindow({BaseWindow::Flags::DisableCustomScaling,
+                  BaseWindow::Flags::Dialog, BaseWindow::DisableLayoutSave},
+                 parent)
 {
     this->setObjectName("SettingsDialog");
     this->setWindowTitle("Chatterino Settings");

--- a/src/widgets/dialogs/UpdateDialog.cpp
+++ b/src/widgets/dialogs/UpdateDialog.cpp
@@ -12,7 +12,7 @@ namespace chatterino {
 
 UpdateDialog::UpdateDialog()
     : BaseWindow({BaseWindow::Frameless, BaseWindow::TopMost,
-                  BaseWindow::EnableCustomFrame})
+                  BaseWindow::EnableCustomFrame, BaseWindow::DisableLayoutSave})
 {
     auto layout =
         LayoutCreator<UpdateDialog>(this).setLayoutType<QVBoxLayout>();

--- a/src/widgets/dialogs/WelcomeDialog.cpp
+++ b/src/widgets/dialogs/WelcomeDialog.cpp
@@ -3,7 +3,7 @@
 namespace chatterino {
 
 WelcomeDialog::WelcomeDialog()
-    : BaseWindow(BaseWindow::EnableCustomFrame)
+    : BaseWindow({BaseWindow::EnableCustomFrame, BaseWindow::DisableLayoutSave})
 {
     this->setWindowTitle("Chatterino quick setup");
 }

--- a/src/widgets/dialogs/switcher/QuickSwitcherPopup.cpp
+++ b/src/widgets/dialogs/switcher/QuickSwitcherPopup.cpp
@@ -32,8 +32,8 @@ namespace {
 const QSize QuickSwitcherPopup::MINIMUM_SIZE(500, 300);
 
 QuickSwitcherPopup::QuickSwitcherPopup(QWidget *parent)
-    : BasePopup(FlagsEnum<BaseWindow::Flags>{BaseWindow::Flags::Frameless,
-                                             BaseWindow::Flags::TopMost},
+    : BasePopup({BaseWindow::Flags::Frameless, BaseWindow::Flags::TopMost,
+                 BaseWindow::DisableLayoutSave},
                 parent)
     , switcherModel_(this)
 {

--- a/src/widgets/helper/SearchPopup.cpp
+++ b/src/widgets/helper/SearchPopup.cpp
@@ -58,7 +58,7 @@ ChannelPtr SearchPopup::filter(const QString &text, const QString &channelName,
 }
 
 SearchPopup::SearchPopup(QWidget *parent, Split *split)
-    : BasePopup({}, parent)
+    : BasePopup({BaseWindow::DisableLayoutSave}, parent)
     , split_(split)
 {
     this->initLayout();

--- a/src/widgets/settingspages/AboutPage.cpp
+++ b/src/widgets/settingspages/AboutPage.cpp
@@ -204,8 +204,9 @@ void AboutPage::addLicense(QFormLayout *form, const QString &name,
     auto *b = new QLabel("<a href=\"" + licenseLink + "\">show license</a>");
     QObject::connect(
         b, &QLabel::linkActivated, [parent = this, name, licenseLink] {
-            auto window = new BasePopup(BaseWindow::Flags::EnableCustomFrame,
-                                        BaseWindow::DisableLayoutSave, parent);
+            auto window = new BasePopup({BaseWindow::Flags::EnableCustomFrame,
+                                         BaseWindow::DisableLayoutSave},
+                                        parent);
             window->setWindowTitle("Chatterino - License for " + name);
             window->setAttribute(Qt::WA_DeleteOnClose);
             auto layout = new QVBoxLayout();

--- a/src/widgets/settingspages/AboutPage.cpp
+++ b/src/widgets/settingspages/AboutPage.cpp
@@ -204,8 +204,8 @@ void AboutPage::addLicense(QFormLayout *form, const QString &name,
     auto *b = new QLabel("<a href=\"" + licenseLink + "\">show license</a>");
     QObject::connect(
         b, &QLabel::linkActivated, [parent = this, name, licenseLink] {
-            auto window =
-                new BasePopup(BaseWindow::Flags::EnableCustomFrame, parent);
+            auto window = new BasePopup(BaseWindow::Flags::EnableCustomFrame,
+                                        BaseWindow::DisableLayoutSave, parent);
             window->setWindowTitle("Chatterino - License for " + name);
             window->setAttribute(Qt::WA_DeleteOnClose);
             auto layout = new QVBoxLayout();

--- a/src/widgets/splits/InputCompletionPopup.cpp
+++ b/src/widgets/splits/InputCompletionPopup.cpp
@@ -44,7 +44,7 @@ namespace {
 
 InputCompletionPopup::InputCompletionPopup(QWidget *parent)
     : BasePopup({BasePopup::EnableCustomFrame, BasePopup::Frameless,
-                 BasePopup::DontFocus},
+                 BasePopup::DontFocus, BaseWindow::DisableLayoutSave},
                 parent)
     , model_(this)
 {


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

`BaseWindow` is forcing delayed layout save
at every resizeEvent
https://github.com/Chatterino/chatterino2/blob/22bd78e3b3dd6721db5f75d3456e3876185f0f3d/src/widgets/BaseWindow.cpp#L543
and moveEvent
https://github.com/Chatterino/chatterino2/blob/22bd78e3b3dd6721db5f75d3456e3876185f0f3d/src/widgets/BaseWindow.cpp#L575

TooltipWidget and other subclasses unnecessarily triggers both of above.
PR adds new BaseWindow flag `DisableLayoutSave` to fix that

Tested movement and resizing of tooltips (after preview images load) and everything works as expected.
