### PR TITLE
Bump suggested clang-format version to `15.0.5`

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The code is formatted using clang format in Qt Creator. [.clang-format](src/.cla
 
 ### Get it automated with QT Creator + Beautifier + Clang Format
 
-1. Download LLVM: https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/LLVM-11.0.0-win64.exe
+1. Download LLVM: https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.5/LLVM-15.0.5-win64.exe
 2. During the installation, make sure to add it to your path
 3. In QT Creator, select `Help` > `About Plugins` > `C++` > `Beautifier` to enable the plugin
 4. Restart QT Creator


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Clang-format version 11 is no longer satisfactory for us, as it does not support `CaseSensitive:`, which was added in #4172

The current latest-release of clang-format is `15.0.6`, but it does not have a win64 asset, so `15.0.5` it is.

Quick testing seems to show this version works as expected for our use case: https://github.com/SevenTV/chatterino7/pull/159#issuecomment-1335661136
![image](https://user-images.githubusercontent.com/41973452/205363169-a4d16c01-123f-438c-a309-77e334fbe4a3.png)
![image](https://user-images.githubusercontent.com/41973452/205363460-fafccdcf-8496-4191-8c31-7ba076bf7361.png)