### PR TITLE
Fix AppImage not containing all SSL dependencies

### DIFF
--- a/.CI/CreateAppImage.sh
+++ b/.CI/CreateAppImage.sh
@@ -2,13 +2,18 @@
 
 set -e
 
+# Print all commands as they are run
+set -x
+
 if [ ! -f ./bin/chatterino ] || [ ! -x ./bin/chatterino ]; then
     echo "ERROR: No chatterino binary file found. This script must be run in the build folder, and chatterino must be built first."
     exit 1
 fi
 
-export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/opt/qt512/lib/"
-export PATH="/opt/qt512/bin:$PATH"
+echo "Qt5_DIR set to: ${Qt5_DIR}"
+
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${Qt5_DIR}/lib"
+export PATH="${Qt5_DIR}/bin:$PATH"
 
 script_path=$(readlink -f "$0")
 script_dir=$(dirname "$script_path")
@@ -25,20 +30,32 @@ echo ""
 
 cp "$chatterino_dir"/resources/icon.png ./appdir/chatterino.png
 
-linuxdeployqt_path="linuxdeployqt-6-x86_64.AppImage"
-linuxdeployqt_url="https://github.com/probonopd/linuxdeployqt/releases/download/6/linuxdeployqt-6-x86_64.AppImage"
+linuxdeployqt_path="linuxdeployqt-x86_64.AppImage"
+linuxdeployqt_url="https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
 
 if [ ! -f "$linuxdeployqt_path" ]; then
-    wget -nv "$linuxdeployqt_url"
+    echo "Downloading LinuxDeployQT from $linuxdeployqt_url to $linuxdeployqt_path"
+    curl --location --fail --silent "$linuxdeployqt_url" -o "$linuxdeployqt_path"
     chmod a+x "$linuxdeployqt_path"
 fi
-if [ ! -f appimagetool-x86_64.AppImage ]; then
-    wget -nv "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage"
-    chmod a+x appimagetool-x86_64.AppImage
+
+appimagetool_path="appimagetool-x86_64.AppImage"
+appimagetool_url="https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage"
+
+if [ ! -f "$appimagetool_path" ]; then
+    echo "Downloading AppImageTool from $appimagetool_url to $appimagetool_path"
+    curl --location --fail --silent "$appimagetool_url" -o "$appimagetool_path"
+    chmod a+x "$appimagetool_path"
 fi
+
+# For some reason, the copyright file for libc was not found. We need to manually copy it from the host system
+mkdir -p appdir/usr/share/doc/libc6/
+cp /usr/share/doc/libc6/copyright appdir/usr/share/doc/libc6/
+
 echo "Run LinuxDeployQT"
 ./"$linuxdeployqt_path" \
