### PR TITLE
Remove unused operators in `Image`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Dev: Migrated to C++ 20 (#4252, #4257)
 - Dev: Enable LTO for main branch builds. (#4258, #4260)
 - Dev: Removed unused include directives. (#4266)
+- Dev: Removed unused operators in `Image` (#4267)
 
 ## 2.4.0
 

--- a/src/messages/Image.cpp
+++ b/src/messages/Image.cpp
@@ -544,23 +544,6 @@ void Image::expireFrames()
     this->shouldLoad_ = true;  // Mark as needing load again
 }
 
-bool Image::operator==(const Image &other) const
-{
-    if (this->isEmpty() && other.isEmpty())
-        return true;
-    if (!this->url_.string.isEmpty() && this->url_ == other.url_)
-        return true;
-    if (this->frames_->first() == other.frames_->first())
-        return true;
-
-    return false;
-}
-
-bool Image::operator!=(const Image &other) const
-{
-    return !this->operator==(other);
-}
-
 ImageExpirationPool::ImageExpirationPool()
 {
     QObject::connect(&this->freeTimer_, &QTimer::timeout, [this] {

--- a/src/messages/Image.hpp
+++ b/src/messages/Image.hpp
@@ -76,8 +76,8 @@ public:
     int height() const;
     bool animated() const;
 
-    bool operator==(const Image &image) const;
-    bool operator!=(const Image &image) const;
+    bool operator==(const Image &image) = delete;
+    bool operator!=(const Image &image) = delete;
 
 private:
     Image();


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

`Image::operator==` and `Image::operator!=` are unused, so I marked them as `delete`.