### PR TITLE
Configure CMake for `clang-tidy` separately

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -278,10 +278,25 @@ jobs:
         if: matrix.clang-tidy-review && github.event_name == 'pull_request'
         uses: ZedThree/clang-tidy-review@v0.13.0
         with:
-          build_dir: build
+          build_dir: build-clang-tidy
           config_file: ".clang-tidy"
           split_workflow: true
           exclude: "tests/*,lib/*"
+          cmake_command: >-
+            cmake -S. -Bbuild-clang-tidy 
+            -DCMAKE_BUILD_TYPE=Release 
+            -DPAJLADA_SETTINGS_USE_BOOST_FILESYSTEM=On 
+            -DUSE_PRECOMPILED_HEADERS=OFF 
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=On 
+            -DCHATTERINO_LTO=Off 
+            -DCHATTERINO_PLUGINS=On 
+            -DBUILD_WITH_QT6=Off
+          apt_packages: >-
+            qttools5-dev, qt5-image-formats-plugins, libqt5svg5-dev, 
+            libsecret-1-dev,
+            libboost-dev, libboost-system-dev, libboost-filesystem-dev,
+            libssl-dev,
+            rapidjson-dev
 
       - name: clang-tidy-review upload
         if: matrix.clang-tidy-review && github.event_name == 'pull_request'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Dev: Added command to set Qt's logging filter/rules at runtime (`/c2-set-logging-rules`). (#4637)
 - Dev: Added the ability to see & load custom themes from the Themes directory. No stable promises are made of this feature, changes might be made that breaks custom themes without notice. (#4570)
 - Dev: Added test cases for emote and tab completion. (#4644)
+- Dev: Fixed `clang-tidy-review` action not picking up dependencies. (#4648)
 
 ## 2.4.4
 

--- a/src/providers/seventv/SeventvBadges.cpp
+++ b/src/providers/seventv/SeventvBadges.cpp
@@ -42,7 +42,7 @@ void SeventvBadges::loadSeventvBadges()
     url.setQuery(urlQuery);
 
     NetworkRequest(url)
-        .onSuccess([this](const NetworkResult &result) -> Outcome {
+        .onSuccess([this](NetworkResult result) -> Outcome {
             auto root = result.parseJson();
 
             std::unique_lock lock(this->mutex_);

--- a/src/providers/seventv/SeventvBadges.cpp
+++ b/src/providers/seventv/SeventvBadges.cpp
@@ -42,7 +42,7 @@ void SeventvBadges::loadSeventvBadges()
     url.setQuery(urlQuery);
 
     NetworkRequest(url)
-        .onSuccess([this](NetworkResult result) -> Outcome {
+        .onSuccess([this](const NetworkResult &result) -> Outcome {
             auto root = result.parseJson();
 
             std::unique_lock lock(this->mutex_);


### PR DESCRIPTION
# Description

Since the [`clang-tidy-review`](https://github.com/marketplace/actions/clang-tidy-review) action runs in Docker, it doesn't have access to all the dependencies outside the container. Packages needed to build can be specified using the `apt_packages` input.

Currently, the `build` folder from the regular build is reused inside the action. This has some conflicts relating to paths changing.

This PR addresses both points by specifying `apt_packages` and (re-)configuring CMake in a different directory. Unfortunately, it doesn't use the Qt version installed by `aqt`, but uses the system's Qt. This shouldn't be much of an issue since the system's Qt is 5.15.3, thus in the supported range.

As a proof, I edited one file to trigger a lint. Without this PR, `clang-tidy` would fail on the `QHash` include (`SeventvBadges.cpp` > `SeventvBadges.hpp` > `Aliases.hpp`) and exit with `1`. **This should be reverted before merging.**

Fixes #4403.

