### PR TITLE
Refactor/Cleanup NetworkRequest and Related Code

### DIFF
--- a/src/common/NetworkPrivate.cpp
+++ b/src/common/NetworkPrivate.cpp
@@ -89,7 +89,7 @@ void loadUncached(std::shared_ptr<NetworkData> &&data)
             data->timer_->start(data->timeoutMS_);
         }
 
-        auto reply = [&]() -> QNetworkReply * {
+        auto *reply = [&]() -> QNetworkReply * {
             switch (data->requestType_)
             {
                 case NetworkRequestType::Get:

--- a/src/common/NetworkPrivate.cpp
+++ b/src/common/NetworkPrivate.cpp
@@ -276,11 +276,15 @@ void loadUncached(std::shared_ptr<NetworkData> &&data)
             if (data->finally_)
             {
                 if (data->executeConcurrently_)
+                {
                     QtConcurrent::run([finally = std::move(data->finally_)] {
                         finally();
                     });
+                }
                 else
+                {
                     data->finally_();
+                }
             }
         };
 

--- a/src/common/NetworkPrivate.hpp
+++ b/src/common/NetworkPrivate.hpp
@@ -68,6 +68,6 @@ private:
     QString hash_;
 };
 
-void load(const std::shared_ptr<NetworkData> &data);
+void load(std::shared_ptr<NetworkData> &&data);
 
 }  // namespace chatterino

--- a/src/common/NetworkRequest.cpp
+++ b/src/common/NetworkRequest.cpp
@@ -54,25 +54,25 @@ NetworkRequest NetworkRequest::caller(const QObject *caller) &&
 
 NetworkRequest NetworkRequest::onReplyCreated(NetworkReplyCreatedCallback cb) &&
 {
-    this->data->onReplyCreated_ = cb;
+    this->data->onReplyCreated_ = std::move(cb);
     return std::move(*this);
 }
 
 NetworkRequest NetworkRequest::onError(NetworkErrorCallback cb) &&
 {
-    this->data->onError_ = cb;
+    this->data->onError_ = std::move(cb);
     return std::move(*this);
 }
 
 NetworkRequest NetworkRequest::onSuccess(NetworkSuccessCallback cb) &&
 {
-    this->data->onSuccess_ = cb;
+    this->data->onSuccess_ = std::move(cb);
     return std::move(*this);
 }
 
 NetworkRequest NetworkRequest::finally(NetworkFinallyCallback cb) &&
 {
-    this->data->finally_ = cb;
+    this->data->finally_ = std::move(cb);
     return std::move(*this);
 }
 

--- a/src/common/NetworkRequest.cpp
+++ b/src/common/NetworkRequest.cpp
@@ -129,20 +129,6 @@ NetworkRequest NetworkRequest::concurrent() &&
     return std::move(*this);
 }
 
-NetworkRequest NetworkRequest::authorizeTwitchV5(const QString &clientID,
-                                                 const QString &oauthToken) &&
-{
-    // TODO: make two overloads, with and without oauth token
-    auto tmp = std::move(*this)
-                   .header("Client-ID", clientID)
-                   .header("Accept", "application/vnd.twitchtv.v5+json");
-
-    if (!oauthToken.isEmpty())
-        return std::move(tmp).header("Authorization", "OAuth " + oauthToken);
-    else
-        return tmp;
-}
-
 NetworkRequest NetworkRequest::multiPart(QHttpMultiPart *payload) &&
 {
     payload->setParent(this->data->lifetimeManager_);
@@ -205,12 +191,6 @@ void NetworkRequest::initializeDefaultValues()
                                .toUtf8();
 
     this->data->request_.setRawHeader("User-Agent", userAgent);
-}
-
-// Helper creator functions
-NetworkRequest NetworkRequest::twitchRequest(QUrl url)
-{
-    return NetworkRequest(url).authorizeTwitchV5(getDefaultClientID());
 }
 
 }  // namespace chatterino

--- a/src/common/NetworkRequest.cpp
+++ b/src/common/NetworkRequest.cpp
@@ -31,10 +31,7 @@ NetworkRequest::NetworkRequest(QUrl url, NetworkRequestType requestType)
     this->initializeDefaultValues();
 }
 
