### PR TITLE
Mark experimental builds at the start of their filename

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -427,7 +427,10 @@ jobs:
 
       - name: Mark experimental
         run: |
-          for file in *; do mv -n "$file" "$(echo $file | sed 's/\(6\(\.[[:digit:]]\)\{2\}\)/\1-EXPERIMENTAL/g')"; done
+          # Mark all Qt6 builds as EXPERIMENTAL
+          mv chatterino-macos-Qt-6.5.0.dmg EXPERIMENTAL-chatterino-macos-Qt-6.5.0-dmg
+          mv Chatterino-ubuntu-22.04-Qt-6.2.4.deb EXPERIMENTAL-Chatterino-ubuntu-22.04-Qt-6.2.4.deb
+          mv chatterino-windows-x86-64-Qt-6.5.0.zip EXPERIMENTAL-chatterino-windows-x86-64-Qt-6.5.0.zip
         working-directory: release-artifacts
         shell: bash
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 - Dev: Add scripting capabilities with Lua (#4341, #4504)
 - Dev: Conan 2.0 is now used instead of Conan 1.0. (#4417)
 - Dev: Added tests and benchmarks for `LinkParser`. (#4436)
-- Dev: Experimental builds with Qt 6 are now provided. (#4522)
+- Dev: Experimental builds with Qt 6 are now provided. (#4522, #4551)
 - Dev: Removed `CHATTERINO_TEST` definitions. (#4526)
 - Dev: Builds for macOS now have `macos` in their name (previously: `osx`). (#4550)
 


### PR DESCRIPTION
# Description

also manually mark the builds as experimental instead of using a god of
war sed replace

The test for if this works can only be checked in the nightly release once this has been merged into the main branch

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
