### PR TITLE
Fix undefined behaviour when loading non-existant credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Dev: Added tools to help debug image GC. (#4578)
 - Dev: Removed duplicate license when having plugins enabled. (#4665)
 - Dev: Replace our QObjectRef class with Qt's QPointer class. (#4666)
-- Dev: Fixed undefined behavior when loading credentials. (#4673)
+- Dev: Fixed undefined behavior when loading non-existant credentials. (#4673)
 
 ## 2.4.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Dev: Added tools to help debug image GC. (#4578)
 - Dev: Removed duplicate license when having plugins enabled. (#4665)
 - Dev: Replace our QObjectRef class with Qt's QPointer class. (#4666)
+- Dev: Fixed undefined behavior when loading credentials. (#4673)
 
 ## 2.4.4
 

--- a/src/common/Credentials.cpp
+++ b/src/common/Credentials.cpp
@@ -197,9 +197,9 @@ void Credentials::get(const QString &provider, const QString &name_,
     }
     else
     {
-        auto &instance = insecureInstance();
+        const auto &instance = insecureInstance();
 
-        onLoaded(instance.object().find(name).value().toString());
+        onLoaded(instance[name].toString());
     }
 }
 


### PR DESCRIPTION
# Description

If `instance` is an empty JSON-value (e.g. when `credentails.json` doesn't exist), [`object`](https://doc.qt.io/qt-6/qjsondocument.html#object) yields an empty object and thus calling [`find`](https://doc.qt.io/qt-6/qjsonobject.html#find) yields `end` which is basically a null-pointer-`QJsonRef`. Calling `toString` on it will cause an assertion to go off.

This function is called when you add an IRC server.