### PR TITLE
Disable ImageExpirationPool during testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - Dev: Added CMake Install Support on Windows. (#4300)
 - Dev: Changed conan generator to [`CMakeDeps`](https://docs.conan.io/en/latest/reference/conanfile/tools/cmake/cmakedeps.html) and [`CMakeToolchain`](https://docs.conan.io/en/latest/reference/conanfile/tools/cmake/cmaketoolchain.html). See PR for migration notes. (#4335)
 - Dev: Refactored 7TV EventAPI implementation. (#4342)
+- Dev: Disabled ImageExpirationPool in tests. (#4363)
 
 ## 2.4.0
 

--- a/src/messages/Image.hpp
+++ b/src/messages/Image.hpp
@@ -19,6 +19,14 @@
 #include <memory>
 #include <mutex>
 
+#ifdef CHATTERINO_TEST
+// When running tests, the ImageExpirationPool destructor can be called before
+// all images are deleted, leading to a use-after-free of its mutex. This
+// happens despite the lifetime of the ImageExpirationPool being (apparently)
+// static. Therefore, just disable it during testing.
+#    define DISABLE_IMAGE_EXPIRATION_POOL
+#endif
+
 namespace chatterino {
 namespace detail {
     template <typename Image>
@@ -105,6 +113,8 @@ private:
 // forward-declarable function that calls Image::getEmpty() under the hood.
 ImagePtr getEmptyImagePtr();
 
+#ifndef DISABLE_IMAGE_EXPIRATION_POOL
+
 class ImageExpirationPool
 {
 private:
@@ -130,5 +140,7 @@ private:
     std::map<Image *, std::weak_ptr<Image>> allImages_;
     std::mutex mutex_;
 };
+
+#endif
 
 }  // namespace chatterino


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

When running tests on **macOS**, the program finishes with the following error:
`libc++abi: terminating with uncaught exception of type std::__1::system_error: mutex lock failed: Invalid argument`

This is caused by `ImageExpirationPool` which is indirectly being used in the `Emojis.ShortcodeParsing` test. When the emoji Image objects are destructed, they are removed from the ImageExpirationPool. Despite having a static lifetime, the `ImageExpirationPool` seems to have been destroyed before these `Image` objects, so the `ImageExpirationPool`'s mutex is used after it has been destructed.

The simple solution is to just disable the `ImageExpirationPool` logic during tests. 