### PR TITLE
Fix Username Font Weight Issue on Qt 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Bugfix: Fixed an issue where it was difficult to hover a zero-width emote. (#4314)
 - Bugfix: Fixed an issue where context-menu items for zero-width emotes displayed the wrong provider. (#4460)
 - Bugfix: Fixed an issue where the "Enable zero-width emotes" setting was showing the inverse state. (#4462)
+- Bugfix: Fixed username rendering in Qt 6. (#4476)
 - Dev: Disabling precompiled headers on Windows is now tested in CI. (#4472)
 - Dev: Ignore unhandled BTTV user-events. (#4438)
 - Dev: Only log debug messages when NDEBUG is not defined. (#4442)

--- a/src/singletons/Fonts.cpp
+++ b/src/singletons/Fonts.cpp
@@ -25,10 +25,13 @@ namespace chatterino {
 namespace {
     int getBoldness()
     {
-#ifdef CHATTERINO
-        return getSettings()->boldScale.getValue();
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        // This setting uses the Qt 5 range of the font-weight (0..99).
+        // The range in Qt 6 is 1..1000.
+        return (int)(1.0 +
+                     (111.0 * getSettings()->boldScale.getValue()) / 11.0);
 #else
-        return QFont::Bold;
+        return getSettings()->boldScale.getValue();
 #endif
     }
 }  // namespace


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

The `QFont::Weight` enum changed its range from `0..99` in Qt 5 to `1..1000` in Qt 6 ([Qt 5 docs](https://doc.qt.io/qt-5/qfont.html#Weight-enum), [Qt 6 docs](https://doc.qt.io/qt-6/qfont.html#Weight-enum)). Since absolute values are used for usernames, this broke the username rendering.

Fixes #4467.