### PR TITLE
Fix inconsistent separator usage in command failure messages

### DIFF
--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -955,7 +955,7 @@ void CommandController::initialize(Settings &, Paths &paths)
                                   QString message) {
         using Error = HelixGetChattersError;
 
-        QString errorMessage = QString("Failed to get chatter count: ");
+        QString errorMessage = QString("Failed to get chatter count - ");
 
         switch (error)
         {
@@ -1063,7 +1063,7 @@ void CommandController::initialize(Settings &, Paths &paths)
     auto formatModsError = [](HelixGetModeratorsError error, QString message) {
         using Error = HelixGetModeratorsError;
 
-        QString errorMessage = QString("Failed to get moderators: ");
+        QString errorMessage = QString("Failed to get moderators - ");
 
         switch (error)
         {


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Fix some microscopic typos in separators used for failure messages, changed them to match the rest (`"something - "`).

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
