### PR TITLE
Update `contributors.txt` instructions

### DIFF
--- a/resources/contributors.txt
+++ b/resources/contributors.txt
@@ -3,10 +3,10 @@
 # TODO: Parse this into a CONTRIBUTORS.md too
 
 # Adding yourself? Copy and paste this template at the bottom of this file and fill in the fields in a PR!
-# Name | Link | Avatar (Loaded as a resource) | Title (description of work done).
+# Name | Link | Avatar (Loaded as a resource, avatars are not required) | Title (description of work done).
 
 # Avatar should be located in avatars/ directory. Its size should be 128x128 (get it from https://github.com/username.png?size=128).
-# Make sure to reduce avatar's size as much as possible with tool like pngcrush or optipng (if the file is in png format) and run ./generate_resources.py
+# Make sure to reduce avatar's size as much as possible with tool like pngcrush or optipng (if the file is in png format).
 # Contributor is what we use for someone who has contributed in general (like sent a programming-related PR).
 
 fourtf | https://fourtf.com | :/avatars/fourtf.png | Author, main developer


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Removed the mention of `/generate_resources.py` due to it's removal in #4159
Also mentioned that the user is not required to add their avatar, due to the fact that it seems common that new contributors include their PFP, while existing contributors omit it