### PR TITLE
Allow messages to be cloned explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Bugfix: Fixed a potential race condition due to using the wrong lock when loading 7TV badges. (#4402)
 - Dev: Add capability to build Chatterino with Qt6. (#4393)
 - Dev: Fix homebrew update action. (#4394)
+- Dev: Added the aibility to clone `Message`s and `MessageElement`s. (#4428)
 
 ## 2.4.1
 

--- a/src/messages/Message.cpp
+++ b/src/messages/Message.cpp
@@ -68,31 +68,31 @@ SBHighlight Message::getScrollBarHighlight() const
 std::shared_ptr<const Message> Message::cloneWith(
     const std::function<void(Message &)> &fn) const
 {
-    Message cloned;
-    cloned.flags = this->flags;
-    cloned.parseTime = this->parseTime;
-    cloned.id = this->id;
-    cloned.searchText = this->searchText;
-    cloned.messageText = this->messageText;
-    cloned.loginName = this->loginName;
-    cloned.displayName = this->displayName;
-    cloned.localizedName = this->localizedName;
-    cloned.timeoutUser = this->timeoutUser;
-    cloned.channelName = this->channelName;
-    cloned.usernameColor = this->usernameColor;
-    cloned.serverReceivedTime = this->serverReceivedTime;
-    cloned.badges = this->badges;
-    cloned.badgeInfos = this->badgeInfos;
-    cloned.highlightColor = this->highlightColor;
-    cloned.replyThread = this->replyThread;
-    cloned.count = this->count;
+    auto cloned = std::make_shared<Message>();
+    cloned->flags = this->flags;
+    cloned->parseTime = this->parseTime;
+    cloned->id = this->id;
+    cloned->searchText = this->searchText;
+    cloned->messageText = this->messageText;
+    cloned->loginName = this->loginName;
+    cloned->displayName = this->displayName;
+    cloned->localizedName = this->localizedName;
+    cloned->timeoutUser = this->timeoutUser;
+    cloned->channelName = this->channelName;
+    cloned->usernameColor = this->usernameColor;
+    cloned->serverReceivedTime = this->serverReceivedTime;
+    cloned->badges = this->badges;
+    cloned->badgeInfos = this->badgeInfos;
+    cloned->highlightColor = this->highlightColor;
+    cloned->replyThread = this->replyThread;
+    cloned->count = this->count;
     std::transform(this->elements.cbegin(), this->elements.cend(),
-                   std::back_inserter(cloned.elements),
+                   std::back_inserter(cloned->elements),
                    [](const auto &element) {
                        return element->clone();
                    });
-    fn(cloned);
-    return std::make_shared<Message>(cloned);
+    fn(*cloned);
+    return std::move(cloned);
 }
 
 // Static

--- a/src/messages/Message.cpp
+++ b/src/messages/Message.cpp
@@ -11,6 +11,9 @@
 #include "util/IrcHelpers.hpp"
 #include "widgets/helper/ScrollbarHighlight.hpp"
 
+#include <algorithm>
+#include <iterator>
+
 using SBHighlight = chatterino::ScrollbarHighlight;
 
 namespace chatterino {
@@ -60,6 +63,36 @@ SBHighlight Message::getScrollBarHighlight() const
     }
 
     return SBHighlight();
+}
+
+std::shared_ptr<const Message> Message::cloneWith(
+    const std::function<void(Message &)> &fn) const
+{
+    Message cloned;
+    cloned.flags = this->flags;
+    cloned.parseTime = this->parseTime;
+    cloned.id = this->id;
+    cloned.searchText = this->searchText;
+    cloned.messageText = this->messageText;
+    cloned.loginName = this->loginName;
+    cloned.displayName = this->displayName;
+    cloned.localizedName = this->localizedName;
+    cloned.timeoutUser = this->timeoutUser;
+    cloned.channelName = this->channelName;
+    cloned.usernameColor = this->usernameColor;
+    cloned.serverReceivedTime = this->serverReceivedTime;
+    cloned.badges = this->badges;
+    cloned.badgeInfos = this->badgeInfos;
+    cloned.highlightColor = this->highlightColor;
+    cloned.replyThread = this->replyThread;
+    cloned.count = this->count;
+    std::transform(this->elements.cbegin(), this->elements.cend(),
+                   std::back_inserter(cloned.elements),
+                   [](const auto &element) {
+                       return element->clone();
+                   });
+    fn(cloned);
+    return std::make_shared<Message>(cloned);
 }
 
 // Static

--- a/src/messages/Message.hpp
+++ b/src/messages/Message.hpp
@@ -8,6 +8,7 @@
 #include <QTime>
 
 #include <cinttypes>
+#include <functional>
 #include <memory>
 #include <unordered_map>
 #include <vector>
@@ -87,6 +88,15 @@ struct Message : boost::noncopyable {
     std::vector<std::unique_ptr<MessageElement>> elements;
 
     ScrollbarHighlight getScrollBarHighlight() const;
+
+    /**
+     * Clones this message. Before contructing the shared pointer, 
+     * `fn` is called with a reference to the new message.
+     *
+     * @return An identical message, independent from this one.
+     */
+    std::shared_ptr<const Message> cloneWith(
+        const std::function<void(Message &)> &fn) const;
 };
 
 using MessagePtr = std::shared_ptr<const Message>;

--- a/src/messages/MessageElement.cpp
+++ b/src/messages/MessageElement.cpp
@@ -13,6 +13,8 @@
 #include "singletons/Theme.hpp"
 #include "util/DebugCount.hpp"
 
+#include <memory>
+
 namespace chatterino {
 
 MessageElement::MessageElement(MessageElementFlags flags)
@@ -98,6 +100,16 @@ MessageElement *MessageElement::updateLink()
     return this;
 }
 
+void MessageElement::cloneFrom(const MessageElement &source)
+{
+    this->text_ = source.text_;
+    this->link_ = source.link_;
+    this->tooltip_ = source.tooltip_;
+    this->thumbnail_ = source.thumbnail_;
+    this->thumbnailType_ = source.thumbnailType_;
+    this->flags_ = source.flags_;
+}
+
 // Empty
 EmptyElement::EmptyElement()
     : MessageElement(MessageElementFlag::None)
@@ -107,6 +119,13 @@ EmptyElement::EmptyElement()
 void EmptyElement::addToContainer(MessageLayoutContainer &container,
                                   MessageElementFlags flags)
 {
+}
+
+std::unique_ptr<MessageElement> EmptyElement::clone() const
+{
+    auto el = std::make_unique<EmptyElement>();
+    el->cloneFrom(*this);
+    return el;
 }
 
 EmptyElement &EmptyElement::instance()
@@ -136,6 +155,13 @@ void ImageElement::addToContainer(MessageLayoutContainer &container,
     }
 }
 
+std::unique_ptr<MessageElement> ImageElement::clone() const
+{
+    auto el = std::make_unique<ImageElement>(this->image_, this->getFlags());
+    el->cloneFrom(*this);
+    return el;
+}
+
 CircularImageElement::CircularImageElement(ImagePtr image, int padding,
                                            QColor background,
                                            MessageElementFlags flags)
@@ -159,6 +185,14 @@ void CircularImageElement::addToContainer(MessageLayoutContainer &container,
                                   this->background_, this->padding_))
                                  ->setLink(this->getLink()));
     }
