### PR TITLE
Suppress Output of Git Command in CMake

### DIFF
--- a/cmake/GIT.cmake
+++ b/cmake/GIT.cmake
@@ -28,6 +28,7 @@ if (GIT_EXECUTABLE)
             COMMAND ${GIT_EXECUTABLE} rev-parse --is-inside-work-tree
             WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
             RESULT_VARIABLE GIT_REPOSITORY_NOT_FOUND
+            OUTPUT_QUIET
             ERROR_QUIET
     )
     if (GIT_REPOSITORY_NOT_FOUND)


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable _- none should be necessary_

# Description

Some may have wondered why `cmake` prints [`true`](https://github.com/Chatterino/chatterino2/actions/runs/4036940542/jobs/6939893312#step:17:41) when configuring. Turns out, it's the output of `git rev-parse --is-inside-work-tree`. I don't see any reason to include the `true` output, since no context is given. This PR adds the `OUTPUT_QUIET` flag to [`execute_process`](https://cmake.org/cmake/help/latest/command/execute_process.html) to suppress output.