-NetworkRequest::~NetworkRequest()
-{
-    //assert(!this->data || this->executed_);
-}
+NetworkRequest::~NetworkRequest() = default;
 
 NetworkRequest NetworkRequest::type(NetworkRequestType newRequestType) &&
 {

--- a/src/common/NetworkRequest.cpp
+++ b/src/common/NetworkRequest.cpp
@@ -1,14 +1,8 @@
 #include "common/NetworkRequest.hpp"
 
 #include "common/NetworkPrivate.hpp"
-#include "common/Outcome.hpp"
 #include "common/QLogging.hpp"
 #include "common/Version.hpp"
-#include "debug/AssertInGuiThread.hpp"
-#include "providers/twitch/TwitchCommon.hpp"
-#include "singletons/Paths.hpp"
-#include "util/DebugCount.hpp"
-#include "util/PostToThread.hpp"
 
 #include <QDebug>
 #include <QFile>

--- a/src/common/NetworkRequest.cpp
+++ b/src/common/NetworkRequest.cpp
@@ -22,7 +22,7 @@ NetworkRequest::NetworkRequest(const std::string &url,
     this->initializeDefaultValues();
 }
 
-NetworkRequest::NetworkRequest(QUrl url, NetworkRequestType requestType)
+NetworkRequest::NetworkRequest(const QUrl &url, NetworkRequestType requestType)
     : data(new NetworkData)
 {
     this->data->request_.setUrl(url);

--- a/src/common/NetworkRequest.cpp
+++ b/src/common/NetworkRequest.cpp
@@ -106,6 +106,13 @@ NetworkRequest NetworkRequest::header(const char *headerName,
     return std::move(*this);
 }
 
+NetworkRequest NetworkRequest::header(QNetworkRequest::KnownHeaders header,
+                                      const QVariant &value) &&
+{
+    this->data->request_.setHeader(header, value);
+    return std::move(*this);
+}
+
 NetworkRequest NetworkRequest::headerList(
     const std::vector<std::pair<QByteArray, QByteArray>> &headers) &&
 {
@@ -191,6 +198,30 @@ void NetworkRequest::initializeDefaultValues()
                                .toUtf8();
 
     this->data->request_.setRawHeader("User-Agent", userAgent);
+}
+
+NetworkRequest NetworkRequest::json(const QJsonArray &root) &&
+{
+    return std::move(*this).json(QJsonDocument(root));
+}
+
+NetworkRequest NetworkRequest::json(const QJsonObject &root) &&
+{
+    return std::move(*this).json(QJsonDocument(root));
+}
+
+NetworkRequest NetworkRequest::json(const QJsonDocument &document) &&
+{
+    return std::move(*this).json(document.toJson(QJsonDocument::Compact));
+}
+
+NetworkRequest NetworkRequest::json(const QByteArray &payload) &&
+{
+    return std::move(*this)
+        .payload(payload)
+        .header(QNetworkRequest::ContentTypeHeader, "application/json")
+        .header(QNetworkRequest::ContentLengthHeader, payload.length())
+        .header("Accept", "application/json");
 }
 
 }  // namespace chatterino

--- a/src/common/NetworkRequest.hpp
+++ b/src/common/NetworkRequest.hpp
@@ -6,6 +6,10 @@
 
 #include <memory>
 
+class QJsonArray;
+class QJsonObject;
+class QJsonDocument;
+
 namespace chatterino {
 
 struct NetworkData;
@@ -54,6 +58,8 @@ public:
     NetworkRequest header(const char *headerName, const char *value) &&;
     NetworkRequest header(const char *headerName, const QByteArray &value) &&;
     NetworkRequest header(const char *headerName, const QString &value) &&;
+    NetworkRequest header(QNetworkRequest::KnownHeaders header,
+                          const QVariant &value) &&;
     NetworkRequest headerList(
         const std::vector<std::pair<QByteArray, QByteArray>> &headers) &&;
     NetworkRequest timeout(int ms) &&;
@@ -64,6 +70,10 @@ public:
      * `QNetworkRequest`'s defaults are used by default (Qt 5: no-follow, Qt 6: follow).
      */
     NetworkRequest followRedirects(bool on) &&;
+    NetworkRequest json(const QJsonObject &root) &&;
+    NetworkRequest json(const QJsonArray &root) &&;
+    NetworkRequest json(const QJsonDocument &document) &&;
+    NetworkRequest json(const QByteArray &payload) &&;
 
     void execute();
 

--- a/src/common/NetworkRequest.hpp
+++ b/src/common/NetworkRequest.hpp
@@ -28,8 +28,8 @@ public:
     explicit NetworkRequest(
         const std::string &url,
         NetworkRequestType requestType = NetworkRequestType::Get);
-    explicit NetworkRequest(
-        QUrl url, NetworkRequestType requestType = NetworkRequestType::Get);
+    explicit NetworkRequest(const QUrl &url, NetworkRequestType requestType =
+                                                 NetworkRequestType::Get);
 
     // Enable move
     NetworkRequest(NetworkRequest &&other) = default;

--- a/src/common/NetworkRequest.hpp
+++ b/src/common/NetworkRequest.hpp
@@ -58,8 +58,6 @@ public:
         const std::vector<std::pair<QByteArray, QByteArray>> &headers) &&;
     NetworkRequest timeout(int ms) &&;
     NetworkRequest concurrent() &&;
-    NetworkRequest authorizeTwitchV5(const QString &clientID,
-                                     const QString &oauthToken = QString()) &&;
     NetworkRequest multiPart(QHttpMultiPart *payload) &&;
     /**
      * This will change `RedirectPolicyAttribute`.
@@ -68,8 +66,6 @@ public:
     NetworkRequest followRedirects(bool on) &&;
 
     void execute();
-
-    static NetworkRequest twitchRequest(QUrl url);
 
 private:
     void initializeDefaultValues();

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -52,7 +52,7 @@ void Helix::fetchUsers(QStringList userIds, QStringList userLogins,
     }
 
     // TODO: set on success and on error
-    this->makeRequest("users", urlQuery)
+    this->makeGet("users", urlQuery)
         .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
             auto root = result.parseJson();
             auto data = root.value("data");
@@ -142,7 +142,7 @@ void Helix::fetchUsersFollows(
     }
 
     // TODO: set on success and on error
-    this->makeRequest("users/follows", urlQuery)
+    this->makeGet("users/follows", urlQuery)
         .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
             auto root = result.parseJson();
             if (root.empty())
@@ -186,7 +186,7 @@ void Helix::fetchStreams(
     }
 
     // TODO: set on success and on error
-    this->makeRequest("streams", urlQuery)
+    this->makeGet("streams", urlQuery)
         .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
             auto root = result.parseJson();
             auto data = root.value("data");
@@ -279,7 +279,7 @@ void Helix::fetchGames(QStringList gameIds, QStringList gameNames,
     }
 
     // TODO: set on success and on error
-    this->makeRequest("games", urlQuery)
+    this->makeGet("games", urlQuery)
         .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
             auto root = result.parseJson();
             auto data = root.value("data");
@@ -315,7 +315,7 @@ void Helix::searchGames(QString gameName,
     QUrlQuery urlQuery;
     urlQuery.addQueryItem("query", gameName);
 
-    this->makeRequest("search/categories", urlQuery)
+    this->makeGet("search/categories", urlQuery)
         .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
             auto root = result.parseJson();
             auto data = root.value("data");
@@ -372,8 +372,7 @@ void Helix::createClip(QString channelId,
     QUrlQuery urlQuery;
     urlQuery.addQueryItem("broadcaster_id", channelId);
 
-    this->makeRequest("clips", urlQuery)
-        .type(NetworkRequestType::Post)
+    this->makePost("clips", urlQuery)
         .header("Content-Type", "application/json")
         .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
             auto root = result.parseJson();
@@ -425,7 +424,7 @@ void Helix::getChannel(QString broadcasterId,
     QUrlQuery urlQuery;
     urlQuery.addQueryItem("broadcaster_id", broadcasterId);
 
-    this->makeRequest("channels", urlQuery)
+    this->makeGet("channels", urlQuery)
         .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
             auto root = result.parseJson();
             auto data = root.value("data");
@@ -460,8 +459,7 @@ void Helix::createStreamMarker(
     }
     payload.insert("user_id", QJsonValue(broadcasterId));
 
-    this->makeRequest("streams/markers", QUrlQuery())
-        .type(NetworkRequestType::Post)
+    this->makePost("streams/markers", QUrlQuery())
         .json(payload)
         .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
             auto root = result.parseJson();
@@ -514,7 +512,7 @@ void Helix::loadBlocks(QString userId,
     urlQuery.addQueryItem("broadcaster_id", userId);
     urlQuery.addQueryItem("first", "100");
 
-    this->makeRequest("users/blocks", urlQuery)
+    this->makeGet("users/blocks", urlQuery)
         .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
             auto root = result.parseJson();
             auto data = root.value("data");
@@ -550,8 +548,7 @@ void Helix::blockUser(QString targetUserId,
     QUrlQuery urlQuery;
     urlQuery.addQueryItem("target_user_id", targetUserId);
 
-    this->makeRequest("users/blocks", urlQuery)
-        .type(NetworkRequestType::Put)
+    this->makePut("users/blocks", urlQuery)
         .onSuccess([successCallback](auto /*result*/) -> Outcome {
             successCallback();
             return Success;
@@ -570,8 +567,7 @@ void Helix::unblockUser(QString targetUserId,
     QUrlQuery urlQuery;
     urlQuery.addQueryItem("target_user_id", targetUserId);
 
-    this->makeRequest("users/blocks", urlQuery)
-        .type(NetworkRequestType::Delete)
+    this->makeDelete("users/blocks", urlQuery)
         .onSuccess([successCallback](auto /*result*/) -> Outcome {
             successCallback();
             return Success;
@@ -610,8 +606,7 @@ void Helix::updateChannel(QString broadcasterId, QString gameId,
     }
 
     urlQuery.addQueryItem("broadcaster_id", broadcasterId);
-    this->makeRequest("channels", urlQuery)
-        .type(NetworkRequestType::Patch)
+    this->makePatch("channels", urlQuery)
         .json(obj)
         .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
             successCallback(result);
@@ -634,8 +629,7 @@ void Helix::manageAutoModMessages(
     payload.insert("msg_id", msgID);
     payload.insert("action", action);
 
-    this->makeRequest("moderation/automod/message", QUrlQuery())
-        .type(NetworkRequestType::Post)
+    this->makePost("moderation/automod/message", QUrlQuery())
         .json(payload)
         .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
             successCallback();
@@ -692,7 +686,7 @@ void Helix::getCheermotes(
 
     urlQuery.addQueryItem("broadcaster_id", broadcasterId);
 
-    this->makeRequest("bits/cheermotes", urlQuery)
+    this->makeGet("bits/cheermotes", urlQuery)
         .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
             auto root = result.parseJson();
             auto data = root.value("data");
@@ -730,7 +724,7 @@ void Helix::getEmoteSetData(QString emoteSetId,
 
     urlQuery.addQueryItem("emote_set_id", emoteSetId);
 
-    this->makeRequest("chat/emotes/set", urlQuery)
+    this->makeGet("chat/emotes/set", urlQuery)
         .onSuccess([successCallback, failureCallback,
                     emoteSetId](auto result) -> Outcome {
             QJsonObject root = result.parseJson();
@@ -762,7 +756,7 @@ void Helix::getChannelEmotes(
     QUrlQuery urlQuery;
     urlQuery.addQueryItem("broadcaster_id", broadcasterId);
 
-    this->makeRequest("chat/emotes", urlQuery)
+    this->makeGet("chat/emotes", urlQuery)
         .onSuccess([successCallback,
                     failureCallback](NetworkResult result) -> Outcome {
             QJsonObject root = result.parseJson();
@@ -802,8 +796,7 @@ void Helix::updateUserChatColor(
     payload.insert("user_id", QJsonValue(userID));
     payload.insert("color", QJsonValue(color));
 
-    this->makeRequest("chat/color", QUrlQuery())
-        .type(NetworkRequestType::Put)
+    this->makePut("chat/color", QUrlQuery())
         .json(payload)
         .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
             auto obj = result.parseJson();
@@ -881,8 +874,7 @@ void Helix::deleteChatMessages(
         urlQuery.addQueryItem("message_id", messageID);
     }
 
-    this->makeRequest("moderation/chat", urlQuery)
-        .type(NetworkRequestType::Delete)
+    this->makeDelete("moderation/chat", urlQuery)
         .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
             if (result.status() != 204)
             {
@@ -960,8 +952,7 @@ void Helix::addChannelModerator(
     urlQuery.addQueryItem("broadcaster_id", broadcasterID);
     urlQuery.addQueryItem("user_id", userID);
 
-    this->makeRequest("moderation/moderators", urlQuery)
-        .type(NetworkRequestType::Post)
+    this->makePost("moderation/moderators", urlQuery)
         .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
             if (result.status() != 204)
             {
@@ -1049,8 +1040,7 @@ void Helix::removeChannelModerator(
     urlQuery.addQueryItem("broadcaster_id", broadcasterID);
     urlQuery.addQueryItem("user_id", userID);
 
-    this->makeRequest("moderation/moderators", urlQuery)
-        .type(NetworkRequestType::Delete)
+    this->makeDelete("moderation/moderators", urlQuery)
         .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
             if (result.status() != 204)
             {
@@ -1136,8 +1126,7 @@ void Helix::sendChatAnnouncement(
         std::string{magic_enum::enum_name<HelixAnnouncementColor>(color)};
     body.insert("color", QString::fromStdString(colorStr).toLower());
 
-    this->makeRequest("chat/announcements", urlQuery)
-        .type(NetworkRequestType::Post)
+    this->makePost("chat/announcements", urlQuery)
         .json(body)
         .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
             if (result.status() != 204)
@@ -1207,8 +1196,7 @@ void Helix::addChannelVIP(
     urlQuery.addQueryItem("broadcaster_id", broadcasterID);
     urlQuery.addQueryItem("user_id", userID);
 
-    this->makeRequest("channels/vips", urlQuery)
-        .type(NetworkRequestType::Post)
+    this->makePost("channels/vips", urlQuery)
         .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
             if (result.status() != 204)
             {
@@ -1286,8 +1274,7 @@ void Helix::removeChannelVIP(
     urlQuery.addQueryItem("broadcaster_id", broadcasterID);
     urlQuery.addQueryItem("user_id", userID);
 
-    this->makeRequest("channels/vips", urlQuery)
-        .type(NetworkRequestType::Delete)
+    this->makeDelete("channels/vips", urlQuery)
         .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
             if (result.status() != 204)
             {
@@ -1376,8 +1363,7 @@ void Helix::unbanUser(
     urlQuery.addQueryItem("moderator_id", moderatorID);
     urlQuery.addQueryItem("user_id", userID);
 
-    this->makeRequest("moderation/bans", urlQuery)
-        .type(NetworkRequestType::Delete)
+    this->makeDelete("moderation/bans", urlQuery)
         .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
             if (result.status() != 204)
             {
@@ -1482,8 +1468,7 @@ void Helix::startRaid(
     urlQuery.addQueryItem("from_broadcaster_id", fromBroadcasterID);
     urlQuery.addQueryItem("to_broadcaster_id", toBroadcasterID);
 
-    this->makeRequest("raids", urlQuery)
-        .type(NetworkRequestType::Post)
+    this->makePost("raids", urlQuery)
         .onSuccess(
             [successCallback, failureCallback](auto /*result*/) -> Outcome {
                 successCallback();
@@ -1563,8 +1548,7 @@ void Helix::cancelRaid(
 
     urlQuery.addQueryItem("broadcaster_id", broadcasterID);
 
-    this->makeRequest("raids", urlQuery)
-        .type(NetworkRequestType::Delete)
+    this->makeDelete("raids", urlQuery)
         .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
             if (result.status() != 204)
             {
@@ -1724,8 +1708,7 @@ void Helix::updateChatSettings(
     urlQuery.addQueryItem("broadcaster_id", broadcasterID);
     urlQuery.addQueryItem("moderator_id", moderatorID);
 
-    this->makeRequest("chat/settings", urlQuery)
-        .type(NetworkRequestType::Patch)
+    this->makePatch("chat/settings", urlQuery)
         .json(payload)
         .onSuccess([successCallback](auto result) -> Outcome {
             if (result.status() != 200)
@@ -1849,7 +1832,7 @@ void Helix::fetchChatters(
         urlQuery.addQueryItem("after", after);
     }
 
-    this->makeRequest("chat/chatters", urlQuery)
+    this->makeGet("chat/chatters", urlQuery)
         .onSuccess([successCallback](auto result) -> Outcome {
             if (result.status() != 200)
             {
@@ -1958,7 +1941,7 @@ void Helix::fetchModerators(
         urlQuery.addQueryItem("after", after);
     }
 
-    this->makeRequest("moderation/moderators", urlQuery)
+    this->makeGet("moderation/moderators", urlQuery)
         .onSuccess([successCallback](auto result) -> Outcome {
             if (result.status() != 200)
             {
@@ -2043,8 +2026,7 @@ void Helix::banUser(QString broadcasterID, QString moderatorID, QString userID,
         payload["data"] = data;
     }
 
-    this->makeRequest("moderation/bans", urlQuery)
-        .type(NetworkRequestType::Post)
+    this->makePost("moderation/bans", urlQuery)
         .json(payload)
         .onSuccess([successCallback](auto result) -> Outcome {
             if (result.status() != 200)
@@ -2141,8 +2123,7 @@ void Helix::sendWhisper(
     QJsonObject payload;
     payload["message"] = message;
 
-    this->makeRequest("whispers", urlQuery)
-        .type(NetworkRequestType::Post)
+    this->makePost("whispers", urlQuery)
         .json(payload)
         .onSuccess([successCallback](auto result) -> Outcome {
             if (result.status() != 204)
@@ -2285,8 +2266,7 @@ void Helix::getChannelVIPs(
     //   as the mod list can go over 100 (I assume, I see no limit)
     urlQuery.addQueryItem("first", "100");
 
-    this->makeRequest("channels/vips", urlQuery)
-        .type(NetworkRequestType::Get)
+    this->makeGet("channels/vips", urlQuery)
         .header("Content-Type", "application/json")
         .onSuccess([successCallback](auto result) -> Outcome {
             if (result.status() != 200)
@@ -2373,8 +2353,7 @@ void Helix::startCommercial(
     payload.insert("broadcaster_id", QJsonValue(broadcasterID));
     payload.insert("length", QJsonValue(length));
 
-    this->makeRequest("channels/commercial", QUrlQuery())
-        .type(NetworkRequestType::Post)
+    this->makePost("channels/commercial", QUrlQuery())
         .json(payload)
         .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
             auto obj = result.parseJson();
@@ -2465,7 +2444,7 @@ void Helix::getGlobalBadges(
 {
     using Error = HelixGetGlobalBadgesError;
 
-    this->makeRequest("chat/badges/global", QUrlQuery())
+    this->makeGet("chat/badges/global", QUrlQuery())
         .onSuccess([successCallback](auto result) -> Outcome {
             if (result.status() != 200)
             {
@@ -2512,7 +2491,7 @@ void Helix::getChannelBadges(
     QUrlQuery urlQuery;
     urlQuery.addQueryItem("broadcaster_id", broadcasterID);
 
-    this->makeRequest("chat/badges", urlQuery)
+    this->makeGet("chat/badges", urlQuery)
         .onSuccess([successCallback](auto result) -> Outcome {
             if (result.status() != 200)
             {
@@ -2564,10 +2543,8 @@ void Helix::updateShieldMode(
     QJsonObject payload;
     payload["is_active"] = isActive;
 
-    this->makeRequest("moderation/shield_mode", urlQuery)
-        .type(NetworkRequestType::Put)
-        .header("Content-Type", "application/json")
-        .payload(QJsonDocument(payload).toJson(QJsonDocument::Compact))
+    this->makePut("moderation/shield_mode", urlQuery)
+        .json(payload)
         .onSuccess([successCallback](auto result) -> Outcome {
             if (result.status() != 200)
             {
@@ -2620,7 +2597,8 @@ void Helix::updateShieldMode(
         .execute();
 }
 
-NetworkRequest Helix::makeRequest(QString url, QUrlQuery urlQuery)
+NetworkRequest Helix::makeRequest(const QString &url, const QUrlQuery &urlQuery,
+                                  NetworkRequestType type)
 {
     assert(!url.startsWith("/"));
 
@@ -2644,11 +2622,36 @@ NetworkRequest Helix::makeRequest(QString url, QUrlQuery urlQuery)
 
     fullUrl.setQuery(urlQuery);
 
-    return NetworkRequest(fullUrl)
+    return NetworkRequest(fullUrl, type)
         .timeout(5 * 1000)
         .header("Accept", "application/json")
         .header("Client-ID", this->clientId)
         .header("Authorization", "Bearer " + this->oauthToken);
+}
+
+NetworkRequest Helix::makeGet(const QString &url, const QUrlQuery &urlQuery)
+{
+    return this->makeRequest(url, urlQuery, NetworkRequestType::Get);
+}
+
+NetworkRequest Helix::makeDelete(const QString &url, const QUrlQuery &urlQuery)
+{
+    return this->makeRequest(url, urlQuery, NetworkRequestType::Delete);
+}
+
+NetworkRequest Helix::makePost(const QString &url, const QUrlQuery &urlQuery)
+{
+    return this->makeRequest(url, urlQuery, NetworkRequestType::Post);
+}
+
+NetworkRequest Helix::makePut(const QString &url, const QUrlQuery &urlQuery)
+{
+    return this->makeRequest(url, urlQuery, NetworkRequestType::Put);
+}
+
+NetworkRequest Helix::makePatch(const QString &url, const QUrlQuery &urlQuery)
+{
+    return this->makeRequest(url, urlQuery, NetworkRequestType::Patch);
 }
 
 void Helix::update(QString clientId, QString oauthToken)

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -462,8 +462,7 @@ void Helix::createStreamMarker(
 
     this->makeRequest("streams/markers", QUrlQuery())
         .type(NetworkRequestType::Post)
-        .header("Content-Type", "application/json")
-        .payload(QJsonDocument(payload).toJson(QJsonDocument::Compact))
+        .json(payload)
         .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
             auto root = result.parseJson();
             auto data = root.value("data");
@@ -590,7 +589,6 @@ void Helix::updateChannel(QString broadcasterId, QString gameId,
                           HelixFailureCallback failureCallback)
 {
     QUrlQuery urlQuery;
-    auto data = QJsonDocument();
     auto obj = QJsonObject();
     if (!gameId.isEmpty())
     {
@@ -611,12 +609,10 @@ void Helix::updateChannel(QString broadcasterId, QString gameId,
         return;
     }
 
-    data.setObject(obj);
     urlQuery.addQueryItem("broadcaster_id", broadcasterId);
     this->makeRequest("channels", urlQuery)
         .type(NetworkRequestType::Patch)
-        .header("Content-Type", "application/json")
-        .payload(data.toJson())
+        .json(obj)
         .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
             successCallback(result);
             return Success;
@@ -640,8 +636,7 @@ void Helix::manageAutoModMessages(
 
     this->makeRequest("moderation/automod/message", QUrlQuery())
         .type(NetworkRequestType::Post)
-        .header("Content-Type", "application/json")
-        .payload(QJsonDocument(payload).toJson(QJsonDocument::Compact))
+        .json(payload)
         .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
             successCallback();
             return Success;
@@ -809,8 +804,7 @@ void Helix::updateUserChatColor(
 
     this->makeRequest("chat/color", QUrlQuery())
         .type(NetworkRequestType::Put)
-        .header("Content-Type", "application/json")
-        .payload(QJsonDocument(payload).toJson(QJsonDocument::Compact))
+        .json(payload)
         .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
             auto obj = result.parseJson();
             if (result.status() != 204)
@@ -1144,8 +1138,7 @@ void Helix::sendChatAnnouncement(
 
     this->makeRequest("chat/announcements", urlQuery)
         .type(NetworkRequestType::Post)
-        .header("Content-Type", "application/json")
-        .payload(QJsonDocument(body).toJson(QJsonDocument::Compact))
+        .json(body)
         .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
             if (result.status() != 204)
             {
@@ -1733,8 +1726,7 @@ void Helix::updateChatSettings(
 
     this->makeRequest("chat/settings", urlQuery)
         .type(NetworkRequestType::Patch)
-        .header("Content-Type", "application/json")
-        .payload(QJsonDocument(payload).toJson(QJsonDocument::Compact))
+        .json(payload)
         .onSuccess([successCallback](auto result) -> Outcome {
             if (result.status() != 200)
             {
@@ -2053,8 +2045,7 @@ void Helix::banUser(QString broadcasterID, QString moderatorID, QString userID,
 
     this->makeRequest("moderation/bans", urlQuery)
         .type(NetworkRequestType::Post)
-        .header("Content-Type", "application/json")
-        .payload(QJsonDocument(payload).toJson(QJsonDocument::Compact))
+        .json(payload)
         .onSuccess([successCallback](auto result) -> Outcome {
             if (result.status() != 200)
             {
@@ -2152,8 +2143,7 @@ void Helix::sendWhisper(
 
     this->makeRequest("whispers", urlQuery)
         .type(NetworkRequestType::Post)
-        .header("Content-Type", "application/json")
-        .payload(QJsonDocument(payload).toJson(QJsonDocument::Compact))
+        .json(payload)
         .onSuccess([successCallback](auto result) -> Outcome {
             if (result.status() != 204)
             {
@@ -2385,8 +2375,7 @@ void Helix::startCommercial(
 
     this->makeRequest("channels/commercial", QUrlQuery())
         .type(NetworkRequestType::Post)
-        .header("Content-Type", "application/json")
-        .payload(QJsonDocument(payload).toJson(QJsonDocument::Compact))
+        .json(payload)
         .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
             auto obj = result.parseJson();
             if (obj.isEmpty())

--- a/src/providers/twitch/api/Helix.hpp
+++ b/src/providers/twitch/api/Helix.hpp
@@ -1361,7 +1361,13 @@ protected:
         FailureCallback<HelixGetModeratorsError, QString> failureCallback);
 
 private:
-    NetworkRequest makeRequest(QString url, QUrlQuery urlQuery);
+    NetworkRequest makeRequest(const QString &url, const QUrlQuery &urlQuery,
+                               NetworkRequestType type);
+    NetworkRequest makeGet(const QString &url, const QUrlQuery &urlQuery);
+    NetworkRequest makeDelete(const QString &url, const QUrlQuery &urlQuery);
+    NetworkRequest makePost(const QString &url, const QUrlQuery &urlQuery);
+    NetworkRequest makePut(const QString &url, const QUrlQuery &urlQuery);
+    NetworkRequest makePatch(const QString &url, const QUrlQuery &urlQuery);
 
     QString clientId;
     QString oauthToken;


### PR DESCRIPTION
# Description

This PR does many small changes - each commit can be reviewed on its own.

The following changes were made:

* Cleanup unused code (Twitch v5)
* Add `json` methods that simplify sending JSON. This also sets the `Accepts` header, since here, when JSON is sent, only JSON is accepted as a response (this is only done in Helix).
* `Helix`'s `makeRequest` now accepts an HTTP method.
* Cleaned some clang-tidy suggestions in `Network{Request,Private}`. The only suggestions left there are (1) a [`const-cast`](https://github.com/Chatterino/chatterino2/blob/4fa2cc26c9bffd5a6c770380c8a8bceb7368edbf/src/common/NetworkRequest.cpp#LL58C31-L58C41) and (2-5) unused `QFuture`'s from `QtConcurrent::run` calls. (1) should be resolved when #4632 is closed. (2-5) can be resolved by using [`QThreadPool::start`](https://doc.qt.io/qt-6/qthreadpool.html#start), since we don't need the future.
* Moved `asserts` to [`Q_ASSERT_X`](https://doc.qt.io/qt-6/qtassert-proxy.html#Q_ASSERT_X), which provides better error messages (mainly with a reasoning in the message).