### PR TITLE
Fix plugin compilation error when using Qt 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - Dev: Only log debug messages when NDEBUG is not defined. (#4442)
 - Dev: Cleaned up theme related code. (#4450)
 - Dev: Ensure tests have default-initialized settings. (#4498)
-- Dev: Add scripting capabilities with Lua (#4341)
+- Dev: Add scripting capabilities with Lua (#4341, #4504)
 - Dev: Conan 2.0 is now used instead of Conan 1.0. (#4417)
 - Dev: Added tests and benchmarks for `LinkParser`. (#4436)
 

--- a/src/controllers/plugins/LuaAPI.cpp
+++ b/src/controllers/plugins/LuaAPI.cpp
@@ -50,7 +50,7 @@ QDebug qdebugStreamForLogLevel(lua::api::LogLevel lvl)
             return base.critical();
         default:
             assert(false && "if this happens magic_enum must have failed us");
-            return {(QString *)nullptr};
+            return QDebug((QString *)nullptr);
     }
 }
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Fixes a small compilation error (I introduced) that only shows up on Qt 6:

* **MSVC:** _error C3445: copy-list-initialization of 'QDebug' cannot use an explicit constructor_
* **clang:** _Chosen constructor is explicit in copy-initialization - clang(selected_explicit_constructor)_

The `QDebug::QDebug(QString *)` constructor [is marked as `explicit` in Qt 6](https://github.com/qt/qtbase/blob/eb8782cb2ea765080945a775a806b377b5943833/src/corelib/io/qdebug.h#L72) and [was marked as `inline` in Qt 5](https://github.com/qt/qtbase/blob/4ee4fc18b4067b90efa46ca9baba74f53b54d9ec/src/corelib/io/qdebug.h#L115).
