### PR TITLE
Add Placeholder Color in Palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Bugfix: Fixed an issue where context-menu items for zero-width emotes displayed the wrong provider. (#4460)
 - Bugfix: Fixed an issue where the "Enable zero-width emotes" setting was showing the inverse state. (#4462)
 - Bugfix: Fixed username rendering in Qt 6. (#4476)
+- Bugfix: Fixed placeholder color in Qt 6. (#4477)
 - Dev: Disabling precompiled headers on Windows is now tested in CI. (#4472)
 - Dev: Ignore unhandled BTTV user-events. (#4438)
 - Dev: Only log debug messages when NDEBUG is not defined. (#4442)

--- a/src/RunGui.cpp
+++ b/src/RunGui.cpp
@@ -44,27 +44,29 @@ namespace {
         dark.setColor(QPalette::Window, QColor(22, 22, 22));
         dark.setColor(QPalette::WindowText, Qt::white);
         dark.setColor(QPalette::Text, Qt::white);
-        dark.setColor(QPalette::Disabled, QPalette::WindowText,
-                      QColor(127, 127, 127));
         dark.setColor(QPalette::Base, QColor("#333"));
         dark.setColor(QPalette::AlternateBase, QColor("#444"));
         dark.setColor(QPalette::ToolTipBase, Qt::white);
         dark.setColor(QPalette::ToolTipText, Qt::white);
-        dark.setColor(QPalette::Disabled, QPalette::Text,
-                      QColor(127, 127, 127));
         dark.setColor(QPalette::Dark, QColor(35, 35, 35));
         dark.setColor(QPalette::Shadow, QColor(20, 20, 20));
         dark.setColor(QPalette::Button, QColor(70, 70, 70));
         dark.setColor(QPalette::ButtonText, Qt::white);
-        dark.setColor(QPalette::Disabled, QPalette::ButtonText,
-                      QColor(127, 127, 127));
         dark.setColor(QPalette::BrightText, Qt::red);
         dark.setColor(QPalette::Link, QColor(42, 130, 218));
         dark.setColor(QPalette::Highlight, QColor(42, 130, 218));
+        dark.setColor(QPalette::HighlightedText, Qt::white);
+        dark.setColor(QPalette::PlaceholderText, QColor(127, 127, 127));
+
         dark.setColor(QPalette::Disabled, QPalette::Highlight,
                       QColor(80, 80, 80));
-        dark.setColor(QPalette::HighlightedText, Qt::white);
         dark.setColor(QPalette::Disabled, QPalette::HighlightedText,
+                      QColor(127, 127, 127));
+        dark.setColor(QPalette::Disabled, QPalette::ButtonText,
+                      QColor(127, 127, 127));
+        dark.setColor(QPalette::Disabled, QPalette::Text,
+                      QColor(127, 127, 127));
+        dark.setColor(QPalette::Disabled, QPalette::WindowText,
                       QColor(127, 127, 127));
 
         qApp->setPalette(dark);


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

This PR specifies a color for [`QPalette::PlaceholderText`](https://doc.qt.io/qt-5/qpalette.html#ColorRole-enum) (added in Qt 5.12). This color wasn't used if not specified in Qt 5, but it's an independent color in Qt 6 ([docs](https://doc.qt.io/qt-6/qpalette.html#placeholderText)).

Furthermore, this PR also reorders the colors to make it more readable - all calls specifying a specific [color-group](https://doc.qt.io/qt-6/qpalette.html#ColorGroup-enum) are below the calls that specify a color for all color groups.

Doing this fixes the placeholder text in the `QLineEdit` in the settings dialog:

|Before|After|
|---|---|
| ![before](https://user-images.githubusercontent.com/19953266/227715396-2c426669-580e-4534-8ab3-52228dcaf139.png) | ![after](https://user-images.githubusercontent.com/19953266/227715404-cd4ac1b3-66b0-4795-92f7-c6196a4fb618.png) |


