### PR TITLE
Allow for local macOS signed builds

### DIFF
--- a/.CI/CreateDMG.sh
+++ b/.CI/CreateDMG.sh
@@ -21,6 +21,12 @@ if [ -z "$SKIP_VENV" ]; then
     python3 -m pip install dmgbuild
 fi
 
+if [ -n "$MACOS_CODESIGN_CERTIFICATE" ]; then
+    echo "Codesigning force deep inside the app"
+    codesign -s "$MACOS_CODESIGN_CERTIFICATE" --deep --force chatterino.app
+    echo "Done!"
+fi
+
 echo "Running dmgbuild.."
 dmgbuild --settings ./../.CI/dmg-settings.py -D app=./chatterino.app Chatterino2 "$OUTPUT_DMG_PATH"
 echo "Done!"

--- a/.CI/CreateDMG.sh
+++ b/.CI/CreateDMG.sh
@@ -7,6 +7,11 @@ if [ -d bin/chatterino.app ] && [ ! -d chatterino.app ]; then
     mv bin/chatterino.app chatterino.app
 fi
 
+if [ -z "$OUTPUT_DMG_PATH" ]; then
+    echo "ERROR: Must specify the path for where to save the final .dmg"
+    exit 1
+fi
+
 if [ -n "$Qt5_DIR" ]; then
     echo "Using Qt DIR from Qt5_DIR: $Qt5_DIR"
     _QT_DIR="$Qt5_DIR"
@@ -45,14 +50,12 @@ if [ -z "$SKIP_VENV" ]; then
     python3 -m pip install dmgbuild
 fi
 
-_dmg_path="chatterino-macos-Qt-$1.dmg"
-
 echo "Running dmgbuild.."
-dmgbuild --settings ./../.CI/dmg-settings.py -D app=./chatterino.app Chatterino2 "$_dmg_path"
+dmgbuild --settings ./../.CI/dmg-settings.py -D app=./chatterino.app Chatterino2 "$OUTPUT_DMG_PATH"
 echo "Done!"
 
 if [ -n "$MACOS_CODESIGN_CERTIFICATE" ]; then
     echo "Codesigning the dmg"
-    codesign -s "$MACOS_CODESIGN_CERTIFICATE" --deep "$_dmg_path"
+    codesign -s "$MACOS_CODESIGN_CERTIFICATE" --deep "$OUTPUT_DMG_PATH"
     echo "Done!"
 fi

--- a/.CI/CreateDMG.sh
+++ b/.CI/CreateDMG.sh
@@ -8,7 +8,7 @@ if [ ! -d chatterino.app ]; then
 fi
 
 if [ -z "$OUTPUT_DMG_PATH" ]; then
-    echo "ERROR: Must specify the path for where to save the final .dmg"
+    echo "ERROR: Must specify the path for where to save the final .dmg. Make sure you've set the OUTPUT_DMG_PATH environment variable."
     exit 1
 fi
 

--- a/.CI/CreateDMG.sh
+++ b/.CI/CreateDMG.sh
@@ -27,6 +27,6 @@ echo "Done!"
 
 if [ -n "$MACOS_CODESIGN_CERTIFICATE" ]; then
     echo "Codesigning the dmg"
-    codesign -s "$MACOS_CODESIGN_CERTIFICATE" --deep "$OUTPUT_DMG_PATH"
+    codesign -s "$MACOS_CODESIGN_CERTIFICATE" --deep --force "$OUTPUT_DMG_PATH"
     echo "Done!"
 fi

--- a/.CI/CreateDMG.sh
+++ b/.CI/CreateDMG.sh
@@ -2,43 +2,14 @@
 
 set -eo pipefail
 
