### PR TITLE
Add ban user by id command `/banid`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unversioned
 
 - Minor: Delete all but the last 5 crashdumps on application start. (#4392)
-- Minor: Added `/banid` command that allows banning by userID. (#4411)
+- Minor: Added `/banid` command that allows banning by user ID. (#4411)
 - Bugfix: Fixed uploaded AppImage not being able most web requests. (#4400)
 - Bugfix: Fixed a potential race condition due to using the wrong lock when loading 7TV badges. (#4402)
 - Dev: Add capability to build Chatterino with Qt6. (#4393)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unversioned
 
 - Minor: Delete all but the last 5 crashdumps on application start. (#4392)
+- Minor: Added `/banid` command that allows banning by user ID. (#4411)
 - Bugfix: Fixed uploaded AppImage not being able most web requests. (#4400)
 - Bugfix: Fixed a potential race condition due to using the wrong lock when loading 7TV badges. (#4402)
 - Dev: Add capability to build Chatterino with Qt6. (#4393)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unversioned
 
 - Minor: Delete all but the last 5 crashdumps on application start. (#4392)
-- Minor: Added `/banid` command that allows banning by user ID. (#4411)
+- Minor: Added `/banid` command that allows banning by userID. (#4411)
 - Bugfix: Fixed uploaded AppImage not being able most web requests. (#4400)
 - Bugfix: Fixed a potential race condition due to using the wrong lock when loading 7TV badges. (#4402)
 - Dev: Add capability to build Chatterino with Qt6. (#4393)

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -2842,7 +2842,7 @@ void CommandController::initialize(Settings &, Paths &paths)
 
         const auto *usageStr =
             "Usage: \"/banid <userID> [reason]\" - Permanently prevent a user "
-            "from chatting via their userID. Reason is optional and will be "
+            "from chatting via their user ID. Reason is optional and will be "
             "shown to the target user and other moderators. Use \"/unban "
             "<username>\" to remove a ban.";
         if (words.size() < 2)

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -2841,10 +2841,10 @@ void CommandController::initialize(Settings &, Paths &paths)
         }
 
         const auto *usageStr =
-            "Usage: \"/banid <userid> [reason]\" - Permanently prevent a user "
-            "ID from chatting. Reason is optional and will be shown to the "
-            "target user and other moderators. Use \"/unban <username>\" to "
-            "remove a ban.";
+            "Usage: \"/banid <userID> [reason]\" - Permanently prevent a user "
+            "from chatting via their userID. Reason is optional and will be "
+            "shown to the target user and other moderators. Use \"/unban "
+            "<username>\" to remove a ban.";
         if (words.size() < 2)
         {
             channel->addMessage(makeSystemMessage(usageStr));

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -2632,7 +2632,7 @@ void CommandController::initialize(Settings &, Paths &paths)
 
     auto formatBanTimeoutError =
         [](const char *operation, HelixBanUserError error,
-           const QString &message, const QString &userDisplayName) -> QString {
+           const QString &message, const QString &userTarget) -> QString {
         using Error = HelixBanUserError;
 
         QString errorMessage = QString("Failed to %1 user - ").arg(operation);
@@ -2659,7 +2659,7 @@ void CommandController::initialize(Settings &, Paths &paths)
             case Error::TargetBanned: {
                 // Equivalent IRC error
                 errorMessage += QString("%1 is already banned in this channel.")
-                                    .arg(userDisplayName);
+                                    .arg(userTarget);
             }
             break;
 
@@ -2670,7 +2670,7 @@ void CommandController::initialize(Settings &, Paths &paths)
                 // "You cannot {op} moderator {mod} unless you are the owner of this channel."
                 // "You cannot {op} the broadcaster."
                 errorMessage += QString("You cannot %1 %2.")
-                                    .arg(operation, userDisplayName);
+                                    .arg(operation, userTarget);
             }
             break;
 
@@ -2824,6 +2824,53 @@ void CommandController::initialize(Settings &, Paths &paths)
                 // Equivalent error from IRC
                 channel->addMessage(makeSystemMessage(
                     QString("Invalid username: %1").arg(target)));
+            });
+
+        return "";
+    });
+
+    this->registerCommand("/banid", [formatBanTimeoutError](
+                                      const QStringList &words, auto channel) {
+        auto *twitchChannel = dynamic_cast<TwitchChannel *>(channel.get());
+        if (twitchChannel == nullptr)
+        {
+            channel->addMessage(makeSystemMessage(
+                QString("The /banid command only works in Twitch channels")));
+            return "";
+        }
+
+        const auto *usageStr =
+            "Usage: \"/banid <userid> [reason]\" - Permanently prevent a user ID "
+            "from chatting. Reason is optional and will be shown to the target "
+            "user and other moderators. Use \"/unban <username>\" to remove a ban.";
+        if (words.size() < 2)
+        {
+            channel->addMessage(makeSystemMessage(usageStr));
+            return "";
+        }
+
+        auto currentUser = getApp()->accounts->twitch.getCurrent();
+        if (currentUser->isAnon())
+        {
+            channel->addMessage(
+                makeSystemMessage("You must be logged in to ban someone!"));
+            return "";
+        }
+
+        auto target = words.at(1);
+        auto reason = words.mid(2).join(' ');
+
+        getHelix()->banUser(
+            twitchChannel->roomId(), currentUser->getUserId(),
+            target, boost::none, reason,
+            [] {
+                // No response for bans, they're emitted over pubsub/IRC instead
+            },
+            [channel, target, formatBanTimeoutError](
+                auto error, auto message) {
+                auto errorMessage = formatBanTimeoutError(
+                    "ban", error, message, "#" + target);
+                channel->addMessage(makeSystemMessage(errorMessage));
             });
 
         return "";

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -2669,8 +2669,8 @@ void CommandController::initialize(Settings &, Paths &paths)
                 // The messages from IRC are formatted like this:
                 // "You cannot {op} moderator {mod} unless you are the owner of this channel."
                 // "You cannot {op} the broadcaster."
-                errorMessage += QString("You cannot %1 %2.")
-                                    .arg(operation, userTarget);
+                errorMessage +=
+                    QString("You cannot %1 %2.").arg(operation, userTarget);
             }
             break;
 
@@ -2830,7 +2830,8 @@ void CommandController::initialize(Settings &, Paths &paths)
     });
 
     this->registerCommand("/banid", [formatBanTimeoutError](
-                                      const QStringList &words, auto channel) {
+                                        const QStringList &words,
+                                        auto channel) {
         auto *twitchChannel = dynamic_cast<TwitchChannel *>(channel.get());
         if (twitchChannel == nullptr)
         {
@@ -2840,9 +2841,10 @@ void CommandController::initialize(Settings &, Paths &paths)
         }
 
         const auto *usageStr =
-            "Usage: \"/banid <userid> [reason]\" - Permanently prevent a user ID "
-            "from chatting. Reason is optional and will be shown to the target "
-            "user and other moderators. Use \"/unban <username>\" to remove a ban.";
+            "Usage: \"/banid <userid> [reason]\" - Permanently prevent a user "
+            "ID from chatting. Reason is optional and will be shown to the "
+            "target user and other moderators. Use \"/unban <username>\" to "
+            "remove a ban.";
         if (words.size() < 2)
         {
             channel->addMessage(makeSystemMessage(usageStr));
@@ -2861,15 +2863,14 @@ void CommandController::initialize(Settings &, Paths &paths)
         auto reason = words.mid(2).join(' ');
 
         getHelix()->banUser(
-            twitchChannel->roomId(), currentUser->getUserId(),
-            target, boost::none, reason,
+            twitchChannel->roomId(), currentUser->getUserId(), target,
+            boost::none, reason,
             [] {
                 // No response for bans, they're emitted over pubsub/IRC instead
             },
-            [channel, target, formatBanTimeoutError](
-                auto error, auto message) {
-                auto errorMessage = formatBanTimeoutError(
-                    "ban", error, message, "#" + target);
+            [channel, target, formatBanTimeoutError](auto error, auto message) {
+                auto errorMessage =
+                    formatBanTimeoutError("ban", error, message, "#" + target);
                 channel->addMessage(makeSystemMessage(errorMessage));
             });
 

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -2843,8 +2843,7 @@ void CommandController::initialize(Settings &, Paths &paths)
         const auto *usageStr =
             "Usage: \"/banid <userID> [reason]\" - Permanently prevent a user "
             "from chatting via their user ID. Reason is optional and will be "
-            "shown to the target user and other moderators. Use \"/unban "
-            "<username>\" to remove a ban.";
+            "shown to the target user and other moderators.";
         if (words.size() < 2)
         {
             channel->addMessage(makeSystemMessage(usageStr));


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

With the `/ban` command migrated to Helix, we are no longer able to ban suspended or deactivated accounts because helix `getUsers` is not able to resolve the `user_id` associated with the login name. However, if a moderator already knows the `user_id`, helix `banUser` *is* able to ban the account, even if suspended or deactivated. Thus, this PR adds a `/banid` command to allow banning users by id.

Note: similar concerns apply for timeout/unban, but are not covered by this PR (and are not as important imo)

![chatterino_W6yakM3S6Z](https://user-images.githubusercontent.com/8106344/221351001-83e7959b-e914-4f79-9a85-bab777739c6a.gif)
