### PR TITLE
Improve error messages when updater fails a download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unversioned
 
+- Dev: Improve debug output when updater fails. (#4594)
+- Dev: Add the ability to control the `followRedirect` mode for requests. (#4594)
+
 ## Slated for 2.4.3
 
 - Bugfix: Fixed the menu warping on macOS on Qt6. (#4595)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 ## Slated for 2.4.3
 
+- Minor: Improved error messages when updater fails a download. (#4594)
 - Bugfix: Fixed the menu warping on macOS on Qt6. (#4595)
 - Bugfix: Fixed link tooltips not showing unless the thumbnail setting was enabled. (#4597)
-- Dev: Improve debug output when updater fails. (#4594)
-- Dev: Add the ability to control the `followRedirect` mode for requests. (#4594)
+- Dev: Added the ability to control the `followRedirect` mode for requests. (#4594)
 
 ## 2.4.3 Beta
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,11 @@
 
 ## Unversioned
 
-- Dev: Improve debug output when updater fails. (#4594)
-- Dev: Add the ability to control the `followRedirect` mode for requests. (#4594)
-
 ## Slated for 2.4.3
 
 - Bugfix: Fixed the menu warping on macOS on Qt6. (#4595)
+- Dev: Improve debug output when updater fails. (#4594)
+- Dev: Add the ability to control the `followRedirect` mode for requests. (#4594)
 
 ## 2.4.3 Beta
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Slated for 2.4.3
 
-- Minor: Improved error messages when updater fails a download. (#4594)
+- Minor: Improved error messages when the updater fails a download. (#4594)
 - Bugfix: Fixed the menu warping on macOS on Qt6. (#4595)
 - Bugfix: Fixed link tooltips not showing unless the thumbnail setting was enabled. (#4597)
 - Dev: Added the ability to control the `followRedirect` mode for requests. (#4594)

--- a/src/common/NetworkRequest.cpp
+++ b/src/common/NetworkRequest.cpp
@@ -150,6 +150,24 @@ NetworkRequest NetworkRequest::multiPart(QHttpMultiPart *payload) &&
     return std::move(*this);
 }
 
+NetworkRequest NetworkRequest::followRedirects(bool on) &&
+{
+    if (on)
+    {
+        this->data->request_.setAttribute(
+            QNetworkRequest::RedirectPolicyAttribute,
+            QNetworkRequest::NoLessSafeRedirectPolicy);
+    }
+    else
+    {
+        this->data->request_.setAttribute(
+            QNetworkRequest::RedirectPolicyAttribute,
+            QNetworkRequest::ManualRedirectPolicy);
+    }
+
+    return std::move(*this);
+}
+
 NetworkRequest NetworkRequest::payload(const QByteArray &payload) &&
 {
     this->data->payload_ = payload;

--- a/src/common/NetworkRequest.hpp
+++ b/src/common/NetworkRequest.hpp
@@ -65,7 +65,7 @@ public:
      * This will change `RedirectPolicyAttribute`.
      * `QNetworkRequest`'s defaults are used by default (Qt 5: no-follow, Qt 6: follow).
      */
-    NetworkRequest followRedirects(bool on = true) &&;
+    NetworkRequest followRedirects(bool on) &&;
 
     void execute();
 

--- a/src/common/NetworkRequest.hpp
+++ b/src/common/NetworkRequest.hpp
@@ -61,6 +61,11 @@ public:
     NetworkRequest authorizeTwitchV5(const QString &clientID,
                                      const QString &oauthToken = QString()) &&;
     NetworkRequest multiPart(QHttpMultiPart *payload) &&;
+    /**
+     * This will change `RedirectPolicyAttribute`.
+     * `QNetworkRequest`'s defaults are used by default (Qt 5: no-follow, Qt 6: follow).
+     */
+    NetworkRequest followRedirects(bool on = true) &&;
 
     void execute();
 

--- a/src/singletons/Updates.cpp
+++ b/src/singletons/Updates.cpp
@@ -195,7 +195,7 @@ void Updates::installUpdates()
                     this->setStatus_(WriteFileFailed);
                     execMessageBox(
                         "Failed to save the update file. This could be due to "
-                        "window settings or antivirus software.\n\nTry "
+                        "Windows settings or antivirus software.\n\nTry "
                         "manually downloading the update.");
 
                     QDesktopServices::openUrl(this->updateExe_);
@@ -212,7 +212,7 @@ void Updates::installUpdates()
                 {
                     execMessageBox(
                         "Failed to execute update binary. This could be due to "
-                        "window settings or antivirus software.\n\nTry "
+                        "Windows settings or antivirus software.\n\nTry "
                         "manually downloading the update.");
 
                     QDesktopServices::openUrl(this->updateExe_);

--- a/src/singletons/Updates.cpp
+++ b/src/singletons/Updates.cpp
@@ -278,52 +278,56 @@ void Updates::checkForUpdates()
     NetworkRequest(url)
         .timeout(60000)
         .onSuccess([this](auto result) -> Outcome {
-            auto object = result.parseJson();
+            const auto object = result.parseJson();
             /// Version available on every platform
-            QJsonValue version_val = object.value("version");
+            auto version = object["version"];
 
-            if (!version_val.isString())
+            if (!version.isString())
             {
                 this->setStatus_(SearchFailed);
-                qCDebug(chatterinoUpdate) << "error updating";
+                qCDebug(chatterinoUpdate)
+                    << "error checking version - missing 'version'" << object;
                 return Failure;
             }
 
 #if defined Q_OS_WIN || defined Q_OS_MACOS
             /// Downloads an installer for the new version
-            QJsonValue updateExe_val = object.value("updateexe");
-            if (!updateExe_val.isString())
+            auto updateExeUrl = object["updateexe"];
+            if (!updateExeUrl.isString())
             {
                 this->setStatus_(SearchFailed);
-                qCDebug(chatterinoUpdate) << "error updating";
+                qCDebug(chatterinoUpdate)
+                    << "error checking version - missing 'updateexe'" << object;
                 return Failure;
             }
-            this->updateExe_ = updateExe_val.toString();
+            this->updateExe_ = updateExeUrl.toString();
 
 #    ifdef Q_OS_WIN
             /// Windows portable
-            QJsonValue portable_val = object.value("portable_download");
-            if (!portable_val.isString())
+            auto portableUrl = object["portable_download"];
+            if (!portableUrl.isString())
             {
                 this->setStatus_(SearchFailed);
-                qCDebug(chatterinoUpdate) << "error updating";
+                qCDebug(chatterinoUpdate)
+                    << "error checking version - missing 'portable_download'"
+                    << object;
                 return Failure;
             }
-            this->updatePortable_ = portable_val.toString();
+            this->updatePortable_ = portableUrl.toString();
 #    endif
 
 #elif defined Q_OS_LINUX
-            QJsonValue updateGuide_val = object.value("updateguide");
-            if (updateGuide_val.isString())
+            QJsonValue updateGuide = object.value("updateguide");
+            if (updateGuide.isString())
             {
-                this->updateGuideLink_ = updateGuide_val.toString();
+                this->updateGuideLink_ = updateGuide.toString();
             }
 #else
             return Failure;
 #endif
 
             /// Current version
-            this->onlineVersion_ = version_val.toString();
+            this->onlineVersion_ = version.toString();
 
             /// Update available :)
             if (this->currentVersion_ != this->onlineVersion_)

--- a/src/singletons/Updates.cpp
+++ b/src/singletons/Updates.cpp
@@ -256,7 +256,6 @@ void Updates::checkForUpdates()
 
     NetworkRequest(url)
         .timeout(60000)
-        .followRedirects()
         .onSuccess([this](auto result) -> Outcome {
             const auto object = result.parseJson();
             /// Version available on every platform


### PR DESCRIPTION
# Description

Context: https://github.com/SevenTV/chatterino7/issues/219.

* Downloads from the updater now follow redirects.
* A dialog is shown when the HTTP status isn't 200.
* Dialogs are simplified.

(I couldn't think of a good title)