### PR TITLE
fix: experimental macOS artifact extension repaired

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -388,7 +388,7 @@ jobs:
         run: |
           ls -l
           # Mark all Qt6 builds as EXPERIMENTAL
-          mv chatterino-macos-Qt-6.5.0.dmg EXPERIMENTAL-chatterino-macos-Qt-6.5.0-dmg
+          mv chatterino-macos-Qt-6.5.0.dmg EXPERIMENTAL-chatterino-macos-Qt-6.5.0.dmg
           mv Chatterino-ubuntu-22.04-x86_64.deb EXPERIMENTAL-Chatterino-ubuntu-22.04-Qt-6.2.4.deb
           mv chatterino-windows-x86-64-Qt-6.5.0.zip EXPERIMENTAL-chatterino-windows-x86-64-Qt-6.5.0.zip
           mv chatterino-Qt-6.5.0.pdb.7z EXPERIMENTAL-chatterino-Qt-6.5.0.pdb.7z


### PR DESCRIPTION
# Description

The `EXPERIMENTAL` macOS artifacts ended in `-dmg` instead of `.dmg`. 

We can amend the changelog with this PR but it already has 5? PRs so 🤷