### PR TITLE
Fix link tooltips showing up blank instead of with text-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## Slated for 2.4.3
 
 - Bugfix: Fixed the menu warping on macOS on Qt6. (#4595)
-- Bugfix: Fixed link tooltips not showing unless the thumbnail setting as enabled. (#4597)
+- Bugfix: Fixed link tooltips not showing unless the thumbnail setting was enabled. (#4597)
 
 ## 2.4.3 Beta
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Slated for 2.4.3
 
 - Bugfix: Fixed the menu warping on macOS on Qt6. (#4595)
+- Bugfix: Fixed link tooltips not showing unless the thumbnail setting as enabled. (#4597)
 
 ## 2.4.3 Beta
 

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1774,9 +1774,10 @@ void ChannelView::mouseMoveEvent(QMouseEvent *event)
                     });
             }
             auto thumbnailSize = getSettings()->thumbnailSize;
-            if (!thumbnailSize)
+            if (thumbnailSize == 0)
             {
-                tooltipWidget->clearEntries();
+                // "Show thumbnails" is set to "Off", show text only
+                tooltipWidget->setOne({nullptr, element->getTooltip()});
             }
             else
             {


### PR DESCRIPTION
# Description

Fixes #4593

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
