### PR TITLE
Improve network error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Bugfix: Fix visual glitches with smooth scrolling. (#4501)
 - Bugfix: Fixed pings firing for the "Your username" highlight when not signed in. (#4698)
 - Bugfix: Fixed partially broken filters on Qt 6 builds. (#4702)
+- Bugfix: Fixed some network errors having `0` as their HTTP status. (#4704)
 - Dev: Added command to set Qt's logging filter/rules at runtime (`/c2-set-logging-rules`). (#4637)
 - Dev: Added the ability to see & load custom themes from the Themes directory. No stable promises are made of this feature, changes might be made that breaks custom themes without notice. (#4570)
 - Dev: Added test cases for emote and tab completion. (#4644)

--- a/src/common/NetworkPrivate.cpp
+++ b/src/common/NetworkPrivate.cpp
@@ -155,7 +155,8 @@ void loadUncached(std::shared_ptr<NetworkData> &&data)
                     {
                         postToThread([data] {
                             data->onError_(NetworkResult(
-                                NetworkResult::Error::TimeoutError, {}, {}));
+                                NetworkResult::NetworkError::TimeoutError, {},
+                                {}));
                         });
                     }
 
@@ -338,7 +339,8 @@ void loadCached(std::shared_ptr<NetworkData> &&data)
 
     // XXX: check if bytes is empty?
     QByteArray bytes = cachedFile.readAll();
-    NetworkResult result(NetworkResult::Error::NoError, QVariant(200), bytes);
+    NetworkResult result(NetworkResult::NetworkError::NoError, QVariant(200),
+                         bytes);
 
     qCDebug(chatterinoHTTP)
         << QString("%1 [CACHED] 200 %2")

--- a/src/common/NetworkResult.cpp
+++ b/src/common/NetworkResult.cpp
@@ -9,7 +9,7 @@
 
 namespace chatterino {
 
-NetworkResult::NetworkResult(Error error, const QVariant &httpStatusCode,
+NetworkResult::NetworkResult(NetworkError error, const QVariant &httpStatusCode,
                              QByteArray data)
     : data_(std::move(data))
     , error_(error)

--- a/src/common/NetworkResult.cpp
+++ b/src/common/NetworkResult.cpp
@@ -16,7 +16,7 @@ NetworkResult::NetworkResult(Error error, const QVariant &httpStatusCode,
 {
     if (httpStatusCode.isValid())
     {
-        this->status_ = static_cast<uint16_t>(httpStatusCode.toInt());
+        this->status_ = httpStatusCode.toInt();
     }
 }
 

--- a/src/common/NetworkResult.hpp
+++ b/src/common/NetworkResult.hpp
@@ -34,7 +34,7 @@ public:
     }
 
     /// The HTTP status code if a request was made.
-    std::optional<uint16_t> status() const
+    std::optional<int> status() const
     {
         return this->status_;
     }
@@ -48,7 +48,7 @@ private:
     QByteArray data_;
 
     Error error_;
-    std::optional<uint16_t> status_;
+    std::optional<int> status_;
 };
 
 }  // namespace chatterino

--- a/src/common/NetworkResult.hpp
+++ b/src/common/NetworkResult.hpp
@@ -12,9 +12,10 @@ namespace chatterino {
 class NetworkResult
 {
 public:
-    using Error = QNetworkReply::NetworkError;
+    using NetworkError = QNetworkReply::NetworkError;
 
-    NetworkResult(Error error, const QVariant &httpStatusCode, QByteArray data);
+    NetworkResult(NetworkError error, const QVariant &httpStatusCode,
+                  QByteArray data);
 
     /// Parses the result as json and returns the root as an object.
     /// Returns empty object if parsing failed.
@@ -28,26 +29,25 @@ public:
 
     /// The error code of the reply.
     /// In case of a successful reply, this will be NoError (0)
-    Error error() const
+    NetworkError error() const
     {
         return this->error_;
     }
 
-    /// The HTTP status code if a request was made.
+    /// The HTTP status code if a response was received.
     std::optional<int> status() const
     {
         return this->status_;
     }
 
-    /// Formats the error:
-    /// without HTTP status: [Name]
-    /// with HTTP status: [HTTP status]
+    /// Formats the error.
+    /// If a reply is received, returns the HTTP status otherwise, the network error.
     QString formatError() const;
 
 private:
     QByteArray data_;
 
-    Error error_;
+    NetworkError error_;
     std::optional<int> status_;
 };
 

--- a/src/providers/IvrApi.cpp
+++ b/src/providers/IvrApi.cpp
@@ -27,7 +27,7 @@ void IvrApi::getSubage(QString userName, QString channelName,
         })
         .onError([failureCallback](auto result) {
             qCWarning(chatterinoIvr)
-                << "Failed IVR API Call!" << result.status()
+                << "Failed IVR API Call!" << result.formatError()
                 << QString(result.getData());
             failureCallback();
         })
@@ -51,7 +51,7 @@ void IvrApi::getBulkEmoteSets(QString emoteSetList,
         })
         .onError([failureCallback](auto result) {
             qCWarning(chatterinoIvr)
-                << "Failed IVR API Call!" << result.status()
+                << "Failed IVR API Call!" << result.formatError()
                 << QString(result.getData());
             failureCallback();
         })

--- a/src/providers/RecentMessagesApi.cpp
+++ b/src/providers/RecentMessagesApi.cpp
@@ -228,7 +228,8 @@ void RecentMessagesApi::loadRecentMessages(const QString &channelName,
                 << "Failed to load recent messages for" << shared->getName();
 
             shared->addMessage(makeSystemMessage(
-                QStringLiteral("Message history service unavailable (%1)")
+                QStringLiteral(
+                    "Message history service unavailable (Error: %1)")
                     .arg(result.formatError())));
 
             onError();

--- a/src/providers/RecentMessagesApi.cpp
+++ b/src/providers/RecentMessagesApi.cpp
@@ -217,17 +217,19 @@ void RecentMessagesApi::loadRecentMessages(const QString &channelName,
 
             return Success;
         })
-        .onError([channelPtr, onError](NetworkResult result) {
+        .onError([channelPtr, onError](const NetworkResult &result) {
             auto shared = channelPtr.lock();
             if (!shared)
+            {
                 return;
+            }
 
             qCDebug(chatterinoRecentMessages)
                 << "Failed to load recent messages for" << shared->getName();
 
             shared->addMessage(makeSystemMessage(
-                QString("Message history service unavailable (Error %1)")
-                    .arg(result.status())));
+                QStringLiteral("Message history service unavailable (%1)")
+                    .arg(result.formatError())));
 
             onError();
         })

--- a/src/providers/bttv/BttvEmotes.cpp
+++ b/src/providers/bttv/BttvEmotes.cpp
@@ -259,23 +259,17 @@ void BttvEmotes::loadChannel(std::weak_ptr<Channel> channel,
                     shared->addMessage(
                         makeSystemMessage(CHANNEL_HAS_NO_EMOTES));
             }
-            else if (result.status() == NetworkResult::timedoutStatus)
-            {
-                // TODO: Auto retry in case of a timeout, with a delay
-                qCWarning(chatterinoBttv)
-                    << "Fetching BTTV emotes for channel" << channelId
-                    << "failed due to timeout";
-                shared->addMessage(makeSystemMessage(
-                    "Failed to fetch BetterTTV channel emotes. (timed out)"));
-            }
             else
             {
+                // TODO: Auto retry in case of a timeout, with a delay
+                auto errorString = result.formatError();
                 qCWarning(chatterinoBttv)
                     << "Error fetching BTTV emotes for channel" << channelId
-                    << ", error" << result.status();
-                shared->addMessage(
-                    makeSystemMessage("Failed to fetch BetterTTV channel "
-                                      "emotes. (unknown error)"));
+                    << ", error" << errorString;
+                shared->addMessage(makeSystemMessage(
+                    QStringLiteral("Failed to fetch BetterTTV channel "
+                                   "emotes. (%1)")
+                        .arg(errorString)));
             }
         })
         .execute();

--- a/src/providers/bttv/BttvEmotes.cpp
+++ b/src/providers/bttv/BttvEmotes.cpp
@@ -268,7 +268,7 @@ void BttvEmotes::loadChannel(std::weak_ptr<Channel> channel,
                     << ", error" << errorString;
                 shared->addMessage(makeSystemMessage(
                     QStringLiteral("Failed to fetch BetterTTV channel "
-                                   "emotes. (%1)")
+                                   "emotes. (Error: %1)")
                         .arg(errorString)));
             }
         })

