### PR TITLE
Fix accidental change of `stripLeadingMentions` setting

### DIFF
--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -848,7 +848,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     layout.addCheckbox("Messages in /mentions highlights tab",
                        s.highlightMentions);
     layout.addCheckbox(
-        "Strip leading mention in replies", s.stripReplyMention, true,
+        "Strip leading mention in replies", s.stripReplyMention, false,
         "When disabled, messages sent in reply threads will include the "
         "@mention for the related thread. If the reply context is hidden, "
         "these mentions will never be stripped.");


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Purely a cosmetic issue, as the checkbox changes based on what setting you already had, but it would cause confusion when reading the setting, if not fixed.

Accidentally implemented in #4213 
