### PR TITLE
Add Setting to Change Message Layout (#4325)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Minor: Delete all but the last 5 crashdumps on application start. (#4392)
 - Minor: Added `/banid` command that allows banning by user ID. (#4411)
+- Minor: Added setting to change message layout. (#4325)
 - Bugfix: Fixed FrankerFaceZ emotes/badges not loading due to API change. (#4432)
 - Bugfix: Fixed uploaded AppImage not being able most web requests. (#4400)
 - Bugfix: Fixed a potential race condition due to using the wrong lock when loading 7TV badges. (#4402)

--- a/resources/contributors.txt
+++ b/resources/contributors.txt
@@ -57,6 +57,7 @@ Jaxkey | https://github.com/Jaxkey | :/avatars/jaxkey.png | Contributor
 Explooosion | https://github.com/Explooosion-code | :/avatars/explooosion_code.png | Contributor
 mohad12211 | https://github.com/mohad12211 | :/avatars/mohad12211.png | Contributor
 Wissididom | https://github.com/Wissididom | :/avatars/wissididom.png | Contributor
+atheridis | https://github.com/atheridis | | Contributor
 
 # If you are a contributor add yourself above this line
 

--- a/src/messages/MessageElement.hpp
+++ b/src/messages/MessageElement.hpp
@@ -154,6 +154,9 @@ enum class MessageElementFlag : int64_t {
     // (1LL << 34) through (1LL << 36) are occupied by
     // SevenTVEmoteImage, SevenTVEmoteText, and BadgeSevenTV,
 
+    // used in message layout
+    LineBreak = (1LL << 37),
+
     Default = Timestamp | Badges | Username | BitsStatic | FfzEmoteImage |
               BttvEmoteImage | SevenTVEmoteImage | TwitchEmoteImage |
               BitsAmount | Text | AlwaysShow,

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -118,6 +118,9 @@ public:
     EnumSetting<NotebookTabLocation> tabDirection = {"/appearance/tabDirection",
                                                      NotebookTabLocation::Top};
 
+    QStringSetting messageLayout = {"/appearance/messageLayout",
+                                    "\\R\\n\\t\\M\\b\\u\\m\\r"};
+
     //    BoolSetting collapseLongMessages =
     //    {"/appearance/messages/collapseLongMessages", false};
     BoolSetting hideReplyContext = {"/appearance/hideReplyContext", false};

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -197,6 +197,8 @@ void WindowManager::updateWordTypeMask()
                                          : MEF::OriginalLink);
     flags.set(MEF::ChannelPointReward);
 
+    flags.set(MEF::LineBreak);
+
     // update flags
     MessageElementFlags newFlags = static_cast<MessageElementFlags>(flags);
 

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -326,6 +326,18 @@ void GeneralPage::initLayout(GeneralPageView &layout)
                                    : args.value;
         },
         true, "a = am/pm, zzz = milliseconds");
+    layout.addDropdown<QString>(
+        "Message layout", {"\\R\\n\\t\\M\\b\\u\\m\\r", "\\R\\n\\t\\M\\b\\u\\n\\m\\r"},
+        s.messageLayout,
+        [](auto val) {
+            return val;
+        },
+        [](auto args) {
+            return args.value;
+        },
+        true,
+        "\\R: reply thread\n\\t: timestamp\n\\M: mod tools\n\\b: badges\n"
+        "\\u: username\n\\m: message\n\\r: reply\n\\n: line break");
     layout.addDropdown<int>(
         "Limit message height",
         {"Never", "2 lines", "3 lines", "4 lines", "5 lines"},


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Implement Feature (https://github.com/Chatterino/chatterino2/issues/4325).

The change should probably use enums rather hardcoding QStrings, but my knowledge of C++ isn't great and I was running into some issues having `layout.addDropdown` return a vector.

The change as it stands allows for hardcoded text to also be applied into the layout (if anyone would want that), but due to the method I chose to parse it (splitting the `QString` on `"\\"`), a backslash can't be outputted.

The default setting should change nothing visually for the user.