### PR TITLE
Allow each layered image to retain its own flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Minor: Added support for FrankerFaceZ animated emotes. (#4434)
 - Bugfix: Fixed an issue where animated emotes would render on top of zero-width emotes. (#4314)
 - Bugfix: Fixed an issue where it was difficult to hover a zero-width emote. (#4314)
+- Bugfix: Fixed an issue where context-menu items for zero-width emotes displayed the wrong provider. (#4460)
 - Dev: Ignore unhandled BTTV user-events. (#4438)
 - Dev: Only log debug messages when NDEBUG is not defined. (#4442)
 - Dev: Cleaned up theme related code. (#4450)

--- a/src/common/FlagsEnum.hpp
+++ b/src/common/FlagsEnum.hpp
@@ -42,6 +42,12 @@ public:
         reinterpret_cast<Q &>(this->value_) |= static_cast<Q>(flag);
     }
 
+    /** Adds the flags from `flags` in this enum. */
+    void set(FlagsEnum flags)
+    {
+        reinterpret_cast<Q &>(this->value_) |= static_cast<Q>(flags.value_);
+    }
+
     void unset(T flag)
     {
         reinterpret_cast<Q &>(this->value_) &= ~static_cast<Q>(flag);
@@ -67,6 +73,12 @@ public:
         xd.set(flag, true);
 
         return xd;
+    }
+
+    FlagsEnum operator|(FlagsEnum rhs)
+    {
+        return static_cast<T>(static_cast<Q>(this->value_) |
+                              static_cast<Q>(rhs.value_));
     }
 
     bool hasAny(FlagsEnum flags) const

--- a/src/messages/MessageElement.hpp
+++ b/src/messages/MessageElement.hpp
@@ -187,6 +187,7 @@ public:
     const Link &getLink() const;
     bool hasTrailingSpace() const;
     MessageElementFlags getFlags() const;
+    void addFlags(MessageElementFlags flags);
     MessageElement *updateLink();
 
     virtual void addToContainer(MessageLayoutContainer &container,
@@ -325,19 +326,24 @@ private:
 class LayeredEmoteElement : public MessageElement
 {
 public:
+    struct Emote {
+        EmotePtr ptr;
+        MessageElementFlags flags;
+    };
+
     LayeredEmoteElement(
-        std::vector<EmotePtr> &&emotes, MessageElementFlags flags,
+        std::vector<Emote> &&emotes, MessageElementFlags flags,
         const MessageColor &textElementColor = MessageColor::Text);
 
-    void addEmoteLayer(const EmotePtr &emote);
+    void addEmoteLayer(const Emote &emote);
 
     void addToContainer(MessageLayoutContainer &container,
                         MessageElementFlags flags) override;
 
     // Returns a concatenation of each emote layer's cleaned copy string
     QString getCleanCopyString() const;
-    const std::vector<EmotePtr> &getEmotes() const;
-    std::vector<EmotePtr> getUniqueEmotes() const;
+    const std::vector<Emote> &getEmotes() const;
+    std::vector<Emote> getUniqueEmotes() const;
     const std::vector<QString> &getEmoteTooltips() const;
 
 private:
@@ -349,7 +355,7 @@ private:
     void updateTooltips();
     std::vector<ImagePtr> getLoadedImages(float scale);
 
-    std::vector<EmotePtr> emotes_;
+    std::vector<Emote> emotes_;
     std::vector<QString> emoteTooltips_;
 
     std::unique_ptr<TextElement> textElement_;

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -1076,17 +1076,20 @@ Outcome TwitchMessageBuilder::tryAppendEmote(const EmoteName &name)
                 // Need to remove EmoteElement and replace with LayeredEmoteElement
                 auto baseEmoteElement = this->releaseBack();
 
-                std::vector<EmotePtr> layers = {baseEmote, emote.get()};
-                this->emplace<LayeredEmoteElement>(std::move(layers),
-                                                   baseEmoteElement->getFlags(),
-                                                   this->textColor_);
+                std::vector<LayeredEmoteElement::Emote> layers = {
+                    {baseEmote, baseEmoteElement->getFlags()},
+                    {emote.get(), flags}};
+                this->emplace<LayeredEmoteElement>(
+                    std::move(layers), baseEmoteElement->getFlags() | flags,
+                    this->textColor_);
                 return Success;
             }
 
             auto asLayered = dynamic_cast<LayeredEmoteElement *>(&this->back());
             if (asLayered)
             {
-                asLayered->addEmoteLayer(emote.get());
+                asLayered->addEmoteLayer({emote.get(), flags});
+                asLayered->addFlags(flags);
                 return Success;
             }
 

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1710,7 +1710,7 @@ void ChannelView::mouseMoveEvent(QMouseEvent *event)
 
                         for (size_t i = 0; i < upperLimit; ++i)
                         {
-                            auto &emote = layeredEmotes[i];
+                            const auto &emote = layeredEmotes[i].ptr;
                             if (i == 0)
                             {
                                 // First entry gets a large image and full description
@@ -2202,10 +2202,10 @@ void ChannelView::addImageContextMenuItems(
             // Give each emote its own submenu
             for (auto &emote : layeredElement->getUniqueEmotes())
             {
-                auto emoteAction = menu.addAction(emote->name.string);
+                auto emoteAction = menu.addAction(emote.ptr->name.string);
                 auto emoteMenu = new QMenu(&menu);
                 emoteAction->setMenu(emoteMenu);
-                addEmoteContextMenuItems(*emote, creatorFlags, *emoteMenu);
+                addEmoteContextMenuItems(*emote.ptr, emote.flags, *emoteMenu);
             }
         }
     }


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

All emotes in a `LayeredEmoteElement` now carry additional flags.

Fixes #4459.