### PR TITLE
Fix scrollbar highlight colors when changing message history limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Bugfix: Fixed tooltip images not appearing if mouse hovered only first pixel. (#4268)
 - Bugfix: Fixed crash that could occur when closing down a split at the wrong time. (#4277)
 - Bugfix: Fixed crash that could occur when closing down the last of a channel when reloading emotes. (#4278)
+- Bugfix: Fixed scrollbar highlight colors when changing message history limit. (#4288)
 - Dev: Remove protocol from QApplication's Organization Domain (so changed from `https://www.chatterino.com` to `chatterino.com`). (#4256)
 - Dev: Ignore `WM_SHOWWINDOW` hide events, causing fewer attempted rescales. (#4198)
 - Dev: Migrated to C++ 20 (#4252, #4257)

--- a/src/widgets/Scrollbar.cpp
+++ b/src/widgets/Scrollbar.cpp
@@ -16,9 +16,10 @@
 
 namespace chatterino {
 
-Scrollbar::Scrollbar(ChannelView *parent)
+Scrollbar::Scrollbar(size_t messagesLimit, ChannelView *parent)
     : BaseWidget(parent)
     , currentValueAnimation_(this, "currentValue_")
+    , highlights_(messagesLimit)
 {
     resize(int(16 * this->scale()), 100);
     this->currentValueAnimation_.setDuration(150);

--- a/src/widgets/Scrollbar.hpp
+++ b/src/widgets/Scrollbar.hpp
@@ -18,7 +18,7 @@ class Scrollbar : public BaseWidget
     Q_OBJECT
 
 public:
-    Scrollbar(ChannelView *parent = nullptr);
+    Scrollbar(size_t messagesLimit, ChannelView *parent = nullptr);
 
     void addHighlight(ScrollbarHighlight highlight);
     void addHighlightsAtStart(

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -147,7 +147,7 @@ ChannelView::ChannelView(BaseWidget *parent, Split *split, Context context,
                          size_t messagesLimit)
     : BaseWidget(parent)
     , split_(split)
-    , scrollBar_(new Scrollbar(this))
+    , scrollBar_(new Scrollbar(messagesLimit, this))
     , highlightAnimation_(this)
     , context_(context)
     , messages_(messagesLimit)


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

If the default channel scrollback limit is changed in settings, more messages will be stored but the original number of highlights are stored in the scrollbar. This PR updates the scrollbar to be consistent with the channel.

Fixes #4270
