### PR TITLE
Fix Ubuntu builds preventing `create-release` from building

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -286,12 +286,12 @@ jobs:
 
       - uses: actions/download-artifact@v3
         with:
-          name: Chatterino-ubuntu-20.04.deb
+          name: Chatterino-ubuntu-20.04-Qt-5.12.12.deb
           path: release-artifacts/
 
       - uses: actions/download-artifact@v3
         with:
-          name: Chatterino-ubuntu-20.04-Qt-5.12.12.deb
+          name: Chatterino-ubuntu-22.04-Qt-5.15.2.deb
           path: release-artifacts/
 
       - uses: actions/download-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -291,7 +291,7 @@ jobs:
 
       - uses: actions/download-artifact@v3
         with:
-          name: Chatterino-ubuntu-22.04.deb
+          name: Chatterino-ubuntu-20.04-Qt-5.12.12.deb
           path: release-artifacts/
 
       - uses: actions/download-artifact@v3


### PR DESCRIPTION
Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable

# Description

I noticed the Nightly Build on the master branch failing, so I checked the artifact names of the last run of my deb PR and found differences that I fixed in this PR.

![image](https://user-images.githubusercontent.com/30803034/218285185-a71526ba-ff03-466d-81a2-97f66524bc6c.png)