--- a/src/providers/ffz/FfzEmotes.cpp
+++ b/src/providers/ffz/FfzEmotes.cpp
@@ -282,7 +282,7 @@ void FfzEmotes::loadChannel(
                     << ", error" << errorString;
                 shared->addMessage(makeSystemMessage(
                     QStringLiteral("Failed to fetch FrankerFaceZ channel "
-                                   "emotes. (%1)")
+                                   "emotes. (Error: %1)")
                         .arg(errorString)));
             }
         })

--- a/src/providers/ffz/FfzEmotes.cpp
+++ b/src/providers/ffz/FfzEmotes.cpp
@@ -273,24 +273,17 @@ void FfzEmotes::loadChannel(
                         makeSystemMessage(CHANNEL_HAS_NO_EMOTES));
                 }
             }
-            else if (result.status() == NetworkResult::timedoutStatus)
-            {
-                // TODO: Auto retry in case of a timeout, with a delay
-                qCWarning(chatterinoFfzemotes)
-                    << "Fetching FFZ emotes for channel" << channelID
-                    << "failed due to timeout";
-                shared->addMessage(
-                    makeSystemMessage("Failed to fetch FrankerFaceZ channel "
-                                      "emotes. (timed out)"));
-            }
             else
             {
+                // TODO: Auto retry in case of a timeout, with a delay
+                auto errorString = result.formatError();
                 qCWarning(chatterinoFfzemotes)
                     << "Error fetching FFZ emotes for channel" << channelID
-                    << ", error" << result.status();
-                shared->addMessage(
-                    makeSystemMessage("Failed to fetch FrankerFaceZ channel "
-                                      "emotes. (unknown error)"));
+                    << ", error" << errorString;
+                shared->addMessage(makeSystemMessage(
+                    QStringLiteral("Failed to fetch FrankerFaceZ channel "
+                                   "emotes. (%1)")
+                        .arg(errorString)));
             }
         })
         .execute();

