### PR TITLE
fix: don't run `push-aur.yml` on pull requests

### DIFF
--- a/.github/workflows/push-aur.yml
+++ b/.github/workflows/push-aur.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
 
 concurrency: 
   group: build-archlinux-${{ github.ref }}


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

The action will always use the (upstream) master branch and never actually build the PR itself. 

It's not really clear from the name of the action what it will do - maybe it should be renamed?
