### PR TITLE
Respect PCH Setting in Windows CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,6 +151,7 @@ jobs:
               -G"NMake Makefiles" `
               -DCMAKE_BUILD_TYPE=RelWithDebInfo `
               -DCMAKE_TOOLCHAIN_FILE="conan_toolchain.cmake" `
+              -DUSE_PRECOMPILED_HEADERS=${{ matrix.pch }} `
               -DBUILD_WITH_CRASHPAD="$Env:C2_ENABLE_CRASHPAD" `
               -DCHATTERINO_LTO="$Env:C2_ENABLE_LTO" `
               -DBUILD_WITH_QT6="$Env:C2_BUILD_WITH_QT6" `

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Bugfix: Fixed an issue where it was difficult to hover a zero-width emote. (#4314)
 - Bugfix: Fixed an issue where context-menu items for zero-width emotes displayed the wrong provider. (#4460)
 - Bugfix: Fixed an issue where the "Enable zero-width emotes" setting was showing the inverse state. (#4462)
+- Dev: Disabling precompiled headers on Windows is now tested in CI. (#4472)
 - Dev: Ignore unhandled BTTV user-events. (#4438)
 - Dev: Only log debug messages when NDEBUG is not defined. (#4442)
 - Dev: Cleaned up theme related code. (#4450)

--- a/src/util/WindowsHelper.hpp
+++ b/src/util/WindowsHelper.hpp
@@ -3,6 +3,7 @@
 #ifdef USEWINSDK
 
 #    include <boost/optional.hpp>
+#    include <QString>
 #    include <Windows.h>
 
 namespace chatterino {


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

The Windows CI didn't respect the `matrix.pch` setting/option. It now respects it.