--- a/src/providers/seventv/SeventvEmotes.cpp
+++ b/src/providers/seventv/SeventvEmotes.cpp
@@ -395,7 +395,7 @@ void SeventvEmotes::loadChannelEmotes(
                         << ", error" << errorString;
                     shared->addMessage(makeSystemMessage(
                         QStringLiteral("Failed to fetch 7TV channel "
-                                       "emotes. (%1)")
+                                       "emotes. (Error: %1)")
                             .arg(errorString)));
                 }
             })

--- a/src/providers/seventv/SeventvEmotes.cpp
+++ b/src/providers/seventv/SeventvEmotes.cpp
@@ -386,23 +386,17 @@ void SeventvEmotes::loadChannelEmotes(
                             makeSystemMessage(CHANNEL_HAS_NO_EMOTES));
                     }
                 }
-                else if (result.status() == NetworkResult::timedoutStatus)
-                {
-                    // TODO: Auto retry in case of a timeout, with a delay
-                    qCWarning(chatterinoSeventv)
-                        << "Fetching 7TV emotes for channel" << channelId
-                        << "failed due to timeout";
-                    shared->addMessage(makeSystemMessage(
-                        "Failed to fetch 7TV channel emotes. (timed out)"));
-                }
                 else
                 {
+                    // TODO: Auto retry in case of a timeout, with a delay
+                    auto errorString = result.formatError();
                     qCWarning(chatterinoSeventv)
                         << "Error fetching 7TV emotes for channel" << channelId
-                        << ", error" << result.status();
-                    shared->addMessage(
-                        makeSystemMessage("Failed to fetch 7TV channel "
-                                          "emotes. (unknown error)"));
+                        << ", error" << errorString;
+                    shared->addMessage(makeSystemMessage(
+                        QStringLiteral("Failed to fetch 7TV channel "
+                                       "emotes. (%1)")
+                            .arg(errorString)));
                 }
             })
         .execute();
