### PR TITLE
feat: Automatically select newly added table rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Minor: Added ability to negate search options by prefixing it with an exclamation mark (e.g. `!badge:mod` to search for messages where the author does not have the moderator badge). (#4207)
 - Minor: Search window input will automatically use currently selected text if present. (#4178)
 - Minor: Cleared up highlight sound settings (#4194)
+- Minor: Tables in settings window will now scroll to newly added rows. (#4216)
 - Bugfix: Fixed highlight sounds not reloading on change properly. (#4194)
 - Bugfix: Fixed CTRL + C not working in reply thread popups. (#4209)
 - Bugfix: Fixed message input showing as red after removing a message that was more than 500 characters. (#4204)

--- a/src/widgets/helper/EditableModelView.cpp
+++ b/src/widgets/helper/EditableModelView.cpp
@@ -82,7 +82,13 @@ EditableModelView::EditableModelView(QAbstractTableModel *model, bool movable)
     QObject::connect(this->model_, &QAbstractTableModel::rowsMoved, this,
                      [this](const QModelIndex &parent, int start, int end,
                             const QModelIndex &destination, int row) {
-                         this->selectRow(row);
+                         this->tableView_->selectRow(row);
+                     });
+
+    // select freshly added row
+    QObject::connect(this->model_, &QAbstractTableModel::rowsInserted, this,
+                     [this](const QModelIndex &parent, int first, int last) {
+                         this->tableView_->selectRow(last);
                      });
 
     // add tableview
@@ -149,15 +155,7 @@ void EditableModelView::moveRow(int dir)
 
     model_->moveRows(model_->index(row, 0), row, selected.size(),
                      model_->index(row + dir, 0), row + dir);
-    this->selectRow(row + dir);
-}
-
-void EditableModelView::selectRow(int row)
-{
-    this->getTableView()->selectionModel()->clear();
-    this->getTableView()->selectionModel()->select(
-        this->model_->index(row, 0),
-        QItemSelectionModel::SelectCurrent | QItemSelectionModel::Rows);
+    this->tableView_->selectRow(row + dir);
 }
 
 }  // namespace chatterino

--- a/src/widgets/helper/EditableModelView.hpp
+++ b/src/widgets/helper/EditableModelView.hpp
@@ -31,9 +31,6 @@ private:
     QHBoxLayout *buttons_{};
 
     void moveRow(int dir);
-
-public:
-    void selectRow(int row);
 };
 
 }  // namespace chatterino

--- a/src/widgets/settingspages/KeyboardSettingsPage.cpp
+++ b/src/widgets/settingspages/KeyboardSettingsPage.cpp
@@ -40,13 +40,6 @@ KeyboardSettingsPage::KeyboardSettingsPage()
             auto newHotkey = dialog.data();
             int vectorIndex = getApp()->hotkeys->hotkeys_.append(newHotkey);
             getApp()->hotkeys->save();
-
-            // Select and scroll to newly added hotkey
-            auto modelRow = model->getModelIndexFromVectorIndex(vectorIndex);
-            auto modelIndex = model->index(modelRow, 0);
-            view->selectRow(modelRow);
-            view->getTableView()->scrollTo(modelIndex,
-                                           QAbstractItemView::PositionAtCenter);
         }
     });
 
@@ -89,11 +82,6 @@ void KeyboardSettingsPage::tableCellClicked(const QModelIndex &clicked,
         auto vectorIndex =
             getApp()->hotkeys->replaceHotkey(hotkey->name(), newHotkey);
         getApp()->hotkeys->save();
-
-        // Select the replaced hotkey
-        auto modelRow = model->getModelIndexFromVectorIndex(vectorIndex);
-        auto modelIndex = model->index(modelRow, 0);
-        view->selectRow(modelRow);
     }
 }
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description
Pressing `Add` button above tables in settings window adds new row at the bottom. 
When table has scrollbar, new rows are not visible right away and its not clear if Add button even worked.

changes introduced in PR:
- new rows are automatically selected (and scrolled to when not visible) in all settings tables
- removed now redundant selections in Hotkeys (`KeyboardSettingsPage`)
- unnecessary `EditableModelView::selectRow(int row)` is removed and `QTableView::selectRow(int row)` is used internally instead. Functionality is still exposed via existing public api: `EditableModelView::getTableView()->selectRow()`



