### PR TITLE
Stop whispers from showing up in /mentions unless they match another highlight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,7 +149,7 @@
 - Bugfix: Fixed crash happening when QuickSwitcher is used with a popout window. (#4187)
 - Bugfix: Fixed low contrast of text in settings tooltips. (#4188)
 - Bugfix: Fixed being unable to see the usercard of VIPs who have Asian language display names. (#4174)
-- Bugfix: Fixed whispers always being shows in the /mentions split. (#4389)
+- Bugfix: Fixed whispers always being shown in the /mentions split. (#4389)
 - Bugfix: Fixed messages where Right-to-Left order is mixed in multiple lines. (#4173)
 - Bugfix: Fixed the wrong right-click menu showing in the chat input box. (#4177)
 - Bugfix: Fixed popup windows not appearing/minimizing correctly on the Windows taskbar. (#4181)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,7 @@
 - Bugfix: Fixed crash happening when QuickSwitcher is used with a popout window. (#4187)
 - Bugfix: Fixed low contrast of text in settings tooltips. (#4188)
 - Bugfix: Fixed being unable to see the usercard of VIPs who have Asian language display names. (#4174)
+- Bugfix: Fixed whispers always being shows in the /mentions split. (#4389)
 - Bugfix: Fixed messages where Right-to-Left order is mixed in multiple lines. (#4173)
 - Bugfix: Fixed the wrong right-click menu showing in the chat input box. (#4177)
 - Bugfix: Fixed popup windows not appearing/minimizing correctly on the Windows taskbar. (#4181)

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -810,7 +810,7 @@ void IrcMessageHandler::handleWhisperMessage(Communi::IrcMessage *message)
 
     getApp()->twitch->lastUserThatWhisperedMe.set(builder.userName);
 
-    if (_message->flags.has(MessageFlag::Highlighted))
+    if (_message->flags.has(MessageFlag::ShowInMentions))
     {
         getApp()->twitch->mentionsChannel->addMessage(_message);
     }

--- a/tests/src/HighlightController.cpp
+++ b/tests/src/HighlightController.cpp
@@ -3,6 +3,7 @@
 #include "Application.hpp"
 #include "BaseSettings.hpp"
 #include "controllers/accounts/AccountController.hpp"
+#include "controllers/highlights/HighlightPhrase.hpp"
 #include "messages/MessageBuilder.hpp"  // for MessageParseArgs
 #include "mocks/UserData.hpp"
 #include "providers/twitch/api/Helix.hpp"
@@ -772,6 +773,56 @@ TEST_F(HighlightControllerTest, A)
                     std::make_shared<QColor>("#6fffffff"),  // color
                     false,
                 },
+            },
+        },
+        {
+            // TEST CASE: Whispers that do not hit a highlight phrase should not be added to /mentions
+            {
+                // input
+                .args =
+                    MessageParseArgs{
+                        .isReceivedWhisper = true,
+                    },
+                .senderName = "forsen",
+                .originalMessage = "Hello NymN!",
+            },
+            {
+                // expected
+                .state = true,  // state
+                .result =
+                    {
+                        false,        // alert
+                        false,        // playsound
+                        boost::none,  // custom sound url
+                        std::make_shared<QColor>(
+                            HighlightPhrase::
+                                FALLBACK_HIGHLIGHT_COLOR),  // color
+                        false,                              // showInMentions
+                    },
+            },
+        },
+        {
+            // TEST CASE: Whispers that do hit a highlight phrase should be added to /mentions
+            {
+                // input
+                .args =
+                    MessageParseArgs{
+                        .isReceivedWhisper = true,
+                    },
+                .senderName = "forsen",
+                .originalMessage = "!testmanxd",
+            },
+            {
+                // expected
+                .state = true,  // state
+                .result =
+                    {
+                        true,         // alert
+                        true,         // playsound
+                        boost::none,  // custom sound url
+                        std::make_shared<QColor>("#7f7f3f49"),  // color
+                        true,  // showInMentions
+                    },
             },
         },
     };


### PR DESCRIPTION
- Only highlight whispers that have the `ShowInMentions` flag
- Add tests for whisper in and out of mentions
- Add changelog entry

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
