### PR TITLE
fix: update user-facing emote picker labels to use "7TV" naming

### DIFF
--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -493,7 +493,7 @@ void EmotePopup::filterTwitchEmotes(std::shared_ptr<Channel> searchChannel,
     }
     if (!seventvGlobalEmotes.empty())
     {
-        addEmotes(*searchChannel, seventvGlobalEmotes, "SevenTV (Global)",
+        addEmotes(*searchChannel, seventvGlobalEmotes, "7TV (Global)",
                   MessageElementFlag::SevenTVEmote);
     }
 
@@ -522,7 +522,7 @@ void EmotePopup::filterTwitchEmotes(std::shared_ptr<Channel> searchChannel,
     }
     if (!seventvChannelEmotes.empty())
     {
-        addEmotes(*searchChannel, seventvChannelEmotes, "SevenTV (Channel)",
+        addEmotes(*searchChannel, seventvChannelEmotes, "7TV (Channel)",
                   MessageElementFlag::SevenTVEmote);
     }
 }


### PR DESCRIPTION
Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable

# Description

This PR aims to update the label for 7TV emotes that is shown to users when searching for emotes in the emote picker. When browsing emotes, the section's label uses the `7TV` name; however, when searching for emotes in the same popup window, the name `SevenTV` was used. 

As suggested by the 7TV crew (I believe Anatole was the one who we had this convo with), any user-facing branding should use the name `7TV`. Only code should reference the name `SevenTV`

Thanks for finding it Malachi :)