### PR TITLE
Enable LTO support for Chatterino builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,9 @@ concurrency:
   group: build-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  C2_ENABLE_LTO: ${{ github.ref == 'refs/heads/master' }}
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -20,15 +23,21 @@ jobs:
         os: [windows-latest, ubuntu-20.04, macos-latest]
         qt-version: [5.15.2, 5.12.12]
         pch: [true]
-        lto: [(github.ref == 'refs/heads/master')]
+        force-lto: [false]
         include:
           - os: ubuntu-20.04
             qt-version: 5.15.2
             pch: false
-            lto: true
+            force-lto: true
       fail-fast: false
 
     steps:
+      - name: Force LTO
+        if: matrix.force-lto == true
+        run: |
+            echo "C2_ENABLE_LTO=ON" >> "$GITHUB_ENV"
+        shell: bash
+
       - name: Set environment variables for windows-latest
         if: matrix.os == 'windows-latest'
         run: |
@@ -86,7 +95,7 @@ jobs:
                 -G"NMake Makefiles" `
                 -DCMAKE_BUILD_TYPE=Release `
                 -DUSE_CONAN=ON `
-                -DCHATTERINO_LTO=${{ matrix.lto }} `
+                -DCHATTERINO_LTO="$Env:C2_ENABLE_LTO" `
                 ..
             set cl=/MP
             nmake /S /NOLOGO
@@ -144,7 +153,7 @@ jobs:
               -DPAJLADA_SETTINGS_USE_BOOST_FILESYSTEM=On \
               -DUSE_PRECOMPILED_HEADERS=${{ matrix.pch }} \
               -DCMAKE_EXPORT_COMPILE_COMMANDS=On \
-              -DCHATTERINO_LTO=${{ matrix.lto }} \
+              -DCHATTERINO_LTO="$C2_ENABLE_LTO" \
               ..
             make -j"$(nproc)"
         shell: bash
@@ -211,7 +220,7 @@ jobs:
                 -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 \
                 -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl \
                 -DUSE_PRECOMPILED_HEADERS=${{ matrix.pch }} \
-                -DCHATTERINO_LTO=${{ matrix.lto }} \
+                -DCHATTERINO_LTO="$C2_ENABLE_LTO" \
                 ..
             make -j"$(sysctl -n hw.logicalcpu)"
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,10 +20,12 @@ jobs:
         os: [windows-latest, ubuntu-20.04, macos-latest]
         qt-version: [5.15.2, 5.12.12]
         pch: [true]
+        lto: [github.ref == 'refs/heads/master']
         include:
           - os: ubuntu-20.04
             qt-version: 5.15.2
             pch: false
+            lto: true
       fail-fast: false
 
     steps:
@@ -80,7 +82,12 @@ jobs:
             mkdir build
             cd build
             conan install ..  -b missing
-            cmake -G"NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DUSE_CONAN=ON ..
+            cmake `
+                -G"NMake Makefiles" `
+                -DCMAKE_BUILD_TYPE=Release `
+                -DUSE_CONAN=ON `
+                -DCHATTERINO_LTO=${{ matrix.lto }} `
+                ..
             set cl=/MP
             nmake /S /NOLOGO
             windeployqt bin/chatterino.exe --release --no-compiler-runtime --no-translations --no-opengl-sw --dir Chatterino2/
@@ -137,6 +144,7 @@ jobs:
               -DPAJLADA_SETTINGS_USE_BOOST_FILESYSTEM=On \
               -DUSE_PRECOMPILED_HEADERS=${{ matrix.pch }} \
               -DCMAKE_EXPORT_COMPILE_COMMANDS=On \
+              -DCHATTERINO_LTO=${{ matrix.lto }} \
               ..
             make -j$(nproc)
         shell: bash
@@ -203,6 +211,7 @@ jobs:
                 -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 \
                 -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl \
                 -DUSE_PRECOMPILED_HEADERS=${{ matrix.pch }} \
+                -DCHATTERINO_LTO=${{ matrix.lto }} \
                 ..
             make -j$(sysctl -n hw.logicalcpu)
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         os: [windows-latest, ubuntu-20.04, macos-latest]
         qt-version: [5.15.2, 5.12.12]
         pch: [true]
