### PR TITLE
Remove Qt::Multimedia as a dependency from CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,6 @@ find_package(Qt${MAJOR_QT_VERSION} REQUIRED
     Widgets
     Gui
     Network
-    Multimedia
     Svg
     Concurrent
     )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -603,7 +603,6 @@ target_link_libraries(${LIBRARY_PROJECT}
         Qt${MAJOR_QT_VERSION}::Widgets
         Qt${MAJOR_QT_VERSION}::Gui
         Qt${MAJOR_QT_VERSION}::Network
-        Qt${MAJOR_QT_VERSION}::Multimedia
         Qt${MAJOR_QT_VERSION}::Svg
         Qt${MAJOR_QT_VERSION}::Concurrent
 


### PR DESCRIPTION
Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable

# Description

I just noticed in the push-aur-workflow that it failed because of it not finding Qt5Multimedia, so this is my attempt in fixing it. I do not know if it fixes it specifically because I do not know how to test the aur-workflow, but I was able to play a sound after compiling this branch on my local machine.

Here is the error in the workflow I'm talking about:
![image](https://user-images.githubusercontent.com/30803034/215335204-47fb4cc6-bfa4-4595-a56f-b549ed340ab8.png)

Here is the version I compiled and tested (by simply pinging myself `#wissididom wissididombot: @Wissididom Testping`):
![image](https://user-images.githubusercontent.com/30803034/215335230-d3a86ec9-bf07-4690-a98a-1041a43081a5.png)
