### PR TITLE
Fix channel search when custom scrollback limit is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Bugfix: Fixed placeholder color in Qt 6. (#4477)
 - Bugfix: Fixed blocked user list being empty when opening the settings dialog for the first time. (#4437)
 - Bugfix: Fixed blocked user list sticking around when switching from a logged in user to being logged out. (#4437)
+- Bugfix: Fixed search popup ignoring setting for message scrollback limit. (#4496)
 - Dev: Disabling precompiled headers on Windows is now tested in CI. (#4472)
 - Dev: Ignore unhandled BTTV user-events. (#4438)
 - Dev: Only log debug messages when NDEBUG is not defined. (#4442)

--- a/src/common/Channel.cpp
+++ b/src/common/Channel.cpp
@@ -28,8 +28,8 @@ Channel::Channel(const QString &name, Type type)
     : completionModel(*this)
     , lastDate_(QDate::currentDate())
     , name_(name)
-    , type_(type)
     , messages_(getSettings()->scrollbackSplitLimit)
+    , type_(type)
 {
 }
 

--- a/src/common/Channel.cpp
+++ b/src/common/Channel.cpp
@@ -29,6 +29,7 @@ Channel::Channel(const QString &name, Type type)
     , lastDate_(QDate::currentDate())
     , name_(name)
     , type_(type)
+    , messages_(getSettings()->scrollbackSplitLimit)
 {
 }
 

--- a/src/widgets/helper/SearchPopup.cpp
+++ b/src/widgets/helper/SearchPopup.cpp
@@ -13,6 +13,7 @@
 #include "messages/search/RegexPredicate.hpp"
 #include "messages/search/SubstringPredicate.hpp"
 #include "messages/search/SubtierPredicate.hpp"
+#include "singletons/Settings.hpp"
 #include "singletons/WindowManager.hpp"
 #include "widgets/helper/ChannelView.hpp"
 #include "widgets/splits/Split.hpp"
@@ -285,8 +286,9 @@ void SearchPopup::initLayout()
 
         // CHANNELVIEW
         {
-            this->channelView_ = new ChannelView(this, this->split_,
-                                                 ChannelView::Context::Search);
+            this->channelView_ = new ChannelView(
+                this, this->split_, ChannelView::Context::Search,
+                getSettings()->scrollbackSplitLimit);
 
             layout1->addWidget(this->channelView_);
         }

--- a/tests/src/HighlightController.cpp
+++ b/tests/src/HighlightController.cpp
@@ -550,14 +550,14 @@ class HighlightControllerTest : public ::testing::Test
 protected:
     void SetUp() override
     {
-        {
-            // Write default settings to the mock settings json file
-            QDir().mkpath("/tmp/c2-tests");
-            QFile settingsFile("/tmp/c2-tests/settings.json");
-            assert(settingsFile.open(QIODevice::WriteOnly | QIODevice::Text));
-            QTextStream out(&settingsFile);
-            out << DEFAULT_SETTINGS;
-        }
+        // Write default settings to the mock settings json file
+        ASSERT_TRUE(QDir().mkpath("/tmp/c2-tests"));
+
+        QFile settingsFile("/tmp/c2-tests/settings.json");
+        ASSERT_TRUE(settingsFile.open(QIODevice::WriteOnly | QIODevice::Text));
+        ASSERT_GT(settingsFile.write(DEFAULT_SETTINGS.toUtf8()), 0);
+        ASSERT_TRUE(settingsFile.flush());
+        settingsFile.close();
 
         this->mockHelix = new MockHelix;
 
@@ -579,7 +579,7 @@ protected:
 
     void TearDown() override
     {
-        QDir().rmdir("/tmp/c2-tests");
+        ASSERT_TRUE(QDir("/tmp/c2-tests").removeRecursively());
         this->mockApplication.reset();
         this->settings.reset();
         this->paths.reset();


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description
PR introduces 2 changes:
- `Channel` messages_ field is initialized to `scrollbackSplitLimit` setting, so it doesnt use default value of 1000.
All code using Channel::getMessageSnapshot() was affected as it returned only up to 1k messages, while `ChannelView` respected custom scrollback setting, so it created at least few problems.
Example: https://i.supa.codes/Fn6J8.mp4 text selection would move up on each new message instead of holding its position. 
- use `scrollbackSplitLimit` for SearchPopup channelView, so all messages for single channel are always searchable.

fixes #4495
Fixes #4324