### PR TITLE
Fix red text color persisting from message overflow highlight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+- Bugfix: Fixed incorrect red coloring of message input. (#4204)
+
 ## 2.4.0
 
 - Major: Added support for emotes, badges, and live emote updates from [7TV](https://7tv.app). [Wiki Page](https://wiki.chatterino.com/Third_party_services/#7tv) (#4002, #4062, #4090)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unversioned
 
-- Bugfix: Fixed incorrect red coloring of message input. (#4204)
+- Bugfix: Fixed message input showing as red after removing a message that was more than 500 characters. (#4204)
 
 ## 2.4.0
 

--- a/src/providers/twitch/TwitchCommon.hpp
+++ b/src/providers/twitch/TwitchCommon.hpp
@@ -15,6 +15,8 @@ namespace chatterino {
 
 static const char *ANONYMOUS_USERNAME ATTR_UNUSED = "justinfan64537";
 
+static constexpr int TWITCH_MESSAGE_LIMIT = 500;
+
 inline QByteArray getDefaultClientID()
 {
     return QByteArray("7ue61iz46fz11y3cugd0l3tawb4taal");

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -6,6 +6,7 @@
 #include "controllers/hotkeys/HotkeyController.hpp"
 #include "messages/Link.hpp"
 #include "providers/twitch/TwitchChannel.hpp"
+#include "providers/twitch/TwitchCommon.hpp"
 #include "providers/twitch/TwitchIrcServer.hpp"
 #include "singletons/Settings.hpp"
 #include "singletons/Theme.hpp"

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -25,6 +25,7 @@
 
 #include <QCompleter>
 #include <QPainter>
+#include <QSignalBlocker>
 
 #include <functional>
 
@@ -885,25 +886,29 @@ void SplitInput::editTextChanged()
             app->commands->execCommand(text, this->split_->getChannel(), true);
     }
 
-    if (getSettings()->messageOverflow.getValue() == MessageOverflow::Highlight)
+    if (text.length() > 0 &&
+        getSettings()->messageOverflow.getValue() == MessageOverflow::Highlight)
     {
-        if (text.length() > TWITCH_MESSAGE_LIMIT &&
-            text.length() > this->lastOverflowLength)
-        {
-            QTextCharFormat format;
-            format.setForeground(Qt::red);
+        QTextCursor cursor = this->ui_.textEdit->textCursor();
+        QTextCharFormat format;
+        QList<QTextEdit::ExtraSelection> selections;
 
-            QTextCursor cursor = this->ui_.textEdit->textCursor();
-            cursor.setPosition(lastOverflowLength, QTextCursor::MoveAnchor);
+        cursor.setPosition(qMin(text.length(), TWITCH_MESSAGE_LIMIT),
+                           QTextCursor::MoveAnchor);
+        cursor.movePosition(QTextCursor::Start, QTextCursor::KeepAnchor);
+        selections.append({cursor, format});
+
+        if (text.length() > TWITCH_MESSAGE_LIMIT)
+        {
+            cursor.setPosition(TWITCH_MESSAGE_LIMIT, QTextCursor::MoveAnchor);
             cursor.movePosition(QTextCursor::End, QTextCursor::KeepAnchor);
-
-            this->lastOverflowLength = text.length();
-
-            cursor.setCharFormat(format);
+            format.setForeground(Qt::red);
+            selections.append({cursor, format});
         }
-        else if (this->lastOverflowLength != TWITCH_MESSAGE_LIMIT)
+        // block reemit of QTextEdit::textChanged()
         {
-            this->lastOverflowLength = TWITCH_MESSAGE_LIMIT;
+            const QSignalBlocker b(this->ui_.textEdit);
+            this->ui_.textEdit->setExtraSelections(selections);
         }
     }
 

--- a/src/widgets/splits/SplitInput.hpp
+++ b/src/widgets/splits/SplitInput.hpp
@@ -52,8 +52,6 @@ public:
     QString getInputText() const;
     void insertText(const QString &text);
 
-    static const int TWITCH_MESSAGE_LIMIT = 500;
-
     void setReply(std::shared_ptr<MessageThread> reply,
                   bool showInlineReplying = true);
     void setPlaceholderText(const QString &text);

--- a/src/widgets/splits/SplitInput.hpp
+++ b/src/widgets/splits/SplitInput.hpp
@@ -151,8 +151,6 @@ protected:
     QString currMsg_;
     int prevIndex_ = 0;
 
-    int lastOverflowLength = TWITCH_MESSAGE_LIMIT;
-
     // Hidden denotes whether this split input should be hidden or not
     // This is used instead of the regular QWidget::hide/show because
     // focus events don't work as expected, so instead we use this bool and


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description
PR fixes problems with message overflow highlight, feature added in #3418

current issues:			
- selecting all (ctrl+a) on overflowed input and typing, will keep red color
- pressing up arrow on overflowed input, will keep red color on history messages
- removing characters at <500 position wont move red overflow marking, which can be useful when trying to edit message to fit
- hidden recursion in `setCharFormat()` re-emiting `QTextEdit::textChanged()`

PR introduced changes to fix above:
- always mark characters up to 500 with default color 
- add blocking of unwanted signals