### PR TITLE
Add Command to Set Logging/Filter Rules at Runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Bugfix: Fixed Ctrl+Backspace not working after Select All in chat search popup. (#4461)
 - Bugfix: Fixed crash when scrolling up really fast. (#4621)
 - Dev: Added the ability to control the `followRedirect` mode for requests. (#4594)
+- Dev: Added command to set Qt's logging filter/rules at runtime (`/c2:loggingrules`). (#4637)
 
 ## 2.4.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+- Dev: Added command to set Qt's logging filter/rules at runtime (`/c2-set-logging-rules`). (#4637)
+
 ## 2.4.4
 
 - Minor: Added a Send button in the input box so you can click to send a message. This is disabled by default and can be enabled with the "Show send message button" setting. (#4607)
@@ -15,7 +17,6 @@
 - Bugfix: Fixed Ctrl+Backspace not working after Select All in chat search popup. (#4461)
 - Bugfix: Fixed crash when scrolling up really fast. (#4621)
 - Dev: Added the ability to control the `followRedirect` mode for requests. (#4594)
-- Dev: Added command to set Qt's logging filter/rules at runtime (`/c2:loggingrules`). (#4637)
 
 ## 2.4.3
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,6 +60,8 @@ set(SOURCE_FILES
         controllers/accounts/AccountModel.cpp
         controllers/accounts/AccountModel.hpp
 
+        controllers/commands/builtin/chatterino/Debugging.cpp
+        controllers/commands/builtin/chatterino/Debugging.hpp
         controllers/commands/builtin/twitch/ChatSettings.cpp
         controllers/commands/builtin/twitch/ChatSettings.hpp
         controllers/commands/builtin/twitch/ShieldMode.cpp

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -3213,7 +3213,7 @@ void CommandController::initialize(Settings &, Paths &paths)
     this->registerCommand("/shield", &commands::shieldModeOn);
     this->registerCommand("/shieldoff", &commands::shieldModeOff);
 
-    this->registerCommand("/c2:loggingrules", &commands::setLoggingRules);
+    this->registerCommand("/c2-set-logging-rules", &commands::setLoggingRules);
 }
 
 void CommandController::save()

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -7,6 +7,7 @@
 #include "common/QLogging.hpp"
 #include "common/SignalVector.hpp"
 #include "controllers/accounts/AccountController.hpp"
+#include "controllers/commands/builtin/chatterino/Debugging.hpp"
 #include "controllers/commands/builtin/twitch/ChatSettings.hpp"
 #include "controllers/commands/builtin/twitch/ShieldMode.hpp"
 #include "controllers/commands/Command.hpp"
@@ -3211,6 +3212,8 @@ void CommandController::initialize(Settings &, Paths &paths)
 
     this->registerCommand("/shield", &commands::shieldModeOn);
     this->registerCommand("/shieldoff", &commands::shieldModeOff);
+
+    this->registerCommand("/c2:loggingrules", &commands::setLoggingRules);
 }
 
 void CommandController::save()

--- a/src/controllers/commands/builtin/chatterino/Debugging.cpp
+++ b/src/controllers/commands/builtin/chatterino/Debugging.cpp
@@ -22,7 +22,16 @@ QString setLoggingRules(const CommandContext &ctx)
         return {};
     }
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
     auto filterRules = QList(ctx.words.begin() + 1, ctx.words.end()).join('\n');
+#else
+    auto filterRules = [&]() {
+        auto tmpList = ctx.words;
+        tmpList.pop_front();
+        return tmpList.join('\n');
+    }();
+#endif
+
     QLoggingCategory::setFilterRules(filterRules);
 
     auto message =

--- a/src/controllers/commands/builtin/chatterino/Debugging.cpp
+++ b/src/controllers/commands/builtin/chatterino/Debugging.cpp
@@ -1,0 +1,43 @@
+#include "controllers/commands/builtin/chatterino/Debugging.hpp"
+
+#include "common/Channel.hpp"
+#include "controllers/commands/CommandContext.hpp"
+#include "messages/MessageBuilder.hpp"
+
+#include <QLoggingCategory>
+#include <QString>
+
+namespace chatterino::commands {
+
+QString setLoggingRules(const CommandContext &ctx)
+{
+    if (ctx.words.size() < 2)
+    {
+        ctx.channel->addMessage(makeSystemMessage(
+            "Usage: /c2:loggingrules <rules...>. To enable debug logging for "
+            "all "
+            "categories from chatterino, use 'chatterino.*.debug=true'. For "
+            "the format on the rules, see "
+            "https://doc.qt.io/qt-6/"
+            "qloggingcategory.html#configuring-categories"));
+        return {};
+    }
+
+    QLoggingCategory::setFilterRules(ctx.words.sliced(1).join('\n'));
+
+    auto message = QStringLiteral("Updated filter rules.");
+
+    if (!qgetenv("QT_LOGGING_RULES").isEmpty())
+    {
+        message += QStringLiteral(
+            " Warning: Logging rules were previously set by the "
+            "QT_LOGGING_RULES environment variable. This might cause "
+            "interference - see: "
+            "https://doc.qt.io/qt-6/qloggingcategory.html#setFilterRules");
+    }
+
+    ctx.channel->addMessage(makeSystemMessage(message));
+    return "";
+}
+
+}  // namespace chatterino::commands

--- a/src/controllers/commands/builtin/chatterino/Debugging.cpp
+++ b/src/controllers/commands/builtin/chatterino/Debugging.cpp
@@ -14,10 +14,9 @@ QString setLoggingRules(const CommandContext &ctx)
     if (ctx.words.size() < 2)
     {
         ctx.channel->addMessage(makeSystemMessage(
-            "Usage: /c2:loggingrules <rules...>. To enable debug logging for "
-            "all "
-            "categories from chatterino, use 'chatterino.*.debug=true'. For "
-            "the format on the rules, see "
+            "Usage: /c2-set-logging-rules <rules...>. To enable debug logging "
+            "for all categories from chatterino, use "
+            "'chatterino.*.debug=true'. For the format on the rules, see "
             "https://doc.qt.io/qt-6/"
             "qloggingcategory.html#configuring-categories"));
         return {};

--- a/src/controllers/commands/builtin/chatterino/Debugging.cpp
+++ b/src/controllers/commands/builtin/chatterino/Debugging.cpp
@@ -23,7 +23,8 @@ QString setLoggingRules(const CommandContext &ctx)
         return {};
     }
 
-    QLoggingCategory::setFilterRules(ctx.words.sliced(1).join('\n'));
+    QLoggingCategory::setFilterRules(
+        QList(ctx.words.begin() + 1, ctx.words.end()).join('\n'));
 
     auto message = QStringLiteral("Updated filter rules.");
 

--- a/src/controllers/commands/builtin/chatterino/Debugging.cpp
+++ b/src/controllers/commands/builtin/chatterino/Debugging.cpp
@@ -23,10 +23,11 @@ QString setLoggingRules(const CommandContext &ctx)
         return {};
     }
 
-    QLoggingCategory::setFilterRules(
-        QList(ctx.words.begin() + 1, ctx.words.end()).join('\n'));
+    auto filterRules = QList(ctx.words.begin() + 1, ctx.words.end()).join('\n');
+    QLoggingCategory::setFilterRules(filterRules);
 
-    auto message = QStringLiteral("Updated filter rules.");
+    auto message =
+        QStringLiteral("Updated filter rules to '%1'.").arg(filterRules);
 
     if (!qgetenv("QT_LOGGING_RULES").isEmpty())
     {
@@ -38,7 +39,7 @@ QString setLoggingRules(const CommandContext &ctx)
     }
 
     ctx.channel->addMessage(makeSystemMessage(message));
-    return "";
+    return {};
 }
 
 }  // namespace chatterino::commands

--- a/src/controllers/commands/builtin/chatterino/Debugging.cpp
+++ b/src/controllers/commands/builtin/chatterino/Debugging.cpp
@@ -22,15 +22,7 @@ QString setLoggingRules(const CommandContext &ctx)
         return {};
     }
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
-    auto filterRules = QList(ctx.words.begin() + 1, ctx.words.end()).join('\n');
-#else
-    auto filterRules = [&]() {
-        auto tmpList = ctx.words;
-        tmpList.pop_front();
-        return tmpList.join('\n');
-    }();
-#endif
+    auto filterRules = ctx.words.mid(1).join('\n');
 
     QLoggingCategory::setFilterRules(filterRules);
 

--- a/src/controllers/commands/builtin/chatterino/Debugging.hpp
+++ b/src/controllers/commands/builtin/chatterino/Debugging.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+class QString;
+
+namespace chatterino {
+
+struct CommandContext;
+
+namespace commands {
+
+    QString setLoggingRules(const CommandContext &ctx);
+
+}  // namespace commands
+
+}  // namespace chatterino

--- a/src/controllers/commands/builtin/chatterino/Debugging.hpp
+++ b/src/controllers/commands/builtin/chatterino/Debugging.hpp
@@ -6,10 +6,10 @@ namespace chatterino {
 
 struct CommandContext;
 
-namespace commands {
-
-    QString setLoggingRules(const CommandContext &ctx);
-
-}  // namespace commands
-
 }  // namespace chatterino
+
+namespace chatterino::commands {
+
+QString setLoggingRules(const CommandContext &ctx);
+
+}  // namespace chatterino::commands


### PR DESCRIPTION
# Description

This PR adds the `/c2:loggingrules` command. You invoke it like this: `/c2:loggingrules chatterino.*.debug=true chatterino.http.debug=false`. This will apply both rules. I'm not too sure about the command name/prefix/namespace (my thinking was to have this behind a namespace/prefix, so it's clear that this is a Chatterino command).

This command is mainly for debugging release builds without restarting - so that you get more logs when you attach a debugger/console or even a dedicated program capturing logs.