@@ -502,14 +496,7 @@ void SeventvEmotes::getEmoteSet(
         })
         .onError([emoteSetId, callback = std::move(errorCallback)](
                      const NetworkResult &result) {
-            if (result.status() == NetworkResult::timedoutStatus)
-            {
-                callback("timed out");
-            }
-            else
-            {
-                callback(QString("status: %1").arg(result.status()));
-            }
+            callback(result.formatError());
         })
         .execute();
 }

--- a/src/singletons/Updates.cpp
+++ b/src/singletons/Updates.cpp
@@ -128,8 +128,8 @@ void Updates::installUpdates()
                     auto *box = new QMessageBox(
                         QMessageBox::Information, "Chatterino Update",
                         QStringLiteral("The update couldn't be downloaded "
-                                       "(HTTP status %1).")
-                            .arg(result.status()));
+                                       "(%1).")
+                            .arg(result.formatError()));
                     box->setAttribute(Qt::WA_DeleteOnClose);
                     box->exec();
                     return Failure;
@@ -189,8 +189,8 @@ void Updates::installUpdates()
                     auto *box = new QMessageBox(
                         QMessageBox::Information, "Chatterino Update",
                         QStringLiteral("The update couldn't be downloaded "
-                                       "(HTTP status %1).")
-                            .arg(result.status()));
+                                       "(%1).")
+                            .arg(result.formatError()));
                     box->setAttribute(Qt::WA_DeleteOnClose);
                     box->exec();
                     return Failure;

--- a/src/singletons/Updates.cpp
+++ b/src/singletons/Updates.cpp
@@ -128,7 +128,7 @@ void Updates::installUpdates()
                     auto *box = new QMessageBox(
                         QMessageBox::Information, "Chatterino Update",
                         QStringLiteral("The update couldn't be downloaded "
-                                       "(%1).")
+                                       "(Error: %1).")
                             .arg(result.formatError()));
                     box->setAttribute(Qt::WA_DeleteOnClose);
                     box->exec();
@@ -189,7 +189,7 @@ void Updates::installUpdates()
                     auto *box = new QMessageBox(
                         QMessageBox::Information, "Chatterino Update",
                         QStringLiteral("The update couldn't be downloaded "
-                                       "(%1).")
+                                       "(Error: %1).")
                             .arg(result.formatError()));
                     box->setAttribute(Qt::WA_DeleteOnClose);
                     box->exec();