-    appdir/usr/share/applications/*.desktop \
+    --appimage-extract-and-run \
+    appdir/usr/share/applications/com.chatterino.chatterino.desktop \
     -no-translations \
     -bundle-non-qt-libs \
     -unsupported-allow-new-glibc
@@ -56,7 +73,9 @@ cd "$here/usr"
 exec "$here/usr/bin/chatterino" "$@"' > appdir/AppRun
 chmod a+x appdir/AppRun
 
-./appimagetool-x86_64.AppImage appdir
+./"$appimagetool_path" \
+    --appimage-extract-and-run \
+    appdir
 
 # TODO: Create appimage in a unique directory instead maybe idk?
 rm -rf appdir

--- a/.docker/Dockerfile-ubuntu-20.04-package
+++ b/.docker/Dockerfile-ubuntu-20.04-package
@@ -1,13 +1,21 @@
 FROM chatterino-ubuntu-20.04-build
 
-ADD .CI /src/.CI
+# In CI, this is set from the aqtinstall action
+ENV Qt5_DIR=/opt/qt512
 
 WORKDIR /src/build
 
-# RUN apt-get install -y wget
+ADD .CI /src/.CI
 
-# create appimage
-# RUN pwd && ./../.CI/CreateAppImage.sh
+# Install dependencies necessary for AppImage packaging
+RUN apt-get update && apt-get -y install --no-install-recommends \
+        curl \
+        libfontconfig \
+        libxrender1 \
+        file
 
 # package deb
-RUN pwd && ./../.CI/CreateUbuntuDeb.sh
+RUN ./../.CI/CreateUbuntuDeb.sh
+
+# package appimage
+RUN ./../.CI/CreateAppImage.sh

--- a/.docker/Dockerfile-ubuntu-22.04-package
+++ b/.docker/Dockerfile-ubuntu-22.04-package
@@ -1,8 +1,21 @@
 FROM chatterino-ubuntu-22.04-build
 
-ADD .CI /src/.CI
+# In CI, this is set from the aqtinstall action
+ENV Qt5_DIR=/opt/qt515
 
 WORKDIR /src/build
 
+ADD .CI /src/.CI
+
+# Install dependencies necessary for AppImage packaging
+RUN apt-get update && apt-get -y install --no-install-recommends \
+        curl \
+        libxcb-shape0 \
+        libfontconfig1 \
+        file
+
 # package deb
 RUN ./../.CI/CreateUbuntuDeb.sh
+
+# package appimage
+RUN ./../.CI/CreateAppImage.sh

--- a/.docker/README.md
+++ b/.docker/README.md
@@ -7,9 +7,9 @@
 To build, from the repo root
 
 1. Build a docker image that contains all the build artifacts and source from building Chatterino on Ubuntu 20.04  
-   `docker build -t chatterino-ubuntu-20.04-build -f .docker/Dockerfile-ubuntu-20.04-build .`
+   `docker buildx build -t chatterino-ubuntu-20.04-build -f .docker/Dockerfile-ubuntu-20.04-build .`
 1. Build a docker image that uses the above-built image & packages it into a .deb file  
-   `docker build -t chatterino-ubuntu-20.04-package -f .docker/Dockerfile-ubuntu-20.04-package .`
+   `docker buildx build -t chatterino-ubuntu-20.04-package -f .docker/Dockerfile-ubuntu-20.04-package .`
 
 To extract the final package, you can run the following command:  
 `docker run -v $PWD:/opt/mount --rm -it chatterino-ubuntu-20.04-package bash -c "cp /src/build/Chatterino-x86_64.deb /opt/mount/"`
@@ -21,9 +21,11 @@ To extract the final package, you can run the following command:
 To build, from the repo root
 
 1. Build a docker image that contains all the build artifacts and source from building Chatterino on Ubuntu 22.04  
-   `docker build -t chatterino-ubuntu-22.04-build -f .docker/Dockerfile-ubuntu-22.04-build .`
+   `docker buildx build -t chatterino-ubuntu-22.04-build -f .docker/Dockerfile-ubuntu-22.04-build .`
 1. Build a docker image that uses the above-built image & packages it into a .deb file  
-   `docker build -t chatterino-ubuntu-22.04-package -f .docker/Dockerfile-ubuntu-22.04-package .`
+   `docker buildx build -t chatterino-ubuntu-22.04-package -f .docker/Dockerfile-ubuntu-22.04-package .`
 
 To extract the final package, you can run the following command:  
 `docker run -v $PWD:/opt/mount --rm -it chatterino-ubuntu-22.04-package bash -c "cp /src/build/Chatterino-x86_64.deb /opt/mount/"`
+
+NOTE: The AppImage from Ubuntu 22.04 is broken. Approach with caution

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -263,7 +263,7 @@ jobs:
             clang-tidy-review-metadata.json
 
       - name: Package - AppImage (Ubuntu)
-        if: startsWith(matrix.os, 'ubuntu') && matrix.skip_artifact != 'yes'
+        if: startsWith(matrix.os, 'ubuntu-20.04') && matrix.skip_artifact != 'yes'
         run: |
           cd build
           sh ./../.CI/CreateAppImage.sh
@@ -277,7 +277,7 @@ jobs:
         shell: bash
 
       - name: Upload artifact - AppImage (Ubuntu)
-        if: startsWith(matrix.os, 'ubuntu') && matrix.skip_artifact != 'yes'
+        if: startsWith(matrix.os, 'ubuntu-20.04') && matrix.skip_artifact != 'yes'
         uses: actions/upload-artifact@v3
         with:
           name: Chatterino-x86_64-${{ matrix.qt-version }}.AppImage
@@ -351,7 +351,7 @@ jobs:
 
       - uses: actions/download-artifact@v3
         with:
-          name: Chatterino-x86_64-5.15.2.AppImage
+          name: Chatterino-x86_64-5.12.12.AppImage
           path: release-artifacts/
 
       - uses: actions/download-artifact@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unversioned
 
 - Minor: Delete all but the last 5 crashdumps on application start. (#4392)
+- Bugfix: Fixed uploaded AppImage not being able most web requests. (#4400)
 - Dev: Add capability to build Chatterino with Qt6. (#4393)
 - Dev: Fix homebrew update action. (#4394)
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

We've updated to the latest version of `linuxdeployqt` in this PR & we now upload the Qt 5.12 AppImage instead of Qt 5.15

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->

Fixes #4397