### PR TITLE
Add changelog link to appdata file

### DIFF
--- a/resources/com.chatterino.chatterino.appdata.xml
+++ b/resources/com.chatterino.chatterino.appdata.xml
@@ -32,6 +32,11 @@
         <binary>chatterino</binary>
     </provides>
     <releases>
-        <release version="2.4.2" date="2023-03-05"/>
+        <release version="2.4.2" date="2023-03-05">
+            <description>
+                <p>See the website for the changelog:</p>
+                <p>https://chatterino.com/changelog</p>
+            </description>
+        </release>
     </releases>
 </component>


### PR DESCRIPTION
# Description
This PR adds a `description` field to the release in the appdata file. This field is used by Linux app stores and Flathub to display release information, e.g. the changes section [here](https://flathub.org/apps/com.chatterino.chatterino).

Maintaining a full changelog there probably doesn't make sense as it would have to be manually updated every release, so I think it's enough to simply have a link to the actual changelog there.

~~EDIT: does this require a changelog entry? :D~~