### PR TITLE
Fix: dont run windeployqt with VCPKG

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -637,15 +637,17 @@ if (BUILD_APP)
         )
 
     if (MSVC)
-        get_target_property(Qt_Core_Location Qt${MAJOR_QT_VERSION}::Core LOCATION)
-        get_filename_component(QT_BIN_DIR ${Qt_Core_Location} DIRECTORY)
-        set(WINDEPLOYQT_COMMAND "${QT_BIN_DIR}/windeployqt.exe" $<TARGET_FILE:${EXECUTABLE_PROJECT}> --release --no-compiler-runtime --no-translations --no-opengl-sw)
+        if (NOT VCPKG_INSTALLED_DIR)
+            get_target_property(Qt_Core_Location Qt${MAJOR_QT_VERSION}::Core LOCATION)
+            get_filename_component(QT_BIN_DIR ${Qt_Core_Location} DIRECTORY)
+            set(WINDEPLOYQT_COMMAND "${QT_BIN_DIR}/windeployqt.exe" $<TARGET_FILE:${EXECUTABLE_PROJECT}> --release --no-compiler-runtime --no-translations --no-opengl-sw)
 
-        install(TARGETS ${EXECUTABLE_PROJECT}
-                RUNTIME DESTINATION .
-                )
+            install(TARGETS ${EXECUTABLE_PROJECT}
+                    RUNTIME DESTINATION .
+                    )
 
-        install(CODE "execute_process(COMMAND ${WINDEPLOYQT_COMMAND} --dir \${CMAKE_INSTALL_PREFIX})")
+            install(CODE "execute_process(COMMAND ${WINDEPLOYQT_COMMAND} --dir \${CMAKE_INSTALL_PREFIX})")
+        endif()
     elseif (APPLE)
         install(TARGETS ${EXECUTABLE_PROJECT}
                 RUNTIME DESTINATION bin


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description
vcpkg handles coping of required dependencies [by itself](https://github.com/microsoft/vcpkg/blob/master/ports/qt5-base/qtdeploy.ps1), PR adds check for VCPKG to skip unnecessary run of windeployqt.exe (which did nothing anyway due to path differences).

suggest no changelog 