### PR TITLE
Removed libgstreamer-plugins-base from build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,7 +139,6 @@ jobs:
               libboost-filesystem-dev \
               libpulse-dev \
               libxkbcommon-x11-0 \
-              libgstreamer-plugins-base1.0-0 \
               build-essential \
               libgl1-mesa-dev \
               libxcb-icccm4 \


### PR DESCRIPTION
Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable

# Description

I just noticed it being in the workflow run and because I heard that gstreamer isn't needed anymore after moving to miniaudio, I decided to try removing it. Also I just used the AppImage build from https://github.com/Wissididom/chatterino2/pull/12 to test it working.