### PR TITLE
Use `macos` rather than `osx` in filenames

### DIFF
--- a/.CI/CreateDMG.sh
+++ b/.CI/CreateDMG.sh
@@ -28,5 +28,5 @@ echo "Entering python3 virtual environment"
 echo "Installing dmgbuild"
 python3 -m pip install dmgbuild
 echo "Running dmgbuild.."
-dmgbuild --settings ./../.CI/dmg-settings.py -D app=./chatterino.app Chatterino2 chatterino-osx-Qt-$1.dmg
+dmgbuild --settings ./../.CI/dmg-settings.py -D app=./chatterino.app Chatterino2 chatterino-macos-Qt-$1.dmg
 echo "Done!"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -348,8 +348,8 @@ jobs:
         if: startsWith(matrix.os, 'macos')
         uses: actions/upload-artifact@v3
         with:
-          name: chatterino-osx-Qt-${{ matrix.qt-version }}.dmg
-          path: build/chatterino-osx-Qt-${{ matrix.qt-version }}.dmg
+          name: chatterino-macos-Qt-${{ matrix.qt-version }}.dmg
+          path: build/chatterino-macos-Qt-${{ matrix.qt-version }}.dmg
   create-release:
     needs: build
     runs-on: ubuntu-latest
@@ -411,13 +411,13 @@ jobs:
       - uses: actions/download-artifact@v3
         name: macOS x86_64 Qt5.15.2 dmg
         with:
-          name: chatterino-osx-Qt-5.15.2.dmg
+          name: chatterino-macos-Qt-5.15.2.dmg
           path: release-artifacts/
 
       - uses: actions/download-artifact@v3
         name: macOS x86_64 Qt6.5.0 dmg
         with:
-          name: chatterino-osx-Qt-6.5.0.dmg
+          name: chatterino-macos-Qt-6.5.0.dmg
           path: release-artifacts/
 
       - name: Copy flatpakref

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Dev: Added tests and benchmarks for `LinkParser`. (#4436)
 - Dev: Experimental builds with Qt 6 are now provided. (#4522)
 - Dev: Removed `CHATTERINO_TEST` definitions. (#4526)
+- Dev: Builds for macOS now have `macos` in their name (previously: `osx`). (#4550)
 
 ## 2.4.2
 

--- a/src/singletons/Toasts.cpp
+++ b/src/singletons/Toasts.cpp
@@ -76,7 +76,7 @@ void Toasts::sendChannelNotification(const QString &channelName,
     };
 #else
     auto sendChannelNotification = [] {
-        // Unimplemented for OSX and Linux
+        // Unimplemented for macOS and Linux
     };
 #endif
     // Fetch user profile avatar


### PR DESCRIPTION
# Description

Apple wants the OS to be called macOS, rather than the previously used OSX. This PR changes the artifact names to use `macos`.

The only other uses of `OSX` in the codebase are related to CMake things (which we can't change) and one comment in [Toasts.hpp](https://github.com/Chatterino/chatterino2/blob/517382ebc967f0ab3b512cf3619fa3b1ba213d76/src/singletons/Toasts.cpp#L79).