-        lto: [github.ref == 'refs/heads/master']
+        lto: [(github.ref == 'refs/heads/master')]
         include:
           - os: ubuntu-20.04
             qt-version: 5.15.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set environment variables for windows-latest
         if: matrix.os == 'windows-latest'
         run: |
-            echo "vs_version=2022" >> $GITHUB_ENV
+            echo "vs_version=2022" >> "$GITHUB_ENV"
         shell: bash
 
       - uses: actions/checkout@v3
@@ -146,7 +146,7 @@ jobs:
               -DCMAKE_EXPORT_COMPILE_COMMANDS=On \
               -DCHATTERINO_LTO=${{ matrix.lto }} \
               ..
-            make -j$(nproc)
+            make -j"$(nproc)"
         shell: bash
 
       - name: clang-tidy review
@@ -213,7 +213,7 @@ jobs:
                 -DUSE_PRECOMPILED_HEADERS=${{ matrix.pch }} \
                 -DCHATTERINO_LTO=${{ matrix.lto }} \
                 ..
-            make -j$(sysctl -n hw.logicalcpu)
+            make -j"$(sysctl -n hw.logicalcpu)"
         shell: bash
 
       - name: Package (MacOS)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Dev: Remove protocol from QApplication's Organization Domain (so changed from `https://www.chatterino.com` to `chatterino.com`). (#4256)
 - Dev: Ignore `WM_SHOWWINDOW` hide events, causing fewer attempted rescales. (#4198)
 - Dev: Migrated to C++ 20 (#4252, #4257)
+- Dev: Enable LTO for main branch builds. (#4258)
 
 ## 2.4.0
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,8 +20,17 @@ option(USE_PRECOMPILED_HEADERS "Use precompiled headers" ON)
 option(BUILD_WITH_QT6 "Use Qt6 instead of default Qt5" OFF)
 option(CHATTERINO_GENERATE_COVERAGE "Generate coverage files" OFF)
 option(BUILD_SHARED_LIBS "" OFF)
+option(CHATTERINO_LTO "Enable LTO for all targets" ON)
 
 option(USE_CONAN "Use conan" OFF)
+
+if(CHATTERINO_LTO)
+    include(CheckIPOSupported)
+    check_ipo_supported(RESULT CHATTERINO_ENABLE_LTO OUTPUT IPO_ERROR)
+    message(STATUS "LTO: Enabled (Supported: ${CHATTERINO_ENABLE_LTO})")
+else()
+    message(STATUS "LTO: Disabled")
+endif()
 
 if (BUILD_WITH_QT6)
     set(MAJOR_QT_VERSION "6")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -665,6 +665,12 @@ if (BUILD_APP)
                 DESTINATION share/icons/hicolor/256x256/apps
                 )
     endif ()
+
+    if(CHATTERINO_ENABLE_LTO)
+        message(STATUS "Enabling LTO for ${EXECUTABLE_PROJECT}")
+        set_property(TARGET ${EXECUTABLE_PROJECT}
+            PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+    endif()
 endif ()
 
 if (USE_PRECOMPILED_HEADERS)
@@ -843,3 +849,9 @@ else ()
         )
     endif()
 endif ()
+
+if(CHATTERINO_ENABLE_LTO)
+    message(STATUS "Enabling LTO for ${LIBRARY_PROJECT}")
+    set_property(TARGET ${LIBRARY_PROJECT}
+                 PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,6 +46,12 @@ set_target_properties(${PROJECT_NAME}
     RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO "${CMAKE_BINARY_DIR}/bin"
     )
 
+if(CHATTERINO_ENABLE_LTO)
+    message(STATUS "Enabling LTO for ${PROJECT_NAME}")
+    set_property(TARGET ${PROJECT_NAME}
+        PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+endif()
+
 # gtest_add_tests manages to discover the tests because it looks through the source files
 # HOWEVER, it fails to run, because we have some bug that causes the QApplication exit to stall when no network requests have been made.
 # ctest runs each test individually, so for now we require that testers just run the ./bin/chatterino-test binary without any filters applied


### PR DESCRIPTION

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

This is disabled by default, and can be enabled by passing `-DCHATTERINO_LTO=On` to your cmake invocation.
I plan on enabling only for 1 of the PR builds, and for all PR builds on the main branch to not slow down CI too much

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
