### PR TITLE
Implement BTTV Emote Modifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Minor: Added accelerators to the right click menu for messages (#4705)
 - Minor: Improved editing hotkeys. (#4628)
 - Minor: Added `/c2-theme-autoreload` command to automatically reload a custom theme. This is useful for when you're developing your own theme. (#4718)
+- Minor: Added support for BTTV emote modifiers (`w!`, `h!`, `v!`, `z!`, `!r`, `!l`). (#4478)
 - Bugfix: Fixed an issue where Subscriptions & Announcements that contained ignored phrases would still appear if the Block option was enabled. (#4748)
 - Bugfix: Increased amount of blocked users loaded from 100 to 1,000. (#4721)
 - Bugfix: Fixed pings firing for the "Your username" highlight when not signed in. (#4698)

--- a/src/messages/MessageElement.hpp
+++ b/src/messages/MessageElement.hpp
@@ -152,6 +152,18 @@ enum class MessageElementFlag : int64_t {
     // (1LL << 34) through (1LL << 36) are occupied by
     // SevenTVEmoteImage, SevenTVEmoteText, and BadgeSevenTV,
 
+    BttvModifierWide = (1LL << 37),
+    BttvModifierFlipH = (1LL << 38),
+    BttvModifierFlipV = (1LL << 39),
+    BttvModifierRotateRight = (1LL << 40),
+    BttvModifierRotateLeft = (1LL << 41),
+    BttvModifierAnyTransform = BttvModifierFlipH | BttvModifierFlipV |
+                               BttvModifierRotateRight | BttvModifierRotateLeft,
+    BttvModifierZeroSpace = (1LL << 42),
+    BttvModifiers = BttvModifierWide | BttvModifierFlipH | BttvModifierFlipV |
+                    BttvModifierZeroSpace | BttvModifierRotateRight |
+                    BttvModifierRotateLeft,
+
     Default = Timestamp | Badges | Username | BitsStatic | FfzEmoteImage |
               BttvEmoteImage | SevenTVEmoteImage | TwitchEmoteImage |
               BitsAmount | Text | AlwaysShow,
@@ -310,6 +322,7 @@ public:
     void addToContainer(MessageLayoutContainer &container,
                         MessageElementFlags flags_) override;
     EmotePtr getEmote() const;
+    QString getCopyString() const;
 
 protected:
     virtual MessageLayoutElement *makeImageLayoutElement(const ImagePtr &image,
@@ -353,7 +366,8 @@ private:
 
     QString getCopyString() const;
     void updateTooltips();
-    std::vector<ImagePtr> getLoadedImages(float scale);
+    std::pair<std::vector<ImagePtr>, std::vector<QSize>> getLoadedImages(
+        float scale);
 
     std::vector<Emote> emotes_;
     std::vector<QString> emoteTooltips_;

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -183,7 +183,8 @@ void MessageLayoutContainer::_addElement(MessageLayoutElement *element,
         yOffset -= (this->margin.top * this->scale_);
     }
 
-    if (getSettings()->removeSpacesBetweenEmotes &&
+    if ((getSettings()->removeSpacesBetweenEmotes ||
+         element->getFlags().has(MessageElementFlag::BttvModifierZeroSpace)) &&
         element->getFlags().hasAny({MessageElementFlag::EmoteImages}) &&
         shouldRemoveSpaceBetweenEmotes())
     {

--- a/src/messages/layouts/MessageLayoutElement.hpp
+++ b/src/messages/layouts/MessageLayoutElement.hpp
@@ -9,9 +9,11 @@
 #include <QPoint>
 #include <QRect>
 #include <QString>
+#include <QTransform>
 
 #include <climits>
 #include <cstdint>
+#include <memory>
 
 class QPainter;
 

--- a/src/providers/twitch/TwitchMessageBuilder.hpp
+++ b/src/providers/twitch/TwitchMessageBuilder.hpp
@@ -115,6 +115,7 @@ private:
                   const std::vector<TwitchEmoteOccurrence> &twitchEmotes);
     void addTextOrEmoji(EmotePtr emote) override;
     void addTextOrEmoji(const QString &value) override;
+    void flushBttvModifier();
 
     void appendTwitchBadges();
     void appendChatterinoBadges();
@@ -131,6 +132,21 @@ private:
     bool bitsStacked = false;
     bool historicalMessage_ = false;
     std::shared_ptr<MessageThread> thread_;
+
+    enum class BttvModifier : uint8_t {
+        None,
+        Wide,
+        FlipH,
+        FlipV,
+        ZeroSpace,
+        RotateLeft,
+        RotateRight,
+    };
+    BttvModifier bttvModifier_ = BttvModifier::None;
+    QString bttvModifierString_;
+    bool parseBttvModifiers_;
+
+    static BttvModifier tryParseBttvModifier(const QString &word);
 
     /**
      * Starting offset to be used on index-based operations on `originalMessage_`.

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -262,6 +262,8 @@ public:
 
     BoolSetting enableBTTVGlobalEmotes = {"/emotes/bttv/global", true};
     BoolSetting enableBTTVChannelEmotes = {"/emotes/bttv/channel", true};
+    BoolSetting enableBTTVEmoteModifiers = {"/emotes/bttv/emotemodifiers",
+                                            true};
     BoolSetting enableBTTVLiveUpdates = {"/emotes/bttv/liveupdates", true};
     BoolSetting enableFFZGlobalEmotes = {"/emotes/ffz/global", true};
     BoolSetting enableFFZChannelEmotes = {"/emotes/ffz/channel", true};

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -552,6 +552,9 @@ void GeneralPage::initLayout(GeneralPageView &layout)
                        s.emojiSet);
     layout.addCheckbox("Show BTTV global emotes", s.enableBTTVGlobalEmotes);
     layout.addCheckbox("Show BTTV channel emotes", s.enableBTTVChannelEmotes);
+    layout.addCheckbox(
+        "Show BTTV emote modifiers", s.enableBTTVEmoteModifiers, false,
+        "Enables BTTV's emote modifiers such as w!, h!, v!, z!.");
     layout.addCheckbox("Enable BTTV live emote updates (requires restart)",
                        s.enableBTTVLiveUpdates);
     layout.addCheckbox("Show FFZ global emotes", s.enableFFZGlobalEmotes);


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

This PR implements BTTV's emote modifiers (`w!`, `h!`, `v!`, `z!`, `!r`, `!l`). They can't be combined. Parsing can be turned off in the settings.

See https://github.com/Chatterino/chatterino2/discussions/4470. Implementation is based on https://github.com/night/betterttv/commit/b60d02091f2565b80ff36bc72ca1014a76df69f2.
