### PR TITLE
Fix Qt6 building

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,9 +39,9 @@ jobs:
             qt-version: 5.15.2
             pch: true
             force-lto: false
-          # Ubuntu 22.04, Qt 6.2.6
+          # Ubuntu 22.04, Qt 6.2.4
           - os: ubuntu-22.04
-            qt-version: 6.2.6
+            qt-version: 6.2.4
             pch: false
             force-lto: false
           # Test for disabling Precompiled Headers & enabling link-time optimization

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ concurrency:
 env:
   C2_ENABLE_LTO: ${{ github.ref == 'refs/heads/master' }}
   CHATTERINO_REQUIRE_CLEAN_GIT: On
+  C2_BUILD_WITH_QT6: Off
 
 jobs:
   build:
@@ -78,6 +79,12 @@ jobs:
           echo "vs_version=2022" >> "$GITHUB_ENV"
         shell: bash
 
+      - name: Set BUILD_WITH_QT6
+        if: startsWith(matrix.qt-version, '6.')
+        run: |
+          echo "C2_BUILD_WITH_QT6=ON" >> "$GITHUB_ENV"
+        shell: bash
+
       - uses: actions/checkout@v3
         with:
           submodules: recursive
@@ -136,6 +143,7 @@ jobs:
               -DCMAKE_TOOLCHAIN_FILE="conan_toolchain.cmake" `
               -DBUILD_WITH_CRASHPAD="$Env:C2_ENABLE_CRASHPAD" `
               -DCHATTERINO_LTO="$Env:C2_ENABLE_LTO" `
+              -DBUILD_WITH_QT6="$Env:C2_BUILD_WITH_QT6" `
               ..
           set cl=/MP
           nmake /S /NOLOGO
@@ -221,6 +229,7 @@ jobs:
             -DUSE_PRECOMPILED_HEADERS=${{ matrix.pch }} \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=On \
             -DCHATTERINO_LTO="$C2_ENABLE_LTO" \
+            -DBUILD_WITH_QT6="$C2_BUILD_WITH_QT6" \
             ..
           make -j"$(nproc)"
         shell: bash
@@ -289,6 +298,7 @@ jobs:
               -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl \
               -DUSE_PRECOMPILED_HEADERS=${{ matrix.pch }} \
               -DCHATTERINO_LTO="$C2_ENABLE_LTO" \
+              -DBUILD_WITH_QT6="$C2_BUILD_WITH_QT6" \
               ..
           make -j"$(sysctl -n hw.logicalcpu)"
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,11 +90,21 @@ jobs:
           submodules: recursive
           fetch-depth: 0 # allows for tags access
 
-      - name: Install Qt
+      - name: Install Qt5
+        if: startsWith(matrix.qt-version, '5.')
         uses: jurplel/install-qt-action@v3.0.0
         with:
           cache: true
           cache-key-prefix: ${{ runner.os }}-QtCache-${{ matrix.qt-version }}-v2
+          version: ${{ matrix.qt-version }}
+
+      - name: Install Qt6
+        if: startsWith(matrix.qt-version, '6.')
+        uses: jurplel/install-qt-action@v3.0.0
+        with:
+          cache: true
+          cache-key-prefix: ${{ runner.os }}-QtCache-${{ matrix.qt-version }}-v2
+          modules: qt5compat
           version: ${{ matrix.qt-version }}
 
       # WINDOWS

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,11 @@ jobs:
             qt-version: 5.15.2
             pch: true
             force-lto: false
