### PR TITLE
Restart the sound device if it's been stopped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Minor: Added system message for empty mod list. (#4546)
 - Minor: Added `/lowtrust` command to open the suspicious user activity feed in browser. (#4542)
 - Minor: Migrated badges to Helix API. (#4537)
+- Bugfix: Fixed an issue where Chatterino could lose track of the sound device in certain scenarios. (#4549)
 - Bugfix: Fixed an issue where animated emotes would render on top of zero-width emotes. (#4314)
 - Bugfix: Fixed an issue where it was difficult to hover a zero-width emote. (#4314)
 - Bugfix: Fixed an issue where context-menu items for zero-width emotes displayed the wrong provider. (#4460)

--- a/src/controllers/sound/SoundController.cpp
+++ b/src/controllers/sound/SoundController.cpp
@@ -190,6 +190,26 @@ void SoundController::play(const QUrl &sound)
         return;
     }
 
+    auto deviceState = ma_device_get_state(this->device.get());
+
+    if (deviceState != ma_device_state_started)
+    {
+        // Device state is not as it should be, try to restart it
+        qCWarning(chatterinoSound)
+            << "Sound device was not started, attempting to restart it"
+            << deviceState;
+
+        auto result = ma_device_start(this->device.get());
+        if (result != MA_SUCCESS)
+        {
+            qCWarning(chatterinoSound)
+                << "Failed to start the sound device" << result;
+            return;
+        }
+
+        qCInfo(chatterinoSound) << "Successfully restarted the sound device";
+    }
+
     if (sound.isLocalFile())
     {
         auto soundPath = sound.toLocalFile();


### PR DESCRIPTION
# Description

Fixes a bug where we don't check if the sound device is active before trying to play a sound to it

We fix this by checking its state before every sound we try to play, and if the device is not in the started state we try to restart it.

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
