### PR TITLE
Add clang-tidy script that runs on all files in parallel

### DIFF
--- a/tools/check-clang-tidy.sh
+++ b/tools/check-clang-tidy.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -eu
+
+clang-tidy --version
+
+find src/ -type f \( -name "*.hpp" -o -name "*.cpp" \) -print0 | parallel -0 -I {} clang-tidy --quiet "$@" "{}"


### PR DESCRIPTION
# Description

Extra options are forwarded to clang-tidy

For example: `./tools/check-clang-tidy.sh --checks '-*,readability-braces-around-statements' --fix`

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
