### PR TITLE
Recreate ma_device on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Bugfix: Fixed partially broken filters on Qt 6 builds. (#4702)
 - Bugfix: Fixed some network errors having `0` as their HTTP status. (#4704)
 - Bugfix: Fixed crash that could occurr when closing the usercard too quickly after blocking or unblocking a user. (#4711)
+- Bugfix: Fixed highlights sometimes not working after changing sound device, or switching users in your operating system. (#4729)
 - Dev: Added command to set Qt's logging filter/rules at runtime (`/c2-set-logging-rules`). (#4637)
 - Dev: Added the ability to see & load custom themes from the Themes directory. No stable promises are made of this feature, changes might be made that breaks custom themes without notice. (#4570)
 - Dev: Added test cases for emote and tab completion. (#4644)

--- a/src/controllers/sound/SoundController.hpp
+++ b/src/controllers/sound/SoundController.hpp
@@ -45,7 +45,7 @@ private:
     // Used for storing & reusing sounds to be played
     std::unique_ptr<ma_resource_manager> resourceManager;
     // The sound device we're playing sound into
-    std::unique_ptr<ma_device> device;
+    std::unique_ptr<ma_device> device{nullptr};
     // The engine is a high-level API for playing sounds from paths in a simple & efficient-enough manner
     std::unique_ptr<ma_engine> engine;
 
@@ -63,6 +63,13 @@ private:
     ThreadGuard tgPlay;
 
     bool initialized{false};
+
+    // Recreates the sound device
+    // This is used during initialization, and can also be used if the device
+    // needs to be recreated during playback
+    //
+    // Returns false on failure
+    bool recreateDevice();
 
     friend class Application;
 };


### PR DESCRIPTION
# Description

If the sound device is stopped by the OS, we used to restart it.
In certain cases, the start fails because the OS has invalidated the sound device. The solve for this, if the restart fails, we recreate the sound device.

Tested on Arch Linux using Pulseaudio, where it works as expected.
<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
