### PR TITLE
Extend viewer list, /mods & /vips with new provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unversioned
 
+- Minor: Extend viewer list with [`Chatters API`](https://github.com/lvoegl/chatters-api).
 - Minor: Nicknames are now taken into consideration when searching for messages. (#4663)
 - Minor: Add an icon showing when streamer mode is enabled (#4410, #4690)
 - Minor: Added `/shoutout <username>` commands to shoutout specified user. (#4638)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unversioned
 
+- Minor: Extend /mods & /vips command output with [`Chatters API`](https://github.com/lvoegl/chatters-api).
 - Minor: Extend viewer list with [`Chatters API`](https://github.com/lvoegl/chatters-api).
 - Minor: Nicknames are now taken into consideration when searching for messages. (#4663)
 - Minor: Add an icon showing when streamer mode is enabled (#4410, #4690)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -231,6 +231,8 @@ set(SOURCE_FILES
         providers/NetworkConfigurationProvider.hpp
         providers/RecentMessagesApi.cpp
         providers/RecentMessagesApi.hpp
+        providers/ChattersApi.cpp
+        providers/ChattersApi.hpp
 
         providers/bttv/BttvEmotes.cpp
         providers/bttv/BttvEmotes.hpp

--- a/src/common/Env.cpp
+++ b/src/common/Env.cpp
@@ -93,6 +93,9 @@ Env::Env()
           readStringEnv("CHATTERINO2_RECENT_MESSAGES_URL",
                         "https://recent-messages.robotty.de/api/v2/"
                         "recent-messages/%1"))
+    , chattersApiBaseUrl(readStringEnv(
+          "CHATTERINO2_CHATTERS_API_BASE_URL",
+          "https://chatters.verotek.net/api/"))
     , linkResolverUrl(readStringEnv(
           "CHATTERINO2_LINK_RESOLVER_URL",
           "https://braize.pajlada.com/chatterino/link_resolver/%1"))

--- a/src/common/Env.hpp
+++ b/src/common/Env.hpp
@@ -13,6 +13,7 @@ public:
     static const Env &get();
 
     const QString recentMessagesApiUrl;
+    const QString chattersApiBaseUrl;
     const QString linkResolverUrl;
     const QString twitchServerHost;
     const uint16_t twitchServerPort;

--- a/src/common/QLogging.cpp
+++ b/src/common/QLogging.cpp
@@ -37,6 +37,8 @@ Q_LOGGING_CATEGORY(chatterinoNuulsuploader, "chatterino.nuulsuploader",
 Q_LOGGING_CATEGORY(chatterinoPubSub, "chatterino.pubsub", logThreshold);
 Q_LOGGING_CATEGORY(chatterinoRecentMessages, "chatterino.recentmessages",
                    logThreshold);
+Q_LOGGING_CATEGORY(chatterinoChattersApi, "chatterino.chattersapi",
+                   logThreshold);
 Q_LOGGING_CATEGORY(chatterinoSettings, "chatterino.settings", logThreshold);
 Q_LOGGING_CATEGORY(chatterinoSeventv, "chatterino.seventv", logThreshold);
 Q_LOGGING_CATEGORY(chatterinoSeventvEventAPI, "chatterino.seventv.eventapi",

--- a/src/common/QLogging.hpp
+++ b/src/common/QLogging.hpp
@@ -28,6 +28,7 @@ Q_DECLARE_LOGGING_CATEGORY(chatterinoNotification);
 Q_DECLARE_LOGGING_CATEGORY(chatterinoNuulsuploader);
 Q_DECLARE_LOGGING_CATEGORY(chatterinoPubSub);
 Q_DECLARE_LOGGING_CATEGORY(chatterinoRecentMessages);
+Q_DECLARE_LOGGING_CATEGORY(chatterinoChattersApi);
 Q_DECLARE_LOGGING_CATEGORY(chatterinoSettings);
 Q_DECLARE_LOGGING_CATEGORY(chatterinoSeventv);
 Q_DECLARE_LOGGING_CATEGORY(chatterinoSeventvEventAPI);

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -787,6 +787,7 @@ void CommandController::initialize(Settings &, Paths &paths)
 
         QStringList debugMessages{
             "recentMessagesApiUrl: " + env.recentMessagesApiUrl,
+            "chattersApiBaseUrl: " + env.chattersApiBaseUrl,
             "linkResolverUrl: " + env.linkResolverUrl,
             "twitchServerHost: " + env.twitchServerHost,
             "twitchServerPort: " + QString::number(env.twitchServerPort),

--- a/src/providers/ChattersApi.cpp
+++ b/src/providers/ChattersApi.cpp
@@ -100,4 +100,62 @@ void ChattersApi::loadChatters(TwitchChannel *channel,
         .execute();
 }
 
+void ChattersApi::loadModerators(TwitchChannel *channel,
+                                 ResultCallback<QStringList> onLoaded,
+                                 ErrorCallback onError)
+{
+    qCDebug(chatterinoChattersApi)
+        << "Loading moderators for" << channel->getName();
+
+    QUrlQuery urlQuery;
+    urlQuery.addQueryItem("channelId", channel->roomId());
+    makeRequest("roles/moderators", urlQuery)
+        .onSuccess([channel, onLoaded](NetworkResult result) -> Outcome {
+            qCDebug(chatterinoChattersApi)
+                << "Successfully loaded moderators for"
+                << channel->getName();
+
+            QJsonArray mods = result.parseJsonArray();
+            QStringList modList = userListFromJsonArray(mods);
+            onLoaded(modList);
+
+            return Success;
+        })
+        .onError([channel, onError](NetworkResult result) {
+            qCDebug(chatterinoChattersApi)
+                << "Failed to load moderators for" << channel->getName();
+            forwardErrorMessage(result, onError);
+        })
+        .execute();
+}
+
+void ChattersApi::loadVips(TwitchChannel *channel,
+                           ResultCallback<QStringList> onLoaded,
+                           ErrorCallback onError)
+{
+    qCDebug(chatterinoChattersApi)
+        << "Loading vips for" << channel->getName();
+
+    QUrlQuery urlQuery;
+    urlQuery.addQueryItem("channelId", channel->roomId());
+    makeRequest("roles/vips", urlQuery)
+        .onSuccess([channel, onLoaded](NetworkResult result) -> Outcome {
+            qCDebug(chatterinoChattersApi)
+                << "Successfully loaded vips for"
+                << channel->getName();
+
+            QJsonArray vips = result.parseJsonArray();
+            QStringList vipList = userListFromJsonArray(vips);
+            onLoaded(vipList);
+
+            return Success;
+        })
+        .onError([channel, onError](NetworkResult result) {
+            qCDebug(chatterinoChattersApi)
+                << "Failed to load chatters list for" << channel->getName();
+            forwardErrorMessage(result, onError);
+        })
+        .execute();
+}
+
 }  // namespace chatterino

--- a/src/providers/ChattersApi.cpp
+++ b/src/providers/ChattersApi.cpp
@@ -1,0 +1,103 @@
+#include "providers/ChattersApi.hpp"
+
+#include "common/Channel.hpp"
+#include "common/Common.hpp"
+#include "common/Env.hpp"
+#include "common/NetworkRequest.hpp"
+#include "common/NetworkResult.hpp"
+#include "common/QLogging.hpp"
+#include "providers/twitch/TwitchChannel.hpp"
+
+#include <QJsonArray>
+#include <QUrl>
+#include <QUrlQuery>
+
+namespace chatterino {
+
+namespace {
+
+    QString chatterFromObject(const QJsonValue chatter)
+    {
+        return chatter.toObject().value("name").toString().toLower();
+    }
+
+    QStringList userListFromJsonArray(const QJsonArray chatterArray)
+    {
+        QStringList chatterList;
+
+        for (const auto chatter : chatterArray)
+        {
+            chatterList.append(chatterFromObject(chatter));
+        }
+
+        return chatterList;
+    }
+
+    NetworkRequest makeRequest(QString url, QUrlQuery urlQuery)
+    {
+        assert(!url.startsWith("/"));
+
+        const QString baseUrl = Env::get().chattersApiBaseUrl;
+        QUrl fullUrl(baseUrl + url);
+        fullUrl.setQuery(urlQuery);
+
+        return NetworkRequest(fullUrl).timeout(10 * 1000).header("Accept",
+                                                                 "application/json");
+    }
+
+    void forwardErrorMessage(NetworkResult result, ErrorCallback onError)
+    {
+        auto root = result.parseJson();
+        QString error = root.value("message").toString();
+        onError(error);
+    }
+
+}  // namespace
+
+void ChattersApi::loadChatters(TwitchChannel *channel,
+                               ResultCallback<QString, QStringList,
+                                   QStringList, QStringList> onLoaded,
+                               ErrorCallback onError)
+{
+    qCDebug(chatterinoChattersApi)
+        << "Loading chatters list for" << channel->getName();
+
+    QUrlQuery urlQuery;
+    urlQuery.addQueryItem("channelId", channel->roomId());
+    makeRequest("chatters/all", urlQuery)
+        .onSuccess([channel, onLoaded](NetworkResult result) -> Outcome {
+            qCDebug(chatterinoChattersApi)
+                << "Successfully loaded chatters list for"
+                << channel->getName();
+
+            auto root = result.parseJson();
+            QJsonValue broadcaster = root.value("broadcaster");
+            QJsonArray moderators = root.value("moderators").toArray();
+            QJsonArray vips = root.value("vips").toArray();
+            QJsonArray viewers = root.value("viewers").toArray();
+
+            QString broadcasterChatter;
+            if (!broadcaster.isNull())
+            {
+                broadcasterChatter = chatterFromObject(broadcaster);
+            }
+
+            QStringList chatterList = userListFromJsonArray(viewers);
+            QStringList modList = userListFromJsonArray(moderators);
+            QStringList vipList = userListFromJsonArray(vips);
+            onLoaded(broadcasterChatter, modList, vipList, chatterList);
+
+            return Success;
+        })
+        .onError([channel, onError](NetworkResult result) {
+            qCDebug(chatterinoChattersApi)
+                << "Failed to load chatters list for" << channel->getName();
+
+            auto root = result.parseJson();
+            QString error = root.value("message").toString();
+            onError(error);
+        })
+        .execute();
+}
+
+}  // namespace chatterino

--- a/src/providers/ChattersApi.hpp
+++ b/src/providers/ChattersApi.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "providers/twitch/TwitchChannel.hpp"
+
+#include <QString>
+
+#include <functional>
+
+namespace chatterino {
+
+template <typename... T>
+using ResultCallback = std::function<void(T...)>;
+using ErrorCallback = std::function<void(QString error)>;
+
+class ChattersApi
+{
+public:
+    /**
+     * @brief Loads chatters for a Twitch channel using Chatters API
+     *
+     * @param channel Twitch channel to load chatters for
+     * @param onLoaded Callback for successful requests
+     * @param onError Callback for failed requests
+     */
+    static void loadChatters(TwitchChannel *channel,
+                             ResultCallback<QString, QStringList,
+                                 QStringList, QStringList> onLoaded,
+                             ErrorCallback onError);
+};
+
+}  // namespace chatterino

--- a/src/providers/ChattersApi.hpp
+++ b/src/providers/ChattersApi.hpp
@@ -26,6 +26,28 @@ public:
                              ResultCallback<QString, QStringList,
                                  QStringList, QStringList> onLoaded,
                              ErrorCallback onError);
+
+    /**
+     * @brief Loads moderators for a Twitch channel using Chatters API
+     *
+     * @param channel Twitch channel to load moderators for
+     * @param onLoaded Callback for successful requests
+     * @param onError Callback for failed requests
+     */
+    static void loadModerators(TwitchChannel *channel,
+                               ResultCallback<QStringList> onLoaded,
+                               ErrorCallback onError);
+
+    /**
+     * @brief Loads vips for a Twitch channel using Chatters API
+     *
+     * @param channel Twitch channel to load vips for
+     * @param onLoaded Callback for successful requests
+     * @param onError Callback for failed requests
+     */
+    static void loadVips(TwitchChannel *channel,
+                         ResultCallback<QStringList> onLoaded,
+                         ErrorCallback onError);
 };
 
 }  // namespace chatterino


### PR DESCRIPTION
# Description

Implements [Chatters API](https://github.com/lvoegl/chatters-api) provider for loading viewer list, VIPs and moderators without moderator/broadcaster rank if authorized. Helix API is preferred if the user is broadcaster, otherwise Chatters API is queried.
