### PR TITLE
Only log debug messages when NDEBUG is not defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+- Dev: Only log debug messages when NDEBUG is not defined. (#4442)
+
 ## 2.4.2
 
 - Minor: Added `/banid` command that allows banning by user ID. (#4411)

--- a/src/common/QLogging.cpp
+++ b/src/common/QLogging.cpp
@@ -1,6 +1,6 @@
 #include "common/QLogging.hpp"
 
-#ifdef DEBUG_OFF
+#ifdef NDEBUG
 static constexpr QtMsgType logThreshold = QtWarningMsg;
 #else
 static constexpr QtMsgType logThreshold = QtDebugMsg;


### PR DESCRIPTION
Regression from https://github.com/Chatterino/chatterino2/commit/044dd8a616e0b712eaf6cb954cd7b999aed18b06

Closes #4440

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable