### PR TITLE
Change emotepopup channel view layout to be faster to navigate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unversioned
-
+- Minor: Emote Popup Menu is now easier to navigate. (#4720)
 - Minor: Nicknames are now taken into consideration when searching for messages. (#4663)
 - Minor: Add an icon showing when streamer mode is enabled (#4410, #4690)
 - Minor: Added `/shoutout <username>` commands to shoutout specified user. (#4638)

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -242,8 +242,8 @@ EmotePopup::EmotePopup(QWidget *parent)
         auto *view = new ChannelView();
 
         view->setOverrideFlags(MessageElementFlags{
-            MessageElementFlag::Default, MessageElementFlag::AlwaysShow,
-            MessageElementFlag::EmoteImages});
+                                                   MessageElementFlag::Default, MessageElementFlag::AlwaysShow,
+                                                   MessageElementFlag::EmoteImages});
         view->setEnableScrollingToBottom(false);
         view->linkClicked.connect(clicked);
 
@@ -263,11 +263,14 @@ EmotePopup::EmotePopup(QWidget *parent)
     layout->setContentsMargins(0, 0, 0, 0);
 
     this->subEmotesView_ = makeView("Subs");
-    this->channelEmotesView_ = makeView("Channel");
-    this->globalEmotesView_ = makeView("Global");
-    this->viewEmojis_ = makeView("Emojis");
 
-    loadEmojis(*this->viewEmojis_, getApp()->emotes->emojis.emojis);
+    this->bttvEmotesView_ = makeView("BTTV");
+    this->SevenTVEmotesView_ = makeView("7TV");
+    this->FFZEmotesView_ = makeView("FFZ");
+
+    this->viewEmojisView_ = makeView("Emojis");
+
+    loadEmojis(*this->viewEmojisView_, getApp()->emotes->emojis.emojis);
     this->addShortcuts();
     this->signalHolder_.managedConnect(getApp()->hotkeys->onItemsUpdated,
                                        [this]() {
@@ -389,6 +392,10 @@ void EmotePopup::loadChannel(ChannelPtr channel)
     auto globalChannel = std::make_shared<Channel>("", Channel::Type::None);
     auto channelChannel = std::make_shared<Channel>("", Channel::Type::None);
 
+    auto seventvChannel = std::make_shared<Channel>("", Channel::Type::None);
+    auto bttvChannel = std::make_shared<Channel>("", Channel::Type::None);
+    auto ffzChannel = std::make_shared<Channel>("", Channel::Type::None);
+
     // twitch
     addTwitchEmoteSets(
         getApp()->accounts->twitch.getCurrent()->accessEmotes()->emoteSets,
@@ -397,41 +404,41 @@ void EmotePopup::loadChannel(ChannelPtr channel)
     // global
     if (Settings::instance().enableBTTVGlobalEmotes)
     {
-        addEmotes(*globalChannel, *getApp()->twitch->getBttvEmotes().emotes(),
-                  "BetterTTV", MessageElementFlag::BttvEmote);
+        addEmotes(*bttvChannel, *getApp()->twitch->getBttvEmotes().emotes(),
+                  "Global", MessageElementFlag::BttvEmote);
     }
     if (Settings::instance().enableFFZGlobalEmotes)
     {
-        addEmotes(*globalChannel, *getApp()->twitch->getFfzEmotes().emotes(),
-                  "FrankerFaceZ", MessageElementFlag::FfzEmote);
+        addEmotes(*ffzChannel, *getApp()->twitch->getFfzEmotes().emotes(),
+                  "Global", MessageElementFlag::FfzEmote);
     }
     if (Settings::instance().enableSevenTVGlobalEmotes)
     {
-        addEmotes(*globalChannel,
-                  *getApp()->twitch->getSeventvEmotes().globalEmotes(), "7TV",
+        addEmotes(*seventvChannel,
+                  *getApp()->twitch->getSeventvEmotes().globalEmotes(), "Global",
                   MessageElementFlag::SevenTVEmote);
     }
 
     // channel
     if (Settings::instance().enableBTTVChannelEmotes)
     {
-        addEmotes(*channelChannel, *this->twitchChannel_->bttvEmotes(),
-                  "BetterTTV", MessageElementFlag::BttvEmote);
+        addEmotes(*bttvChannel, *this->twitchChannel_->bttvEmotes(), "Channel", MessageElementFlag::BttvEmote);
     }
     if (Settings::instance().enableFFZChannelEmotes)
     {
-        addEmotes(*channelChannel, *this->twitchChannel_->ffzEmotes(),
-                  "FrankerFaceZ", MessageElementFlag::FfzEmote);
+        addEmotes(*ffzChannel, *this->twitchChannel_->ffzEmotes(),
+                  "Channel", MessageElementFlag::FfzEmote);
     }
     if (Settings::instance().enableSevenTVChannelEmotes)
     {
-        addEmotes(*channelChannel, *this->twitchChannel_->seventvEmotes(),
-                  "7TV", MessageElementFlag::SevenTVEmote);
+        addEmotes(*seventvChannel, *this->twitchChannel_->seventvEmotes(), "Channel", MessageElementFlag::SevenTVEmote);
     }
 
-    this->globalEmotesView_->setChannel(globalChannel);
     this->subEmotesView_->setChannel(subChannel);
-    this->channelEmotesView_->setChannel(channelChannel);
+
+    this->bttvEmotesView_->setChannel(bttvChannel);
+    this->SevenTVEmotesView_->setChannel(seventvChannel);
+    this->FFZEmotesView_->setChannel(ffzChannel);
 
     if (subChannel->getMessageSnapshot().size() == 0)
     {

--- a/src/widgets/dialogs/EmotePopup.hpp
+++ b/src/widgets/dialogs/EmotePopup.hpp
@@ -26,10 +26,12 @@ public:
     pajlada::Signals::Signal<Link> linkClicked;
 
 private:
-    ChannelView *globalEmotesView_{};
-    ChannelView *channelEmotesView_{};
     ChannelView *subEmotesView_{};
-    ChannelView *viewEmojis_{};
+    ChannelView *viewEmojisView_{};
+    ChannelView *bttvEmotesView_{};
+    ChannelView *SevenTVEmotesView_{};
+    ChannelView *FFZEmotesView_{};
+
     /**
      * @brief Visible only when the user has specified a search query into the `search_` input.
      * Otherwise the `notebook_` and all other views are visible.


### PR DESCRIPTION
# Description

Currently, the emotepopup menu layout is a bit slow to navigate. This is especially true with global and channel emote views as they have all the bttv, ffz, 7tv emotes packed in and hence scrolling becomes long. I refactored it to so that it's more distinctive and scrolling is easier. Let me know.

Updated Look
![image](https://github.com/Chatterino/chatterino2/assets/46773404/2e42d102-a533-4d4e-90a8-de4525a5e82a)