-if [ -d bin/chatterino.app ] && [ ! -d chatterino.app ]; then
-    >&2 echo "Moving bin/chatterino.app down one directory"
-    mv bin/chatterino.app chatterino.app
+if [ ! -d chatterino.app ]; then
+    echo "ERROR: No 'chatterino.app' dir found in the build directory. Make sure you've run ./CI/MacDeploy.sh"
+    exit 1
 fi
 
 if [ -z "$OUTPUT_DMG_PATH" ]; then
     echo "ERROR: Must specify the path for where to save the final .dmg"
     exit 1
-fi
-
-if [ -n "$Qt5_DIR" ]; then
-    echo "Using Qt DIR from Qt5_DIR: $Qt5_DIR"
-    _QT_DIR="$Qt5_DIR"
-elif [ -n "$Qt6_DIR" ]; then
-    echo "Using Qt DIR from Qt6_DIR: $Qt6_DIR"
-    _QT_DIR="$Qt6_DIR"
-fi
-
-if [ -n "$_QT_DIR" ]; then
-    export PATH="${_QT_DIR}/bin:$PATH"
-else
-    echo "No Qt environment variable set, assuming system-installed Qt"
-fi
-
-echo "Running MACDEPLOYQT"
-
-_macdeployqt_args=()
-
-if [ -n "$MACOS_CODESIGN_CERTIFICATE" ]; then
-    _macdeployqt_args+=("-codesign=$MACOS_CODESIGN_CERTIFICATE")
-fi
-
-macdeployqt chatterino.app "${_macdeployqt_args[@]}"
-
-if [ -n "$MACOS_CODESIGN_CERTIFICATE" ]; then
-    # Validate that chatterino.app was codesigned correctly
-    codesign -v chatterino.app
 fi
 
 if [ -z "$SKIP_VENV" ]; then

--- a/.CI/CreateDMG.sh
+++ b/.CI/CreateDMG.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 if [ -d bin/chatterino.app ] && [ ! -d chatterino.app ]; then
     >&2 echo "Moving bin/chatterino.app down one directory"
     mv bin/chatterino.app chatterino.app

--- a/.CI/CreateDMG.sh
+++ b/.CI/CreateDMG.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 if [ -d bin/chatterino.app ] && [ ! -d chatterino.app ]; then
     >&2 echo "Moving bin/chatterino.app down one directory"
@@ -20,7 +20,14 @@ else
 fi
 
 echo "Running MACDEPLOYQT"
-macdeployqt chatterino.app
+
+_macdeployqt_args=()
+
+if [ -n "$MACDEPLOYQT_CODESIGN" ]; then
+    _macdeployqt_args+=("-codesign=$MACDEPLOYQT_CODESIGN")
+fi
+
+macdeployqt chatterino.app "${_macdeployqt_args[@]}"
 
 if [ -z "$SKIP_VENV" ]; then
     echo "Creating python3 virtual environment"

--- a/.CI/CreateDMG.sh
+++ b/.CI/CreateDMG.sh
@@ -53,6 +53,6 @@ echo "Done!"
 
 if [ -n "$MACOS_CODESIGN_CERTIFICATE" ]; then
     echo "Codesigning the dmg"
-    codesign -s --deep "$MACOS_CODESIGN_CERTIFICATE"
+    codesign -s "$MACOS_CODESIGN_CERTIFICATE" --deep "$_dmg_path"
     echo "Done!"
 fi

