### PR TITLE
Use `CMakeDeps` and `CMakeToolchain` as Generators on Conan

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,20 +76,20 @@ jobs:
         if: startsWith(matrix.os, 'windows')
         run: echo "C:\Program Files\Conan\conan\" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
-      - name: Enable Developer Command Prompt
-        if: startsWith(matrix.os, 'windows')
-        uses: ilammy/msvc-dev-cmd@v1.12.0
-
       - name: Install dependencies (Windows)
         if: startsWith(matrix.os, 'windows')
         run: |
           choco install conan -y
 
+      - name: Enable Developer Command Prompt
+        if: startsWith(matrix.os, 'windows')
+        uses: ilammy/msvc-dev-cmd@v1.12.0
+
       - name: Setup Conan (Windows)
         if: startsWith(matrix.os, 'windows')
         run: |
           conan profile new --detect --force default
-          conan profile update conf.tools.cmake.cmaketoolchain:generator=Ninja default
+          conan profile update conf.tools.cmake.cmaketoolchain:generator="NMake Makefiles" default
 
       - name: Build (Windows)
         if: startsWith(matrix.os, 'windows')
@@ -98,12 +98,13 @@ jobs:
           cd build
           conan install .. -s build_type=Release -b missing -pr:b=default
           cmake `
-              -GNinja `
+              -G"NMake Makefiles" `
               -DCMAKE_BUILD_TYPE=Release `
               -DCMAKE_TOOLCHAIN_FILE="conan_toolchain.cmake" `
               -DCHATTERINO_LTO="$Env:C2_ENABLE_LTO" `
               ..
-          ninja
+          set cl=/MP
+          nmake /S /NOLOGO
           windeployqt bin/chatterino.exe --release --no-compiler-runtime --no-translations --no-opengl-sw --dir Chatterino2/
           cp bin/chatterino.exe Chatterino2/
           echo nightly > Chatterino2/modes

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,11 +90,10 @@ jobs:
         run: |
           mkdir build
           cd build
-          conan install ..  -b missing
+          conan install .. -b missing
           cmake `
               -G"NMake Makefiles" `
               -DCMAKE_BUILD_TYPE=Release `
-              -DUSE_CONAN=ON `
               -DCHATTERINO_LTO="$Env:C2_ENABLE_LTO" `
               ..
           set cl=/MP

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,28 +76,34 @@ jobs:
         if: startsWith(matrix.os, 'windows')
         run: echo "C:\Program Files\Conan\conan\" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
+      - name: Enable Developer Command Prompt
+        if: startsWith(matrix.os, 'windows')
+        uses: ilammy/msvc-dev-cmd@v1.12.0
+
       - name: Install dependencies (Windows)
         if: startsWith(matrix.os, 'windows')
         run: |
           choco install conan -y
 
-      - name: Enable Developer Command Prompt
+      - name: Setup Conan (Windows)
         if: startsWith(matrix.os, 'windows')
-        uses: ilammy/msvc-dev-cmd@v1.12.0
+        run: |
+          conan profile new --detect --force default
+          conan profile update conf.tools.cmake.cmaketoolchain:generator=Ninja default
 
       - name: Build (Windows)
         if: startsWith(matrix.os, 'windows')
         run: |
           mkdir build
           cd build
-          conan install .. -b missing
+          conan install .. -s build_type=Release -b missing -pr:b=default
           cmake `
-              -G"NMake Makefiles" `
+              -GNinja `
               -DCMAKE_BUILD_TYPE=Release `
+              -DCMAKE_TOOLCHAIN_FILE="conan_toolchain.cmake" `
               -DCHATTERINO_LTO="$Env:C2_ENABLE_LTO" `
               ..
-          set cl=/MP
-          nmake /S /NOLOGO
+          ninja
           windeployqt bin/chatterino.exe --release --no-compiler-runtime --no-translations --no-opengl-sw --dir Chatterino2/
           cp bin/chatterino.exe Chatterino2/
           echo nightly > Chatterino2/modes

--- a/BUILDING_ON_WINDOWS.md
+++ b/BUILDING_ON_WINDOWS.md
@@ -131,7 +131,7 @@ Open up your terminal with the Visual Studio environment variables, then enter t
 
 1. `mkdir build`
 2. `cd build`
-3. `cmake -G"NMake Makefiles" -DCMAKE_BUILD_TYPE=Release ..`
+3. `cmake -G"NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE="conan_toolchain.cmake" ..`
 4. `nmake`
 
 ## Building on MSVC with AddressSanitizer
@@ -160,6 +160,7 @@ Now open the project in CLion. You will be greeted with the _Open Project Wizard
 
 ```
 -DCMAKE_PREFIX_PATH=C:\Qt\5.15.2\msvc2019_64\lib\cmake\Qt5
+-DCMAKE_TOOLCHAIN_FILE="conan_toolchain.cmake"
 ```
 
 and the _Build Directory_ to `build`.

