### PR TITLE
Remove CHATTERINO_TEST definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Dev: Add scripting capabilities with Lua (#4341, #4504)
 - Dev: Conan 2.0 is now used instead of Conan 1.0. (#4417)
 - Dev: Added tests and benchmarks for `LinkParser`. (#4436)
+- Dev: Removed `CHATTERINO_TEST` definitions. (#4526)
 
 ## 2.4.2
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,10 +169,6 @@ endif()
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-if (BUILD_TESTS OR BUILD_BENCHMARKS)
-    add_definitions(-DCHATTERINO_TEST)
-endif ()
-
 # Generate resource files
 include(cmake/resources/generate_resources.cmake)
 

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -18,10 +18,6 @@ target_link_libraries(${PROJECT_NAME} PRIVATE chatterino-lib)
 
 target_link_libraries(${PROJECT_NAME} PRIVATE benchmark::benchmark)
 
-target_compile_definitions(${PROJECT_NAME} PRIVATE
-    CHATTERINO_TEST
-    )
-
 set_target_properties(${PROJECT_NAME}
     PROPERTIES
     ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"

--- a/src/messages/Image.cpp
+++ b/src/messages/Image.cpp
@@ -8,6 +8,11 @@
 #include "common/QLogging.hpp"
 #include "debug/AssertInGuiThread.hpp"
 #include "debug/Benchmark.hpp"
+#include "singletons/Emotes.hpp"
+#include "singletons/helper/GifTimer.hpp"
+#include "singletons/WindowManager.hpp"
+#include "util/DebugCount.hpp"
+#include "util/PostToThread.hpp"
 
 #include <boost/functional/hash.hpp>
 #include <QBuffer>
@@ -20,13 +25,6 @@
 #include <functional>
 #include <queue>
 #include <thread>
-#ifndef CHATTERINO_TEST
-#    include "singletons/Emotes.hpp"
-#endif
-#include "singletons/helper/GifTimer.hpp"
-#include "singletons/WindowManager.hpp"
-#include "util/DebugCount.hpp"
-#include "util/PostToThread.hpp"
 
 // Duration between each check of every Image instance
 const auto IMAGE_POOL_CLEANUP_INTERVAL = std::chrono::minutes(1);
@@ -55,12 +53,10 @@ namespace detail {
         {
             DebugCount::increase("animated images");
 
-#ifndef CHATTERINO_TEST
             this->gifTimerConnection_ =
                 getApp()->emotes->gifTimer.signal.connect([this] {
                     this->advance();
                 });
-#endif
         }
 
         auto totalLength =
@@ -75,11 +71,9 @@ namespace detail {
         }
         else
         {
-#ifndef CHATTERINO_TEST
             this->durationOffset_ = std::min<int>(
                 int(getApp()->emotes->gifTimer.position() % totalLength),
                 60000);
-#endif
         }
         this->processOffset();
     }

--- a/src/messages/Image.cpp
+++ b/src/messages/Image.cpp
@@ -551,8 +551,9 @@ void Image::expireFrames()
 #ifndef DISABLE_IMAGE_EXPIRATION_POOL
 
 ImageExpirationPool::ImageExpirationPool()
+    : freeTimer_(new QTimer)
 {
-    QObject::connect(&this->freeTimer_, &QTimer::timeout, [this] {
+    QObject::connect(this->freeTimer_, &QTimer::timeout, [this] {
         if (isGuiThread())
         {
             this->freeOld();
@@ -565,7 +566,7 @@ ImageExpirationPool::ImageExpirationPool()
         }
     });
 
-    this->freeTimer_.start(
+    this->freeTimer_->start(
         std::chrono::duration_cast<std::chrono::milliseconds>(
             IMAGE_POOL_CLEANUP_INTERVAL));
 }

--- a/src/messages/Image.cpp
+++ b/src/messages/Image.cpp
@@ -228,9 +228,8 @@ namespace detail {
             }
         }
 
-#ifndef CHATTERINO_TEST
         getApp()->windows->forceLayoutChannelViews();
-#endif
+
         loadedEventQueued = false;
     }
 

--- a/src/messages/Image.hpp
+++ b/src/messages/Image.hpp
@@ -19,14 +19,6 @@
 #include <memory>
 #include <mutex>
 
-#ifdef CHATTERINO_TEST
-// When running tests, the ImageExpirationPool destructor can be called before
-// all images are deleted, leading to a use-after-free of its mutex. This
-// happens despite the lifetime of the ImageExpirationPool being (apparently)
-// static. Therefore, just disable it during testing.
-#    define DISABLE_IMAGE_EXPIRATION_POOL
-#endif
-
 namespace chatterino {
 namespace detail {
     template <typename Image>

--- a/src/messages/Image.hpp
+++ b/src/messages/Image.hpp
@@ -136,7 +136,7 @@ private:
 
 private:
     // Timer to periodically run freeOld()
-    QTimer freeTimer_;
+    QTimer *freeTimer_;
     std::map<Image *, std::weak_ptr<Image>> allImages_;
     std::mutex mutex_;
 };

--- a/src/messages/ImageSet.cpp
+++ b/src/messages/ImageSet.cpp
@@ -61,9 +61,7 @@ const ImagePtr &ImageSet::getImage3() const
 
 const std::shared_ptr<Image> &getImagePriv(const ImageSet &set, float scale)
 {
-#ifndef CHATTERINO_TEST
     scale *= getSettings()->emoteScale;
-#endif
 
     int quality = 1;
 

--- a/src/providers/emoji/Emojis.cpp
+++ b/src/providers/emoji/Emojis.cpp
@@ -216,11 +216,7 @@ void Emojis::sortEmojis()
 
 void Emojis::loadEmojiSet()
 {
-#ifndef CHATTERINO_TEST
     getSettings()->emojiSet.connect([this](const auto &emojiSet) {
-#else
-    const QString emojiSet = "twitter";
-#endif
         this->emojis.each([=](const auto &name,
                               std::shared_ptr<EmojiData> &emoji) {
             QString emojiSetToUse = emojiSet;
@@ -265,9 +261,7 @@ void Emojis::loadEmojiSet()
                 EmoteName{emoji->value}, ImageSet{Image::fromUrl({url}, 0.35)},
                 Tooltip{":" + emoji->shortCodes[0] + ":<br/>Emoji"}, Url{}});
         });
-#ifndef CHATTERINO_TEST
     });
-#endif
 }
 
 std::vector<boost::variant<EmotePtr, QString>> Emojis::parse(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,10 +35,6 @@ target_link_libraries(${PROJECT_NAME} PRIVATE chatterino-lib)
 
 target_link_libraries(${PROJECT_NAME} PRIVATE gtest gmock)
 
-target_compile_definitions(${PROJECT_NAME} PRIVATE
-    CHATTERINO_TEST
-    )
-
 set_target_properties(${PROJECT_NAME}
     PROPERTIES
     ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"


### PR DESCRIPTION
# Description

- Remove Emojis.cpp CHATTERINO_TEST ifdefs
- Remove ImageSet.cpp CHATTERINO_TEST ifdefs
- Remove Image.cpp CHATTERINO_TEST ifdef around forceLayoutChannelViews
- Remove Image.cpp CHATTERINO_TEST ifdefs around gif timers
- Purposefully leak the ImageExpirationPool timer
- Remove ImageExpirationPool CHATTERINO_TEST definition
- Remove CHATTERINO_TEST definitions in the CMakeLists.txt files

Fixes #4524

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
