### PR TITLE
Add `qt5-imageformats` to Fedora dependency list

### DIFF
--- a/BUILDING_ON_LINUX.md
+++ b/BUILDING_ON_LINUX.md
@@ -20,7 +20,7 @@ Alternatively you can use the [chatterino2-git](https://aur.archlinux.org/packag
 
 _Most likely works the same for other Red Hat-like distros. Substitute `dnf` with `yum`._
 
-Install all of the dependencies using `sudo dnf install qt5-qtbase-devel qt5-qtmultimedia-devel qt5-qtsvg-devel qt5-linguist libsecret-devel openssl-devel boost-devel cmake`
+Install all of the dependencies using `sudo dnf install qt5-qtbase-devel qt5-qtmultimedia-devel qt5-imageformats qt5-qtsvg-devel qt5-linguist libsecret-devel openssl-devel boost-devel cmake`
 
 ### NixOS 18.09+
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Fixes #4264
