### PR TITLE
Attempt to catch `std::bad_function_call` when adding a channel point reward

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Bugfix: Fixed the split "Search" menu action not opening the correct search window. (#4305)
 - Bugfix: Fixed an issue on Windows when opening links in incognito mode that contained forward slashes in hash (#4307)
 - Bugfix: Fixed an issue where beta versions wouldn't update to stable versions correctly. (#4329)
+- Bugfix: Avoided crash that could occur when receiving channel point reward information. (#4360)
 - Dev: Changed sound backend from Qt to miniaudio. (#4334)
 - Dev: Remove protocol from QApplication's Organization Domain (so changed from `https://www.chatterino.com` to `chatterino.com`). (#4256)
 - Dev: Ignore `WM_SHOWWINDOW` hide events, causing fewer attempted rescales. (#4198)

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -315,7 +315,7 @@ void TwitchChannel::addChannelPointReward(const ChannelPointReward &reward)
         {
             qCWarning(chatterinoTwitch).nospace()
                 << "[TwitchChannel " << this->getName()
-                << "] Cought std::bad_function_call when adding channel point "
+                << "] Caught std::bad_function_call when adding channel point "
                    "reward ChannelPointReward{ id: "
                 << reward.id << ", title: " << reward.title << " }.";
         }

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -304,7 +304,21 @@ void TwitchChannel::addChannelPointReward(const ChannelPointReward &reward)
             << "[TwitchChannel" << this->getName()
             << "] Channel point reward added:" << reward.id << ","
             << reward.title << "," << reward.isUserInputRequired;
-        this->channelPointRewardAdded.invoke(reward);
+
+        // TODO: There's an underlying bug here. This bug should be fixed.
+        // This only attempts to prevent a crash when invoking the signal.
+        try
+        {
+            this->channelPointRewardAdded.invoke(reward);
+        }
+        catch (const std::bad_function_call &)
+        {
+            qCWarning(chatterinoTwitch).nospace()
+                << "[TwitchChannel " << this->getName()
+                << "] Cought std::bad_function_call when adding channel point "
+                   "reward ChannelPointReward{ id: "
+                << reward.id << ", title: " << reward.title << " }.";
+        }
     }
 }
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Related to https://github.com/Chatterino/chatterino2/issues/3942#issuecomment-1421226657. This attempts to catch a [`std::bad_function_call`](https://en.cppreference.com/w/cpp/utility/functional/bad_function_call). **This doesn't resolve the underlying issue that causes this to be thrown.** Furthermore, there are probably more issues related to this, as some crash reports suggest that no exception is thrown.
