### PR TITLE
Fix spacing issue with mentions inside RTL text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Minor: Added `/shoutout <username>` commands to shoutout specified user. (#4638)
 - Minor: Improved editing hotkeys. (#4628)
 - Bugfix: Fixed generation of crashdumps by the browser-extension process when the browser was closed. (#4667)
+- Bugfix: Fix spacing issue with mentions inside RTL text. (#4677)
 - Dev: Added command to set Qt's logging filter/rules at runtime (`/c2-set-logging-rules`). (#4637)
 - Dev: Added the ability to see & load custom themes from the Themes directory. No stable promises are made of this feature, changes might be made that breaks custom themes without notice. (#4570)
 - Dev: Added test cases for emote and tab completion. (#4644)

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -276,21 +276,24 @@ void MessageLayoutContainer::reorderRTL(int firstTextIndex)
     // 2 - in LTR mode, the previous word should be RTL (i.e. reversed)
     for (int i = startIndex; i <= endIndex; i++)
     {
-        bool neutral = isNeutral(this->elements_[i]->getText()) ||
-                       this->elements_[i]->getFlags().hasAny(
-                           {MessageElementFlag::BoldUsername,
-                            MessageElementFlag::NonBoldUsername});
+        auto &element = this->elements_[i];
 
-        if (isNeutral(this->elements_[i]->getText()) &&
+        const auto neutral = isNeutral(element->getText());
+        const auto neutralOrUsername =
+            neutral ||
+            element->getFlags().hasAny({MessageElementFlag::BoldUsername,
+                                        MessageElementFlag::NonBoldUsername});
+
+        if (neutral &&
             ((this->first == FirstWord::RTL && !this->wasPrevReversed_) ||
              (this->first == FirstWord::LTR && this->wasPrevReversed_)))
         {
-            this->elements_[i]->reversedNeutral = true;
+            element->reversedNeutral = true;
         }
-        if (((this->elements_[i]->getText().isRightToLeft() !=
+        if (((element->getText().isRightToLeft() !=
               (this->first == FirstWord::RTL)) &&
-             !neutral) ||
-            (neutral && this->wasPrevReversed_))
+             !neutralOrUsername) ||
+            (neutralOrUsername && this->wasPrevReversed_))
         {
             swappedSequence.push(i);
             this->wasPrevReversed_ = true;

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -276,6 +276,11 @@ void MessageLayoutContainer::reorderRTL(int firstTextIndex)
     // 2 - in LTR mode, the previous word should be RTL (i.e. reversed)
     for (int i = startIndex; i <= endIndex; i++)
     {
+        bool neutral = isNeutral(this->elements_[i]->getText()) ||
+                       this->elements_[i]->getFlags().hasAny(
+                           {MessageElementFlag::BoldUsername,
+                            MessageElementFlag::NonBoldUsername});
+
         if (isNeutral(this->elements_[i]->getText()) &&
             ((this->first == FirstWord::RTL && !this->wasPrevReversed_) ||
              (this->first == FirstWord::LTR && this->wasPrevReversed_)))
@@ -284,9 +289,8 @@ void MessageLayoutContainer::reorderRTL(int firstTextIndex)
         }
         if (((this->elements_[i]->getText().isRightToLeft() !=
               (this->first == FirstWord::RTL)) &&
-             !isNeutral(this->elements_[i]->getText())) ||
-            (isNeutral(this->elements_[i]->getText()) &&
-             this->wasPrevReversed_))
+             !neutral) ||
+            (neutral && this->wasPrevReversed_))
         {
             swappedSequence.push(i);
             this->wasPrevReversed_ = true;


### PR DESCRIPTION
## Treat elements with usernames (mentions) as neutral elements
Before PR: 
![image](https://github.com/Chatterino/chatterino2/assets/51754973/3385e576-6805-474c-ac61-8fca43b8b475)
After PR: 
![image](https://github.com/Chatterino/chatterino2/assets/51754973/67ba6de4-033a-4736-bc06-4043f097f307)
Spacing issue is solved.
Also fixes the comma "," so that it's to the left of the mention (should be the case since text should be read from RTL)
The change is only in the function `reoderRTL` so LTR only text shouldn't be affected at all since `reoderRTL` is only called when RTL is detected.