### PR TITLE
Fixed crash when scrolling up really fast.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Bugfix: Domains starting with `http` are now parsed as links again. (#4598)
 - Bugfix: Fixed click effects on buttons not being antialiased. (#4473)
 - Bugfix: Fixed Ctrl+Backspace not working after Select All in chat search popup. (#4461)
+- Bugfix: Fixed crash when scrolling up really fast. (#4621)
 - Dev: Added the ability to control the `followRedirect` mode for requests. (#4594)
 
 ## 2.4.3

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1362,7 +1362,8 @@ void ChannelView::wheelEvent(QWheelEvent *event)
     {
         float mouseMultiplier = getSettings()->mouseScrollMultiplier;
 
-        qreal desired = this->scrollBar_->getDesiredValue();
+        // This ensures snapshot won't be indexed out of bounds when scrolling really fast
+        qreal desired = std::max<qreal>(0, this->scrollBar_->getDesiredValue());
         qreal delta = event->angleDelta().y() * qreal(1.5) * mouseMultiplier;
 
         auto &snapshot = this->getMessagesSnapshot();


### PR DESCRIPTION
# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->

This fixes a crash that happens if you happen to scroll up really fast in a fast chat like tmiloadtesting2. The scrollbar would want to be out of bounds, the message snapshot would be indexed out of bounds and Chatterino would segfault.

Old behavior:
https://github.com/Chatterino/chatterino2/assets/25011746/19580242-0c5d-4450-b062-ec1a32340d23

New one does not crash :).