### PR TITLE
Change the highlight order to prioritize Message highlights over User highlights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unversioned
 
+- Minor: Change the highlight order to prioritize Message highlights over User highlights. (#4303)
 - Minor: Added ability to negate search options by prefixing it with an exclamation mark (e.g. `!badge:mod` to search for messages where the author does not have the moderator badge). (#4207)
 - Minor: Search window input will automatically use currently selected text if present. (#4178)
 - Minor: Cleared up highlight sound settings (#4194)

--- a/src/controllers/highlights/HighlightController.cpp
+++ b/src/controllers/highlights/HighlightController.cpp
@@ -445,15 +445,15 @@ void HighlightController::rebuildChecks(Settings &settings)
     checks->clear();
 
     // CURRENT ORDER:
-    // Subscription -> Whisper -> User -> Message -> Reply Threads -> Badge
+    // Subscription -> Whisper -> Message -> User -> Reply Threads -> Badge
 
     rebuildSubscriptionHighlights(settings, *checks);
 
     rebuildWhisperHighlights(settings, *checks);
 
-    rebuildUserHighlights(settings, *checks);
-
     rebuildMessageHighlights(settings, *checks);
+
+    rebuildUserHighlights(settings, *checks);
 
     rebuildReplyThreadHighlight(settings, *checks);
 

--- a/src/widgets/settingspages/HighlightingPage.cpp
+++ b/src/widgets/settingspages/HighlightingPage.cpp
@@ -63,8 +63,8 @@ HighlightingPage::HighlightingPage()
                 highlights.emplace<QLabel>(
                     "Play notification sounds and highlight messages based on "
                     "certain patterns.\n"
-                    "Message highlights are prioritized over badge highlights, "
-                    "but under user highlights");
+                    "Message highlights are prioritized over badge highlights "
+                    "and user highlights.");
 
                 auto view =
                     highlights
@@ -109,8 +109,8 @@ HighlightingPage::HighlightingPage()
                 pingUsers.emplace<QLabel>(
                     "Play notification sounds and highlight messages from "
                     "certain users.\n"
-                    "User highlights are prioritized over message and badge "
-                    "highlights.");
+                    "User highlights are prioritized badge highlights, but "
+                    "under message highlights.");
                 EditableModelView *view =
                     pingUsers
                         .emplace<EditableModelView>(


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

- Change the highlight order to prioritize Message highlights over User highlights
- Add changelog entry

Fixes #4259

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
