### PR TITLE
Add a mechanism for making a theme that has the same name as a built in theme.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Bugfix: Fixed a memory leak that occurred when loading message history. This was mostly noticeable with unstable internet connections where reconnections were frequent or long-running instances of Chatterino. (#4499)
 - Bugfix: Fixed Twitch channel-specific filters not being applied correctly. (#4529)
 - Bugfix: Fixed emote & badge tooltips not showing up when thumbnails were hidden. (#4509)
+- Dev: Add the ability to load themes from the Themes directory. (#4570)
 - Dev: Disabling precompiled headers on Windows is now tested in CI. (#4472)
 - Dev: Themes are now stored as JSON files in `resources/themes`. (#4471, #4533)
 - Dev: Ignore unhandled BTTV user-events. (#4438)

--- a/src/singletons/Paths.cpp
+++ b/src/singletons/Paths.cpp
@@ -142,6 +142,7 @@ void Paths::initSubDirectories()
     this->miscDirectory = makePath("Misc");
     this->twitchProfileAvatars = makePath("ProfileAvatars");
     this->pluginsDirectory = makePath("Plugins");
+    this->themesDirectory = makePath("Themes");
     this->crashdumpDirectory = makePath("Crashes");
     //QDir().mkdir(this->twitchProfileAvatars + "/twitch");
 }

--- a/src/singletons/Paths.hpp
+++ b/src/singletons/Paths.hpp
@@ -37,6 +37,9 @@ public:
     // Plugin files live here. <appDataDirectory>/Plugins
     QString pluginsDirectory;
 
+    // Custom themes live here. <appDataDirectory>/Themes
+    QString themesDirectory;
+
     bool createFolder(const QString &folderPath);
     bool isPortable();
 

--- a/src/singletons/Theme.cpp
+++ b/src/singletons/Theme.cpp
@@ -296,6 +296,13 @@ void Theme::loadAvailableThemes()
 
         auto themeName = info.baseName();
 
+        // Check if theme name already exists and is a built-in theme
+        auto themeIt = this->availableThemes_.find(themeName);
+        if (themeIt != this->availableThemes_.end() && !themeIt->second.custom)
+        {
+            themeName += " ";
+        }
+
         this->availableThemes_.emplace(themeName, themeDescriptor);
     }
 }

--- a/src/singletons/Theme.cpp
+++ b/src/singletons/Theme.cpp
@@ -3,17 +3,21 @@
 
 #include "Application.hpp"
 #include "common/QLogging.hpp"
+#include "singletons/Paths.hpp"
 #include "singletons/Resources.hpp"
 
 #include <QColor>
+#include <QDir>
 #include <QFile>
 #include <QJsonDocument>
-#include <QJsonObject>
 #include <QSet>
 
 #include <cmath>
 
 namespace {
+
+using namespace chatterino;
+
 void parseInto(const QJsonObject &obj, const QLatin1String &key, QColor &color)
 {
     const auto &jsonValue = obj[key];
@@ -139,62 +143,161 @@ void parseColors(const QJsonObject &root, chatterino::Theme &theme)
 }
 #undef parseColor
 
-QString getThemePath(const QString &name)
+/**
+ * Load the given theme descriptor from its path
+ *
+ * Returns a JSON object containing theme data if the theme is valid, otherwise nullopt
+ *
+ * NOTE: No theme validation is done by this function
+ **/
+std::optional<QJsonObject> loadTheme(const ThemeDescriptor &theme)
 {
-    static QSet<QString> knownThemes = {"White", "Light", "Dark", "Black"};
-
-    if (knownThemes.contains(name))
+    QFile file(theme.path);
+    if (!file.open(QFile::ReadOnly))
     {
-        return QStringLiteral(":/themes/%1.json").arg(name);
+        qCWarning(chatterinoTheme)
+            << "Failed to open" << file.fileName() << "at" << theme.path;
+        return std::nullopt;
     }
-    return name;
+
+    QJsonParseError error{};
+    auto json = QJsonDocument::fromJson(file.readAll(), &error);
+    if (!json.isObject())
+    {
+        qCWarning(chatterinoTheme) << "Failed to parse" << file.fileName()
+                                   << "error:" << error.errorString();
+        return std::nullopt;
+    }
+
+    // TODO: Validate JSON schema?
+
+    return json.object();
 }
 
 }  // namespace
 
 namespace chatterino {
 
+const std::map<QString, ThemeDescriptor> Theme::builtInThemes{
+    {"White", {":/themes/White.json", false}},
+    {"Light", {":/themes/Light.json", false}},
+    {"Dark", {":/themes/Dark.json", false}},
+    {"Black", {":/themes/Black.json", false}},
+};
+
+const ThemeDescriptor Theme::fallbackTheme = Theme::builtInThemes.at("Dark");
+
 bool Theme::isLightTheme() const
 {
     return this->isLight_;
 }
 
-Theme::Theme()
+void Theme::initialize(Settings &settings, Paths &paths)
 {
-    this->update();
-
-    this->themeName.connectSimple(
-        [this](auto) {
+    this->themeName.connect(
+        [this](auto themeName) {
+            qCDebug(chatterinoTheme) << "Theme updated to" << themeName;
             this->update();
         },
         false);
+
+    this->loadAvailableThemes();
+
+    this->update();
 }
 
 void Theme::update()
 {
-    this->parse();
+    auto theme = this->availableThemes_.find(this->themeName);
+
+    std::optional<QJsonObject> themeJSON;
+
+    if (theme == this->availableThemes_.end())
+    {
+        qCWarning(chatterinoTheme)
+            << "Theme" << this->themeName
+            << "not found, falling back to the fallback theme";
+
+        themeJSON = loadTheme(fallbackTheme);
+    }
+    else
+    {
+        themeJSON = loadTheme(theme->second);
+
+        if (!themeJSON)
+        {
+            qCWarning(chatterinoTheme)
+                << "Theme" << this->themeName
+                << "not valid, falling back to the fallback theme";
+
+            // Parsing the theme failed, fall back
+            themeJSON = loadTheme(fallbackTheme);
+        }
+    }
+
+    if (!themeJSON)
+    {
+        qCWarning(chatterinoTheme)
+            << "Failed to load" << this->themeName << "or the fallback theme";
+        return;
+    }
+
+    this->parseFrom(*themeJSON);
+
     this->updated.invoke();
 }
 
-void Theme::parse()
+QStringList Theme::availableThemeNames() const
 {
-    QFile file(getThemePath(this->themeName));
-    if (!file.open(QFile::ReadOnly))
+    QStringList themeNames;
+
+    for (const auto &[name, theme] : this->availableThemes_)
     {
-        qCWarning(chatterinoTheme) << "Failed to open" << file.fileName();
-        return;
+        // NOTE: This check could also use `Theme::builtInThemes.contains(name)` instead
+        if (theme.custom)
+        {
+            themeNames.append(QString("Custom: %1").arg(name));
+        }
+        else
+        {
+            themeNames.append(name);
+        }
     }
 
-    QJsonParseError error{};
-    auto json = QJsonDocument::fromJson(file.readAll(), &error);
-    if (json.isNull())
-    {
-        qCWarning(chatterinoTheme) << "Failed to parse" << file.fileName()
-                                   << "error:" << error.errorString();
-        return;
-    }
+    return themeNames;
+}
 
-    this->parseFrom(json.object());
+void Theme::loadAvailableThemes()
+{
+    this->availableThemes_ = Theme::builtInThemes;
+
+    auto dir = QDir(getPaths()->themesDirectory);
+    for (const auto &info :
+         dir.entryInfoList(QDir::Files | QDir::NoDotAndDotDot, QDir::Name))
+    {
+        if (!info.isFile())
+        {
+            continue;
+        }
+
+        if (!info.fileName().endsWith(".json"))
+        {
+            continue;
+        }
+
+        auto themeDescriptor = ThemeDescriptor{info.absoluteFilePath(), true};
+
+        auto theme = loadTheme(themeDescriptor);
+        if (!theme)
+        {
+            qCWarning(chatterinoTheme) << "Failed to parse theme at" << info;
+            continue;
+        }
+
+        auto themeName = info.baseName();
+
+        this->availableThemes_.emplace(themeName, themeDescriptor);
+    }
 }
 
 void Theme::parseFrom(const QJsonObject &root)

--- a/src/singletons/Theme.cpp
+++ b/src/singletons/Theme.cpp
@@ -294,14 +294,7 @@ void Theme::loadAvailableThemes()
             continue;
         }
 
-        auto themeName = info.baseName();
-
-        // Check if theme name already exists and is a built-in theme
-        auto themeIt = this->availableThemes_.find(themeName);
-        if (themeIt != this->availableThemes_.end() && !themeIt->second.custom)
-        {
-            themeName += " ";
-        }
+        auto themeName = info.baseName() + ".json";
 
         this->availableThemes_.emplace(themeName, themeDescriptor);
     }

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -114,8 +114,27 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     auto &s = *getSettings();
 
     layout.addTitle("Interface");
-    layout.addDropdown("Theme", {"White", "Light", "Dark", "Black"},
-                       getApp()->themes->themeName);
+
+    // NOTE: Available theme names are only initialized on startup here
+    QStringList availableThemeNames = getApp()->themes->availableThemeNames();
+
+    layout.addDropdown<QString>(
+        "Theme", availableThemeNames, getApp()->themes->themeName,
+        [](auto val) {
+            if (!Theme::builtInThemes.contains(val))
+            {
+                return QString("Custom: %1").arg(val);
+            }
+
+            return val;
+        },
+        [](const DropdownArgs &args) {
+            // Remove "Custom: " prefix from the dropdown
+            // XXX: This should be a regex or "trim prefix"
+            QString value = args.value;
+            return value.replace("Custom: ", "");
+        });
+
     layout.addDropdown<QString>(
         "Font", {"Segoe UI", "Arial", "Choose..."},
         getApp()->fonts->chatFontFamily,


### PR DESCRIPTION
# Description
**Currently Themes that have a name that's the same as a built in theme don't show up in the menu at all. We could either leave it like this or go with the preposed two options for fixing this issue below.**
![image](https://github.com/Chatterino/chatterino2/assets/27637025/93d0a07e-f648-4268-a295-a29f05d129c9) ![image](https://github.com/Chatterino/chatterino2/assets/27637025/dbe009b8-ef14-49d5-a347-b3ffcba888cf)


Option 1:
Add a Blank space/char at the end of every custom theme with a name that's the same as a built in theme.
![s06t3](https://github.com/Chatterino/chatterino2/assets/27637025/7a84057a-f7a9-479b-b7de-aed8a7422e21)
Option 2:
Add .json to every custom theme.
![Ui3sX](https://github.com/Chatterino/chatterino2/assets/27637025/3bb50456-8a52-4f4a-9ab9-fa36f8ae2459)

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
