### PR TITLE
Fix crash resulting from a mutex deadlock when switching users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Minor: Added `/shoutout <username>` commands to shoutout specified user. (#4638)
 - Minor: Improved editing hotkeys. (#4628)
 - Bugfix: Fixed generation of crashdumps by the browser-extension process when the browser was closed. (#4667)
+- Bugfix: Fixed a crash when opening and closing a reply thread and switching the user. (#4675)
 - Dev: Added command to set Qt's logging filter/rules at runtime (`/c2-set-logging-rules`). (#4637)
 - Dev: Added the ability to see & load custom themes from the Themes directory. No stable promises are made of this feature, changes might be made that breaks custom themes without notice. (#4570)
 - Dev: Added test cases for emote and tab completion. (#4644)

--- a/src/widgets/dialogs/ReplyThreadPopup.hpp
+++ b/src/widgets/dialogs/ReplyThreadPopup.hpp
@@ -34,6 +34,8 @@ private:
     std::shared_ptr<MessageThread> thread_;
     // The channel that the reply thread is in
     ChannelPtr channel_;
+    // The channel for the `threadView`
+    ChannelPtr virtualChannel_;
     Split *split_;
 
     struct {


### PR DESCRIPTION
# Description

### Reproduction

* Open a reply thread popup in a Twitch channel
* Close it
* Switch the current user (make sure no message was sent in that channel after you closed the popup)
* 💥 

### Why?

1. The reply thread popup creates a virtual channel that displays the messages in that thread: https://github.com/Chatterino/chatterino2/blob/ca9c91a15b550afab2eb28087b45c5b745679eda/src/widgets/dialogs/ReplyThreadPopup.cpp#L141-L146
2. This channel is then part of the `messageAppended` callback: https://github.com/Chatterino/chatterino2/blob/ca9c91a15b550afab2eb28087b45c5b745679eda/src/widgets/dialogs/ReplyThreadPopup.cpp#L174-L175
3. When you close the popup, the connection is destroyed ([`~ScopedConnection`](https://github.com/pajlada/signals/blob/6561aa559ff47cbad4058b8144d4a72fd14edc29/include/pajlada/signals/scoped-connection.hpp#LL41C9-L41C39) ⇒ [`Callback::disconnect`](https://github.com/pajlada/signals/blob/6561aa559ff47cbad4058b8144d4a72fd14edc29/include/pajlada/signals/connection.hpp#LL193C9-L193C38) ⇒ [`CallbackBodyBase::disconnect`](https://github.com/pajlada/signals/blob/6561aa559ff47cbad4058b8144d4a72fd14edc29/include/pajlada/signals/connection.hpp#LL39C9-L39C36)).
4. When you switch the current user, the application reconnects: https://github.com/Chatterino/chatterino2/blob/ca9c91a15b550afab2eb28087b45c5b745679eda/src/providers/twitch/TwitchIrcServer.cpp#L73-L75 https://github.com/Chatterino/chatterino2/blob/ca9c91a15b550afab2eb28087b45c5b745679eda/src/providers/irc/AbstractIrcServer.cpp#L113-L117
5. Eventually you'll get disconnected, causing `AbstractIrcServer::onDisconnected` to be called. This will send a message on all channels:https://github.com/Chatterino/chatterino2/blob/ca9c91a15b550afab2eb28087b45c5b745679eda/src/providers/irc/AbstractIrcServer.cpp#L346-L364
6. Specifically, it will send a message in the channel you opened the reply popup from.
7. This will invoke the `messageAppended` signal: https://github.com/Chatterino/chatterino2/blob/ca9c91a15b550afab2eb28087b45c5b745679eda/src/common/Channel.cpp#L111
8. This will [destroy all disconnected callback bodies](https://github.com/pajlada/signals/blob/6561aa559ff47cbad4058b8144d4a72fd14edc29/include/pajlada/signals/signal.hpp#L73-L74).
9. Remember the disconnected callback body with our virtual channel from step 3? It will get destroyed here.
10. Since the virtual channel is part of that callback, it will be destroyed. Thus, `dropSeventvChannel` will be called: https://github.com/Chatterino/chatterino2/blob/ca9c91a15b550afab2eb28087b45c5b745679eda/src/providers/twitch/TwitchChannel.cpp#L162-L165
11. This will lock the `channelMutex`: https://github.com/Chatterino/chatterino2/blob/ca9c91a15b550afab2eb28087b45c5b745679eda/src/providers/twitch/TwitchIrcServer.cpp#L647-L655 But `AbstractIrcServer` locked this mutex in step 5.

---

This PR moves the virtual channel to the popup, thus it will be destroyed when the popup is destroyed.


