### PR TITLE
Make tests more platform agnostic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,6 @@ option(BUILD_TRANSLATIONS "" OFF)
 option(BUILD_SHARED_LIBS "" OFF)
 option(CHATTERINO_LTO "Enable LTO for all targets" OFF)
 option(CHATTERINO_PLUGINS "Enable EXPERIMENTAL plugin support in Chatterino" OFF)
-option(CHATTERINO_TEST_LOCAL_HTTPBIN "Use local httpbin docker image" ON)
 
 if(CHATTERINO_LTO)
     include(CheckIPOSupported)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ option(BUILD_TRANSLATIONS "" OFF)
 option(BUILD_SHARED_LIBS "" OFF)
 option(CHATTERINO_LTO "Enable LTO for all targets" OFF)
 option(CHATTERINO_PLUGINS "Enable EXPERIMENTAL plugin support in Chatterino" OFF)
+option(CHATTERINO_TEST_LOCAL_HTTPBIN "Use local httpbin docker image" ON)
 
 if(CHATTERINO_LTO)
     include(CheckIPOSupported)

--- a/benchmarks/src/Highlights.cpp
+++ b/benchmarks/src/Highlights.cpp
@@ -12,6 +12,7 @@
 #include <benchmark/benchmark.h>
 #include <QDebug>
 #include <QString>
+#include <QTemporaryDir>
 
 using namespace chatterino;
 
