### PR TITLE
Remove sending part of the multipart emoji workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Minor: Added link to streamlink docs for easier user setup. (#4217)
 - Minor: Added setting to turn off rendering of reply context. (#4224)
 - Minor: Added setting to select which channels to log. (#4302)
-- Minor: Partially remove workaround for multipart emoji. (#4361)
+- Minor: Remove sending part of the multipart emoji workaround (#4361)
 - Bugfix: Fixed crash that would occur when performing certain actions after removing all tabs. (#4271)
 - Bugfix: Fixed highlight sounds not reloading on change properly. (#4194)
 - Bugfix: Fixed CTRL + C not working in reply thread popups. (#4209)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Minor: Added link to streamlink docs for easier user setup. (#4217)
 - Minor: Added setting to turn off rendering of reply context. (#4224)
 - Minor: Added setting to select which channels to log. (#4302)
+- Minor: Partially remove workaround for multipart emoji. (#4361)
 - Bugfix: Fixed crash that would occur when performing certain actions after removing all tabs. (#4271)
 - Bugfix: Fixed highlight sounds not reloading on change properly. (#4194)
 - Bugfix: Fixed CTRL + C not working in reply thread popups. (#4209)

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -84,12 +84,6 @@ void sendWhisperMessage(const QString &text)
     auto app = getApp();
     QString toSend = text.simplified();
 
-    // This is to make sure that combined emoji go through properly, see
-    // https://github.com/Chatterino/chatterino2/issues/3384 and
-    // https://mm2pl.github.io/emoji_rfc.pdf for more details
-    // Constants used here are defined in TwitchChannel.hpp
-    toSend.replace(ZERO_WIDTH_JOINER, ESCAPE_TAG);
-
     app->twitch->sendMessage("jtv", toSend);
 }
 

--- a/src/providers/RecentMessagesApi.cpp
+++ b/src/providers/RecentMessagesApi.cpp
@@ -84,6 +84,9 @@ namespace {
         for (const auto jsonMessage : jsonMessages)
         {
             auto content = jsonMessage.toString();
+
+            // For explanation of why this exists, see src/providers/twitch/TwitchChannel.hpp,
+            // where these constants are defined
             content.replace(COMBINED_FIXER, ZERO_WIDTH_JOINER);
 
             auto message =

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -311,10 +311,11 @@ std::vector<MessagePtr> IrcMessageHandler::parsePrivMessage(
 void IrcMessageHandler::handlePrivMessage(Communi::IrcPrivateMessage *message,
                                           TwitchIrcServer &server)
 {
-    // This is to make sure that combined emoji go through properly, see
-    // https://github.com/Chatterino/chatterino2/issues/3384 and
+    // This is for compatibility with older Chatterino versions. Twitch didn't use
+    // to allow ZERO WIDTH JOINER unicode character, so Chatterino used ESCAPE_TAG
+    // instead.
+    // See https://github.com/Chatterino/chatterino2/issues/3384 and
     // https://mm2pl.github.io/emoji_rfc.pdf for more details
-    // Constants used here are defined in TwitchChannel.hpp
 
     this->addMessage(
         message, message->target(),

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -370,10 +370,6 @@ QString TwitchChannel::prepareMessage(const QString &message) const
     auto app = getApp();
     QString parsedMessage = app->emotes->emojis.replaceShortCodes(message);
 
-    // This is to make sure that combined emoji go through properly, see
-    // https://github.com/Chatterino/chatterino2/issues/3384 and
-    // https://mm2pl.github.io/emoji_rfc.pdf for more details
-    parsedMessage.replace(ZERO_WIDTH_JOINER, ESCAPE_TAG);
     parsedMessage = parsedMessage.simplified();
 
     if (parsedMessage.isEmpty())

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -22,8 +22,10 @@
 
 namespace chatterino {
 
-// This is to make sure that combined emoji go through properly, see
-// https://github.com/Chatterino/chatterino2/issues/3384 and
+// This is for compatibility with older Chatterino versions. Twitch didn't use
+// to allow ZERO WIDTH JOINER unicode character, so Chatterino used ESCAPE_TAG
+// instead.
+// See https://github.com/Chatterino/chatterino2/issues/3384 and
 // https://mm2pl.github.io/emoji_rfc.pdf for more details
 const QString ZERO_WIDTH_JOINER = QString(QChar(0x200D));
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
Now chatterino will use ZERO WIDTH JOINER when sending messages again.