### PR TITLE
Add `qtimageformats` Module in Qt6 CI Builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,7 +116,7 @@ jobs:
         with:
           cache: true
           cache-key-prefix: ${{ runner.os }}-QtCache-${{ matrix.qt-version }}-v2
-          modules: qt5compat
+          modules: qt5compat qtimageformats
           version: ${{ matrix.qt-version }}
 
       # WINDOWS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 - Dev: Add scripting capabilities with Lua (#4341, #4504)
 - Dev: Conan 2.0 is now used instead of Conan 1.0. (#4417)
 - Dev: Added tests and benchmarks for `LinkParser`. (#4436)
-- Dev: Experimental builds with Qt 6 are now provided. (#4522, #4551, #4553, #4554, #4555)
+- Dev: Experimental builds with Qt 6 are now provided. (#4522, #4551, #4553, #4554, #4555, #4556)
 - Dev: Removed `CHATTERINO_TEST` definitions. (#4526)
 - Dev: Builds for macOS now have `macos` in their name (previously: `osx`). (#4550)
 


### PR DESCRIPTION
# Description

The current **EXPERIMENTAL** Qt6 builds (at least on Windows) are missing `imageformats/qwebp.dll`, which is not provided by `qtbase` ([`qtimageformats`](https://qt.mirror.constant.com/online/qtsdkrepository/windows_x86/desktop/qt6_650/qt.qt6.650.addons.qtimageformats.win64_msvc2019_64/6.5.0-0-202303290841qtimageformats-Windows-Windows_10_22H2-MSVC2019-Windows-Windows_10_22H2-X86_64.7z), [`qtbase`](https://qt.mirror.constant.com/online/qtsdkrepository/windows_x86/desktop/qt6_650/qt.qt6.650.win64_msvc2019_64/6.5.0-0-202303290841qtbase-Windows-Windows_10_22H2-MSVC2019-Windows-Windows_10_22H2-X86_64.7z)). This PR adds `qtimageformats` as a required module. 
