### PR TITLE
Add CMake Install Support for Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Dev: Fixed `final-dtor-non-final-class` warnings. (#4296)
 - Dev: Fixed `ambiguous-reversed-operator` warnings. (#4296)
 - Dev: Format YAML and JSON files with prettier. (#4304)
+- Dev: Addded CMake Install Support on Windows. (#4300)
 
 ## 2.4.0
 

--- a/resources/qt.conf
+++ b/resources/qt.conf
@@ -1,4 +1,2 @@
 [Platforms]
 WindowArguments = dpiawareness=2
-[Paths]
-Plugins = ./plugins

--- a/resources/qt.conf
+++ b/resources/qt.conf
@@ -1,2 +1,4 @@
 [Platforms]
 WindowArguments = dpiawareness=2
+[Paths]
+Plugins = ./plugins

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -649,17 +649,32 @@ if (BUILD_APP)
         )
 
     if (MSVC)
-        if (NOT VCPKG_INSTALLED_DIR)
+        if (NOT WINDEPLOYQT_PATH)
             get_target_property(Qt_Core_Location Qt${MAJOR_QT_VERSION}::Core LOCATION)
             get_filename_component(QT_BIN_DIR ${Qt_Core_Location} DIRECTORY)
-            set(WINDEPLOYQT_COMMAND "${QT_BIN_DIR}/windeployqt.exe" $<TARGET_FILE:${EXECUTABLE_PROJECT}> --release --no-compiler-runtime --no-translations --no-opengl-sw)
-
-            install(TARGETS ${EXECUTABLE_PROJECT}
-                    RUNTIME DESTINATION .
-                    )
-
-            install(CODE "execute_process(COMMAND ${WINDEPLOYQT_COMMAND} --dir \${CMAKE_INSTALL_PREFIX})")
+            string(APPEND WINDEPLOYQT_PATH ${QT_BIN_DIR} /windeployqt.exe)
+        else()
+            file(TO_CMAKE_PATH "${WINDEPLOYQT_PATH}" WINDEPLOYQT_PATH)
         endif()
+
+        if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+            set(WINDEPLOYQT_MODE --debug)
+        else()
+            set(WINDEPLOYQT_MODE --release)
+        endif()
+
+        set(WINDEPLOYQT_COMMAND_ARGV "${WINDEPLOYQT_PATH}" "$<TARGET_FILE:${EXECUTABLE_PROJECT}>" ${WINDEPLOYQT_MODE} --no-compiler-runtime --no-translations --no-opengl-sw)
+        string(REPLACE ";" " " WINDEPLOYQT_COMMAND "${WINDEPLOYQT_COMMAND_ARGV}")
+
+        install(TARGETS ${EXECUTABLE_PROJECT} 
+            RUNTIME_DEPENDENCIES 
+                PRE_EXCLUDE_REGEXES "api-ms-" "ext-ms-"
+                POST_EXCLUDE_REGEXES ".*system32/.*\\.dll" 
+                DIRECTORIES ${QT_BIN_DIR}
+            RUNTIME DESTINATION .)
+
+        install(CODE "message(\"Running: ${WINDEPLOYQT_COMMAND} --dir \\\"\${CMAKE_INSTALL_PREFIX}\\\"\")")
+        install(CODE "execute_process(COMMAND ${WINDEPLOYQT_COMMAND} --dir \"\${CMAKE_INSTALL_PREFIX}\" COMMAND_ERROR_IS_FATAL ANY)")
     elseif (APPLE)
         install(TARGETS ${EXECUTABLE_PROJECT}
                 RUNTIME DESTINATION bin

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -668,10 +668,6 @@ if (BUILD_APP)
 
         if (X_VCPKG_APPLOCAL_DEPS_INSTALL)
             install(TARGETS ${EXECUTABLE_PROJECT} RUNTIME DESTINATION .)
-            install(CODE "message(\"-- Flattening plugins/\")")
-            # vcpkg will add the plugin folders (like "iconengines" or "mediaformats") inside a `plugins` folder.
-            # We need to flatten this folder, thus we're running `mv plugins/* . && rm plugins` in powershell.
-            install(CODE "execute_process(COMMAND powershell \"& { Move-Item -Path \\\"${CMAKE_INSTALL_PREFIX}/plugins/*\\\" -Destination \\\"${CMAKE_INSTALL_PREFIX}\\\"; Remove-Item \\\"${CMAKE_INSTALL_PREFIX}/plugins\\\" }\" COMMAND_ERROR_IS_FATAL ANY)")
         else()
             install(TARGETS ${EXECUTABLE_PROJECT} 
                 RUNTIME_DEPENDENCIES 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -667,8 +667,10 @@ if (BUILD_APP)
         string(REPLACE ";" " " WINDEPLOYQT_COMMAND "${WINDEPLOYQT_COMMAND_ARGV}")
 
         if (X_VCPKG_APPLOCAL_DEPS_INSTALL)
+            # Requires CMake 3.14
             install(TARGETS ${EXECUTABLE_PROJECT} RUNTIME DESTINATION .)
         else()
+            # Requires CMake 3.21
             install(TARGETS ${EXECUTABLE_PROJECT} 
                 RUNTIME_DEPENDENCIES 
                     PRE_EXCLUDE_REGEXES "api-ms-" "ext-ms-"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -648,7 +648,7 @@ if (BUILD_APP)
         RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO "${CMAKE_BINARY_DIR}/bin"
         )
 
-    if (MSVC)
+    if (WIN32)
         if (NOT WINDEPLOYQT_PATH)
             get_target_property(Qt_Core_Location Qt${MAJOR_QT_VERSION}::Core LOCATION)
             get_filename_component(QT_BIN_DIR ${Qt_Core_Location} DIRECTORY)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -667,10 +667,12 @@ if (BUILD_APP)
         string(REPLACE ";" " " WINDEPLOYQT_COMMAND "${WINDEPLOYQT_COMMAND_ARGV}")
 
         if (X_VCPKG_APPLOCAL_DEPS_INSTALL)
-            # Requires CMake 3.14
             install(TARGETS ${EXECUTABLE_PROJECT} RUNTIME DESTINATION .)
+            install(CODE "message(\"-- Flattening plugins/\")")
+            # vcpkg will add the plugin folders (like "iconengines" or "mediaformats") inside a `plugins` folder.
+            # We need to flatten this folder, thus we're running `mv plugins/* . && rm plugins` in powershell.
+            install(CODE "execute_process(COMMAND powershell \"& { Move-Item -Path \\\"${CMAKE_INSTALL_PREFIX}/plugins/*\\\" -Destination \\\"${CMAKE_INSTALL_PREFIX}\\\"; Remove-Item \\\"${CMAKE_INSTALL_PREFIX}/plugins\\\" }\" COMMAND_ERROR_IS_FATAL ANY)")
         else()
-            # Requires CMake 3.21
             install(TARGETS ${EXECUTABLE_PROJECT} 
                 RUNTIME_DEPENDENCIES 
                     PRE_EXCLUDE_REGEXES "api-ms-" "ext-ms-"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -666,15 +666,18 @@ if (BUILD_APP)
         set(WINDEPLOYQT_COMMAND_ARGV "${WINDEPLOYQT_PATH}" "$<TARGET_FILE:${EXECUTABLE_PROJECT}>" ${WINDEPLOYQT_MODE} --no-compiler-runtime --no-translations --no-opengl-sw)
         string(REPLACE ";" " " WINDEPLOYQT_COMMAND "${WINDEPLOYQT_COMMAND_ARGV}")
 
-        install(TARGETS ${EXECUTABLE_PROJECT} 
-            RUNTIME_DEPENDENCIES 
-                PRE_EXCLUDE_REGEXES "api-ms-" "ext-ms-"
-                POST_EXCLUDE_REGEXES ".*system32/.*\\.dll" 
-                DIRECTORIES ${QT_BIN_DIR}
-            RUNTIME DESTINATION .)
-
-        install(CODE "message(\"Running: ${WINDEPLOYQT_COMMAND} --dir \\\"\${CMAKE_INSTALL_PREFIX}\\\"\")")
-        install(CODE "execute_process(COMMAND ${WINDEPLOYQT_COMMAND} --dir \"\${CMAKE_INSTALL_PREFIX}\" COMMAND_ERROR_IS_FATAL ANY)")
+        if (X_VCPKG_APPLOCAL_DEPS_INSTALL)
+            install(TARGETS ${EXECUTABLE_PROJECT} RUNTIME DESTINATION .)
+        else()
+            install(TARGETS ${EXECUTABLE_PROJECT} 
+                RUNTIME_DEPENDENCIES 
+                    PRE_EXCLUDE_REGEXES "api-ms-" "ext-ms-"
+                    POST_EXCLUDE_REGEXES ".*system32/.*\\.dll" 
+                    DIRECTORIES ${QT_BIN_DIR}
+                RUNTIME DESTINATION .)
+            install(CODE "message(\"-- Running: ${WINDEPLOYQT_COMMAND} --dir \\\"\${CMAKE_INSTALL_PREFIX}\\\"\")")
+            install(CODE "execute_process(COMMAND ${WINDEPLOYQT_COMMAND} --dir \"\${CMAKE_INSTALL_PREFIX}\" COMMAND_ERROR_IS_FATAL ANY)")        
+        endif()
     elseif (APPLE)
         install(TARGETS ${EXECUTABLE_PROJECT}
                 RUNTIME DESTINATION bin


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Chatterino had only [rudimentary support](https://github.com/Chatterino/chatterino2/blob/5ad8ca791c0498fb39e21d07b3c0e856b3e7677b/src/CMakeLists.txt#L640-L648) for `<build-tool> install` on Windows, because it only copied the `chatterino.exe`.

There were two main issues:

1. No shared libraries such as openssl were copied to `CMAKE_INSTALL_PREFIX`.
2. `windeployqt` never ran, because the command silently failed (cmake's [set](https://cmake.org/cmake/help/latest/command/set.html) joins [multiple arguments](https://github.com/Chatterino/chatterino2/blob/5ad8ca791c0498fb39e21d07b3c0e856b3e7677b/src/CMakeLists.txt#L642) as a semicolon-separated list).

This PR addresses these issues:

1. The [`RUNTIME_DEPENDENCIES`](https://cmake.org/cmake/help/latest/command/install.html#targets) are included. Windows DLLs are excluded, as done [here](https://discourse.cmake.org/t/runtime-dependencies-cannot-find-dll/3782).
2. `windeployqt` is run and aborts in case of any error ([`COMMAND_ERROR_IS_FATAL ANY`](https://cmake.org/cmake/help/latest/command/execute_process.html))

Furthermore, it reverts #4297 and adds awareness for `CMAKE_BUILD_TYPE`.

### How to build and install

**Using conan:**
```cmd
cmake .. -DUSE_CONAN=On -DCMAKE_PREFIX_PATH=<qt-path>\msvc2019_64\lib\cmake\Qt5 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=<install-dir> -GNinja
ninja
ninja install
```

### Known issues

For `vcpkg`, `-DX_VCPKG_APPLOCAL_DEPS_INSTALL` is required.

### Documentation

I didn't add any documentation since this feature was never used. I want to rewrite the documentation for Windows (to include VS Code, Visual Studio, and vcpkg) so I'll add it there.
