### PR TITLE
fix: Copy Shortcut Not Working In Reply Thread Popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+- Bugfix: Fixed CTRL + C not working in reply thread popups. (#4209)
+
 ## 2.4.0
 
 - Major: Added support for emotes, badges, and live emote updates from [7TV](https://7tv.app). [Wiki Page](https://wiki.chatterino.com/Third_party_services/#7tv) (#4002, #4062, #4090)

--- a/src/widgets/dialogs/ReplyThreadPopup.cpp
+++ b/src/widgets/dialogs/ReplyThreadPopup.cpp
@@ -81,7 +81,8 @@ ReplyThreadPopup::ReplyThreadPopup(bool closeAutomatically, QWidget *parent,
     });
 
     // Create SplitInput with inline replying disabled
-    this->ui_.replyInput = new SplitInput(this, this->split_, false);
+    this->ui_.replyInput =
+        new SplitInput(this, this->split_, this->ui_.threadView, false);
 
     this->bSignals_.emplace_back(
         getApp()->accounts->twitch.currentUserChanged.connect([this] {

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -166,9 +166,13 @@ ChannelView::ChannelView(BaseWidget *parent, Split *split, Context context,
         this->updatePauses();
     });
 
+    // This shortcut is not used in splits, it's used in views that
+    // don't have a SplitInput like the SearchPopup or EmotePopup.
+    // See SplitInput::installKeyPressedEvent for the copy event
+    // from views with a SplitInput.
     auto shortcut = new QShortcut(QKeySequence::StandardKey::Copy, this);
     QObject::connect(shortcut, &QShortcut::activated, [this] {
-        crossPlatformCopy(this->getSelectedText());
+        this->copySelectedText();
     });
 
     this->clickTimer_ = new QTimer(this);
@@ -590,6 +594,11 @@ void ChannelView::clearSelection()
 {
     this->selection_ = Selection();
     queueLayout();
+}
+
+void ChannelView::copySelectedText()
+{
+    crossPlatformCopy(this->getSelectedText());
 }
 
 void ChannelView::setEnableScrollingToBottom(bool value)

--- a/src/widgets/helper/ChannelView.hpp
+++ b/src/widgets/helper/ChannelView.hpp
@@ -77,9 +77,17 @@ public:
 
     void queueUpdate();
     Scrollbar &getScrollBar();
+
     QString getSelectedText();
     bool hasSelection();
     void clearSelection();
+    /**
+     * Copies the currently selected text to the users clipboard.
+     *
+     * @see ::getSelectedText()
+     */
+    void copySelectedText();
+
     void setEnableScrollingToBottom(bool);
     bool getEnableScrollingToBottom() const;
     void setOverrideFlags(boost::optional<MessageElementFlags> value);

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -1121,11 +1121,6 @@ void Split::openSubPage()
     }
 }
 
-void Split::copyToClipboard()
-{
-    crossPlatformCopy(this->view_->getSelectedText());
-}
-
 void Split::startWatching()
 {
 #ifdef USEWEBENGINE

--- a/src/widgets/splits/Split.hpp
+++ b/src/widgets/splits/Split.hpp
@@ -168,7 +168,6 @@ public slots:
     void openBrowserPlayer();
     void openInStreamlink();
     void openWithCustomScheme();
-    void copyToClipboard();
     void startWatching();
     void setFiltersDialog();
     void showSearch(bool singleChannel);

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -31,14 +31,16 @@
 namespace chatterino {
 
 SplitInput::SplitInput(Split *_chatWidget, bool enableInlineReplying)
-    : SplitInput(_chatWidget, _chatWidget, enableInlineReplying)
+    : SplitInput(_chatWidget, _chatWidget, _chatWidget->view_,
+                 enableInlineReplying)
 {
 }
 
 SplitInput::SplitInput(QWidget *parent, Split *_chatWidget,
-                       bool enableInlineReplying)
+                       ChannelView *_channelView, bool enableInlineReplying)
     : BaseWidget(parent)
     , split_(_chatWidget)
+    , channelView_(_channelView)
     , enableInlineReplying_(enableInlineReplying)
 {
     this->installEventFilter(this);
@@ -560,7 +562,7 @@ void SplitInput::addShortcuts()
 
              if (copyFromSplit)
              {
-                 this->split_->copyToClipboard();
+                 this->channelView_->copySelectedText();
              }
              else
              {
@@ -639,9 +641,9 @@ void SplitInput::installKeyPressedEvent()
         if ((event->key() == Qt::Key_C || event->key() == Qt::Key_Insert) &&
             event->modifiers() == Qt::ControlModifier)
         {
-            if (this->split_->view_->hasSelection())
+            if (this->channelView_->hasSelection())
             {
-                this->split_->copyToClipboard();
+                this->channelView_->copySelectedText();
                 event->accept();
             }
         }

--- a/src/widgets/splits/SplitInput.hpp
+++ b/src/widgets/splits/SplitInput.hpp
@@ -22,6 +22,7 @@ class InputCompletionPopup;
 class EffectLabel;
 class MessageThread;
 class ResizingTextEdit;
+class ChannelView;
 
 // MessageOverflow is used for controlling how to guide the user into not
 // sending a message that will be discarded by Twitch
@@ -42,7 +43,7 @@ class SplitInput : public BaseWidget
 
 public:
     SplitInput(Split *_chatWidget, bool enableInlineReplying = true);
-    SplitInput(QWidget *parent, Split *_chatWidget,
+    SplitInput(QWidget *parent, Split *_chatWidget, ChannelView *_channelView,
                bool enableInlineReplying = true);
 
     bool hasSelection() const;
@@ -126,6 +127,7 @@ protected:
     bool shouldPreventInput(const QString &text) const;
 
     Split *const split_;
+    ChannelView *const channelView_;
     QObjectRef<EmotePopup> emotePopup_;
     QObjectRef<InputCompletionPopup> inputCompletionPopup_;
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Previously, pressing CTRL + C would attempt to copy from the original split (→ and its channel view) instead. This PR fixes the bug.

Fixes #4208.
