### PR TITLE
use AssocQueryString instead of directly querying the registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Bugfix: Fixed an issue on Windows when opening links in incognito mode that contained forward slashes in hash (#4307)
 - Bugfix: Fixed an issue where beta versions wouldn't update to stable versions correctly. (#4329)
 - Bugfix: Avoided crash that could occur when receiving channel point reward information. (#4360)
+- Bugfix: Don't rely on undocumented registry keys to find the default browser on Windows. (#4362)
 - Dev: Changed sound backend from Qt to miniaudio. (#4334)
 - Dev: Remove protocol from QApplication's Organization Domain (so changed from `https://www.chatterino.com` to `chatterino.com`). (#4256)
 - Dev: Ignore `WM_SHOWWINDOW` hide events, causing fewer attempted rescales. (#4198)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@
 - Bugfix: Fixed an issue on Windows when opening links in incognito mode that contained forward slashes in hash (#4307)
 - Bugfix: Fixed an issue where beta versions wouldn't update to stable versions correctly. (#4329)
 - Bugfix: Avoided crash that could occur when receiving channel point reward information. (#4360)
-- Bugfix: Don't rely on undocumented registry keys to find the default browser on Windows. (#4362)
 - Dev: Changed sound backend from Qt to miniaudio. (#4334)
 - Dev: Remove protocol from QApplication's Organization Domain (so changed from `https://www.chatterino.com` to `chatterino.com`). (#4256)
 - Dev: Ignore `WM_SHOWWINDOW` hide events, causing fewer attempted rescales. (#4198)
@@ -48,6 +47,7 @@
 - Dev: Added CMake Install Support on Windows. (#4300)
 - Dev: Changed conan generator to [`CMakeDeps`](https://docs.conan.io/en/latest/reference/conanfile/tools/cmake/cmakedeps.html) and [`CMakeToolchain`](https://docs.conan.io/en/latest/reference/conanfile/tools/cmake/cmaketoolchain.html). See PR for migration notes. (#4335)
 - Dev: Refactored 7TV EventAPI implementation. (#4342)
+- Dev: Don't rely on undocumented registry keys to find the default browser on Windows. (#4362)
 
 ## 2.4.0
 

--- a/src/util/IncognitoBrowser.cpp
+++ b/src/util/IncognitoBrowser.cpp
@@ -1,12 +1,11 @@
 #include "util/IncognitoBrowser.hpp"
+#ifdef USEWINSDK
+#    include "util/WindowsHelper.hpp"
+#endif
 
 #include <QProcess>
 #include <QRegularExpression>
 #include <QVariant>
-
-#ifdef USEWINSDK
-#    include "WindowsHelper.hpp"
-#endif
 
 namespace {
 
@@ -51,18 +50,21 @@ QString injectPrivateSwitch(QString command)
 QString getCommand()
 {
     // get default browser start command, by protocol if possible, falling back to extension if not
-    QString command = getAssociatedCommand(AQT_PROTOCOL, L"http");
+    QString command =
+        getAssociatedCommand(AssociationQueryType::Protocol, L"http");
 
     if (command.isNull())
     {
         // failed to fetch default browser by protocol, try by file extension instead
-        command = getAssociatedCommand(AQT_FILE_EXTENSION, L".html");
+        command =
+            getAssociatedCommand(AssociationQueryType::FileExtension, L".html");
     }
 
     if (command.isNull())
     {
         // also try the equivalent .htm extension
-        command = getAssociatedCommand(AQT_FILE_EXTENSION, L".htm");
+        command =
+            getAssociatedCommand(AssociationQueryType::FileExtension, L".htm");
     }
 
     if (command.isNull())

--- a/src/util/WindowsHelper.cpp
+++ b/src/util/WindowsHelper.cpp
@@ -91,10 +91,13 @@ void setRegisteredForStartup(bool isRegistered)
 QString getAssociatedCommand(AssociationQueryType queryType, LPCWSTR query)
 {
     static HINSTANCE shlwapi = LoadLibrary(L"shlwapi");
-    static auto assocQueryString = AssocQueryString_(
-        (shlwapi == NULL) ? NULL
-                          : GetProcAddress(shlwapi, "AssocQueryStringW"));
+    if (shlwapi == NULL)
+    {
+        return QString();
+    }
 
+    static auto assocQueryString =
+        AssocQueryString_(GetProcAddress(shlwapi, "AssocQueryStringW"));
     if (assocQueryString == NULL)
     {
         return QString();

--- a/src/util/WindowsHelper.cpp
+++ b/src/util/WindowsHelper.cpp
@@ -134,7 +134,10 @@ QString getAssociatedCommand(AssociationQueryType queryType, LPCWSTR query)
     if (SUCCEEDED(assocQueryString(flags, ASSOCSTR_COMMAND, query, NULL, buf,
                                    &resultSize)))
     {
-        result = QString::fromWCharArray(buf, resultSize);
+        // QString::fromWCharArray expects the length in characters *not
+        // including* the null terminator, but AssocQueryStringW calculates
+        // length including the null terminator
+        result = QString::fromWCharArray(buf, resultSize - 1);
     }
     delete[] buf;
     return result;

--- a/src/util/WindowsHelper.cpp
+++ b/src/util/WindowsHelper.cpp
@@ -119,8 +119,8 @@ QString getAssociatedCommand(AssociationQueryType queryType, LPCWSTR query)
     }
 
     DWORD resultSize = 0;
-    if (!SUCCEEDED(assocQueryString(flags, ASSOCSTR_COMMAND, query, NULL, NULL,
-                                    &resultSize)) ||
+    if (FAILED(assocQueryString(flags, ASSOCSTR_COMMAND, query, NULL, NULL,
+                                &resultSize)) ||
         resultSize == 0)
     {
         return QString();

--- a/src/util/WindowsHelper.cpp
+++ b/src/util/WindowsHelper.cpp
@@ -124,7 +124,9 @@ QString getAssociatedCommand(AssociationQueryType queryType, LPCWSTR query)
     DWORD resultSize = 0;
     if (FAILED(assocQueryString(flags, ASSOCSTR_COMMAND, query, NULL, NULL,
                                 &resultSize)) ||
-        resultSize == 0)
+        // resultSize includes the null terminator. if resultSize is 1, the
+        // returned value would be the empty string.
+        resultSize == 0 || resultSize == 1)
     {
         return QString();
     }

--- a/src/util/WindowsHelper.cpp
+++ b/src/util/WindowsHelper.cpp
@@ -91,14 +91,14 @@ void setRegisteredForStartup(bool isRegistered)
 QString getAssociatedCommand(AssociationQueryType queryType, LPCWSTR query)
 {
     static HINSTANCE shlwapi = LoadLibrary(L"shlwapi");
-    if (shlwapi == NULL)
+    if (shlwapi == nullptr)
     {
         return QString();
     }
 
     static auto assocQueryString =
         AssocQueryString_(GetProcAddress(shlwapi, "AssocQueryStringW"));
-    if (assocQueryString == NULL)
+    if (assocQueryString == nullptr)
     {
         return QString();
     }
@@ -122,8 +122,8 @@ QString getAssociatedCommand(AssociationQueryType queryType, LPCWSTR query)
     }
 
     DWORD resultSize = 0;
-    if (FAILED(assocQueryString(flags, ASSOCSTR_COMMAND, query, NULL, NULL,
-                                &resultSize)))
+    if (FAILED(assocQueryString(flags, ASSOCSTR_COMMAND, query, nullptr,
+                                nullptr, &resultSize)))
     {
         return QString();
     }
@@ -137,7 +137,7 @@ QString getAssociatedCommand(AssociationQueryType queryType, LPCWSTR query)
 
     QString result;
     auto buf = new wchar_t[resultSize];
-    if (SUCCEEDED(assocQueryString(flags, ASSOCSTR_COMMAND, query, NULL, buf,
+    if (SUCCEEDED(assocQueryString(flags, ASSOCSTR_COMMAND, query, nullptr, buf,
                                    &resultSize)))
     {
         // QString::fromWCharArray expects the length in characters *not

--- a/src/util/WindowsHelper.cpp
+++ b/src/util/WindowsHelper.cpp
@@ -123,11 +123,15 @@ QString getAssociatedCommand(AssociationQueryType queryType, LPCWSTR query)
 
     DWORD resultSize = 0;
     if (FAILED(assocQueryString(flags, ASSOCSTR_COMMAND, query, NULL, NULL,
-                                &resultSize)) ||
+                                &resultSize)))
+    {
+        return QString();
+    }
+
+    if (resultSize <= 1)
+    {
         // resultSize includes the null terminator. if resultSize is 1, the
         // returned value would be the empty string.
-        resultSize == 0 || resultSize == 1)
-    {
         return QString();
     }
 

--- a/src/util/WindowsHelper.hpp
+++ b/src/util/WindowsHelper.hpp
@@ -7,10 +7,7 @@
 
 namespace chatterino {
 
-typedef enum ASSOCIATION_QUERY_TYPE {
-    AQT_PROTOCOL,
-    AQT_FILE_EXTENSION
-} ASSOCIATION_QUERY_TYPE;
+enum class AssociationQueryType { Protocol, FileExtension };
 
 boost::optional<UINT> getWindowDpi(HWND hwnd);
 void flushClipboard();
@@ -18,7 +15,7 @@ void flushClipboard();
 bool isRegisteredForStartup();
 void setRegisteredForStartup(bool isRegistered);
 
-QString getAssociatedCommand(ASSOCIATION_QUERY_TYPE queryType, LPCWSTR query);
+QString getAssociatedCommand(AssociationQueryType queryType, LPCWSTR query);
 
 }  // namespace chatterino
 

--- a/src/util/WindowsHelper.hpp
+++ b/src/util/WindowsHelper.hpp
@@ -7,11 +7,18 @@
 
 namespace chatterino {
 
+typedef enum ASSOCIATION_QUERY_TYPE {
+    AQT_PROTOCOL,
+    AQT_FILE_EXTENSION
+} ASSOCIATION_QUERY_TYPE;
+
 boost::optional<UINT> getWindowDpi(HWND hwnd);
 void flushClipboard();
 
 bool isRegisteredForStartup();
 void setRegisteredForStartup(bool isRegistered);
+
+QString getAssociatedCommand(ASSOCIATION_QUERY_TYPE queryType, LPCWSTR query);
 
 }  // namespace chatterino
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

The existing getCommand() in IncognitoBrowser.cpp directly queries undocumented registry keys which could break if Windows decides to change the registry layout (as they have in the past.)

This PR changes getCommand() to instead call AssocQueryString, which smooths out differences between versions of Windows.