--- a/BUILDING_ON_WINDOWS.md
+++ b/BUILDING_ON_WINDOWS.md
@@ -131,7 +131,7 @@ Open up your terminal with the Visual Studio environment variables, then enter t
 
 1. `mkdir build`
 2. `cd build`
-3. `cmake -G"NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DUSE_CONAN=ON ..`
+3. `cmake -G"NMake Makefiles" -DCMAKE_BUILD_TYPE=Release ..`
 4. `nmake`
 
 ## Building on MSVC with AddressSanitizer
@@ -160,7 +160,6 @@ Now open the project in CLion. You will be greeted with the _Open Project Wizard
 
 ```
 -DCMAKE_PREFIX_PATH=C:\Qt\5.15.2\msvc2019_64\lib\cmake\Qt5
--DUSE_CONAN=ON
 ```
 
 and the _Build Directory_ to `build`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@
 - Dev: Fixed `final-dtor-non-final-class` warnings. (#4296)
 - Dev: Fixed `ambiguous-reversed-operator` warnings. (#4296)
 - Dev: Format YAML and JSON files with prettier. (#4304)
-- Dev: Addded CMake Install Support on Windows. (#4300)
+- Dev: Added CMake Install Support on Windows. (#4300)
 - Dev: Changed conan generator to [`CMakeDeps`](https://docs.conan.io/en/latest/reference/conanfile/tools/cmake/cmakedeps.html) and [`CMakeToolchain`](https://docs.conan.io/en/latest/reference/conanfile/tools/cmake/cmaketoolchain.html). See PR for migration notes. (#4335)
 
 ## 2.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@
 - Dev: Fixed `ambiguous-reversed-operator` warnings. (#4296)
 - Dev: Format YAML and JSON files with prettier. (#4304)
 - Dev: Addded CMake Install Support on Windows. (#4300)
-- Dev: Changed conan generator to [`CMakeDeps`](https://docs.conan.io/en/latest/reference/conanfile/tools/cmake/cmakedeps.html). See PR for migration notes. (#4335)
+- Dev: Changed conan generator to [`CMakeDeps`](https://docs.conan.io/en/latest/reference/conanfile/tools/cmake/cmakedeps.html) and [`CMakeToolchain`](https://docs.conan.io/en/latest/reference/conanfile/tools/cmake/cmaketoolchain.html). See PR for migration notes. (#4335)
 
 ## 2.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Dev: Fixed `final-dtor-non-final-class` warnings. (#4296)
 - Dev: Fixed `ambiguous-reversed-operator` warnings. (#4296)
 - Dev: Format YAML and JSON files with prettier. (#4304)
+- Dev: Changed conan generator to [`CMakeDeps`](https://docs.conan.io/en/latest/reference/conanfile/tools/cmake/cmakedeps.html). See PR for migration notes. (#4335)
 
 ## 2.4.0
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,12 @@
-cmake_minimum_required(VERSION 3.12)
-cmake_policy(SET CMP0087 NEW)
+cmake_minimum_required(VERSION 3.15)
+cmake_policy(SET CMP0087 NEW) # evaluates generator expressions in `install(CODE/SCRIPT)`
+cmake_policy(SET CMP0091 NEW) # select MSVC runtime library through `CMAKE_MSVC_RUNTIME_LIBRARY`
 include(FeatureSummary)
 
 list(APPEND CMAKE_MODULE_PATH
-    "${CMAKE_SOURCE_DIR}/cmake"
-    "${CMAKE_SOURCE_DIR}/cmake/sanitizers-cmake/cmake"
-    )
+        "${CMAKE_SOURCE_DIR}/cmake"
+        "${CMAKE_SOURCE_DIR}/cmake/sanitizers-cmake/cmake"
+        )
 
 project(chatterino VERSION 2.4.0)
 
@@ -45,15 +46,15 @@ endif ()
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/GIT.cmake)
 
 find_package(Qt${MAJOR_QT_VERSION} REQUIRED
-    COMPONENTS
-    Core
-    Widgets
-    Gui
-    Network
-    Multimedia
-    Svg
-    Concurrent
-    )
+        COMPONENTS
+        Core
+        Widgets
+        Gui
+        Network
+        Multimedia
+        Svg
+        Concurrent
+        )
 
 message(STATUS "Qt version: ${Qt${MAJOR_QT_VERSION}_VERSION}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,6 @@ option(CHATTERINO_GENERATE_COVERAGE "Generate coverage files" OFF)
 option(BUILD_SHARED_LIBS "" OFF)
 option(CHATTERINO_LTO "Enable LTO for all targets" OFF)
 
-option(USE_CONAN "Use conan" OFF)
-
 if(CHATTERINO_LTO)
     include(CheckIPOSupported)
     check_ipo_supported(RESULT CHATTERINO_ENABLE_LTO OUTPUT IPO_ERROR)
@@ -36,13 +34,6 @@ if (BUILD_WITH_QT6)
     set(MAJOR_QT_VERSION "6")
 else()
     set(MAJOR_QT_VERSION "5")
-endif()
-
-if (USE_CONAN OR CONAN_EXPORTED)
-    include(${CMAKE_CURRENT_BINARY_DIR}/conanbuildinfo.cmake)
-    conan_basic_setup(TARGETS NO_OUTPUT_DIRS)
-else ()
-    set(QT_CREATOR_SKIP_CONAN_SETUP ON)
 endif()
 
 find_program(CCACHE_PROGRAM ccache)
@@ -73,8 +64,9 @@ endif ()
 find_package(Sanitizers)
 
 # Find boost on the system
-find_package(Boost REQUIRED)
-find_package(Boost COMPONENTS random)
+# `OPTIONAL_COMPONENTS random` is required for vcpkg builds to link.
+# `OPTIONAL` is required, because conan doesn't set `boost_random_FOUND`.
+find_package(Boost REQUIRED OPTIONAL_COMPONENTS random)
 
 # Find OpenSSL on the system
 find_package(OpenSSL REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,9 @@ cmake_policy(SET CMP0091 NEW) # select MSVC runtime library through `CMAKE_MSVC_
 include(FeatureSummary)
 
 list(APPEND CMAKE_MODULE_PATH
-        "${CMAKE_SOURCE_DIR}/cmake"
-        "${CMAKE_SOURCE_DIR}/cmake/sanitizers-cmake/cmake"
-        )
+    "${CMAKE_SOURCE_DIR}/cmake"
+    "${CMAKE_SOURCE_DIR}/cmake/sanitizers-cmake/cmake"
+    )
 
 project(chatterino VERSION 2.4.0)
 
@@ -48,15 +48,15 @@ endif ()
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/GIT.cmake)
 
 find_package(Qt${MAJOR_QT_VERSION} REQUIRED
-        COMPONENTS
-        Core
-        Widgets
-        Gui
-        Network
-        Multimedia
-        Svg
-        Concurrent
-        )
+    COMPONENTS
+    Core
+    Widgets
+    Gui
+    Network
+    Multimedia
+    Svg
+    Concurrent
+    )
 
 message(STATUS "Qt version: ${Qt${MAJOR_QT_VERSION}_VERSION}")
 

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -4,6 +4,7 @@ boost/1.80.0
 
 [generators]
 CMakeDeps
+CMakeToolchain
 
 [options]
 openssl:shared=True

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -3,7 +3,7 @@ openssl/1.1.1s
 boost/1.80.0
 
 [generators]
-cmake
+CMakeDeps
 
 [options]
 openssl:shared=True

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -777,30 +777,16 @@ if (WinToast_FOUND)
         WinToast)
 endif ()
 
-if (USE_CONAN AND TARGET CONAN_PKG::boost)
-    target_link_libraries(${LIBRARY_PROJECT}
-        PUBLIC
-        CONAN_PKG::boost
-        )
-else ()
-    target_link_libraries(${LIBRARY_PROJECT}
+target_link_libraries(${LIBRARY_PROJECT}
         PUBLIC
         ${Boost_LIBRARIES}
         )
-endif ()
 
-if (USE_CONAN AND TARGET CONAN_PKG::openssl)
-    target_link_libraries(${LIBRARY_PROJECT}
-        PUBLIC
-        CONAN_PKG::openssl
-        )
-else ()
-    target_link_libraries(${LIBRARY_PROJECT}
+target_link_libraries(${LIBRARY_PROJECT}
         PUBLIC
         OpenSSL::SSL
         OpenSSL::Crypto
         )
-endif ()
 
 target_include_directories(${LIBRARY_PROJECT} PUBLIC ${RapidJSON_INCLUDE_DIRS})
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

The [`cmake`](https://docs.conan.io/en/latest/reference/generators/cmake.html) generator is marked as deprecated - [`CMakeDeps`](https://docs.conan.io/en/latest/reference/conanfile/tools/cmake/cmakedeps.html) and [`CMakeToolchain`](https://docs.conan.io/en/latest/reference/conanfile/tools/cmake/cmaketoolchain.html) are recommended. This PR migrates to these generators.

### Migration Notes

0. Make sure you're using at least version 1.33 (Jan-2021).
1. Rerun `conan install`
2. Remove `-DUSE_CONAN` from your CMake arguments, and add `-DCMAKE_TOOLCHAIN_FILE="conan_toolchain.cmake"`.
3. CMake might give you an error similar to `Generator <generator> does not support platform specification...`. If that's the case, set `conf.tools.cmake.cmaketoolchain:generator` in `~/.conan/profiles/<your-profile>` to your generator. You can do this from the command line: `conan profile update conf.tools.cmake.cmaketoolchain:generator=<generator> <profile>`.