### PR TITLE
Fix Twitch-Specific Filters Not Being Applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Bugfix: Fixed blocked user list sticking around when switching from a logged in user to being logged out. (#4437)
 - Bugfix: Fixed search popup ignoring setting for message scrollback limit. (#4496)
 - Bugfix: Fixed a memory leak that occurred when loading message history. This was mostly noticeable with unstable internet connections where reconnections were frequent or long-running instances of Chatterino. (#4499)
+- Bugfix: Fixed Twitch channel-specific filters not being applied correctly. (#4529)
 - Bugfix: Fixed emote & badge tooltips not showing up when thumbnails were hidden. (#4509)
 - Dev: Disabling precompiled headers on Windows is now tested in CI. (#4472)
 - Dev: Themes are now stored as JSON files in `resources/themes`. (#4471)

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -838,7 +838,7 @@ bool ChannelView::shouldIncludeMessage(const MessagePtr &m) const
                 m->loginName, Qt::CaseInsensitive) == 0)
             return true;
 
-        return this->channelFilters_->filter(m, this->channel_);
+        return this->channelFilters_->filter(m, this->underlyingChannel_);
     }
 
     return true;


### PR DESCRIPTION
# Description

#4107 previously tried to fix this issue, but was later reverted (https://github.com/Chatterino/chatterino2/pull/4111), because having a filter like `channel.live` in a live channel would "freeze" (deadlock) the app (https://github.com/Chatterino/chatterino2/issues/4110). This PR fixes this deadlock and applies the fix by #4107.

The deadlock was caused, because the lock-guard in [`TwitchChannel::setLive`](https://github.com/Chatterino/chatterino2/blob/34db692895b3a5e49092e33a2513617938018c21/src/providers/twitch/TwitchChannel.cpp#L912-L996) was kept alive for too long. Specifically, `setLive` [adds a message](https://github.com/Chatterino/chatterino2/blob/34db692895b3a5e49092e33a2513617938018c21/src/providers/twitch/TwitchChannel.cpp#L943) which then gets to the filter which tries to access `streamStatus_`, which is locked in `setLive` (deadlock).

I prevented this by reducing the critical-section where the guard is kept alive.

I also noticed that [`TwitchChanne::isLive`](https://github.com/Chatterino/chatterino2/blob/34db692895b3a5e49092e33a2513617938018c21/src/providers/twitch/TwitchChannel.cpp#L576-L579) called `access` over `accessConst` which lead me down a shallow rabbit-hole:

* The `UniqueAccess` for `streamStatus_` isn't actually needed (probably similar for others as well). If you add `assertInGuiThread` before every access, you'll see that the app works fine. This is because (1) helix-calls aren't concurrent, (2) command-variables are substituted concurrently, (3) commands aren't executed concurrently, and (4) filters aren't checked concurrently.
* [`TwitchChannel::twitchBadge`](https://github.com/Chatterino/chatterino2/blob/34db692895b3a5e49092e33a2513617938018c21/src/providers/twitch/TwitchChannel.cpp#L1524-L1538), [`TwitchChannel::cheerEmote`](https://github.com/Chatterino/chatterino2/blob/34db692895b3a5e49092e33a2513617938018c21/src/providers/twitch/TwitchChannel.cpp#L1550-L1577), [`TwitchBadges::badge`](https://github.com/Chatterino/chatterino2/blob/00642ef7836c15c7a67140bbb0ea9567ab615ac9/src/providers/twitch/TwitchBadges.cpp#L127-L155), [`DebugCount::getDebugText`](https://github.com/Chatterino/chatterino2/blob/00642ef7836c15c7a67140bbb0ea9567ab615ac9/src/util/DebugCount.hpp#L74-L84), and [`ChannelChatters::colorsSize`](https://github.com/Chatterino/chatterino2/blob/34db692895b3a5e49092e33a2513617938018c21/src/common/ChannelChatters.cpp#L86-L90) use `UniqueAccess::access` over `UniqueAccess::accessConst`, even though they don't modify the underlying data.
* [`UniqueAccess<T> &operator=(const T &element)`](https://github.com/Chatterino/chatterino2/blob/34db692895b3a5e49092e33a2513617938018c21/src/common/UniqueAccess.hpp#L71-L75) and [`UniqueAccess<T> &operator=(T &&element)`](https://github.com/Chatterino/chatterino2/blob/34db692895b3a5e49092e33a2513617938018c21/src/common/UniqueAccess.hpp#L77-L81) are unsound. They should lock the mutex before modifying the data. Only `UniqueAccess<T> &operator=(const T &element)` is used [here](https://github.com/Chatterino/chatterino2/blob/34db692895b3a5e49092e33a2513617938018c21/src/providers/twitch/TwitchChannel.cpp#L571).

Fixes #4112.