### PR TITLE
Fixed tab completion rarely completing the wrong word.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Bugfix: Fixed crash that could occurr when closing the usercard too quickly after blocking or unblocking a user. (#4711)
 - Bugfix: Fixed highlights sometimes not working after changing sound device, or switching users in your operating system. (#4729)
 - Bugfix: Fixed key bindings not showing in context menus on Mac. (#4722)
+- Bugfix: Fixed tab completion rarely completing the wrong word. (#4735)
 - Dev: Added command to set Qt's logging filter/rules at runtime (`/c2-set-logging-rules`). (#4637)
 - Dev: Added the ability to see & load custom themes from the Themes directory. No stable promises are made of this feature, changes might be made that breaks custom themes without notice. (#4570)
 - Dev: Added test cases for emote and tab completion. (#4644)

--- a/src/widgets/helper/ResizingTextEdit.cpp
+++ b/src/widgets/helper/ResizingTextEdit.cpp
@@ -202,7 +202,7 @@ void ResizingTextEdit::keyPressEvent(QKeyEvent *event)
         }
 
         {
-            // this blocks cursor movement events from resetting tab completion
+            // this blocks cursor movement events from updating tab completion
             QSignalBlocker dontTriggerCursorMovement(this);
             this->completer_->complete();
         }

--- a/src/widgets/helper/ResizingTextEdit.hpp
+++ b/src/widgets/helper/ResizingTextEdit.hpp
@@ -66,6 +66,21 @@ private:
      */
     bool completionInProgress_ = false;
 
+    /**
+     * This is set whenever the tab completion is triggered.
+     * When this variable is set, moving the cursor will not reset tab completion.
+     *
+     * For example:
+     *
+     * input: "pog"
+     *  - type Tab to complete to "PogBones"
+     *    - updatingText_ is set to true,
+     *    - text is updated, cursor is moved after the new word
+     *    - updatingText_ is set to false,
+     *  - moving the cursor now would result in completionInProgress_ being set to false
+     */
+    bool updatingText_ = false;
+
     bool eventFilter(QObject *obj, QEvent *event) override;
 
 private slots:

--- a/src/widgets/helper/ResizingTextEdit.hpp
+++ b/src/widgets/helper/ResizingTextEdit.hpp
@@ -61,25 +61,10 @@ private:
      * `Tab` pressed again:
      *   - complete ["pog"] to "PogChamp"
      *
-     * [other key] pressed - updating the input text:
+     * [other key] pressed or cursor moved - updating the input text:
      *   - set `completionInProgress_ = false`
      */
     bool completionInProgress_ = false;
-
-    /**
-     * This is set whenever the tab completion is triggered.
-     * When this variable is set, moving the cursor will not reset tab completion.
-     *
-     * For example:
-     *
-     * input: "pog"
-     *  - type Tab to complete to "PogBones"
-     *    - updatingText_ is set to true,
-     *    - text is updated, cursor is moved after the new word
-     *    - updatingText_ is set to false,
-     *  - moving the cursor now would result in completionInProgress_ being set to false
-     */
-    bool updatingText_ = false;
 
     bool eventFilter(QObject *obj, QEvent *event) override;
 


### PR DESCRIPTION
# Description

Now moving the cursor in any way will result in the completion being cancelled.

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
Fixes: #3101