### PR TITLE
SplitContainer refactor

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -48,7 +48,7 @@ CheckOptions:
     value:           _
   - key:             readability-identifier-naming.UnionCase
     value:           CamelCase
-  - key:             readability-identifier-naming.GlobalVariableCase
+  - key:             readability-identifier-naming.GlobalConstantCase
     value:           UPPER_CASE
   - key:             readability-identifier-naming.VariableCase
     value:           camelBack

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -525,6 +525,8 @@ set(SOURCE_FILES
 
         widgets/splits/ClosedSplits.cpp
         widgets/splits/ClosedSplits.hpp
+        widgets/splits/DraggedSplit.cpp
+        widgets/splits/DraggedSplit.hpp
         widgets/splits/InputCompletionItem.cpp
         widgets/splits/InputCompletionItem.hpp
         widgets/splits/InputCompletionPopup.cpp

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -555,7 +555,7 @@ void WindowManager::encodeNodeRecursively(SplitNode *node, QJsonObject &obj)
 {
     switch (node->getType())
     {
-        case SplitNode::_Split: {
+        case SplitNode::Type::Split: {
             obj.insert("type", "split");
             obj.insert("moderationMode", node->getSplit()->getModerationMode());
 
@@ -569,11 +569,12 @@ void WindowManager::encodeNodeRecursively(SplitNode *node, QJsonObject &obj)
             obj.insert("filters", filters);
         }
         break;
-        case SplitNode::HorizontalContainer:
-        case SplitNode::VerticalContainer: {
-            obj.insert("type", node->getType() == SplitNode::HorizontalContainer
-                                   ? "horizontal"
-                                   : "vertical");
+        case SplitNode::Type::HorizontalContainer:
+        case SplitNode::Type::VerticalContainer: {
+            obj.insert("type",
+                       node->getType() == SplitNode::Type::HorizontalContainer
+                           ? "horizontal"
+                           : "vertical");
 
             QJsonArray itemsArr;
             for (const std::unique_ptr<SplitNode> &n : node->getChildren())

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -424,7 +424,7 @@ void Window::addShortcuts()
              split->setChannel(
                  getApp()->twitch->getOrAddChannel(si.channelName));
              split->setFilters(si.filters);
-             splitContainer->appendSplit(split);
+             splitContainer->insertSplit(split);
              splitContainer->setSelected(split);
              this->notebook_->select(splitContainer);
              return "";

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -313,7 +313,7 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically, QWidget *parent,
                                 SplitContainer *container = nb.addPage(true);
                                 Split *split = new Split(container);
                                 split->setChannel(channel);
-                                container->appendSplit(split);
+                                container->insertSplit(split);
                             });
                         menu->popup(QCursor::pos());
                         menu->raise();

--- a/src/widgets/dialogs/switcher/NewTabItem.cpp
+++ b/src/widgets/dialogs/switcher/NewTabItem.cpp
@@ -26,7 +26,7 @@ void NewTabItem::action()
 
     Split *split = new Split(container);
     split->setChannel(getApp()->twitch->getOrAddChannel(this->channelName_));
-    container->appendSplit(split);
+    container->insertSplit(split);
 }
 
 void NewTabItem::paint(QPainter *painter, const QRect &rect) const

--- a/src/widgets/dialogs/switcher/QuickSwitcherPopup.cpp
+++ b/src/widgets/dialogs/switcher/QuickSwitcherPopup.cpp
@@ -1,6 +1,7 @@
 #include "widgets/dialogs/switcher/QuickSwitcherPopup.hpp"
 
 #include "Application.hpp"
+#include "common/Channel.hpp"
 #include "singletons/Theme.hpp"
 #include "singletons/WindowManager.hpp"
 #include "util/LayoutCreator.hpp"
@@ -10,6 +11,8 @@
 #include "widgets/helper/NotebookTab.hpp"
 #include "widgets/listview/GenericListView.hpp"
 #include "widgets/Notebook.hpp"
+#include "widgets/splits/Split.hpp"
+#include "widgets/splits/SplitContainer.hpp"
 #include "widgets/Window.hpp"
 
 namespace chatterino {

--- a/src/widgets/dialogs/switcher/QuickSwitcherPopup.hpp
+++ b/src/widgets/dialogs/switcher/QuickSwitcherPopup.hpp
@@ -1,10 +1,7 @@
 #pragma once
 
-#include "common/Channel.hpp"
 #include "widgets/BasePopup.hpp"
 #include "widgets/dialogs/switcher/QuickSwitcherModel.hpp"
-#include "widgets/splits/Split.hpp"
-#include "widgets/splits/SplitContainer.hpp"
 
 #include <QLineEdit>
 

--- a/src/widgets/helper/NotebookButton.cpp
+++ b/src/widgets/helper/NotebookButton.cpp
@@ -1,8 +1,10 @@
 #include "widgets/helper/NotebookButton.hpp"
 
+#include "common/QLogging.hpp"
 #include "singletons/Theme.hpp"
 #include "widgets/helper/Button.hpp"
 #include "widgets/Notebook.hpp"
+#include "widgets/splits/DraggedSplit.hpp"
 #include "widgets/splits/Split.hpp"
 #include "widgets/splits/SplitContainer.hpp"
 
@@ -67,7 +69,7 @@ void NotebookButton::paintEvent(QPaintEvent *event)
         case Plus: {
             painter.setPen([&] {
                 QColor tmp = foreground;
-                if (SplitContainer::isDraggingSplit)
+                if (isDraggingSplit())
                 {
                     tmp = this->theme->tabs.selected.line.regular;
                 }
@@ -181,22 +183,30 @@ void NotebookButton::dragLeaveEvent(QDragLeaveEvent *)
 
 void NotebookButton::dropEvent(QDropEvent *event)
 {
-    if (SplitContainer::isDraggingSplit)
+    auto *draggedSplit = dynamic_cast<Split *>(event->source());
+    if (!draggedSplit)
     {
-        event->acceptProposedAction();
-
-        Notebook *notebook = dynamic_cast<Notebook *>(this->parentWidget());
-
-        if (notebook != nuuls)
-        {
-            SplitContainer *page = new SplitContainer(notebook);
-            auto *tab = notebook->addPage(page);
-            page->setTab(tab);
-
-            SplitContainer::draggingSplit->setParent(page);
-            page->insertSplit(SplitContainer::draggingSplit);
-        }
+        qCDebug(chatterinoWidget)
+            << "Dropped something that wasn't a split onto a notebook button";
+        return;
     }
+
+    auto *notebook = dynamic_cast<Notebook *>(this->parentWidget());
+    if (!notebook)
+    {
+        qCDebug(chatterinoWidget) << "Dropped a split onto a notebook button "
+                                     "without a parent notebook";
+        return;
+    }
+
+    event->acceptProposedAction();
+
+    auto *page = new SplitContainer(notebook);
+    auto *tab = notebook->addPage(page);
+    page->setTab(tab);
+
+    draggedSplit->setParent(page);
+    page->insertSplit(draggedSplit);
 }
 
 void NotebookButton::hideEvent(QHideEvent *)

--- a/src/widgets/helper/NotebookButton.cpp
+++ b/src/widgets/helper/NotebookButton.cpp
@@ -194,7 +194,7 @@ void NotebookButton::dropEvent(QDropEvent *event)
             page->setTab(tab);
 
             SplitContainer::draggingSplit->setParent(page);
-            page->appendSplit(SplitContainer::draggingSplit);
+            page->insertSplit(SplitContainer::draggingSplit);
         }
     }
 }

--- a/src/widgets/helper/NotebookTab.cpp
+++ b/src/widgets/helper/NotebookTab.cpp
@@ -12,6 +12,7 @@
 #include "util/Helpers.hpp"
 #include "widgets/dialogs/SettingsDialog.hpp"
 #include "widgets/Notebook.hpp"
+#include "widgets/splits/DraggedSplit.hpp"
 #include "widgets/splits/SplitContainer.hpp"
 
 #include <boost/bind/bind.hpp>
@@ -695,10 +696,15 @@ void NotebookTab::leaveEvent(QEvent *event)
 void NotebookTab::dragEnterEvent(QDragEnterEvent *event)
 {
     if (!event->mimeData()->hasFormat("chatterino/split"))
+    {
         return;
+    }
 
-    if (!SplitContainer::isDraggingSplit)
+    if (!isDraggingSplit())
+    {
+        // Ensure dragging a split from a different Chatterino instance doesn't switch tabs around
         return;
+    }
 
     if (this->notebook_->getAllowUserTabManagement())
     {

--- a/src/widgets/settingspages/GeneralPageView.hpp
+++ b/src/widgets/settingspages/GeneralPageView.hpp
@@ -12,6 +12,7 @@
 #include <QDebug>
 #include <QPushButton>
 #include <QSpinBox>
+#include <QVBoxLayout>
 
 class QScrollArea;
 

--- a/src/widgets/splits/DraggedSplit.cpp
+++ b/src/widgets/splits/DraggedSplit.cpp
@@ -1,0 +1,17 @@
+#include "widgets/splits/DraggedSplit.hpp"
+
+namespace chatterino {
+
+static bool currentlyDraggingSplit = false;
+
+bool isDraggingSplit()
+{
+    return currentlyDraggingSplit;
+}
+
+void setDraggingSplit(bool isDraggingSplit)
+{
+    currentlyDraggingSplit = isDraggingSplit;
+}
+
+}  // namespace chatterino

--- a/src/widgets/splits/DraggedSplit.cpp
+++ b/src/widgets/splits/DraggedSplit.cpp
@@ -1,5 +1,7 @@
 #include "widgets/splits/DraggedSplit.hpp"
 
+#include <cassert>
+
 namespace chatterino {
 
 static bool currentlyDraggingSplit = false;
@@ -9,9 +11,18 @@ bool isDraggingSplit()
     return currentlyDraggingSplit;
 }
 
-void setDraggingSplit(bool isDraggingSplit)
+void startDraggingSplit()
 {
-    currentlyDraggingSplit = isDraggingSplit;
+    assert(currentlyDraggingSplit == false);
+
+    currentlyDraggingSplit = true;
+}
+
+void stopDraggingSplit()
+{
+    assert(currentlyDraggingSplit == true);
+
+    currentlyDraggingSplit = false;
 }
 
 }  // namespace chatterino

--- a/src/widgets/splits/DraggedSplit.hpp
+++ b/src/widgets/splits/DraggedSplit.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "widgets/splits/Split.hpp"
+
+namespace chatterino {
+
+// Returns true if the user is currently dragging a split in this Chatterino instance
+// We need to keep track of this to ensure splits from other Chatterino instances aren't treated as memory we own
+[[nodiscard]] bool isDraggingSplit();
+
+// Set the current split dragging state
+// Controlled by Split's drag function
+void setDraggingSplit(bool isDraggingSplit);
+
+}  // namespace chatterino

--- a/src/widgets/splits/DraggedSplit.hpp
+++ b/src/widgets/splits/DraggedSplit.hpp
@@ -6,8 +6,12 @@ namespace chatterino {
 // We need to keep track of this to ensure splits from other Chatterino instances aren't treated as memory we own
 [[nodiscard]] bool isDraggingSplit();
 
-// Set the current split dragging state
-// Controlled by Split's drag function
-void setDraggingSplit(bool isDraggingSplit);
+// Set that a split is currently being dragged
+// Used by the Split::drag function when a drag is initiated
+void startDraggingSplit();
+
+// Set that a split is no longer being dragged
+// Used by the Split::drag function when a drag is finished
+void stopDraggingSplit();
 
 }  // namespace chatterino

--- a/src/widgets/splits/DraggedSplit.hpp
+++ b/src/widgets/splits/DraggedSplit.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "widgets/splits/Split.hpp"
-
 namespace chatterino {
 
 // Returns true if the user is currently dragging a split in this Chatterino instance

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -628,7 +628,7 @@ void Split::joinChannelInNewTab(ChannelPtr channel)
 
     Split *split = new Split(container);
     split->setChannel(channel);
-    container->appendSplit(split);
+    container->insertSplit(split);
 }
 
 void Split::openChannelInBrowserPlayer(ChannelPtr channel)
@@ -899,7 +899,7 @@ void Split::popup()
     split->setModerationMode(this->getModerationMode());
     split->setFilters(this->getFilters());
 
-    window.getNotebook().getOrAddSelectedPage()->appendSplit(split);
+    window.getNotebook().getOrAddSelectedPage()->insertSplit(split);
     window.show();
 }
 
@@ -1270,7 +1270,7 @@ void Split::drag()
 
         if (drag->exec(Qt::MoveAction) == Qt::IgnoreAction)
         {
-            container->insertSplit(this, originalLocation);
+            container->insertSplit(this, {.position = originalLocation});
         }
 
         SplitContainer::isDraggingSplit = false;

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -1265,7 +1265,7 @@ void Split::drag()
         return;
     }
 
-    setDraggingSplit(true);
+    startDraggingSplit();
 
     auto originalLocation = container->releaseSplit(this);
     auto drag = new QDrag(this);
@@ -1281,7 +1281,7 @@ void Split::drag()
         container->insertSplit(this, {.position = originalLocation});
     }
 
-    setDraggingSplit(false);
+    stopDraggingSplit();
 }
 
 void Split::setInputReply(const std::shared_ptr<MessageThread> &reply)

--- a/src/widgets/splits/SplitContainer.cpp
+++ b/src/widgets/splits/SplitContainer.cpp
@@ -502,31 +502,30 @@ void SplitContainer::layout()
         Node *node = this->baseNode_.findNodeContainingSplit(split);
 
         // left
-        dropRects.push_back(
-            DropRect(QRect(g.left(), g.top(), g.width() / 3, g.height()),
-                     Position(node, Direction::Left)));
+        dropRects.emplace_back(
+            QRect(g.left(), g.top(), g.width() / 3, g.height()),
+            Position(node, Direction::Left));
         // right
-        dropRects.push_back(DropRect(QRect(g.right() - g.width() / 3, g.top(),
-                                           g.width() / 3, g.height()),
-                                     Position(node, Direction::Right)));
+        dropRects.emplace_back(QRect(g.right() - g.width() / 3, g.top(),
+                                     g.width() / 3, g.height()),
+                               Position(node, Direction::Right));
 
         // top
-        dropRects.push_back(
-            DropRect(QRect(g.left(), g.top(), g.width(), g.height() / 2),
-                     Position(node, Direction::Above)));
+        dropRects.emplace_back(
+            QRect(g.left(), g.top(), g.width(), g.height() / 2),
+            Position(node, Direction::Above));
         // bottom
-        dropRects.push_back(
-            DropRect(QRect(g.left(), g.bottom() - g.height() / 2, g.width(),
-                           g.height() / 2),
-                     Position(node, Direction::Below)));
+        dropRects.emplace_back(QRect(g.left(), g.bottom() - g.height() / 2,
+                                     g.width(), g.height() / 2),
+                               Position(node, Direction::Below));
     }
 
     if (this->splits_.empty())
     {
         QRect g = this->rect();
-        dropRects.push_back(
-            DropRect(QRect(g.left(), g.top(), g.width() - 1, g.height() - 1),
-                     Position(nullptr, Direction::Below)));
+        dropRects.emplace_back(
+            QRect(g.left(), g.top(), g.width() - 1, g.height() - 1),
+            Position(nullptr, Direction::Below));
     }
 
     this->overlay_.setRects(std::move(dropRects));

