### PR TITLE
Parse Domains Starting With `http`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+- Bugfix: Domains starting with `http` are now parsed as links again. (#4598)
+
 ## Slated for 2.4.3
 
 - Bugfix: Fixed the menu warping on macOS on Qt6. (#4595)

--- a/src/common/LinkParser.cpp
+++ b/src/common/LinkParser.cpp
@@ -137,16 +137,18 @@ LinkParser::LinkParser(const QString &unparsedString)
     if (remaining.startsWith(QStringLiteral("http"), Qt::CaseInsensitive) &&
         remaining.length() >= 4 + 3 + 1)  // 'http' + '://' + [any]
     {
-        remaining = remaining.mid(4);  // 'http'
+        // optimistic view assuming there's a protocol (http or https)
+        auto withProto = remaining.mid(4);  // 'http'
 
-        if (remaining[0] == QChar(u's') || remaining[0] == QChar(u'S'))
+        if (withProto[0] == QChar(u's') || withProto[0] == QChar(u'S'))
         {
-            remaining = remaining.mid(1);
+            withProto = withProto.mid(1);
         }
 
-        if (remaining.startsWith(QStringLiteral("://")))
+        if (withProto.startsWith(QStringLiteral("://")))
         {
-            remaining = remaining.mid(3);
+            // there's really a protocol => consume it
+            remaining = withProto.mid(3);
 #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
             result.protocol = {protocol.begin(), remaining.begin()};
 #else

--- a/tests/src/LinkParser.cpp
+++ b/tests/src/LinkParser.cpp
@@ -50,7 +50,10 @@ TEST(LinkParser, parseDomainLinks)
         {"https://", "127.0.0.1.com"},
         {"https://", "http.cat", "/200"},
         {"https://", "http.cat"},
+        {"", "http.cat", ":8080"},
         {"", "http.cat"},
+        {"", "https.cat"},
+        {"", "httpsd.cat"},
         {"", "http.cat", "/200"},
         // test case-insensitiveness
         {"HtTpS://", "127.0.0.1.CoM"},
@@ -157,6 +160,11 @@ TEST(LinkParser, doesntParseInvalidLinks)
         "pn.",
         "http/chatterino.com",
         "http/wiki.chatterino.com",
+        "http:cat.com",
+        "https:cat.com",
+        "http:/cat.com",
+        "http:/cat.com",
+        "https:/cat.com",
     };
 
     for (const auto &input : inputs)

--- a/tests/src/LinkParser.cpp
+++ b/tests/src/LinkParser.cpp
@@ -48,6 +48,10 @@ TEST(LinkParser, parseDomainLinks)
         {"", "1.com"},
         {"", "127.0.0.1.com"},
         {"https://", "127.0.0.1.com"},
+        {"https://", "http.cat", "/200"},
+        {"https://", "http.cat"},
+        {"", "http.cat"},
+        {"", "http.cat", "/200"},
         // test case-insensitiveness
         {"HtTpS://", "127.0.0.1.CoM"},
         {"HTTP://", "XD.CHATTERINO.COM", "/#?FOO"},
@@ -146,6 +150,13 @@ TEST(LinkParser, doesntParseInvalidLinks)
         "a",
         "://chatterino.com",
         "//chatterino.com",
+        "http://pn.",
+        "http://pn./",
+        "https://pn./",
+        "pn./",
+        "pn.",
+        "http/chatterino.com",
+        "http/wiki.chatterino.com",
     };
 
     for (const auto &input : inputs)


### PR DESCRIPTION
# Description

Domains starting with `http` were previously not parsed (see test-cases).