+}
+
+std::unique_ptr<MessageElement> CircularImageElement::clone() const
+{
+    auto el = std::make_unique<CircularImageElement>(
+        this->image_, this->padding_, this->background_, this->getFlags());
+    el->cloneFrom(*this);
+    return el;
 }
 
 // EMOTE
@@ -216,6 +250,15 @@ MessageLayoutElement *EmoteElement::makeImageLayoutElement(
     return new ImageLayoutElement(*this, image, size);
 }
 
+std::unique_ptr<MessageElement> EmoteElement::clone() const
+{
+    auto el = std::make_unique<EmoteElement>(this->emote_, this->getFlags());
+    el->textElement_ = std::unique_ptr<TextElement>(
+        dynamic_cast<TextElement *>(this->textElement_->clone().release()));
+    el->cloneFrom(*this);
+    return el;
+}
+
 // BADGE
 BadgeElement::BadgeElement(const EmotePtr &emote, MessageElementFlags flags)
     : MessageElement(flags)
@@ -255,6 +298,13 @@ MessageLayoutElement *BadgeElement::makeImageLayoutElement(
     return element;
 }
 
+std::unique_ptr<MessageElement> BadgeElement::clone() const
+{
+    auto el = std::make_unique<BadgeElement>(this->emote_, this->getFlags());
+    el->cloneFrom(*this);
+    return el;
+}
+
 // MOD BADGE
 ModBadgeElement::ModBadgeElement(const EmotePtr &data,
                                  MessageElementFlags flags_)
@@ -274,6 +324,13 @@ MessageLayoutElement *ModBadgeElement::makeImageLayoutElement(
     return element;
 }
 
