### PR TITLE
Add Fuzzy Matching to emote input completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Minor: Added support for FrankerFaceZ animated emotes. (#4434)
 - Minor: Added a local backup of the Twitch Badges API in case the request fails. (#4463)
 - Minor: Added the ability to reply to a message by `Shift + Right Click`ing the username. (#4424)
+- Minor: Added Fuzzy Matching to emote input completion. (#4519)
 - Bugfix: Fixed an issue where animated emotes would render on top of zero-width emotes. (#4314)
 - Bugfix: Fixed an issue where it was difficult to hover a zero-width emote. (#4314)
 - Bugfix: Fixed an issue where context-menu items for zero-width emotes displayed the wrong provider. (#4460)

--- a/src/widgets/splits/InputCompletionPopup.cpp
+++ b/src/widgets/splits/InputCompletionPopup.cpp
@@ -24,18 +24,17 @@ struct CompletionEmote {
     QString providerName;
 };
 
-//TODO: Check with code guidelines
-
 //Returns true if each character in pattern is found sequentially within str
-static bool fuzzy_match(QString const & pattern, QString const & str) 
+static bool fuzzyMatch(QString const &pattern, QString const &str)
 {
-    int i = 0;int j = 0;
-    while (i < pattern.length() && j < str.length())  {
+    int i{};
+    int j{};
+    while (i < pattern.length() && j < str.length())
+    {
         if (pattern.at(i) == str.at(j))
             ++i;
         ++j;
     }
-
     return i == pattern.length();
 }
 
@@ -44,9 +43,7 @@ void addEmotes(std::vector<CompletionEmote> &out, const EmoteMap &map,
 {
     for (auto &&emote : map)
     {
-        //TODO: Check with code guidelines
-
-        if (fuzzy_match(text.toLower(),emote.first.string.toLower()))
+        if (fuzzyMatch(text.toLower(), emote.first.string.toLower()))
         {
             out.push_back(
                 {emote.second, emote.second->name.string, providerName});
@@ -60,9 +57,7 @@ void addEmojis(std::vector<CompletionEmote> &out, const EmojiMap &map,
     map.each([&](const QString &, const std::shared_ptr<EmojiData> &emoji) {
         for (auto &&shortCode : emoji->shortCodes)
         {
-        //TODO: Check with code guidelines
-
-            if (fuzzy_match(text.toLower(),shortCode.toLower()))
+            if (fuzzyMatch(text.toLower(), shortCode.toLower()))
             {
                 out.push_back({emoji->emote, shortCode, "Emoji"});
             }

--- a/src/widgets/splits/InputCompletionPopup.cpp
+++ b/src/widgets/splits/InputCompletionPopup.cpp
@@ -24,12 +24,33 @@ struct CompletionEmote {
     QString providerName;
 };
 
+//TODO: Check with code guidelines
+
+//Returns true if each character in pattern is found sequentially within str
+static bool fuzzy_match(char const * pattern, char const * str) {
+    while (*pattern != '\0' && *str != '\0')  {
+        if (tolower(*pattern) == tolower(*str))
+            ++pattern;
+        ++str;
+    }
+
+    return *pattern == '\0' ? true : false;
+}
+
 void addEmotes(std::vector<CompletionEmote> &out, const EmoteMap &map,
                const QString &text, const QString &providerName)
 {
     for (auto &&emote : map)
     {
-        if (emote.first.string.contains(text, Qt::CaseInsensitive))
+        //TODO: Check with code guidelines
+        //TODO: Fix memory leak
+        QByteArray textba = text.toLower().toLocal8Bit();
+        const char *c_text = textba.data();
+
+        QByteArray emoteba = emote.first.string.toLower().toLocal8Bit();
+        const char *c_emote = emoteba.data();
+
+        if (fuzzy_match(c_text,c_emote))
         {
             out.push_back(
                 {emote.second, emote.second->name.string, providerName});
@@ -43,7 +64,15 @@ void addEmojis(std::vector<CompletionEmote> &out, const EmojiMap &map,
     map.each([&](const QString &, const std::shared_ptr<EmojiData> &emoji) {
         for (auto &&shortCode : emoji->shortCodes)
         {
-            if (shortCode.contains(text, Qt::CaseInsensitive))
+        //TODO: Check with code guidelines
+        //TODO: Fix memory leak
+        QByteArray textba = text.toLower().toLocal8Bit();
+        const char *c_text = textba.data();
+
+        QByteArray shortcodeba = shortCode.toLower().toLocal8Bit();
+        const char *c_shortcode = shortcodeba.data();
+
+            if (fuzzy_match(c_text,c_shortcode))
             {
                 out.push_back({emoji->emote, shortCode, "Emoji"});
             }

--- a/src/widgets/splits/InputCompletionPopup.cpp
+++ b/src/widgets/splits/InputCompletionPopup.cpp
@@ -27,14 +27,16 @@ struct CompletionEmote {
 //TODO: Check with code guidelines
 
 //Returns true if each character in pattern is found sequentially within str
-static bool fuzzy_match(char const * pattern, char const * str) {
-    while (*pattern != '\0' && *str != '\0')  {
-        if (tolower(*pattern) == tolower(*str))
-            ++pattern;
-        ++str;
+static bool fuzzy_match(QString const & pattern, QString const & str) 
+{
+    int i = 0;int j = 0;
+    while (i < pattern.length() && j < str.length())  {
+        if (pattern.at(i) == str.at(j))
+            ++i;
+        ++j;
     }
 
-    return *pattern == '\0' ? true : false;
+    return i == pattern.length();
 }
 
 void addEmotes(std::vector<CompletionEmote> &out, const EmoteMap &map,
@@ -44,7 +46,7 @@ void addEmotes(std::vector<CompletionEmote> &out, const EmoteMap &map,
     {
         //TODO: Check with code guidelines
 
-        if (fuzzy_match(text.toLocal8Bit().data(),emote.first.string.toLocal8Bit().data()))
+        if (fuzzy_match(text.toLower(),emote.first.string.toLower()))
         {
             out.push_back(
                 {emote.second, emote.second->name.string, providerName});
@@ -60,7 +62,7 @@ void addEmojis(std::vector<CompletionEmote> &out, const EmojiMap &map,
         {
         //TODO: Check with code guidelines
 
-            if (fuzzy_match(text.toLocal8Bit().data(),shortCode.toLocal8Bit().data()))
+            if (fuzzy_match(text.toLower(),shortCode.toLower()))
             {
                 out.push_back({emoji->emote, shortCode, "Emoji"});
             }

--- a/src/widgets/splits/InputCompletionPopup.cpp
+++ b/src/widgets/splits/InputCompletionPopup.cpp
@@ -43,14 +43,8 @@ void addEmotes(std::vector<CompletionEmote> &out, const EmoteMap &map,
     for (auto &&emote : map)
     {
         //TODO: Check with code guidelines
-        //TODO: Fix memory leak
-        QByteArray textba = text.toLower().toLocal8Bit();
-        const char *c_text = textba.data();
 
-        QByteArray emoteba = emote.first.string.toLower().toLocal8Bit();
-        const char *c_emote = emoteba.data();
-
-        if (fuzzy_match(c_text,c_emote))
+        if (fuzzy_match(text.toLocal8Bit().data(),emote.first.string.toLocal8Bit().data()))
         {
             out.push_back(
                 {emote.second, emote.second->name.string, providerName});
@@ -65,14 +59,8 @@ void addEmojis(std::vector<CompletionEmote> &out, const EmojiMap &map,
         for (auto &&shortCode : emoji->shortCodes)
         {
         //TODO: Check with code guidelines
-        //TODO: Fix memory leak
-        QByteArray textba = text.toLower().toLocal8Bit();
-        const char *c_text = textba.data();
 
-        QByteArray shortcodeba = shortCode.toLower().toLocal8Bit();
-        const char *c_shortcode = shortcodeba.data();
-
-            if (fuzzy_match(c_text,c_shortcode))
+            if (fuzzy_match(text.toLocal8Bit().data(),shortCode.toLocal8Bit().data()))
             {
                 out.push_back({emoji->emote, shortCode, "Emoji"});
             }


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

This change adds Fuzzy Matching to the emote popup when colon (:) is typed in chat.

Example:

Before:
![Before](https://user-images.githubusercontent.com/70465804/230680848-2ababe7e-1152-4b67-90cb-e5326185220a.png)

After:
![After](https://user-images.githubusercontent.com/70465804/230681186-f9b2775d-1d7f-4955-9f84-0b00f18c2b52.png)