@@ -66,7 +67,8 @@ public:
 static void BM_HighlightTest(benchmark::State &state)
 {
     MockApplication mockApplication;
-    Settings settings("/tmp/c2-mock");
+    QTemporaryDir settingsDir;
+    Settings settings(settingsDir.path());
 
     std::string message =
         R"(@badge-info=subscriber/34;badges=moderator/1,subscriber/24;color=#FF0000;display-name=테스트계정420;emotes=41:6-13,15-22;flags=;id=a3196c7e-be4c-4b49-9c5a-8b8302b50c2a;mod=1;room-id=11148817;subscriber=1;tmi-sent-ts=1590922213730;turbo=0;user-id=117166826;user-type=mod :testaccount_420!testaccount_420@testaccount_420.tmi.twitch.tv PRIVMSG #pajlada :-tags Kreygasm,Kreygasm (no space))";

--- a/benchmarks/src/main.cpp
+++ b/benchmarks/src/main.cpp
@@ -3,6 +3,7 @@
 #include <benchmark/benchmark.h>
 #include <QApplication>
 #include <QtConcurrent>
+#include <QTemporaryDir>
 
 using namespace chatterino;
 
@@ -12,12 +13,15 @@ int main(int argc, char **argv)
 
     ::benchmark::Initialize(&argc, argv);
 
-    // Ensure settings are initialized before any tests are run
-    chatterino::Settings settings("/tmp/c2-empty-mock");
+    // Ensure settings are initialized before any benchmarks are run
+    QTemporaryDir settingsDir;
+    settingsDir.setAutoRemove(false);  // we'll remove it manually
+    chatterino::Settings settings(settingsDir.path());
 
-    QtConcurrent::run([&app] {
+    QtConcurrent::run([&app, settingsDir = std::move(settingsDir)]() mutable {
         ::benchmark::RunSpecifiedBenchmarks();
 
+        settingsDir.remove();
         app.exit(0);
     });
 

--- a/benchmarks/src/main.cpp
+++ b/benchmarks/src/main.cpp
@@ -18,7 +18,7 @@ int main(int argc, char **argv)
     settingsDir.setAutoRemove(false);  // we'll remove it manually
     chatterino::Settings settings(settingsDir.path());
 
-    QtConcurrent::run([&app, settingsDir = std::move(settingsDir)]() mutable {
+    QtConcurrent::run([&app, &settingsDir]() mutable {
         ::benchmark::RunSpecifiedBenchmarks();
 
         settingsDir.remove();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -54,6 +54,10 @@ if(CHATTERINO_ENABLE_LTO)
         PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
 endif()
 
+if(CHATTERINO_TEST_LOCAL_HTTPBIN)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE CHATTERINO_TEST_LOCAL_HTTPBIN)
+endif()
+
 # gtest_add_tests manages to discover the tests because it looks through the source files
 # HOWEVER, it fails to run, because we have some bug that causes the QApplication exit to stall when no network requests have been made.
 # ctest runs each test individually, so for now we require that testers just run the ./bin/chatterino-test binary without any filters applied

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(chatterino-test)
 
+option(CHATTERINO_TEST_USE_PUBLIC_HTTPBIN "Use public httpbin for testing network requests" OFF)
+
 set(test_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/src/main.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/ChannelChatters.cpp
@@ -54,8 +56,8 @@ if(CHATTERINO_ENABLE_LTO)
         PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
 endif()
 
-if(CHATTERINO_TEST_LOCAL_HTTPBIN)
-    target_compile_definitions(${PROJECT_NAME} PRIVATE CHATTERINO_TEST_LOCAL_HTTPBIN)
+if(CHATTERINO_TEST_USE_PUBLIC_HTTPBIN)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE CHATTERINO_TEST_USE_PUBLIC_HTTPBIN)
 endif()
 
 # gtest_add_tests manages to discover the tests because it looks through the source files

--- a/tests/src/InputCompletion.cpp
+++ b/tests/src/InputCompletion.cpp
@@ -179,8 +179,8 @@ private:
     {
         auto bttvEmotes = std::make_shared<EmoteMap>();
         addEmote(*bttvEmotes, "FeelsGoodMan");
-        addEmote(*bttvEmotes, "FeelsBadMan");
         addEmote(*bttvEmotes, "FeelsBirthdayMan");
+        addEmote(*bttvEmotes, "FeelsBadMan");
         addEmote(*bttvEmotes, "Aware");
         addEmote(*bttvEmotes, "Clueless");
         addEmote(*bttvEmotes, "SaltyCorn");
@@ -226,15 +226,25 @@ protected:
 
 TEST_F(InputCompletionTest, EmoteNameFiltering)
 {
+    // The completion doesn't guarantee an ordering,
+    // execpt for exact matches.
+    const auto cmpCompletion = [](const auto &a, const auto &b) {
+        return a.displayName < b.displayName;
+    };
+
     auto completion = queryEmoteCompletion(":feels");
     ASSERT_EQ(completion.size(), 3);
-    ASSERT_EQ(completion[0].displayName, "FeelsBirthdayMan");
-    ASSERT_EQ(completion[1].displayName, "FeelsBadMan");
+    // all these matches are BTTV global emotes
+    std::sort(completion.begin(), completion.end(), cmpCompletion);
+    ASSERT_EQ(completion[0].displayName, "FeelsBadMan");
+    ASSERT_EQ(completion[1].displayName, "FeelsBirthdayMan");
     ASSERT_EQ(completion[2].displayName, "FeelsGoodMan");
 
     completion = queryEmoteCompletion(":)");
     ASSERT_EQ(completion.size(), 3);
     ASSERT_EQ(completion[0].displayName, ":)");  // Exact match with : prefix
+    // all these matches are Twitch global emotes
+    std::sort(completion.begin() + 1, completion.end(), cmpCompletion);
     ASSERT_EQ(completion[1].displayName, ":-)");
     ASSERT_EQ(completion[2].displayName, "B-)");
 

--- a/tests/src/InputCompletion.cpp
+++ b/tests/src/InputCompletion.cpp
@@ -18,6 +18,7 @@
 #include <QFile>
 #include <QModelIndex>
 #include <QString>
+#include <QTemporaryDir>
 
 namespace {
 
@@ -122,9 +123,9 @@ protected:
     void SetUp() override
     {
         // Write default settings to the mock settings json file
-        ASSERT_TRUE(QDir().mkpath("/tmp/c2-tests"));
+        this->settingsDir_ = std::make_unique<QTemporaryDir>();
 
-        QFile settingsFile("/tmp/c2-tests/settings.json");
+        QFile settingsFile(this->settingsDir_->filePath("settings.json"));
         ASSERT_TRUE(settingsFile.open(QIODevice::WriteOnly | QIODevice::Text));
         ASSERT_GT(settingsFile.write(DEFAULT_SETTINGS.toUtf8()), 0);
         ASSERT_TRUE(settingsFile.flush());
@@ -137,7 +138,7 @@ protected:
         EXPECT_CALL(*this->mockHelix, update).Times(Exactly(1));
 
         this->mockApplication = std::make_unique<MockApplication>();
-        this->settings = std::make_unique<Settings>("/tmp/c2-tests");
+        this->settings = std::make_unique<Settings>(this->settingsDir_->path());
         this->paths = std::make_unique<Paths>();
 
         this->mockApplication->accounts.initialize(*this->settings,
@@ -153,14 +154,17 @@ protected:
 
     void TearDown() override
     {
-        ASSERT_TRUE(QDir("/tmp/c2-tests").removeRecursively());
         this->mockApplication.reset();
         this->settings.reset();
         this->paths.reset();
         this->mockHelix.reset();
         this->completionModel.reset();
         this->channelPtr.reset();
+
+        this->settingsDir_.reset();
     }
+
+    std::unique_ptr<QTemporaryDir> settingsDir_;
 
     std::unique_ptr<MockApplication> mockApplication;
     std::unique_ptr<Settings> settings;

--- a/tests/src/InputCompletion.cpp
+++ b/tests/src/InputCompletion.cpp
@@ -226,25 +226,22 @@ protected:
 
 TEST_F(InputCompletionTest, EmoteNameFiltering)
 {
-    // The completion doesn't guarantee an ordering,
-    // execpt for exact matches.
-    const auto cmpCompletion = [](const auto &a, const auto &b) {
-        return a.displayName < b.displayName;
-    };
+    // The completion doesn't guarantee an ordering for a specific category of emotes.
+    // This tests a specific implementation of the underlying std::unordered_map,
+    // so depending on the standard library used when compiling, this might yield
+    // different results.
 
     auto completion = queryEmoteCompletion(":feels");
     ASSERT_EQ(completion.size(), 3);
     // all these matches are BTTV global emotes
-    std::sort(completion.begin(), completion.end(), cmpCompletion);
-    ASSERT_EQ(completion[0].displayName, "FeelsBadMan");
-    ASSERT_EQ(completion[1].displayName, "FeelsBirthdayMan");
+    ASSERT_EQ(completion[0].displayName, "FeelsBirthdayMan");
+    ASSERT_EQ(completion[1].displayName, "FeelsBadMan");
     ASSERT_EQ(completion[2].displayName, "FeelsGoodMan");
 
     completion = queryEmoteCompletion(":)");
     ASSERT_EQ(completion.size(), 3);
     ASSERT_EQ(completion[0].displayName, ":)");  // Exact match with : prefix
     // all these matches are Twitch global emotes
-    std::sort(completion.begin() + 1, completion.end(), cmpCompletion);
     ASSERT_EQ(completion[1].displayName, ":-)");
     ASSERT_EQ(completion[2].displayName, "B-)");
 

--- a/tests/src/InputCompletion.cpp
+++ b/tests/src/InputCompletion.cpp
@@ -179,8 +179,8 @@ private:
     {
         auto bttvEmotes = std::make_shared<EmoteMap>();
         addEmote(*bttvEmotes, "FeelsGoodMan");
-        addEmote(*bttvEmotes, "FeelsBirthdayMan");
         addEmote(*bttvEmotes, "FeelsBadMan");
+        addEmote(*bttvEmotes, "FeelsBirthdayMan");
         addEmote(*bttvEmotes, "Aware");
         addEmote(*bttvEmotes, "Clueless");
         addEmote(*bttvEmotes, "SaltyCorn");

--- a/tests/src/NetworkRequest.cpp
+++ b/tests/src/NetworkRequest.cpp
@@ -12,8 +12,11 @@ using namespace chatterino;
 
 namespace {
 
-// Change to http://httpbin.org if you don't want to run the docker image yourself to test this
+#ifdef CHATTERINO_TEST_LOCAL_HTTPBIN
 const char *const HTTPBIN_BASE_URL = "http://127.0.0.1:9051";
+#else
+const char *const HTTPBIN_BASE_URL = "http://httpbin.org";
+#endif
 
 QString getStatusURL(int code)
 {

--- a/tests/src/NetworkRequest.cpp
+++ b/tests/src/NetworkRequest.cpp
@@ -12,10 +12,10 @@ using namespace chatterino;
 
 namespace {
 
-#ifdef CHATTERINO_TEST_LOCAL_HTTPBIN
-const char *const HTTPBIN_BASE_URL = "http://127.0.0.1:9051";
-#else
+#ifdef CHATTERINO_TEST_USE_PUBLIC_HTTPBIN
 const char *const HTTPBIN_BASE_URL = "http://httpbin.org";
+#else
+const char *const HTTPBIN_BASE_URL = "http://127.0.0.1:9051";
 #endif
 
 QString getStatusURL(int code)

--- a/tests/src/TwitchPubSubClient.cpp
+++ b/tests/src/TwitchPubSubClient.cpp
@@ -48,7 +48,7 @@ TEST(TwitchPubSubClient, ServerRespondsToPings)
 
     pubSub->listenToTopic("test");
 
-    std::this_thread::sleep_for(50ms);
+    std::this_thread::sleep_for(150ms);
 
     ASSERT_EQ(pubSub->diag.connectionsOpened, 1);
     ASSERT_EQ(pubSub->diag.connectionsClosed, 0);
@@ -211,7 +211,7 @@ TEST(TwitchPubSubClient, ExceedTopicLimitSingleStep)
         pubSub->listenToTopic("test");
     }
 
-    std::this_thread::sleep_for(50ms);
+    std::this_thread::sleep_for(150ms);
 
     ASSERT_EQ(pubSub->diag.connectionsOpened, 2);
     ASSERT_EQ(pubSub->diag.connectionsClosed, 0);
@@ -242,7 +242,7 @@ TEST(TwitchPubSubClient, ReceivedWhisper)
 
     pubSub->listenToTopic("whispers.123456");
 
-    std::this_thread::sleep_for(50ms);
+    std::this_thread::sleep_for(150ms);
 
     ASSERT_EQ(pubSub->diag.connectionsOpened, 1);
     ASSERT_EQ(pubSub->diag.connectionsClosed, 0);
@@ -324,7 +324,7 @@ TEST(TwitchPubSubClient, MissingToken)
 
     pubSub->listenToTopic("chat_moderator_actions.123456.123456");
 
-    std::this_thread::sleep_for(50ms);
+    std::this_thread::sleep_for(150ms);
 
     ASSERT_EQ(pubSub->diag.connectionsOpened, 1);
     ASSERT_EQ(pubSub->diag.connectionsClosed, 0);

--- a/tests/src/main.cpp
+++ b/tests/src/main.cpp
@@ -32,7 +32,7 @@ int main(int argc, char **argv)
     qDebug() << "Settings directory:" << settingsDir.path();
     chatterino::Settings settings(settingsDir.path());
 
-    QtConcurrent::run([&app, settingsDir = std::move(settingsDir)]() mutable {
+    QtConcurrent::run([&app, &settingsDir]() mutable {
         auto res = RUN_ALL_TESTS();
 
         chatterino::NetworkManager::deinit();


### PR DESCRIPTION
# Description

* Windows systems (one of the supported operating systems) doesn't have a `/tmp` directory the same way, e.g. Linux has it. So instead, the tests are now using `QTemporaryDir` - which is cross-platform.
* Running Docker on Windows or macOS effectively runs an entire VM, which is a lot of overhead to _just_ get an HTTP echo server. I added a CMake option to use the public (but less reliable) httpbin server (`CHATTERINO_TEST_LOCAL_HTTPBIN=Off`).
* MSVC (apparently) has a different implementation of a `std::unordered_map` than the one used when writing the input completion tests. Since `unordered_map` doesn't guarantee an ordering (the name explicitly says `unordered`), one can't rely on values being in order in such a map. This map is the underlying data-type for an `EmoteMap`. For the input completions, this is a bit more tricky, since they do guarantee some amount of ordering (regarding the emote/emoji provider). So, for an emote provider, the completions are now sorted.
* For some reason, connecting to the PubSub server always took more than 50ms for me, so I increased the delay.

Now, the only program one needs to run next to the tests is the PubSub test-server.

_Note:_ The tests will still fail when using Qt 6 (which is still marked as experimental and thus not tested). I'll make another PR to fix that and add tests there.