### PR TITLE
Fix crash that could occur when closing a split before its display name was updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Bugfix: Fixed generation of crashdumps by the browser-extension process when the browser was closed. (#4667)
 - Bugfix: Fix spacing issue with mentions inside RTL text. (#4677)
 - Bugfix: Fixed a crash when opening and closing a reply thread and switching the user. (#4675)
+- Bugfix: Fixed a crash that could happen when closing splits before their display name was updated. This was especially noticeable after the live controller changes. (#4731)
 - Bugfix: Fix visual glitches with smooth scrolling. (#4501)
 - Bugfix: Fixed pings firing for the "Your username" highlight when not signed in. (#4698)
 - Bugfix: Fixed partially broken filters on Qt 6 builds. (#4702)

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -73,7 +73,7 @@ namespace {
 TwitchChannel::TwitchChannel(const QString &name)
     : Channel(name, Channel::Type::Twitch)
     , ChannelChatters(*static_cast<Channel *>(this))
-    , nameOptions{name, name}
+    , nameOptions{name, name, name}
     , subscriptionUrl_("https://www.twitch.tv/subs/" + name)
     , channelUrl_("https://twitch.tv/" + name)
     , popoutPlayerUrl_("https://player.twitch.tv/?parent=twitch.tv&channel=" +

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -472,13 +472,15 @@ void TwitchChannel::updateStreamTitle(const QString &title)
 
 void TwitchChannel::updateDisplayName(const QString &displayName)
 {
-    if (displayName == this->getDisplayName())
+    if (displayName == this->nameOptions.actualDisplayName)
     {
         // Display name has not changed
         return;
     }
 
     // Display name has changed
+
+    this->nameOptions.actualDisplayName = displayName;
 
     if (QString::compare(displayName, this->getName(), Qt::CaseInsensitive) ==
         0)

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -229,8 +229,17 @@ public:
 
 private:
     struct NameOptions {
+        // displayName is the non-CJK-display name for this user
+        // This will always be the same as their `name_`, but potentially with different casing
         QString displayName;
+
+        // localizedName is their display name that *may* contain CJK characters
+        // If the display name does not contain any CJK characters, this will be
+        // the same as `displayName`
         QString localizedName;
+
+        // actualDisplayName is the raw display name string received from Twitch
+        QString actualDisplayName;
     } nameOptions;
 
 private:

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -850,9 +850,10 @@ void Split::setChannel(IndirectChannel newChannel)
         this->header_->setViewersButtonVisible(false);
     }
 
-    this->channel_.get()->displayNameChanged.connect([this] {
-        this->actionRequested.invoke(Action::RefreshTab);
-    });
+    this->channelSignalHolder_.managedConnect(
+        this->channel_.get()->displayNameChanged, [this] {
+            this->actionRequested.invoke(Action::RefreshTab);
+        });
 
     this->channelChanged.invoke();
     this->actionRequested.invoke(Action::RefreshTab);

--- a/src/widgets/splits/Split.hpp
+++ b/src/widgets/splits/Split.hpp
@@ -163,6 +163,10 @@ private:
     pajlada::Signals::Connection roomModeChangedConnection_;
 
     pajlada::Signals::Connection indirectChannelChangedConnection_;
+
+    // This signal-holder is cleared whenever this split changes the underlying channel
+    pajlada::Signals::SignalHolder channelSignalHolder_;
+
     pajlada::Signals::SignalHolder signalHolder_;
     std::vector<boost::signals2::scoped_connection> bSignals_;
 


### PR DESCRIPTION
# Description

- Disconnect the `displayNameChanged` signal when the split closes
- Store the "raw" display name sent from Twitch

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
