### PR TITLE
Fix Linux appdata file

### DIFF
--- a/resources/com.chatterino.chatterino.appdata.xml
+++ b/resources/com.chatterino.chatterino.appdata.xml
@@ -33,10 +33,7 @@
     </provides>
     <releases>
         <release version="2.4.2" date="2023-03-05">
-            <description>
-                <p>See the website for the changelog:</p>
-                <p>https://chatterino.com/changelog</p>
-            </description>
+            <url>https://github.com/Chatterino/chatterino2/releases/tag/v2.4.2</url>
         </release>
     </releases>
 </component>


### PR DESCRIPTION
# Description

Unfortunately the changes in #4573 were not actually valid, as you aren't allowed to put urls in `description`, causing Flatpak builds to fail:
```
builddir/files/share/appdata/com.chatterino.chatterino.appdata.xml: FAILED:
• style-invalid         : <release> description should be prose and not contain hyperlinks [<p>See the website for the changelog:</p><p>https://chatterino.com/changelog</p>]
```
This changes the file to link to the release in the `url` field. It doesn't seem to be possible to link to a specific version on https://chatterino.com/changelog, so it's linking to a Github release instead.