### PR TITLE
Fix dot commands (ie .ban) not being recognized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unversioned
 
 - Dev: Only log debug messages when NDEBUG is not defined. (#4442)
+- Minor: Fixed dot commands not being recognized. (#4455)
 
 ## 2.4.2
 

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -3194,6 +3194,11 @@ QString CommandController::execCommand(const QString &textNoEmoji,
 
     QString commandName = words[0];
 
+    if (commandName.startsWith("."))
+    {
+        commandName.replace(0, 1, "/");
+    }
+
     {
         // check if user command exists
         const auto it = this->userCommands_.find(commandName);


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Allows you to use commands with . as a prefix again

Using .ban then /ban:

Before (current 2.4.2)

![image](https://user-images.githubusercontent.com/10341753/225937664-3bca8857-e081-4731-ac9c-35874e3e08ed.png)

With fix:

![image](https://user-images.githubusercontent.com/10341753/225937792-186ff74d-c285-4697-9fcb-675406de62ee.png)
