### PR TITLE
feat: Add Setting to Hide Reply Context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Minor: Cleared up highlight sound settings (#4194)
 - Minor: Tables in settings window will now scroll to newly added rows. (#4216)
 - Minor: Added link to streamlink docs for easier user setup. (#4217)
+- Minor: Added setting to turn off rendering of reply context. (#4224)
 - Bugfix: Fixed highlight sounds not reloading on change properly. (#4194)
 - Bugfix: Fixed CTRL + C not working in reply thread popups. (#4209)
 - Bugfix: Fixed message input showing as red after removing a message that was more than 500 characters. (#4204)

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -70,7 +70,7 @@ MessagePtr generateBannedMessage(bool confirmedBan)
 
 int stripLeadingReplyMention(const QVariantMap &tags, QString &content)
 {
-    if (!getSettings()->stripReplyMention)
+    if (!getSettings()->stripReplyMention || !getSettings()->showReplyContext)
     {
         return 0;
     }

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -119,6 +119,7 @@ public:
 
     //    BoolSetting collapseLongMessages =
     //    {"/appearance/messages/collapseLongMessages", false};
+    BoolSetting showReplyContext = {"/appearance/showReplyContext", true};
     BoolSetting showReplyButton = {"/appearance/showReplyButton", false};
     BoolSetting stripReplyMention = {"/appearance/stripReplyMention", true};
     IntSetting collpseMessagesMinLines = {

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1124,9 +1124,11 @@ MessageElementFlags ChannelView::getFlags() const
     if (this->sourceChannel_ == app->twitch->mentionsChannel)
         flags.set(MessageElementFlag::ChannelName);
 
-    if (this->context_ == Context::ReplyThread)
+    if (this->context_ == Context::ReplyThread ||
+        !getSettings()->showReplyContext)
     {
         // Don't show inline replies within the ReplyThreadPopup
+        // or if they're disabled
         flags.unset(MessageElementFlag::RepliedMessage);
     }
 

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -190,6 +190,10 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     tabDirectionDropdown->setMinimumWidth(
         tabDirectionDropdown->minimumSizeHint().width());
 
+    layout.addCheckbox(
+        "Show message reply context", s.showReplyContext, false,
+        "This setting will only affect how messages are rendered. You can "
+        "reply to a message regardless of this setting.");
     layout.addCheckbox("Show message reply button", s.showReplyButton);
     layout.addCheckbox("Show tab close button", s.showTabCloseButton);
     layout.addCheckbox("Always on top", s.windowTopMost, false,
@@ -843,10 +847,11 @@ void GeneralPage::initLayout(GeneralPageView &layout)
                        "message) into one cheermote.");
     layout.addCheckbox("Messages in /mentions highlights tab",
                        s.highlightMentions);
-    layout.addCheckbox("Strip leading mention in replies", s.stripReplyMention,
-                       true,
-                       "When disabled, messages sent in reply threads will "
-                       "include the @mention for the related thread");
+    layout.addCheckbox(
+        "Strip leading mention in replies", s.stripReplyMention, true,
+        "When disabled, messages sent in reply threads will "
+        "include the @mention for the related thread. If the rendering of the"
+        "reply context is turned off, these mentions will never be stripped.");
 
     // Helix timegate settings
     auto helixTimegateGetValue = [](auto val) {


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

As discussed in #4220:

> Some people don't like reply threads or how they're displayed in Chatterino and want to "hide replies" - hide the reply context.

> My thinking was to add a setting that hides the reply context in the rendered messages, so these messages look like regular messages. I don't think adding a setting that completely ignores replies is good, as it will overcomplicate a lot of the code.

