### PR TITLE
Format and Lint CMake Files

### DIFF
--- a/.cmake-format.yaml
+++ b/.cmake-format.yaml
@@ -1,0 +1,189 @@
+# Options affecting listfile parsing
+parse:
+  # Specify structure for custom cmake functions
+  additional_commands:
+    setup_target_for_coverage_lcov:
+      kwargs:
+        NAME: "*"
+        EXECUTABLE: "*"
+        BASE_DIRECTORY: "*"
+        EXCLUDE: "*"
+  # Override configurations per-command where available
+  override_spec: {}
+  # Specify variable tags.
+  vartags: []
+  # Specify property tags.
+  proptags: []
+# Options affecting formatting.
+format:
+  # Disable formatting entirely, making cmake-format a no-op
+  disable: false
+  # How wide to allow formatted cmake files
+  line_width: 80
+  # How many spaces to tab for indent
+  tab_size: 4
+  # If true, lines are indented using tab characters (utf-8
+  # 0x09) instead of <tab_size> space characters (utf-8 0x20).
+  # In cases where the layout would require a fractional tab
+  # character, the behavior of the  fractional indentation is
+  # governed by <fractional_tab_policy>
+  use_tabchars: false
+  # If <use_tabchars> is True, then the value of this variable
+  # indicates how fractional indentions are handled during
+  # whitespace replacement. If set to 'use-space', fractional
+  # indentation is left as spaces (utf-8 0x20). If set to
+  # '`round-up` fractional indentation is replaced with a single'
+  # tab character (utf-8 0x09) effectively shifting the column
+  # to the next tabstop
+  fractional_tab_policy: use-space
+  # If an argument group contains more than this many sub-groups
+  # (parg or kwarg groups) then force it to a vertical layout.
+  max_subgroups_hwrap: 2
+  # If a positional argument group contains more than this many
+  # arguments, then force it to a vertical layout.
+  max_pargs_hwrap: 6
+  # If a cmdline positional group consumes more than this many
+  # lines without nesting, then invalidate the layout (and nest)
+  max_rows_cmdline: 2
+  # If true, separate flow control names from their parentheses
+  # with a space
+  separate_ctrl_name_with_space: false
+  # If true, separate function names from parentheses with a
+  # space
+  separate_fn_name_with_space: false
+  # If a statement is wrapped to more than one line, than dangle
+  # the closing parenthesis on its own line.
+  dangle_parens: true
+  # If the trailing parenthesis must be 'dangled' on its on
+  # 'line, then align it to this reference: `prefix`: the start'
+  # 'of the statement,  `prefix-indent`: the start of the'
+  # 'statement, plus one indentation  level, `child`: align to'
+  # the column of the arguments
+  dangle_align: prefix
+  # If the statement spelling length (including space and
+  # parenthesis) is smaller than this amount, then force reject
+  # nested layouts.
+  min_prefix_chars: 4
+  # If the statement spelling length (including space and
+  # parenthesis) is larger than the tab width by more than this
+  # amount, then force reject un-nested layouts.
+  max_prefix_chars: 10
+  # If a candidate layout is wrapped horizontally but it exceeds
+  # this many lines, then reject the layout.
+  max_lines_hwrap: 2
+  # What style line endings to use in the output.
+  line_ending: unix
+  # Format command names consistently as 'lower' or 'upper' case
+  command_case: canonical
+  # Format keywords consistently as 'lower' or 'upper' case
+  keyword_case: unchanged
+  # A list of command names which should always be wrapped
+  always_wrap: []
+  # If true, the argument lists which are known to be sortable
+  # will be sorted lexicographicall
+  enable_sort: true
+  # If true, the parsers may infer whether or not an argument
+  # list is sortable (without annotation).
+  autosort: false
+  # By default, if cmake-format cannot successfully fit
+  # everything into the desired linewidth it will apply the
+  # last, most agressive attempt that it made. If this flag is
+  # True, however, cmake-format will print error, exit with non-
+  # zero status code, and write-out nothing
+  require_valid_layout: false
+  # A dictionary mapping layout nodes to a list of wrap
+  # decisions. See the documentation for more information.
+  layout_passes: {}
+# Options affecting comment reflow and formatting.
+markup:
+  # What character to use for bulleted lists
+  bullet_char: "*"
+  # What character to use as punctuation after numerals in an
+  # enumerated list
+  enum_char: .
+  # If comment markup is enabled, don't reflow the first comment
+  # block in each listfile. Use this to preserve formatting of
+  # your copyright/license statements.
+  first_comment_is_literal: false
+  # If comment markup is enabled, don't reflow any comment block
+  # which matches this (regex) pattern. Default is `None`
+  # (disabled).
+  literal_comment_pattern: null
+  # Regular expression to match preformat fences in comments
+  # default= ``r'^\s*([`~]{3}[`~]*)(.*)$'``
+  fence_pattern: ^\s*([`~]{3}[`~]*)(.*)$
+  # Regular expression to match rulers in comments default=
+  # '``r''^\s*[^\w\s]{3}.*[^\w\s]{3}$''``'
+  ruler_pattern: ^\s*[^\w\s]{3}.*[^\w\s]{3}$
+  # If a comment line matches starts with this pattern then it
+  # is explicitly a trailing comment for the preceeding
+  # argument. Default is '#<'
+  explicit_trailing_pattern: "#<"
+  # If a comment line starts with at least this many consecutive
+  # hash characters, then don't lstrip() them off. This allows
+  # for lazy hash rulers where the first hash char is not
+  # separated by space
+  hashruler_min_length: 10
+  # If true, then insert a space between the first hash char and
+  # remaining hash chars in a hash ruler, and normalize its
+  # length to fill the column
+  canonicalize_hashrulers: true
+  # enable comment markup parsing and reflow
+  enable_markup: true
+# Options affecting the linter
+lint:
+  # a list of lint codes to disable
+  disabled_codes: []
+  # regular expression pattern describing valid function names
+  function_pattern: "[0-9a-z_]+"
+  # regular expression pattern describing valid macro names
+  macro_pattern: "[0-9A-Z_]+"
+  # regular expression pattern describing valid names for
+  # variables with global (cache) scope
+  global_var_pattern: "[A-Z][0-9A-Z_]+"
+  # regular expression pattern describing valid names for
+  # variables with global scope (but internal semantic)
+  internal_var_pattern: _[A-Z][0-9A-Z_]+
+  # regular expression pattern describing valid names for
+  # variables with local scope
+  local_var_pattern: "[a-z][a-z0-9_]+"
+  # regular expression pattern describing valid names for
+  # privatedirectory variables
+  private_var_pattern: _[0-9a-z_]+
+  # regular expression pattern describing valid names for public
+  # directory variables
+  public_var_pattern: "[A-Z][0-9A-Z_]+"
+  # regular expression pattern describing valid names for
+  # function/macro arguments and loop variables.
+  argument_var_pattern: "[a-z][a-z0-9_]+"
+  # regular expression pattern describing valid names for
+  # keywords used in functions or macros
+  keyword_pattern: "[A-Z][0-9A-Z_]+"
+  # In the heuristic for C0201, how many conditionals to match
+  # within a loop in before considering the loop a parser.
+  max_conditionals_custom_parser: 2
+  # Require at least this many newlines between statements
+  min_statement_spacing: 1
+  # Require no more than this many newlines between statements
+  max_statement_spacing: 2
+  max_returns: 6
+  max_branches: 12
+  max_arguments: 5
+  max_localvars: 15
+  max_statements: 50
+# Options affecting file encoding
+encode:
+  # If true, emit the unicode byte-order mark (BOM) at the start
+  # of the file
+  emit_byteorder_mark: false
+  # Specify the encoding of the input file. Defaults to utf-8
+  input_encoding: utf-8
+  # Specify the encoding of the output file. Defaults to utf-8.
+  # Note that cmake only claims to support utf-8 so be careful
+  # when using anything else
+  output_encoding: utf-8
+# Miscellaneous configurations options.
+misc:
+  # A dictionary containing any per-command configuration
+  # overrides. Currently only `command_case` is supported.
+  per_command: {}

--- a/.cmake-format.yaml
+++ b/.cmake-format.yaml
@@ -84,7 +84,7 @@ format:
   enable_sort: true
   # If true, the parsers may infer whether or not an argument
   # list is sortable (without annotation).
-  autosort: false
+  autosort: true
   # By default, if cmake-format cannot successfully fit
   # everything into the desired linewidth it will apply the
   # last, most agressive attempt that it made. If this flag is

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,6 @@ jobs:
           args: --check .
       - name: Install cmakelang
         run: |
-          apt-get install python3 python3-pip -y
           pip install cmakelang[YAML]
       - name: Check format and lint CMake files
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,3 +23,11 @@ jobs:
         with:
           # prettier CLI arguments.
           args: --check .
