### PR TITLE
Fix Qt6 crash when dragging rows in table views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@
 - Bugfix: Fixed a memory leak that occurred when loading message history. This was mostly noticeable with unstable internet connections where reconnections were frequent or long-running instances of Chatterino. (#4499)
 - Bugfix: Fixed Twitch channel-specific filters not being applied correctly. (#4529)
 - Bugfix: Fixed emote & badge tooltips not showing up when thumbnails were hidden. (#4509)
-- Bugfix: Fixed a crash when dragging rows in table-views. (#4567)
 - Dev: Disabling precompiled headers on Windows is now tested in CI. (#4472)
 - Dev: Themes are now stored as JSON files in `resources/themes`. (#4471, #4533)
 - Dev: Ignore unhandled BTTV user-events. (#4438)
@@ -39,6 +38,7 @@
 - Dev: Experimental builds with Qt 6 are now provided. (#4522, #4551, #4553, #4554, #4555, #4556)
 - Dev: Removed `CHATTERINO_TEST` definitions. (#4526)
 - Dev: Builds for macOS now have `macos` in their name (previously: `osx`). (#4550)
+- Dev: Fixed a crash when dragging rows in table-views in builds with Qt 6. (#4567)
 
 ## 2.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Bugfix: Fixed a memory leak that occurred when loading message history. This was mostly noticeable with unstable internet connections where reconnections were frequent or long-running instances of Chatterino. (#4499)
 - Bugfix: Fixed Twitch channel-specific filters not being applied correctly. (#4529)
 - Bugfix: Fixed emote & badge tooltips not showing up when thumbnails were hidden. (#4509)
+- Bugfix: Fixed a crash when dragging rows in table-views. (#4567)
 - Dev: Disabling precompiled headers on Windows is now tested in CI. (#4472)
 - Dev: Themes are now stored as JSON files in `resources/themes`. (#4471, #4533)
 - Dev: Ignore unhandled BTTV user-events. (#4438)

--- a/src/common/SignalVectorModel.hpp
+++ b/src/common/SignalVectorModel.hpp
@@ -333,7 +333,7 @@ public:
 
             if (from != to)
             {
-                this->moveRow(this->index(from, to), from, parent, to);
+                this->moveRow(this->index(from, 0), from, parent, to);
             }
 
             // We return false since we remove items ourselves.


### PR DESCRIPTION
# Description

This PR fixes the crash described in #4563.

I have no clue why the previous code worked in the first place.

- It's quite clear that both `from` and `to` are row-indices:
https://github.com/Chatterino/chatterino2/blob/6338d09104a3075c21dd7a1ba80e744a544f22d1/src/common/SignalVectorModel.hpp#L322-L323
- [`QAbstractItemModel::index`](https://doc.qt.io/qt-6/qabstractitemmodel.html#index) takes a `row`, `column`, and (optional) `parent` (🤓 actually [`QAbstractTableModel::index`](https://doc.qt.io/qt-6/qabstracttablemodel.html#index) is called, but this doesn't do any fancy things).
- `to` is passed at the second argument - in the position of column 💫 https://github.com/Chatterino/chatterino2/blob/6338d09104a3075c21dd7a1ba80e744a544f22d1/src/common/SignalVectorModel.hpp#L336
- `to` isn't a column-index - this won't end well 🤦‍♀️
- It might happen that the target row index is larger than the amount of columns. In this case, an invalid model-index is returned 🤔
- This invalid index will eventually be used to look up a row in qt-internals 🕵️‍♂️
- This returns a null pointer 🙅‍♂️
- The null pointer will be dereferenced 💥

I changed the column index to `0` which should always be a valid column index. One could also use the column index of `parent`. But this doesn't really matter since we're moving _rows_.

Fixes #4563.
