### PR TITLE
Fix the menu position on macOS when using Qt 6.5

### DIFF
--- a/src/widgets/helper/Button.cpp
+++ b/src/widgets/helper/Button.cpp
@@ -348,27 +348,24 @@ void Button::showMenu()
     if (!this->menu_)
         return;
 
-    auto point = [this] {
-        auto point = this->mapToGlobal(
-            QPoint(this->width() - this->menu_->width(), this->height()));
+    auto menuSizeHint = this->menu_->sizeHint();
+    auto point = this->mapToGlobal(
+        QPoint(this->width() - menuSizeHint.width(), this->height()));
 
-        auto *screen = QApplication::screenAt(point);
-        if (screen == nullptr)
-        {
-            screen = QApplication::primaryScreen();
-        }
-        auto bounds = screen->availableGeometry();
+    auto *screen = QApplication::screenAt(point);
+    if (screen == nullptr)
+    {
+        screen = QApplication::primaryScreen();
+    }
+    auto bounds = screen->availableGeometry();
 
-        if (point.y() + this->menu_->height() > bounds.bottom())
-        {
-            point.setY(point.y() - this->menu_->height() - this->height());
-        }
+    if (point.y() + menuSizeHint.height() > bounds.bottom())
+    {
+        // Menu doesn't fit going down, flip it to go up instead
+        point.setY(point.y() - menuSizeHint.height() - this->height());
+    }
 
-        return point;
-    };
-
-    this->menu_->popup(point());
-    this->menu_->move(point());
+    this->menu_->popup(point);
     this->menuVisible_ = true;
 }
 


### PR DESCRIPTION
# Description

Reported in Discord by Trummler - see video: https://cdn.discordapp.com/attachments/459650160658481152/1103008038576721921/Bildschirmaufnahme_2023-05-02_um_19.19.36.mov

This happened because we called popup then move on the menu, and the position was only correct when the move call was called because the size had not yet been evaluated in the menu.
Instead, when figuring out the position, we now use the menu's sizehint which should be correct even before the menu is ever shown.

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
