### PR TITLE
Replace QMediaPlayer with QSoundEffect for consistent highlight audio

### DIFF
--- a/.CI/CreateAppImage.sh
+++ b/.CI/CreateAppImage.sh
@@ -25,8 +25,8 @@ echo ""
 
 cp "$chatterino_dir"/resources/icon.png ./appdir/chatterino.png
 
-linuxdeployqt_path="linuxdeployqt-6-x86_64.AppImage"
-linuxdeployqt_url="https://github.com/probonopd/linuxdeployqt/releases/download/6/linuxdeployqt-6-x86_64.AppImage"
+linuxdeployqt_path="linuxdeployqt-continuous-x86_64.AppImage"
+linuxdeployqt_url="https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
 
 if [ ! -f "$linuxdeployqt_path" ]; then
     wget -nv "$linuxdeployqt_url"

--- a/.CI/CreateAppImage.sh
+++ b/.CI/CreateAppImage.sh
@@ -25,8 +25,8 @@ echo ""
 
 cp "$chatterino_dir"/resources/icon.png ./appdir/chatterino.png
 
-linuxdeployqt_path="linuxdeployqt-continuous-x86_64.AppImage"
-linuxdeployqt_url="https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
+linuxdeployqt_path="linuxdeployqt-6-x86_64.AppImage"
+linuxdeployqt_url="https://github.com/probonopd/linuxdeployqt/releases/download/6/linuxdeployqt-6-x86_64.AppImage"
 
 if [ ! -f "$linuxdeployqt_path" ]; then
     wget -nv "$linuxdeployqt_url"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Dev: Fixed `final-dtor-non-final-class` warnings. (#4296)
 - Dev: Fixed `ambiguous-reversed-operator` warnings. (#4296)
 - Dev: Format YAML and JSON files with prettier. (#4304)
+- Dev: Use QSoundEffect instead of QMediaPlayer. (#4285, #4316)
 
 ## 2.4.0
 

--- a/src/controllers/notifications/NotificationController.cpp
+++ b/src/controllers/notifications/NotificationController.cpp
@@ -97,7 +97,7 @@ void NotificationController::removeChannelNotification(
 }
 void NotificationController::playSound()
 {
-    static auto player = new QSoundEffect;
+    static auto *player = new QSoundEffect;
     static QUrl currentPlayerUrl;
 
     QUrl highlightSoundUrl =

--- a/src/controllers/notifications/NotificationController.cpp
+++ b/src/controllers/notifications/NotificationController.cpp
@@ -97,7 +97,7 @@ void NotificationController::removeChannelNotification(
 }
 void NotificationController::playSound()
 {
-    static QSoundEffect player = new QSoundEffect;
+    static QSoundEffect *player = new QSoundEffect;
     static QUrl currentPlayerUrl;
 
     QUrl highlightSoundUrl =

--- a/src/controllers/notifications/NotificationController.cpp
+++ b/src/controllers/notifications/NotificationController.cpp
@@ -21,7 +21,7 @@
 
 #include <QDesktopServices>
 #include <QDir>
-#include <QMediaPlayer>
+#include <QSoundEffect>
 #include <QUrl>
 
 #include <unordered_set>
@@ -97,7 +97,7 @@ void NotificationController::removeChannelNotification(
 }
 void NotificationController::playSound()
 {
-    static auto player = new QMediaPlayer;
+    static QSoundEffect player = new QSoundEffect;
     static QUrl currentPlayerUrl;
 
     QUrl highlightSoundUrl =
@@ -106,11 +106,10 @@ void NotificationController::playSound()
                   getSettings()->notificationPathSound.getValue())
             : QUrl("qrc:/sounds/ping2.wav");
 
-    // Set media if the highlight sound url has changed, or if media is buffered
-    if (currentPlayerUrl != highlightSoundUrl ||
-        player->mediaStatus() == QMediaPlayer::BufferedMedia)
+    // Set player source and url if the highlight sound url has changed
+    if (currentPlayerUrl != highlightSoundUrl)
     {
-        player->setMedia(highlightSoundUrl);
+        player->setSource(highlightSoundUrl);
 
         currentPlayerUrl = highlightSoundUrl;
     }

--- a/src/controllers/notifications/NotificationController.cpp
+++ b/src/controllers/notifications/NotificationController.cpp
@@ -97,7 +97,7 @@ void NotificationController::removeChannelNotification(
 }
 void NotificationController::playSound()
 {
-    static QSoundEffect *player = new QSoundEffect;
+    static auto player = new QSoundEffect;
     static QUrl currentPlayerUrl;
 
     QUrl highlightSoundUrl =

--- a/src/messages/SharedMessageBuilder.cpp
+++ b/src/messages/SharedMessageBuilder.cpp
@@ -202,7 +202,7 @@ inline QSoundEffect *getPlayer()
 {
     if (isGuiThread())
     {
-        static QSoundEffect player = new QSoundEffect;
+        static QSoundEffect *player = new QSoundEffect;
         return player;
     }
     else

--- a/src/messages/SharedMessageBuilder.cpp
+++ b/src/messages/SharedMessageBuilder.cpp
@@ -202,7 +202,7 @@ inline QSoundEffect *getPlayer()
 {
     if (isGuiThread())
     {
-        static QSoundEffect *player = new QSoundEffect;
+        static auto player = new QSoundEffect;
         return player;
     }
     else

--- a/src/messages/SharedMessageBuilder.cpp
+++ b/src/messages/SharedMessageBuilder.cpp
@@ -16,7 +16,7 @@
 #include "util/StreamerMode.hpp"
 
 #include <QFileInfo>
-#include <QMediaPlayer>
+#include <QSoundEffect>
 
 namespace chatterino {
 
@@ -198,11 +198,11 @@ void SharedMessageBuilder::appendChannelName()
         ->setLink(link);
 }
 
-inline QMediaPlayer *getPlayer()
+inline QSoundEffect *getPlayer()
 {
     if (isGuiThread())
     {
-        static auto player = new QMediaPlayer;
+        static QSoundEffect player = new QSoundEffect;
         return player;
     }
     else
@@ -234,11 +234,10 @@ void SharedMessageBuilder::triggerHighlights()
     {
         if (auto player = getPlayer())
         {
-            // Set media if the highlight sound url has changed, or if media is buffered
-            if (currentPlayerUrl != this->highlightSoundUrl_ ||
-                player->mediaStatus() == QMediaPlayer::BufferedMedia)
+            // Set player source and url if the highlight sound url has changed
+            if (currentPlayerUrl != this->highlightSoundUrl_)
             {
-                player->setMedia(this->highlightSoundUrl_);
+                player->setSource(this->highlightSoundUrl_);
 
                 currentPlayerUrl = this->highlightSoundUrl_;
             }

--- a/src/messages/SharedMessageBuilder.cpp
+++ b/src/messages/SharedMessageBuilder.cpp
@@ -202,7 +202,7 @@ inline QSoundEffect *getPlayer()
 {
     if (isGuiThread())
     {
-        static auto player = new QSoundEffect;
+        static auto *player = new QSoundEffect;
         return player;
     }
     else


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description
### Reason
Currently Chatterino2 uses the QMediaPlayer class for playing the highlight sound.
There are a two problems:

- After a few highlights the audio degrades and eventually becomes basically muted, unless the media/source is reset.
- Sometimes the highlights queue up in the background and then randomly replays the highlights, unless the media/source is reset.

And as far as I know, they are not fixed in QT6.

I've tried to find a few ways, and searched for solutions for both, but there are no solutions so far, unless we use QSoundEffect. It's a problem with the way QMediaPlayer works.

### Solution
This Pull Request should (or is an attempt to) fix the audio issues that plague Chatterino2, the highlight audio playback should be more consistent, and much like the current solution does not leak memory. It's also compatible with QT6 for the eventual migration.

