### PR TITLE
Add the ability to select custom themes in the settings dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unversioned
 
 - Dev: Added command to set Qt's logging filter/rules at runtime (`/c2-set-logging-rules`). (#4637)
+- Dev: Added the ability to see & load custom themes from the Themes directory. No stable promises are made of this feature, changes might be made that breaks custom themes without notice. (#4570)
 
 ## 2.4.4
 

--- a/src/singletons/Paths.cpp
+++ b/src/singletons/Paths.cpp
@@ -142,6 +142,7 @@ void Paths::initSubDirectories()
     this->miscDirectory = makePath("Misc");
     this->twitchProfileAvatars = makePath("ProfileAvatars");
     this->pluginsDirectory = makePath("Plugins");
+    this->themesDirectory = makePath("Themes");
     this->crashdumpDirectory = makePath("Crashes");
     //QDir().mkdir(this->twitchProfileAvatars + "/twitch");
 }

--- a/src/singletons/Paths.hpp
+++ b/src/singletons/Paths.hpp
@@ -37,6 +37,9 @@ public:
     // Plugin files live here. <appDataDirectory>/Plugins
     QString pluginsDirectory;
 
+    // Custom themes live here. <appDataDirectory>/Themes
+    QString themesDirectory;
+
     bool createFolder(const QString &folderPath);
     bool isPortable();
 

--- a/src/singletons/Theme.cpp
+++ b/src/singletons/Theme.cpp
@@ -3,17 +3,21 @@
 
 #include "Application.hpp"
 #include "common/QLogging.hpp"
+#include "singletons/Paths.hpp"
 #include "singletons/Resources.hpp"
 
 #include <QColor>
+#include <QDir>
 #include <QFile>
 #include <QJsonDocument>
