### PR TITLE
fix: compilation on macOS without precompiled headers

### DIFF
--- a/src/messages/Message.hpp
+++ b/src/messages/Message.hpp
@@ -9,6 +9,7 @@
 
 #include <cinttypes>
 #include <memory>
+#include <unordered_map>
 #include <vector>
 
 namespace chatterino {

--- a/src/providers/irc/Irc2.hpp
+++ b/src/providers/irc/Irc2.hpp
@@ -4,6 +4,8 @@
 
 #include <rapidjson/rapidjson.h>
 
+#include <unordered_map>
+
 class QAbstractTableModel;
 
 namespace chatterino {

--- a/src/providers/twitch/TwitchMessageBuilder.hpp
+++ b/src/providers/twitch/TwitchMessageBuilder.hpp
@@ -9,6 +9,8 @@
 #include <QString>
 #include <QVariant>
 
+#include <unordered_map>
+
 namespace chatterino {
 
 struct Emote;


### PR DESCRIPTION
Pull request checklist:

- [ ] ~`CHANGELOG.md` was updated, if applicable~ (not really necessary)

# Description

Same thing as #3741, still no Clue why macOS/clang needs these imports and everything else doesn't, but I noticed it stopped working again when debugging #4347, so might as well fix it.