--- a/.CI/MacDeploy.sh
+++ b/.CI/MacDeploy.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Bundle relevant qt & system dependencies into the ./chatterino.app folder
+
+set -eo pipefail
+
+if [ -d bin/chatterino.app ] && [ ! -d chatterino.app ]; then
+    >&2 echo "Moving bin/chatterino.app down one directory"
+    mv bin/chatterino.app chatterino.app
+fi
+
+if [ -n "$Qt5_DIR" ]; then
+    echo "Using Qt DIR from Qt5_DIR: $Qt5_DIR"
+    _QT_DIR="$Qt5_DIR"
+elif [ -n "$Qt6_DIR" ]; then
+    echo "Using Qt DIR from Qt6_DIR: $Qt6_DIR"
+    _QT_DIR="$Qt6_DIR"
+fi
+
+if [ -n "$_QT_DIR" ]; then
+    export PATH="${_QT_DIR}/bin:$PATH"
+else
+    echo "No Qt environment variable set, assuming system-installed Qt"
+fi
+
+echo "Running MACDEPLOYQT"
+
+_macdeployqt_args=()
+
+if [ -n "$MACOS_CODESIGN_CERTIFICATE" ]; then
+    _macdeployqt_args+=("-codesign=$MACOS_CODESIGN_CERTIFICATE")
+fi
+
+macdeployqt chatterino.app "${_macdeployqt_args[@]}"
+
+if [ -n "$MACOS_CODESIGN_CERTIFICATE" ]; then
+    # Validate that chatterino.app was codesigned correctly
+    codesign -v chatterino.app
+fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -343,8 +343,8 @@ jobs:
           pwd
           ls -la build || true
           cd build
-          sh ./../.CI/MacDeploy.sh
-          sh ./../.CI/CreateDMG.sh
+          ./../.CI/MacDeploy.sh
+          ./../.CI/CreateDMG.sh
         shell: bash
 
       - name: Upload artifact (MacOS)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -337,7 +337,7 @@ jobs:
       - name: Package (MacOS)
         if: startsWith(matrix.os, 'macos')
         env:
-          OUTPUT_DMG_PATH: chatterino-macos-qt-${{ matrix.qt-version}}.dmg
+          OUTPUT_DMG_PATH: chatterino-macos-Qt-${{ matrix.qt-version}}.dmg
         run: |
           ls -la
           pwd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -441,7 +441,7 @@ jobs:
       - name: Create release
         uses: ncipollo/release-action@v1.12.0
         with:
-          removeArtifacts: true
+          replacesArtifacts: true
           allowUpdates: true
           artifactErrorsFailBuild: true
           artifacts: "release-artifacts/*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -336,12 +336,14 @@ jobs:
 
       - name: Package (MacOS)
         if: startsWith(matrix.os, 'macos')
+        env:
+          OUTPUT_DMG_PATH: chatterino-macos-qt-${{ matrix.qt-version}}.dmg
         run: |
           ls -la
           pwd
           ls -la build || true
           cd build
-          sh ./../.CI/CreateDMG.sh ${{ matrix.qt-version }}
+          sh ./../.CI/CreateDMG.sh
         shell: bash
 
       - name: Upload artifact (MacOS)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -343,6 +343,7 @@ jobs:
           pwd
           ls -la build || true
           cd build
+          sh ./../.CI/MacDeploy.sh
           sh ./../.CI/CreateDMG.sh
         shell: bash
 

--- a/src/common/Version.cpp
+++ b/src/common/Version.cpp
@@ -25,7 +25,7 @@ Version::Version()
         QString(FROM_EXTERNAL_DEFINE(CHATTERINO_CMAKE_GEN_DATE)).remove('"');
 #endif
 
-    this->fullVersion_ = "TEST 1 Chatterino ";
+    this->fullVersion_ = "Chatterino ";
     if (Modes::instance().isNightly)
     {
         this->fullVersion_ += "Nightly ";


### PR DESCRIPTION
# Description

Split up the CreateDMG.sh macos script to two scripts:
MacDeploy.sh - this calls macdeployqt on the built app
CreateDMG.sh - this calls dmgbuild on the built & deployed app

Add a `SKIP_VENV` environment variable to CreateDMG.sh, this can be used to use the system version of dmgbuild
Add the ability to codesign the created dmg and its contents using the `MACOS_CODESIGN_CERTIFICATE` environment variable
Moved the output name logic from CreateDMG to the `OUTPUT_DMG_PATH` environment variable

The nightly release create job also doesn't remove artifacts now, it only replaces artifacts that are conflicting.
The downside to this is that if we change the name of an artifact, we need to manually delete the old artifact.
The upside to this is that we can now upload artifacts that are not handled in the same CI job.

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