--- a/src/widgets/splits/SplitContainer.cpp
+++ b/src/widgets/splits/SplitContainer.cpp
@@ -938,26 +938,26 @@ void SplitContainer::refreshTabLiveStatus()
 // Node
 //
 
-SplitContainer::Node::Type SplitContainer::Node::getType()
+SplitContainer::Node::Type SplitContainer::Node::getType() const
 {
     return this->type_;
 }
-Split *SplitContainer::Node::getSplit()
+Split *SplitContainer::Node::getSplit() const
 {
     return this->split_;
 }
 
-SplitContainer::Node *SplitContainer::Node::getParent()
+SplitContainer::Node *SplitContainer::Node::getParent() const
 {
     return this->parent_;
 }
 
-qreal SplitContainer::Node::getHorizontalFlex()
+qreal SplitContainer::Node::getHorizontalFlex() const
 {
     return this->flexH_;
 }
 
-qreal SplitContainer::Node::getVerticalFlex()
+qreal SplitContainer::Node::getVerticalFlex() const
 {
     return this->flexV_;
 }

--- a/src/widgets/splits/SplitContainer.cpp
+++ b/src/widgets/splits/SplitContainer.cpp
@@ -755,11 +755,6 @@ void SplitContainer::refreshTab()
     this->refreshTabLiveStatus();
 }
 