--- a/src/util/NuulsUploader.cpp
+++ b/src/util/NuulsUploader.cpp
@@ -208,7 +208,7 @@ void uploadImageToNuuls(RawImageData imageData, ChannelPtr channel,
         .onError([channel](NetworkResult result) -> bool {
             auto errorMessage =
                 QString("An error happened while uploading your image: %1")
-                    .arg(result.status());
+                    .arg(result.formatError());
 
             // Try to read more information from the result body
             auto obj = result.parseJson();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ set(test_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/src/AccessGuard.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/NetworkCommon.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/NetworkRequest.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/NetworkResult.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/ChatterSet.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/HighlightPhrase.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/Emojis.cpp

--- a/tests/src/NetworkRequest.cpp
+++ b/tests/src/NetworkRequest.cpp
@@ -210,7 +210,8 @@ TEST(NetworkRequest, TimeoutTimingOut)
         .onError([&waiter, url](const NetworkResult &result) {
             qDebug() << QTime::currentTime().toString()
                      << "timeout request finish error";
-            EXPECT_EQ(result.error(), NetworkResult::Error::TimeoutError);
+            EXPECT_EQ(result.error(),
+                      NetworkResult::NetworkError::TimeoutError);
             EXPECT_EQ(result.status(), std::nullopt);
 
             waiter.requestDone();
@@ -268,7 +269,8 @@ TEST(NetworkRequest, FinallyCallbackOnTimeout)
         })
         .onError([&](const NetworkResult &result) {
             onErrorCalled = true;
-            EXPECT_EQ(result.error(), NetworkResult::Error::TimeoutError);
+            EXPECT_EQ(result.error(),
+                      NetworkResult::NetworkError::TimeoutError);
             EXPECT_EQ(result.status(), std::nullopt);
         })
         .finally([&] {

--- a/tests/src/NetworkRequest.cpp
+++ b/tests/src/NetworkRequest.cpp
@@ -210,7 +210,8 @@ TEST(NetworkRequest, TimeoutTimingOut)
         .onError([&waiter, url](const NetworkResult &result) {
             qDebug() << QTime::currentTime().toString()
                      << "timeout request finish error";
-            EXPECT_EQ(result.status(), NetworkResult::timedoutStatus);
+            EXPECT_EQ(result.error(), NetworkResult::Error::TimeoutError);
+            EXPECT_EQ(result.status(), std::nullopt);
 
             waiter.requestDone();
         })
@@ -267,7 +268,8 @@ TEST(NetworkRequest, FinallyCallbackOnTimeout)
         })
         .onError([&](const NetworkResult &result) {
             onErrorCalled = true;
-            EXPECT_EQ(result.status(), NetworkResult::timedoutStatus);
+            EXPECT_EQ(result.error(), NetworkResult::Error::TimeoutError);
+            EXPECT_EQ(result.status(), std::nullopt);
         })
         .finally([&] {
             finallyCalled = true;

--- a/tests/src/NetworkResult.cpp
+++ b/tests/src/NetworkResult.cpp
@@ -9,7 +9,7 @@ using Error = NetworkResult::Error;
 namespace {
 
 void checkResult(const NetworkResult &res, Error error,
-                 std::optional<uint16_t> status, const QString &formatted)
+                 std::optional<int> status, const QString &formatted)
 {
     ASSERT_EQ(res.error(), error);
     ASSERT_EQ(res.status(), status);

--- a/tests/src/NetworkResult.cpp
+++ b/tests/src/NetworkResult.cpp
@@ -1,0 +1,48 @@
+#include "common/NetworkResult.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace chatterino;
+
+using Error = NetworkResult::Error;
+
+namespace {
+
+void checkResult(const NetworkResult &res, Error error,
+                 std::optional<uint16_t> status, const QString &formatted)
+{
+    ASSERT_EQ(res.error(), error);
+    ASSERT_EQ(res.status(), status);
+    ASSERT_EQ(res.formatError(), formatted);
+}
+
+}  // namespace
+
+TEST(NetworkResult, NoError)
+{
+    checkResult({Error::NoError, 200, {}}, Error::NoError, 200, "200");
+    checkResult({Error::NoError, 202, {}}, Error::NoError, 202, "202");
+
+    // no status code
+    checkResult({Error::NoError, {}, {}}, Error::NoError, std::nullopt,
+                "NoError");
+}
+
+TEST(NetworkResult, Errors)
+{
+    checkResult({Error::TimeoutError, {}, {}}, Error::TimeoutError,
+                std::nullopt, "TimeoutError");
+    checkResult({Error::RemoteHostClosedError, {}, {}},
+                Error::RemoteHostClosedError, std::nullopt,
+                "RemoteHostClosedError");
+
+    // status code takes precedence
+    checkResult({Error::TimeoutError, 400, {}}, Error::TimeoutError, 400,
+                "400");
+}
+
+TEST(NetworkResult, InvalidError)
+{
+    checkResult({static_cast<Error>(-1), {}, {}}, static_cast<Error>(-1),
+                std::nullopt, "unknown error (-1)");
+}

--- a/tests/src/NetworkResult.cpp
+++ b/tests/src/NetworkResult.cpp
@@ -4,7 +4,7 @@
 
 using namespace chatterino;
 
-using Error = NetworkResult::Error;
+using Error = NetworkResult::NetworkError;
 
 namespace {
 


### PR DESCRIPTION
# Description

Previously, some network errors would print `0` as their status code. This was because no status code was set for the reply. Instead, the error was in [`QNetworkReply::error`](https://doc.qt.io/qt-6/qnetworkreply.html#error) which wasn't used in error reporting. It's now used - if available, the HTTP status is still preferred.

I couldn't really come up with a good test case for `NetworkRequest` to test that the error is actually set.