### PR TITLE
Fix crash that could occur when closing down splits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Bugfix: Fixed text sometimes not pasting properly when image uploader was disabled. (#4246)
 - Bugfix: Fixed text cursor(caret) not showing in open channel dialog. (#4196)
 - Bugfix: Fixed tooltip images not appearing if mouse hovered only first pixel. (#4268)
+- Bugfix: Fixed crash that could occurr when closing down a split at the wrong time. (#4277)
 - Dev: Remove protocol from QApplication's Organization Domain (so changed from `https://www.chatterino.com` to `chatterino.com`). (#4256)
 - Dev: Ignore `WM_SHOWWINDOW` hide events, causing fewer attempted rescales. (#4198)
 - Dev: Migrated to C++ 20 (#4252, #4257)

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -804,6 +804,7 @@ void SplitHeader::updateChannelText()
                  this->lastThumbnail_.elapsed() > THUMBNAIL_MAX_AGE_MS))
             {
                 NetworkRequest(url, NetworkRequestType::Get)
+                    .caller(this)
                     .onSuccess([this](auto result) -> Outcome {
                         // NOTE: We do not follow the redirects, so we need to make sure we only treat code 200 as a valid image
                         if (result.status() == 200)


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Specifically, if a split was closed after the request for a thumbnail
had been made, but before the request had finished, we'd run into a
use-after-free issue

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
