### PR TITLE
More Accurately Convert Font-Weights in Qt 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Bugfix: Fixed an issue where it was difficult to hover a zero-width emote. (#4314)
 - Bugfix: Fixed an issue where context-menu items for zero-width emotes displayed the wrong provider. (#4460)
 - Bugfix: Fixed an issue where the "Enable zero-width emotes" setting was showing the inverse state. (#4462)
-- Bugfix: Fixed username rendering in Qt 6. (#4476)
+- Bugfix: Fixed username rendering in Qt 6. (#4476, #4568)
 - Bugfix: Fixed placeholder color in Qt 6. (#4477)
 - Bugfix: Fixed blocked user list being empty when opening the settings dialog for the first time. (#4437)
 - Bugfix: Fixed blocked user list sticking around when switching from a logged in user to being logged out. (#4437)

--- a/src/singletons/Fonts.cpp
+++ b/src/singletons/Fonts.cpp
@@ -28,7 +28,7 @@ namespace {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
         // From qfont.cpp
         // https://github.com/qt/qtbase/blob/589c6d066f84833a7c3dda1638037f4b2e91b7aa/src/gui/text/qfont.cpp#L143-L169
-        static constexpr std::array<std::array<int, 2>, 9> legacyToOpenTypeMap({
+        static constexpr std::array<std::array<int, 2>, 9> legacyToOpenTypeMap{{
             {0, QFont::Thin},
             {12, QFont::ExtraLight},
             {25, QFont::Light},
@@ -38,7 +38,7 @@ namespace {
             {75, QFont::Bold},
             {81, QFont::ExtraBold},
             {87, QFont::Black},
-        });
+        }};
 
         const int target = getSettings()->boldScale.getValue();
 

--- a/src/singletons/Fonts.cpp
+++ b/src/singletons/Fonts.cpp
@@ -26,10 +26,42 @@ namespace {
     int getBoldness()
     {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-        // This setting uses the Qt 5 range of the font-weight (0..99).
-        // The range in Qt 6 is 1..1000.
-        return (int)(1.0 +
-                     (111.0 * getSettings()->boldScale.getValue()) / 11.0);
+        // From qfont.cpp
+        // https://github.com/qt/qtbase/blob/589c6d066f84833a7c3dda1638037f4b2e91b7aa/src/gui/text/qfont.cpp#L143-L169
+        static constexpr std::array<std::array<int, 2>, 9> legacyToOpenTypeMap({
+            {0, QFont::Thin},
+            {12, QFont::ExtraLight},
+            {25, QFont::Light},
+            {50, QFont::Normal},
+            {57, QFont::Medium},
+            {63, QFont::DemiBold},
+            {75, QFont::Bold},
+            {81, QFont::ExtraBold},
+            {87, QFont::Black},
+        });
+
+        const int target = getSettings()->boldScale.getValue();
+
+        int result = QFont::Medium;
+        int closestDist = INT_MAX;
+
+        // Go through and find the closest mapped value
+        for (const auto [weightOld, weightNew] : legacyToOpenTypeMap)
+        {
+            const int dist = qAbs(weightOld - target);
+            if (dist < closestDist)
+            {
+                result = weightNew;
+                closestDist = dist;
+            }
+            else
+            {
+                // Break early since following values will be further away
+                break;
+            }
+        }
+
+        return result;
 #else
         return getSettings()->boldScale.getValue();
 #endif


### PR DESCRIPTION
# Description

In #4476 I added a mapping function. It turns out the function isn't ideal and Qt recommends to use [`setLegacyWeight`](https://doc.qt.io/qt-6/qfont-obsolete.html#setLegacyWeight). You can see the differences here: https://www.desmos.com/calculator/igvv6oe9pd. This makes sure the default values for the settings will be as identical as possible.