-#include <QJsonObject>
 #include <QSet>
 
 #include <cmath>
 
 namespace {
+
+using namespace chatterino;
+
 void parseInto(const QJsonObject &obj, const QLatin1String &key, QColor &color)
 {
     const auto &jsonValue = obj[key];
@@ -139,62 +143,161 @@ void parseColors(const QJsonObject &root, chatterino::Theme &theme)
 }
 #undef parseColor
 
-QString getThemePath(const QString &name)
+/**
+ * Load the given theme descriptor from its path
+ *
+ * Returns a JSON object containing theme data if the theme is valid, otherwise nullopt
+ *
+ * NOTE: No theme validation is done by this function
+ **/
+std::optional<QJsonObject> loadTheme(const ThemeDescriptor &theme)
 {
-    static QSet<QString> knownThemes = {"White", "Light", "Dark", "Black"};
-
-    if (knownThemes.contains(name))
+    QFile file(theme.path);
+    if (!file.open(QFile::ReadOnly))
     {
-        return QStringLiteral(":/themes/%1.json").arg(name);
+        qCWarning(chatterinoTheme)
+            << "Failed to open" << file.fileName() << "at" << theme.path;
+        return std::nullopt;
     }
-    return name;
+
+    QJsonParseError error{};
+    auto json = QJsonDocument::fromJson(file.readAll(), &error);
+    if (!json.isObject())
+    {
+        qCWarning(chatterinoTheme) << "Failed to parse" << file.fileName()
+                                   << "error:" << error.errorString();
+        return std::nullopt;
+    }
+
+    // TODO: Validate JSON schema?
+
+    return json.object();
 }
 
 }  // namespace
 
 namespace chatterino {
 
+const std::map<QString, ThemeDescriptor> Theme::builtInThemes{
+    {"White", {":/themes/White.json", false}},
+    {"Light", {":/themes/Light.json", false}},
+    {"Dark", {":/themes/Dark.json", false}},
+    {"Black", {":/themes/Black.json", false}},
+};
+
+const ThemeDescriptor Theme::fallbackTheme = Theme::builtInThemes.at("Dark");
+
 bool Theme::isLightTheme() const
 {
     return this->isLight_;
 }
 
-Theme::Theme()
+void Theme::initialize(Settings &settings, Paths &paths)
 {
-    this->update();
-
-    this->themeName.connectSimple(
-        [this](auto) {
+    this->themeName.connect(
+        [this](auto themeName) {
+            qCDebug(chatterinoTheme) << "Theme updated to" << themeName;
             this->update();
         },
         false);
+
+    this->loadAvailableThemes();
+
+    this->update();
 }
 
 void Theme::update()
 {
-    this->parse();
+    auto theme = this->availableThemes_.find(this->themeName);
+
+    std::optional<QJsonObject> themeJSON;
+
+    if (theme == this->availableThemes_.end())
+    {
+        qCWarning(chatterinoTheme)
+            << "Theme" << this->themeName
+            << "not found, falling back to the fallback theme";
+
+        themeJSON = loadTheme(fallbackTheme);
+    }
+    else
+    {
+        themeJSON = loadTheme(theme->second);
+
+        if (!themeJSON)
+        {
+            qCWarning(chatterinoTheme)
+                << "Theme" << this->themeName
+                << "not valid, falling back to the fallback theme";
+
+            // Parsing the theme failed, fall back
+            themeJSON = loadTheme(fallbackTheme);
+        }
+    }
+
+    if (!themeJSON)
+    {
+        qCWarning(chatterinoTheme)
+            << "Failed to load" << this->themeName << "or the fallback theme";
+        return;
+    }
+
+    this->parseFrom(*themeJSON);
+
     this->updated.invoke();
 }
 
-void Theme::parse()
+QStringList Theme::availableThemeNames() const
 {
-    QFile file(getThemePath(this->themeName));
-    if (!file.open(QFile::ReadOnly))
+    QStringList themeNames;
+
+    for (const auto &[name, theme] : this->availableThemes_)
     {
-        qCWarning(chatterinoTheme) << "Failed to open" << file.fileName();
-        return;
+        // NOTE: This check could also use `Theme::builtInThemes.contains(name)` instead
+        if (theme.custom)
+        {
+            themeNames.append(QString("Custom: %1").arg(name));
+        }
+        else
+        {
+            themeNames.append(name);
+        }
     }
 
-    QJsonParseError error{};
-    auto json = QJsonDocument::fromJson(file.readAll(), &error);
-    if (json.isNull())
-    {
-        qCWarning(chatterinoTheme) << "Failed to parse" << file.fileName()
-                                   << "error:" << error.errorString();
-        return;
-    }
+    return themeNames;
+}
 
-    this->parseFrom(json.object());
+void Theme::loadAvailableThemes()
+{
+    this->availableThemes_ = Theme::builtInThemes;
+
+    auto dir = QDir(getPaths()->themesDirectory);
+    for (const auto &info :
+         dir.entryInfoList(QDir::Files | QDir::NoDotAndDotDot, QDir::Name))
+    {
+        if (!info.isFile())
+        {
+            continue;
+        }
+
+        if (!info.fileName().endsWith(".json"))
+        {
+            continue;
+        }
+
+        auto themeDescriptor = ThemeDescriptor{info.absoluteFilePath(), true};
+
+        auto theme = loadTheme(themeDescriptor);
+        if (!theme)
+        {
+            qCWarning(chatterinoTheme) << "Failed to parse theme at" << info;
+            continue;
+        }
+
+        auto themeName = info.baseName();
+
+        this->availableThemes_.emplace(themeName, themeDescriptor);
+    }
 }
 
 void Theme::parseFrom(const QJsonObject &root)

--- a/src/singletons/Theme.cpp
+++ b/src/singletons/Theme.cpp
@@ -213,7 +213,7 @@ void Theme::initialize(Settings &settings, Paths &paths)
 {
     this->themeName.connect(
         [this](auto themeName) {
-            qCDebug(chatterinoTheme) << "Theme updated to" << themeName;
+            qCInfo(chatterinoTheme) << "Theme updated to" << themeName;
             this->update();
         },
         false);

--- a/src/singletons/Theme.hpp
+++ b/src/singletons/Theme.hpp
@@ -8,6 +8,7 @@
 #include <QColor>
 #include <QJsonObject>
 #include <QPixmap>
+#include <QString>
 #include <QVariant>
 
 #include <optional>

--- a/src/singletons/Theme.hpp
+++ b/src/singletons/Theme.hpp
@@ -10,8 +10,8 @@
 #include <QPixmap>
 #include <QVariant>
 
-#include <map>
 #include <optional>
+#include <vector>
 
 namespace chatterino {
 

--- a/src/singletons/Theme.hpp
+++ b/src/singletons/Theme.hpp
@@ -8,6 +8,7 @@
 #include <QColor>
 #include <QJsonObject>
 #include <QPixmap>
+#include <QVariant>
 
 #include <map>
 #include <optional>
@@ -17,17 +18,22 @@ namespace chatterino {
 class WindowManager;
 
 struct ThemeDescriptor {
+    QString key;
+
     // Path to the theme on disk
     // Can be a Qt resource path
     QString path;
 
-    bool custom;
+    // Name of the theme
+    QString name;
+
+    bool custom{};
 };
 
 class Theme final : public Singleton
 {
 public:
-    static const std::map<QString, ThemeDescriptor> builtInThemes;
+    static const std::vector<ThemeDescriptor> builtInThemes;
 
     // The built in theme that will be used if some theme parsing fails
     static const ThemeDescriptor fallbackTheme;
@@ -133,10 +139,8 @@ public:
 
     /**
      * Return a list of available themes
-     *
-     * Custom themes are prefixed with "Custom: "
      **/
-    QStringList availableThemeNames() const;
+    std::vector<std::pair<QString, QVariant>> availableThemes() const;
 
     pajlada::Signals::NoArgSignal updated;
 
@@ -145,7 +149,7 @@ public:
 private:
     bool isLight_ = false;
 
-    std::map<QString, ThemeDescriptor> availableThemes_;
+    std::vector<ThemeDescriptor> availableThemes_;
 
     /**
      * Figure out which themes are available in the Themes directory
@@ -153,6 +157,8 @@ private:
      * NOTE: This is currently not built to be reloadable
      **/
     void loadAvailableThemes();
+
+    std::optional<ThemeDescriptor> findThemeByKey(const QString &key);
 
     void parseFrom(const QJsonObject &root);
 

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -115,25 +115,17 @@ void GeneralPage::initLayout(GeneralPageView &layout)
 
     layout.addTitle("Interface");
 
-    // NOTE: Available theme names are only initialized on startup here
-    QStringList availableThemeNames = getApp()->themes->availableThemeNames();
-
     layout.addDropdown<QString>(
-        "Theme", availableThemeNames, getApp()->themes->themeName,
-        [](auto val) {
-            if (!Theme::builtInThemes.contains(val))
-            {
-                return QString("Custom: %1").arg(val);
-            }
-
-            return val;
+        "Theme", getApp()->themes->availableThemes(),
+        getApp()->themes->themeName,
+        [](ComboBox *combo,
+           const QString &themeKey) -> boost::variant<int, QString> {
+            return combo->findData(themeKey, Qt::UserRole);
         },
-        [](const DropdownArgs &args) {
-            // Remove "Custom: " prefix from the dropdown
-            // XXX: This should be a regex or "trim prefix"
-            QString value = args.value;
-            return value.replace("Custom: ", "");
-        });
+        [](const DropdownArgs &args) -> QString {
+            return args.combobox->itemData(args.index, Qt::UserRole).toString();
+        },
+        "Theme", Theme::fallbackTheme.name);
 
     layout.addDropdown<QString>(
         "Font", {"Segoe UI", "Arial", "Choose..."},

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -118,11 +118,10 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     layout.addDropdown<QString>(
         "Theme", getApp()->themes->availableThemes(),
         getApp()->themes->themeName,
-        [](ComboBox *combo,
-           const QString &themeKey) -> boost::variant<int, QString> {
+        [](const auto *combo, const auto &themeKey) {
             return combo->findData(themeKey, Qt::UserRole);
         },
-        [](const DropdownArgs &args) -> QString {
+        [](const auto &args) {
             return args.combobox->itemData(args.index, Qt::UserRole).toString();
         },
         "Theme", Theme::fallbackTheme.name);

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -114,8 +114,27 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     auto &s = *getSettings();
 
     layout.addTitle("Interface");
-    layout.addDropdown("Theme", {"White", "Light", "Dark", "Black"},
-                       getApp()->themes->themeName);
+
+    // NOTE: Available theme names are only initialized on startup here
+    QStringList availableThemeNames = getApp()->themes->availableThemeNames();
+
+    layout.addDropdown<QString>(
+        "Theme", availableThemeNames, getApp()->themes->themeName,
+        [](auto val) {
+            if (!Theme::builtInThemes.contains(val))
+            {
+                return QString("Custom: %1").arg(val);
+            }
+
+            return val;
+        },
+        [](const DropdownArgs &args) {
+            // Remove "Custom: " prefix from the dropdown
+            // XXX: This should be a regex or "trim prefix"
+            QString value = args.value;
+            return value.replace("Custom: ", "");
+        });
+
     layout.addDropdown<QString>(
         "Font", {"Segoe UI", "Arial", "Choose..."},
         getApp()->fonts->chatFontFamily,

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -124,7 +124,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         [](const auto &args) {
             return args.combobox->itemData(args.index, Qt::UserRole).toString();
         },
-        "Theme", Theme::fallbackTheme.name);
+        {}, Theme::fallbackTheme.name);
 
     layout.addDropdown<QString>(
         "Font", {"Segoe UI", "Arial", "Choose..."},


### PR DESCRIPTION
# Description

This loads themes (any .json file) from the <chatterino appdata>/Themes directory on startup and lists those in the settings page.
The custom themes in that directory will have a _Custom:_ prefix to show that they're custom.
In the settingsfile, we save the name of the theme (e.g. 'forsen', no more info).

When the theme is updated or on Chatterino startup, we find the best matching theme with that name, whether it's a built in theme or a custom theme.

There's currently no mechanism for making a theme that has the same name as a built in theme, and they still show up in the menu. IMO we should just not allow duplicate names for simplicity's sake.

There's a few things left to do, and a few things to discuss before taking this step, even though I still deem it to be "pre-production" even when this PR is merged in.

The changelog entry is left as a Dev entry on purpose since I don't think this is a feature that should be fully announced until there's more testing & better UX for users.

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
