### PR TITLE
Use `qintptr` in `QWidget::nativeEvent` on Qt 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - Dev: Disabled ImageExpirationPool in tests. (#4363)
 - Dev: Don't rely on undocumented registry keys to find the default browser on Windows. (#4362)
 - Dev: Use `QEnterEvent` for `QWidget::enterEvent` on Qt 6. (#4365)
+- Dev: Use `qintptr` in `QWidget::nativeEvent` on Qt 6. (#4376)
 
 ## 2.4.0
 

--- a/src/widgets/BaseWindow.cpp
+++ b/src/widgets/BaseWindow.cpp
@@ -631,8 +631,13 @@ void BaseWindow::moveIntoDesktopRect(QPoint point)
     this->move(point);
 }
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+bool BaseWindow::nativeEvent(const QByteArray &eventType, void *message,
+                             qintptr *result)
+#else
 bool BaseWindow::nativeEvent(const QByteArray &eventType, void *message,
                              long *result)
+#endif
 {
 #ifdef USEWINSDK
     MSG *msg = reinterpret_cast<MSG *>(message);
@@ -830,7 +835,11 @@ bool BaseWindow::handleSHOWWINDOW(MSG *msg)
 #endif
 }
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+bool BaseWindow::handleNCCALCSIZE(MSG *msg, qintptr *result)
+#else
 bool BaseWindow::handleNCCALCSIZE(MSG *msg, long *result)
+#endif
 {
 #ifdef USEWINSDK
     if (this->hasCustomWindowFrame())
@@ -914,7 +923,11 @@ bool BaseWindow::handleMOVE(MSG *msg)
     return false;
 }
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+bool BaseWindow::handleNCHITTEST(MSG *msg, qintptr *result)
+#else
 bool BaseWindow::handleNCHITTEST(MSG *msg, long *result)
+#endif
 {
 #ifdef USEWINSDK
     const LONG border_width = 8;  // in pixels

--- a/src/widgets/BaseWindow.hpp
+++ b/src/widgets/BaseWindow.hpp
@@ -67,8 +67,13 @@ public:
     static bool supportsCustomWindowFrame();
 
 protected:
-    virtual bool nativeEvent(const QByteArray &eventType, void *message,
-                             long *result) override;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    bool nativeEvent(const QByteArray &eventType, void *message,
+                     qintptr *result) override;
+#else
+    bool nativeEvent(const QByteArray &eventType, void *message,
+                     long *result) override;
+#endif
     virtual void scaleChangedEvent(float) override;
 
     virtual void paintEvent(QPaintEvent *) override;
@@ -103,10 +108,15 @@ private:
 
     bool handleDPICHANGED(MSG *msg);
     bool handleSHOWWINDOW(MSG *msg);
-    bool handleNCCALCSIZE(MSG *msg, long *result);
     bool handleSIZE(MSG *msg);
     bool handleMOVE(MSG *msg);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    bool handleNCCALCSIZE(MSG *msg, qintptr *result);
+    bool handleNCHITTEST(MSG *msg, qintptr *result);
+#else
+    bool handleNCCALCSIZE(MSG *msg, long *result);
     bool handleNCHITTEST(MSG *msg, long *result);
+#endif
 
     bool enableCustomFrame_;
     ActionOnFocusLoss actionOnFocusLoss_ = Nothing;

--- a/src/widgets/FramelessEmbedWindow.cpp
+++ b/src/widgets/FramelessEmbedWindow.cpp
@@ -27,8 +27,13 @@ FramelessEmbedWindow::FramelessEmbedWindow()
 }
 
 #ifdef USEWINSDK
+#    if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+bool FramelessEmbedWindow::nativeEvent(const QByteArray &eventType,
+                                       void *message, qintptr *result)
+#    else
 bool FramelessEmbedWindow::nativeEvent(const QByteArray &eventType,
                                        void *message, long *result)
+#    endif
 {
     MSG *msg = reinterpret_cast<MSG *>(message);
 

--- a/src/widgets/FramelessEmbedWindow.hpp
+++ b/src/widgets/FramelessEmbedWindow.hpp
@@ -13,8 +13,15 @@ public:
 
 protected:
 #ifdef USEWINSDK
+
+#    if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    bool nativeEvent(const QByteArray &eventType, void *message,
+                     qintptr *result) override;
+#    else
     bool nativeEvent(const QByteArray &eventType, void *message,
                      long *result) override;
+#    endif
+
     void showEvent(QShowEvent *event) override;
 #endif
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

[`QWidget::nativeEvent`](https://doc.qt.io/qt-6/qwidget.html#nativeEvent) in Qt 6 takes `qintptr*` as its last argument ([Qt 5 docs](https://doc.qt.io/qt-5/qwidget.html#nativeEvent)). `qintptr*` doesn't mix well with `long*`, that's why it's ifdef'd.