+          # Ubuntu 22.04, Qt 6.2.6
+          - os: ubuntu-22.04
+            qt-version: 6.2.6
+            pch: false
+            force-lto: false
           # Test for disabling Precompiled Headers & enabling link-time optimization
           - os: ubuntu-22.04
             qt-version: 5.15.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+- Dev: Add capability to build Chatterino with Qt6. (#4393)
+
 ## 2.4.1
 
 - Major: Added live emote updates for BTTV. (#4147)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,13 @@ find_package(Qt${MAJOR_QT_VERSION} REQUIRED
     Concurrent
     )
 
+if (BUILD_WITH_QT6)
+    find_package(Qt${MAJOR_QT_VERSION} REQUIRED
+        COMPONENTS
+        Core5Compat
+        )
+endif ()
+
 message(STATUS "Qt version: ${Qt${MAJOR_QT_VERSION}_VERSION}")
 
 if (WIN32)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -620,6 +620,14 @@ target_link_libraries(${LIBRARY_PROJECT}
         LRUCache
         MagicEnum
         )
+
+if (BUILD_WITH_QT6)
+    target_link_libraries(${LIBRARY_PROJECT}
+            PUBLIC
+            Qt${MAJOR_QT_VERSION}::Core5Compat
+            )
+endif ()
+
 if (BUILD_WITH_QTKEYCHAIN)
     target_link_libraries(${LIBRARY_PROJECT}
             PUBLIC

--- a/src/PrecompiledHeader.hpp
+++ b/src/PrecompiledHeader.hpp
@@ -105,7 +105,6 @@
 #    include <QThreadPool>
 #    include <QTime>
 #    include <QTimer>
-#    include <QtWidgets/QAction>
 #    include <QtWidgets/QApplication>
 #    include <QtWidgets/QButtonGroup>
 #    include <QtWidgets/QDialog>

--- a/src/common/LinkParser.cpp
+++ b/src/common/LinkParser.cpp
@@ -16,7 +16,12 @@ namespace {
             QFile file(":/tlds.txt");
             file.open(QFile::ReadOnly);
             QTextStream stream(&file);
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            // Default encoding of QTextStream is already UTF-8, at least in Qt6
+#else
             stream.setCodec("UTF-8");
+#endif
             int safetyMax = 20000;
 
             QSet<QString> set;

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -3191,7 +3191,8 @@ QString CommandController::execCommand(const QString &textNoEmoji,
         }
     }
 
-    auto maxSpaces = std::min(this->maxSpaces_, words.length() - 1);
+    // We have checks to ensure words cannot be empty, so this can never wrap around
+    auto maxSpaces = std::min(this->maxSpaces_, (qsizetype)words.length() - 1);
     for (int i = 0; i < maxSpaces; ++i)
     {
         commandName += ' ' + words[i + 1];

--- a/src/controllers/commands/CommandController.hpp
+++ b/src/controllers/commands/CommandController.hpp
@@ -62,7 +62,7 @@ private:
 
     // User-created commands
     QMap<QString, Command> userCommands_;
-    int maxSpaces_ = 0;
+    qsizetype maxSpaces_ = 0;
 
     std::shared_ptr<pajlada::Settings::SettingManager> sm_;
     // Because the setting manager is not initialized until the initialize

--- a/src/controllers/sound/SoundController.cpp
+++ b/src/controllers/sound/SoundController.cpp
@@ -7,6 +7,7 @@
 
 #define MINIAUDIO_IMPLEMENTATION
 #include <miniaudio.h>
+#include <QFile>
 
 #include <limits>
 #include <memory>

--- a/src/providers/bttv/liveupdates/BttvLiveUpdateSubscription.cpp
+++ b/src/providers/bttv/liveupdates/BttvLiveUpdateSubscription.cpp
@@ -1,5 +1,6 @@
 #include "providers/bttv/liveupdates/BttvLiveUpdateSubscription.hpp"
 
+#include <QDebug>
 #include <QJsonDocument>
 
 namespace chatterino {

--- a/src/providers/irc/IrcServer.cpp
+++ b/src/providers/irc/IrcServer.cpp
@@ -94,7 +94,8 @@ void IrcServer::initializeConnectionSignals(IrcConnection *connection,
 
     QObject::connect(connection, &Communi::IrcConnection::nickNameRequired,
                      this, [](const QString &reserved, QString *result) {
-                         *result = reserved + (std::rand() % 100);
+                         *result = QString("%1%2").arg(
+                             reserved, QString::number(std::rand() % 100));
                      });
 
     QObject::connect(connection, &Communi::IrcConnection::noticeMessageReceived,

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -325,7 +325,7 @@ std::shared_ptr<Channel> TwitchIrcServer::getChannelOrEmptyByID(
             continue;
 
         if (twitchChannel->roomId() == channelId &&
-            twitchChannel->getName().splitRef(":").size() < 3)
+            QStringView{twitchChannel->getName()}.split(':').size() < 3)
         {
             return twitchChannel;
         }

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -325,7 +325,7 @@ std::shared_ptr<Channel> TwitchIrcServer::getChannelOrEmptyByID(
             continue;
 
         if (twitchChannel->roomId() == channelId &&
-            QStringView{twitchChannel->getName()}.split(':').size() < 3)
+            twitchChannel->getName().count(':') < 2)
         {
             return twitchChannel;
         }

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -843,7 +843,7 @@ void TwitchMessageBuilder::runIgnoreReplaces(
                     }
                     twitchEmotes.push_back(TwitchEmoteOccurrence{
                         startIndex + pos,
-                        startIndex + pos + emote.first.string.length(),
+                        startIndex + pos + (int)emote.first.string.length(),
                         emote.second,
                         emote.first,
                     });

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -905,7 +905,7 @@ void TwitchMessageBuilder::runIgnoreReplaces(
                 shiftIndicesAfter(from + len, midsize - len);
 
                 auto midExtendedRef =
-                    this->originalMessage_.midRef(pos1, pos2 - pos1);
+                    QStringView{this->originalMessage_}.mid(pos1, pos2 - pos1);
 
                 for (auto &tup : vret)
                 {
@@ -970,7 +970,7 @@ void TwitchMessageBuilder::runIgnoreReplaces(
                 shiftIndicesAfter(from + len, replacesize - len);
 
                 auto midExtendedRef =
-                    this->originalMessage_.midRef(pos1, pos2 - pos1);
+                    QStringView{this->originalMessage_}.mid(pos1, pos2 - pos1);
 
                 for (auto &tup : vret)
                 {

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -821,14 +821,14 @@ void TwitchMessageBuilder::runIgnoreReplaces(
     };
 
     auto addReplEmotes = [&twitchEmotes](const IgnorePhrase &phrase,
-                                         const QStringRef &midrepl,
+                                         const QStringView &midrepl,
                                          int startIndex) mutable {
         if (!phrase.containsEmote())
         {
             return;
         }
 
-        QVector<QStringRef> words = midrepl.split(' ');
+        auto words = midrepl.split(' ');
         int pos = 0;
         for (const auto &word : words)
         {

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -821,7 +821,7 @@ void TwitchMessageBuilder::runIgnoreReplaces(
     };
 
     auto addReplEmotes = [&twitchEmotes](const IgnorePhrase &phrase,
-                                         const QStringView &midrepl,
+                                         const auto &midrepl,
                                          int startIndex) mutable {
         if (!phrase.containsEmote())
         {
@@ -904,8 +904,13 @@ void TwitchMessageBuilder::runIgnoreReplaces(
 
                 shiftIndicesAfter(from + len, midsize - len);
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
                 auto midExtendedRef =
                     QStringView{this->originalMessage_}.mid(pos1, pos2 - pos1);
+#else
+                auto midExtendedRef =
+                    this->originalMessage_.midRef(pos1, pos2 - pos1);
+#endif
 
                 for (auto &tup : vret)
                 {
@@ -969,8 +974,13 @@ void TwitchMessageBuilder::runIgnoreReplaces(
 
                 shiftIndicesAfter(from + len, replacesize - len);
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
                 auto midExtendedRef =
                     QStringView{this->originalMessage_}.mid(pos1, pos2 - pos1);
+#else
+                auto midExtendedRef =
+                    this->originalMessage_.midRef(pos1, pos2 - pos1);
+#endif
 
                 for (auto &tup : vret)
                 {

--- a/src/util/Helpers.cpp
+++ b/src/util/Helpers.cpp
@@ -174,6 +174,12 @@ QString localizeNumbers(unsigned int number)
     return locale.toString(number);
 }
 
+QString localizeNumbers(qsizetype number)
+{
+    QLocale locale;
+    return locale.toString(number);
+}
+
 QString kFormatNumbers(const int &number)
 {
     return QString("%1K").arg(number / 1000);

--- a/src/util/Helpers.hpp
+++ b/src/util/Helpers.hpp
@@ -74,6 +74,7 @@ QString shortenString(const QString &str, unsigned maxWidth = 50);
 
 QString localizeNumbers(const int &number);
 QString localizeNumbers(unsigned int number);
+QString localizeNumbers(qsizetype number);
 
 QString kFormatNumbers(const int &number);
 

--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -641,8 +641,8 @@ void Notebook::performLayout(bool animated)
                 bool isLastColumn = col == columnCount - 1;
                 auto largestWidth = 0;
                 int tabStart = col * tabsPerColumn;
-                int tabEnd =
-                    std::min((col + 1) * tabsPerColumn, this->items_.size());
+                int tabEnd = std::min((col + 1) * tabsPerColumn,
+                                      (int)this->items_.size());
 
                 for (int i = tabStart; i < tabEnd; i++)
                 {
@@ -743,8 +743,8 @@ void Notebook::performLayout(bool animated)
                 bool isLastColumn = col == columnCount - 1;
                 auto largestWidth = 0;
                 int tabStart = col * tabsPerColumn;
-                int tabEnd =
-                    std::min((col + 1) * tabsPerColumn, this->items_.size());
+                int tabEnd = std::min((col + 1) * tabsPerColumn,
+                                      (int)this->items_.size());
 
                 for (int i = tabStart; i < tabEnd; i++)
                 {

--- a/src/widgets/dialogs/SettingsDialog.cpp
+++ b/src/widgets/dialogs/SettingsDialog.cpp
@@ -22,6 +22,7 @@
 #include "widgets/settingspages/NotificationPage.hpp"
 
 #include <QDialogButtonBox>
+#include <QFile>
 #include <QLineEdit>
 
 namespace chatterino {

--- a/src/widgets/helper/ResizingTextEdit.cpp
+++ b/src/widgets/helper/ResizingTextEdit.cpp
@@ -62,7 +62,11 @@ QString ResizingTextEdit::textUnderCursor(bool *hadSpace) const
 
     auto textUpToCursor = currentText.left(tc.selectionStart());
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
     auto words = QStringView{textUpToCursor}.split(' ');
+#else
+    auto words = textUpToCursor.splitRef(' ');
+#endif
     if (words.size() == 0)
     {
         return QString();

--- a/src/widgets/helper/ResizingTextEdit.cpp
+++ b/src/widgets/helper/ResizingTextEdit.cpp
@@ -62,7 +62,7 @@ QString ResizingTextEdit::textUnderCursor(bool *hadSpace) const
 
     auto textUpToCursor = currentText.left(tc.selectionStart());
 
-    auto words = textUpToCursor.splitRef(' ');
+    auto words = QStringView{textUpToCursor}.split(' ');
     if (words.size() == 0)
     {
         return QString();

--- a/src/widgets/helper/SettingsDialogTab.cpp
+++ b/src/widgets/helper/SettingsDialogTab.cpp
@@ -54,7 +54,7 @@ void SettingsDialogTab::paintEvent(QPaintEvent *)
     QPainter painter(this);
 
     QStyleOption opt;
-    opt.init(this);
+    opt.initFrom(this);
 
     this->style()->drawPrimitive(QStyle::PE_Widget, &opt, &painter, this);
 

--- a/src/widgets/settingspages/AboutPage.cpp
+++ b/src/widgets/settingspages/AboutPage.cpp
@@ -8,6 +8,7 @@
 #include "widgets/BasePopup.hpp"
 #include "widgets/helper/SignalLabel.hpp"
 
+#include <QFile>
 #include <QFormLayout>
 #include <QGroupBox>
 #include <QLabel>

--- a/src/widgets/settingspages/AboutPage.cpp
+++ b/src/widgets/settingspages/AboutPage.cpp
@@ -145,7 +145,11 @@ AboutPage::AboutPage()
             contributorsFile.open(QFile::ReadOnly);
 
             QTextStream stream(&contributorsFile);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            // Default encoding of QTextStream is already UTF-8
+#else
             stream.setCodec("UTF-8");
+#endif
 
             QString line;
 

--- a/src/widgets/settingspages/ModerationPage.cpp
+++ b/src/widgets/settingspages/ModerationPage.cpp
@@ -112,35 +112,36 @@ ModerationPage::ModerationPage()
         // Show how big (size-wise) the logs are
         auto logsPathSizeLabel = logs.emplace<QLabel>();
         logsPathSizeLabel->setText(QtConcurrent::run([] {
-            return fetchLogDirectorySize();
-        }));
+                                       return fetchLogDirectorySize();
+                                   }).result());
 
         // Select event
-        QObject::connect(selectDir.getElement(), &QPushButton::clicked, this,
-                         [this, logsPathSizeLabel]() mutable {
-                             auto dirName =
-                                 QFileDialog::getExistingDirectory(this);
+        QObject::connect(
+            selectDir.getElement(), &QPushButton::clicked, this,
+            [this, logsPathSizeLabel]() mutable {
+                auto dirName = QFileDialog::getExistingDirectory(this);
 
-                             getSettings()->logPath = dirName;
+                getSettings()->logPath = dirName;
 
-                             // Refresh: Show how big (size-wise) the logs are
-                             logsPathSizeLabel->setText(QtConcurrent::run([] {
-                                 return fetchLogDirectorySize();
-                             }));
-                         });
+                // Refresh: Show how big (size-wise) the logs are
+                logsPathSizeLabel->setText(QtConcurrent::run([] {
+                                               return fetchLogDirectorySize();
+                                           }).result());
+            });
 
         buttons->addSpacing(16);
 
         // Reset custom logpath
-        QObject::connect(resetDir.getElement(), &QPushButton::clicked, this,
-                         [logsPathSizeLabel]() mutable {
-                             getSettings()->logPath = "";
+        QObject::connect(
+            resetDir.getElement(), &QPushButton::clicked, this,
+            [logsPathSizeLabel]() mutable {
+                getSettings()->logPath = "";
 
-                             // Refresh: Show how big (size-wise) the logs are
-                             logsPathSizeLabel->setText(QtConcurrent::run([] {
-                                 return fetchLogDirectorySize();
-                             }));
-                         });
+                // Refresh: Show how big (size-wise) the logs are
+                logsPathSizeLabel->setText(QtConcurrent::run([] {
+                                               return fetchLogDirectorySize();
+                                           }).result());
+            });
 
         QCheckBox *onlyLogListedChannels =
             this->createCheckBox("Only log channels listed below",

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -699,7 +699,7 @@ void SplitInput::updateCompletionPopup()
         return;
     }
 
-    for (int i = clamp(position, 0, text.length() - 1); i >= 0; i--)
+    for (int i = clamp(position, 0, (int)text.length() - 1); i >= 0; i--)
     {
         if (text[i] == ' ')
         {
@@ -789,7 +789,7 @@ void SplitInput::insertCompletionText(const QString &input_) const
     auto text = edit.toPlainText();
     auto position = edit.textCursor().position() - 1;
 
-    for (int i = clamp(position, 0, text.length() - 1); i >= 0; i--)
+    for (int i = clamp(position, 0, (int)text.length() - 1); i >= 0; i--)
     {
         bool done = false;
         if (text[i] == ':')

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -766,7 +766,7 @@ void SplitInput::showCompletionPopup(const QString &text, bool emoteCompletion)
         popup->updateUsers(text, this->split_->getChannel());
     }
 
-    auto pos = this->mapToGlobal({0, 0}) - QPoint(0, popup->height()) +
+    auto pos = this->mapToGlobal(QPoint{0, 0}) - QPoint(0, popup->height()) +
                QPoint((this->width() - popup->width()) / 2, 0);
 
     popup->move(pos);


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

- Add Qt Core5Compat dependency if building with Qt6
- Add specialization to `localizeNumber` that accepts a `qsizetype`
- Add missing `QFile` include to `SoundController.cpp`
- Add missing `QFile` include to `SettingsDialog.cpp`
- Add missing `QFile` include to `AboutPage.cpp`
- Format IRC username-randomizer in IrcServer using QString arg
- Comment out usage of `setCodec` in `LinkParser.cpp` for Qt6
- Comment out usage of `setCodec` in `AboutPage.cpp` for Qt6
- Store max spaces as a `qsizetype` in `CommandController`
- Use QStringView.split instead of QString splitRef
- `int`ify some usages of `size`
- Replace QStringRef with QStringView in TwitchMessageBuilder
- Replace `QStringRef` with `QStringView` in ResizingTextEdit
- Clarify QPoint constructor in SplitInput.cpp
- Use `initFrom` instead of `init` in QStyleOption
- Call `result` on QConcurrent runs in ModerationPage
- Add github workflow for building on Qt6

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
