### PR TITLE
fix: Remove Unused Include Directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Dev: Ignore `WM_SHOWWINDOW` hide events, causing fewer attempted rescales. (#4198)
 - Dev: Migrated to C++ 20 (#4252, #4257)
 - Dev: Enable LTO for main branch builds. (#4258, #4260)
+- Dev: Removed unused include directives. (#4266)
 
 ## 2.4.0
 

--- a/src/util/StreamerMode.cpp
+++ b/src/util/StreamerMode.cpp
@@ -13,6 +13,13 @@
 #    include <WtsApi32.h>
 // clang-format on
 #    pragma comment(lib, "Wtsapi32.lib")
+#else
+#    include "Application.hpp"
+#    include "messages/MessageBuilder.hpp"
+#    include "providers/twitch/TwitchIrcServer.hpp"
+#    include "widgets/Notebook.hpp"
+#    include "widgets/splits/Split.hpp"
+#    include "widgets/Window.hpp"
 #endif
 
 namespace chatterino {

--- a/src/util/StreamerMode.cpp
+++ b/src/util/StreamerMode.cpp
@@ -20,6 +20,8 @@
 #    include "widgets/Notebook.hpp"
 #    include "widgets/splits/Split.hpp"
 #    include "widgets/Window.hpp"
+
+#    include <QProcess>
 #endif
 
 namespace chatterino {

--- a/src/util/StreamerMode.cpp
+++ b/src/util/StreamerMode.cpp
@@ -1,4 +1,4 @@
-#include "StreamerMode.hpp"
+#include "util/StreamerMode.hpp"
 
 #include "common/QLogging.hpp"
 #include "singletons/Settings.hpp"

--- a/src/util/StreamerMode.cpp
+++ b/src/util/StreamerMode.cpp
@@ -1,9 +1,17 @@
 #include "util/StreamerMode.hpp"
 
+#include "Application.hpp"
 #include "common/QLogging.hpp"
+#include "messages/MessageBuilder.hpp"
+#include "providers/twitch/TwitchIrcServer.hpp"
 #include "singletons/Settings.hpp"
 #include "singletons/WindowManager.hpp"
 #include "widgets/helper/NotebookTab.hpp"
+#include "widgets/Notebook.hpp"
+#include "widgets/splits/Split.hpp"
+#include "widgets/Window.hpp"
+
+#include <QProcess>
 
 #ifdef USEWINSDK
 // clang-format off
@@ -13,15 +21,6 @@
 #    include <WtsApi32.h>
 // clang-format on
 #    pragma comment(lib, "Wtsapi32.lib")
-#else
-#    include "Application.hpp"
-#    include "messages/MessageBuilder.hpp"
-#    include "providers/twitch/TwitchIrcServer.hpp"
-#    include "widgets/Notebook.hpp"
-#    include "widgets/splits/Split.hpp"
-#    include "widgets/Window.hpp"
-
-#    include <QProcess>
 #endif
 
 namespace chatterino {

--- a/src/util/StreamerMode.cpp
+++ b/src/util/StreamerMode.cpp
@@ -1,27 +1,19 @@
 #include "StreamerMode.hpp"
 
-#include "Application.hpp"
 #include "common/QLogging.hpp"
-#include "messages/MessageBuilder.hpp"
-#include "providers/twitch/TwitchIrcServer.hpp"
 #include "singletons/Settings.hpp"
 #include "singletons/WindowManager.hpp"
 #include "widgets/helper/NotebookTab.hpp"
-#include "widgets/Notebook.hpp"
-#include "widgets/splits/Split.hpp"
-#include "widgets/Window.hpp"
 
 #ifdef USEWINSDK
 // clang-format off
+// These imports cannot be ordered alphabetically.
 #    include <Windows.h>
-
 #    include <VersionHelpers.h>
 #    include <WtsApi32.h>
-#    pragma comment(lib, "Wtsapi32.lib")
 // clang-format on
+#    pragma comment(lib, "Wtsapi32.lib")
 #endif
-
-#include <QProcess>
 
 namespace chatterino {
 

--- a/src/util/WindowsHelper.hpp
+++ b/src/util/WindowsHelper.hpp
@@ -2,10 +2,8 @@
 
 #ifdef USEWINSDK
 
-// clang-format off
-#    include <Windows.h>
 #    include <boost/optional.hpp>
-// clang-format on
+#    include <Windows.h>
 
 namespace chatterino {
 

--- a/src/widgets/AttachedWindow.cpp
+++ b/src/widgets/AttachedWindow.cpp
@@ -1,4 +1,4 @@
-#include "AttachedWindow.hpp"
+#include "widgets/AttachedWindow.hpp"
 
 #include "Application.hpp"
 #include "common/QLogging.hpp"

--- a/src/widgets/AttachedWindow.cpp
+++ b/src/widgets/AttachedWindow.cpp
@@ -13,14 +13,14 @@
 #include <memory>
 
 #ifdef USEWINSDK
-// clang-format off
 #    include "util/WindowsHelper.hpp"
 
-#    include "Windows.h"
+// clang-format off
 // don't even think about reordering these
+#    include "Windows.h"
 #    include "Psapi.h"
-#    pragma comment(lib, "Dwmapi.lib")
 // clang-format on
+#    pragma comment(lib, "Dwmapi.lib")
 #endif
 
 namespace chatterino {

--- a/src/widgets/BaseWindow.cpp
+++ b/src/widgets/BaseWindow.cpp
@@ -1,4 +1,4 @@
-#include "BaseWindow.hpp"
+#include "widgets/BaseWindow.hpp"
 
 #include "BaseSettings.hpp"
 #include "singletons/Theme.hpp"

--- a/src/widgets/BaseWindow.cpp
+++ b/src/widgets/BaseWindow.cpp
@@ -1,7 +1,6 @@
 #include "BaseWindow.hpp"
 
 #include "BaseSettings.hpp"
-#include "boost/algorithm/algorithm.hpp"
 #include "singletons/Theme.hpp"
 #include "util/DebugCount.hpp"
 #include "util/PostToThread.hpp"
@@ -11,7 +10,6 @@
 #include "widgets/TooltipWidget.hpp"
 
 #include <QApplication>
-#include <QDebug>
 #include <QDesktopWidget>
 #include <QFont>
 #include <QIcon>
@@ -24,22 +22,16 @@
 #endif
 
 #ifdef USEWINSDK
-// clang-format off
-#    include <ObjIdl.h>
+#    include <dwmapi.h>
 #    include <VersionHelpers.h>
 #    include <Windows.h>
-#    include <dwmapi.h>
-#    include <gdiplus.h>
 #    include <windowsx.h>
 
-//#include <ShellScalingApi.h>
 #    pragma comment(lib, "Dwmapi.lib")
 
 #    include <QHBoxLayout>
-#    include <QVBoxLayout>
 
 #    define WM_DPICHANGED 0x02E0
-// clang-format on
 #endif
 
 #include "widgets/helper/TitlebarButton.hpp"

--- a/src/widgets/FramelessEmbedWindow.cpp
+++ b/src/widgets/FramelessEmbedWindow.cpp
@@ -1,4 +1,4 @@
-#include "FramelessEmbedWindow.hpp"
+#include "widgets/FramelessEmbedWindow.hpp"
 
 #include "Application.hpp"
 #include "common/Args.hpp"

--- a/src/widgets/FramelessEmbedWindow.cpp
+++ b/src/widgets/FramelessEmbedWindow.cpp
@@ -1,13 +1,13 @@
 #include "FramelessEmbedWindow.hpp"
 
 #include "Application.hpp"
+#include "common/Args.hpp"
 #include "providers/twitch/TwitchIrcServer.hpp"
-#include "QJsonDocument"
-#include "QMessageBox"
+#include "widgets/splits/Split.hpp"
 
 #include <QHBoxLayout>
-#include "common/Args.hpp"
-#include "widgets/splits/Split.hpp"
+#include <QJsonDocument>
+#include <QMessageBox>
 
 #ifdef USEWINSDK
 #    include "Windows.h"

--- a/src/widgets/FramelessEmbedWindow.cpp
+++ b/src/widgets/FramelessEmbedWindow.cpp
@@ -6,7 +6,6 @@
 #include "QMessageBox"
 
 #include <QHBoxLayout>
-//#include "widgets/helper/ChannelView.hpp"
 #include "common/Args.hpp"
 #include "widgets/splits/Split.hpp"
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

**This doesn't remove all unused include directives.** I only checked files that had imports that were only present on Windows (`#ifdef USEWINSDK`). Notably, this removes `gdiplus.h` from `BaseWindow.h` which sometimes relied on the `min` and `max` macros defined through `Windows.h`.
