### PR TITLE
Add 'joined channel' system message.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Minor: Added a Send button in the input box so you can click to send a message. This is disabled by default and can be enabled with the "Show send message button" setting. (#4607)
 - Minor: Improved error messages when the updater fails a download. (#4594)
 - Minor: Added `/shield` and `/shieldoff` commands to toggle shield mode. (#4580)
+- Minor: Added a message for when Chatterino joins a channel (#4616)
 - Bugfix: Fixed the menu warping on macOS on Qt6. (#4595)
 - Bugfix: Fixed link tooltips not showing unless the thumbnail setting was enabled. (#4597)
 - Bugfix: Domains starting with `http` are now parsed as links again. (#4598)

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -1145,9 +1145,12 @@ void IrcMessageHandler::handleJoinMessage(Communi::IrcMessage *message)
         return;
     }
 
-    if (message->nick() !=
-            getApp()->accounts->twitch.getCurrent()->getUserName() &&
-        getSettings()->showJoins.getValue())
+    if (message->nick() ==
+        getApp()->accounts->twitch.getCurrent()->getUserName())
+    {
+        twitchChannel->addMessage(makeSystemMessage("joined channel"));
+    }
+    else if (getSettings()->showJoins.getValue())
     {
         twitchChannel->addJoinedUser(message->nick());
     }


### PR DESCRIPTION
# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
This is a very simple implementation of something like #4615. This doesn't check if it's a reconnect, just shows the message. There is no setting either, as I don't see why we should add one.