### PR TITLE
Handle non-versioned annotated tags gracefully when building a Ubuntu .deb package

### DIFF
--- a/.CI/CreateUbuntuDeb.sh
+++ b/.CI/CreateUbuntuDeb.sh
@@ -41,8 +41,8 @@ if [ ! -f ./bin/chatterino ] || [ ! -x ./bin/chatterino ]; then
 fi
 
 chatterino_version=$(git describe 2>/dev/null) || true
-if [[ ${chatterino_version:0:1} == 'v' ]]; then
-    chatterino_version=${chatterino_version:1}
+if [ "$(echo "$chatterino_version" | cut -c1-1)" = 'v' ]; then
+    chatterino_version="$(echo "$chatterino_version" | cut -c2-)"
 else
     chatterino_version="0.0.0-dev"
 fi

--- a/.CI/CreateUbuntuDeb.sh
+++ b/.CI/CreateUbuntuDeb.sh
@@ -40,17 +40,11 @@ if [ ! -f ./bin/chatterino ] || [ ! -x ./bin/chatterino ]; then
     exit 1
 fi
 
-chatterino_version=$(git describe 2>/dev/null | cut -c 2-) || true
-if [ -z "$chatterino_version" ]; then
-    # Fall back to this in case the build happened outside of a git repo or a repo without tags
+chatterino_version=$(git describe 2>/dev/null) || true
+if [[ ${chatterino_version:0:1} == 'v' ]]; then
+    chatterino_version=${chatterino_version:1}
+else
     chatterino_version="0.0.0-dev"
-elif [ "$chatterino_version" = "ightly-build" ]; then
-    chatterino_version=$(git describe --abbrev=0 --tags `git rev-list --tags --skip=1 --max-count=1` 2>/dev/null | cut -c 2-) || true
-    # Found Chatterino nightly build. Falling back to the second to last tag.
-    if [ -z "$chatterino_version" ]; then
-        # Fall back to this in case the build happened in a git repo without tags
-        chatterino_version="0.0.0-dev"
-    fi
 fi
 
 # Make sure no old remnants of a previous packaging remains

--- a/.CI/CreateUbuntuDeb.sh
+++ b/.CI/CreateUbuntuDeb.sh
@@ -44,6 +44,13 @@ chatterino_version=$(git describe 2>/dev/null | cut -c 2-) || true
 if [ -z "$chatterino_version" ]; then
     # Fall back to this in case the build happened outside of a git repo or a repo without tags
     chatterino_version="0.0.0-dev"
+elif [ "$chatterino_version" = "ightly-build" ]; then
+    chatterino_version=$(git describe --abbrev=0 --tags `git rev-list --tags --skip=1 --max-count=1` 2>/dev/null | cut -c 2-) || true
+    # Found Chatterino nightly build. Falling back to the second to last tag.
+    if [ -z "$chatterino_version" ]; then
+        # Fall back to this in case the build happened in a git repo without tags
+        chatterino_version="0.0.0-dev"
+    fi
 fi
 
 # Make sure no old remnants of a previous packaging remains


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

pajlada: "If you want to improve this, I'd rather it be done in a separate PR so we can nitpick over it without blocking the main purpose of the PR" from https://github.com/Chatterino/chatterino2/pull/4374