### PR TITLE
Fix crash when using /unstable-set-user-color without any arguments

### DIFF
--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -3190,13 +3190,15 @@ void CommandController::initialize(Settings &, Paths &paths)
                                   "works in Twitch channels"));
             return "";
         }
-        auto userID = ctx.words.at(1);
         if (ctx.words.size() < 2)
         {
             ctx.channel->addMessage(
                 makeSystemMessage(QString("Usage: %1 <TwitchUserID> [color]")
                                       .arg(ctx.words.at(0))));
+            return "";
         }
+
+        auto userID = ctx.words.at(1);
 
         auto color = ctx.words.value(2);
 


### PR DESCRIPTION
# Description

I told you it was unstable

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
