### PR TITLE
Remove duplicate Fluent icons license

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Dev: Fixed `clang-tidy-review` action not picking up dependencies. (#4648)
 - Dev: Expanded upon `$$$` test channels. (#4655)
 - Dev: Added tools to help debug image GC. (#4578)
+- Dev: Removed duplicate license when having plugins enabled. (#4665)
 
 ## 2.4.4
 

--- a/src/widgets/settingspages/AboutPage.cpp
+++ b/src/widgets/settingspages/AboutPage.cpp
@@ -117,9 +117,6 @@ AboutPage::AboutPage()
 #ifdef CHATTERINO_HAVE_PLUGINS
             addLicense(form.getElement(), "lua", "https://lua.org",
                        ":/licenses/lua.txt");
-            addLicense(form.getElement(), "Fluent icons",
-                       "https://github.com/microsoft/fluentui-system-icons",
-                       ":/licenses/fluenticons.txt");
 #endif
 #ifdef CHATTERINO_WITH_CRASHPAD
             addLicense(form.getElement(), "sentry-crashpad",


### PR DESCRIPTION
# Description

I noticed in the About Page that there were two Fluent icon links which seem to do exactly the same, so I thought I'd PR a removal.

See:
![image](https://github.com/Chatterino/chatterino2/assets/30803034/d43a7a3d-5cbc-405c-ae89-c43864f763e8)

I'm not sure if I should make it a Minor or Bugfix entry :thinking: