### PR TITLE
Ensure live status requests are always batched

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -49,6 +49,8 @@ CheckOptions:
     value: CamelCase
   - key: readability-identifier-naming.GlobalConstantCase
     value: UPPER_CASE
+  - key: readability-identifier-naming.GlobalVariableCase
+    value: UPPER_CASE
   - key: readability-identifier-naming.VariableCase
     value: camelBack
   - key: readability-implicit-bool-conversion.AllowPointerConditions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Minor: Added option to subscribe to and unsubscribe from reply threads. (#4680)
 - Minor: Added a message for when Chatterino joins a channel (#4616)
 - Minor: Add pin action to usercards and reply threads. (#4692)
+- Minor: Stream status requests are now batched. (#4713)
 - Bugfix: Fixed generation of crashdumps by the browser-extension process when the browser was closed. (#4667)
 - Bugfix: Fix spacing issue with mentions inside RTL text. (#4677)
 - Bugfix: Fixed a crash when opening and closing a reply thread and switching the user. (#4675)

--- a/mocks/include/mocks/EmptyApplication.hpp
+++ b/mocks/include/mocks/EmptyApplication.hpp
@@ -76,6 +76,11 @@ public:
     {
         return nullptr;
     }
+
+    ITwitchLiveController *getTwitchLiveController() override
+    {
+        return nullptr;
+    }
 };
 
 }  // namespace chatterino::mock

--- a/mocks/include/mocks/Helix.hpp
+++ b/mocks/include/mocks/Helix.hpp
@@ -86,6 +86,12 @@ public:
                  std::function<void()> finallyCallback),
                 (override));
 
+    MOCK_METHOD(void, fetchChannels,
+                (QStringList userIDs,
+                 ResultCallback<std::vector<HelixChannel>> successCallback,
+                 HelixFailureCallback failureCallback),
+                (override));
+
     MOCK_METHOD(void, getChannel,
                 (QString broadcasterId,
                  ResultCallback<HelixChannel> successCallback,

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -14,6 +14,7 @@
 #    include "controllers/plugins/PluginController.hpp"
 #endif
 #include "controllers/sound/SoundController.hpp"
+#include "controllers/twitch/LiveController.hpp"
 #include "controllers/userdata/UserDataController.hpp"
 #include "debug/AssertInGuiThread.hpp"
 #include "messages/Message.hpp"
@@ -88,6 +89,7 @@ Application::Application(Settings &_settings, Paths &_paths)
     , seventvBadges(&this->emplace<SeventvBadges>())
     , userData(&this->emplace<UserDataController>())
     , sound(&this->emplace<SoundController>())
+    , twitchLiveController(&this->emplace<TwitchLiveController>())
 #ifdef CHATTERINO_HAVE_PLUGINS
     , plugins(&this->emplace<PluginController>())
 #endif
@@ -243,6 +245,11 @@ IEmotes *Application::getEmotes()
 IUserDataController *Application::getUserData()
 {
     return this->userData;
+}
+
+ITwitchLiveController *Application::getTwitchLiveController()
+{
+    return this->twitchLiveController;
 }
 
 ITwitchIrcServer *Application::getTwitch()

--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -23,6 +23,8 @@ class HotkeyController;
 class IUserDataController;
 class UserDataController;
 class SoundController;
+class ITwitchLiveController;
+class TwitchLiveController;
 #ifdef CHATTERINO_HAVE_PLUGINS
 class PluginController;
 #endif
@@ -62,6 +64,7 @@ public:
     virtual ChatterinoBadges *getChatterinoBadges() = 0;
     virtual FfzBadges *getFfzBadges() = 0;
     virtual IUserDataController *getUserData() = 0;
+    virtual ITwitchLiveController *getTwitchLiveController() = 0;
 };
 
 class Application : public IApplication
@@ -101,6 +104,10 @@ public:
     UserDataController *const userData{};
     SoundController *const sound{};
 
+private:
+    TwitchLiveController *const twitchLiveController{};
+
+public:
 #ifdef CHATTERINO_HAVE_PLUGINS
     PluginController *const plugins{};
 #endif
@@ -154,6 +161,7 @@ public:
         return this->ffzBadges;
     }
     IUserDataController *getUserData() override;
+    ITwitchLiveController *getTwitchLiveController() override;
 
     pajlada::Signals::NoArgSignal streamerModeChanged;
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -171,6 +171,9 @@ set(SOURCE_FILES
         controllers/userdata/UserDataController.hpp
         controllers/userdata/UserData.hpp
 
+        controllers/twitch/LiveController.cpp
+        controllers/twitch/LiveController.hpp
+
         controllers/sound/SoundController.cpp
         controllers/sound/SoundController.hpp
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -167,15 +167,15 @@ set(SOURCE_FILES
         controllers/plugins/LuaUtilities.cpp
         controllers/plugins/LuaUtilities.hpp
 
-        controllers/userdata/UserDataController.cpp
-        controllers/userdata/UserDataController.hpp
-        controllers/userdata/UserData.hpp
+        controllers/sound/SoundController.cpp
+        controllers/sound/SoundController.hpp
 
         controllers/twitch/LiveController.cpp
         controllers/twitch/LiveController.hpp
 
-        controllers/sound/SoundController.cpp
-        controllers/sound/SoundController.hpp
+        controllers/userdata/UserDataController.cpp
+        controllers/userdata/UserDataController.hpp
+        controllers/userdata/UserData.hpp
 
         debug/Benchmark.cpp
         debug/Benchmark.hpp

--- a/src/common/QLogging.cpp
+++ b/src/common/QLogging.cpp
@@ -48,6 +48,8 @@ Q_LOGGING_CATEGORY(chatterinoStreamlink, "chatterino.streamlink", logThreshold);
 Q_LOGGING_CATEGORY(chatterinoTheme, "chatterino.theme", logThreshold);
 Q_LOGGING_CATEGORY(chatterinoTokenizer, "chatterino.tokenizer", logThreshold);
 Q_LOGGING_CATEGORY(chatterinoTwitch, "chatterino.twitch", logThreshold);
+Q_LOGGING_CATEGORY(chatterinoTwitchLiveController,
+                   "chatterino.twitch.livecontroller", logThreshold);
 Q_LOGGING_CATEGORY(chatterinoUpdate, "chatterino.update", logThreshold);
 Q_LOGGING_CATEGORY(chatterinoWebsocket, "chatterino.websocket", logThreshold);
 Q_LOGGING_CATEGORY(chatterinoWidget, "chatterino.widget", logThreshold);

--- a/src/common/QLogging.hpp
+++ b/src/common/QLogging.hpp
@@ -37,6 +37,7 @@ Q_DECLARE_LOGGING_CATEGORY(chatterinoStreamlink);
 Q_DECLARE_LOGGING_CATEGORY(chatterinoTheme);
 Q_DECLARE_LOGGING_CATEGORY(chatterinoTokenizer);
 Q_DECLARE_LOGGING_CATEGORY(chatterinoTwitch);
+Q_DECLARE_LOGGING_CATEGORY(chatterinoTwitchLiveController);
 Q_DECLARE_LOGGING_CATEGORY(chatterinoUpdate);
 Q_DECLARE_LOGGING_CATEGORY(chatterinoWebsocket);
 Q_DECLARE_LOGGING_CATEGORY(chatterinoWidget);

--- a/src/controllers/twitch/LiveController.cpp
+++ b/src/controllers/twitch/LiveController.cpp
@@ -47,7 +47,7 @@ TwitchLiveController::TwitchLiveController()
         TwitchLiveController::IMMEDIATE_REQUEST_INTERVAL);
 }
 
-void TwitchLiveController::add(std::shared_ptr<TwitchChannel> newChannel)
+void TwitchLiveController::add(const std::shared_ptr<TwitchChannel> &newChannel)
 {
     assert(newChannel != nullptr);
 

--- a/src/controllers/twitch/LiveController.cpp
+++ b/src/controllers/twitch/LiveController.cpp
@@ -1,0 +1,179 @@
+#include "controllers/twitch/LiveController.hpp"
+
+#include "providers/twitch/api/Helix.hpp"
+#include "providers/twitch/TwitchChannel.hpp"
+#include "singletons/Paths.hpp"
+#include "util/CombinePath.hpp"
+#include "util/Helpers.hpp"
+
+#include <QDebug>
+
+namespace chatterino {
+
+TwitchLiveController::TwitchLiveController()
+{
+    QObject::connect(&this->refreshTimer, &QTimer::timeout, [this] {
+        this->request();
+    });
+    this->refreshTimer.start(60 * 1000);
+
+    QObject::connect(&this->immediateRequestTimer, &QTimer::timeout, [this] {
+        QStringList channelIDs;
+
+        {
+            std::unique_lock immediateRequestsLock(
+                this->immediateRequestsMutex);
+            for (const auto &channelID : this->immediateRequests)
+            {
+                channelIDs.append(channelID);
+            }
+            this->immediateRequests.clear();
+        }
+
+        this->request(channelIDs);
+    });
+    this->immediateRequestTimer.start(1 * 1000);
+
+    qDebug() << "XD";
+}
+
+void TwitchLiveController::add(std::shared_ptr<TwitchChannel> newChannel)
+{
+    assert(newChannel != nullptr);
+
+    const auto channelID = newChannel->roomId();
+    assert(!channelID.isEmpty());
+
+    qDebug() << "XXX: Add" << channelID;
+
+    std::unique_lock lock(this->channelsMutex);
+    auto &channelList = this->channels[channelID];
+
+    if (channelList.empty())
+    {
+        std::unique_lock immediateRequestsLock(this->immediateRequestsMutex);
+        this->immediateRequests.emplace(channelID);
+    }
+
+    channelList.emplace_back(newChannel);
+}
+
+void TwitchLiveController::remove(std::shared_ptr<TwitchChannel> channel)
+{
+    const auto channelID = channel->roomId();
+    assert(!channelID.isEmpty());
+
+    qDebug() << "XXX: Remove" << channelID;
+
+    std::unique_lock lock(this->channelsMutex);
+    auto &channelList = this->channels[channelID];
+
+    channelList.erase(std::remove_if(channelList.begin(), channelList.end(),
+                                     [](const auto &c) {
+                                         return c.expired();
+                                     }),
+                      channelList.end());
+
+    if (channelList.empty())
+    {
+        this->channels.erase(channelID);
+    }
+}
+
+void TwitchLiveController::request(std::optional<QStringList> optChannelIDs)
+{
+    QStringList channelIDs;
+
+    if (optChannelIDs)
+    {
+        qDebug() << "XXX Load requests from channels map" << channelIDs;
+        channelIDs = *optChannelIDs;
+    }
+    else
+    {
+        std::shared_lock lock(this->channelsMutex);
+
+        for (const auto &channelList : this->channels)
+        {
+            channelIDs.append(channelList.first);
+        }
+    }
+
+    if (channelIDs.isEmpty())
+    {
+        qDebug() << "XXX: eraly out, no requests";
+        return;
+    }
+
+    auto batches = splitListIntoBatches(channelIDs, 3);
+
+    for (const auto &batch : batches)
+    {
+        qDebug() << "XXX MAKE REQUEST" << batch;
+
+        // TODO: make concurrent
+        getHelix()->fetchStreams(
+            batch, {},
+            [this, batch{batch}](const auto &streams) {
+                // on success
+                qDebug() << "XXX: success xd";
+                std::unordered_map<QString, std::optional<HelixStream>> results;
+
+                for (const auto &channelID : batch)
+                {
+                    results[channelID] = std::nullopt;
+                }
+
+                for (const auto &stream : streams)
+                {
+                    results[stream.userId] = stream;
+                    qDebug() << "XXX: stream" << stream.userLogin;
+                }
+
+                {
+                    std::unique_lock lock(this->channelsMutex);
+                    QStringList deadChannels;
+                    for (const auto &result : results)
+                    {
+                        auto it = this->channels.find(result.first);
+                        if (it != channels.end())
+                        {
+                            const auto &weakChannelList = it->second;
+                            for (const auto &weakChannel : weakChannelList)
+                            {
+                                auto channel = weakChannel.lock();
+                                if (channel)
+                                {
+                                    qDebug() << "XXX: channel is alive"
+                                             << channel->getName();
+                                    channel->updateLiveStatus(result.second);
+                                    // POST LIVE STATUS
+                                }
+                                else
+                                {
+                                    qDebug() << "XXX: channel is dead"
+                                             << result.first;
+                                    // channel is dead, mark as dead
+                                    deadChannels.append(result.first);
+                                }
+                            }
+                        }
+                    }
+
+                    for (const auto &deadChannel : deadChannels)
+                    {
+                        this->channels.erase(deadChannel);
+                    }
+                }
+            },
+            [] {
+                qDebug() << "XXX: failed xd";
+                // on failure
+            },
+            [] {
+                // finally
+            });
+    }
+}
+
+}  // namespace chatterino

--- a/src/controllers/twitch/LiveController.cpp
+++ b/src/controllers/twitch/LiveController.cpp
@@ -99,7 +99,6 @@ void TwitchLiveController::request(std::optional<QStringList> optChannelIDs)
         getHelix()->fetchStreams(
             batch, {},
             [this, batch{batch}](const auto &streams) {
-                // on success
                 std::unordered_map<QString, std::optional<HelixStream>> results;
 
                 for (const auto &channelID : batch)

--- a/src/controllers/twitch/LiveController.hpp
+++ b/src/controllers/twitch/LiveController.hpp
@@ -30,7 +30,7 @@ class TwitchLiveController : public ITwitchLiveController, public Singleton
 {
 public:
     // Controls how often all channels have their stream status refreshed
-    static constexpr std::chrono::seconds REFRESH_INTERVAL{60};
+    static constexpr std::chrono::seconds REFRESH_INTERVAL{30};
 
     // Controls how quickly new channels have their stream status loaded
     static constexpr std::chrono::seconds IMMEDIATE_REQUEST_INTERVAL{1};

--- a/src/controllers/twitch/LiveController.hpp
+++ b/src/controllers/twitch/LiveController.hpp
@@ -23,7 +23,7 @@ class ITwitchLiveController
 public:
     virtual ~ITwitchLiveController() = default;
 
-    virtual void add(std::shared_ptr<TwitchChannel> newChannel) = 0;
+    virtual void add(const std::shared_ptr<TwitchChannel> &newChannel) = 0;
 };
 
 class TwitchLiveController : public ITwitchLiveController, public Singleton
@@ -46,7 +46,7 @@ public:
 
     // Add a Twitch channel to be queried for live status
     // A request is made within a few seconds if this is the first time this channel is added
-    void add(std::shared_ptr<TwitchChannel> newChannel) override;
+    void add(const std::shared_ptr<TwitchChannel> &newChannel) override;
 
 private:
     void request(std::optional<QStringList> optChannelIDs = std::nullopt);

--- a/src/controllers/twitch/LiveController.hpp
+++ b/src/controllers/twitch/LiveController.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "common/Singleton.hpp"
+#include "util/QStringHash.hpp"
+#include "util/RapidjsonHelpers.hpp"
+#include "util/RapidJsonSerializeQString.hpp"
+#include "util/serialize/Container.hpp"
+
+#include <boost/optional.hpp>
+#include <QColor>
+#include <QString>
+#include <QTimer>
+
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <shared_mutex>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace chatterino {
+
+class TwitchChannel;
+
+class ITwitchLiveController
+{
+public:
+    virtual ~ITwitchLiveController() = default;
+
+    virtual void add(std::shared_ptr<TwitchChannel> newChannel) = 0;
+    virtual void remove(std::shared_ptr<TwitchChannel> channel) = 0;
+};
+
+class TwitchLiveController : public ITwitchLiveController, public Singleton
+{
+public:
+    TwitchLiveController();
+
+    void add(std::shared_ptr<TwitchChannel> newChannel) override;
+    void remove(std::shared_ptr<TwitchChannel> channel) override;
+
+private:
+    void request(std::optional<QStringList> optChannelIDs = std::nullopt);
+
+    // List of channel IDs pointing to Twitch Channels
+    std::unordered_map<QString, std::vector<std::weak_ptr<TwitchChannel>>>
+        channels;
+    std::shared_mutex channelsMutex;
+
+    QTimer refreshTimer;
+
+    // List of channels that need an immediate live status update
+    std::unordered_set<QString> immediateRequests;
+    std::mutex immediateRequestsMutex;
+
+    QTimer immediateRequestTimer;
+};
+
+}  // namespace chatterino

--- a/src/controllers/twitch/LiveController.hpp
+++ b/src/controllers/twitch/LiveController.hpp
@@ -40,7 +40,7 @@ public:
      *
      * Should not be more than 100
      **/
-    static constexpr int BATCH_SIZE{3};
+    static constexpr int BATCH_SIZE{100};
 
     TwitchLiveController();
 

--- a/src/controllers/twitch/LiveController.hpp
+++ b/src/controllers/twitch/LiveController.hpp
@@ -2,15 +2,11 @@
 
 #include "common/Singleton.hpp"
 #include "util/QStringHash.hpp"
-#include "util/RapidjsonHelpers.hpp"
-#include "util/RapidJsonSerializeQString.hpp"
-#include "util/serialize/Container.hpp"
 
-#include <boost/optional.hpp>
-#include <QColor>
 #include <QString>
 #include <QTimer>
 
+#include <chrono>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -28,23 +24,36 @@ public:
     virtual ~ITwitchLiveController() = default;
 
     virtual void add(std::shared_ptr<TwitchChannel> newChannel) = 0;
-    virtual void remove(std::shared_ptr<TwitchChannel> channel) = 0;
 };
 
 class TwitchLiveController : public ITwitchLiveController, public Singleton
 {
 public:
+    // Controls how often all channels have their stream status refreshed
+    static constexpr std::chrono::seconds REFRESH_INTERVAL{60};
+
+    // Controls how quickly new channels have their stream status loaded
+    static constexpr std::chrono::seconds IMMEDIATE_REQUEST_INTERVAL{1};
+
+    /**
+     * How many channels to include in a single request
+     *
+     * Should not be more than 100
+     **/
+    static constexpr int BATCH_SIZE{3};
+
     TwitchLiveController();
 
+    // Add a Twitch channel to be queried for live status
+    // A request is made within a few seconds if this is the first time this channel is added
     void add(std::shared_ptr<TwitchChannel> newChannel) override;
-    void remove(std::shared_ptr<TwitchChannel> channel) override;
 
 private:
     void request(std::optional<QStringList> optChannelIDs = std::nullopt);
 
-    // List of channel IDs pointing to Twitch Channels
-    std::unordered_map<QString, std::vector<std::weak_ptr<TwitchChannel>>>
-        channels;
+    // List of channel IDs pointing to their Twitch Channel
+    // These channels will have their stream status updated every INTERVAL seconds
+    std::unordered_map<QString, std::weak_ptr<TwitchChannel>> channels;
     std::shared_mutex channelsMutex;
 
     QTimer refreshTimer;

--- a/src/controllers/twitch/LiveController.hpp
+++ b/src/controllers/twitch/LiveController.hpp
@@ -49,19 +49,40 @@ public:
     void add(const std::shared_ptr<TwitchChannel> &newChannel) override;
 
 private:
+    /**
+     * Run batched Helix Channels & Stream requests for channels
+     *
+     * If a list of channel IDs is passed to request, we only make a request for those channels
+     *
+     * If no list of channels is passed to request (the default behaviour), we make requests for all channels
+     * in the `channels` map.
+     **/
     void request(std::optional<QStringList> optChannelIDs = std::nullopt);
 
-    // List of channel IDs pointing to their Twitch Channel
-    // These channels will have their stream status updated every INTERVAL seconds
+    /**
+     * List of channel IDs pointing to their Twitch Channel
+     *
+     * These channels will have their stream status updated every REFRESH_INTERVAL seconds
+     **/
     std::unordered_map<QString, std::weak_ptr<TwitchChannel>> channels;
     std::shared_mutex channelsMutex;
 
-    QTimer refreshTimer;
-
-    // List of channels that need an immediate live status update
+    /**
+     * List of channels that need an immediate live status update
+     *
+     * These channels will have their stream status updated after at most IMMEDIATE_REQUEST_INTERVAL seconds
+     **/
     std::unordered_set<QString> immediateRequests;
     std::mutex immediateRequestsMutex;
 
+    /**
+     * Timer responsible for refreshing `channels`
+     **/
+    QTimer refreshTimer;
+
+    /**
+     * Timer responsible for refreshing `immediateRequests`
+     **/
     QTimer immediateRequestTimer;
 };
 

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -8,6 +8,7 @@
 #include "common/QLogging.hpp"
 #include "controllers/accounts/AccountController.hpp"
 #include "controllers/notifications/NotificationController.hpp"
+#include "controllers/twitch/LiveController.hpp"
 #include "messages/Emote.hpp"
 #include "messages/Image.hpp"
 #include "messages/Link.hpp"
@@ -106,6 +107,8 @@ TwitchChannel::TwitchChannel(const QString &name)
         this->refreshBTTVChannelEmotes(false);
         this->refreshSevenTVChannelEmotes(false);
         this->joinBttvChannel();
+        getIApp()->getTwitchLiveController()->add(
+            std::dynamic_pointer_cast<TwitchChannel>(shared_from_this()));
     });
 
     this->connected.connect([this]() {
@@ -338,6 +341,20 @@ boost::optional<ChannelPointReward> TwitchChannel::channelPointReward(
     if (it == rewards->end())
         return boost::none;
     return it->second;
+}
+
+void TwitchChannel::updateLiveStatus(
+    const std::optional<HelixStream> &helixStream)
+{
+    qDebug() << "XXX: Update live status for " << this->getName();
+    if (helixStream)
+    {
+        qDebug() << "XXX: stream is live";
+    }
+    else
+    {
+        qDebug() << "XXX: stream is not live";
+    }
 }
 
 void TwitchChannel::showLoginMessage()

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -18,6 +18,7 @@
 
 #include <atomic>
 #include <mutex>
+#include <optional>
 #include <unordered_map>
 
 namespace chatterino {

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -205,6 +205,9 @@ public:
     boost::optional<ChannelPointReward> channelPointReward(
         const QString &rewardId) const;
 
+    // Live status
+    void updateLiveStatus(const std::optional<HelixStream> &helixStream);
+
 private:
     struct NameOptions {
         QString displayName;

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -120,7 +120,6 @@ public:
     virtual bool hasHighRateLimit() const override;
     virtual bool canReconnect() const override;
     virtual void reconnect() override;
-    void refreshTitle();
     void createClip();
 
     // Data
@@ -194,7 +193,23 @@ public:
     // Signals
     pajlada::Signals::NoArgSignal roomIdChanged;
     pajlada::Signals::NoArgSignal userStateChanged;
-    pajlada::Signals::NoArgSignal liveStatusChanged;
+
+    /**
+     * This signals fires whenever the live status is changed
+     *
+     * Streams are counted as offline by default, so if a stream does not go online
+     * this signal will never fire
+     **/
+    pajlada::Signals::Signal<bool> liveStatusChanged;
+
+    /**
+     * This signal fires whenever the stream status is changed
+     *
+     * This includes when the stream goes from offline to online,
+     * or the viewer count changes, or the title has been updated
+     **/
+    pajlada::Signals::NoArgSignal streamStatusChanged;
+
     pajlada::Signals::NoArgSignal roomModesChanged;
 
     // Channel point rewards
@@ -206,7 +221,10 @@ public:
         const QString &rewardId) const;
 
     // Live status
-    void updateLiveStatus(const std::optional<HelixStream> &helixStream);
+    void updateStreamStatus(const std::optional<HelixStream> &helixStream);
+    void updateStreamTitle(const QString &title);
+
+    void updateDisplayName(const QString &displayName);
 
 private:
     struct NameOptions {
@@ -216,21 +234,23 @@ private:
 
 private:
     // Methods
-    void refreshLiveStatus();
-    void parseLiveStatus(bool live, const HelixStream &stream);
     void refreshPubSub();
     void refreshChatters();
     void refreshBadges();
     void refreshCheerEmotes();
     void loadRecentMessages();
     void loadRecentMessagesReconnect();
-    void fetchDisplayName();
     void cleanUpReplyThreads();
     void showLoginMessage();
     /** Joins (subscribes to) a Twitch channel for updates on BTTV. */
     void joinBttvChannel() const;
 
-    void setLive(bool newLiveStatus);
+    /**
+     * @brief Sets the live status of this Twitch channel
+     *
+     * Returns true if the live status changed with this call
+     **/
+    bool setLive(bool newLiveStatus);
     void setMod(bool value);
     void setVIP(bool value);
     void setStaff(bool value);
@@ -239,7 +259,16 @@ private:
     void setDisplayName(const QString &name);
     void setLocalizedName(const QString &name);
 
+    /**
+     * Returns the display name of the user
+     *
+     * If the display name contained chinese, japenese, or korean characters, the user's login name is returned instead
+     **/
     const QString &getDisplayName() const override;
+
+    /**
+     * Returns the localized name of the user
+     **/
     const QString &getLocalizedName() const override;
 
     QString prepareMessage(const QString &message) const;

--- a/src/providers/twitch/TwitchIrcServer.hpp
+++ b/src/providers/twitch/TwitchIrcServer.hpp
@@ -49,8 +49,6 @@ public:
 
     std::shared_ptr<Channel> getChannelOrEmptyByID(const QString &channelID);
 
-    void bulkRefreshLiveStatus();
-
     void reloadBTTVGlobalEmotes();
     void reloadAllBTTVChannelEmotes();
     void reloadFFZGlobalEmotes();
@@ -124,7 +122,6 @@ private:
     BttvEmotes bttv;
     FfzEmotes ffz;
     SeventvEmotes seventv_;
-    QTimer bulkLiveStatusTimer_;
 
     pajlada::Signals::SignalHolder signalHolder_;
 };

--- a/src/providers/twitch/api/Helix.hpp
+++ b/src/providers/twitch/api/Helix.hpp
@@ -789,6 +789,12 @@ public:
                             std::function<void()> finallyCallback) = 0;
 
     // https://dev.twitch.tv/docs/api/reference#get-channel-information
+    virtual void fetchChannels(
+        QStringList userIDs,
+        ResultCallback<std::vector<HelixChannel>> successCallback,
+        HelixFailureCallback failureCallback) = 0;
+
+    // https://dev.twitch.tv/docs/api/reference#get-channel-information
     virtual void getChannel(QString broadcasterId,
                             ResultCallback<HelixChannel> successCallback,
                             HelixFailureCallback failureCallback) = 0;
@@ -1100,6 +1106,12 @@ public:
                     ResultCallback<HelixClip> successCallback,
                     std::function<void(HelixClipError)> failureCallback,
                     std::function<void()> finallyCallback) final;
+
+    // https://dev.twitch.tv/docs/api/reference#get-channel-information
+    void fetchChannels(
+        QStringList userIDs,
+        ResultCallback<std::vector<HelixChannel>> successCallback,
+        HelixFailureCallback failureCallback) final;
 
     // https://dev.twitch.tv/docs/api/reference#get-channel-information
     void getChannel(QString broadcasterId,

--- a/src/providers/twitch/api/README.md
+++ b/src/providers/twitch/api/README.md
@@ -43,7 +43,7 @@ URL: https://dev.twitch.tv/docs/api/reference#get-streams
 
 Used in:
 
-- `TwitchChannel` to get live status, game, title, and viewer count of a channel
+- `LiveController` to get live status, game, title, and viewer count of a channel
 - `NotificationController` to provide notifications for channels you might not have open in Chatterino, but are still interested in getting notifications for
 
 ### Create Clip
@@ -61,7 +61,7 @@ URL: https://dev.twitch.tv/docs/api/reference#get-channel-information
 
 Used in:
 
-- `TwitchChannel` to refresh stream title
+- `LiveController` to refresh stream title & display name
 
 ### Update Channel
 

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -800,7 +800,7 @@ void ChannelView::setChannel(ChannelPtr underlyingChannel)
     if (auto tc = dynamic_cast<TwitchChannel *>(underlyingChannel.get()))
     {
         this->channelConnections_.managedConnect(
-            tc->liveStatusChanged, [this]() {
+            tc->streamStatusChanged, [this]() {
                 this->liveStatusChanged.invoke();
             });
     }

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -740,7 +740,7 @@ void SplitHeader::handleChannelChanged()
     if (auto *twitchChannel = dynamic_cast<TwitchChannel *>(channel.get()))
     {
         this->channelConnections_.managedConnect(
-            twitchChannel->liveStatusChanged, [this]() {
+            twitchChannel->streamStatusChanged, [this]() {
                 this->updateChannelText();
             });
     }
@@ -956,10 +956,6 @@ void SplitHeader::enterEvent(QEvent *event)
     if (!this->tooltipText_.isEmpty())
     {
         auto *channel = this->split_->getChannel().get();
-        if (channel->getType() == Channel::Type::Twitch)
-        {
-            dynamic_cast<TwitchChannel *>(channel)->refreshTitle();
-        }
 
         auto *tooltip = TooltipWidget::instance();
         tooltip->setOne({nullptr, this->tooltipText_});


### PR DESCRIPTION
# Description

This makes sure live status requests are always batched, including the first one

Titles are also now always batched, and updated frequently rather than just randomly when we hover over the split header.

The display name of a channel is now also updated, if necessary, alongside the livestatus changes. Technically unrelated to the live status-ness but since we have that data in the same request, we might as well update it.

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
