### PR TITLE
Release v2.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,7 @@
 
 ## Unversioned
 
-## Slated for 2.4.3
-
-- Minor: Improved error messages when the updater fails a download. (#4594)
-- Bugfix: Fixed the menu warping on macOS on Qt6. (#4595)
-- Bugfix: Fixed link tooltips not showing unless the thumbnail setting was enabled. (#4597)
-- Dev: Added the ability to control the `followRedirect` mode for requests. (#4594)
-
-## 2.4.3 Beta
+## 2.4.4
 
 - Major: Added support for FrankerFaceZ animated emotes. (#4434)
 - Minor: Added the ability to reply to a message by `Shift + Right Click`ing the username. (#4424)
@@ -22,6 +15,7 @@
 - Minor: Re-added leading @mentions from replies in chat logs. These were accidentally removed during the reply overhaul. (#4420)
 - Minor: Added a local backup of the Twitch Badges API in case the request fails. (#4463)
 - Minor: Updated the macOS icon to be consistent with the design of other applications on macOS. (#4577)
+- Minor: Improved error messages when the updater fails a download. (#4594)
 - Bugfix: Fixed an issue where Chatterino could lose track of the sound device in certain scenarios. (#4549)
 - Bugfix: Fixed an issue where animated emotes would render on top of zero-width emotes. (#4314)
 - Bugfix: Fixed an issue where it was difficult to hover a zero-width emote. (#4314)
@@ -36,6 +30,8 @@
 - Bugfix: Fixed emote & badge tooltips not showing up when thumbnails were hidden. (#4509)
 - Bugfix: Fixed links with invalid IPv4 addresses being parsed. (#4576)
 - Bugfix: Fixed the macOS icon changing to the wrong icon when the application is open. (#4577)
+- Bugfix: Fixed the menu warping on macOS on Qt6. (#4595)
+- Bugfix: Fixed link tooltips not showing unless the thumbnail setting was enabled. (#4597)
 - Dev: Disabling precompiled headers on Windows is now tested in CI. (#4472)
 - Dev: Themes are now stored as JSON files in `resources/themes`. (#4471, #4533)
 - Dev: Ignore unhandled BTTV user-events. (#4438)
@@ -52,6 +48,7 @@
 - Dev: Removed `CHATTERINO_TEST` definitions. (#4526)
 - Dev: Builds for macOS now have `macos` in their name (previously: `osx`). (#4550)
 - Dev: Fixed a crash when dragging rows in table-views in builds with Qt 6. (#4567)
+- Dev: Added the ability to control the `followRedirect` mode for requests. (#4594)
 
 ## 2.4.2
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ list(APPEND CMAKE_MODULE_PATH
     "${CMAKE_SOURCE_DIR}/cmake/sanitizers-cmake/cmake"
     )
 
-project(chatterino VERSION 2.4.3)
+project(chatterino VERSION 2.4.4)
 
 option(BUILD_APP "Build Chatterino" ON)
 option(BUILD_TESTS "Build the tests for Chatterino" OFF)

--- a/resources/com.chatterino.chatterino.appdata.xml
+++ b/resources/com.chatterino.chatterino.appdata.xml
@@ -32,8 +32,8 @@
         <binary>chatterino</binary>
     </provides>
     <releases>
-        <release version="2.4.3" date="2023-04-30">
-            <url>https://github.com/Chatterino/chatterino2/releases/tag/v2.4.3</url>
+        <release version="2.4.4" date="2023-05-03">
+            <url>https://github.com/Chatterino/chatterino2/releases/tag/v2.4.4</url>
         </release>
         <release version="2.4.2" date="2023-03-05">
             <url>https://github.com/Chatterino/chatterino2/releases/tag/v2.4.2</url>

--- a/src/common/Version.hpp
+++ b/src/common/Version.hpp
@@ -24,7 +24,7 @@
  *  - 2.4.0-alpha.2
  *  - 2.4.0-alpha
  **/
-#define CHATTERINO_VERSION "2.4.3"
+#define CHATTERINO_VERSION "2.4.4"
 
 #if defined(Q_OS_WIN)
 #    define CHATTERINO_OS "win"


### PR DESCRIPTION
# Description

## Checklist for making a release

- [x] Updated version code in `src/common/Version.hpp`
- [x] Updated version code in `CMakeLists.txt`  
       This can only be "whole versions", so if you're releasing `2.4.0-beta` you'll need to condense it to `2.4.0`
- [x] Updated version code in `resources/com.chatterino.chatterino.appdata.xml`  
       This cannot use dash to denote a pre-release identifier, you have to use a tilde instead.
- [x] Update the changelog `## Unreleased` section to the new version `CHANGELOG.md`  
       Make sure to leave the `## Unreleased` line unchanged for easier merges

Associated website PR to be merged in after artifacts have been fully uploaded: https://github.com/Chatterino/website/pull/182

## Artifacts

The artifacts that are different for this release that I'd like uploaded to the release bucket:

- **macOS** `Chatterino-universal-Qt-6.5.0.dmg`  
  This artifact is our first stable 6.5.0 release, it's a universal build meaning it works natively on Intel & Apple Silicon macs. Minimum macOS supported version is 11. The bump to Qt6 is required to make a universal build (unless we bought commercial Qt support ![KKona](https://user-images.githubusercontent.com/962989/235346483-27483753-258d-4073-a6fd-5cce8dd34be1.png) )
- **Linux Ubuntu 20.04** `Chatterino-ubuntu-20.04-x86_64.deb`
- **Linux Ubuntu 22.04** `Chatterino-ubuntu-22.04-x86_64.deb`
  The .deb files are preferred over the AppImage release for Ubuntu users
