### PR TITLE
Use `unique_lock` when loading 7TV badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Minor: Delete all but the last 5 crashdumps on application start. (#4392)
 - Bugfix: Fixed uploaded AppImage not being able most web requests. (#4400)
-- Bugfix: Fixed a potential thread race due to using the wrong lock when loading 7TV badges. (#4402)
+- Bugfix: Fixed a potential race condition due to using the wrong lock when loading 7TV badges. (#4402)
 - Dev: Add capability to build Chatterino with Qt6. (#4393)
 - Dev: Fix homebrew update action. (#4394)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Minor: Delete all but the last 5 crashdumps on application start. (#4392)
 - Bugfix: Fixed uploaded AppImage not being able most web requests. (#4400)
+- Bugfix: Fixed a locking bug related to 7TV badges. (#4402)
 - Dev: Add capability to build Chatterino with Qt6. (#4393)
 - Dev: Fix homebrew update action. (#4394)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Minor: Delete all but the last 5 crashdumps on application start. (#4392)
 - Bugfix: Fixed uploaded AppImage not being able most web requests. (#4400)
-- Bugfix: Fixed a locking bug related to 7TV badges. (#4402)
+- Bugfix: Fixed a potential thread race due to using the wrong lock when loading 7TV badges. (#4402)
 - Dev: Add capability to build Chatterino with Qt6. (#4393)
 - Dev: Fix homebrew update action. (#4394)
 

--- a/src/providers/seventv/SeventvBadges.cpp
+++ b/src/providers/seventv/SeventvBadges.cpp
@@ -19,7 +19,7 @@ void SeventvBadges::initialize(Settings & /*settings*/, Paths & /*paths*/)
 
 boost::optional<EmotePtr> SeventvBadges::getBadge(const UserId &id)
 {
-    std::shared_lock lock(this->mutex_);
+    const std::shared_lock lock(this->mutex_);
 
     auto it = this->badgeMap_.find(id.string);
     if (it != this->badgeMap_.end())
@@ -45,7 +45,7 @@ void SeventvBadges::loadSeventvBadges()
         .onSuccess([this](const NetworkResult &result) -> Outcome {
             auto root = result.parseJson();
 
-            std::shared_lock lock(this->mutex_);
+            const std::unique_lock lock(this->mutex_);
 
             int index = 0;
             for (const auto &jsonBadge : root.value("badges").toArray())

--- a/src/providers/seventv/SeventvBadges.cpp
+++ b/src/providers/seventv/SeventvBadges.cpp
@@ -19,7 +19,7 @@ void SeventvBadges::initialize(Settings & /*settings*/, Paths & /*paths*/)
 
 boost::optional<EmotePtr> SeventvBadges::getBadge(const UserId &id)
 {
-    const std::shared_lock lock(this->mutex_);
+    std::shared_lock lock(this->mutex_);
 
     auto it = this->badgeMap_.find(id.string);
     if (it != this->badgeMap_.end())
@@ -45,7 +45,7 @@ void SeventvBadges::loadSeventvBadges()
         .onSuccess([this](const NetworkResult &result) -> Outcome {
             auto root = result.parseJson();
 
-            const std::unique_lock lock(this->mutex_);
+            std::unique_lock lock(this->mutex_);
 
             int index = 0;
             for (const auto &jsonBadge : root.value("badges").toArray())


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

While looking through the code I found that `SeventvBadges` used a `shared_lock` while writing to the locked data. This wasn't an issue, because the badges are only ever loaded once at the start.