### PR TITLE
Consider nicknames when searching

### DIFF
--- a/src/controllers/nicknames/Nickname.hpp
+++ b/src/controllers/nicknames/Nickname.hpp
@@ -58,25 +58,24 @@ public:
         return this->isCaseSensitive_;
     }
 
-    [[nodiscard]] bool match(QString &usernameText) const
+    [[nodiscard]] boost::optional<QString> match(const QString &usernameText) const
     {
         if (this->isRegex())
         {
             if (!this->regex_.isValid())
             {
-                return false;
+                return boost::none;
             }
             if (this->name().isEmpty())
             {
-                return false;
+                return boost::none;
             }
 
             auto workingCopy = usernameText;
             workingCopy.replace(this->regex_, this->replace());
             if (workingCopy != usernameText)
             {
-                usernameText = workingCopy;
-                return true;
+                return workingCopy;
             }
         }
         else
@@ -85,12 +84,11 @@ public:
                 this->name().compare(usernameText, this->caseSensitivity());
             if (res == 0)
             {
-                usernameText = this->replace();
-                return true;
+                return this->replace();
             }
         }
 
-        return false;
+        return boost::none;
     }
 
 private:

--- a/src/messages/SharedMessageBuilder.cpp
+++ b/src/messages/SharedMessageBuilder.cpp
@@ -270,14 +270,8 @@ QString SharedMessageBuilder::stylizeUsername(const QString &username,
         break;
     }
 
-    auto nicknames = getCSettings().nicknames.readOnly();
-
-    for (const auto &nickname : *nicknames)
-    {
-        if (nickname.match(usernameText))
-        {
-            break;
-        }
+    if (auto nicknameText = getCSettings().matchNickname(usernameText)) {
+        usernameText = *nicknameText;
     }
 
     return usernameText;

--- a/src/providers/irc/IrcMessageBuilder.cpp
+++ b/src/providers/irc/IrcMessageBuilder.cpp
@@ -63,8 +63,10 @@ MessagePtr IrcMessageBuilder::build()
 
     // message
     this->addIrcMessageText(this->originalMessage_);
+    
+    QString stylizedUsername = this->stylizeUsername(this->userName, this->message());
 
-    this->message().searchText = this->message().localizedName + " " +
+    this->message().searchText = stylizedUsername + " " + this->message().localizedName + " " +
                                  this->userName + ": " + this->originalMessage_;
 
     // highlights

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -294,8 +294,10 @@ MessagePtr TwitchMessageBuilder::build()
 
     this->addWords(splits, twitchEmotes);
 
+    QString stylizedUsername = this->stylizeUsername(this->userName, this->message());
+
     this->message().messageText = this->originalMessage_;
-    this->message().searchText = this->message().localizedName + " " +
+    this->message().searchText = stylizedUsername + " " + this->message().localizedName + " " +
                                  this->userName + ": " + this->originalMessage_;
 
     // highlights

--- a/src/singletons/Settings.cpp
+++ b/src/singletons/Settings.cpp
@@ -81,6 +81,20 @@ bool ConcurrentSettings::isMutedChannel(const QString &channelName)
     return false;
 }
 
+boost::optional<QString> ConcurrentSettings::matchNickname(const QString &usernameText) {
+    auto nicknames = getCSettings().nicknames.readOnly();
+
+    for (const auto &nickname : *nicknames)
+    {
+        if (auto nicknameText = nickname.match(usernameText))
+        {
+            return nicknameText;
+        }
+    }
+
+    return boost::none;
+}
+
 void ConcurrentSettings::mute(const QString &channelName)
 {
     mutedChannels.append(channelName);

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -47,6 +47,7 @@ public:
     bool isBlacklistedUser(const QString &username);
     bool isMutedChannel(const QString &channelName);
     bool toggleMutedChannel(const QString &channelName);
+    boost::optional<QString> matchNickname(const QString &username);
 
 private:
     void mute(const QString &channelName);


### PR DESCRIPTION
![image](https://github.com/Chatterino/chatterino2/assets/9766338/386e6f98-e4aa-433c-afe1-dc4b4bc16983)

With this PR, searching now also finds results using nicknames instead of usernames.

The way I've done this is by prepending the stylized username to the search text, as it seems that nickname matching is based on the stylized username, instead of only the login name / display name. This isn't the best solution, as it does lead to a bit of duplication in the search text (for example, for the username `chrrrs`, it would lead to something like `chrrrs chrrrs: message`). If anyone has a better solution here, I'd be up for changing things around.