+      - name: Install cmakelang
+        run: |
+          apt-get install python3 python3-pip -y
+          pip install cmakelang[YAML]
+      - name: Check format and lint CMake files
+        run: |
+          cmake-format --check CMakeLists.txt benchmarks/CMakeLists.txt src/CMakeLists.txt tests/CMakeLists.txt
+          cmake-lint CMakeLists.txt benchmarks/CMakeLists.txt src/CMakeLists.txt tests/CMakeLists.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Dev: Fixed `final-dtor-non-final-class` warnings. (#4296)
 - Dev: Fixed `ambiguous-reversed-operator` warnings. (#4296)
 - Dev: Format YAML and JSON files with prettier. (#4304)
+- Dev: Format and Lint CMake Files. (#4306)
 
 ## 2.4.0
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,10 +2,9 @@ cmake_minimum_required(VERSION 3.12)
 cmake_policy(SET CMP0087 NEW)
 include(FeatureSummary)
 
-list(APPEND CMAKE_MODULE_PATH
-    "${CMAKE_SOURCE_DIR}/cmake"
-    "${CMAKE_SOURCE_DIR}/cmake/sanitizers-cmake/cmake"
-    )
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake"
+     "${CMAKE_SOURCE_DIR}/cmake/sanitizers-cmake/cmake"
+)
 
 project(chatterino VERSION 2.4.0)
 
@@ -15,7 +14,9 @@ option(BUILD_BENCHMARKS "Build the benchmarks for Chatterino" OFF)
 option(USE_SYSTEM_PAJLADA_SETTINGS "Use system pajlada settings library" OFF)
 option(USE_SYSTEM_LIBCOMMUNI "Use system communi library" OFF)
 option(USE_SYSTEM_QTKEYCHAIN "Use system QtKeychain library" OFF)
-option(BUILD_WITH_QTKEYCHAIN "Build Chatterino with support for your system key chain" ON)
+option(BUILD_WITH_QTKEYCHAIN
+       "Build Chatterino with support for your system key chain" ON
+)
 option(USE_PRECOMPILED_HEADERS "Use precompiled headers" ON)
 option(BUILD_WITH_QT6 "Use Qt6 instead of default Qt5" OFF)
 option(CHATTERINO_GENERATE_COVERAGE "Generate coverage files" OFF)
@@ -32,43 +33,43 @@ else()
     message(STATUS "LTO: Disabled")
 endif()
 
-if (BUILD_WITH_QT6)
+if(BUILD_WITH_QT6)
     set(MAJOR_QT_VERSION "6")
 else()
     set(MAJOR_QT_VERSION "5")
 endif()
 
-if (USE_CONAN OR CONAN_EXPORTED)
+if(USE_CONAN OR CONAN_EXPORTED)
     include(${CMAKE_CURRENT_BINARY_DIR}/conanbuildinfo.cmake)
     conan_basic_setup(TARGETS NO_OUTPUT_DIRS)
-else ()
+else()
     set(QT_CREATOR_SKIP_CONAN_SETUP ON)
 endif()
 
 find_program(CCACHE_PROGRAM ccache)
-if (CCACHE_PROGRAM)
+if(CCACHE_PROGRAM)
     set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
     message("Using ${CCACHE_PROGRAM} for speeding up build")
-endif ()
+endif()
 
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/GIT.cmake)
 
-find_package(Qt${MAJOR_QT_VERSION} REQUIRED
-    COMPONENTS
-    Core
-    Widgets
-    Gui
-    Network
-    Multimedia
-    Svg
-    Concurrent
-    )
+find_package(
+    Qt${MAJOR_QT_VERSION} REQUIRED
+    COMPONENTS Core
+               Widgets
+               Gui
+               Network
+               Multimedia
+               Svg
+               Concurrent
+)
 
 message(STATUS "Qt version: ${Qt${MAJOR_QT_VERSION}_VERSION}")
 
-if (WIN32)
+if(WIN32)
     find_package(WinToast REQUIRED)
-endif ()
+endif()
 
 find_package(Sanitizers)
 
@@ -83,30 +84,38 @@ find_package(Threads REQUIRED)
 
 find_library(LIBRT rt)
 
-if (USE_SYSTEM_LIBCOMMUNI)
+if(USE_SYSTEM_LIBCOMMUNI)
     find_package(LibCommuni REQUIRED)
 else()
     set(LIBCOMMUNI_ROOT_LIB_FOLDER "${CMAKE_SOURCE_DIR}/lib/libcommuni")
-    if (NOT EXISTS "${LIBCOMMUNI_ROOT_LIB_FOLDER}/CMakeLists.txt")
-        message(FATAL_ERROR "Submodules probably not loaded, unable to find lib/libcommuni/CMakeLists.txt")
+    if(NOT EXISTS "${LIBCOMMUNI_ROOT_LIB_FOLDER}/CMakeLists.txt")
+        message(FATAL_ERROR "Submodules probably not loaded, unable to find "
+                            "lib/libcommuni/CMakeLists.txt"
+        )
     endif()
 
     add_subdirectory("${LIBCOMMUNI_ROOT_LIB_FOLDER}" EXCLUDE_FROM_ALL)
 endif()
 
-if (BUILD_WITH_QTKEYCHAIN)
+if(BUILD_WITH_QTKEYCHAIN)
     # Link QtKeychain statically
-    if (USE_SYSTEM_QTKEYCHAIN)
+    if(USE_SYSTEM_QTKEYCHAIN)
         find_package(Qt${MAJOR_QT_VERSION}Keychain REQUIRED)
     else()
         set(QTKEYCHAIN_ROOT_LIB_FOLDER "${CMAKE_SOURCE_DIR}/lib/qtkeychain")
-        if (NOT EXISTS "${QTKEYCHAIN_ROOT_LIB_FOLDER}/CMakeLists.txt")
-            message(FATAL_ERROR "Submodules probably not loaded, unable to find lib/qtkeychain/CMakeLists.txt")
+        if(NOT EXISTS "${QTKEYCHAIN_ROOT_LIB_FOLDER}/CMakeLists.txt")
+            message(
+                FATAL_ERROR "Submodules probably not loaded, unable to find "
+                            "lib/qtkeychain/CMakeLists.txt"
+            )
         endif()
 
         add_subdirectory("${QTKEYCHAIN_ROOT_LIB_FOLDER}" EXCLUDE_FROM_ALL)
-        if (NOT TARGET qt${MAJOR_QT_VERSION}keychain)
-            message(FATAL_ERROR "qt${MAJOR_QT_VERSION}keychain target was not created :@")
+        if(NOT TARGET qt${MAJOR_QT_VERSION}keychain)
+            message(
+                FATAL_ERROR
+                    "qt${MAJOR_QT_VERSION}keychain target was not created :@"
+            )
         endif()
     endif()
 endif()
@@ -115,40 +124,59 @@ find_package(RapidJSON REQUIRED)
 
 find_package(Websocketpp REQUIRED)
 
-if (BUILD_TESTS)
-    # For MSVC: Prevent overriding the parent project's compiler/linker settings
+if(BUILD_TESTS)
+    # cmake-format: off
+    # cmake-lint: disable=C0301
+    #
+    # For MSVC: Prevent overriding the parent project's compiler/linker settings.
     # See https://github.com/google/googletest/blob/main/googletest/README.md#visual-studio-dynamic-vs-static-runtimes
-    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+    #
+    # cmake-lint: disable=C0103
+    # cmake-format: on
+    set(gtest_force_shared_crt
+        ON
+        CACHE BOOL "" FORCE
+    )
 
-    add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/lib/googletest" "lib/googletest")
+    add_subdirectory(
+        "${CMAKE_CURRENT_LIST_DIR}/lib/googletest" "lib/googletest"
+    )
 
     mark_as_advanced(
-            BUILD_GMOCK BUILD_GTEST BUILD_SHARED_LIBS
-            gmock_build_tests gtest_build_samples gtest_build_tests
-            gtest_disable_pthreads gtest_force_shared_crt gtest_hide_internal_symbols
+        BUILD_GMOCK
+        BUILD_GTEST
+        BUILD_SHARED_LIBS
+        gmock_build_tests
+        gtest_build_samples
+        gtest_build_tests
+        gtest_disable_pthreads
+        gtest_force_shared_crt
+        gtest_hide_internal_symbols
     )
 
     set_target_properties(gtest PROPERTIES FOLDER lib)
     set_target_properties(gtest_main PROPERTIES FOLDER lib)
     set_target_properties(gmock PROPERTIES FOLDER lib)
     set_target_properties(gmock_main PROPERTIES FOLDER lib)
-endif ()
+endif()
 
-if (BUILD_BENCHMARKS)
+if(BUILD_BENCHMARKS)
     # Include system benchmark (Google Benchmark)
     find_package(benchmark REQUIRED)
-endif ()
+endif()
 
 find_package(PajladaSerialize REQUIRED)
 find_package(PajladaSignals REQUIRED)
 find_package(LRUCache REQUIRED)
 find_package(MagicEnum REQUIRED)
 
-if (USE_SYSTEM_PAJLADA_SETTINGS)
+if(USE_SYSTEM_PAJLADA_SETTINGS)
     find_package(PajladaSettings REQUIRED)
 else()
-    if (NOT EXISTS "${CMAKE_SOURCE_DIR}/lib/settings/CMakeLists.txt")
-        message(FATAL_ERROR "Submodules probably not loaded, unable to find lib/settings/CMakeLists.txt")
+    if(NOT EXISTS "${CMAKE_SOURCE_DIR}/lib/settings/CMakeLists.txt")
+        message(FATAL_ERROR "Submodules probably not loaded, unable to find "
+                            "lib/settings/CMakeLists.txt"
+        )
     endif()
 
     add_subdirectory("${CMAKE_SOURCE_DIR}/lib/settings" EXCLUDE_FROM_ALL)
@@ -157,22 +185,22 @@ endif()
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-if (BUILD_TESTS OR BUILD_BENCHMARKS)
+if(BUILD_TESTS OR BUILD_BENCHMARKS)
     add_definitions(-DCHATTERINO_TEST)
-endif ()
+endif()
 
 # Generate resource files
 include(cmake/resources/generate_resources.cmake)
 
 add_subdirectory(src)
 
-if (BUILD_TESTS)
+if(BUILD_TESTS)
     enable_testing()
     add_subdirectory(tests)
-endif ()
+endif()
 
-if (BUILD_BENCHMARKS)
+if(BUILD_BENCHMARKS)
     add_subdirectory(benchmarks)
-endif ()
+endif()
 
 feature_summary(WHAT ALL)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,10 @@ This is a set of guidelines for contributing to Chatterino. The goal is to teach
 
 Code is automatically formatted using `clang-format`. It takes the burden off of the programmer and ensures that all contributors use the same style (even if mess something up accidentally). We recommend that you set up automatic formatting on file save in your editor.
 
+`CMakeLists.txt` files are formatted and linted using [`cmake-format`](https://cmake-format.readthedocs.io/en/latest/cmake-format.html) and [`cmake-lint`](https://cmake-format.readthedocs.io/en/latest/cmake-lint.html).
+
+Markdown files are formatted using [`prettier`](https://prettier.io/).
+
 # Comments
 
 Comments should only be used to:

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,6 +1,7 @@
 project(chatterino-benchmark)
 
 set(benchmark_SOURCES
+    # cmake-format: sort
     ${CMAKE_CURRENT_LIST_DIR}/src/main.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/Emojis.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/Highlights.cpp

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,33 +1,32 @@
 project(chatterino-benchmark)
 
-set(benchmark_SOURCES
+set(BENCHMARK_SOURCES
     # cmake-format: sort
-    ${CMAKE_CURRENT_LIST_DIR}/src/main.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/Emojis.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/src/Highlights.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/FormatTime.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/Helpers.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/Highlights.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/LimitedQueue.cpp
     # Add your new file above this line!
-    )
+    ${CMAKE_CURRENT_LIST_DIR}/src/main.cpp
+)
 
-add_executable(${PROJECT_NAME} ${benchmark_SOURCES})
+add_executable(${PROJECT_NAME} ${BENCHMARK_SOURCES})
 add_sanitizers(${PROJECT_NAME})
 
 target_link_libraries(${PROJECT_NAME} PRIVATE chatterino-lib)
 
 target_link_libraries(${PROJECT_NAME} PRIVATE benchmark::benchmark)
 
-target_compile_definitions(${PROJECT_NAME} PRIVATE
-    CHATTERINO_TEST
-    )
+target_compile_definitions(${PROJECT_NAME} PRIVATE CHATTERINO_TEST)
 
-set_target_properties(${PROJECT_NAME}
-    PROPERTIES
-    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
-    RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/bin"
-    RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_BINARY_DIR}/bin"
-    RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO "${CMAKE_BINARY_DIR}/bin"
-    )
+set_target_properties(
+    ${PROJECT_NAME}
+    PROPERTIES ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+               LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+               RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+               RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/bin"
+               RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_BINARY_DIR}/bin"
+               RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO
+               "${CMAKE_BINARY_DIR}/bin"
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,566 +3,528 @@ set(EXECUTABLE_PROJECT "${PROJECT_NAME}")
 add_compile_definitions(QT_DISABLE_DEPRECATED_BEFORE=0x050F00)
 
 set(SOURCE_FILES
-        Application.cpp
-        Application.hpp
-        BaseSettings.cpp
-        BaseSettings.hpp
-        BrowserExtension.cpp
-        BrowserExtension.hpp
-        RunGui.cpp
-        RunGui.hpp
+    Application.cpp
+    Application.hpp
+    BaseSettings.cpp
+    BaseSettings.hpp
+    BrowserExtension.cpp
+    BrowserExtension.hpp
+    RunGui.cpp
+    RunGui.hpp
+    common/Args.cpp
+    common/Args.hpp
+    common/Channel.cpp
+    common/Channel.hpp
+    common/ChannelChatters.cpp
+    common/ChannelChatters.hpp
+    common/ChatterinoSetting.cpp
+    common/ChatterinoSetting.hpp
+    common/ChatterSet.cpp
+    common/ChatterSet.hpp
+    common/CompletionModel.cpp
+    common/CompletionModel.hpp
+    common/Credentials.cpp
+    common/Credentials.hpp
+    common/DownloadManager.cpp
+    common/DownloadManager.hpp
+    common/Env.cpp
+    common/Env.hpp
+    common/LinkParser.cpp
+    common/LinkParser.hpp
+    common/Modes.cpp
+    common/Modes.hpp
+    common/NetworkCommon.cpp
+    common/NetworkCommon.hpp
+    common/NetworkManager.cpp
+    common/NetworkManager.hpp
+    common/NetworkPrivate.cpp
+    common/NetworkPrivate.hpp
+    common/NetworkRequest.cpp
+    common/NetworkRequest.hpp
+    common/NetworkResult.cpp
+    common/NetworkResult.hpp
+    common/QLogging.cpp
+    common/QLogging.hpp
+    common/Version.cpp
+    common/Version.hpp
+    common/WindowDescriptors.cpp
+    common/WindowDescriptors.hpp
+    controllers/accounts/Account.cpp
+    controllers/accounts/Account.hpp
+    controllers/accounts/AccountController.cpp
+    controllers/accounts/AccountController.hpp
+    controllers/accounts/AccountModel.cpp
+    controllers/accounts/AccountModel.hpp
+    controllers/commands/builtin/twitch/ChatSettings.cpp
+    controllers/commands/builtin/twitch/ChatSettings.hpp
+    controllers/commands/CommandContext.hpp
+    controllers/commands/CommandController.cpp
+    controllers/commands/CommandController.hpp
+    controllers/commands/Command.cpp
+    controllers/commands/Command.hpp
+    controllers/commands/CommandModel.cpp
+    controllers/commands/CommandModel.hpp
+    controllers/filters/FilterModel.cpp
+    controllers/filters/FilterModel.hpp
+    controllers/filters/FilterRecord.cpp
+    controllers/filters/FilterRecord.hpp
+    controllers/filters/FilterSet.cpp
+    controllers/filters/FilterSet.hpp
+    controllers/filters/parser/FilterParser.cpp
+    controllers/filters/parser/FilterParser.hpp
+    controllers/filters/parser/Tokenizer.cpp
+    controllers/filters/parser/Tokenizer.hpp
+    controllers/filters/parser/Types.cpp
+    controllers/filters/parser/Types.hpp
+    controllers/highlights/BadgeHighlightModel.cpp
+    controllers/highlights/BadgeHighlightModel.hpp
+    controllers/highlights/HighlightBadge.cpp
+    controllers/highlights/HighlightBadge.hpp
+    controllers/highlights/HighlightBlacklistModel.cpp
+    controllers/highlights/HighlightBlacklistModel.hpp
+    controllers/highlights/HighlightController.cpp
+    controllers/highlights/HighlightController.hpp
+    controllers/highlights/HighlightModel.cpp
+    controllers/highlights/HighlightModel.hpp
+    controllers/highlights/HighlightPhrase.cpp
+    controllers/highlights/HighlightPhrase.hpp
+    controllers/highlights/UserHighlightModel.cpp
+    controllers/highlights/UserHighlightModel.hpp
+    controllers/hotkeys/ActionNames.hpp
+    controllers/hotkeys/Hotkey.cpp
+    controllers/hotkeys/Hotkey.hpp
+    controllers/hotkeys/HotkeyCategory.hpp
+    controllers/hotkeys/HotkeyController.cpp
+    controllers/hotkeys/HotkeyController.hpp
+    controllers/hotkeys/HotkeyHelpers.cpp
+    controllers/hotkeys/HotkeyHelpers.hpp
+    controllers/hotkeys/HotkeyModel.cpp
+    controllers/hotkeys/HotkeyModel.hpp
+    controllers/ignores/IgnoreController.cpp
+    controllers/ignores/IgnoreController.hpp
+    controllers/ignores/IgnoreModel.cpp
+    controllers/ignores/IgnoreModel.hpp
+    controllers/ignores/IgnorePhrase.cpp
+    controllers/ignores/IgnorePhrase.hpp
+    controllers/moderationactions/ModerationAction.cpp
+    controllers/moderationactions/ModerationAction.hpp
+    controllers/moderationactions/ModerationActionModel.cpp
+    controllers/moderationactions/ModerationActionModel.hpp
+    controllers/logging/ChannelLog.cpp
+    controllers/logging/ChannelLog.hpp
+    controllers/logging/ChannelLoggingModel.cpp
+    controllers/logging/ChannelLoggingModel.hpp
+    controllers/nicknames/NicknamesModel.cpp
+    controllers/nicknames/NicknamesModel.hpp
+    controllers/nicknames/Nickname.hpp
+    controllers/notifications/NotificationController.cpp
+    controllers/notifications/NotificationController.hpp
+    controllers/notifications/NotificationModel.cpp
+    controllers/notifications/NotificationModel.hpp
+    controllers/pings/MutedChannelModel.cpp
+    controllers/pings/MutedChannelModel.hpp
+    controllers/userdata/UserDataController.cpp
+    controllers/userdata/UserDataController.hpp
+    controllers/userdata/UserData.hpp
+    debug/Benchmark.cpp
+    debug/Benchmark.hpp
+    messages/Emote.cpp
+    messages/Emote.hpp
+    messages/Image.cpp
+    messages/Image.hpp
+    messages/ImageSet.cpp
+    messages/ImageSet.hpp
+    messages/Link.cpp
+    messages/Link.hpp
+    messages/Message.cpp
+    messages/Message.hpp
+    messages/MessageBuilder.cpp
+    messages/MessageBuilder.hpp
+    messages/MessageColor.cpp
+    messages/MessageColor.hpp
+    messages/MessageElement.cpp
+    messages/MessageElement.hpp
+    messages/MessageThread.cpp
+    messages/MessageThread.hpp
+    messages/SharedMessageBuilder.cpp
+    messages/SharedMessageBuilder.hpp
+    messages/layouts/MessageLayout.cpp
+    messages/layouts/MessageLayout.hpp
+    messages/layouts/MessageLayoutContainer.cpp
+    messages/layouts/MessageLayoutContainer.hpp
+    messages/layouts/MessageLayoutElement.cpp
+    messages/layouts/MessageLayoutElement.hpp
+    messages/search/AuthorPredicate.cpp
+    messages/search/AuthorPredicate.hpp
+    messages/search/BadgePredicate.cpp
+    messages/search/BadgePredicate.hpp
+    messages/search/ChannelPredicate.cpp
+    messages/search/ChannelPredicate.hpp
+    messages/search/LinkPredicate.cpp
+    messages/search/LinkPredicate.hpp
+    messages/search/MessageFlagsPredicate.cpp
+    messages/search/MessageFlagsPredicate.hpp
+    messages/search/RegexPredicate.cpp
+    messages/search/RegexPredicate.hpp
+    messages/search/SubstringPredicate.cpp
+    messages/search/SubstringPredicate.hpp
+    messages/search/SubtierPredicate.cpp
+    messages/search/SubtierPredicate.hpp
+    providers/IvrApi.cpp
+    providers/IvrApi.hpp
+    providers/LinkResolver.cpp
+    providers/LinkResolver.hpp
+    providers/RecentMessagesApi.cpp
+    providers/RecentMessagesApi.hpp
+    providers/bttv/BttvEmotes.cpp
+    providers/bttv/BttvEmotes.hpp
+    providers/chatterino/ChatterinoBadges.cpp
+    providers/chatterino/ChatterinoBadges.hpp
+    providers/colors/ColorProvider.cpp
+    providers/colors/ColorProvider.hpp
+    providers/emoji/Emojis.cpp
+    providers/emoji/Emojis.hpp
+    providers/ffz/FfzBadges.cpp
+    providers/ffz/FfzBadges.hpp
+    providers/ffz/FfzEmotes.cpp
+    providers/ffz/FfzEmotes.hpp
+    providers/irc/AbstractIrcServer.cpp
+    providers/irc/AbstractIrcServer.hpp
+    providers/irc/Irc2.cpp
+    providers/irc/Irc2.hpp
+    providers/irc/IrcAccount.cpp
+    providers/irc/IrcAccount.hpp
+    providers/irc/IrcChannel2.cpp
+    providers/irc/IrcChannel2.hpp
+    providers/irc/IrcCommands.cpp
+    providers/irc/IrcCommands.hpp
+    providers/irc/IrcConnection2.cpp
+    providers/irc/IrcConnection2.hpp
+    providers/irc/IrcMessageBuilder.cpp
+    providers/irc/IrcMessageBuilder.hpp
+    providers/irc/IrcServer.cpp
+    providers/irc/IrcServer.hpp
+    providers/liveupdates/BasicPubSubClient.hpp
+    providers/liveupdates/BasicPubSubManager.hpp
+    providers/liveupdates/BasicPubSubWebsocket.hpp
+    providers/seventv/SeventvBadges.cpp
+    providers/seventv/SeventvBadges.hpp
+    providers/seventv/SeventvEmotes.cpp
+    providers/seventv/SeventvEmotes.hpp
+    providers/seventv/SeventvEventAPI.cpp
+    providers/seventv/SeventvEventAPI.hpp
+    providers/seventv/eventapi/SeventvEventAPIClient.cpp
+    providers/seventv/eventapi/SeventvEventAPIClient.hpp
+    providers/seventv/eventapi/SeventvEventAPIDispatch.cpp
+    providers/seventv/eventapi/SeventvEventAPIDispatch.hpp
+    providers/seventv/eventapi/SeventvEventAPIMessage.cpp
+    providers/seventv/eventapi/SeventvEventAPIMessage.hpp
+    providers/seventv/eventapi/SeventvEventAPISubscription.cpp
+    providers/seventv/eventapi/SeventvEventAPISubscription.hpp
+    providers/twitch/ChannelPointReward.cpp
+    providers/twitch/ChannelPointReward.hpp
+    providers/twitch/IrcMessageHandler.cpp
+    providers/twitch/IrcMessageHandler.hpp
+    providers/twitch/PubSubActions.cpp
+    providers/twitch/PubSubActions.hpp
+    providers/twitch/PubSubClient.cpp
+    providers/twitch/PubSubClient.hpp
+    providers/twitch/PubSubClientOptions.hpp
+    providers/twitch/PubSubHelpers.hpp
+    providers/twitch/PubSubManager.cpp
+    providers/twitch/PubSubManager.hpp
+    providers/twitch/PubSubMessages.hpp
+    providers/twitch/PubSubWebsocket.hpp
+    providers/twitch/TwitchAccount.cpp
+    providers/twitch/TwitchAccount.hpp
+    providers/twitch/TwitchAccountManager.cpp
+    providers/twitch/TwitchAccountManager.hpp
+    providers/twitch/TwitchBadge.cpp
+    providers/twitch/TwitchBadge.hpp
+    providers/twitch/TwitchBadges.cpp
+    providers/twitch/TwitchBadges.hpp
+    providers/twitch/TwitchChannel.cpp
+    providers/twitch/TwitchChannel.hpp
+    providers/twitch/TwitchEmotes.cpp
+    providers/twitch/TwitchEmotes.hpp
+    providers/twitch/TwitchHelpers.cpp
+    providers/twitch/TwitchHelpers.hpp
+    providers/twitch/TwitchIrcServer.cpp
+    providers/twitch/TwitchIrcServer.hpp
+    providers/twitch/TwitchMessageBuilder.cpp
+    providers/twitch/TwitchMessageBuilder.hpp
+    providers/twitch/TwitchUser.cpp
+    providers/twitch/TwitchUser.hpp
+    providers/twitch/pubsubmessages/AutoMod.cpp
+    providers/twitch/pubsubmessages/AutoMod.hpp
+    providers/twitch/pubsubmessages/Base.cpp
+    providers/twitch/pubsubmessages/Base.hpp
+    providers/twitch/pubsubmessages/ChannelPoints.cpp
+    providers/twitch/pubsubmessages/ChannelPoints.hpp
+    providers/twitch/pubsubmessages/ChatModeratorAction.cpp
+    providers/twitch/pubsubmessages/ChatModeratorAction.hpp
+    providers/twitch/pubsubmessages/Listen.cpp
+    providers/twitch/pubsubmessages/Listen.hpp
+    providers/twitch/pubsubmessages/Message.hpp
+    providers/twitch/pubsubmessages/Unlisten.cpp
+    providers/twitch/pubsubmessages/Unlisten.hpp
+    providers/twitch/pubsubmessages/Whisper.cpp
+    providers/twitch/pubsubmessages/Whisper.hpp
+    providers/twitch/api/Helix.cpp
+    providers/twitch/api/Helix.hpp
+    singletons/Badges.cpp
+    singletons/Badges.hpp
+    singletons/Emotes.cpp
+    singletons/Emotes.hpp
+    singletons/Fonts.cpp
+    singletons/Fonts.hpp
+    singletons/Logging.cpp
+    singletons/Logging.hpp
+    singletons/NativeMessaging.cpp
+    singletons/NativeMessaging.hpp
+    singletons/Paths.cpp
+    singletons/Paths.hpp
+    singletons/Resources.cpp
+    singletons/Resources.hpp
+    singletons/Settings.cpp
+    singletons/Settings.hpp
+    singletons/Theme.cpp
+    singletons/Theme.hpp
+    singletons/Toasts.cpp
+    singletons/Toasts.hpp
+    singletons/Updates.cpp
+    singletons/Updates.hpp
+    singletons/WindowManager.cpp
+    singletons/WindowManager.hpp
+    singletons/helper/GifTimer.cpp
+    singletons/helper/GifTimer.hpp
+    singletons/helper/LoggingChannel.cpp
+    singletons/helper/LoggingChannel.hpp
+    util/AttachToConsole.cpp
+    util/AttachToConsole.hpp
+    util/Clipboard.cpp
+    util/Clipboard.hpp
+    util/ConcurrentMap.hpp
+    util/DebugCount.cpp
+    util/DebugCount.hpp
+    util/DisplayBadge.cpp
+    util/DisplayBadge.hpp
+    util/FormatTime.cpp
+    util/FormatTime.hpp
+    util/FunctionEventFilter.cpp
+    util/FunctionEventFilter.hpp
+    util/FuzzyConvert.cpp
+    util/FuzzyConvert.hpp
+    util/Helpers.cpp
+    util/Helpers.hpp
+    util/IncognitoBrowser.cpp
+    util/IncognitoBrowser.hpp
+    util/InitUpdateButton.cpp
+    util/InitUpdateButton.hpp
+    util/LayoutHelper.cpp
+    util/LayoutHelper.hpp
+    util/NuulsUploader.cpp
+    util/NuulsUploader.hpp
+    util/RapidjsonHelpers.cpp
+    util/RapidjsonHelpers.hpp
+    util/RatelimitBucket.cpp
+    util/RatelimitBucket.hpp
+    util/SampleData.cpp
+    util/SampleData.hpp
+    util/SharedPtrElementLess.hpp
+    util/SplitCommand.cpp
+    util/SplitCommand.hpp
+    util/StreamLink.cpp
+    util/StreamLink.hpp
+    util/StreamerMode.cpp
+    util/StreamerMode.hpp
+    util/ThreadGuard.hpp
+    util/Twitch.cpp
+    util/Twitch.hpp
+    util/TypeName.hpp
+    util/WindowsHelper.cpp
+    util/WindowsHelper.hpp
+    util/serialize/Container.hpp
+    widgets/AccountSwitchPopup.cpp
+    widgets/AccountSwitchPopup.hpp
+    widgets/AccountSwitchWidget.cpp
+    widgets/AccountSwitchWidget.hpp
+    widgets/AttachedWindow.cpp
+    widgets/AttachedWindow.hpp
+    widgets/BasePopup.cpp
+    widgets/BasePopup.hpp
+    widgets/BaseWidget.cpp
+    widgets/BaseWidget.hpp
+    widgets/BaseWindow.cpp
+    widgets/BaseWindow.hpp
+    widgets/DraggablePopup.cpp
+    widgets/DraggablePopup.hpp
+    widgets/FramelessEmbedWindow.cpp
+    widgets/FramelessEmbedWindow.hpp
+    widgets/Label.cpp
+    widgets/Label.hpp
+    widgets/Notebook.cpp
+    widgets/Notebook.hpp
+    widgets/Scrollbar.cpp
+    widgets/Scrollbar.hpp
+    widgets/StreamView.cpp
+    widgets/StreamView.hpp
+    widgets/TooltipWidget.cpp
+    widgets/TooltipWidget.hpp
+    widgets/Window.cpp
+    widgets/Window.hpp
+    widgets/dialogs/BadgePickerDialog.cpp
+    widgets/dialogs/BadgePickerDialog.hpp
+    widgets/dialogs/ChannelFilterEditorDialog.cpp
+    widgets/dialogs/ChannelFilterEditorDialog.hpp
+    widgets/dialogs/ColorPickerDialog.cpp
+    widgets/dialogs/ColorPickerDialog.hpp
+    widgets/dialogs/EditHotkeyDialog.cpp
+    widgets/dialogs/EditHotkeyDialog.hpp
+    widgets/dialogs/EmotePopup.cpp
+    widgets/dialogs/EmotePopup.hpp
+    widgets/dialogs/IrcConnectionEditor.cpp
+    widgets/dialogs/IrcConnectionEditor.hpp
+    widgets/dialogs/IrcConnectionEditor.ui
+    widgets/dialogs/LastRunCrashDialog.cpp
+    widgets/dialogs/LastRunCrashDialog.hpp
+    widgets/dialogs/LoginDialog.cpp
+    widgets/dialogs/LoginDialog.hpp
+    widgets/dialogs/NotificationPopup.cpp
+    widgets/dialogs/NotificationPopup.hpp
+    widgets/dialogs/QualityPopup.cpp
+    widgets/dialogs/QualityPopup.hpp
+    widgets/dialogs/ReplyThreadPopup.cpp
+    widgets/dialogs/ReplyThreadPopup.hpp
+    widgets/dialogs/SelectChannelDialog.cpp
+    widgets/dialogs/SelectChannelDialog.hpp
+    widgets/dialogs/SelectChannelFiltersDialog.cpp
+    widgets/dialogs/SelectChannelFiltersDialog.hpp
+    widgets/dialogs/SettingsDialog.cpp
+    widgets/dialogs/SettingsDialog.hpp
+    widgets/dialogs/UpdateDialog.cpp
+    widgets/dialogs/UpdateDialog.hpp
+    widgets/dialogs/UserInfoPopup.cpp
+    widgets/dialogs/UserInfoPopup.hpp
+    widgets/dialogs/WelcomeDialog.cpp
+    widgets/dialogs/WelcomeDialog.hpp
+    widgets/dialogs/switcher/NewPopupItem.cpp
+    widgets/dialogs/switcher/NewPopupItem.hpp
+    widgets/dialogs/switcher/NewTabItem.cpp
+    widgets/dialogs/switcher/NewTabItem.hpp
+    widgets/dialogs/switcher/QuickSwitcherModel.cpp
+    widgets/dialogs/switcher/QuickSwitcherModel.hpp
+    widgets/dialogs/switcher/QuickSwitcherPopup.cpp
+    widgets/dialogs/switcher/QuickSwitcherPopup.hpp
+    widgets/dialogs/switcher/SwitchSplitItem.cpp
+    widgets/dialogs/switcher/SwitchSplitItem.hpp
+    widgets/helper/Button.cpp
+    widgets/helper/Button.hpp
+    widgets/helper/ChannelView.cpp
+    widgets/helper/ChannelView.hpp
+    widgets/helper/ColorButton.cpp
+    widgets/helper/ColorButton.hpp
+    widgets/helper/ComboBoxItemDelegate.cpp
+    widgets/helper/ComboBoxItemDelegate.hpp
+    widgets/helper/DebugPopup.cpp
+    widgets/helper/DebugPopup.hpp
+    widgets/helper/EditableModelView.cpp
+    widgets/helper/EditableModelView.hpp
+    widgets/helper/EffectLabel.cpp
+    widgets/helper/EffectLabel.hpp
+    widgets/helper/NotebookButton.cpp
+    widgets/helper/NotebookButton.hpp
+    widgets/helper/NotebookTab.cpp
+    widgets/helper/NotebookTab.hpp
+    widgets/helper/QColorPicker.cpp
+    widgets/helper/QColorPicker.hpp
+    widgets/helper/RegExpItemDelegate.cpp
+    widgets/helper/RegExpItemDelegate.hpp
+    widgets/helper/TrimRegExpValidator.cpp
+    widgets/helper/TrimRegExpValidator.hpp
+    widgets/helper/ResizingTextEdit.cpp
+    widgets/helper/ResizingTextEdit.hpp
+    widgets/helper/ScrollbarHighlight.cpp
+    widgets/helper/ScrollbarHighlight.hpp
+    widgets/helper/SearchPopup.cpp
+    widgets/helper/SearchPopup.hpp
+    widgets/helper/SettingsDialogTab.cpp
+    widgets/helper/SettingsDialogTab.hpp
+    widgets/helper/SignalLabel.cpp
+    widgets/helper/SignalLabel.hpp
+    widgets/helper/TitlebarButton.cpp
+    widgets/helper/TitlebarButton.hpp
+    widgets/listview/GenericItemDelegate.cpp
+    widgets/listview/GenericItemDelegate.hpp
+    widgets/listview/GenericListItem.cpp
+    widgets/listview/GenericListItem.hpp
+    widgets/listview/GenericListModel.cpp
+    widgets/listview/GenericListModel.hpp
+    widgets/listview/GenericListView.cpp
+    widgets/listview/GenericListView.hpp
+    widgets/settingspages/AboutPage.cpp
+    widgets/settingspages/AboutPage.hpp
+    widgets/settingspages/AccountsPage.cpp
+    widgets/settingspages/AccountsPage.hpp
+    widgets/settingspages/CommandPage.cpp
+    widgets/settingspages/CommandPage.hpp
+    widgets/settingspages/ExternalToolsPage.cpp
+    widgets/settingspages/ExternalToolsPage.hpp
+    widgets/settingspages/FiltersPage.cpp
+    widgets/settingspages/FiltersPage.hpp
+    widgets/settingspages/GeneralPage.cpp
+    widgets/settingspages/GeneralPage.hpp
+    widgets/settingspages/GeneralPageView.cpp
+    widgets/settingspages/GeneralPageView.hpp
+    widgets/settingspages/HighlightingPage.cpp
+    widgets/settingspages/HighlightingPage.hpp
+    widgets/settingspages/IgnoresPage.cpp
+    widgets/settingspages/IgnoresPage.hpp
+    widgets/settingspages/KeyboardSettingsPage.cpp
+    widgets/settingspages/KeyboardSettingsPage.hpp
+    widgets/settingspages/ModerationPage.cpp
+    widgets/settingspages/ModerationPage.hpp
+    widgets/settingspages/NicknamesPage.cpp
+    widgets/settingspages/NicknamesPage.hpp
+    widgets/settingspages/NotificationPage.cpp
+    widgets/settingspages/NotificationPage.hpp
+    widgets/settingspages/SettingsPage.cpp
+    widgets/settingspages/SettingsPage.hpp
+    widgets/splits/ClosedSplits.cpp
+    widgets/splits/ClosedSplits.hpp
+    widgets/splits/DraggedSplit.cpp
+    widgets/splits/DraggedSplit.hpp
+    widgets/splits/InputCompletionItem.cpp
+    widgets/splits/InputCompletionItem.hpp
+    widgets/splits/InputCompletionPopup.cpp
+    widgets/splits/InputCompletionPopup.hpp
+    widgets/splits/Split.cpp
+    widgets/splits/Split.hpp
+    widgets/splits/SplitContainer.cpp
+    widgets/splits/SplitContainer.hpp
+    widgets/splits/SplitHeader.cpp
+    widgets/splits/SplitHeader.hpp
+    widgets/splits/SplitInput.cpp
+    widgets/splits/SplitInput.hpp
+    widgets/splits/SplitOverlay.cpp
+    widgets/splits/SplitOverlay.hpp
+    ${CMAKE_SOURCE_DIR}/resources/resources.qrc
+)
 
-        common/Args.cpp
-        common/Args.hpp
-        common/Channel.cpp
-        common/Channel.hpp
-        common/ChannelChatters.cpp
-        common/ChannelChatters.hpp
-        common/ChatterinoSetting.cpp
-        common/ChatterinoSetting.hpp
-        common/ChatterSet.cpp
-        common/ChatterSet.hpp
-        common/CompletionModel.cpp
-        common/CompletionModel.hpp
-        common/Credentials.cpp
-        common/Credentials.hpp
-        common/DownloadManager.cpp
-        common/DownloadManager.hpp
-        common/Env.cpp
-        common/Env.hpp
-        common/LinkParser.cpp
-        common/LinkParser.hpp
-        common/Modes.cpp
-        common/Modes.hpp
-        common/NetworkCommon.cpp
-        common/NetworkCommon.hpp
-        common/NetworkManager.cpp
-        common/NetworkManager.hpp
-        common/NetworkPrivate.cpp
-        common/NetworkPrivate.hpp
-        common/NetworkRequest.cpp
-        common/NetworkRequest.hpp
-        common/NetworkResult.cpp
-        common/NetworkResult.hpp
-        common/QLogging.cpp
-        common/QLogging.hpp
-        common/Version.cpp
-        common/Version.hpp
-        common/WindowDescriptors.cpp
-        common/WindowDescriptors.hpp
-
-        controllers/accounts/Account.cpp
-        controllers/accounts/Account.hpp
-        controllers/accounts/AccountController.cpp
-        controllers/accounts/AccountController.hpp
-        controllers/accounts/AccountModel.cpp
-        controllers/accounts/AccountModel.hpp
-
-        controllers/commands/builtin/twitch/ChatSettings.cpp
-        controllers/commands/builtin/twitch/ChatSettings.hpp
-        controllers/commands/CommandContext.hpp
-        controllers/commands/CommandController.cpp
-        controllers/commands/CommandController.hpp
-        controllers/commands/Command.cpp
-        controllers/commands/Command.hpp
-        controllers/commands/CommandModel.cpp
-        controllers/commands/CommandModel.hpp
-
-        controllers/filters/FilterModel.cpp
-        controllers/filters/FilterModel.hpp
-        controllers/filters/FilterRecord.cpp
-        controllers/filters/FilterRecord.hpp
-        controllers/filters/FilterSet.cpp
-        controllers/filters/FilterSet.hpp
-        controllers/filters/parser/FilterParser.cpp
-        controllers/filters/parser/FilterParser.hpp
-        controllers/filters/parser/Tokenizer.cpp
-        controllers/filters/parser/Tokenizer.hpp
-        controllers/filters/parser/Types.cpp
-        controllers/filters/parser/Types.hpp
-
-        controllers/highlights/BadgeHighlightModel.cpp
-        controllers/highlights/BadgeHighlightModel.hpp
-        controllers/highlights/HighlightBadge.cpp
-        controllers/highlights/HighlightBadge.hpp
-        controllers/highlights/HighlightBlacklistModel.cpp
-        controllers/highlights/HighlightBlacklistModel.hpp
-        controllers/highlights/HighlightController.cpp
-        controllers/highlights/HighlightController.hpp
-        controllers/highlights/HighlightModel.cpp
-        controllers/highlights/HighlightModel.hpp
-        controllers/highlights/HighlightPhrase.cpp
-        controllers/highlights/HighlightPhrase.hpp
-        controllers/highlights/UserHighlightModel.cpp
-        controllers/highlights/UserHighlightModel.hpp
-
-        controllers/hotkeys/ActionNames.hpp
-        controllers/hotkeys/Hotkey.cpp
-        controllers/hotkeys/Hotkey.hpp
-        controllers/hotkeys/HotkeyCategory.hpp
-        controllers/hotkeys/HotkeyController.cpp
-        controllers/hotkeys/HotkeyController.hpp
-        controllers/hotkeys/HotkeyHelpers.cpp
-        controllers/hotkeys/HotkeyHelpers.hpp
-        controllers/hotkeys/HotkeyModel.cpp
-        controllers/hotkeys/HotkeyModel.hpp
-
-        controllers/ignores/IgnoreController.cpp
-        controllers/ignores/IgnoreController.hpp
-        controllers/ignores/IgnoreModel.cpp
-        controllers/ignores/IgnoreModel.hpp
-        controllers/ignores/IgnorePhrase.cpp
-        controllers/ignores/IgnorePhrase.hpp
-
-        controllers/moderationactions/ModerationAction.cpp
-        controllers/moderationactions/ModerationAction.hpp
-        controllers/moderationactions/ModerationActionModel.cpp
-        controllers/moderationactions/ModerationActionModel.hpp
-
-        controllers/logging/ChannelLog.cpp
-        controllers/logging/ChannelLog.hpp
-        controllers/logging/ChannelLoggingModel.cpp
-        controllers/logging/ChannelLoggingModel.hpp
-
-        controllers/nicknames/NicknamesModel.cpp
-        controllers/nicknames/NicknamesModel.hpp
-        controllers/nicknames/Nickname.hpp
-
-        controllers/notifications/NotificationController.cpp
-        controllers/notifications/NotificationController.hpp
-        controllers/notifications/NotificationModel.cpp
-        controllers/notifications/NotificationModel.hpp
-
-        controllers/pings/MutedChannelModel.cpp
-        controllers/pings/MutedChannelModel.hpp
-
-        controllers/userdata/UserDataController.cpp
-        controllers/userdata/UserDataController.hpp
-        controllers/userdata/UserData.hpp
-
-        debug/Benchmark.cpp
-        debug/Benchmark.hpp
-
-        messages/Emote.cpp
-        messages/Emote.hpp
-        messages/Image.cpp
-        messages/Image.hpp
-        messages/ImageSet.cpp
-        messages/ImageSet.hpp
-        messages/Link.cpp
-        messages/Link.hpp
-        messages/Message.cpp
-        messages/Message.hpp
-        messages/MessageBuilder.cpp
-        messages/MessageBuilder.hpp
-        messages/MessageColor.cpp
-        messages/MessageColor.hpp
-        messages/MessageElement.cpp
-        messages/MessageElement.hpp
-        messages/MessageThread.cpp
-        messages/MessageThread.hpp
-
-        messages/SharedMessageBuilder.cpp
-        messages/SharedMessageBuilder.hpp
-
-        messages/layouts/MessageLayout.cpp
-        messages/layouts/MessageLayout.hpp
-        messages/layouts/MessageLayoutContainer.cpp
-        messages/layouts/MessageLayoutContainer.hpp
-        messages/layouts/MessageLayoutElement.cpp
-        messages/layouts/MessageLayoutElement.hpp
-        messages/search/AuthorPredicate.cpp
-        messages/search/AuthorPredicate.hpp
-        messages/search/BadgePredicate.cpp
-        messages/search/BadgePredicate.hpp
-        messages/search/ChannelPredicate.cpp
-        messages/search/ChannelPredicate.hpp
-        messages/search/LinkPredicate.cpp
-        messages/search/LinkPredicate.hpp
-        messages/search/MessageFlagsPredicate.cpp
-        messages/search/MessageFlagsPredicate.hpp
-        messages/search/RegexPredicate.cpp
-        messages/search/RegexPredicate.hpp
-        messages/search/SubstringPredicate.cpp
-        messages/search/SubstringPredicate.hpp
-        messages/search/SubtierPredicate.cpp
-        messages/search/SubtierPredicate.hpp
-
-        providers/IvrApi.cpp
-        providers/IvrApi.hpp
-        providers/LinkResolver.cpp
-        providers/LinkResolver.hpp
-        providers/RecentMessagesApi.cpp
-        providers/RecentMessagesApi.hpp
-
-        providers/bttv/BttvEmotes.cpp
-        providers/bttv/BttvEmotes.hpp
-
-        providers/chatterino/ChatterinoBadges.cpp
-        providers/chatterino/ChatterinoBadges.hpp
-
-        providers/colors/ColorProvider.cpp
-        providers/colors/ColorProvider.hpp
-
-        providers/emoji/Emojis.cpp
-        providers/emoji/Emojis.hpp
-
-        providers/ffz/FfzBadges.cpp
-        providers/ffz/FfzBadges.hpp
-        providers/ffz/FfzEmotes.cpp
-        providers/ffz/FfzEmotes.hpp
-
-        providers/irc/AbstractIrcServer.cpp
-        providers/irc/AbstractIrcServer.hpp
-        providers/irc/Irc2.cpp
-        providers/irc/Irc2.hpp
-        providers/irc/IrcAccount.cpp
-        providers/irc/IrcAccount.hpp
-        providers/irc/IrcChannel2.cpp
-        providers/irc/IrcChannel2.hpp
-        providers/irc/IrcCommands.cpp
-        providers/irc/IrcCommands.hpp
-        providers/irc/IrcConnection2.cpp
-        providers/irc/IrcConnection2.hpp
-        providers/irc/IrcMessageBuilder.cpp
-        providers/irc/IrcMessageBuilder.hpp
-        providers/irc/IrcServer.cpp
-        providers/irc/IrcServer.hpp
-
-        providers/liveupdates/BasicPubSubClient.hpp
-        providers/liveupdates/BasicPubSubManager.hpp
-        providers/liveupdates/BasicPubSubWebsocket.hpp
-
-        providers/seventv/SeventvBadges.cpp
-        providers/seventv/SeventvBadges.hpp
-        providers/seventv/SeventvEmotes.cpp
-        providers/seventv/SeventvEmotes.hpp
-        providers/seventv/SeventvEventAPI.cpp
-        providers/seventv/SeventvEventAPI.hpp
-
-        providers/seventv/eventapi/SeventvEventAPIClient.cpp
-        providers/seventv/eventapi/SeventvEventAPIClient.hpp
-        providers/seventv/eventapi/SeventvEventAPIDispatch.cpp
-        providers/seventv/eventapi/SeventvEventAPIDispatch.hpp
-        providers/seventv/eventapi/SeventvEventAPIMessage.cpp
-        providers/seventv/eventapi/SeventvEventAPIMessage.hpp
-        providers/seventv/eventapi/SeventvEventAPISubscription.cpp
-        providers/seventv/eventapi/SeventvEventAPISubscription.hpp
-
-        providers/twitch/ChannelPointReward.cpp
-        providers/twitch/ChannelPointReward.hpp
-        providers/twitch/IrcMessageHandler.cpp
-        providers/twitch/IrcMessageHandler.hpp
-        providers/twitch/PubSubActions.cpp
-        providers/twitch/PubSubActions.hpp
-        providers/twitch/PubSubClient.cpp
-        providers/twitch/PubSubClient.hpp
-        providers/twitch/PubSubClientOptions.hpp
-        providers/twitch/PubSubHelpers.hpp
-        providers/twitch/PubSubManager.cpp
-        providers/twitch/PubSubManager.hpp
-        providers/twitch/PubSubMessages.hpp
-        providers/twitch/PubSubWebsocket.hpp
-        providers/twitch/TwitchAccount.cpp
-        providers/twitch/TwitchAccount.hpp
-        providers/twitch/TwitchAccountManager.cpp
-        providers/twitch/TwitchAccountManager.hpp
-        providers/twitch/TwitchBadge.cpp
-        providers/twitch/TwitchBadge.hpp
-        providers/twitch/TwitchBadges.cpp
-        providers/twitch/TwitchBadges.hpp
-        providers/twitch/TwitchChannel.cpp
-        providers/twitch/TwitchChannel.hpp
-        providers/twitch/TwitchEmotes.cpp
-        providers/twitch/TwitchEmotes.hpp
-        providers/twitch/TwitchHelpers.cpp
-        providers/twitch/TwitchHelpers.hpp
-        providers/twitch/TwitchIrcServer.cpp
-        providers/twitch/TwitchIrcServer.hpp
-        providers/twitch/TwitchMessageBuilder.cpp
-        providers/twitch/TwitchMessageBuilder.hpp
-        providers/twitch/TwitchUser.cpp
-        providers/twitch/TwitchUser.hpp
-
-        providers/twitch/pubsubmessages/AutoMod.cpp
-        providers/twitch/pubsubmessages/AutoMod.hpp
-        providers/twitch/pubsubmessages/Base.cpp
-        providers/twitch/pubsubmessages/Base.hpp
-        providers/twitch/pubsubmessages/ChannelPoints.cpp
-        providers/twitch/pubsubmessages/ChannelPoints.hpp
-        providers/twitch/pubsubmessages/ChatModeratorAction.cpp
-        providers/twitch/pubsubmessages/ChatModeratorAction.hpp
-        providers/twitch/pubsubmessages/Listen.cpp
-        providers/twitch/pubsubmessages/Listen.hpp
-        providers/twitch/pubsubmessages/Message.hpp
-        providers/twitch/pubsubmessages/Unlisten.cpp
-        providers/twitch/pubsubmessages/Unlisten.hpp
-        providers/twitch/pubsubmessages/Whisper.cpp
-        providers/twitch/pubsubmessages/Whisper.hpp
-
-        providers/twitch/api/Helix.cpp
-        providers/twitch/api/Helix.hpp
-
-        singletons/Badges.cpp
-        singletons/Badges.hpp
-        singletons/Emotes.cpp
-        singletons/Emotes.hpp
-        singletons/Fonts.cpp
-        singletons/Fonts.hpp
-        singletons/Logging.cpp
-        singletons/Logging.hpp
-        singletons/NativeMessaging.cpp
-        singletons/NativeMessaging.hpp
-        singletons/Paths.cpp
-        singletons/Paths.hpp
-        singletons/Resources.cpp
-        singletons/Resources.hpp
-        singletons/Settings.cpp
-        singletons/Settings.hpp
-        singletons/Theme.cpp
-        singletons/Theme.hpp
-        singletons/Toasts.cpp
-        singletons/Toasts.hpp
-        singletons/Updates.cpp
-        singletons/Updates.hpp
-        singletons/WindowManager.cpp
-        singletons/WindowManager.hpp
-
-        singletons/helper/GifTimer.cpp
-        singletons/helper/GifTimer.hpp
-        singletons/helper/LoggingChannel.cpp
-        singletons/helper/LoggingChannel.hpp
-
-        util/AttachToConsole.cpp
-        util/AttachToConsole.hpp
-        util/Clipboard.cpp
-        util/Clipboard.hpp
-        util/ConcurrentMap.hpp
-        util/DebugCount.cpp
-        util/DebugCount.hpp
-        util/DisplayBadge.cpp
-        util/DisplayBadge.hpp
-        util/FormatTime.cpp
-        util/FormatTime.hpp
-        util/FunctionEventFilter.cpp
-        util/FunctionEventFilter.hpp
-        util/FuzzyConvert.cpp
-        util/FuzzyConvert.hpp
-        util/Helpers.cpp
-        util/Helpers.hpp
-        util/IncognitoBrowser.cpp
-        util/IncognitoBrowser.hpp
-        util/InitUpdateButton.cpp
-        util/InitUpdateButton.hpp
-        util/LayoutHelper.cpp
-        util/LayoutHelper.hpp
-        util/NuulsUploader.cpp
-        util/NuulsUploader.hpp
-        util/RapidjsonHelpers.cpp
-        util/RapidjsonHelpers.hpp
-        util/RatelimitBucket.cpp
-        util/RatelimitBucket.hpp
-        util/SampleData.cpp
-        util/SampleData.hpp
-        util/SharedPtrElementLess.hpp
-        util/SplitCommand.cpp
-        util/SplitCommand.hpp
-        util/StreamLink.cpp
-        util/StreamLink.hpp
-        util/StreamerMode.cpp
-        util/StreamerMode.hpp
-        util/ThreadGuard.hpp
-        util/Twitch.cpp
-        util/Twitch.hpp
-        util/TypeName.hpp
-        util/WindowsHelper.cpp
-        util/WindowsHelper.hpp
-
-        util/serialize/Container.hpp
-
-        widgets/AccountSwitchPopup.cpp
-        widgets/AccountSwitchPopup.hpp
-        widgets/AccountSwitchWidget.cpp
-        widgets/AccountSwitchWidget.hpp
-        widgets/AttachedWindow.cpp
-        widgets/AttachedWindow.hpp
-        widgets/BasePopup.cpp
-        widgets/BasePopup.hpp
-        widgets/BaseWidget.cpp
-        widgets/BaseWidget.hpp
-        widgets/BaseWindow.cpp
-        widgets/BaseWindow.hpp
-        widgets/DraggablePopup.cpp
-        widgets/DraggablePopup.hpp
-        widgets/FramelessEmbedWindow.cpp
-        widgets/FramelessEmbedWindow.hpp
-        widgets/Label.cpp
-        widgets/Label.hpp
-        widgets/Notebook.cpp
-        widgets/Notebook.hpp
-        widgets/Scrollbar.cpp
-        widgets/Scrollbar.hpp
-        widgets/StreamView.cpp
-        widgets/StreamView.hpp
-        widgets/TooltipWidget.cpp
-        widgets/TooltipWidget.hpp
-        widgets/Window.cpp
-        widgets/Window.hpp
-
-        widgets/dialogs/BadgePickerDialog.cpp
-        widgets/dialogs/BadgePickerDialog.hpp
-        widgets/dialogs/ChannelFilterEditorDialog.cpp
-        widgets/dialogs/ChannelFilterEditorDialog.hpp
-        widgets/dialogs/ColorPickerDialog.cpp
-        widgets/dialogs/ColorPickerDialog.hpp
-        widgets/dialogs/EditHotkeyDialog.cpp
-        widgets/dialogs/EditHotkeyDialog.hpp
-        widgets/dialogs/EmotePopup.cpp
-        widgets/dialogs/EmotePopup.hpp
-        widgets/dialogs/IrcConnectionEditor.cpp
-        widgets/dialogs/IrcConnectionEditor.hpp
-        widgets/dialogs/IrcConnectionEditor.ui
-        widgets/dialogs/LastRunCrashDialog.cpp
-        widgets/dialogs/LastRunCrashDialog.hpp
-        widgets/dialogs/LoginDialog.cpp
-        widgets/dialogs/LoginDialog.hpp
-        widgets/dialogs/NotificationPopup.cpp
-        widgets/dialogs/NotificationPopup.hpp
-        widgets/dialogs/QualityPopup.cpp
-        widgets/dialogs/QualityPopup.hpp
-        widgets/dialogs/ReplyThreadPopup.cpp
-        widgets/dialogs/ReplyThreadPopup.hpp
-        widgets/dialogs/SelectChannelDialog.cpp
-        widgets/dialogs/SelectChannelDialog.hpp
-        widgets/dialogs/SelectChannelFiltersDialog.cpp
-        widgets/dialogs/SelectChannelFiltersDialog.hpp
-        widgets/dialogs/SettingsDialog.cpp
-        widgets/dialogs/SettingsDialog.hpp
-        widgets/dialogs/UpdateDialog.cpp
-        widgets/dialogs/UpdateDialog.hpp
-        widgets/dialogs/UserInfoPopup.cpp
-        widgets/dialogs/UserInfoPopup.hpp
-        widgets/dialogs/WelcomeDialog.cpp
-        widgets/dialogs/WelcomeDialog.hpp
-        widgets/dialogs/switcher/NewPopupItem.cpp
-        widgets/dialogs/switcher/NewPopupItem.hpp
-        widgets/dialogs/switcher/NewTabItem.cpp
-        widgets/dialogs/switcher/NewTabItem.hpp
-        widgets/dialogs/switcher/QuickSwitcherModel.cpp
-        widgets/dialogs/switcher/QuickSwitcherModel.hpp
-        widgets/dialogs/switcher/QuickSwitcherPopup.cpp
-        widgets/dialogs/switcher/QuickSwitcherPopup.hpp
-        widgets/dialogs/switcher/SwitchSplitItem.cpp
-        widgets/dialogs/switcher/SwitchSplitItem.hpp
-
-        widgets/helper/Button.cpp
-        widgets/helper/Button.hpp
-        widgets/helper/ChannelView.cpp
-        widgets/helper/ChannelView.hpp
-        widgets/helper/ColorButton.cpp
-        widgets/helper/ColorButton.hpp
-        widgets/helper/ComboBoxItemDelegate.cpp
-        widgets/helper/ComboBoxItemDelegate.hpp
-        widgets/helper/DebugPopup.cpp
-        widgets/helper/DebugPopup.hpp
-        widgets/helper/EditableModelView.cpp
-        widgets/helper/EditableModelView.hpp
-        widgets/helper/EffectLabel.cpp
-        widgets/helper/EffectLabel.hpp
-        widgets/helper/NotebookButton.cpp
-        widgets/helper/NotebookButton.hpp
-        widgets/helper/NotebookTab.cpp
-        widgets/helper/NotebookTab.hpp
-        widgets/helper/QColorPicker.cpp
-        widgets/helper/QColorPicker.hpp
-        widgets/helper/RegExpItemDelegate.cpp
-        widgets/helper/RegExpItemDelegate.hpp
-        widgets/helper/TrimRegExpValidator.cpp
-        widgets/helper/TrimRegExpValidator.hpp
-        widgets/helper/ResizingTextEdit.cpp
-        widgets/helper/ResizingTextEdit.hpp
-        widgets/helper/ScrollbarHighlight.cpp
-        widgets/helper/ScrollbarHighlight.hpp
-        widgets/helper/SearchPopup.cpp
-        widgets/helper/SearchPopup.hpp
-        widgets/helper/SettingsDialogTab.cpp
-        widgets/helper/SettingsDialogTab.hpp
-        widgets/helper/SignalLabel.cpp
-        widgets/helper/SignalLabel.hpp
-        widgets/helper/TitlebarButton.cpp
-        widgets/helper/TitlebarButton.hpp
-
-        widgets/listview/GenericItemDelegate.cpp
-        widgets/listview/GenericItemDelegate.hpp
-        widgets/listview/GenericListItem.cpp
-        widgets/listview/GenericListItem.hpp
-        widgets/listview/GenericListModel.cpp
-        widgets/listview/GenericListModel.hpp
-        widgets/listview/GenericListView.cpp
-        widgets/listview/GenericListView.hpp
-
-        widgets/settingspages/AboutPage.cpp
-        widgets/settingspages/AboutPage.hpp
-        widgets/settingspages/AccountsPage.cpp
-        widgets/settingspages/AccountsPage.hpp
-        widgets/settingspages/CommandPage.cpp
-        widgets/settingspages/CommandPage.hpp
-        widgets/settingspages/ExternalToolsPage.cpp
-        widgets/settingspages/ExternalToolsPage.hpp
-        widgets/settingspages/FiltersPage.cpp
-        widgets/settingspages/FiltersPage.hpp
-        widgets/settingspages/GeneralPage.cpp
-        widgets/settingspages/GeneralPage.hpp
-        widgets/settingspages/GeneralPageView.cpp
-        widgets/settingspages/GeneralPageView.hpp
-        widgets/settingspages/HighlightingPage.cpp
-        widgets/settingspages/HighlightingPage.hpp
-        widgets/settingspages/IgnoresPage.cpp
-        widgets/settingspages/IgnoresPage.hpp
-        widgets/settingspages/KeyboardSettingsPage.cpp
-        widgets/settingspages/KeyboardSettingsPage.hpp
-        widgets/settingspages/ModerationPage.cpp
-        widgets/settingspages/ModerationPage.hpp
-        widgets/settingspages/NicknamesPage.cpp
-        widgets/settingspages/NicknamesPage.hpp
-        widgets/settingspages/NotificationPage.cpp
-        widgets/settingspages/NotificationPage.hpp
-        widgets/settingspages/SettingsPage.cpp
-        widgets/settingspages/SettingsPage.hpp
-
-        widgets/splits/ClosedSplits.cpp
-        widgets/splits/ClosedSplits.hpp
-        widgets/splits/DraggedSplit.cpp
-        widgets/splits/DraggedSplit.hpp
-        widgets/splits/InputCompletionItem.cpp
-        widgets/splits/InputCompletionItem.hpp
-        widgets/splits/InputCompletionPopup.cpp
-        widgets/splits/InputCompletionPopup.hpp
-        widgets/splits/Split.cpp
-        widgets/splits/Split.hpp
-        widgets/splits/SplitContainer.cpp
-        widgets/splits/SplitContainer.hpp
-        widgets/splits/SplitHeader.cpp
-        widgets/splits/SplitHeader.hpp
-        widgets/splits/SplitInput.cpp
-        widgets/splits/SplitInput.hpp
-        widgets/splits/SplitOverlay.cpp
-        widgets/splits/SplitOverlay.hpp
-
-        ${CMAKE_SOURCE_DIR}/resources/resources.qrc
-        )
-
-if (WIN32)
+if(WIN32)
     # clang-cl doesn't support resource files
-    if (NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    if(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         list(APPEND SOURCE_FILES "${CMAKE_SOURCE_DIR}/resources/windows.rc")
-    endif ()
+    endif()
 
-elseif (APPLE)
+elseif(APPLE)
     set(MACOS_BUNDLE_ICON_FILE "${CMAKE_SOURCE_DIR}/resources/chatterino.icns")
     list(APPEND SOURCE_FILES "${MACOS_BUNDLE_ICON_FILE}")
-    set_source_files_properties(${MACOS_BUNDLE_ICON_FILE} PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
-endif ()
+    set_source_files_properties(
+        ${MACOS_BUNDLE_ICON_FILE} PROPERTIES MACOSX_PACKAGE_LOCATION
+                                             "Resources"
+    )
+endif()
 
 # Generate source groups for use in IDEs
 source_group(TREE ${CMAKE_SOURCE_DIR} FILES ${SOURCE_FILES})
@@ -572,7 +534,7 @@ list(APPEND SOURCE_FILES ${RES_AUTOGEN_FILES})
 
 add_library(${LIBRARY_PROJECT} OBJECT ${SOURCE_FILES})
 
-if (CHATTERINO_GENERATE_COVERAGE)
+if(CHATTERINO_GENERATE_COVERAGE)
     include(CodeCoverage)
     append_coverage_compiler_flags_to_target(${LIBRARY_PROJECT})
     target_link_libraries(${LIBRARY_PROJECT} PUBLIC gcov)
@@ -581,292 +543,289 @@ if (CHATTERINO_GENERATE_COVERAGE)
         NAME coverage
         EXECUTABLE ./bin/chatterino-test
         BASE_DIRECTORY ${PROJECT_SOURCE_DIR}/src
-        EXCLUDE "/usr/include/*"
-        EXCLUDE "build-*/*"
-        EXCLUDE "lib/*"
-        )
-endif ()
-
-target_link_libraries(${LIBRARY_PROJECT}
-        PUBLIC
-        Qt${MAJOR_QT_VERSION}::Core
-        Qt${MAJOR_QT_VERSION}::Widgets
-        Qt${MAJOR_QT_VERSION}::Gui
-        Qt${MAJOR_QT_VERSION}::Network
-        Qt${MAJOR_QT_VERSION}::Multimedia
-        Qt${MAJOR_QT_VERSION}::Svg
-        Qt${MAJOR_QT_VERSION}::Concurrent
-
-        LibCommuni::LibCommuni
-        Pajlada::Serialize
-        Pajlada::Settings
-        Pajlada::Signals
-        websocketpp::websocketpp
-        Threads::Threads
-        RapidJSON::RapidJSON
-        LRUCache
-        MagicEnum
-        )
-if (BUILD_WITH_QTKEYCHAIN)
-    target_link_libraries(${LIBRARY_PROJECT}
-            PUBLIC
-            qt${MAJOR_QT_VERSION}keychain
-            )
-else()
-    target_compile_definitions(${LIBRARY_PROJECT}
-        PUBLIC
-        NO_QTKEYCHAIN
-        )
+        EXCLUDE "/usr/include/*" "build-*/*" "lib/*"
+    )
 endif()
 
-if (BUILD_APP)
-    if (APPLE)
+target_link_libraries(
+    ${LIBRARY_PROJECT}
+    PUBLIC Qt${MAJOR_QT_VERSION}::Core
+           Qt${MAJOR_QT_VERSION}::Widgets
+           Qt${MAJOR_QT_VERSION}::Gui
+           Qt${MAJOR_QT_VERSION}::Network
+           Qt${MAJOR_QT_VERSION}::Multimedia
+           Qt${MAJOR_QT_VERSION}::Svg
+           Qt${MAJOR_QT_VERSION}::Concurrent
+           LibCommuni::LibCommuni
+           Pajlada::Serialize
+           Pajlada::Settings
+           Pajlada::Signals
+           websocketpp::websocketpp
+           Threads::Threads
+           RapidJSON::RapidJSON
+           LRUCache
+           MagicEnum
+)
+if(BUILD_WITH_QTKEYCHAIN)
+    target_link_libraries(
+        ${LIBRARY_PROJECT} PUBLIC qt${MAJOR_QT_VERSION}keychain
+    )
+else()
+    target_compile_definitions(${LIBRARY_PROJECT} PUBLIC NO_QTKEYCHAIN)
+endif()
+
+if(BUILD_APP)
+    if(APPLE)
         add_executable(${EXECUTABLE_PROJECT} ${MACOS_BUNDLE_ICON_FILE} main.cpp)
     else()
         add_executable(${EXECUTABLE_PROJECT} main.cpp)
     endif()
     add_sanitizers(${EXECUTABLE_PROJECT})
 
-    target_include_directories(${EXECUTABLE_PROJECT} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_BINARY_DIR}/autogen/)
+    target_include_directories(
+        ${EXECUTABLE_PROJECT} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+                                      ${CMAKE_BINARY_DIR}/autogen/
+    )
 
     target_link_libraries(${EXECUTABLE_PROJECT} PUBLIC ${LIBRARY_PROJECT})
 
-    set_target_properties(${EXECUTABLE_PROJECT}
-        PROPERTIES
-        ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-        LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
-        RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/bin"
-        RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_BINARY_DIR}/bin"
-        RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO "${CMAKE_BINARY_DIR}/bin"
+    set_target_properties(
+        ${EXECUTABLE_PROJECT}
+        PROPERTIES ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+                   LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+                   RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+                   RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/bin"
+                   RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_BINARY_DIR}/bin"
+                   RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO
+                   "${CMAKE_BINARY_DIR}/bin"
+    )
+
+    if(MSVC)
+        if(NOT VCPKG_INSTALLED_DIR)
+            get_target_property(
+                Qt_Core_Location Qt${MAJOR_QT_VERSION}::Core LOCATION
+            )
+            get_filename_component(QT_BIN_DIR ${Qt_Core_Location} DIRECTORY)
+            set(WINDEPLOYQT_COMMAND
+                "${QT_BIN_DIR}/windeployqt.exe"
+                $<TARGET_FILE:${EXECUTABLE_PROJECT}> --release
+                --no-compiler-runtime --no-translations --no-opengl-sw
+            )
+
+            install(TARGETS ${EXECUTABLE_PROJECT} RUNTIME DESTINATION .)
+
+            # cmake-format: off
+            # W0106: String looks like a variable reference
+            # C0301: Line too long
+            # cmake-lint: disable=W0106
+            # cmake-lint: disable=C0301
+            # cmake-format: on
+            install(
+                CODE "execute_process(COMMAND ${WINDEPLOYQT_COMMAND} --dir \${CMAKE_INSTALL_PREFIX})"
+            )
+        endif()
+    elseif(APPLE)
+        install(
+            TARGETS ${EXECUTABLE_PROJECT}
+            RUNTIME DESTINATION bin
+            BUNDLE DESTINATION bin
+            LIBRARY DESTINATION lib
+            ARCHIVE DESTINATION lib/static
+        )
+    else()
+        install(
+            TARGETS ${EXECUTABLE_PROJECT}
+            RUNTIME DESTINATION bin
+            LIBRARY DESTINATION lib
+            ARCHIVE DESTINATION lib/static
         )
 
-    if (MSVC)
-        if (NOT VCPKG_INSTALLED_DIR)
-            get_target_property(Qt_Core_Location Qt${MAJOR_QT_VERSION}::Core LOCATION)
-            get_filename_component(QT_BIN_DIR ${Qt_Core_Location} DIRECTORY)
-            set(WINDEPLOYQT_COMMAND "${QT_BIN_DIR}/windeployqt.exe" $<TARGET_FILE:${EXECUTABLE_PROJECT}> --release --no-compiler-runtime --no-translations --no-opengl-sw)
+        install(
+            FILES
+                ${CMAKE_SOURCE_DIR}/resources/com.chatterino.chatterino.desktop
+            DESTINATION share/applications
+        )
 
-            install(TARGETS ${EXECUTABLE_PROJECT}
-                    RUNTIME DESTINATION .
-                    )
-
-            install(CODE "execute_process(COMMAND ${WINDEPLOYQT_COMMAND} --dir \${CMAKE_INSTALL_PREFIX})")
-        endif()
-    elseif (APPLE)
-        install(TARGETS ${EXECUTABLE_PROJECT}
-                RUNTIME DESTINATION bin
-                BUNDLE DESTINATION bin
-                LIBRARY DESTINATION lib
-                ARCHIVE DESTINATION lib/static
-                )
-    else ()
-        install(TARGETS ${EXECUTABLE_PROJECT}
-                RUNTIME DESTINATION bin
-                LIBRARY DESTINATION lib
-                ARCHIVE DESTINATION lib/static
-                )
-
-        install(FILES ${CMAKE_SOURCE_DIR}/resources/com.chatterino.chatterino.desktop
-                DESTINATION share/applications
-                )
-
-        install(FILES ${CMAKE_SOURCE_DIR}/resources/icon.png
-                RENAME com.chatterino.chatterino.png
-                DESTINATION share/icons/hicolor/256x256/apps
-                )
-    endif ()
+        install(
+            FILES ${CMAKE_SOURCE_DIR}/resources/icon.png
+            RENAME com.chatterino.chatterino.png
+            DESTINATION share/icons/hicolor/256x256/apps
+        )
+    endif()
 
     if(CHATTERINO_ENABLE_LTO)
         message(STATUS "Enabling LTO for ${EXECUTABLE_PROJECT}")
-        set_property(TARGET ${EXECUTABLE_PROJECT}
-            PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+        set_property(
+            TARGET ${EXECUTABLE_PROJECT} PROPERTY INTERPROCEDURAL_OPTIMIZATION
+                                                  TRUE
+        )
     endif()
-endif ()
+endif()
 
-if (USE_PRECOMPILED_HEADERS)
+if(USE_PRECOMPILED_HEADERS)
     message(STATUS "Building with precompiled headers")
     target_precompile_headers(${LIBRARY_PROJECT} PRIVATE PrecompiledHeader.hpp)
-else ()
+else()
     message(STATUS "Building without precompiled headers")
-endif ()
+endif()
 
 # Enable autogeneration of Qts MOC/RCC/UIC
-set_target_properties(${LIBRARY_PROJECT}
-    PROPERTIES
-    AUTOMOC ON
-    AUTORCC ON
-    AUTOUIC ON
-    )
+set_target_properties(
+    ${LIBRARY_PROJECT}
+    PROPERTIES AUTOMOC ON
+               AUTORCC ON
+               AUTOUIC ON
+)
 
-# Used to provide a date of build in the About page (for nightly builds). Getting the actual time of
-# compilation in CMake is a more involved, as documented in https://stackoverflow.com/q/24292898.
-# For CI runs, however, the date of build file generation should be consistent with the date of
+# Used to provide a date of build in the About page (for nightly builds).
+# Getting the actual time of compilation in CMake is a more involved, as
+# documented in https://stackoverflow.com/q/24292898. For CI runs, however, the
+# date of build file generation should be consistent with the date of
 # compilation so this approximation is "good enough" for our purpose.
-if (DEFINED ENV{CHATTERINO_SKIP_DATE_GEN})
-    set(cmake_gen_date "1970-01-01")
-else ()
-    string(TIMESTAMP cmake_gen_date "%Y-%m-%d")
-endif ()
+if(DEFINED ENV{CHATTERINO_SKIP_DATE_GEN})
+    set(CMAKE_GEN_DATE "1970-01-01")
+else()
+    string(TIMESTAMP CMAKE_GEN_DATE "%Y-%m-%d")
+endif()
 
-target_compile_definitions(${LIBRARY_PROJECT} PUBLIC
-    CHATTERINO
-    UNICODE
-    AB_CUSTOM_SETTINGS
-    IRC_STATIC
-    IRC_NAMESPACE=Communi
-
-    CHATTERINO_GIT_HASH=\"${GIT_HASH}\"
-    CHATTERINO_GIT_RELEASE=\"${GIT_RELEASE}\"
-    CHATTERINO_GIT_COMMIT=\"${GIT_COMMIT}\"
-
-    CHATTERINO_CMAKE_GEN_DATE=\"${cmake_gen_date}\"
+target_compile_definitions(
+    ${LIBRARY_PROJECT}
+    PUBLIC CHATTERINO
+           UNICODE
+           AB_CUSTOM_SETTINGS
+           IRC_STATIC
+           IRC_NAMESPACE=Communi
+           CHATTERINO_GIT_HASH=\"${GIT_HASH}\"
+           CHATTERINO_GIT_RELEASE=\"${GIT_RELEASE}\"
+           CHATTERINO_GIT_COMMIT=\"${GIT_COMMIT}\"
+           CHATTERINO_CMAKE_GEN_DATE=\"${CMAKE_GEN_DATE}\"
+)
+if(GIT_MODIFIED)
+    target_compile_definitions(
+        ${LIBRARY_PROJECT} PUBLIC CHATTERINO_GIT_MODIFIED
     )
-if (GIT_MODIFIED)
-    target_compile_definitions(${LIBRARY_PROJECT} PUBLIC
-        CHATTERINO_GIT_MODIFIED
+endif()
+if(USE_SYSTEM_QTKEYCHAIN)
+    target_compile_definitions(${LIBRARY_PROJECT} PUBLIC CMAKE_BUILD)
+endif()
+if(WIN32)
+    target_compile_definitions(${LIBRARY_PROJECT} PUBLIC USEWINSDK)
+    if(BUILD_APP)
+        set_target_properties(
+            ${EXECUTABLE_PROJECT} PROPERTIES WIN32_EXECUTABLE TRUE
         )
-endif ()
-if (USE_SYSTEM_QTKEYCHAIN)
-    target_compile_definitions(${LIBRARY_PROJECT} PUBLIC
-        CMAKE_BUILD
-        )
-endif ()
-if (WIN32)
-    target_compile_definitions(${LIBRARY_PROJECT} PUBLIC
-        USEWINSDK
-        )
-    if (BUILD_APP)
-        set_target_properties(${EXECUTABLE_PROJECT} PROPERTIES WIN32_EXECUTABLE TRUE)
-    endif ()
-endif ()
+    endif()
+endif()
 
-if (MSVC)
+if(MSVC)
     target_compile_options(${LIBRARY_PROJECT} PUBLIC /EHsc /bigobj)
-endif ()
+endif()
 
-if (APPLE AND BUILD_APP)
+if(APPLE AND BUILD_APP)
     set_target_properties(${EXECUTABLE_PROJECT} PROPERTIES MACOSX_BUNDLE TRUE)
-    set_target_properties(${EXECUTABLE_PROJECT}
-        PROPERTIES
-        MACOSX_BUNDLE_BUNDLE_NAME "Chatterino"
-        MACOSX_BUNDLE_GUI_IDENTIFIER "com.chatterino"
-        MACOSX_BUNDLE_INFO_STRING "Chat client for Twitch"
-        MACOSX_BUNDLE_LONG_VERSION_STRING "${PROJECT_VERSION}"
-        MACOSX_BUNDLE_SHORT_VERSION_STRING "${PROJECT_VERSION}"
-        MACOSX_BUNDLE_BUNDLE_VERSION "${PROJECT_VERSION}"
-        MACOSX_BUNDLE_ICON_FILE chatterino.icns
-        )
-endif ()
+    set_target_properties(
+        ${EXECUTABLE_PROJECT}
+        PROPERTIES MACOSX_BUNDLE_BUNDLE_NAME "Chatterino"
+                   MACOSX_BUNDLE_GUI_IDENTIFIER "com.chatterino"
+                   MACOSX_BUNDLE_INFO_STRING "Chat client for Twitch"
+                   MACOSX_BUNDLE_LONG_VERSION_STRING "${PROJECT_VERSION}"
+                   MACOSX_BUNDLE_SHORT_VERSION_STRING "${PROJECT_VERSION}"
+                   MACOSX_BUNDLE_BUNDLE_VERSION "${PROJECT_VERSION}"
+                   MACOSX_BUNDLE_ICON_FILE chatterino.icns
+    )
+endif()
 
-target_include_directories(${LIBRARY_PROJECT} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_BINARY_DIR}/autogen/)
+target_include_directories(
+    ${LIBRARY_PROJECT} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+                              ${CMAKE_BINARY_DIR}/autogen/
+)
 
-if (WinToast_FOUND)
-    target_link_libraries(${LIBRARY_PROJECT}
-        PUBLIC
-        WinToast)
-endif ()
+if(WinToast_FOUND)
+    target_link_libraries(${LIBRARY_PROJECT} PUBLIC WinToast)
+endif()
 
-if (USE_CONAN AND TARGET CONAN_PKG::boost)
-    target_link_libraries(${LIBRARY_PROJECT}
-        PUBLIC
-        CONAN_PKG::boost
-        )
-else ()
-    target_link_libraries(${LIBRARY_PROJECT}
-        PUBLIC
-        ${Boost_LIBRARIES}
-        )
-endif ()
+if(USE_CONAN AND TARGET CONAN_PKG::boost)
+    target_link_libraries(${LIBRARY_PROJECT} PUBLIC CONAN_PKG::boost)
+else()
+    target_link_libraries(${LIBRARY_PROJECT} PUBLIC ${Boost_LIBRARIES})
+endif()
 
-if (USE_CONAN AND TARGET CONAN_PKG::openssl)
-    target_link_libraries(${LIBRARY_PROJECT}
-        PUBLIC
-        CONAN_PKG::openssl
-        )
-else ()
-    target_link_libraries(${LIBRARY_PROJECT}
-        PUBLIC
-        OpenSSL::SSL
-        OpenSSL::Crypto
-        )
-endif ()
+if(USE_CONAN AND TARGET CONAN_PKG::openssl)
+    target_link_libraries(${LIBRARY_PROJECT} PUBLIC CONAN_PKG::openssl)
+else()
+    target_link_libraries(
+        ${LIBRARY_PROJECT} PUBLIC OpenSSL::SSL OpenSSL::Crypto
+    )
+endif()
 
 target_include_directories(${LIBRARY_PROJECT} PUBLIC ${RapidJSON_INCLUDE_DIRS})
 
-if (LIBRT)
-    target_link_libraries(${LIBRARY_PROJECT}
-        PUBLIC
-        ${LIBRT}
-        )
-endif ()
+if(LIBRT)
+    target_link_libraries(${LIBRARY_PROJECT} PUBLIC ${LIBRT})
+endif()
 
 # Configure compiler warnings
-if (MSVC)
-    # Someone adds /W3 before we add /W4.
-    # This makes sure, only /W4 is specified.
+if(MSVC)
+    # Someone adds /W3 before we add /W4. This makes sure, only /W4 is
+    # specified.
     string(REPLACE "/W3" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-    # 4505 - "unreferenced local version has been removed"
-    #        Although this might give hints on dead code,
-    #        there are some cases where it's distracting.
+    # 4505 - "unreferenced local version has been removed" Although this might
+    # give hints on dead code, there are some cases where it's distracting.
     #
-    # 4100 - "unreferenced formal parameter"
-    #        There are a lot of functions and methods where
-    #        an argument was given a name but never used.
-    #        There's a clang-tidy rule that will catch this
-    #        for new/updated functions/methods.
+    # 4100 - "unreferenced formal parameter" There are a lot of functions and
+    # methods where an argument was given a name but never used. There's a
+    # clang-tidy rule that will catch this for new/updated functions/methods.
     #
-    # 4267 - "possible loss of data in return"
-    #        These are implicit conversions from size_t to int/qsizetype.
-    #        We don't use size_t in a lot of cases, since
-    #        Qt doesn't use it - it uses int (or qsizetype in Qt6).
-    target_compile_options(${LIBRARY_PROJECT} PUBLIC
-        /W4
-        # 5038 - warnings about initialization order
-        /w15038
-        # 4855 - implicit capture of 'this' via '[=]' is deprecated
-        /w14855
-        # Disable the following warnings (see reasoning above)
-        /wd4505
-        /wd4100
-        /wd4267
+    # 4267 - "possible loss of data in return" These are implicit conversions
+    # from size_t to int/qsizetype. We don't use size_t in a lot of cases, since
+    # Qt doesn't use it - it uses int (or qsizetype in Qt6).
+    target_compile_options(
+        ${LIBRARY_PROJECT}
+        PUBLIC /W4
+               # 5038 - warnings about initialization order
+               /w15038
+               # 4855 - implicit capture of 'this' via '[=]' is deprecated
+               /w14855
+               # Disable the following warnings (see reasoning above)
+               /wd4505
+               /wd4100
+               /wd4267
     )
     target_compile_definitions(${LIBRARY_PROJECT} PUBLIC NOMINMAX)
-else ()
-    target_compile_options(${LIBRARY_PROJECT} PUBLIC
-        -Wall
-        # Disable the following warnings
-        -Wno-unused-function
-        -Wno-switch
-        -Wno-deprecated-declarations
-        -Wno-sign-compare
-        -Wno-unused-variable
-
-        # Disabling strict-aliasing warnings for now, although we probably want to re-enable this in the future
-        -Wno-strict-aliasing
-
-        -Werror=return-type
-        -Werror=reorder
+else()
+    target_compile_options(
+        ${LIBRARY_PROJECT}
+        PUBLIC -Wall
+               # Disable the following warnings
+               -Wno-unused-function
+               -Wno-switch
+               -Wno-deprecated-declarations
+               -Wno-sign-compare
+               -Wno-unused-variable
+               # Disabling strict-aliasing warnings for now, although we
+               # probably want to re-enable this in the future
+               -Wno-strict-aliasing
+               -Werror=return-type
+               -Werror=reorder
     )
 
-    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-        target_compile_options(${LIBRARY_PROJECT} PUBLIC
-            -Wno-unused-local-typedef
-            -Wno-unused-private-field
-            -Werror=inconsistent-missing-override
-            -Werror=final-dtor-non-final-class
-            -Werror=ambiguous-reversed-operator
-
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        target_compile_options(
+            ${LIBRARY_PROJECT}
+            PUBLIC -Wno-unused-local-typedef
+                   -Wno-unused-private-field
+                   -Werror=inconsistent-missing-override
+                   -Werror=final-dtor-non-final-class
+                   -Werror=ambiguous-reversed-operator
         )
-    else ()
-        target_compile_options(${LIBRARY_PROJECT} PUBLIC
-            -Wno-class-memaccess
-        )
+    else()
+        target_compile_options(${LIBRARY_PROJECT} PUBLIC -Wno-class-memaccess)
     endif()
-endif ()
+endif()
 
 if(CHATTERINO_ENABLE_LTO)
     message(STATUS "Enabling LTO for ${LIBRARY_PROJECT}")
-    set_property(TARGET ${LIBRARY_PROJECT}
-                 PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+    set_property(
+        TARGET ${LIBRARY_PROJECT} PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE
+    )
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,14 +3,14 @@ set(EXECUTABLE_PROJECT "${PROJECT_NAME}")
 add_compile_definitions(QT_DISABLE_DEPRECATED_BEFORE=0x050F00)
 
 set(SOURCE_FILES
+    # cmake-format: sort
+    ${CMAKE_SOURCE_DIR}/resources/resources.qrc
     Application.cpp
     Application.hpp
     BaseSettings.cpp
     BaseSettings.hpp
     BrowserExtension.cpp
     BrowserExtension.hpp
-    RunGui.cpp
-    RunGui.hpp
     common/Args.cpp
     common/Args.hpp
     common/Channel.cpp
@@ -57,11 +57,11 @@ set(SOURCE_FILES
     controllers/accounts/AccountModel.hpp
     controllers/commands/builtin/twitch/ChatSettings.cpp
     controllers/commands/builtin/twitch/ChatSettings.hpp
+    controllers/commands/Command.cpp
+    controllers/commands/Command.hpp
     controllers/commands/CommandContext.hpp
     controllers/commands/CommandController.cpp
     controllers/commands/CommandController.hpp
-    controllers/commands/Command.cpp
-    controllers/commands/Command.hpp
     controllers/commands/CommandModel.cpp
     controllers/commands/CommandModel.hpp
     controllers/filters/FilterModel.cpp
@@ -106,26 +106,26 @@ set(SOURCE_FILES
     controllers/ignores/IgnoreModel.hpp
     controllers/ignores/IgnorePhrase.cpp
     controllers/ignores/IgnorePhrase.hpp
-    controllers/moderationactions/ModerationAction.cpp
-    controllers/moderationactions/ModerationAction.hpp
-    controllers/moderationactions/ModerationActionModel.cpp
-    controllers/moderationactions/ModerationActionModel.hpp
     controllers/logging/ChannelLog.cpp
     controllers/logging/ChannelLog.hpp
     controllers/logging/ChannelLoggingModel.cpp
     controllers/logging/ChannelLoggingModel.hpp
+    controllers/moderationactions/ModerationAction.cpp
+    controllers/moderationactions/ModerationAction.hpp
+    controllers/moderationactions/ModerationActionModel.cpp
+    controllers/moderationactions/ModerationActionModel.hpp
+    controllers/nicknames/Nickname.hpp
     controllers/nicknames/NicknamesModel.cpp
     controllers/nicknames/NicknamesModel.hpp
-    controllers/nicknames/Nickname.hpp
     controllers/notifications/NotificationController.cpp
     controllers/notifications/NotificationController.hpp
     controllers/notifications/NotificationModel.cpp
     controllers/notifications/NotificationModel.hpp
     controllers/pings/MutedChannelModel.cpp
     controllers/pings/MutedChannelModel.hpp
+    controllers/userdata/UserData.hpp
     controllers/userdata/UserDataController.cpp
     controllers/userdata/UserDataController.hpp
-    controllers/userdata/UserData.hpp
     debug/Benchmark.cpp
     debug/Benchmark.hpp
     messages/Emote.cpp
@@ -134,6 +134,12 @@ set(SOURCE_FILES
     messages/Image.hpp
     messages/ImageSet.cpp
     messages/ImageSet.hpp
+    messages/layouts/MessageLayout.cpp
+    messages/layouts/MessageLayout.hpp
+    messages/layouts/MessageLayoutContainer.cpp
+    messages/layouts/MessageLayoutContainer.hpp
+    messages/layouts/MessageLayoutElement.cpp
+    messages/layouts/MessageLayoutElement.hpp
     messages/Link.cpp
     messages/Link.hpp
     messages/Message.cpp
@@ -146,14 +152,6 @@ set(SOURCE_FILES
     messages/MessageElement.hpp
     messages/MessageThread.cpp
     messages/MessageThread.hpp
-    messages/SharedMessageBuilder.cpp
-    messages/SharedMessageBuilder.hpp
-    messages/layouts/MessageLayout.cpp
-    messages/layouts/MessageLayout.hpp
-    messages/layouts/MessageLayoutContainer.cpp
-    messages/layouts/MessageLayoutContainer.hpp
-    messages/layouts/MessageLayoutElement.cpp
-    messages/layouts/MessageLayoutElement.hpp
     messages/search/AuthorPredicate.cpp
     messages/search/AuthorPredicate.hpp
     messages/search/BadgePredicate.cpp
@@ -170,12 +168,8 @@ set(SOURCE_FILES
     messages/search/SubstringPredicate.hpp
     messages/search/SubtierPredicate.cpp
     messages/search/SubtierPredicate.hpp
-    providers/IvrApi.cpp
-    providers/IvrApi.hpp
-    providers/LinkResolver.cpp
-    providers/LinkResolver.hpp
-    providers/RecentMessagesApi.cpp
-    providers/RecentMessagesApi.hpp
+    messages/SharedMessageBuilder.cpp
+    messages/SharedMessageBuilder.hpp
     providers/bttv/BttvEmotes.cpp
     providers/bttv/BttvEmotes.hpp
     providers/chatterino/ChatterinoBadges.cpp
@@ -204,15 +198,15 @@ set(SOURCE_FILES
     providers/irc/IrcMessageBuilder.hpp
     providers/irc/IrcServer.cpp
     providers/irc/IrcServer.hpp
+    providers/IvrApi.cpp
+    providers/IvrApi.hpp
+    providers/LinkResolver.cpp
+    providers/LinkResolver.hpp
     providers/liveupdates/BasicPubSubClient.hpp
     providers/liveupdates/BasicPubSubManager.hpp
     providers/liveupdates/BasicPubSubWebsocket.hpp
-    providers/seventv/SeventvBadges.cpp
-    providers/seventv/SeventvBadges.hpp
-    providers/seventv/SeventvEmotes.cpp
-    providers/seventv/SeventvEmotes.hpp
-    providers/seventv/SeventvEventAPI.cpp
-    providers/seventv/SeventvEventAPI.hpp
+    providers/RecentMessagesApi.cpp
+    providers/RecentMessagesApi.hpp
     providers/seventv/eventapi/SeventvEventAPIClient.cpp
     providers/seventv/eventapi/SeventvEventAPIClient.hpp
     providers/seventv/eventapi/SeventvEventAPIDispatch.cpp
@@ -221,6 +215,14 @@ set(SOURCE_FILES
     providers/seventv/eventapi/SeventvEventAPIMessage.hpp
     providers/seventv/eventapi/SeventvEventAPISubscription.cpp
     providers/seventv/eventapi/SeventvEventAPISubscription.hpp
+    providers/seventv/SeventvBadges.cpp
+    providers/seventv/SeventvBadges.hpp
+    providers/seventv/SeventvEmotes.cpp
+    providers/seventv/SeventvEmotes.hpp
+    providers/seventv/SeventvEventAPI.cpp
+    providers/seventv/SeventvEventAPI.hpp
+    providers/twitch/api/Helix.cpp
+    providers/twitch/api/Helix.hpp
     providers/twitch/ChannelPointReward.cpp
     providers/twitch/ChannelPointReward.hpp
     providers/twitch/IrcMessageHandler.cpp
@@ -234,6 +236,21 @@ set(SOURCE_FILES
     providers/twitch/PubSubManager.cpp
     providers/twitch/PubSubManager.hpp
     providers/twitch/PubSubMessages.hpp
+    providers/twitch/pubsubmessages/AutoMod.cpp
+    providers/twitch/pubsubmessages/AutoMod.hpp
+    providers/twitch/pubsubmessages/Base.cpp
+    providers/twitch/pubsubmessages/Base.hpp
+    providers/twitch/pubsubmessages/ChannelPoints.cpp
+    providers/twitch/pubsubmessages/ChannelPoints.hpp
+    providers/twitch/pubsubmessages/ChatModeratorAction.cpp
+    providers/twitch/pubsubmessages/ChatModeratorAction.hpp
+    providers/twitch/pubsubmessages/Listen.cpp
+    providers/twitch/pubsubmessages/Listen.hpp
+    providers/twitch/pubsubmessages/Message.hpp
+    providers/twitch/pubsubmessages/Unlisten.cpp
+    providers/twitch/pubsubmessages/Unlisten.hpp
+    providers/twitch/pubsubmessages/Whisper.cpp
+    providers/twitch/pubsubmessages/Whisper.hpp
     providers/twitch/PubSubWebsocket.hpp
     providers/twitch/TwitchAccount.cpp
     providers/twitch/TwitchAccount.hpp
@@ -255,29 +272,18 @@ set(SOURCE_FILES
     providers/twitch/TwitchMessageBuilder.hpp
     providers/twitch/TwitchUser.cpp
     providers/twitch/TwitchUser.hpp
-    providers/twitch/pubsubmessages/AutoMod.cpp
-    providers/twitch/pubsubmessages/AutoMod.hpp
-    providers/twitch/pubsubmessages/Base.cpp
-    providers/twitch/pubsubmessages/Base.hpp
-    providers/twitch/pubsubmessages/ChannelPoints.cpp
-    providers/twitch/pubsubmessages/ChannelPoints.hpp
-    providers/twitch/pubsubmessages/ChatModeratorAction.cpp
-    providers/twitch/pubsubmessages/ChatModeratorAction.hpp
-    providers/twitch/pubsubmessages/Listen.cpp
-    providers/twitch/pubsubmessages/Listen.hpp
-    providers/twitch/pubsubmessages/Message.hpp
-    providers/twitch/pubsubmessages/Unlisten.cpp
-    providers/twitch/pubsubmessages/Unlisten.hpp
-    providers/twitch/pubsubmessages/Whisper.cpp
-    providers/twitch/pubsubmessages/Whisper.hpp
-    providers/twitch/api/Helix.cpp
-    providers/twitch/api/Helix.hpp
+    RunGui.cpp
+    RunGui.hpp
     singletons/Badges.cpp
     singletons/Badges.hpp
     singletons/Emotes.cpp
     singletons/Emotes.hpp
     singletons/Fonts.cpp
     singletons/Fonts.hpp
+    singletons/helper/GifTimer.cpp
+    singletons/helper/GifTimer.hpp
+    singletons/helper/LoggingChannel.cpp
+    singletons/helper/LoggingChannel.hpp
     singletons/Logging.cpp
     singletons/Logging.hpp
     singletons/NativeMessaging.cpp
@@ -296,10 +302,6 @@ set(SOURCE_FILES
     singletons/Updates.hpp
     singletons/WindowManager.cpp
     singletons/WindowManager.hpp
-    singletons/helper/GifTimer.cpp
-    singletons/helper/GifTimer.hpp
-    singletons/helper/LoggingChannel.cpp
-    singletons/helper/LoggingChannel.hpp
     util/AttachToConsole.cpp
     util/AttachToConsole.hpp
     util/Clipboard.cpp
@@ -331,20 +333,20 @@ set(SOURCE_FILES
     util/RatelimitBucket.hpp
     util/SampleData.cpp
     util/SampleData.hpp
+    util/serialize/Container.hpp
     util/SharedPtrElementLess.hpp
     util/SplitCommand.cpp
     util/SplitCommand.hpp
-    util/StreamLink.cpp
-    util/StreamLink.hpp
     util/StreamerMode.cpp
     util/StreamerMode.hpp
+    util/StreamLink.cpp
+    util/StreamLink.hpp
     util/ThreadGuard.hpp
     util/Twitch.cpp
     util/Twitch.hpp
     util/TypeName.hpp
     util/WindowsHelper.cpp
     util/WindowsHelper.hpp
-    util/serialize/Container.hpp
     widgets/AccountSwitchPopup.cpp
     widgets/AccountSwitchPopup.hpp
     widgets/AccountSwitchWidget.cpp
@@ -357,22 +359,6 @@ set(SOURCE_FILES
     widgets/BaseWidget.hpp
     widgets/BaseWindow.cpp
     widgets/BaseWindow.hpp
-    widgets/DraggablePopup.cpp
-    widgets/DraggablePopup.hpp
-    widgets/FramelessEmbedWindow.cpp
-    widgets/FramelessEmbedWindow.hpp
-    widgets/Label.cpp
-    widgets/Label.hpp
-    widgets/Notebook.cpp
-    widgets/Notebook.hpp
-    widgets/Scrollbar.cpp
-    widgets/Scrollbar.hpp
-    widgets/StreamView.cpp
-    widgets/StreamView.hpp
-    widgets/TooltipWidget.cpp
-    widgets/TooltipWidget.hpp
-    widgets/Window.cpp
-    widgets/Window.hpp
     widgets/dialogs/BadgePickerDialog.cpp
     widgets/dialogs/BadgePickerDialog.hpp
     widgets/dialogs/ChannelFilterEditorDialog.cpp
@@ -402,12 +388,6 @@ set(SOURCE_FILES
     widgets/dialogs/SelectChannelFiltersDialog.hpp
     widgets/dialogs/SettingsDialog.cpp
     widgets/dialogs/SettingsDialog.hpp
-    widgets/dialogs/UpdateDialog.cpp
-    widgets/dialogs/UpdateDialog.hpp
-    widgets/dialogs/UserInfoPopup.cpp
-    widgets/dialogs/UserInfoPopup.hpp
-    widgets/dialogs/WelcomeDialog.cpp
-    widgets/dialogs/WelcomeDialog.hpp
     widgets/dialogs/switcher/NewPopupItem.cpp
     widgets/dialogs/switcher/NewPopupItem.hpp
     widgets/dialogs/switcher/NewTabItem.cpp
@@ -418,6 +398,16 @@ set(SOURCE_FILES
     widgets/dialogs/switcher/QuickSwitcherPopup.hpp
     widgets/dialogs/switcher/SwitchSplitItem.cpp
     widgets/dialogs/switcher/SwitchSplitItem.hpp
+    widgets/dialogs/UpdateDialog.cpp
+    widgets/dialogs/UpdateDialog.hpp
+    widgets/dialogs/UserInfoPopup.cpp
+    widgets/dialogs/UserInfoPopup.hpp
+    widgets/dialogs/WelcomeDialog.cpp
+    widgets/dialogs/WelcomeDialog.hpp
+    widgets/DraggablePopup.cpp
+    widgets/DraggablePopup.hpp
+    widgets/FramelessEmbedWindow.cpp
+    widgets/FramelessEmbedWindow.hpp
     widgets/helper/Button.cpp
     widgets/helper/Button.hpp
     widgets/helper/ChannelView.cpp
@@ -440,8 +430,6 @@ set(SOURCE_FILES
     widgets/helper/QColorPicker.hpp
     widgets/helper/RegExpItemDelegate.cpp
     widgets/helper/RegExpItemDelegate.hpp
-    widgets/helper/TrimRegExpValidator.cpp
-    widgets/helper/TrimRegExpValidator.hpp
     widgets/helper/ResizingTextEdit.cpp
     widgets/helper/ResizingTextEdit.hpp
     widgets/helper/ScrollbarHighlight.cpp
@@ -454,6 +442,10 @@ set(SOURCE_FILES
     widgets/helper/SignalLabel.hpp
     widgets/helper/TitlebarButton.cpp
     widgets/helper/TitlebarButton.hpp
+    widgets/helper/TrimRegExpValidator.cpp
+    widgets/helper/TrimRegExpValidator.hpp
+    widgets/Label.cpp
+    widgets/Label.hpp
     widgets/listview/GenericItemDelegate.cpp
     widgets/listview/GenericItemDelegate.hpp
     widgets/listview/GenericListItem.cpp
@@ -462,6 +454,10 @@ set(SOURCE_FILES
     widgets/listview/GenericListModel.hpp
     widgets/listview/GenericListView.cpp
     widgets/listview/GenericListView.hpp
+    widgets/Notebook.cpp
+    widgets/Notebook.hpp
+    widgets/Scrollbar.cpp
+    widgets/Scrollbar.hpp
     widgets/settingspages/AboutPage.cpp
     widgets/settingspages/AboutPage.hpp
     widgets/settingspages/AccountsPage.cpp
@@ -508,7 +504,12 @@ set(SOURCE_FILES
     widgets/splits/SplitInput.hpp
     widgets/splits/SplitOverlay.cpp
     widgets/splits/SplitOverlay.hpp
-    ${CMAKE_SOURCE_DIR}/resources/resources.qrc
+    widgets/StreamView.cpp
+    widgets/StreamView.hpp
+    widgets/TooltipWidget.cpp
+    widgets/TooltipWidget.hpp
+    widgets/Window.cpp
+    widgets/Window.hpp
 )
 
 if(WIN32)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,28 +1,29 @@
 project(chatterino-test)
 
 set(TEST_SOURCES
-    ${CMAKE_CURRENT_LIST_DIR}/src/main.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/src/ChannelChatters.cpp
+    # cmake-format: sort
     ${CMAKE_CURRENT_LIST_DIR}/src/AccessGuard.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/src/NetworkCommon.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/src/NetworkRequest.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/BasicPubSub.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/ChannelChatters.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/ChatterSet.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/src/HighlightPhrase.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/Emojis.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/ExponentialBackoff.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/src/Helpers.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/src/RatelimitBucket.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/src/Hotkeys.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/src/UtilTwitch.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/src/IrcHelpers.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/src/TwitchPubSubClient.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/src/TwitchMessageBuilder.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/src/HighlightController.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/FormatTime.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/Helpers.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/HighlightController.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/HighlightPhrase.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/Hotkeys.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/IrcHelpers.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/LimitedQueue.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/src/BasicPubSub.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/main.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/NetworkCommon.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/NetworkRequest.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/RatelimitBucket.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/SeventvEventAPI.cpp
     # Add your new file above this line!
+    ${CMAKE_CURRENT_LIST_DIR}/src/TwitchMessageBuilder.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/TwitchPubSubClient.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/UtilTwitch.cpp
 )
 
 add_executable(${PROJECT_NAME} ${TEST_SOURCES})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(chatterino-test)
 
-set(test_SOURCES
+set(TEST_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/src/main.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/ChannelChatters.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/AccessGuard.cpp
@@ -23,39 +23,38 @@ set(test_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/src/BasicPubSub.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/SeventvEventAPI.cpp
     # Add your new file above this line!
-    )
+)
 
-add_executable(${PROJECT_NAME} ${test_SOURCES})
+add_executable(${PROJECT_NAME} ${TEST_SOURCES})
 add_sanitizers(${PROJECT_NAME})
 
 target_link_libraries(${PROJECT_NAME} PRIVATE chatterino-lib)
 
 target_link_libraries(${PROJECT_NAME} PRIVATE gtest gmock)
 
-target_compile_definitions(${PROJECT_NAME} PRIVATE
-    CHATTERINO_TEST
-    )
+target_compile_definitions(${PROJECT_NAME} PRIVATE CHATTERINO_TEST)
 
-set_target_properties(${PROJECT_NAME}
-    PROPERTIES
-    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
-    RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/bin"
-    RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_BINARY_DIR}/bin"
-    RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO "${CMAKE_BINARY_DIR}/bin"
-    )
+set_target_properties(
+    ${PROJECT_NAME}
+    PROPERTIES ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+               LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+               RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+               RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/bin"
+               RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_BINARY_DIR}/bin"
+               RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO
+               "${CMAKE_BINARY_DIR}/bin"
+)
 
 if(CHATTERINO_ENABLE_LTO)
     message(STATUS "Enabling LTO for ${PROJECT_NAME}")
-    set_property(TARGET ${PROJECT_NAME}
-        PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+    set_property(
+        TARGET ${PROJECT_NAME} PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE
+    )
 endif()
 
-# gtest_add_tests manages to discover the tests because it looks through the source files
-# HOWEVER, it fails to run, because we have some bug that causes the QApplication exit to stall when no network requests have been made.
-# ctest runs each test individually, so for now we require that testers just run the ./bin/chatterino-test binary without any filters applied
-# gtest_add_tests(
-#     TARGET ${PROJECT_NAME}
-#     SOURCES ${test_SOURCES}
-#     )
+# gtest_add_tests manages to discover the tests because it looks through the
+# source files HOWEVER, it fails to run, because we have some bug that causes
+# the QApplication exit to stall when no network requests have been made. ctest
+# runs each test individually, so for now we require that testers just run the
+# ./bin/chatterino-test binary without any filters applied gtest_add_tests(
+# TARGET ${PROJECT_NAME} SOURCES ${test_SOURCES} )


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

This PR adds formatting and linting for `CMakeLists.txt` files using https://github.com/cheshirekow/cmake_format.

The sorting in `src/CMakeLists.txt` should probably be different and with newlines between different directories, but there's no such option.

Closes #2474.