+std::unique_ptr<MessageElement> ModBadgeElement::clone() const
+{
+    auto el = std::make_unique<ModBadgeElement>(this->emote_, this->getFlags());
+    el->cloneFrom(*this);
+    return el;
+}
+
 // VIP BADGE
 VipBadgeElement::VipBadgeElement(const EmotePtr &data,
                                  MessageElementFlags flags_)
@@ -288,6 +345,13 @@ MessageLayoutElement *VipBadgeElement::makeImageLayoutElement(
         (new ImageLayoutElement(*this, image, size))->setLink(this->getLink());
 
     return element;
+}
+
+std::unique_ptr<MessageElement> VipBadgeElement::clone() const
+{
+    auto el = std::make_unique<VipBadgeElement>(this->emote_, this->getFlags());
+    el->cloneFrom(*this);
+    return el;
 }
 
 // FFZ Badge
@@ -306,6 +370,14 @@ MessageLayoutElement *FfzBadgeElement::makeImageLayoutElement(
             ->setLink(this->getLink());
 
     return element;
+}
+
+std::unique_ptr<MessageElement> FfzBadgeElement::clone() const
+{
+    auto el = std::make_unique<FfzBadgeElement>(this->emote_, this->getFlags(),
+                                                this->color);
+    el->cloneFrom(*this);
+    return el;
 }
 
 // TEXT
@@ -422,6 +494,15 @@ void TextElement::addToContainer(MessageLayoutContainer &container,
                 text.mid(wordStart), width, this->hasTrailingSpace()));
         }
     }
+}
+
+std::unique_ptr<MessageElement> TextElement::clone() const
+{
+    auto el = std::make_unique<TextElement>(QString(), this->getFlags(),
+                                            this->color_, this->style_);
+    el->words_ = this->words_;
+    el->cloneFrom(*this);
+    return el;
 }
 
 SingleLineTextElement::SingleLineTextElement(const QString &text,
@@ -572,6 +653,15 @@ void SingleLineTextElement::addToContainer(MessageLayoutContainer &container,
     }
 }
 
+std::unique_ptr<MessageElement> SingleLineTextElement::clone() const
+{
+    auto el = std::make_unique<SingleLineTextElement>(
+        QString(), this->getFlags(), this->color_, this->style_);
+    el->words_ = this->words_;
+    el->cloneFrom(*this);
+    return el;
+}
+
 // TIMESTAMP
 TimestampElement::TimestampElement(QTime time)
     : MessageElement(MessageElementFlag::Timestamp)
@@ -604,6 +694,13 @@ TextElement *TimestampElement::formatTime(const QTime &time)
 
     return new TextElement(format, MessageElementFlag::Timestamp,
                            MessageColor::System, FontStyle::ChatMedium);
+}
+
+std::unique_ptr<MessageElement> TimestampElement::clone() const
+{
+    auto el = std::make_unique<TimestampElement>(this->time_);
+    el->cloneFrom(*this);
+    return el;
 }
 
 // TWITCH MODERATION
@@ -640,6 +737,13 @@ void TwitchModerationElement::addToContainer(MessageLayoutContainer &container,
     }
 }
 
+std::unique_ptr<MessageElement> TwitchModerationElement::clone() const
+{
+    auto el = std::make_unique<TwitchModerationElement>();
+    el->cloneFrom(*this);
+    return el;
+}
+
 LinebreakElement::LinebreakElement(MessageElementFlags flags)
     : MessageElement(flags)
 {
@@ -652,6 +756,13 @@ void LinebreakElement::addToContainer(MessageLayoutContainer &container,
     {
         container.breakLine();
     }
+}
+
+std::unique_ptr<MessageElement> LinebreakElement::clone() const
+{
+    auto el = std::make_unique<LinebreakElement>(this->getFlags());
+    el->cloneFrom(*this);
+    return el;
 }
 
 ScalingImageElement::ScalingImageElement(ImageSet images,
@@ -679,6 +790,14 @@ void ScalingImageElement::addToContainer(MessageLayoutContainer &container,
     }
 }
 
+std::unique_ptr<MessageElement> ScalingImageElement::clone() const
+{
+    auto el =
+        std::make_unique<ScalingImageElement>(this->images_, this->getFlags());
+    el->cloneFrom(*this);
+    return el;
+}
+
 ReplyCurveElement::ReplyCurveElement()
     : MessageElement(MessageElementFlag::RepliedMessage)
 {
@@ -699,6 +818,13 @@ void ReplyCurveElement::addToContainer(MessageLayoutContainer &container,
             new ReplyCurveLayoutElement(*this, width * scale, thickness * scale,
                                         radius * scale, margin * scale));
     }
+}
+
+std::unique_ptr<MessageElement> ReplyCurveElement::clone() const
+{
+    auto el = std::make_unique<ReplyCurveElement>();
+    el->cloneFrom(*this);
+    return el;
 }
 
 }  // namespace chatterino

