### PR TITLE
Add feature to select channels to log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@
 - Dev: Fixed `inconsistent-missing-override` warnings. (#4296)
 - Dev: Fixed `final-dtor-non-final-class` warnings. (#4296)
 - Dev: Fixed `ambiguous-reversed-operator` warnings. (#4296)
-- Dev: Add settings to select which channels to log. (#4302)
+- Minor: Add settings to select which channels to log. (#4302)
 
 ## 2.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Minor: Tables in settings window will now scroll to newly added rows. (#4216)
 - Minor: Added link to streamlink docs for easier user setup. (#4217)
 - Minor: Added setting to turn off rendering of reply context. (#4224)
+- Minor: Added setting to select which channels to log. (#4302)
 - Bugfix: Fixed crash that would occur when performing certain actions after removing all tabs. (#4271)
 - Bugfix: Fixed highlight sounds not reloading on change properly. (#4194)
 - Bugfix: Fixed CTRL + C not working in reply thread popups. (#4209)
@@ -33,7 +34,6 @@
 - Dev: Fixed `inconsistent-missing-override` warnings. (#4296)
 - Dev: Fixed `final-dtor-non-final-class` warnings. (#4296)
 - Dev: Fixed `ambiguous-reversed-operator` warnings. (#4296)
-- Minor: Add settings to select which channels to log. (#4302)
 
 ## 2.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Dev: Fixed `inconsistent-missing-override` warnings. (#4296)
 - Dev: Fixed `final-dtor-non-final-class` warnings. (#4296)
 - Dev: Fixed `ambiguous-reversed-operator` warnings. (#4296)
+- Dev: Add settings to select which channels to log. (#4302)
 
 ## 2.4.0
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -119,6 +119,9 @@ set(SOURCE_FILES
         controllers/moderationactions/ModerationActionModel.cpp
         controllers/moderationactions/ModerationActionModel.hpp
 
+        controllers/logging/ChannelLoggingModel.cpp
+        controllers/logging/ChannelLoggingModel.hpp
+
         controllers/nicknames/NicknamesModel.cpp
         controllers/nicknames/NicknamesModel.hpp
         controllers/nicknames/Nickname.hpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -119,6 +119,8 @@ set(SOURCE_FILES
         controllers/moderationactions/ModerationActionModel.cpp
         controllers/moderationactions/ModerationActionModel.hpp
 
+        controllers/logging/ChannelLog.cpp
+        controllers/logging/ChannelLog.hpp
         controllers/logging/ChannelLoggingModel.cpp
         controllers/logging/ChannelLoggingModel.hpp
 

--- a/src/controllers/logging/ChannelLog.cpp
+++ b/src/controllers/logging/ChannelLog.cpp
@@ -2,14 +2,19 @@
 
 namespace chatterino {
 
-ChannelLog::ChannelLog(QString channel_)
-    : channel(std::move(channel_))
+ChannelLog::ChannelLog(QString channelName)
+    : channelName_(std::move(channelName))
 {
+}
+
+QString ChannelLog::channelName() const
+{
+    return this->channelName_;
 }
 
 QString ChannelLog::toString() const
 {
-    return this->channel;
+    return this->channelName_;
 }
 
 ChannelLog ChannelLog::createEmpty()

--- a/src/controllers/logging/ChannelLog.cpp
+++ b/src/controllers/logging/ChannelLog.cpp
@@ -2,9 +2,8 @@
 
 namespace chatterino {
 
-// ChannelLog
-ChannelLog::ChannelLog(const QString &channel)
-    : channel(channel)
+ChannelLog::ChannelLog(QString channel_)
+    : channel(std::move(channel_))
 {
 }
 

--- a/src/controllers/logging/ChannelLog.cpp
+++ b/src/controllers/logging/ChannelLog.cpp
@@ -1,0 +1,22 @@
+#include "ChannelLog.hpp"
+
+namespace chatterino {
+
+// ChannelLog
+ChannelLog::ChannelLog(const QString &channel, bool loggingEnabled)
+{
+    this->channel = channel;
+    this->loggingEnabled = loggingEnabled;
+}
+
+QString ChannelLog::toString() const
+{
+    return this->channel;
+}
+
+ChannelLog ChannelLog::createEmpty()
+{
+    return ChannelLog("", false);
+}
+
+}  // namespace chatterino

--- a/src/controllers/logging/ChannelLog.cpp
+++ b/src/controllers/logging/ChannelLog.cpp
@@ -1,12 +1,12 @@
-#include "ChannelLog.hpp"
+#include "controllers/logging/ChannelLog.hpp"
 
 namespace chatterino {
 
 // ChannelLog
 ChannelLog::ChannelLog(const QString &channel, bool loggingEnabled)
+    : channel(channel)
+    , loggingEnabled(loggingEnabled)
 {
-    this->channel = channel;
-    this->loggingEnabled = loggingEnabled;
 }
 
 QString ChannelLog::toString() const

--- a/src/controllers/logging/ChannelLog.cpp
+++ b/src/controllers/logging/ChannelLog.cpp
@@ -14,7 +14,7 @@ QString ChannelLog::toString() const
 
 ChannelLog ChannelLog::createEmpty()
 {
-    return ChannelLog("");
+    return {""};
 }
 
 }  // namespace chatterino

--- a/src/controllers/logging/ChannelLog.cpp
+++ b/src/controllers/logging/ChannelLog.cpp
@@ -3,9 +3,8 @@
 namespace chatterino {
 
 // ChannelLog
-ChannelLog::ChannelLog(const QString &channel, bool loggingEnabled)
+ChannelLog::ChannelLog(const QString &channel)
     : channel(channel)
-    , loggingEnabled(loggingEnabled)
 {
 }
 
@@ -16,7 +15,7 @@ QString ChannelLog::toString() const
 
 ChannelLog ChannelLog::createEmpty()
 {
-    return ChannelLog("", false);
+    return ChannelLog("");
 }
 
 }  // namespace chatterino

--- a/src/controllers/logging/ChannelLog.hpp
+++ b/src/controllers/logging/ChannelLog.hpp
@@ -45,28 +45,28 @@ struct Deserialize<chatterino::ChannelLog> {
     static chatterino::ChannelLog get(const rapidjson::Value &value,
                                       bool *error = nullptr)
     {
-        chatterino::ChannelLog ChannelLog =
+        chatterino::ChannelLog channelLog =
             chatterino::ChannelLog::createEmpty();
 
         if (!value.IsObject())
         {
             PAJLADA_REPORT_ERROR(error);
-            return ChannelLog;
+            return channelLog;
         }
 
-        if (!chatterino::rj::getSafe(value, "channel", ChannelLog.channel))
+        if (!chatterino::rj::getSafe(value, "channel", channelLog.channel))
         {
             PAJLADA_REPORT_ERROR(error);
-            return ChannelLog;
+            return channelLog;
         }
         if (!chatterino::rj::getSafe(value, "loggingEnabled",
-                                     ChannelLog.loggingEnabled))
+                                     channelLog.loggingEnabled))
         {
             PAJLADA_REPORT_ERROR(error);
-            return ChannelLog;
+            return channelLog;
         }
 
-        return ChannelLog;
+        return channelLog;
     }
 };
 

--- a/src/controllers/logging/ChannelLog.hpp
+++ b/src/controllers/logging/ChannelLog.hpp
@@ -16,9 +16,9 @@ public:
 
     bool operator==(const ChannelLog &other) const;
 
-    QString toString() const;
+    [[nodiscard]] QString toString() const;
 
-    static ChannelLog createEmpty();
+    [[nodiscard]] static ChannelLog createEmpty();
 };
 
 }  // namespace chatterino

--- a/src/controllers/logging/ChannelLog.hpp
+++ b/src/controllers/logging/ChannelLog.hpp
@@ -12,7 +12,7 @@ class ChannelLog
 public:
     QString channel;
 
-    ChannelLog(const QString &channel);
+    ChannelLog(QString channel_);
 
     bool operator==(const ChannelLog &other) const;
 

--- a/src/controllers/logging/ChannelLog.hpp
+++ b/src/controllers/logging/ChannelLog.hpp
@@ -9,12 +9,14 @@ namespace chatterino {
 
 class ChannelLog
 {
-public:
-    QString channel;
+    QString channelName_;
 
-    ChannelLog(QString channel_);
+public:
+    ChannelLog(QString channelName);
 
     bool operator==(const ChannelLog &other) const;
+
+    [[nodiscard]] QString channelName() const;
 
     [[nodiscard]] QString toString() const;
 
@@ -32,7 +34,7 @@ struct Serialize<chatterino::ChannelLog> {
     {
         rapidjson::Value ret(rapidjson::kObjectType);
 
-        chatterino::rj::set(ret, "channel", value.channel, a);
+        chatterino::rj::set(ret, "channelName", value.channelName(), a);
 
         return ret;
     }
@@ -43,22 +45,21 @@ struct Deserialize<chatterino::ChannelLog> {
     static chatterino::ChannelLog get(const rapidjson::Value &value,
                                       bool *error = nullptr)
     {
-        chatterino::ChannelLog channelLog =
-            chatterino::ChannelLog::createEmpty();
-
         if (!value.IsObject())
         {
             PAJLADA_REPORT_ERROR(error);
-            return channelLog;
+            return chatterino::ChannelLog::createEmpty();
         }
 
-        if (!chatterino::rj::getSafe(value, "channel", channelLog.channel))
+        QString channelName;
+
+        if (!chatterino::rj::getSafe(value, "channelName", channelName))
         {
             PAJLADA_REPORT_ERROR(error);
-            return channelLog;
+            return chatterino::ChannelLog::createEmpty();
         }
 
-        return channelLog;
+        return {channelName};
     }
 };
 

--- a/src/controllers/logging/ChannelLog.hpp
+++ b/src/controllers/logging/ChannelLog.hpp
@@ -11,9 +11,8 @@ class ChannelLog
 {
 public:
     QString channel;
-    bool loggingEnabled;
 
-    ChannelLog(const QString &channel, bool loggingEnabled);
+    ChannelLog(const QString &channel);
 
     bool operator==(const ChannelLog &other) const;
 
@@ -34,7 +33,6 @@ struct Serialize<chatterino::ChannelLog> {
         rapidjson::Value ret(rapidjson::kObjectType);
 
         chatterino::rj::set(ret, "channel", value.channel, a);
-        chatterino::rj::set(ret, "loggingEnabled", value.loggingEnabled, a);
 
         return ret;
     }
@@ -55,12 +53,6 @@ struct Deserialize<chatterino::ChannelLog> {
         }
 
         if (!chatterino::rj::getSafe(value, "channel", channelLog.channel))
-        {
-            PAJLADA_REPORT_ERROR(error);
-            return channelLog;
-        }
-        if (!chatterino::rj::getSafe(value, "loggingEnabled",
-                                     channelLog.loggingEnabled))
         {
             PAJLADA_REPORT_ERROR(error);
             return channelLog;

--- a/src/controllers/logging/ChannelLog.hpp
+++ b/src/controllers/logging/ChannelLog.hpp
@@ -7,7 +7,8 @@
 
 namespace chatterino {
 
-class ChannelLog {
+class ChannelLog
+{
 public:
     QString channel;
     bool loggingEnabled;
@@ -42,9 +43,10 @@ struct Serialize<chatterino::ChannelLog> {
 template <>
 struct Deserialize<chatterino::ChannelLog> {
     static chatterino::ChannelLog get(const rapidjson::Value &value,
-                                   bool *error = nullptr)
+                                      bool *error = nullptr)
     {
-        chatterino::ChannelLog ChannelLog = chatterino::ChannelLog::createEmpty();
+        chatterino::ChannelLog ChannelLog =
+            chatterino::ChannelLog::createEmpty();
 
         if (!value.IsObject())
         {
@@ -57,7 +59,8 @@ struct Deserialize<chatterino::ChannelLog> {
             PAJLADA_REPORT_ERROR(error);
             return ChannelLog;
         }
-        if (!chatterino::rj::getSafe(value, "loggingEnabled", ChannelLog.loggingEnabled))
+        if (!chatterino::rj::getSafe(value, "loggingEnabled",
+                                     ChannelLog.loggingEnabled))
         {
             PAJLADA_REPORT_ERROR(error);
             return ChannelLog;

--- a/src/controllers/logging/ChannelLog.hpp
+++ b/src/controllers/logging/ChannelLog.hpp
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "util/RapidjsonHelpers.hpp"
+
+#include <pajlada/serialize.hpp>
+#include <QString>
+
+namespace chatterino {
+
+class ChannelLog {
+public:
+    QString channel;
+    bool loggingEnabled;
+
+    ChannelLog(const QString &channel, bool loggingEnabled);
+
+    bool operator==(const ChannelLog &other) const;
+
+    QString toString() const;
+
+    static ChannelLog createEmpty();
+};
+
+}  // namespace chatterino
+
+namespace pajlada {
+
+template <>
+struct Serialize<chatterino::ChannelLog> {
+    static rapidjson::Value get(const chatterino::ChannelLog &value,
+                                rapidjson::Document::AllocatorType &a)
+    {
+        rapidjson::Value ret(rapidjson::kObjectType);
+
+        chatterino::rj::set(ret, "channel", value.channel, a);
+        chatterino::rj::set(ret, "loggingEnabled", value.loggingEnabled, a);
+
+        return ret;
+    }
+};
+
+template <>
+struct Deserialize<chatterino::ChannelLog> {
+    static chatterino::ChannelLog get(const rapidjson::Value &value,
+                                   bool *error = nullptr)
+    {
+        chatterino::ChannelLog ChannelLog = chatterino::ChannelLog::createEmpty();
+
+        if (!value.IsObject())
+        {
+            PAJLADA_REPORT_ERROR(error);
+            return ChannelLog;
+        }
+
+        if (!chatterino::rj::getSafe(value, "channel", ChannelLog.channel))
+        {
+            PAJLADA_REPORT_ERROR(error);
+            return ChannelLog;
+        }
+        if (!chatterino::rj::getSafe(value, "loggingEnabled", ChannelLog.loggingEnabled))
+        {
+            PAJLADA_REPORT_ERROR(error);
+            return ChannelLog;
+        }
+
+        return ChannelLog;
+    }
+};
+
+}  // namespace pajlada

--- a/src/controllers/logging/ChannelLog.hpp
+++ b/src/controllers/logging/ChannelLog.hpp
@@ -7,6 +7,9 @@
 
 namespace chatterino {
 
+/**
+ * @brief Contains the description of a channel that will be logged
+ **/
 class ChannelLog
 {
     QString channelName_;

--- a/src/controllers/logging/ChannelLoggingModel.cpp
+++ b/src/controllers/logging/ChannelLoggingModel.cpp
@@ -18,7 +18,7 @@ ChannelLog ChannelLoggingModel::getItemFromRow(
 void ChannelLoggingModel::getRowFromItem(const ChannelLog &item,
                                          std::vector<QStandardItem *> &row)
 {
-    setStringItem(row[0], item.channel);
+    setStringItem(row[Column::Channel], item.channel);
 }
 
 }  // namespace chatterino

--- a/src/controllers/logging/ChannelLoggingModel.cpp
+++ b/src/controllers/logging/ChannelLoggingModel.cpp
@@ -10,7 +10,7 @@ ChannelLoggingModel ::ChannelLoggingModel(QObject *parent)
 }
 
 ChannelLog ChannelLoggingModel::getItemFromRow(
-    std::vector<QStandardItem *> &row, const ChannelLog &channelLog)
+    std::vector<QStandardItem *> &row, const ChannelLog & /*original*/)
 {
     return ChannelLog(row[Column::Channel]->data(Qt::DisplayRole).toString());
 }

--- a/src/controllers/logging/ChannelLoggingModel.cpp
+++ b/src/controllers/logging/ChannelLoggingModel.cpp
@@ -1,4 +1,5 @@
 #include "controllers/logging/ChannelLoggingModel.hpp"
+
 #include "util/StandardItemHelper.hpp"
 
 namespace chatterino {
@@ -13,13 +14,14 @@ ChannelLoggingModel ::ChannelLoggingModel(QObject *parent)
 ChannelLog ChannelLoggingModel::getItemFromRow(
     std::vector<QStandardItem *> &row, const ChannelLog &channelLog)
 {
-    return ChannelLog(row[Column::Channel]->data(Qt::DisplayRole).toString(),
-                      row[Column::LoggingEnabled]->data(Qt::CheckStateRole).toBool());
+    return ChannelLog(
+        row[Column::Channel]->data(Qt::DisplayRole).toString(),
+        row[Column::LoggingEnabled]->data(Qt::CheckStateRole).toBool());
 }
 
 // turns a row in the model into a vector item
 void ChannelLoggingModel::getRowFromItem(const ChannelLog &item,
-                                           std::vector<QStandardItem *> &row)
+                                         std::vector<QStandardItem *> &row)
 {
     setStringItem(row[0], item.channel);
     setBoolItem(row[1], item.loggingEnabled);

--- a/src/controllers/logging/ChannelLoggingModel.cpp
+++ b/src/controllers/logging/ChannelLoggingModel.cpp
@@ -6,7 +6,7 @@ namespace chatterino {
 
 // commandmodel
 ChannelLoggingModel ::ChannelLoggingModel(QObject *parent)
-    : SignalVectorModel<ChannelLog>(1, parent)
+    : SignalVectorModel<ChannelLog>(Column::COUNT, parent)
 {
 }
 

--- a/src/controllers/logging/ChannelLoggingModel.cpp
+++ b/src/controllers/logging/ChannelLoggingModel.cpp
@@ -6,7 +6,7 @@ namespace chatterino {
 
 // commandmodel
 ChannelLoggingModel ::ChannelLoggingModel(QObject *parent)
-    : SignalVectorModel<ChannelLog>(2, parent)
+    : SignalVectorModel<ChannelLog>(1, parent)
 {
 }
 
@@ -15,8 +15,7 @@ ChannelLog ChannelLoggingModel::getItemFromRow(
     std::vector<QStandardItem *> &row, const ChannelLog &channelLog)
 {
     return ChannelLog(
-        row[Column::Channel]->data(Qt::DisplayRole).toString(),
-        row[Column::LoggingEnabled]->data(Qt::CheckStateRole).toBool());
+        row[Column::Channel]->data(Qt::DisplayRole).toString());
 }
 
 // turns a row in the model into a vector item
@@ -24,7 +23,6 @@ void ChannelLoggingModel::getRowFromItem(const ChannelLog &item,
                                          std::vector<QStandardItem *> &row)
 {
     setStringItem(row[0], item.channel);
-    setBoolItem(row[1], item.loggingEnabled);
 }
 
 }  // namespace chatterino

--- a/src/controllers/logging/ChannelLoggingModel.cpp
+++ b/src/controllers/logging/ChannelLoggingModel.cpp
@@ -4,20 +4,17 @@
 
 namespace chatterino {
 
-// commandmodel
 ChannelLoggingModel ::ChannelLoggingModel(QObject *parent)
     : SignalVectorModel<ChannelLog>(Column::COUNT, parent)
 {
 }
 
-// turn a vector item into a model row
 ChannelLog ChannelLoggingModel::getItemFromRow(
     std::vector<QStandardItem *> &row, const ChannelLog &channelLog)
 {
     return ChannelLog(row[Column::Channel]->data(Qt::DisplayRole).toString());
 }
 
-// turns a row in the model into a vector item
 void ChannelLoggingModel::getRowFromItem(const ChannelLog &item,
                                          std::vector<QStandardItem *> &row)
 {

--- a/src/controllers/logging/ChannelLoggingModel.cpp
+++ b/src/controllers/logging/ChannelLoggingModel.cpp
@@ -5,22 +5,24 @@ namespace chatterino {
 
 // commandmodel
 ChannelLoggingModel ::ChannelLoggingModel(QObject *parent)
-    : SignalVectorModel<QString>(1, parent)
+    : SignalVectorModel<ChannelLog>(2, parent)
 {
 }
 
 // turn a vector item into a model row
-QString ChannelLoggingModel::getItemFromRow(
-    std::vector<QStandardItem *> &row, const QString &original)
+ChannelLog ChannelLoggingModel::getItemFromRow(
+    std::vector<QStandardItem *> &row, const ChannelLog &channelLog)
 {
-    return QString(row[0]->data(Qt::DisplayRole).toString());
+    return ChannelLog(row[Column::Channel]->data(Qt::DisplayRole).toString(),
+                      row[Column::LoggingEnabled]->data(Qt::CheckStateRole).toBool());
 }
 
 // turns a row in the model into a vector item
-void ChannelLoggingModel::getRowFromItem(const QString &item,
+void ChannelLoggingModel::getRowFromItem(const ChannelLog &item,
                                            std::vector<QStandardItem *> &row)
 {
-    setStringItem(row[0], item);
+    setStringItem(row[0], item.channel);
+    setBoolItem(row[1], item.loggingEnabled);
 }
 
 }  // namespace chatterino

--- a/src/controllers/logging/ChannelLoggingModel.cpp
+++ b/src/controllers/logging/ChannelLoggingModel.cpp
@@ -12,7 +12,8 @@ ChannelLoggingModel ::ChannelLoggingModel(QObject *parent)
 ChannelLog ChannelLoggingModel::getItemFromRow(
     std::vector<QStandardItem *> &row, const ChannelLog & /*original*/)
 {
-    return ChannelLog(row[Column::Channel]->data(Qt::DisplayRole).toString());
+    auto channelName = row[Column::Channel]->data(Qt::DisplayRole).toString();
+    return {channelName};
 }
 
 void ChannelLoggingModel::getRowFromItem(const ChannelLog &item,

--- a/src/controllers/logging/ChannelLoggingModel.cpp
+++ b/src/controllers/logging/ChannelLoggingModel.cpp
@@ -1,0 +1,26 @@
+#include "controllers/logging/ChannelLoggingModel.hpp"
+#include "util/StandardItemHelper.hpp"
+
+namespace chatterino {
+
+// commandmodel
+ChannelLoggingModel ::ChannelLoggingModel(QObject *parent)
+    : SignalVectorModel<QString>(1, parent)
+{
+}
+
+// turn a vector item into a model row
+QString ChannelLoggingModel::getItemFromRow(
+    std::vector<QStandardItem *> &row, const QString &original)
+{
+    return QString(row[0]->data(Qt::DisplayRole).toString());
+}
+
+// turns a row in the model into a vector item
+void ChannelLoggingModel::getRowFromItem(const QString &item,
+                                           std::vector<QStandardItem *> &row)
+{
+    setStringItem(row[0], item);
+}
+
+}  // namespace chatterino

--- a/src/controllers/logging/ChannelLoggingModel.cpp
+++ b/src/controllers/logging/ChannelLoggingModel.cpp
@@ -19,7 +19,7 @@ ChannelLog ChannelLoggingModel::getItemFromRow(
 void ChannelLoggingModel::getRowFromItem(const ChannelLog &item,
                                          std::vector<QStandardItem *> &row)
 {
-    setStringItem(row[Column::Channel], item.channel);
+    setStringItem(row[Column::Channel], item.channelName());
 }
 
 }  // namespace chatterino

--- a/src/controllers/logging/ChannelLoggingModel.cpp
+++ b/src/controllers/logging/ChannelLoggingModel.cpp
@@ -14,8 +14,7 @@ ChannelLoggingModel ::ChannelLoggingModel(QObject *parent)
 ChannelLog ChannelLoggingModel::getItemFromRow(
     std::vector<QStandardItem *> &row, const ChannelLog &channelLog)
 {
-    return ChannelLog(
-        row[Column::Channel]->data(Qt::DisplayRole).toString());
+    return ChannelLog(row[Column::Channel]->data(Qt::DisplayRole).toString());
 }
 
 // turns a row in the model into a vector item

--- a/src/controllers/logging/ChannelLoggingModel.hpp
+++ b/src/controllers/logging/ChannelLoggingModel.hpp
@@ -12,16 +12,12 @@ class ChannelLoggingModel : public SignalVectorModel<ChannelLog>
 public:
     explicit ChannelLoggingModel(QObject *parent);
 
-    enum Column {
-        Channel = 0,
-        LoggingEnabled = 1
-    };
+    enum Column { Channel = 0, LoggingEnabled = 1 };
 
 protected:
     // turn a vector item into a model row
-    virtual ChannelLog getItemFromRow(
-        std::vector<QStandardItem *> &row,
-        const ChannelLog &channelLog) override;
+    virtual ChannelLog getItemFromRow(std::vector<QStandardItem *> &row,
+                                      const ChannelLog &channelLog) override;
 
     // turns a row in the model into a vector item
     virtual void getRowFromItem(const ChannelLog &item,

--- a/src/controllers/logging/ChannelLoggingModel.hpp
+++ b/src/controllers/logging/ChannelLoggingModel.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "common/SignalVectorModel.hpp"
+
+#include <QObject>
+
+namespace chatterino {
+
+class ChannelLoggingModel : public SignalVectorModel<QString>
+{
+public:
+    explicit ChannelLoggingModel(QObject *parent);
+
+protected:
+    // turn a vector item into a model row
+    virtual QString getItemFromRow(
+        std::vector<QStandardItem *> &row,
+        const QString &original) override;
+
+    // turns a row in the model into a vector item
+    virtual void getRowFromItem(const QString &item,
+                                std::vector<QStandardItem *> &row) override;
+};
+
+}  // namespace chatterino

--- a/src/controllers/logging/ChannelLoggingModel.hpp
+++ b/src/controllers/logging/ChannelLoggingModel.hpp
@@ -12,16 +12,16 @@ class ChannelLoggingModel : public SignalVectorModel<ChannelLog>
 public:
     explicit ChannelLoggingModel(QObject *parent);
 
-    enum Column { Channel = 0, LoggingEnabled = 1 };
+    enum Column { Channel = 0 };
 
 protected:
     // turn a vector item into a model row
     ChannelLog getItemFromRow(std::vector<QStandardItem *> &row,
-                                      const ChannelLog &channelLog) override;
+                              const ChannelLog &channelLog) override;
 
     // turns a row in the model into a vector item
     void getRowFromItem(const ChannelLog &item,
-                                std::vector<QStandardItem *> &row) override;
+                        std::vector<QStandardItem *> &row) override;
 };
 
 }  // namespace chatterino

--- a/src/controllers/logging/ChannelLoggingModel.hpp
+++ b/src/controllers/logging/ChannelLoggingModel.hpp
@@ -1,24 +1,30 @@
 #pragma once
 
 #include "common/SignalVectorModel.hpp"
+#include "controllers/logging/ChannelLog.hpp"
 
 #include <QObject>
 
 namespace chatterino {
 
-class ChannelLoggingModel : public SignalVectorModel<QString>
+class ChannelLoggingModel : public SignalVectorModel<ChannelLog>
 {
 public:
     explicit ChannelLoggingModel(QObject *parent);
 
+    enum Column {
+        Channel = 0,
+        LoggingEnabled = 1
+    };
+
 protected:
     // turn a vector item into a model row
-    virtual QString getItemFromRow(
+    virtual ChannelLog getItemFromRow(
         std::vector<QStandardItem *> &row,
-        const QString &original) override;
+        const ChannelLog &channelLog) override;
 
     // turns a row in the model into a vector item
-    virtual void getRowFromItem(const QString &item,
+    virtual void getRowFromItem(const ChannelLog &item,
                                 std::vector<QStandardItem *> &row) override;
 };
 

--- a/src/controllers/logging/ChannelLoggingModel.hpp
+++ b/src/controllers/logging/ChannelLoggingModel.hpp
@@ -12,7 +12,10 @@ class ChannelLoggingModel : public SignalVectorModel<ChannelLog>
 public:
     explicit ChannelLoggingModel(QObject *parent);
 
-    enum Column { Channel = 0 };
+    enum Column {
+        Channel,
+        COUNT,
+    };
 
 protected:
     // turn a vector item into a model row

--- a/src/controllers/logging/ChannelLoggingModel.hpp
+++ b/src/controllers/logging/ChannelLoggingModel.hpp
@@ -16,11 +16,11 @@ public:
 
 protected:
     // turn a vector item into a model row
-    virtual ChannelLog getItemFromRow(std::vector<QStandardItem *> &row,
+    ChannelLog getItemFromRow(std::vector<QStandardItem *> &row,
                                       const ChannelLog &channelLog) override;
 
     // turns a row in the model into a vector item
-    virtual void getRowFromItem(const ChannelLog &item,
+    void getRowFromItem(const ChannelLog &item,
                                 std::vector<QStandardItem *> &row) override;
 };
 

--- a/src/controllers/logging/ChannelLoggingModel.hpp
+++ b/src/controllers/logging/ChannelLoggingModel.hpp
@@ -20,7 +20,7 @@ public:
 protected:
     // turn a vector item into a model row
     ChannelLog getItemFromRow(std::vector<QStandardItem *> &row,
-                              const ChannelLog &channelLog) override;
+                              const ChannelLog &original) override;
 
     // turns a row in the model into a vector item
     void getRowFromItem(const ChannelLog &item,

--- a/src/controllers/logging/ChannelLoggingModel.hpp
+++ b/src/controllers/logging/ChannelLoggingModel.hpp
@@ -9,7 +9,6 @@ namespace chatterino {
 
 class ChannelLoggingModel : public SignalVectorModel<ChannelLog>
 {
-public:
     explicit ChannelLoggingModel(QObject *parent);
 
     enum Column {
@@ -25,6 +24,8 @@ protected:
     // turns a row in the model into a vector item
     void getRowFromItem(const ChannelLog &item,
                         std::vector<QStandardItem *> &row) override;
+
+    friend class ModerationPage;
 };
 
 }  // namespace chatterino

--- a/src/singletons/Logging.cpp
+++ b/src/singletons/Logging.cpp
@@ -28,13 +28,19 @@ void Logging::addMessage(const QString &channelName, MessagePtr message,
 
     if (getSettings()->onlyLogListedChannels)
     {
+        bool foundChannel = false;
         SignalVector<ChannelLog> &channelLogs = getSettings()->loggedChannels;
         for (const ChannelLog &channelLog : channelLogs.raw())
         {
-            if (channelLog.channel == channelName && !channelLog.loggingEnabled)
+            if (channelLog.channel == channelName)
             {
-                return;
+                foundChannel = true;
+                break;
             }
+        }
+        if (!foundChannel)
+        {
+            return;
         }
     }
 

--- a/src/singletons/Logging.cpp
+++ b/src/singletons/Logging.cpp
@@ -26,7 +26,7 @@ void Logging::addMessage(const QString &channelName, MessagePtr message,
         return;
     }
 
-    if (getSettings()->enableCustomLogging)
+    if (getSettings()->onlyLogListedChannels)
     {
         SignalVector<ChannelLog> &channelLogs = getSettings()->loggedChannels;
         for (const ChannelLog &channelLog : channelLogs.raw())

--- a/src/singletons/Logging.cpp
+++ b/src/singletons/Logging.cpp
@@ -31,13 +31,11 @@ void Logging::addMessage(const QString &channelName, MessagePtr message,
         SignalVector<ChannelLog> &channelLogs = getSettings()->loggedChannels;
         for (const ChannelLog &channelLog : channelLogs.raw())
         {
-            if (channelLog.channel == channelName &&
-                !channelLog.loggingEnabled)
+            if (channelLog.channel == channelName && !channelLog.loggingEnabled)
             {
                 return;
             }
         }
-
     }
 
     auto platIt = this->loggingChannels_.find(platformName);

--- a/src/singletons/Logging.cpp
+++ b/src/singletons/Logging.cpp
@@ -1,6 +1,5 @@
 #include "singletons/Logging.hpp"
 
-#include "Application.hpp"
 #include "singletons/helper/LoggingChannel.hpp"
 #include "singletons/Paths.hpp"
 #include "singletons/Settings.hpp"
@@ -9,18 +8,29 @@
 #include <QStandardPaths>
 
 #include <memory>
-#include <unordered_map>
 #include <utility>
 
 namespace chatterino {
 
-void Logging::initialize(Settings &settings, Paths &paths)
+void Logging::initialize(Settings &settings, Paths & /*paths*/)
 {
+    settings.loggedChannels.delayedItemsChanged.connect([this, &settings]() {
+        this->threadGuard.guard();
+
+        this->onlyLogListedChannels.clear();
+
+        for (const auto &loggedChannel : *settings.loggedChannels.readOnly())
+        {
+            this->onlyLogListedChannels.insert(loggedChannel.channel);
+        }
+    });
 }
 
 void Logging::addMessage(const QString &channelName, MessagePtr message,
                          const QString &platformName)
 {
+    this->threadGuard.guard();
+
     if (!getSettings()->enableLogging)
     {
         return;
@@ -28,17 +38,7 @@ void Logging::addMessage(const QString &channelName, MessagePtr message,
 
     if (getSettings()->onlyLogListedChannels)
     {
-        bool foundChannel = false;
-        SignalVector<ChannelLog> &channelLogs = getSettings()->loggedChannels;
-        for (const ChannelLog &channelLog : channelLogs.raw())
-        {
-            if (channelLog.channel == channelName)
-            {
-                foundChannel = true;
-                break;
-            }
-        }
-        if (!foundChannel)
+        if (!this->onlyLogListedChannels.contains(channelName))
         {
             return;
         }

--- a/src/singletons/Logging.cpp
+++ b/src/singletons/Logging.cpp
@@ -26,6 +26,20 @@ void Logging::addMessage(const QString &channelName, MessagePtr message,
         return;
     }
 
+    if (getSettings()->enableCustomLogging)
+    {
+        SignalVector<ChannelLog> &channelLogs = getSettings()->loggedChannels;
+        for (const ChannelLog &channelLog : channelLogs.raw())
+        {
+            if (channelLog.channel == channelName &&
+                !channelLog.loggingEnabled)
+            {
+                return;
+            }
+        }
+
+    }
+
     auto platIt = this->loggingChannels_.find(platformName);
     if (platIt == this->loggingChannels_.end())
     {

--- a/src/singletons/Logging.cpp
+++ b/src/singletons/Logging.cpp
@@ -21,7 +21,7 @@ void Logging::initialize(Settings &settings, Paths & /*paths*/)
 
         for (const auto &loggedChannel : *settings.loggedChannels.readOnly())
         {
-            this->onlyLogListedChannels.insert(loggedChannel.channel);
+            this->onlyLogListedChannels.insert(loggedChannel.channelName());
         }
     });
 }

--- a/src/singletons/Logging.hpp
+++ b/src/singletons/Logging.hpp
@@ -1,11 +1,14 @@
 #pragma once
 
 #include "common/Singleton.hpp"
+#include "util/QStringHash.hpp"
+#include "util/ThreadGuard.hpp"
 
 #include <QString>
 
 #include <map>
 #include <memory>
+#include <unordered_set>
 
 namespace chatterino {
 
@@ -32,6 +35,10 @@ private:
     std::map<PlatformName,
              std::map<ChannelName, std::unique_ptr<LoggingChannel>>>
         loggingChannels_;
+
+    // Keeps the value of the `loggedChannels` settings
+    std::unordered_set<ChannelName> onlyLogListedChannels;
+    ThreadGuard threadGuard;
 };
 
 }  // namespace chatterino

--- a/src/singletons/Settings.cpp
+++ b/src/singletons/Settings.cpp
@@ -25,6 +25,7 @@ ConcurrentSettings::ConcurrentSettings()
     , filterRecords(*new SignalVector<FilterRecordPtr>())
     , nicknames(*new SignalVector<Nickname>())
     , moderationActions(*new SignalVector<ModerationAction>)
+    , loggedChannels(*new SignalVector<QString>)
 {
     persist(this->highlightedMessages, "/highlighting/highlights");
     persist(this->blacklistedUsers, "/highlighting/blacklist");

--- a/src/singletons/Settings.cpp
+++ b/src/singletons/Settings.cpp
@@ -25,7 +25,7 @@ ConcurrentSettings::ConcurrentSettings()
     , filterRecords(*new SignalVector<FilterRecordPtr>())
     , nicknames(*new SignalVector<Nickname>())
     , moderationActions(*new SignalVector<ModerationAction>)
-    , loggedChannels(*new SignalVector<QString>)
+    , loggedChannels(*new SignalVector<ChannelLog>)
 {
     persist(this->highlightedMessages, "/highlighting/highlights");
     persist(this->blacklistedUsers, "/highlighting/blacklist");
@@ -37,6 +37,7 @@ ConcurrentSettings::ConcurrentSettings()
     persist(this->nicknames, "/nicknames");
     // tagged users?
     persist(this->moderationActions, "/moderation/actions");
+    persist(this->loggedChannels, "/logging/channels");
 }
 
 bool ConcurrentSettings::isHighlightedUser(const QString &username)

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -40,6 +40,7 @@ public:
     SignalVector<FilterRecordPtr> &filterRecords;
     SignalVector<Nickname> &nicknames;
     SignalVector<ModerationAction> &moderationActions;
+    SignalVector<QString> &loggedChannels;
 
     bool isHighlightedUser(const QString &username);
     bool isBlacklistedUser(const QString &username);
@@ -364,6 +365,7 @@ public:
 
     /// Logging
     BoolSetting enableLogging = {"/logging/enabled", false};
+    BoolSetting enableCustomLogging = {"/logging/customLogging", false};
 
     QStringSetting logPath = {"/logging/path", ""};
 

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -3,6 +3,7 @@
 #include "BaseSettings.hpp"
 #include "common/Channel.hpp"
 #include "common/SignalVector.hpp"
+#include "controllers/logging/ChannelLog.hpp"
 #include "singletons/Toasts.hpp"
 #include "util/RapidJsonSerializeQString.hpp"
 #include "util/StreamerMode.hpp"
@@ -40,7 +41,7 @@ public:
     SignalVector<FilterRecordPtr> &filterRecords;
     SignalVector<Nickname> &nicknames;
     SignalVector<ModerationAction> &moderationActions;
-    SignalVector<QString> &loggedChannels;
+    SignalVector<ChannelLog> &loggedChannels;
 
     bool isHighlightedUser(const QString &username);
     bool isBlacklistedUser(const QString &username);

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -366,7 +366,8 @@ public:
 
     /// Logging
     BoolSetting enableLogging = {"/logging/enabled", false};
-    BoolSetting onlyLogListedChannels = {"/logging/onlyLogListedChannels", false};
+    BoolSetting onlyLogListedChannels = {"/logging/onlyLogListedChannels",
+                                         false};
 
     QStringSetting logPath = {"/logging/path", ""};
 

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -366,7 +366,7 @@ public:
 
     /// Logging
     BoolSetting enableLogging = {"/logging/enabled", false};
-    BoolSetting enableCustomLogging = {"/logging/customLogging", false};
+    BoolSetting onlyLogListedChannels = {"/logging/onlyLogListedChannels", false};
 
     QStringSetting logPath = {"/logging/path", ""};
 

--- a/src/widgets/settingspages/ModerationPage.cpp
+++ b/src/widgets/settingspages/ModerationPage.cpp
@@ -73,18 +73,18 @@ ModerationPage::ModerationPage()
         QCheckBox *enableLogging = this->createCheckBox(
             "Enable logging", getSettings()->enableLogging);
         logs.append(enableLogging);
-        QCheckBox *customLogging =
-            this->createCheckBox("Enable logging for specific channels",
-                                 getSettings()->enableCustomLogging);
+        QCheckBox *onlyLogListedChannels =
+            this->createCheckBox("Only log channels listed below",
+                                 getSettings()->onlyLogListedChannels);
 
-        customLogging->setEnabled(getSettings()->enableLogging);
-        logs.append(customLogging);
+        onlyLogListedChannels->setEnabled(getSettings()->enableLogging);
+        logs.append(onlyLogListedChannels);
 
         // Select event
         QObject::connect(
             enableLogging, &QCheckBox::stateChanged, this,
-            [enableLogging, customLogging]() mutable {
-                customLogging->setEnabled(enableLogging->isChecked());
+            [enableLogging, onlyLogListedChannels]() mutable {
+                onlyLogListedChannels->setEnabled(enableLogging->isChecked());
             });
 
         auto logsPathLabel = logs.emplace<QLabel>();

--- a/src/widgets/settingspages/ModerationPage.cpp
+++ b/src/widgets/settingspages/ModerationPage.cpp
@@ -73,17 +73,19 @@ ModerationPage::ModerationPage()
         QCheckBox *enableLogging = this->createCheckBox(
             "Enable logging", getSettings()->enableLogging);
         logs.append(enableLogging);
-        QCheckBox *customLogging = this->createCheckBox("Enable logging for specific channels",
-                                         getSettings()->enableCustomLogging);
+        QCheckBox *customLogging =
+            this->createCheckBox("Enable logging for specific channels",
+                                 getSettings()->enableCustomLogging);
 
         customLogging->setEnabled(getSettings()->enableLogging);
         logs.append(customLogging);
 
         // Select event
-        QObject::connect(enableLogging, &QCheckBox::stateChanged,
-                         this, [enableLogging, customLogging]() mutable {
-                                 customLogging->setEnabled(enableLogging->isChecked());
-                         });
+        QObject::connect(
+            enableLogging, &QCheckBox::stateChanged, this,
+            [enableLogging, customLogging]() mutable {
+                customLogging->setEnabled(enableLogging->isChecked());
+            });
 
         auto logsPathLabel = logs.emplace<QLabel>();
 
@@ -155,8 +157,7 @@ ModerationPage::ModerationPage()
                          });
 
         EditableModelView *view =
-            logs
-                .emplace<EditableModelView>(
+            logs.emplace<EditableModelView>(
                     (new ChannelLoggingModel(nullptr))
                         ->initialized(&getSettings()->loggedChannels))
                 .getElement();
@@ -168,8 +169,7 @@ ModerationPage::ModerationPage()
             0, QHeaderView::Stretch);
 
         view->addButtonPressed.connect([] {
-            getSettings()->loggedChannels.append(
-                ChannelLog("channel", false));
+            getSettings()->loggedChannels.append(ChannelLog("channel", false));
         });
 
     }  // logs end

--- a/src/widgets/settingspages/ModerationPage.cpp
+++ b/src/widgets/settingspages/ModerationPage.cpp
@@ -73,19 +73,6 @@ ModerationPage::ModerationPage()
         QCheckBox *enableLogging = this->createCheckBox(
             "Enable logging", getSettings()->enableLogging);
         logs.append(enableLogging);
-        QCheckBox *onlyLogListedChannels =
-            this->createCheckBox("Only log channels listed below",
-                                 getSettings()->onlyLogListedChannels);
-
-        onlyLogListedChannels->setEnabled(getSettings()->enableLogging);
-        logs.append(onlyLogListedChannels);
-
-        // Select event
-        QObject::connect(
-            enableLogging, &QCheckBox::stateChanged, this,
-            [enableLogging, onlyLogListedChannels]() mutable {
-                onlyLogListedChannels->setEnabled(enableLogging->isChecked());
-            });
 
         auto logsPathLabel = logs.emplace<QLabel>();
 
@@ -121,7 +108,6 @@ ModerationPage::ModerationPage()
             });
 
         buttons->addStretch();
-        logs->addStretch(1);
 
         // Show how big (size-wise) the logs are
         auto logsPathSizeLabel = logs.emplace<QLabel>();
@@ -155,6 +141,20 @@ ModerationPage::ModerationPage()
                                  return fetchLogDirectorySize();
                              }));
                          });
+
+        QCheckBox *onlyLogListedChannels =
+            this->createCheckBox("Only log channels listed below",
+                                 getSettings()->onlyLogListedChannels);
+
+        onlyLogListedChannels->setEnabled(getSettings()->enableLogging);
+        logs.append(onlyLogListedChannels);
+
+        // Select event
+        QObject::connect(
+            enableLogging, &QCheckBox::stateChanged, this,
+            [enableLogging, onlyLogListedChannels]() mutable {
+                onlyLogListedChannels->setEnabled(enableLogging->isChecked());
+            });
 
         EditableModelView *view =
             logs.emplace<EditableModelView>(

--- a/src/widgets/settingspages/ModerationPage.cpp
+++ b/src/widgets/settingspages/ModerationPage.cpp
@@ -162,14 +162,14 @@ ModerationPage::ModerationPage()
                         ->initialized(&getSettings()->loggedChannels))
                 .getElement();
 
-        view->setTitles({"Twitch channels", "Enable Logs"});
+        view->setTitles({"Twitch channels"});
         view->getTableView()->horizontalHeader()->setSectionResizeMode(
             QHeaderView::Fixed);
         view->getTableView()->horizontalHeader()->setSectionResizeMode(
             0, QHeaderView::Stretch);
 
         view->addButtonPressed.connect([] {
-            getSettings()->loggedChannels.append(ChannelLog("channel", false));
+            getSettings()->loggedChannels.append(ChannelLog("channel"));
         });
 
     }  // logs end

--- a/src/widgets/settingspages/ModerationPage.cpp
+++ b/src/widgets/settingspages/ModerationPage.cpp
@@ -161,7 +161,7 @@ ModerationPage::ModerationPage()
                         ->initialized(&getSettings()->loggedChannels))
                 .getElement();
 
-        view->setTitles({"Twitch channels"});
+        view->setTitles({"Twitch channels", "Enable Logs"});
         view->getTableView()->horizontalHeader()->setSectionResizeMode(
             QHeaderView::Fixed);
         view->getTableView()->horizontalHeader()->setSectionResizeMode(
@@ -169,7 +169,7 @@ ModerationPage::ModerationPage()
 
         view->addButtonPressed.connect([] {
             getSettings()->loggedChannels.append(
-                ("channel"));
+                ChannelLog("channel", false));
         });
 
     }  // logs end


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Implemented feature requested in https://github.com/Chatterino/chatterino2/issues/1456 to allow custom selection of channels to log. Added a new setting on Moderation(Logs) page to enable this feature as well as a table to add channels and a checkbox for whether messages for each channel should be logged or not
