### PR TITLE
Remove Deprecated `QDesktopWidget`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Dev: Removed unused include directives. (#4266, #4275)
 - Dev: Removed TooltipPreviewImage. (#4268)
 - Dev: Removed unused operators in `Image` (#4267)
+- Dev: Removed usage of deprecated `QDesktopWidget` (#4287)
 
 ## 2.4.0
 

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -26,7 +26,6 @@
 
 #include <boost/optional.hpp>
 #include <QDebug>
-#include <QDesktopWidget>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>

--- a/src/widgets/BaseWindow.cpp
+++ b/src/widgets/BaseWindow.cpp
@@ -12,9 +12,9 @@
 #include "widgets/TooltipWidget.hpp"
 
 #include <QApplication>
-#include <QDesktopWidget>
 #include <QFont>
 #include <QIcon>
+#include <QScreen>
 
 #include <functional>
 
@@ -244,7 +244,7 @@ void BaseWindow::setStayInScreenRect(bool value)
 {
     this->stayInScreenRect_ = value;
 
-    this->moveIntoDesktopRect(this, this->pos());
+    this->moveIntoDesktopRect(this->pos());
 }
 
 bool BaseWindow::getStayInScreenRect() const
@@ -522,21 +522,16 @@ void BaseWindow::moveTo(QWidget *parent, QPoint point, bool offset)
         point.ry() += 16;
     }
 
-    this->moveIntoDesktopRect(parent, point);
+    this->moveIntoDesktopRect(point);
 }
 
 void BaseWindow::resizeEvent(QResizeEvent *)
 {
     // Queue up save because: Window resized
-#ifdef CHATTERINO
     if (!flags_.has(DisableLayoutSave))
     {
         getApp()->windows->queueSave();
     }
-
-#endif
-
-    //this->moveIntoDesktopRect(this);
 
 #ifdef USEWINSDK
     if (this->hasCustomWindowFrame() && !this->isResizeFixing_)
@@ -581,50 +576,55 @@ void BaseWindow::closeEvent(QCloseEvent *)
 
 void BaseWindow::showEvent(QShowEvent *)
 {
-    this->moveIntoDesktopRect(this, this->pos());
+    this->moveIntoDesktopRect(this->pos());
     if (this->frameless_)
     {
         QTimer::singleShot(30, this, [this] {
-            this->moveIntoDesktopRect(this, this->pos());
+            this->moveIntoDesktopRect(this->pos());
         });
     }
 }
 
-void BaseWindow::moveIntoDesktopRect(QWidget *parent, QPoint point)
+void BaseWindow::moveIntoDesktopRect(QPoint point)
 {
     if (!this->stayInScreenRect_)
+    {
         return;
+    }
 
     // move the widget into the screen geometry if it's not already in there
-    QDesktopWidget *desktop = QApplication::desktop();
-    QPoint globalCursorPos = QCursor::pos();
-
-    QRect s = desktop->availableGeometry(parent);
+    auto *screen = QApplication::screenAt(point);
+    if (screen == nullptr)
+    {
+        screen = QApplication::primaryScreen();
+    }
+    const QRect bounds = screen->availableGeometry();
 
     bool stickRight = false;
     bool stickBottom = false;
 
-    if (point.x() < s.left())
+    if (point.x() < bounds.left())
     {
-        point.setX(s.left());
+        point.setX(bounds.left());
     }
-    if (point.y() < s.top())
+    if (point.y() < bounds.top())
     {
-        point.setY(s.top());
+        point.setY(bounds.top());
     }
-    if (point.x() + this->width() > s.right())
+    if (point.x() + this->width() > bounds.right())
     {
         stickRight = true;
-        point.setX(s.right() - this->width());
+        point.setX(bounds.right() - this->width());
     }
-    if (point.y() + this->height() > s.bottom())
+    if (point.y() + this->height() > bounds.bottom())
     {
         stickBottom = true;
-        point.setY(s.bottom() - this->height());
+        point.setY(bounds.bottom() - this->height());
     }
 
     if (stickRight && stickBottom)
     {
+        const QPoint globalCursorPos = QCursor::pos();
         point.setY(globalCursorPos.y() - this->height() - 16);
     }
 

--- a/src/widgets/BaseWindow.hpp
+++ b/src/widgets/BaseWindow.hpp
@@ -96,7 +96,7 @@ protected:
 
 private:
     void init();
-    void moveIntoDesktopRect(QWidget *parent, QPoint point);
+    void moveIntoDesktopRect(QPoint point);
     void calcButtonsSizes();
     void drawCustomWindowFrame(QPainter &painter);
     void onFocusLost();

--- a/src/widgets/dialogs/NotificationPopup.cpp
+++ b/src/widgets/dialogs/NotificationPopup.cpp
@@ -5,7 +5,6 @@
 #include "widgets/helper/ChannelView.hpp"
 
 #include <QApplication>
-#include <QDesktopWidget>
 #include <QScreen>
 #include <QVBoxLayout>
 

--- a/src/widgets/helper/Button.cpp
+++ b/src/widgets/helper/Button.cpp
@@ -5,8 +5,8 @@
 
 #include <QApplication>
 #include <QDebug>
-#include <QDesktopWidget>
 #include <QPainter>
+#include <QScreen>
 
 namespace chatterino {
 namespace {
@@ -345,10 +345,15 @@ void Button::showMenu()
         return;
 
     auto point = [this] {
-        auto bounds = QApplication::desktop()->availableGeometry(this);
-
         auto point = this->mapToGlobal(
             QPoint(this->width() - this->menu_->width(), this->height()));
+
+        auto *screen = QApplication::screenAt(point);
+        if (screen == nullptr)
+        {
+            screen = QApplication::primaryScreen();
+        }
+        auto bounds = screen->availableGeometry();
 
         if (point.y() + this->menu_->height() > bounds.bottom())
         {

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -28,7 +28,6 @@
 #include "widgets/splits/SplitContainer.hpp"
 #include "widgets/TooltipWidget.hpp"
 
-#include <QDesktopWidget>
 #include <QDrag>
 #include <QHBoxLayout>
 #include <QInputDialog>


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

[`QDesktopWidget` is marked as obsolete](https://doc.qt.io/qt-5/qdesktopwidget.html) in Qt 5 and removed in Qt 6. This PR migrates two (similar) usages.

Both used `QDesktopWidget` to check if something is inside the screen or not. [`QDesktopWidget::availableGeometry`](https://doc.qt.io/qt-5/qdesktopwidget.html#screenGeometry-1) used to return the available geometry of the screen the widget was in. Now, [`QGuiApplication::screenAt`](https://doc.qt.io/qt-5/qguiapplication.html#screenAt) is used.

Fixes #1926