--- a/src/messages/MessageElement.cpp
+++ b/src/messages/MessageElement.cpp
@@ -79,6 +79,11 @@ const MessageElement::ThumbnailType &MessageElement::getThumbnailType() const
     return this->thumbnailType_;
 }
 
+const QString &MessageElement::getText() const
+{
+    return this->text_;
+}
+
 const Link &MessageElement::getLink() const
 {
     return this->link_;
@@ -392,6 +397,16 @@ TextElement::TextElement(const QString &text, MessageElementFlags flags,
         this->words_.push_back({word, -1});
         // fourtf: add logic to store multiple spaces after message
     }
+}
+
+MessageColor TextElement::color() const
+{
+    return this->color_;
+}
+
+FontStyle TextElement::style() const
+{
+    return this->style_;
 }
 
 void TextElement::addToContainer(MessageLayoutContainer &container,

--- a/src/messages/MessageElement.hpp
+++ b/src/messages/MessageElement.hpp
@@ -194,11 +194,15 @@ public:
     virtual void addToContainer(MessageLayoutContainer &container,
                                 MessageElementFlags flags) = 0;
 
+    virtual std::unique_ptr<MessageElement> clone() const = 0;
+
     pajlada::Signals::NoArgSignal linkChanged;
 
 protected:
     MessageElement(MessageElementFlags flags);
     bool trailingSpace = true;
+
+    void cloneFrom(const MessageElement &source);
 
 private:
     QString text_;
@@ -218,6 +222,8 @@ public:
     void addToContainer(MessageLayoutContainer &container,
                         MessageElementFlags flags) override;
 
+    std::unique_ptr<MessageElement> clone() const override;
+
     static EmptyElement &instance();
 
 private:
@@ -233,6 +239,8 @@ public:
     void addToContainer(MessageLayoutContainer &container,
                         MessageElementFlags flags) override;
 
+    std::unique_ptr<MessageElement> clone() const override;
+
 private:
     ImagePtr image_;
 };
@@ -246,6 +254,8 @@ public:
 
     void addToContainer(MessageLayoutContainer &container,
                         MessageElementFlags flags) override;
+
+    std::unique_ptr<MessageElement> clone() const override;
 
 private:
     ImagePtr image_;
@@ -264,6 +274,8 @@ public:
 
     void addToContainer(MessageLayoutContainer &container,
                         MessageElementFlags flags) override;
+
+    std::unique_ptr<MessageElement> clone() const override;
 
 private:
     MessageColor color_;
@@ -287,6 +299,8 @@ public:
 
     void addToContainer(MessageLayoutContainer &container,
                         MessageElementFlags flags) override;
+
+    std::unique_ptr<MessageElement> clone() const override;
 
 private:
     MessageColor color_;
@@ -312,6 +326,8 @@ public:
                         MessageElementFlags flags_) override;
     EmotePtr getEmote() const;
 
+    std::unique_ptr<MessageElement> clone() const override;
+
 protected:
     virtual MessageLayoutElement *makeImageLayoutElement(const ImagePtr &image,
                                                          const QSize &size);
@@ -331,11 +347,11 @@ public:
 
     EmotePtr getEmote() const;
 
+    std::unique_ptr<MessageElement> clone() const override;
+
 protected:
     virtual MessageLayoutElement *makeImageLayoutElement(const ImagePtr &image,
                                                          const QSize &size);
-
-private:
     EmotePtr emote_;
 };
 
