### PR TITLE
Revert "Dim disabled items in context menus (#4423)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,6 @@
 - Bugfix: Fixed emote & badge tooltips not showing up when thumbnails were hidden. (#4509)
 - Bugfix: Fixed links with invalid IPv4 addresses being parsed. (#4576)
 - Bugfix: Fixed the macOS icon changing to the wrong icon when the application is open. (#4577)
-- Bugfix: Fixed disabled items in context-menus having a weird text-effect or the default text color. (#4423)
 - Dev: Disabling precompiled headers on Windows is now tested in CI. (#4472)
 - Dev: Themes are now stored as JSON files in `resources/themes`. (#4471, #4533)
 - Dev: Ignore unhandled BTTV user-events. (#4438)

--- a/resources/qss/settings.qss
+++ b/resources/qss/settings.qss
@@ -66,14 +66,3 @@ chatterino--NavigationLabel {
     font-size: 15px;
     color: #A6DDF4;
 }
-
-QMenu {
-    background: #242424;
-    border: #555555;
-    color: #ffffff;
-    selection-background-color: #555555;
-}
-
-QMenu::item:disabled {
-    color: #8c7f7f;
-}

--- a/src/singletons/Theme.cpp
+++ b/src/singletons/Theme.cpp
@@ -212,14 +212,6 @@ void Theme::parseFrom(const QJsonObject &root)
         (this->isLightTheme() ? "#68B1FF"
                               : this->tabs.selected.backgrounds.regular.name());
 
-    this->window.contextMenuStyleSheet =
-        QStringLiteral("QMenu { background: %1; border: %2; color: %3; "
-                       "selection-background-color: %2; } "
-                       "QMenu::item:disabled { color: #8c7f7f; }")
-            .arg(splits.input.background.name(QColor::HexArgb),
-                 tabs.selected.backgrounds.regular.name(QColor::HexArgb),
-                 tabs.selected.text.name(QColor::HexArgb));
-
     // Usercard buttons
     if (this->isLightTheme())
     {

--- a/src/singletons/Theme.hpp
+++ b/src/singletons/Theme.hpp
@@ -39,8 +39,6 @@ public:
     struct {
         QColor background;
         QColor text;
-
-        QString contextMenuStyleSheet;
     } window;
 
     /// TABS

--- a/src/widgets/BaseWindow.cpp
+++ b/src/widgets/BaseWindow.cpp
@@ -292,11 +292,6 @@ bool BaseWindow::supportsCustomWindowFrame()
 
 void BaseWindow::themeChangedEvent()
 {
-    if (!this->flags_.has(BaseWindow::DisableStyleSheet))
-    {
-        this->setStyleSheet(this->theme->window.contextMenuStyleSheet);
-    }
-
     if (this->hasCustomWindowFrame())
     {
         QPalette palette;

--- a/src/widgets/BaseWindow.hpp
+++ b/src/widgets/BaseWindow.hpp
@@ -24,17 +24,16 @@ class BaseWindow : public BaseWidget
     Q_OBJECT
 
 public:
-    enum Flags : uint32_t {
+    enum Flags {
         None = 0,
         EnableCustomFrame = 1,
-        Frameless = (1 << 1),
-        TopMost = (1 << 2),
-        DisableCustomScaling = (1 << 3),
-        FramelessDraggable = (1 << 4),
-        DontFocus = (1 << 5),
-        Dialog = (1 << 6),
-        DisableLayoutSave = (1 << 7),
-        DisableStyleSheet = (1 << 8),
+        Frameless = 2,
+        TopMost = 4,
+        DisableCustomScaling = 8,
+        FramelessDraggable = 16,
+        DontFocus = 32,
+        Dialog = 64,
+        DisableLayoutSave = 128,
     };
 
     enum ActionOnFocusLoss { Nothing, Delete, Close, Hide };

--- a/src/widgets/dialogs/SettingsDialog.cpp
+++ b/src/widgets/dialogs/SettingsDialog.cpp
@@ -29,10 +29,9 @@
 namespace chatterino {
 
 SettingsDialog::SettingsDialog(QWidget *parent)
-    : BaseWindow(
-          {BaseWindow::Flags::DisableCustomScaling, BaseWindow::Flags::Dialog,
-           BaseWindow::DisableLayoutSave, BaseWindow::DisableStyleSheet},
-          parent)
+    : BaseWindow({BaseWindow::Flags::DisableCustomScaling,
+                  BaseWindow::Flags::Dialog, BaseWindow::DisableLayoutSave},
+                 parent)
 {
     this->setObjectName("SettingsDialog");
     this->setWindowTitle("Chatterino Settings");


### PR DESCRIPTION
# Description

This reverts commit 642718474c19479208482e08ad61dbf0a42089d2.

The commit is being reverted because it had some consequences that we didn't notice during the PR testing, so we're waiting to include the changes later with some more testing.

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
