### PR TITLE
Fix build on latest Fedora

### DIFF
--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -391,7 +391,7 @@ void Notebook::setShowTabs(bool value)
     if (!value && getSettings()->informOnTabVisibilityToggle.getValue())
     {
         auto unhideSeq = getApp()->hotkeys->getDisplaySequence(
-            HotkeyCategory::Window, "setTabVisibility", {{}});
+            HotkeyCategory::Window, "setTabVisibility", {});
         if (unhideSeq.isEmpty())
         {
             unhideSeq = getApp()->hotkeys->getDisplaySequence(
@@ -436,7 +436,7 @@ void Notebook::setShowTabs(bool value)
 void Notebook::updateTabVisibilityMenuAction()
 {
     auto toggleSeq = getApp()->hotkeys->getDisplaySequence(
-        HotkeyCategory::Window, "setTabVisibility", {{}});
+        HotkeyCategory::Window, "setTabVisibility", {});
     if (toggleSeq.isEmpty())
     {
         toggleSeq = getApp()->hotkeys->getDisplaySequence(

--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -391,7 +391,8 @@ void Notebook::setShowTabs(bool value)
     if (!value && getSettings()->informOnTabVisibilityToggle.getValue())
     {
         auto unhideSeq = getApp()->hotkeys->getDisplaySequence(
-            HotkeyCategory::Window, "setTabVisibility", {});
+            HotkeyCategory::Window, "setTabVisibility",
+            {std::vector<QString>()});
         if (unhideSeq.isEmpty())
         {
             unhideSeq = getApp()->hotkeys->getDisplaySequence(
@@ -436,7 +437,7 @@ void Notebook::setShowTabs(bool value)
 void Notebook::updateTabVisibilityMenuAction()
 {
     auto toggleSeq = getApp()->hotkeys->getDisplaySequence(
-        HotkeyCategory::Window, "setTabVisibility", {});
+        HotkeyCategory::Window, "setTabVisibility", {std::vector<QString>()});
     if (toggleSeq.isEmpty())
     {
         toggleSeq = getApp()->hotkeys->getDisplaySequence(

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -452,7 +452,7 @@ std::unique_ptr<QMenu> SplitHeader::createMainMenu()
     if (twitchChannel)
     {
         auto bothSeq =
-            h->getDisplaySequence(HotkeyCategory::Split, "reloadEmotes", {{}});
+            h->getDisplaySequence(HotkeyCategory::Split, "reloadEmotes", {});
         auto channelSeq = h->getDisplaySequence(HotkeyCategory::Split,
                                                 "reloadEmotes", {{"channel"}});
         auto subSeq = h->getDisplaySequence(HotkeyCategory::Split,
@@ -485,7 +485,7 @@ std::unique_ptr<QMenu> SplitHeader::createMainMenu()
     if (modModeSeq.isEmpty())
     {
         modModeSeq = h->getDisplaySequence(HotkeyCategory::Split,
-                                           "setModerationMode", {{}});
+                                           "setModerationMode", {});
         // this makes a full std::optional<> with an empty vector inside
     }
     moreMenu->addAction(
@@ -529,7 +529,7 @@ std::unique_ptr<QMenu> SplitHeader::createMainMenu()
         if (notifySeq.isEmpty())
         {
             notifySeq = h->getDisplaySequence(HotkeyCategory::Split,
-                                              "setChannelNotification", {{}});
+                                              "setChannelNotification", {});
             // this makes a full std::optional<> with an empty vector inside
         }
         action->setShortcut(notifySeq);

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -451,8 +451,8 @@ std::unique_ptr<QMenu> SplitHeader::createMainMenu()
 
     if (twitchChannel)
     {
-        auto bothSeq =
-            h->getDisplaySequence(HotkeyCategory::Split, "reloadEmotes", {});
+        auto bothSeq = h->getDisplaySequence(
+            HotkeyCategory::Split, "reloadEmotes", {std::vector<QString>()});
         auto channelSeq = h->getDisplaySequence(HotkeyCategory::Split,
                                                 "reloadEmotes", {{"channel"}});
         auto subSeq = h->getDisplaySequence(HotkeyCategory::Split,
@@ -484,8 +484,9 @@ std::unique_ptr<QMenu> SplitHeader::createMainMenu()
                                             "setModerationMode", {{"toggle"}});
     if (modModeSeq.isEmpty())
     {
-        modModeSeq = h->getDisplaySequence(HotkeyCategory::Split,
-                                           "setModerationMode", {});
+        modModeSeq =
+            h->getDisplaySequence(HotkeyCategory::Split, "setModerationMode",
+                                  {std::vector<QString>()});
         // this makes a full std::optional<> with an empty vector inside
     }
     moreMenu->addAction(
@@ -529,7 +530,8 @@ std::unique_ptr<QMenu> SplitHeader::createMainMenu()
         if (notifySeq.isEmpty())
         {
             notifySeq = h->getDisplaySequence(HotkeyCategory::Split,
-                                              "setChannelNotification", {});
+                                              "setChannelNotification",
+                                              {std::vector<QString>()});
             // this makes a full std::optional<> with an empty vector inside
         }
         action->setShortcut(notifySeq);


### PR DESCRIPTION
Note: I am not a c++ developer at all. I don't know if these changes are sound. But they let me build the project, and it seems to work.

# Description

Fixes issues of this form: 
```
/home/guipsp/local/chatterino2/src/widgets/splits/SplitHeader.cpp:531:46: error: converting to ‘const std::optional<std::vector<QString> >’ from initializer list would use explicit constructor ‘constexpr std::optional<_Tp>::optional(std::in_place_t, _Args&& ...) [with _Args = {}; typename std::enable_if<__and_v<std::is_constructible<_Tp, _Args ...> >, bool>::type <anonymous> = false; _Tp = std::vector<QString>]’
  531 |             notifySeq = h->getDisplaySequence(HotkeyCategory::Split,
      |                         ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
  532 |                                               "setChannelNotification", {{}});
```