### PR TITLE
Ignore BTTV user-events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+- Dev: Ignore unhandled BTTV user-events. (#4438)
+
 ## 2.4.2
 
 - Minor: Added `/banid` command that allows banning by user ID. (#4411)

--- a/src/providers/bttv/BttvLiveUpdates.cpp
+++ b/src/providers/bttv/BttvLiveUpdates.cpp
@@ -83,6 +83,10 @@ void BttvLiveUpdates::onMessage(
 
         this->signals_.emoteRemoved.invoke(message);
     }
+    else if (eventType == "lookup_user")
+    {
+        // ignored
+    }
     else
     {
         qCDebug(chatterinoBttv) << "Unhandled event:" << json;


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

The JSON payload of the [_User Update_](https://betterttv.com/developers/websocket#user-update) event was always logged as an unhandled event. The payload is really large however and pollutes the log, since it's known that this message is unhandled.
