### PR TITLE
Don't add QLayouts to QWidgets that already have one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Dev: Added tools to help debug image GC. (#4578)
 - Dev: Removed duplicate license when having plugins enabled. (#4665)
 - Dev: Replace our QObjectRef class with Qt's QPointer class. (#4666)
+- Dev: Fixed warnings about QWidgets already having a QLayout. (#4672)
 
 ## 2.4.4
 

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -152,7 +152,7 @@ void Window::closeEvent(QCloseEvent *)
 
 void Window::addLayout()
 {
-    QVBoxLayout *layout = new QVBoxLayout(this);
+    auto *layout = new QVBoxLayout();
 
     layout->addWidget(this->notebook_);
     this->getLayoutContainer()->setLayout(layout);

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -209,7 +209,7 @@ EmotePopup::EmotePopup(QWidget *parent)
     this->setStayInScreenRect(true);
     this->moveTo(this, getApp()->windows->emotePopupPos(), false);
 
-    auto *layout = new QVBoxLayout(this);
+    auto *layout = new QVBoxLayout();
     this->getLayoutContainer()->setLayout(layout);
 
     QRegularExpression searchRegex("\\S*");
@@ -218,7 +218,7 @@ EmotePopup::EmotePopup(QWidget *parent)
     layout->setContentsMargins(0, 0, 0, 0);
     layout->setSpacing(0);
 
-    auto *layout2 = new QHBoxLayout(this);
+    auto *layout2 = new QHBoxLayout();
     layout2->setContentsMargins(8, 8, 8, 8);
     layout2->setSpacing(8);
 

--- a/src/widgets/helper/EditableModelView.cpp
+++ b/src/widgets/helper/EditableModelView.cpp
@@ -32,7 +32,7 @@ EditableModelView::EditableModelView(QAbstractTableModel *model, bool movable)
     vbox->setContentsMargins(0, 0, 0, 0);
 
     // create button layout
-    QHBoxLayout *buttons = new QHBoxLayout(this);
+    QHBoxLayout *buttons = new QHBoxLayout();
     this->buttons_ = buttons;
     vbox->addLayout(buttons);
 

--- a/src/widgets/helper/EditableModelView.cpp
+++ b/src/widgets/helper/EditableModelView.cpp
@@ -32,7 +32,7 @@ EditableModelView::EditableModelView(QAbstractTableModel *model, bool movable)
     vbox->setContentsMargins(0, 0, 0, 0);
 
     // create button layout
-    QHBoxLayout *buttons = new QHBoxLayout();
+    auto *buttons = new QHBoxLayout();
     this->buttons_ = buttons;
     vbox->addLayout(buttons);
 

--- a/src/widgets/helper/SearchPopup.cpp
+++ b/src/widgets/helper/SearchPopup.cpp
@@ -280,7 +280,7 @@ void SearchPopup::initLayout()
 
         // HBOX
         {
-            auto *layout2 = new QHBoxLayout(this);
+            auto *layout2 = new QHBoxLayout();
             layout2->setContentsMargins(8, 8, 8, 8);
             layout2->setSpacing(8);
 

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -1124,7 +1124,7 @@ void Split::showViewerList()
     viewerDock->move(0, this->header_->height());
 
     auto multiWidget = new QWidget(viewerDock);
-    auto dockVbox = new QVBoxLayout(viewerDock);
+    auto dockVbox = new QVBoxLayout();
     auto searchBar = new QLineEdit(viewerDock);
 
     auto chattersList = new QListWidget();

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -1124,7 +1124,7 @@ void Split::showViewerList()
     viewerDock->move(0, this->header_->height());
 
     auto multiWidget = new QWidget(viewerDock);
-    auto dockVbox = new QVBoxLayout();
+    auto *dockVbox = new QVBoxLayout();
     auto searchBar = new QLineEdit(viewerDock);
 
     auto chattersList = new QListWidget();


### PR DESCRIPTION
# Description

Looking at the logs of Chatterino, you sometimes find a `QLayout: Attempting to add QLayout "" to QWidget "", which already has a layout`. [This StackOverflow answer](https://stackoverflow.com/a/25451334/16300717) has a good explanation.

If you have a `QLayout foo(widget)` and a `QLayout bar(widget)`, then the first constructor will set the layout of `widget` to be `foo` - calling [`setLayout`](https://doc.qt.io/qt-6/qwidget.html#setLayout). The second constructor will [try to set the layout as well](https://github.com/qt/qtbase/blob/727b6256c1921bedb7c3f23d49abe866e262ba97/src/widgets/kernel/qlayout.cpp#L101-L116), which will fail, because `widget`'s layout was already set, and you can't overwrite the layout if it already exists. The thing to keep in mind: The constructor of a `QLayout` automatically sets the layout for the widget that's passed in as the parent.

This PR removes these instances (I hope I didn't miss any).