@@ -343,6 +359,8 @@ class ModBadgeElement : public BadgeElement
 {
 public:
     ModBadgeElement(const EmotePtr &data, MessageElementFlags flags_);
+
+    std::unique_ptr<MessageElement> clone() const override;
 
 protected:
     MessageLayoutElement *makeImageLayoutElement(const ImagePtr &image,
@@ -354,6 +372,8 @@ class VipBadgeElement : public BadgeElement
 public:
     VipBadgeElement(const EmotePtr &data, MessageElementFlags flags_);
 
+    std::unique_ptr<MessageElement> clone() const override;
+
 protected:
     MessageLayoutElement *makeImageLayoutElement(const ImagePtr &image,
                                                  const QSize &size) override;
@@ -364,6 +384,8 @@ class FfzBadgeElement : public BadgeElement
 public:
     FfzBadgeElement(const EmotePtr &data, MessageElementFlags flags_,
                     QColor color_);
+
+    std::unique_ptr<MessageElement> clone() const override;
 
 protected:
     MessageLayoutElement *makeImageLayoutElement(const ImagePtr &image,
@@ -383,6 +405,8 @@ public:
 
     TextElement *formatTime(const QTime &time);
 
+    std::unique_ptr<MessageElement> clone() const override;
+
 private:
     QTime time_;
     std::unique_ptr<TextElement> element_;
@@ -398,6 +422,8 @@ public:
 
     void addToContainer(MessageLayoutContainer &container,
                         MessageElementFlags flags) override;
+
+    std::unique_ptr<MessageElement> clone() const override;
 };
 
 // Forces a linebreak
@@ -408,6 +434,8 @@ public:
 
     void addToContainer(MessageLayoutContainer &container,
                         MessageElementFlags flags) override;
+
+    std::unique_ptr<MessageElement> clone() const override;
 };
 
 // Image element which will pick the quality of the image based on ui scale
@@ -418,6 +446,8 @@ public:
 
     void addToContainer(MessageLayoutContainer &container,
                         MessageElementFlags flags) override;
+
+    std::unique_ptr<MessageElement> clone() const override;
 
 private:
     ImageSet images_;
@@ -430,6 +460,8 @@ public:
 
     void addToContainer(MessageLayoutContainer &container,
                         MessageElementFlags flags) override;
+
+    std::unique_ptr<MessageElement> clone() const override;
 };
 
 }  // namespace chatterino

--- a/src/messages/MessageElement.hpp
+++ b/src/messages/MessageElement.hpp
@@ -186,6 +186,7 @@ public:
     const ImagePtr &getThumbnail() const;
     const ThumbnailType &getThumbnailType() const;
 
+    const QString &getText() const;
     const Link &getLink() const;
     bool hasTrailingSpace() const;
     MessageElementFlags getFlags() const;
@@ -271,6 +272,9 @@ public:
                 const MessageColor &color = MessageColor::Text,
                 FontStyle style = FontStyle::ChatMedium);
     ~TextElement() override = default;
+
+    MessageColor color() const;
+    FontStyle style() const;
 
     void addToContainer(MessageLayoutContainer &container,
                         MessageElementFlags flags) override;


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Currently, messages and their elements are marked as `boost::noncopyable`, meaning you can't just copy a message and change some properties or add/remove/update elements. There wasn't really a use-case for allowing this that couldn't be worked around. One thing that has to be mentioned here is that [`Message::flags`](https://github.com/Chatterino/chatterino2/blob/1dc2bcc445d50378ed6c6664cf009373cbf7b0a7/src/messages/Message.hpp#L61-L67) is marked as `mutable`. Which is, as the comment above it describes, not ideal. Though, here, the approach of cloning the message is non-optimal, as it has a lot more overhead. Timeouts, connection messages, and live-emote-update messages are the only messages that update past messages. They achieve this by [adding information to the message](https://github.com/Chatterino/chatterino2/blob/1dc2bcc445d50378ed6c6664cf009373cbf7b0a7/src/messages/Message.hpp#L75) or by [keeping state somewhere else](https://github.com/Chatterino/chatterino2/blob/1dc2bcc445d50378ed6c6664cf009373cbf7b0a7/src/providers/twitch/TwitchChannel.hpp#L333-L340).

The use-case that comes up now is updates for badges and personal emotes on BTTV and 7TV. Take a look at the following example:

```mermaid
sequenceDiagram
    BadgeHaver42->>+BadgeHaver42: send-message
    BadgeHaver42--)+Twitch:  send(xd)
    BadgeHaver42--)+BadgeProvider: signal-activity
    Twitch--)-_xXCluefulUserXx_: BadgeHaver42: xd
    note right of _xXCluefulUserXx_: message built
    BadgeProvider--)-_xXCluefulUserXx_: badge-info(BadgeHaver42)
```

Because _\_xXCluefulUserXx\__ received the info, that _BadgeHaver42_ has a badge after receiving the message, _\_xXCluefulUserXx\__ won't see the badge that _BadgeHaver42_ has, as the message was already built. Only the next messages of _BadgeHaver42_ will display the badge. The same issue arises with personal emotes.

We can solve this by updating the last $n$ messages of _BadgeHaver42_ when we receive the badge information. To do this, we either need the original [`communi::Message*`](https://github.com/Chatterino/chatterino2/blob/1dc2bcc445d50378ed6c6664cf009373cbf7b0a7/src/providers/twitch/TwitchMessageBuilder.hpp#L45-L51) or the ability to update messages. I think the second one is easier to implement, that's why I'm implementing it here.