-int SplitContainer::getSplitCount()
-{
-    return this->splits_.size();
-}
-
 std::vector<Split *> SplitContainer::getSplits() const
 {
     return this->splits_;

--- a/src/widgets/splits/SplitContainer.cpp
+++ b/src/widgets/splits/SplitContainer.cpp
@@ -1224,14 +1224,7 @@ void SplitContainer::Node::layout(bool addSpacing, float _scale,
 {
     for (std::unique_ptr<Node> &node : this->children_)
     {
-        if (node->flexH_ <= 0)
-        {
-            node->flexH_ = 0;
-        }
-        if (node->flexV_ <= 0)
-        {
-            node->flexV_ = 0;
-        }
+        node->clamp();
     }
 
     switch (this->type_)
@@ -1378,6 +1371,19 @@ void SplitContainer::Node::layout(bool addSpacing, float _scale,
             }
         }
         break;
+    }
+}
+
+void SplitContainer::Node::clamp()
+{
+    if (this->flexH_ < 0)
+    {
+        this->flexH_ = 0;
+    }
+
+    if (this->flexV_ < 0)
+    {
+        this->flexV_ = 0;
     }
 }
 

--- a/src/widgets/splits/SplitContainer.cpp
+++ b/src/widgets/splits/SplitContainer.cpp
@@ -450,11 +450,15 @@ Split *SplitContainer::getTopRightSplit(Node &node)
             return node.getSplit();
         case Node::Type::VerticalContainer:
             if (!node.getChildren().empty())
+            {
                 return getTopRightSplit(*node.getChildren().front());
+            }
             break;
         case Node::Type::HorizontalContainer:
             if (!node.getChildren().empty())
+            {
                 return getTopRightSplit(*node.getChildren().back());
+            }
             break;
         default:;
     }
@@ -471,10 +475,14 @@ void SplitContainer::layout()
     // update top right split
     auto *topRight = this->getTopRightSplit(this->baseNode_);
     if (this->topRight_)
+    {
         this->topRight_->setIsTopRightSplit(false);
+    }
     this->topRight_ = topRight;
     if (topRight)
+    {
         this->topRight_->setIsTopRightSplit(true);
+    }
 
     // layout
     this->baseNode_.geometry_ = this->rect().adjusted(-1, -1, 0, 0);
