### PR TITLE
Delete all but the last 5 crash dumps on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unversioned
 
-- Bugfix: Only store the five most recent crashdumps. (#4392)
+- Minor: Delete all but the last 5 crashdumps on application start. (#4392)
 
 ## 2.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+- Bugfix: Only store the five most recent crashdumps. (#4392)
+
 ## 2.4.1
 
 - Major: Added live emote updates for BTTV. (#4147)

--- a/src/RunGui.cpp
+++ b/src/RunGui.cpp
@@ -20,6 +20,7 @@
 #include <QtConcurrent>
 
 #include <csignal>
+#include <ranges>
 
 #ifdef USEWINSDK
 #    include "util/WindowsHelper.hpp"
@@ -185,6 +186,24 @@ namespace {
         }
         qCDebug(chatterinoCache) << "Deleted" << deletedCount << "files";
     }
+
+    // We delete all but the five most recent crashdumps. This strategy may be
+    // improved in the future.
+    void clearCrashes(QDir dir)
+    {
+        dir.setNameFilters({"*.dmp"});
+
+        size_t deletedCount = 0;
+        for (auto &&info :
+             dir.entryInfoList(QDir::Files, QDir::Time) | std::views::drop(5))
+        {
+            if (QFile(info.absoluteFilePath()).remove())
+            {
+                deletedCount++;
+            }
+        }
+        qCDebug(chatterinoApp) << "Deleted" << deletedCount << "crashdumps";
+    }
 }  // namespace
 
 void runGui(QApplication &a, Paths &paths, Settings &settings)
@@ -215,10 +234,20 @@ void runGui(QApplication &a, Paths &paths, Settings &settings)
     });
 
     // Clear the cache 1 minute after start.
-    QTimer::singleShot(60 * 1000, [cachePath = paths.cacheDirectory()] {
+    QTimer::singleShot(60 * 1000, [cachePath = paths.cacheDirectory(),
+                                   crashDirectory = paths.crashdumpDirectory] {
         QtConcurrent::run([cachePath]() {
             clearCache(cachePath);
         });
+
+        auto crashReportsDir = QDir(crashDirectory);
+        // check if the /reports directory exists
+        if (crashReportsDir.cd("reports"))
+        {
+            QtConcurrent::run([crashReportsDir]() {
+                clearCrashes(crashReportsDir);
+            });
+        }
     });
 
     chatterino::NetworkManager::init();

--- a/src/RunGui.cpp
+++ b/src/RunGui.cpp
@@ -20,7 +20,6 @@
 #include <QtConcurrent>
 
 #include <csignal>
-#include <ranges>
 
 #ifdef USEWINSDK
 #    include "util/WindowsHelper.hpp"
@@ -194,9 +193,16 @@ namespace {
         dir.setNameFilters({"*.dmp"});
 
         size_t deletedCount = 0;
-        for (auto &&info :
-             dir.entryInfoList(QDir::Files, QDir::Time) | std::views::drop(5))
+        // TODO: use std::views::drop once supported by all compilers
+        size_t filesToSkip = 5;
+        for (auto &&info : dir.entryInfoList(QDir::Files, QDir::Time))
         {
+            if (filesToSkip > 0)
+            {
+                filesToSkip--;
+                continue;
+            }
+
             if (QFile(info.absoluteFilePath()).remove())
             {
                 deletedCount++;

--- a/src/RunGui.cpp
+++ b/src/RunGui.cpp
@@ -190,6 +190,13 @@ namespace {
     // improved in the future.
     void clearCrashes(QDir dir)
     {
+        // crashpad crashdumps are stored inside the Crashes/report directory
+        if (!dir.cd("reports"))
+        {
+            // no reports directory exists = no files to delete
+            return;
+        }
+
         dir.setNameFilters({"*.dmp"});
 
         size_t deletedCount = 0;
@@ -246,14 +253,9 @@ void runGui(QApplication &a, Paths &paths, Settings &settings)
             clearCache(cachePath);
         });
 
-        auto crashReportsDir = QDir(crashDirectory);
-        // check if the /reports directory exists
-        if (crashReportsDir.cd("reports"))
-        {
-            QtConcurrent::run([crashReportsDir]() {
-                clearCrashes(crashReportsDir);
-            });
-        }
+        QtConcurrent::run([crashDirectory]() {
+            clearCrashes(crashDirectory);
+        });
     });
 
     chatterino::NetworkManager::init();


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

As mentioned in #4391, this ensures only the five most recent crashdumps are saved. This uses a similar strategy to how the cache is cleaned up after starting Chatterino.

Fixes #4391.
