### PR TITLE
Restore missing copy and pin buttons in the Usercard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - Bugfix: Fixed a memory leak that occurred when loading message history. This was mostly noticeable with unstable internet connections where reconnections were frequent or long-running instances of Chatterino. (#4499)
 - Bugfix: Fixed emote & badge tooltips not showing up when thumbnails were hidden. (#4509)
 - Dev: Disabling precompiled headers on Windows is now tested in CI. (#4472)
-- Dev: Themes are now stored as JSON files in `resources/themes`. (#4471)
+- Dev: Themes are now stored as JSON files in `resources/themes`. (#4471, #4533)
 - Dev: Ignore unhandled BTTV user-events. (#4438)
 - Dev: Only log debug messages when NDEBUG is not defined. (#4442)
 - Dev: Cleaned up theme related code. (#4450)

--- a/src/singletons/Theme.cpp
+++ b/src/singletons/Theme.cpp
@@ -3,6 +3,7 @@
 
 #include "Application.hpp"
 #include "common/QLogging.hpp"
+#include "singletons/Resources.hpp"
 
 #include <QColor>
 #include <QFile>
@@ -210,6 +211,18 @@ void Theme::parseFrom(const QJsonObject &root)
         "selection-background-color:" +
         (this->isLightTheme() ? "#68B1FF"
                               : this->tabs.selected.backgrounds.regular.name());
+
+    // Usercard buttons
+    if (this->isLightTheme())
+    {
+        this->buttons.copy = getResources().buttons.copyDark;
+        this->buttons.pin = getResources().buttons.pinDisabledDark;
+    }
+    else
+    {
+        this->buttons.copy = getResources().buttons.copyLight;
+        this->buttons.pin = getResources().buttons.pinDisabledLight;
+    }
 }
 
 void Theme::normalizeColor(QColor &color) const


### PR DESCRIPTION
# Description

In #4471 I removed too much code and accidentally removed code that loaded the icons for the usercard-buttons.

Fixes #4532.