@@ -689,10 +697,14 @@ void SplitContainer::paintEvent(QPaintEvent *)
 void SplitContainer::dragEnterEvent(QDragEnterEvent *event)
 {
     if (!event->mimeData()->hasFormat("chatterino/split"))
+    {
         return;
+    }
 
     if (!SplitContainer::isDraggingSplit)
+    {
         return;
+    }
 
     this->isDragging_ = true;
     this->layout();
@@ -1217,9 +1229,13 @@ void SplitContainer::Node::layout(bool addSpacing, float _scale,
     for (std::unique_ptr<Node> &node : this->children_)
     {
         if (node->flexH_ <= 0)
+        {
             node->flexH_ = 0;
+        }
         if (node->flexV_ <= 0)
+        {
             node->flexV_ = 0;
+        }
     }
 
     switch (this->type_)

--- a/src/widgets/splits/SplitContainer.cpp
+++ b/src/widgets/splits/SplitContainer.cpp
@@ -252,7 +252,7 @@ void SplitContainer::addSplit(Split *split)
                 case Split::Action::Delete: {
                     this->deleteSplit(split);
                     auto *tab = this->getTab();
-                    tab->connect(tab, &QWidget::destroyed, [tab]() mutable {
+                    QObject::connect(tab, &QWidget::destroyed, [tab]() mutable {
                         ClosedSplits::invalidateTab(tab);
                     });
                     ClosedSplits::push({split->getChannel()->getName(),

--- a/src/widgets/splits/SplitContainer.cpp
+++ b/src/widgets/splits/SplitContainer.cpp
@@ -324,7 +324,7 @@ SplitContainer::Position SplitContainer::releaseSplit(Split *split)
     split->setParent(nullptr);
     Position position = node->releaseSplit();
     this->layout();
-    if (splits_.size() == 0)
+    if (splits_.empty())
     {
         this->setSelected(nullptr);
         this->setCursor(Qt::PointingHandCursor);
@@ -571,7 +571,7 @@ void SplitContainer::mouseReleaseEvent(QMouseEvent *event)
 {
     if (event->button() == Qt::LeftButton)
     {
-        if (this->splits_.size() == 0)
+        if (this->splits_.empty())
         {
             // "Add Chat" was clicked
             this->appendNewSplit(true);
@@ -598,7 +598,7 @@ void SplitContainer::paintEvent(QPaintEvent *)
 {
     QPainter painter(this);
 
-    if (this->splits_.size() == 0)
+    if (this->splits_.empty())
     {
         painter.fillRect(rect(), this->theme->splits.background);
 
@@ -1106,7 +1106,7 @@ void SplitContainer::Node::insertNextToThis(Split *_split, Direction _direction)
 void SplitContainer::Node::setSplit(Split *_split)
 {
     assert(this->split_ == nullptr);
-    assert(this->children_.size() == 0);
+    assert(this->children_.empty());
 
     this->split_ = _split;
     this->type_ = Type::Split;

--- a/src/widgets/splits/SplitContainer.cpp
+++ b/src/widgets/splits/SplitContainer.cpp
@@ -755,7 +755,7 @@ int SplitContainer::getSplitCount()
     return this->splits_.size();
 }
 
-const std::vector<Split *> SplitContainer::getSplits() const
+std::vector<Split *> SplitContainer::getSplits() const
 {
     return this->splits_;
 }

--- a/src/widgets/splits/SplitContainer.cpp
+++ b/src/widgets/splits/SplitContainer.cpp
@@ -90,9 +90,9 @@ NotebookTab *SplitContainer::getTab() const
     return this->tab_;
 }
 
-void SplitContainer::setTab(NotebookTab *_tab)
+void SplitContainer::setTab(NotebookTab *tab)
 {
-    this->tab_ = _tab;
+    this->tab_ = tab;
 
     this->tab_->page = this;
 

--- a/src/widgets/splits/SplitContainer.cpp
+++ b/src/widgets/splits/SplitContainer.cpp
@@ -6,7 +6,6 @@
 #include "singletons/Fonts.hpp"
 #include "singletons/Theme.hpp"
 #include "singletons/WindowManager.hpp"
-#include "util/LayoutCreator.hpp"
 #include "widgets/helper/ChannelView.hpp"
 #include "widgets/helper/NotebookTab.hpp"
 #include "widgets/Notebook.hpp"
@@ -16,15 +15,10 @@
 
 #include <boost/foreach.hpp>
 #include <QApplication>
-#include <QDebug>
-#include <QHBoxLayout>
 #include <QJsonArray>
 #include <QJsonObject>
 #include <QMimeData>
-#include <QObject>
 #include <QPainter>
-#include <QVBoxLayout>
-#include <QWidget>
 
 #include <algorithm>
 

--- a/src/widgets/splits/SplitContainer.cpp
+++ b/src/widgets/splits/SplitContainer.cpp
@@ -1415,7 +1415,7 @@ void SplitContainer::DropOverlay::setRects(
 
 // pajlada::Signals::NoArgSignal dragEnded;
 
-void SplitContainer::DropOverlay::paintEvent(QPaintEvent *)
+void SplitContainer::DropOverlay::paintEvent(QPaintEvent * /*event*/)
 {
     QPainter painter(this);
 
@@ -1455,7 +1455,7 @@ void SplitContainer::DropOverlay::dragMoveEvent(QDragMoveEvent *event)
     this->update();
 }
 
-void SplitContainer::DropOverlay::dragLeaveEvent(QDragLeaveEvent *)
+void SplitContainer::DropOverlay::dragLeaveEvent(QDragLeaveEvent * /*event*/)
 {
     this->mouseOverPoint_ = QPoint(-10000, -10000);
     this->close();
@@ -1503,7 +1503,7 @@ SplitContainer::ResizeHandle::ResizeHandle(SplitContainer *_parent)
     this->hide();
 }
 
-void SplitContainer::ResizeHandle::paintEvent(QPaintEvent *)
+void SplitContainer::ResizeHandle::paintEvent(QPaintEvent * /*event*/)
 {
     QPainter painter(this);
     painter.setPen(QPen(getApp()->themes->splits.resizeHandle, 2));
@@ -1533,7 +1533,7 @@ void SplitContainer::ResizeHandle::mousePressEvent(QMouseEvent *event)
     }
 }
 
-void SplitContainer::ResizeHandle::mouseReleaseEvent(QMouseEvent *)
+void SplitContainer::ResizeHandle::mouseReleaseEvent(QMouseEvent * /*event*/)
 {
     this->isMouseDown_ = false;
 }

--- a/src/widgets/splits/SplitContainer.cpp
+++ b/src/widgets/splits/SplitContainer.cpp
@@ -854,7 +854,7 @@ void SplitContainer::applyFromDescriptorRecursively(
                 auto *_node = new Node();
                 _node->parent_ = node;
 
-                if (auto *n = std::get_if<ContainerNodeDescriptor>(&item))
+                if (const auto *n = std::get_if<ContainerNodeDescriptor>(&item))
                 {
                     _node->flexH_ = n->flexH_;
                     _node->flexV_ = n->flexV_;

--- a/src/widgets/splits/SplitContainer.cpp
+++ b/src/widgets/splits/SplitContainer.cpp
@@ -803,7 +803,7 @@ void SplitContainer::popup()
 }
 
 void SplitContainer::applyFromDescriptorRecursively(
-    const NodeDescriptor &rootNode, Node *node)
+    const NodeDescriptor &rootNode, Node *baseNode)
 {
     if (std::holds_alternative<SplitNodeDescriptor>(rootNode))
     {
@@ -831,8 +831,8 @@ void SplitContainer::applyFromDescriptorRecursively(
 
         bool vertical = containerNode.vertical_;
 
-        node->type_ = vertical ? Node::Type::VerticalContainer
-                               : Node::Type::HorizontalContainer;
+        baseNode->type_ = vertical ? Node::Type::VerticalContainer
+                                   : Node::Type::HorizontalContainer;
 
         for (const auto &item : containerNode.items_)
         {
@@ -850,20 +850,20 @@ void SplitContainer::applyFromDescriptorRecursively(
                 split->setFilters(splitNode.filters_);
 
                 auto *_node = new Node();
-                _node->parent_ = node;
+                _node->parent_ = baseNode;
                 _node->split_ = split;
                 _node->type_ = Node::Type::Split;
 
                 _node->flexH_ = splitNode.flexH_;
                 _node->flexV_ = splitNode.flexV_;
-                node->children_.emplace_back(_node);
+                baseNode->children_.emplace_back(_node);
 
                 this->addSplit(split);
             }
             else
             {
                 auto *_node = new Node();
-                _node->parent_ = node;
+                _node->parent_ = baseNode;
 
                 if (const auto *n = std::get_if<ContainerNodeDescriptor>(&item))
                 {
@@ -871,7 +871,7 @@ void SplitContainer::applyFromDescriptorRecursively(
                     _node->flexV_ = n->flexV_;
                 }
 
-                node->children_.emplace_back(_node);
+                baseNode->children_.emplace_back(_node);
                 this->applyFromDescriptorRecursively(item, _node);
             }
         }

--- a/src/widgets/splits/SplitContainer.cpp
+++ b/src/widgets/splits/SplitContainer.cpp
@@ -155,8 +155,6 @@ void SplitContainer::insertSplit(Split *split, InsertOptions &&options)
             this->baseNode_.findNodeContainingSplit(options.relativeSplit);
         assert(node != nullptr);
 
-        InsertOptions opts{};
-
         options.relativeNode = node;
     }
 

--- a/src/widgets/splits/SplitContainer.cpp
+++ b/src/widgets/splits/SplitContainer.cpp
@@ -486,13 +486,14 @@ void SplitContainer::layout()
     // layout
     this->baseNode_.geometry_ = this->rect().adjusted(-1, -1, 0, 0);
 
-    std::vector<DropRect> _dropRects;
-    std::vector<ResizeRect> _resizeRects;
-    this->baseNode_.layout(
-        Split::modifierStatus == showAddSplitRegions || this->isDragging_,
-        this->scale(), _dropRects, _resizeRects);
+    std::vector<DropRect> dropRects;
+    std::vector<ResizeRect> resizeRects;
 
-    this->dropRects_ = _dropRects;
+    const bool addSpacing =
+        Split::modifierStatus == showAddSplitRegions || this->isDragging_;
+    this->baseNode_.layout(addSpacing, this->scale(), dropRects, resizeRects);
+
+    this->dropRects_ = dropRects;
 
     for (Split *split : this->splits_)
     {
@@ -501,20 +502,20 @@ void SplitContainer::layout()
         Node *node = this->baseNode_.findNodeContainingSplit(split);
 
         // left
-        _dropRects.push_back(
+        dropRects.push_back(
             DropRect(QRect(g.left(), g.top(), g.width() / 3, g.height()),
                      Position(node, Direction::Left)));
         // right
-        _dropRects.push_back(DropRect(QRect(g.right() - g.width() / 3, g.top(),
-                                            g.width() / 3, g.height()),
-                                      Position(node, Direction::Right)));
+        dropRects.push_back(DropRect(QRect(g.right() - g.width() / 3, g.top(),
+                                           g.width() / 3, g.height()),
+                                     Position(node, Direction::Right)));
 
         // top
-        _dropRects.push_back(
+        dropRects.push_back(
             DropRect(QRect(g.left(), g.top(), g.width(), g.height() / 2),
                      Position(node, Direction::Above)));
         // bottom
-        _dropRects.push_back(
+        dropRects.push_back(
             DropRect(QRect(g.left(), g.bottom() - g.height() / 2, g.width(),
                            g.height() / 2),
                      Position(node, Direction::Below)));
@@ -523,30 +524,30 @@ void SplitContainer::layout()
     if (this->splits_.empty())
     {
         QRect g = this->rect();
-        _dropRects.push_back(
+        dropRects.push_back(
             DropRect(QRect(g.left(), g.top(), g.width() - 1, g.height() - 1),
                      Position(nullptr, Direction::Below)));
     }
 
-    this->overlay_.setRects(std::move(_dropRects));
+    this->overlay_.setRects(std::move(dropRects));
 
     // handle resizeHandles
-    if (this->resizeHandles_.size() < _resizeRects.size())
+    if (this->resizeHandles_.size() < resizeRects.size())
     {
-        while (this->resizeHandles_.size() < _resizeRects.size())
+        while (this->resizeHandles_.size() < resizeRects.size())
         {
             this->resizeHandles_.push_back(
                 std::make_unique<ResizeHandle>(this));
         }
     }
-    else if (this->resizeHandles_.size() > _resizeRects.size())
+    else if (this->resizeHandles_.size() > resizeRects.size())
     {
-        this->resizeHandles_.resize(_resizeRects.size());
+        this->resizeHandles_.resize(resizeRects.size());
     }
 
     {
         size_t i = 0;
-        for (ResizeRect &resizeRect : _resizeRects)
+        for (ResizeRect &resizeRect : resizeRects)
         {
             ResizeHandle *handle = this->resizeHandles_[i].get();
             handle->setGeometry(resizeRect.rect);

--- a/src/widgets/splits/SplitContainer.cpp
+++ b/src/widgets/splits/SplitContainer.cpp
@@ -119,7 +119,7 @@ Split *SplitContainer::appendNewSplit(bool openChannelNameDialog)
 {
     assertInGuiThread();
 
-    Split *split = new Split(this);
+    auto *split = new Split(this);
     this->appendSplit(split);
 
     if (openChannelNameDialog)
@@ -469,7 +469,7 @@ void SplitContainer::layout()
     }
 
     // update top right split
-    auto topRight = this->getTopRightSplit(this->baseNode_);
+    auto *topRight = this->getTopRightSplit(this->baseNode_);
     if (this->topRight_)
         this->topRight_->setIsTopRightSplit(false);
     this->topRight_ = topRight;
@@ -610,7 +610,7 @@ void SplitContainer::paintEvent(QPaintEvent *)
 
         QString text = "Click to add a split";
 
-        Notebook *notebook = dynamic_cast<Notebook *>(this->parentWidget());
+        auto *notebook = dynamic_cast<Notebook *>(this->parentWidget());
 
         if (notebook != nullptr)
         {
@@ -767,7 +767,7 @@ void SplitContainer::applyFromDescriptor(const NodeDescriptor &rootNode)
 void SplitContainer::popup()
 {
     Window &window = getApp()->windows->createWindow(WindowType::Popup);
-    auto popupContainer = window.getNotebook().getOrAddSelectedPage();
+    auto *popupContainer = window.getNotebook().getOrAddSelectedPage();
 
     QJsonObject encodedTab;
     WindowManager::encodeTab(this, true, encodedTab);
@@ -796,7 +796,7 @@ void SplitContainer::applyFromDescriptorRecursively(
 {
     if (std::holds_alternative<SplitNodeDescriptor>(rootNode))
     {
-        auto *n = std::get_if<SplitNodeDescriptor>(&rootNode);
+        const auto *n = std::get_if<SplitNodeDescriptor>(&rootNode);
         if (!n)
         {
             return;
@@ -811,7 +811,7 @@ void SplitContainer::applyFromDescriptorRecursively(
     }
     else if (std::holds_alternative<ContainerNodeDescriptor>(rootNode))
     {
-        auto *n = std::get_if<ContainerNodeDescriptor>(&rootNode);
+        const auto *n = std::get_if<ContainerNodeDescriptor>(&rootNode);
         if (!n)
         {
             return;
@@ -827,7 +827,7 @@ void SplitContainer::applyFromDescriptorRecursively(
         {
             if (std::holds_alternative<SplitNodeDescriptor>(item))
             {
-                auto *n = std::get_if<SplitNodeDescriptor>(&item);
+                const auto *n = std::get_if<SplitNodeDescriptor>(&item);
                 if (!n)
                 {
                     return;
@@ -838,7 +838,7 @@ void SplitContainer::applyFromDescriptorRecursively(
                 split->setModerationMode(splitNode.moderationMode_);
                 split->setFilters(splitNode.filters_);
 
-                Node *_node = new Node();
+                auto *_node = new Node();
                 _node->parent_ = node;
                 _node->split_ = split;
                 _node->type_ = Node::_Split;
@@ -851,7 +851,7 @@ void SplitContainer::applyFromDescriptorRecursively(
             }
             else
             {
-                Node *_node = new Node();
+                auto *_node = new Node();
                 _node->parent_ = node;
 
                 if (auto *n = std::get_if<ContainerNodeDescriptor>(&item))
@@ -1152,7 +1152,7 @@ SplitContainer::Position SplitContainer::Node::releaseSplit()
                     siblings.begin() == it ? Direction::Left : Direction::Right;
             }
 
-            Node *_parent = this->parent_;
+            auto *_parent = this->parent_;
             siblings.erase(it);
             std::unique_ptr<Node> &sibling = siblings.front();
             _parent->type_ = sibling->type_;
@@ -1235,7 +1235,7 @@ void SplitContainer::Node::layout(bool addSpacing, float _scale,
             bool isVertical = this->type_ == Node::VerticalContainer;
 
             // vars
-            qreal minSize = qreal(48 * _scale);
+            qreal minSize(48 * _scale);
 
             qreal totalFlex = std::max<qreal>(
                 0.0001, this->getChildrensTotalFlex(isVertical));
@@ -1530,7 +1530,7 @@ void SplitContainer::ResizeHandle::mouseMoveEvent(QMouseEvent *event)
     assert(node != nullptr);
     assert(node->parent_ != nullptr);
 
-    auto &siblings = node->parent_->getChildren();
+    const auto &siblings = node->parent_->getChildren();
     auto it = std::find_if(siblings.begin(), siblings.end(),
                            [this](const std::unique_ptr<Node> &n) {
                                return n.get() == this->node;
@@ -1590,7 +1590,7 @@ void SplitContainer::ResizeHandle::mouseDoubleClickEvent(QMouseEvent *event)
 
 void SplitContainer::ResizeHandle::resetFlex()
 {
-    for (auto &sibling : this->node->getParent()->getChildren())
+    for (const auto &sibling : this->node->getParent()->getChildren())
     {
         sibling->flexH_ = 1;
         sibling->flexV_ = 1;

--- a/src/widgets/splits/SplitContainer.cpp
+++ b/src/widgets/splits/SplitContainer.cpp
@@ -6,7 +6,6 @@
 #include "singletons/Fonts.hpp"
 #include "singletons/Theme.hpp"
 #include "singletons/WindowManager.hpp"
-#include "util/Helpers.hpp"
 #include "util/LayoutCreator.hpp"
 #include "widgets/helper/ChannelView.hpp"
 #include "widgets/helper/NotebookTab.hpp"

--- a/src/widgets/splits/SplitContainer.cpp
+++ b/src/widgets/splits/SplitContainer.cpp
@@ -1161,18 +1161,18 @@ SplitContainer::Position SplitContainer::Node::releaseSplit()
                 siblings.begin() == it ? Direction::Left : Direction::Right;
         }
 
-        auto *_parent = this->parent_;
+        auto *parent = this->parent_;
         siblings.erase(it);
         std::unique_ptr<Node> &sibling = siblings.front();
-        _parent->type_ = sibling->type_;
-        _parent->split_ = sibling->split_;
+        parent->type_ = sibling->type_;
+        parent->split_ = sibling->split_;
         std::vector<std::unique_ptr<Node>> nodes =
             std::move(sibling->children_);
         for (auto &node : nodes)
         {
-            node->parent_ = _parent;
+            node->parent_ = parent;
         }
-        _parent->children_ = std::move(nodes);
+        parent->children_ = std::move(nodes);
     }
     else
     {

--- a/src/widgets/splits/SplitContainer.cpp
+++ b/src/widgets/splits/SplitContainer.cpp
@@ -165,11 +165,11 @@ void SplitContainer::insertSplit(Split *split, Direction direction,
 
     if (relativeTo == nullptr)
     {
-        if (this->baseNode_.type_ == Node::EmptyRoot)
+        if (this->baseNode_.type_ == Node::Type::EmptyRoot)
         {
             this->baseNode_.setSplit(split);
         }
-        else if (this->baseNode_.type_ == Node::_Split)
+        else if (this->baseNode_.type_ == Node::Type::Split)
         {
             this->baseNode_.nestSplitIntoCollection(split, direction);
         }
@@ -413,13 +413,13 @@ void SplitContainer::focusSplitRecursive(Node *node)
 {
     switch (node->type_)
     {
-        case Node::_Split: {
+        case Node::Type::Split: {
             node->split_->setFocus(Qt::FocusReason::OtherFocusReason);
         }
         break;
 
-        case Node::HorizontalContainer:
-        case Node::VerticalContainer: {
+        case Node::Type::HorizontalContainer:
+        case Node::Type::VerticalContainer: {
             auto &children = node->children_;
 
             auto it = std::find_if(
@@ -446,13 +446,13 @@ Split *SplitContainer::getTopRightSplit(Node &node)
 {
     switch (node.getType())
     {
-        case Node::_Split:
+        case Node::Type::Split:
             return node.getSplit();
-        case Node::VerticalContainer:
+        case Node::Type::VerticalContainer:
             if (!node.getChildren().empty())
                 return getTopRightSplit(*node.getChildren().front());
             break;
-        case Node::HorizontalContainer:
+        case Node::Type::HorizontalContainer:
             if (!node.getChildren().empty())
                 return getTopRightSplit(*node.getChildren().back());
             break;
@@ -756,7 +756,7 @@ SplitContainer::Node *SplitContainer::getBaseNode()
 
 void SplitContainer::applyFromDescriptor(const NodeDescriptor &rootNode)
 {
-    assert(this->baseNode_.type_ == Node::EmptyRoot);
+    assert(this->baseNode_.type_ == Node::Type::EmptyRoot);
 
     this->disableLayouting_ = true;
     this->applyFromDescriptorRecursively(rootNode, &this->baseNode_);
@@ -820,8 +820,8 @@ void SplitContainer::applyFromDescriptorRecursively(
 
         bool vertical = containerNode.vertical_;
 
-        node->type_ =
-            vertical ? Node::VerticalContainer : Node::HorizontalContainer;
+        node->type_ = vertical ? Node::Type::VerticalContainer
+                               : Node::Type::HorizontalContainer;
 
         for (const auto &item : containerNode.items_)
         {
@@ -841,7 +841,7 @@ void SplitContainer::applyFromDescriptorRecursively(
                 auto *_node = new Node();
                 _node->parent_ = node;
                 _node->split_ = split;
-                _node->type_ = Node::_Split;
+                _node->type_ = Node::Type::Split;
 
                 _node->flexH_ = splitNode.flexH_;
                 _node->flexV_ = splitNode.flexV_;
@@ -965,7 +965,7 @@ SplitContainer::Node::Node()
 }
 
 SplitContainer::Node::Node(Split *_split, Node *_parent)
-    : type_(Type::_Split)
+    : type_(Type::Split)
     , split_(_split)
     , parent_(_parent)
 {
@@ -987,7 +987,7 @@ bool SplitContainer::Node::isOrContainsNode(SplitContainer::Node *_node)
 SplitContainer::Node *SplitContainer::Node::findNodeContainingSplit(
     Split *_split)
 {
-    if (this->type_ == Type::_Split && this->split_ == _split)
+    if (this->type_ == Type::Split && this->split_ == _split)
     {
         return this;
     }
@@ -1011,19 +1011,19 @@ void SplitContainer::Node::insertSplitRelative(Split *_split,
     {
         switch (this->type_)
         {
-            case Node::EmptyRoot: {
+            case Node::Type::EmptyRoot: {
                 this->setSplit(_split);
             }
             break;
-            case Node::_Split: {
+            case Node::Type::Split: {
                 this->nestSplitIntoCollection(_split, _direction);
             }
             break;
-            case Node::HorizontalContainer: {
+            case Node::Type::HorizontalContainer: {
                 this->nestSplitIntoCollection(_split, _direction);
             }
             break;
-            case Node::VerticalContainer: {
+            case Node::Type::VerticalContainer: {
                 this->nestSplitIntoCollection(_split, _direction);
             }
             break;
@@ -1109,12 +1109,12 @@ void SplitContainer::Node::setSplit(Split *_split)
     assert(this->children_.size() == 0);
 
     this->split_ = _split;
-    this->type_ = Type::_Split;
+    this->type_ = Type::Split;
 }
 
 SplitContainer::Position SplitContainer::Node::releaseSplit()
 {
-    assert(this->type_ == Type::_Split);
+    assert(this->type_ == Type::Split);
 
     if (parent_ == nullptr)
     {
@@ -1224,15 +1224,15 @@ void SplitContainer::Node::layout(bool addSpacing, float _scale,
 
     switch (this->type_)
     {
-        case Node::_Split: {
+        case Node::Type::Split: {
             QRect rect = this->geometry_.toRect();
             this->split_->setGeometry(
                 rect.marginsRemoved(QMargins(1, 1, 0, 0)));
         }
         break;
-        case Node::VerticalContainer:
-        case Node::HorizontalContainer: {
-            bool isVertical = this->type_ == Node::VerticalContainer;
+        case Node::Type::VerticalContainer:
+        case Node::Type::HorizontalContainer: {
+            bool isVertical = this->type_ == Node::Type::VerticalContainer;
 
             // vars
             qreal minSize(48 * _scale);

--- a/src/widgets/splits/SplitContainer.cpp
+++ b/src/widgets/splits/SplitContainer.cpp
@@ -601,7 +601,7 @@ void SplitContainer::mouseReleaseEvent(QMouseEvent *event)
     }
 }
 
-void SplitContainer::paintEvent(QPaintEvent *)
+void SplitContainer::paintEvent(QPaintEvent * /*event*/)
 {
     QPainter painter(this);
 
@@ -724,13 +724,13 @@ void SplitContainer::mouseMoveEvent(QMouseEvent *event)
     this->update();
 }
 
-void SplitContainer::leaveEvent(QEvent *)
+void SplitContainer::leaveEvent(QEvent * /*event*/)
 {
     this->mouseOverPoint_ = QPoint(-10000, -10000);
     this->update();
 }
 
-void SplitContainer::focusInEvent(QFocusEvent *)
+void SplitContainer::focusInEvent(QFocusEvent * /*event*/)
 {
     if (this->baseNode_.findNodeContainingSplit(this->selected_) != nullptr)
     {

--- a/src/widgets/splits/SplitContainer.cpp
+++ b/src/widgets/splits/SplitContainer.cpp
@@ -1383,15 +1383,8 @@ void SplitContainer::Node::layout(bool addSpacing, float _scale,
 
 void SplitContainer::Node::clamp()
 {
-    if (this->flexH_ < 0)
-    {
-        this->flexH_ = 0;
-    }
-
-    if (this->flexV_ < 0)
-    {
-        this->flexV_ = 0;
-    }
+    this->flexH_ = std::max(0.0, this->flexH_);
+    this->flexV_ = std::max(0.0, this->flexV_);
 }
 
 SplitContainer::Node::Type SplitContainer::Node::toContainerType(Direction _dir)

--- a/src/widgets/splits/SplitContainer.cpp
+++ b/src/widgets/splits/SplitContainer.cpp
@@ -142,8 +142,7 @@ void SplitContainer::appendSplit(Split *split)
 
 void SplitContainer::insertSplit(Split *split, const Position &position)
 {
-    this->insertSplit(split, position.direction_,
-                      reinterpret_cast<Node *>(position.relativeNode_));
+    this->insertSplit(split, position.direction_, position.relativeNode_);
 }
 
 void SplitContainer::insertSplit(Split *split, Direction direction,

--- a/src/widgets/splits/SplitContainer.hpp
+++ b/src/widgets/splits/SplitContainer.hpp
@@ -192,7 +192,7 @@ public:
     void setSelected(Split *split);
 
     int getSplitCount();
-    const std::vector<Split *> getSplits() const;
+    std::vector<Split *> getSplits() const;
 
     void refreshTab();
 

--- a/src/widgets/splits/SplitContainer.hpp
+++ b/src/widgets/splits/SplitContainer.hpp
@@ -238,19 +238,7 @@ private:
     void refreshTabTitle();
     void refreshTabLiveStatus();
 
-    struct DropRegion {
-        QRect rect;
-        std::pair<int, int> position;
-
-        DropRegion(QRect rect, std::pair<int, int> position)
-        {
-            this->rect = rect;
-            this->position = position;
-        }
-    };
-
     std::vector<DropRect> dropRects_;
-    std::vector<DropRegion> dropRegions_;
     DropOverlay overlay_;
     std::vector<std::unique_ptr<ResizeHandle>> resizeHandles_;
     QPoint mouseOverPoint_;

--- a/src/widgets/splits/SplitContainer.hpp
+++ b/src/widgets/splits/SplitContainer.hpp
@@ -83,7 +83,12 @@ private:
 
 public:
     struct Node final {
-        enum Type { EmptyRoot, _Split, VerticalContainer, HorizontalContainer };
+        enum class Type {
+            EmptyRoot,
+            Split,
+            VerticalContainer,
+            HorizontalContainer,
+        };
 
         Type getType();
         Split *getSplit();

--- a/src/widgets/splits/SplitContainer.hpp
+++ b/src/widgets/splits/SplitContainer.hpp
@@ -223,9 +223,6 @@ public:
     void hideResizeHandles();
     void resetMouseStatus();
 
-    static bool isDraggingSplit;
-    static Split *draggingSplit;
-
     void applyFromDescriptor(const NodeDescriptor &rootNode);
 
     void popup();
@@ -276,6 +273,7 @@ private:
 
     pajlada::Signals::SignalHolder signalHolder_;
 
+    // Specifies whether the user is currently dragging something over this container
     bool isDragging_ = false;
 };
 

--- a/src/widgets/splits/SplitContainer.hpp
+++ b/src/widgets/splits/SplitContainer.hpp
@@ -115,6 +115,9 @@ public:
                     std::vector<DropRect> &dropRects_,
                     std::vector<ResizeRect> &resizeRects);
 
+        // Clamps the flex values ensuring they're never below 0
+        void clamp();
+
         static Type toContainerType(Direction _dir);
 
         Type type_;

--- a/src/widgets/splits/SplitContainer.hpp
+++ b/src/widgets/splits/SplitContainer.hpp
@@ -194,7 +194,7 @@ public:
     NotebookTab *getTab() const;
     Node *getBaseNode();
 
-    void setTab(NotebookTab *tab_);
+    void setTab(NotebookTab *tab);
     void hideResizeHandles();
     void resetMouseStatus();
 

--- a/src/widgets/splits/SplitContainer.hpp
+++ b/src/widgets/splits/SplitContainer.hpp
@@ -6,14 +6,10 @@
 #include <pajlada/signals/signal.hpp>
 #include <pajlada/signals/signalholder.hpp>
 #include <QDragEnterEvent>
-#include <QHBoxLayout>
 #include <QRect>
-#include <QVBoxLayout>
-#include <QVector>
 #include <QWidget>
 
 #include <algorithm>
-#include <functional>
 #include <optional>
 #include <unordered_map>
 #include <vector>

--- a/src/widgets/splits/SplitContainer.hpp
+++ b/src/widgets/splits/SplitContainer.hpp
@@ -211,7 +211,6 @@ public:
     void selectNextSplit(Direction direction);
     void setSelected(Split *split);
 
-    int getSplitCount();
     std::vector<Split *> getSplits() const;
 
     void refreshTab();

--- a/src/widgets/splits/SplitContainer.hpp
+++ b/src/widgets/splits/SplitContainer.hpp
@@ -227,7 +227,7 @@ protected:
 
 private:
     void applyFromDescriptorRecursively(const NodeDescriptor &rootNode,
-                                        Node *node);
+                                        Node *baseNode);
 
     void layout();
     void selectSplitRecursive(Node *node, Direction direction);

--- a/src/widgets/splits/SplitContainer.hpp
+++ b/src/widgets/splits/SplitContainer.hpp
@@ -189,7 +189,7 @@ public:
     Position deleteSplit(Split *split);
 
     void selectNextSplit(Direction direction);
-    void setSelected(Split *selected_);
+    void setSelected(Split *split);
 
     int getSplitCount();
     const std::vector<Split *> getSplits() const;

--- a/src/widgets/splits/SplitContainer.hpp
+++ b/src/widgets/splits/SplitContainer.hpp
@@ -90,11 +90,11 @@ public:
             HorizontalContainer,
         };
 
-        Type getType();
-        Split *getSplit();
-        Node *getParent();
-        qreal getHorizontalFlex();
-        qreal getVerticalFlex();
+        Type getType() const;
+        Split *getSplit() const;
+        Node *getParent() const;
+        qreal getHorizontalFlex() const;
+        qreal getVerticalFlex() const;
         const std::vector<std::unique_ptr<Node>> &getChildren();
 
     private:


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

- Remove unused include util/Helpers.hpp
- SplitContainer::setTag fix parameter naming
- autofy/constify where possible
- Make SplitNode::Type an enum class
- Make SplitNode::Type an enum class
- Move QuickSwitcherPopup includes from header to source file
- Remove unused DropRegion code
- use empty() instead of size() == 0
- Add curly braces everywhere
- More const auto ptr magicifying
- Remove useless reinterpret_cast
- Clarify that the connect is QObject::connect
- SplitContainer::setSelected fix parameter naming
- Rename function variables to remove unneccesary underscore
- emplace_back where possible
- Name parameters
- Remove ineffective const from return type
- Make node getters const
- Flatten Node::releaseSplit
- Rename in-function variable to match code style
- [ACTUAL CODE CHANGE/MOVE] Move clamp logic to its own function
- name params
- applyFromDescriptorRecursively: rename node to baseNode
- Remove the many overloads for append/insertSplit

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
