### PR TITLE
Only try to extract images if the image uploader is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Bugfix: Fixed unnecessary saving of windows layout. (#4201)
 - Bugfix: Fixed Reply window missing selection clear behaviour between chat and input box. (#4218)
 - Bugfix: Fixed crash that could occur when changing Tab layout and utilizing multiple windows. (#4248)
+- Bugfix: Fixed text sometimes not pasting properly when image uploader was disabled. (#4246)
 - Dev: Remove protocol from QApplication's Organization Domain (so changed from `https://www.chatterino.com` to `chatterino.com`). (#4256)
 - Dev: Ignore `WM_SHOWWINDOW` hide events, causing fewer attempted rescales. (#4198)
 - Dev: Migrated to C++ 20 (#4252, #4257)

--- a/src/widgets/helper/ResizingTextEdit.cpp
+++ b/src/widgets/helper/ResizingTextEdit.cpp
@@ -286,30 +286,33 @@ bool ResizingTextEdit::canInsertFromMimeData(const QMimeData *source) const
 
 void ResizingTextEdit::insertFromMimeData(const QMimeData *source)
 {
-    if (source->hasImage())
+    if (getSettings()->imageUploaderEnabled)
     {
-        this->imagePasted.invoke(source);
-        return;
-    }
-
-    if (source->hasUrls())
-    {
-        bool hasUploadable = false;
-        auto mimeDb = QMimeDatabase();
-        for (const QUrl &url : source->urls())
-        {
-            QMimeType mime = mimeDb.mimeTypeForUrl(url);
-            if (mime.name().startsWith("image"))
-            {
-                hasUploadable = true;
-                break;
-            }
-        }
-
-        if (hasUploadable)
+        if (source->hasImage())
         {
             this->imagePasted.invoke(source);
             return;
+        }
+
+        if (source->hasUrls())
+        {
+            bool hasUploadable = false;
+            auto mimeDb = QMimeDatabase();
+            for (const QUrl &url : source->urls())
+            {
+                QMimeType mime = mimeDb.mimeTypeForUrl(url);
+                if (mime.name().startsWith("image"))
+                {
+                    hasUploadable = true;
+                    break;
+                }
+            }
+
+            if (hasUploadable)
+            {
+                this->imagePasted.invoke(source);
+                return;
+            }
         }
     }
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Tries to be a bit smarter for when to just paste regular old text instead of an image

Needs some thorough testing with mixed clipboards

Fixes #4245


To test:
1) Open excel/openoffice
2) Copy 1 or more cells
3) Paste into Chatterino with an image uploader configured. It should, atm, post an image of it
4) Disable your image uploader and paste it into Chatterino again. Before this PR it would just not paste anything, after this PR it should paste the text of the cells


Tested on Windows, macOS, Linux X11
Not tested on Wayland, someone can do that and make another PR if this breaks it (although I don't think it would)

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
