### PR TITLE
Streamline the look of the Black theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Minor: Added support for FrankerFaceZ animated emotes. (#4434)
 - Minor: Added a local backup of the Twitch Badges API in case the request fails. (#4463)
 - Minor: Added the ability to reply to a message by `Shift + Right Click`ing the username. (#4424)
+- Minor: Updated the look of the Black Theme to be more in line with the other themes. (#4523)
 - Bugfix: Fixed an issue where animated emotes would render on top of zero-width emotes. (#4314)
 - Bugfix: Fixed an issue where it was difficult to hover a zero-width emote. (#4314)
 - Bugfix: Fixed an issue where context-menu items for zero-width emotes displayed the wrong provider. (#4460)

--- a/resources/themes/Black.json
+++ b/resources/themes/Black.json
@@ -34,15 +34,15 @@
       "dropTargetRect": "#000094ff",
       "dropTargetRectBorder": "#000094ff",
       "header": {
-        "background": "#191919",
-        "border": "#262626",
-        "focusedBackground": "#363636",
-        "focusedBorder": "#383838",
+        "background": "#050505",
+        "border": "#121212",
+        "focusedBackground": "#1a1a1a",
+        "focusedBorder": "#1c1c1c",
         "focusedText": "#84c1ff",
         "text": "#ffffff"
       },
       "input": {
-        "background": "#0d0d0d",
+        "background": "#080808",
         "text": "#ffffff"
       },
       "messageSeperator": "#3c3c3c",
@@ -53,9 +53,9 @@
       "dividerLine": "#555555",
       "highlighted": {
         "backgrounds": {
-          "hover": "#252525",
-          "regular": "#252525",
-          "unfocused": "#252525"
+          "hover": "#0b0b0b",
+          "regular": "#0b0b0b",
+          "unfocused": "#0b0b0b"
         },
         "line": {
           "hover": "#ee6166",
@@ -66,9 +66,9 @@
       },
       "newMessage": {
         "backgrounds": {
-          "hover": "#252525",
-          "regular": "#252525",
-          "unfocused": "#252525"
+          "hover": "#0b0b0b",
+          "regular": "#0b0b0b",
+          "unfocused": "#0b0b0b"
         },
         "line": {
           "hover": "#888888",
@@ -79,9 +79,9 @@
       },
       "regular": {
         "backgrounds": {
-          "hover": "#252525",
-          "regular": "#252525",
-          "unfocused": "#252525"
+          "hover": "#0b0b0b",
+          "regular": "#0b0b0b",
+          "unfocused": "#0b0b0b"
         },
         "line": {
           "hover": "#444444",
@@ -92,9 +92,9 @@
       },
       "selected": {
         "backgrounds": {
-          "hover": "#555555",
-          "regular": "#555555",
-          "unfocused": "#555555"
+          "hover": "#333333",
+          "regular": "#333333",
+          "unfocused": "#333333"
         },
         "line": {
           "hover": "#00aeef",
@@ -105,7 +105,7 @@
       }
     },
     "window": {
-      "background": "#111111",
+      "background": "#040404",
       "text": "#eeeeee"
     }
   }


### PR DESCRIPTION
# Description
As stated in my previous PR #4140 "This PR sets out to make the current black theme better match other themes. On the current black theme the only thing that is changed is the chat background which has bothered me for a while. So, I decided to try to match the rest of Chatterino Themes with the black theme. I'm open to changes to any of the colours I have changed if you feel something would look better." Now that #4471 has been merged I feel that the request of Pajlada ↓↓ has been met.
> Pajlada commented Nov 12, 2022, 5:45AM CST
> While the thematic changes are good and I think the improvement in looks is nice, how this looks in the code is not maintainable. Some better facility for specifying the colors are needed for me to be ok with merging this in.
<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
‎‎‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏**‎‏‏‎Updated**‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎‏‏‎ ‎‎‏‏‎ ‎‏‏‎ ‎‏‏‎ ‎‏‏‎  ‎**Current**
![201411569-baea5072-58ca-4e2e-aa7b-8d78cda6369b](https://user-images.githubusercontent.com/27637025/230736036-0eb6606a-a100-4b41-b26a-9e2b680c6324.png)
