### PR TITLE
Automatically update `nightly-build` tag every nightly release

### DIFF
--- a/.CI/CreateUbuntuDeb.sh
+++ b/.CI/CreateUbuntuDeb.sh
@@ -48,7 +48,7 @@ elif [ "$chatterino_version" = "ightly-build" ]; then
     chatterino_version=$(git describe --abbrev=0 --tags `git rev-list --tags --skip=1 --max-count=1` 2>/dev/null | cut -c 2-) || true
     echo "Found Chatterino nightly build via git. Falling back to the second to last tag"
     if [ -z "$chatterino_version" ]; then
-        # Fall back to this in case the build happened in a git repo without tags
+        # Fall back to this in case the build happened in a git repo with just the nightly-build tag
         chatterino_version="0.0.0-dev"
     fi
 fi

--- a/.CI/CreateUbuntuDeb.sh
+++ b/.CI/CreateUbuntuDeb.sh
@@ -42,8 +42,15 @@ fi
 
 chatterino_version=$(git describe 2>/dev/null | cut -c 2-) || true
 if [ -z "$chatterino_version" ]; then
-    # Fall back to this in case the build happened outside of a git repo
+    # Fall back to this in case the build happened outside of a git repo or a repo without tags
     chatterino_version="0.0.0-dev"
+elif [ "$chatterino_version" = "ightly-build" ]; then
+    chatterino_version=$(git describe --abbrev=0 --tags `git rev-list --tags --skip=1 --max-count=1` 2>/dev/null | cut -c 2-) || true
+    echo "Found Chatterino nightly build via git. Falling back to the second to last tag"
+    if [ -z "$chatterino_version" ]; then
+        # Fall back to this in case the build happened in a git repo without tags
+        chatterino_version="0.0.0-dev"
+    fi
 fi
 
 # Make sure no old remnants of a previous packaging remains

--- a/.CI/CreateUbuntuDeb.sh
+++ b/.CI/CreateUbuntuDeb.sh
@@ -44,13 +44,6 @@ chatterino_version=$(git describe 2>/dev/null | cut -c 2-) || true
 if [ -z "$chatterino_version" ]; then
     # Fall back to this in case the build happened outside of a git repo or a repo without tags
     chatterino_version="0.0.0-dev"
-elif [ "$chatterino_version" = "ightly-build" ]; then
-    chatterino_version=$(git describe --abbrev=0 --tags `git rev-list --tags --skip=1 --max-count=1` 2>/dev/null | cut -c 2-) || true
-    echo "Found Chatterino nightly build via git. Falling back to the second to last tag"
-    if [ -z "$chatterino_version" ]; then
-        # Fall back to this in case the build happened in a git repo with just the nightly-build tag
-        chatterino_version="0.0.0-dev"
-    fi
 fi
 
 # Make sure no old remnants of a previous packaging remains

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -308,7 +308,7 @@ jobs:
   create-release:
     needs: build
     runs-on: ubuntu-latest
-    # if: (github.event_name == 'push' && github.ref == 'refs/heads/master')
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/master')
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -308,7 +308,7 @@ jobs:
   create-release:
     needs: build
     runs-on: ubuntu-latest
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/master')
+    # if: (github.event_name == 'push' && github.ref == 'refs/heads/master')
 
     steps:
       - uses: actions/download-artifact@v3
@@ -340,6 +340,12 @@ jobs:
         with:
           name: chatterino-osx-5.15.2.dmg
           path: release-artifacts/
+
+      - name: Update nightly-build tag
+        run: |
+          git tag -f nightly-build
+          git push -f origin nightly-build
+        shell: bash
 
       - name: Create release
         uses: ncipollo/release-action@v1.12.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -308,7 +308,7 @@ jobs:
   create-release:
     needs: build
     runs-on: ubuntu-latest
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/master')
+    # if: (github.event_name == 'push' && github.ref == 'refs/heads/master')
 
     steps:
       - uses: actions/checkout@v3
@@ -345,12 +345,6 @@ jobs:
           name: chatterino-osx-5.15.2.dmg
           path: release-artifacts/
 
-      - name: Update nightly-build tag
-        run: |
-          git tag -f nightly-build
-          git push -f origin nightly-build
-        shell: bash
-
       - name: Create release
         uses: ncipollo/release-action@v1.12.0
         with:
@@ -362,3 +356,9 @@ jobs:
           prerelease: true
           name: Nightly Release
           tag: nightly-build
+
+      - name: Update nightly-build tag
+        run: |
+          git tag -f nightly-build
+          git push -f origin nightly-build
+        shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -313,7 +313,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          submodules: recursive
           fetch-depth: 0 # allows for tags access
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -311,6 +311,10 @@ jobs:
     # if: (github.event_name == 'push' && github.ref == 'refs/heads/master')
 
     steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0 # allows for tags access
       - uses: actions/download-artifact@v3
         with:
           name: chatterino-windows-x86-64-5.15.2.zip


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

This PR makes the nightly build workflow update the tag to have up-to-date source code options on the Nightly Release.

References/Proof:
https://github.com/ncipollo/release-action/issues/31
https://i.imgur.com/zkKPrem.png

(felanbird): Fixes #3443