### PR TITLE
Clean up GenericListModel

### DIFF
--- a/src/widgets/listview/GenericListModel.cpp
+++ b/src/widgets/listview/GenericListModel.cpp
@@ -15,10 +15,14 @@ int GenericListModel::rowCount(const QModelIndex &parent) const
 QVariant GenericListModel::data(const QModelIndex &index, int /* role */) const
 {
     if (!index.isValid())
+    {
         return QVariant();
+    }
 
     if (index.row() >= this->items_.size())
+    {
         return QVariant();
+    }
 
     auto item = this->items_[index.row()].get();
     // See https://stackoverflow.com/a/44503822 .
@@ -37,7 +41,9 @@ void GenericListModel::addItem(std::unique_ptr<GenericListItem> item)
 void GenericListModel::clear()
 {
     if (this->items_.empty())
+    {
         return;
+    }
 
     // {begin,end}RemoveRows needs to be called to notify attached views
     this->beginRemoveRows(QModelIndex(), 0, this->items_.size() - 1);

--- a/src/widgets/listview/GenericListModel.cpp
+++ b/src/widgets/listview/GenericListModel.cpp
@@ -48,4 +48,9 @@ void GenericListModel::clear()
     this->endRemoveRows();
 }
 
+void GenericListModel::reserve(size_t capacity)
+{
+    this->items_.reserve(capacity);
+}
+
 }  // namespace chatterino

--- a/src/widgets/listview/GenericListModel.cpp
+++ b/src/widgets/listview/GenericListModel.cpp
@@ -2,7 +2,7 @@
 
 namespace chatterino {
 
-GenericListModel::GenericListModel(QWidget *parent)
+GenericListModel::GenericListModel(QObject *parent)
     : QAbstractListModel(parent)
 {
 }

--- a/src/widgets/listview/GenericListModel.cpp
+++ b/src/widgets/listview/GenericListModel.cpp
@@ -24,7 +24,7 @@ QVariant GenericListModel::data(const QModelIndex &index, int /* role */) const
         return QVariant();
     }
 
-    auto item = this->items_[index.row()].get();
+    auto *item = this->items_[index.row()].get();
     // See https://stackoverflow.com/a/44503822 .
     return QVariant::fromValue(static_cast<void *>(item));
 }

--- a/src/widgets/listview/GenericListModel.cpp
+++ b/src/widgets/listview/GenericListModel.cpp
@@ -7,7 +7,7 @@ GenericListModel::GenericListModel(QObject *parent)
 {
 }
 
-int GenericListModel::rowCount(const QModelIndex &parent) const
+int GenericListModel::rowCount(const QModelIndex & /*parent*/) const
 {
     return this->items_.size();
 }

--- a/src/widgets/listview/GenericListModel.cpp
+++ b/src/widgets/listview/GenericListModel.cpp
@@ -16,12 +16,12 @@ QVariant GenericListModel::data(const QModelIndex &index, int /* role */) const
 {
     if (!index.isValid())
     {
-        return QVariant();
+        return {};
     }
 
     if (index.row() >= this->items_.size())
     {
-        return QVariant();
+        return {};
     }
 
     auto *item = this->items_[index.row()].get();

--- a/src/widgets/listview/GenericListModel.hpp
+++ b/src/widgets/listview/GenericListModel.hpp
@@ -6,6 +6,7 @@
 #include <QObject>
 
 #include <memory>
+#include <vector>
 
 namespace chatterino {
 

--- a/src/widgets/listview/GenericListModel.hpp
+++ b/src/widgets/listview/GenericListModel.hpp
@@ -19,7 +19,7 @@ public:
      *
      * @return  number of items currently present in this model
      */
-    int rowCount(const QModelIndex &parent = QModelIndex()) const;
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
 
     /**
      * @brief   Reimplements QAbstractItemModel::data. Currently, the role parameter
@@ -30,7 +30,7 @@ public:
      *
      * @return  GenericListItem * (wrapped as QVariant) at index
      */
-    QVariant data(const QModelIndex &index, int role) const;
+    QVariant data(const QModelIndex &index, int role) const override;
 
     /**
      * @brief   Add an item to this QuickSwitcherModel. It will be displayed in

--- a/src/widgets/listview/GenericListModel.hpp
+++ b/src/widgets/listview/GenericListModel.hpp
@@ -3,7 +3,7 @@
 #include "widgets/listview/GenericListItem.hpp"
 
 #include <QAbstractListModel>
-#include <QWidget>
+#include <QObject>
 
 #include <memory>
 
@@ -12,7 +12,7 @@ namespace chatterino {
 class GenericListModel : public QAbstractListModel
 {
 public:
-    GenericListModel(QWidget *parent = nullptr);
+    GenericListModel(QObject *parent = nullptr);
 
     /**
      * @brief   Reimplements QAbstractItemModel::rowCount.

--- a/src/widgets/listview/GenericListModel.hpp
+++ b/src/widgets/listview/GenericListModel.hpp
@@ -17,7 +17,7 @@ public:
     /**
      * @brief   Reimplements QAbstractItemModel::rowCount.
      *
-     * @return  number of items currrently present in this model
+     * @return  number of items currently present in this model
      */
     int rowCount(const QModelIndex &parent = QModelIndex()) const;
 

--- a/src/widgets/listview/GenericListModel.hpp
+++ b/src/widgets/listview/GenericListModel.hpp
@@ -50,6 +50,11 @@ public:
      */
     void clear();
 
+    /**
+     * @brief   Increases the capacity of the list model.
+     */
+    void reserve(size_t capacity);
+
 private:
     std::vector<std::unique_ptr<GenericListItem>> items_;
 };


### PR DESCRIPTION
# Description

- Change GenericListModel parent type to QObject
- GenericListModel comment typo
- GenericListModel: Mark functions as override where possible
- add reserve method to GenericListModel
- GenericListModel clang-tidy: add braces
- GenericListModel clang-tidy: Comment out unused parameter
- GenericListModel clang-tidy: explicitly use auto \*
- GenericListModel clang-tidy: avoid repeating type
- GenericListModel: add vector include

Initial changes taken from https://github.com/Chatterino/chatterino2/pull/4639

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
