### PR TITLE
Add option to subscribe to and pin reply threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Minor: Improved editing hotkeys. (#4628)
 - Minor: The input completion and quick switcher are now styled to match your theme. (#4671)
 - Minor: Added setting to only show tabs with live channels (default toggle hotkey: Ctrl+Shift+L). (#4358)
+- Minor: Added option to subscribe to and unsubscribe from reply threads. (#4680)
 - Bugfix: Fixed generation of crashdumps by the browser-extension process when the browser was closed. (#4667)
 - Bugfix: Fix spacing issue with mentions inside RTL text. (#4677)
 - Bugfix: Fixed a crash when opening and closing a reply thread and switching the user. (#4675)

--- a/src/controllers/highlights/HighlightController.cpp
+++ b/src/controllers/highlights/HighlightController.cpp
@@ -163,7 +163,7 @@ void rebuildReplyThreadHighlight(Settings &settings,
                 const auto & /*senderName*/, const auto & /*originalMessage*/,
                 const auto &flags,
                 const auto self) -> boost::optional<HighlightResult> {
-                if (flags.has(MessageFlag::ParticipatedThread) && !self)
+                if (flags.has(MessageFlag::SubscribedThread) && !self)
                 {
                     return HighlightResult{
                         highlightAlert,

--- a/src/controllers/highlights/HighlightModel.cpp
+++ b/src/controllers/highlights/HighlightModel.cpp
@@ -210,7 +210,7 @@ void HighlightModel::afterInit()
     std::vector<QStandardItem *> threadMessageRow = this->createRow();
     setBoolItem(threadMessageRow[Column::Pattern],
                 getSettings()->enableThreadHighlight.getValue(), true, false);
-    threadMessageRow[Column::Pattern]->setData("Participated Reply Threads",
+    threadMessageRow[Column::Pattern]->setData("Subscribed Reply Threads",
                                                Qt::DisplayRole);
     setBoolItem(threadMessageRow[Column::ShowInMentions],
                 getSettings()->showThreadHighlightInMentions.getValue(), true,

--- a/src/messages/Message.hpp
+++ b/src/messages/Message.hpp
@@ -46,7 +46,7 @@ enum class MessageFlag : int64_t {
     FirstMessage = (1LL << 23),
     ReplyMessage = (1LL << 24),
     ElevatedMessage = (1LL << 25),
-    ParticipatedThread = (1LL << 26),
+    SubscribedThread = (1LL << 26),
     CheerMessage = (1LL << 27),
     LiveUpdatesAdd = (1LL << 28),
     LiveUpdatesRemove = (1LL << 29),

--- a/src/messages/MessageThread.cpp
+++ b/src/messages/MessageThread.cpp
@@ -1,4 +1,4 @@
-#include "MessageThread.hpp"
+#include "messages/MessageThread.hpp"
 
 #include "messages/Message.hpp"
 #include "util/DebugCount.hpp"
@@ -58,14 +58,26 @@ size_t MessageThread::liveCount(
     return count;
 }
 
-bool MessageThread::participated() const
+void MessageThread::markSubscribed()
 {
-    return this->participated_;
+    if (this->subscription_ == Subscription::Subscribed)
+    {
+        return;
+    }
+
+    this->subscription_ = Subscription::Subscribed;
+    this->subscriptionUpdated();
 }
 
-void MessageThread::markParticipated()
+void MessageThread::markUnsubscribed()
 {
-    this->participated_ = true;
+    if (this->subscription_ == Subscription::Unsubscribed)
+    {
+        return;
+    }
+
+    this->subscription_ = Subscription::Unsubscribed;
+    this->subscriptionUpdated();
 }
 
 }  // namespace chatterino

--- a/src/messages/MessageThread.hpp
+++ b/src/messages/MessageThread.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <boost/signals2.hpp>
 #include <QString>
 
 #include <memory>
@@ -11,6 +12,12 @@ struct Message;
 class MessageThread
 {
 public:
+    enum class Subscription : uint8_t {
+        None,
+        Subscribed,
+        Unsubscribed,
+    };
+
     MessageThread(std::shared_ptr<const Message> rootMessage);
     ~MessageThread();
 
@@ -23,9 +30,22 @@ public:
     /// Returns the number of live reply references
     size_t liveCount(const std::shared_ptr<const Message> &exclude) const;
 
-    bool participated() const;
+    bool subscribed() const
+    {
+        return this->subscription_ == Subscription::Subscribed;
+    }
 
-    void markParticipated();
+    /// Returns true if and only if the user manually unsubscribed from the thread
+    /// @see #markUnsubscribed()
+    bool unsubscribed() const
+    {
+        return this->subscription_ == Subscription::Unsubscribed;
+    }
+
+    /// Subscribe to this thread.
+    void markSubscribed();
+    /// Unsubscribe from this thread.
+    void markUnsubscribed();
 
     const QString &rootId() const
     {
@@ -42,11 +62,14 @@ public:
         return replies_;
     }
 
+    boost::signals2::signal<void()> subscriptionUpdated;
+
 private:
     const QString rootMessageId_;
     const std::shared_ptr<const Message> rootMessage_;
     std::vector<std::weak_ptr<const Message>> replies_;
-    bool participated_ = false;
+
+    Subscription subscription_ = Subscription::None;
 };
 
 }  // namespace chatterino

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -126,30 +126,33 @@ void updateReplyParticipatedStatus(const QVariantMap &tags,
         return;
     }
 
-    if (thread->unsubscribed() || !getSettings()->subToParticipatedThreads)
+    if (thread->unsubscribed())
     {
         return;
     }
 
-    if (isNew)
+    if (getSettings()->subToParticipatedThreads)
     {
-        if (const auto it = tags.find("reply-parent-user-login");
-            it != tags.end())
+        if (isNew)
         {
-            auto name = it.value().toString();
-            if (name == currentLogin)
+            if (const auto it = tags.find("reply-parent-user-login");
+                it != tags.end())
             {
-                thread->markSubscribed();
-                builder.message().flags.set(MessageFlag::SubscribedThread);
-                return;  // already marked as participated
+                auto name = it.value().toString();
+                if (name == currentLogin)
+                {
+                    thread->markSubscribed();
+                    builder.message().flags.set(MessageFlag::SubscribedThread);
+                    return;  // already marked as participated
+                }
             }
         }
-    }
 
-    if (senderLogin == currentLogin)
-    {
-        thread->markSubscribed();
-        // don't set the highlight here
+        if (senderLogin == currentLogin)
+        {
+            thread->markSubscribed();
+            // don't set the highlight here
+        }
     }
 }
 

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -119,9 +119,15 @@ void updateReplyParticipatedStatus(const QVariantMap &tags,
 {
     const auto &currentLogin =
         getApp()->accounts->twitch.getCurrent()->getUserName();
-    if (thread->participated())
+
+    if (thread->subscribed())
     {
-        builder.message().flags.set(MessageFlag::ParticipatedThread);
+        builder.message().flags.set(MessageFlag::SubscribedThread);
+        return;
+    }
+
+    if (thread->unsubscribed() || !getSettings()->subToParticipatedThreads)
+    {
         return;
     }
 
@@ -133,8 +139,8 @@ void updateReplyParticipatedStatus(const QVariantMap &tags,
             auto name = it.value().toString();
             if (name == currentLogin)
             {
-                thread->markParticipated();
-                builder.message().flags.set(MessageFlag::ParticipatedThread);
+                thread->markSubscribed();
+                builder.message().flags.set(MessageFlag::SubscribedThread);
                 return;  // already marked as participated
             }
         }
@@ -142,7 +148,7 @@ void updateReplyParticipatedStatus(const QVariantMap &tags,
 
     if (senderLogin == currentLogin)
     {
-        thread->markParticipated();
+        thread->markSubscribed();
         // don't set the highlight here
     }
 }

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -131,7 +131,7 @@ void updateReplyParticipatedStatus(const QVariantMap &tags,
         return;
     }
 
-    if (getSettings()->subToParticipatedThreads)
+    if (getSettings()->autoSubToParticipatedThreads)
     {
         if (isNew)
         {

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -195,7 +195,7 @@ public:
     BoolSetting autoCloseThreadPopup = {"/behaviour/autoCloseThreadPopup",
                                         false};
     BoolSetting subToParticipatedThreads = {
-        "/appearance/subToParticipatedThreads",
+        "/behaviour/subToParticipatedThreads",
         true,
     };
     // BoolSetting twitchSeperateWriteConnection =

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -194,6 +194,8 @@ public:
     BoolSetting autoCloseUserPopup = {"/behaviour/autoCloseUserPopup", true};
     BoolSetting autoCloseThreadPopup = {"/behaviour/autoCloseThreadPopup",
                                         false};
+    BoolSetting subToParticipatedThreads = {
+        "/appearance/subToParticipatedThreads", true};
     // BoolSetting twitchSeperateWriteConnection =
     // {"/behaviour/twitchSeperateWriteConnection", false};
 

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -195,7 +195,9 @@ public:
     BoolSetting autoCloseThreadPopup = {"/behaviour/autoCloseThreadPopup",
                                         false};
     BoolSetting subToParticipatedThreads = {
-        "/appearance/subToParticipatedThreads", true};
+        "/appearance/subToParticipatedThreads",
+        true,
+    };
     // BoolSetting twitchSeperateWriteConnection =
     // {"/behaviour/twitchSeperateWriteConnection", false};
 

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -194,8 +194,8 @@ public:
     BoolSetting autoCloseUserPopup = {"/behaviour/autoCloseUserPopup", true};
     BoolSetting autoCloseThreadPopup = {"/behaviour/autoCloseThreadPopup",
                                         false};
-    BoolSetting subToParticipatedThreads = {
-        "/behaviour/subToParticipatedThreads",
+    BoolSetting autoSubToParticipatedThreads = {
+        "/behaviour/autoSubToParticipatedThreads",
         true,
     };
     // BoolSetting twitchSeperateWriteConnection =

--- a/src/widgets/DraggablePopup.cpp
+++ b/src/widgets/DraggablePopup.cpp
@@ -1,4 +1,8 @@
-#include "DraggablePopup.hpp"
+#include "widgets/DraggablePopup.hpp"
+
+#include "singletons/Resources.hpp"
+#include "singletons/Theme.hpp"
+#include "widgets/helper/Button.hpp"
 
 #include <QMouseEvent>
 
@@ -88,6 +92,48 @@ void DraggablePopup::mouseMoveEvent(QMouseEvent *event)
             (event->screenPos() - this->movingRelativePos).toPoint();
         this->isMoving_ = true;
     }
+}
+
+Button *DraggablePopup::createPinButton()
+{
+    auto *button = new Button(this);
+
+    struct Functor {
+        DraggablePopup *popup = nullptr;
+        Button *button = nullptr;
+        bool pinned = false;
+
+        void operator()()
+        {
+            this->pinned = !this->pinned;
+            this->updateStatus();
+        }
+
+        void updateStatus() const
+        {
+            if (this->pinned)
+            {
+                this->popup->setActionOnFocusLoss(BaseWindow::Nothing);
+                this->button->setPixmap(getResources().buttons.pinEnabled);
+            }
+            else
+            {
+                this->popup->setActionOnFocusLoss(BaseWindow::Delete);
+                this->button->setPixmap(getTheme()->buttons.pin);
+            }
+        }
+    };
+
+    button->setPixmap(getTheme()->buttons.pin);
+    button->setScaleIndependantSize(18, 18);
+    button->setToolTip("Pin Window");
+
+    QObject::connect(button, &Button::leftClicked,
+                     Functor{
+                         .popup = this,
+                         .button = button,
+                     });
+    return button;
 }
 
 }  // namespace chatterino

--- a/src/widgets/DraggablePopup.cpp
+++ b/src/widgets/DraggablePopup.cpp
@@ -97,42 +97,25 @@ void DraggablePopup::mouseMoveEvent(QMouseEvent *event)
 Button *DraggablePopup::createPinButton()
 {
     auto *button = new Button(this);
-
-    struct Functor {
-        DraggablePopup *popup = nullptr;
-        Button *button = nullptr;
-        bool pinned = false;
-
-        void operator()()
-        {
-            this->pinned = !this->pinned;
-            this->updateStatus();
-        }
-
-        void updateStatus() const
-        {
-            if (this->pinned)
-            {
-                this->popup->setActionOnFocusLoss(BaseWindow::Nothing);
-                this->button->setPixmap(getResources().buttons.pinEnabled);
-            }
-            else
-            {
-                this->popup->setActionOnFocusLoss(BaseWindow::Delete);
-                this->button->setPixmap(getTheme()->buttons.pin);
-            }
-        }
-    };
-
     button->setPixmap(getTheme()->buttons.pin);
     button->setScaleIndependantSize(18, 18);
     button->setToolTip("Pin Window");
 
-    QObject::connect(button, &Button::leftClicked,
-                     Functor{
-                         .popup = this,
-                         .button = button,
-                     });
+    bool pinned = false;
+    QObject::connect(
+        button, &Button::leftClicked, [this, button, pinned]() mutable {
+            pinned = !pinned;
+            if (pinned)
+            {
+                this->setActionOnFocusLoss(BaseWindow::Nothing);
+                button->setPixmap(getResources().buttons.pinEnabled);
+            }
+            else
+            {
+                this->setActionOnFocusLoss(BaseWindow::Delete);
+                button->setPixmap(getTheme()->buttons.pin);
+            }
+        });
     return button;
 }
 

--- a/src/widgets/DraggablePopup.hpp
+++ b/src/widgets/DraggablePopup.hpp
@@ -26,6 +26,8 @@ protected:
     void mouseReleaseEvent(QMouseEvent *event) override;
     void mouseMoveEvent(QMouseEvent *event) override;
 
+    Button *createPinButton();
+
     // lifetimeHack_ is used to check that the window hasn't been destroyed yet
     std::shared_ptr<bool> lifetimeHack_;
 

--- a/src/widgets/DraggablePopup.hpp
+++ b/src/widgets/DraggablePopup.hpp
@@ -26,6 +26,9 @@ protected:
     void mouseReleaseEvent(QMouseEvent *event) override;
     void mouseMoveEvent(QMouseEvent *event) override;
 
+    /// Creates a pin button that is scoped to this window.
+    /// When clicked, the user can toggle whether the window is pinned.
+    /// The window is considered unpinned at the start.
     Button *createPinButton();
 
     // lifetimeHack_ is used to check that the window hasn't been destroyed yet

--- a/src/widgets/dialogs/ReplyThreadPopup.hpp
+++ b/src/widgets/dialogs/ReplyThreadPopup.hpp
@@ -7,6 +7,8 @@
 #include <pajlada/signals/scoped-connection.hpp>
 #include <pajlada/signals/signal.hpp>
 
+class QCheckBox;
+
 namespace chatterino {
 
 class MessageThread;
@@ -41,10 +43,13 @@ private:
     struct {
         ChannelView *threadView = nullptr;
         SplitInput *replyInput = nullptr;
+
+        QCheckBox *notificationCheckbox = nullptr;
     } ui_;
 
     std::unique_ptr<pajlada::Signals::ScopedConnection> messageConnection_;
     std::vector<boost::signals2::scoped_connection> bSignals_;
+    boost::signals2::scoped_connection replySubscriptionSignal_;
 };
 
 }  // namespace chatterino

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -142,7 +142,6 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically, QWidget *parent,
            "split being nullptr causes lots of bugs down the road");
     this->setWindowTitle("Usercard");
     this->setStayInScreenRect(true);
-    this->updateFocusLoss();
 
     HotkeyController::HotkeyMap actions{
         {"delete",
@@ -361,17 +360,7 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically, QWidget *parent,
                 // button to pin the window (only if we close automatically)
                 if (this->closeAutomatically_)
                 {
-                    this->ui_.pinButton = box.emplace<Button>().getElement();
-                    this->ui_.pinButton->setPixmap(
-                        getApp()->themes->buttons.pin);
-                    this->ui_.pinButton->setScaleIndependantSize(18, 18);
-                    this->ui_.pinButton->setToolTip("Pin Window");
-                    QObject::connect(this->ui_.pinButton, &Button::leftClicked,
-                                     [this]() {
-                                         this->closeAutomatically_ =
-                                             !this->closeAutomatically_;
-                                         this->updateFocusLoss();
-                                     });
+                    box->addWidget(this->createPinButton());
                 }
             }
 
@@ -918,26 +907,6 @@ void UserInfoPopup::updateUserData()
 
     this->ui_.block->setEnabled(false);
     this->ui_.ignoreHighlights->setEnabled(false);
-}
-
-void UserInfoPopup::updateFocusLoss()
-{
-    if (this->closeAutomatically_)
-    {
-        this->setActionOnFocusLoss(BaseWindow::Delete);
-        if (this->ui_.pinButton != nullptr)
-        {
-            this->ui_.pinButton->setPixmap(getApp()->themes->buttons.pin);
-        }
-    }
-    else
-    {
-        this->setActionOnFocusLoss(BaseWindow::Nothing);
-        if (this->ui_.pinButton != nullptr)
-        {
-            this->ui_.pinButton->setPixmap(getResources().buttons.pinEnabled);
-        }
-    }
 }
 
 void UserInfoPopup::loadAvatar(const QUrl &url)

--- a/src/widgets/dialogs/UserInfoPopup.hpp
+++ b/src/widgets/dialogs/UserInfoPopup.hpp
@@ -37,7 +37,6 @@ private:
     void installEvents();
     void updateUserData();
     void updateLatestMessages();
-    void updateFocusLoss();
 
     void loadAvatar(const QUrl &url);
     bool isMod_;
@@ -73,8 +72,6 @@ private:
         Label *followerCountLabel = nullptr;
         Label *createdDateLabel = nullptr;
         Label *userIDLabel = nullptr;
-        // Can be uninitialized if usercard is not configured to close on focus loss
-        Button *pinButton = nullptr;
         Label *followageLabel = nullptr;
         Label *subageLabel = nullptr;
 

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -916,6 +916,10 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         "Highlight received inline whispers", s.highlightInlineWhispers, false,
         "Highlight the whispers shown in all splits.\nIf \"Show Twitch "
         "whispers inline\" is disabled, this setting will do nothing.");
+    layout.addCheckbox(
+        "Subscribe to participated reply threads", s.subToParticipatedThreads,
+        false,
+        "When enabled, reply threads you participated in will be highlighted.");
     layout.addCheckbox("Load message history on connect",
                        s.loadTwitchMessageHistoryOnConnect);
     // TODO: Change phrasing to use better english once we can tag settings, right now it's kept as history instead of historical so that the setting shows up when the user searches for history

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -917,9 +917,12 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         "Highlight the whispers shown in all splits.\nIf \"Show Twitch "
         "whispers inline\" is disabled, this setting will do nothing.");
     layout.addCheckbox(
-        "Subscribe to participated reply threads", s.subToParticipatedThreads,
-        false,
-        "When enabled, reply threads you participated in will be highlighted.");
+        "Automatically subscribe to participated reply threads",
+        s.autoSubToParticipatedThreads, false,
+        "When enabled, you will automatically subscribe to reply threads you "
+        "participate in.\n"
+        "This means reply threads you participate in will use your "
+        "\"Subscribed Reply Threads\" highlight settings.");
     layout.addCheckbox("Load message history on connect",
                        s.loadTwitchMessageHistoryOnConnect);
     // TODO: Change phrasing to use better english once we can tag settings, right now it's kept as history instead of historical so that the setting shows up when the user searches for history


### PR DESCRIPTION
# Description

There are two changes in this PR. First, the option to change the subscription status of a reply thread is added. Secondly, a pin-button is added, like on user cards:

![example](https://github.com/Chatterino/chatterino2/assets/19953266/5426bf58-05ae-4f73-bf72-7b1379058144)

This adds the concept of a subscribed thread. If one is subscribed to a thread, new messages will be highlighted (requires the _Subscribed Reply Threads_ highlight option). One can subscribe to threads through the popup and by participating in a thread (requires _Subscribe to participated reply threads_).