### PR TITLE
Refactor Native Messages

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -270,7 +270,7 @@ void Application::initNm(Paths &paths)
     (void)paths;
 
 #ifdef Q_OS_WIN
-#    if defined QT_NO_DEBUG || defined C_DEBUG_NM
+#    if defined QT_NO_DEBUG || defined CHATTERINO_DEBUG_NM
     registerNmHost(paths);
     this->nmServer.start();
 #    endif

--- a/src/BrowserExtension.cpp
+++ b/src/BrowserExtension.cpp
@@ -30,7 +30,7 @@ namespace {
 #endif
     }
 
-    void runLoop(NativeMessagingClient &client)
+    void runLoop()
     {
         auto received_message = std::make_shared<std::atomic_bool>(true);
 
@@ -73,7 +73,7 @@ namespace {
 
             received_message->store(true);
 
-            client.sendMessage(data);
+            nm_client::sendMessage(data);
         }
         _Exit(0);
     }
@@ -83,9 +83,7 @@ void runBrowserExtensionHost()
 {
     initFileMode();
 
-    NativeMessagingClient client;
-
-    runLoop(client);
+    runLoop();
 }
 
 }  // namespace chatterino

--- a/src/BrowserExtension.cpp
+++ b/src/BrowserExtension.cpp
@@ -73,7 +73,7 @@ namespace {
 
             received_message->store(true);
 
-            nm_client::sendMessage(data);
+            nm::client::sendMessage(data);
         }
         _Exit(0);
     }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,9 @@ set(VERSION_PROJECT "${LIBRARY_PROJECT}-version")
 set(EXECUTABLE_PROJECT "${PROJECT_NAME}")
 add_compile_definitions(QT_DISABLE_DEPRECATED_BEFORE=0x050F00)
 
+# registers the native messageing host
+option(DEBUG_NATIVE_MESSAGES "Debug native messages" OFF)
+
 set(SOURCE_FILES
         Application.cpp
         Application.hpp
@@ -405,6 +408,8 @@ set(SOURCE_FILES
         util/IncognitoBrowser.hpp
         util/InitUpdateButton.cpp
         util/InitUpdateButton.hpp
+        util/IpcQueue.cpp
+        util/IpcQueue.hpp
         util/LayoutHelper.cpp
         util/LayoutHelper.hpp
         util/NuulsUploader.cpp
@@ -843,6 +848,9 @@ if (WIN32)
     if (BUILD_APP)
         set_target_properties(${EXECUTABLE_PROJECT} PROPERTIES WIN32_EXECUTABLE TRUE)
     endif ()
+endif ()
+if (DEBUG_NATIVE_MESSAGES)
+    target_compile_definitions(${LIBRARY_PROJECT} PRIVATE C_DEBUG_NM)
 endif ()
 
 if (MSVC)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,7 +4,7 @@ set(EXECUTABLE_PROJECT "${PROJECT_NAME}")
 add_compile_definitions(QT_DISABLE_DEPRECATED_BEFORE=0x050F00)
 
 # registers the native messageing host
-option(DEBUG_NATIVE_MESSAGES "Debug native messages" OFF)
+option(CHATTERINO_DEBUG_NATIVE_MESSAGES "Debug native messages" OFF)
 
 set(SOURCE_FILES
         Application.cpp
@@ -849,7 +849,7 @@ if (WIN32)
         set_target_properties(${EXECUTABLE_PROJECT} PROPERTIES WIN32_EXECUTABLE TRUE)
     endif ()
 endif ()
-if (DEBUG_NATIVE_MESSAGES)
+if (CHATTERINO_DEBUG_NATIVE_MESSAGES)
     target_compile_definitions(${LIBRARY_PROJECT} PRIVATE CHATTERINO_DEBUG_NM)
 endif ()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -850,7 +850,7 @@ if (WIN32)
     endif ()
 endif ()
 if (DEBUG_NATIVE_MESSAGES)
-    target_compile_definitions(${LIBRARY_PROJECT} PRIVATE C_DEBUG_NM)
+    target_compile_definitions(${LIBRARY_PROJECT} PRIVATE CHATTERINO_DEBUG_NM)
 endif ()
 
 if (MSVC)

--- a/src/singletons/NativeMessaging.cpp
+++ b/src/singletons/NativeMessaging.cpp
@@ -18,7 +18,6 @@
 #ifdef Q_OS_WIN
 // clang-format off
 #    include <QSettings>
-#    include <Windows.h>
 // clang-format on
 #    include "singletons/WindowManager.hpp"
 #    include "widgets/AttachedWindow.hpp"
@@ -223,8 +222,7 @@ void NativeMessagingServer::ReceiverThread::handleMessage(
                 if (attach || attachFullscreen)
                 {
 #ifdef USEWINSDK
-                    auto *window =
-                        AttachedWindow::get(::GetForegroundWindow(), args);
+                    auto *window = AttachedWindow::getForeground(args);
                     if (!name.isEmpty())
                     {
                         window->setChannel(app->twitch->getOrAddChannel(name));

--- a/src/singletons/NativeMessaging.cpp
+++ b/src/singletons/NativeMessaging.cpp
@@ -150,7 +150,7 @@ void NativeMessagingServer::ReceiverThread::run()
         return;
     }
 
-    auto messageQueue = std::move(std::get<ipc::IpcQueue>(result));
+    auto &messageQueue = std::get<ipc::IpcQueue>(result);
     while (true)
     {
         auto buf = messageQueue.receive();

--- a/src/singletons/NativeMessaging.cpp
+++ b/src/singletons/NativeMessaging.cpp
@@ -109,20 +109,26 @@ std::string &getNmQueueName(Paths &paths)
 
 // CLIENT
 
-void NativeMessagingClient::sendMessage(const QByteArray &array)
-{
-    ipc::sendMessage("chatterino_gui", array);
-}
+namespace nm_client {
 
-void NativeMessagingClient::writeToCout(const QByteArray &array)
-{
-    auto *data = array.data();
-    auto size = uint32_t(array.size());
+    void sendMessage(const QByteArray &array)
+    {
+        ipc::sendMessage("chatterino_gui", array);
+    }
 
-    std::cout.write(reinterpret_cast<char *>(&size), 4);
-    std::cout.write(data, size);
-    std::cout.flush();
-}
+    void writeToCout(const QByteArray &array)
+    {
+        const auto *data = array.data();
+        auto size = uint32_t(array.size());
+
+        // We're writing the raw bytes to cout.
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        std::cout.write(reinterpret_cast<char *>(&size), 4);
+        std::cout.write(data, size);
+        std::cout.flush();
+    }
+
+}  // namespace nm_client
 
 // SERVER
 

--- a/src/singletons/NativeMessaging.cpp
+++ b/src/singletons/NativeMessaging.cpp
@@ -141,45 +141,38 @@ void registerNmHost(Paths &paths)
         return;
     }
 
-    auto getBaseDocument = [&] {
-        QJsonObject obj;
-        obj.insert("name", "com.chatterino.chatterino");
-        obj.insert("description", "Browser interaction with chatterino.");
-        obj.insert("path", QCoreApplication::applicationFilePath());
-        obj.insert("type", "stdio");
-
-        return obj;
+    auto getBaseDocument = [] {
+        return QJsonObject{
+            {u"name"_s, "com.chatterino.chatterino"_L1},
+            {u"description"_s, "Browser interaction with chatterino."_L1},
+            {u"path"_s, QCoreApplication::applicationFilePath()},
+            {u"type"_s, "stdio"_L1},
+        };
     };
 
     // chrome
     {
-        QJsonDocument document;
-
         auto obj = getBaseDocument();
         QJsonArray allowedOriginsArr = {
             u"chrome-extension://%1/"_s.arg(EXTENSION_ID)};
         obj.insert("allowed_origins", allowedOriginsArr);
-        document.setObject(obj);
 
         registerNmManifest(paths, "/native-messaging-manifest-chrome.json",
                            "HKCU\\Software\\Google\\Chrome\\NativeMessagingHost"
                            "s\\com.chatterino.chatterino",
-                           document);
+                           QJsonDocument(obj));
     }
 
     // firefox
     {
-        QJsonDocument document;
-
         auto obj = getBaseDocument();
         QJsonArray allowedExtensions = {"chatterino_native@chatterino.com"};
         obj.insert("allowed_extensions", allowedExtensions);
-        document.setObject(obj);
 
         registerNmManifest(paths, "/native-messaging-manifest-firefox.json",
                            "HKCU\\Software\\Mozilla\\NativeMessagingHosts\\com."
                            "chatterino.chatterino",
-                           document);
+                           QJsonDocument(obj));
     }
 }
 

--- a/src/singletons/NativeMessaging.cpp
+++ b/src/singletons/NativeMessaging.cpp
@@ -20,13 +20,13 @@
 #    include "widgets/AttachedWindow.hpp"
 #endif
 
-#define EXTENSION_ID "glknmaideaikkmemifbfkhnomoknepka"
-#define MESSAGE_SIZE 1024
-
 namespace {
 
 using namespace chatterino;
 using namespace literals;
+
+const QString EXTENSION_ID = u"glknmaideaikkmemifbfkhnomoknepka"_s;
+constexpr const size_t MESSAGE_SIZE = 1024;
 
 void handleSelect(const QJsonObject &root)
 {
@@ -137,7 +137,9 @@ void registerNmManifest(Paths &paths, const QString &manifestFilename,
 void registerNmHost(Paths &paths)
 {
     if (paths.isPortable())
+    {
         return;
+    }
 
     auto getBaseDocument = [&] {
         QJsonObject obj;
@@ -154,9 +156,9 @@ void registerNmHost(Paths &paths)
         QJsonDocument document;
 
         auto obj = getBaseDocument();
-        QJsonArray allowed_origins_arr = {"chrome-extension://" EXTENSION_ID
-                                          "/"};
-        obj.insert("allowed_origins", allowed_origins_arr);
+        QJsonArray allowedOriginsArr = {
+            u"chrome-extension://%1/"_s.arg(EXTENSION_ID)};
+        obj.insert("allowed_origins", allowedOriginsArr);
         document.setObject(obj);
 
         registerNmManifest(paths, "/native-messaging-manifest-chrome.json",
@@ -170,8 +172,8 @@ void registerNmHost(Paths &paths)
         QJsonDocument document;
 
         auto obj = getBaseDocument();
-        QJsonArray allowed_extensions = {"chatterino_native@chatterino.com"};
-        obj.insert("allowed_extensions", allowed_extensions);
+        QJsonArray allowedExtensions = {"chatterino_native@chatterino.com"};
+        obj.insert("allowed_extensions", allowedExtensions);
         document.setObject(obj);
 
         registerNmManifest(paths, "/native-messaging-manifest-firefox.json",

--- a/src/singletons/NativeMessaging.cpp
+++ b/src/singletons/NativeMessaging.cpp
@@ -14,16 +14,11 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonValue>
+#include <QSettings>
 
 #ifdef Q_OS_WIN
-// clang-format off
-#    include <QSettings>
-// clang-format on
-#    include "singletons/WindowManager.hpp"
 #    include "widgets/AttachedWindow.hpp"
 #endif
-
-#include <iostream>
 
 #define EXTENSION_ID "glknmaideaikkmemifbfkhnomoknepka"
 #define MESSAGE_SIZE 1024

--- a/src/singletons/NativeMessaging.cpp
+++ b/src/singletons/NativeMessaging.cpp
@@ -50,45 +50,42 @@ void handleSelect(const QJsonObject &root)
     qCDebug(chatterinoNativeMessage)
         << args.x << args.pixelRatio << args.width << args.height << args.winId;
 
-    if (type.isNull() || args.winId.isNull())
+    if (args.winId.isNull())
     {
-        qCDebug(chatterinoNativeMessage) << "NM type, name or winId missing";
-        attach = false;
-        attachFullscreen = false;
+        qCDebug(chatterinoNativeMessage) << "winId in select is missing";
         return;
     }
 #endif
 
-    if (type == "twitch")
-    {
-        postToThread([=] {
-            auto *app = getApp();
-
-            if (!name.isEmpty())
-            {
-                auto channel = app->twitch->getOrAddChannel(name);
-                if (app->twitch->watchingChannel.get() != channel)
-                {
-                    app->twitch->watchingChannel.reset(channel);
-                }
-            }
-
-            if (attach || attachFullscreen)
-            {
-#ifdef USEWINSDK
-                auto *window = AttachedWindow::getForeground(args);
-                if (!name.isEmpty())
-                {
-                    window->setChannel(app->twitch->getOrAddChannel(name));
-                }
-#endif
-            }
-        });
-    }
-    else
+    if (type != u"twtich"_s)
     {
         qCDebug(chatterinoNativeMessage) << "NM unknown channel type";
+        return;
     }
+
+    postToThread([=] {
+        auto *app = getApp();
+
+        if (!name.isEmpty())
+        {
+            auto channel = app->twitch->getOrAddChannel(name);
+            if (app->twitch->watchingChannel.get() != channel)
+            {
+                app->twitch->watchingChannel.reset(channel);
+            }
+        }
+
+        if (attach || attachFullscreen)
+        {
+#ifdef USEWINSDK
+            auto *window = AttachedWindow::getForeground(args);
+            if (!name.isEmpty())
+            {
+                window->setChannel(app->twitch->getOrAddChannel(name));
+            }
+#endif
+        }
+    });
 }
 
 void handleDetach(const QJsonObject &root)

--- a/src/singletons/NativeMessaging.cpp
+++ b/src/singletons/NativeMessaging.cpp
@@ -1,13 +1,13 @@
 #include "singletons/NativeMessaging.hpp"
 
 #include "Application.hpp"
+#include "common/Literals.hpp"
 #include "common/QLogging.hpp"
 #include "providers/twitch/TwitchIrcServer.hpp"
 #include "singletons/Paths.hpp"
 #include "util/IpcQueue.hpp"
 #include "util/PostToThread.hpp"
 
-#include <boost/date_time/posix_time/posix_time.hpp>
 #include <QCoreApplication>
 #include <QFile>
 #include <QJsonArray>
@@ -29,6 +29,8 @@
 #define MESSAGE_SIZE 1024
 
 namespace chatterino {
+
+using namespace literals;
 
 void registerNmManifest(Paths &paths, const QString &manifestFilename,
                         const QString &registryKeyName,
@@ -167,7 +169,7 @@ void NativeMessagingServer::ReceiverThread::run()
 void NativeMessagingServer::ReceiverThread::handleMessage(
     const QJsonObject &root)
 {
-    QString action = root.value("action").toString();
+    QString action = root["action"_L1].toString();
 
     if (action.isNull())
     {
@@ -177,22 +179,22 @@ void NativeMessagingServer::ReceiverThread::handleMessage(
 
     if (action == "select")
     {
-        QString _type = root.value("type").toString();
-        bool attach = root.value("attach").toBool();
-        bool attachFullscreen = root.value("attach_fullscreen").toBool();
-        QString name = root.value("name").toString();
+        QString type = root["type"_L1].toString();
+        bool attach = root["attach"_L1].toBool();
+        bool attachFullscreen = root["attach_fullscreen"_L1].toBool();
+        QString name = root["name"_L1].toString();
 
 #ifdef USEWINSDK
         AttachedWindow::GetArgs args;
-        args.winId = root.value("winId").toString();
-        args.yOffset = root.value("yOffset").toInt(-1);
+        args.winId = root["winId"_L1].toString();
+        args.yOffset = root["yOffset"_L1].toInt(-1);
 
         {
-            const auto sizeObject = root.value("size").toObject();
-            args.x = sizeObject.value("x").toDouble(-1.0);
-            args.pixelRatio = sizeObject.value("pixelRatio").toDouble(-1.0);
-            args.width = sizeObject.value("width").toInt(-1);
-            args.height = sizeObject.value("height").toInt(-1);
+            const auto sizeObject = root["size"_L1].toObject();
+            args.x = sizeObject["x"_L1].toDouble(-1.0);
+            args.pixelRatio = sizeObject["pixelRatio"_L1].toDouble(-1.0);
+            args.width = sizeObject["width"_L1].toInt(-1);
+            args.height = sizeObject["height"_L1].toInt(-1);
         }
 
         args.fullscreen = attachFullscreen;
@@ -201,7 +203,7 @@ void NativeMessagingServer::ReceiverThread::handleMessage(
             << args.x << args.pixelRatio << args.width << args.height
             << args.winId;
 
-        if (_type.isNull() || args.winId.isNull())
+        if (type.isNull() || args.winId.isNull())
         {
             qCDebug(chatterinoNativeMessage)
                 << "NM type, name or winId missing";
@@ -211,7 +213,7 @@ void NativeMessagingServer::ReceiverThread::handleMessage(
         }
 #endif
 
-        if (_type == "twitch")
+        if (type == "twitch")
         {
             postToThread([=] {
                 auto *app = getApp();
@@ -244,7 +246,7 @@ void NativeMessagingServer::ReceiverThread::handleMessage(
     }
     else if (action == "detach")
     {
-        QString winId = root.value("winId").toString();
+        QString winId = root["winId"_L1].toString();
 
         if (winId.isNull())
         {

--- a/src/singletons/NativeMessaging.cpp
+++ b/src/singletons/NativeMessaging.cpp
@@ -107,7 +107,7 @@ std::string &getNmQueueName(Paths &paths)
 
 // CLIENT
 
-namespace nm_client {
+namespace nm::client {
 
     void sendMessage(const QByteArray &array)
     {
@@ -126,7 +126,7 @@ namespace nm_client {
         std::cout.flush();
     }
 
-}  // namespace nm_client
+}  // namespace nm::client
 
 // SERVER
 

--- a/src/singletons/NativeMessaging.cpp
+++ b/src/singletons/NativeMessaging.cpp
@@ -185,19 +185,16 @@ void NativeMessagingServer::ReceiverThread::handleMessage(
         QString name = root["name"_L1].toString();
 
 #ifdef USEWINSDK
-        AttachedWindow::GetArgs args;
-        args.winId = root["winId"_L1].toString();
-        args.yOffset = root["yOffset"_L1].toInt(-1);
-
-        {
-            const auto sizeObject = root["size"_L1].toObject();
-            args.x = sizeObject["x"_L1].toDouble(-1.0);
-            args.pixelRatio = sizeObject["pixelRatio"_L1].toDouble(-1.0);
-            args.width = sizeObject["width"_L1].toInt(-1);
-            args.height = sizeObject["height"_L1].toInt(-1);
-        }
-
-        args.fullscreen = attachFullscreen;
+        const auto sizeObject = root["size"_L1].toObject();
+        AttachedWindow::GetArgs args = {
+            .winId = root["winId"_L1].toString(),
+            .yOffset = root["yOffset"_L1].toInt(-1),
+            .x = sizeObject["x"_L1].toDouble(-1.0),
+            .pixelRatio = sizeObject["pixelRatio"_L1].toDouble(-1.0),
+            .width = sizeObject["width"_L1].toInt(-1),
+            .height = sizeObject["height"_L1].toInt(-1),
+            .fullscreen = attachFullscreen,
+        };
 
         qCDebug(chatterinoNativeMessage)
             << args.x << args.pixelRatio << args.width << args.height

--- a/src/singletons/NativeMessaging.cpp
+++ b/src/singletons/NativeMessaging.cpp
@@ -137,12 +137,11 @@ void NativeMessagingServer::start()
 
 void NativeMessagingServer::ReceiverThread::run()
 {
-    auto result =
+    auto [messageQueue, error] =
         ipc::IpcQueue::tryReplaceOrCreate("chatterino_gui", 100, MESSAGE_SIZE);
 
-    if (std::holds_alternative<QString>(result))
+    if (!error.isEmpty())
     {
-        auto error = std::get<QString>(result);
         qCDebug(chatterinoNativeMessage)
             << "Failed to create message queue:" << error;
 
@@ -150,10 +149,9 @@ void NativeMessagingServer::ReceiverThread::run()
         return;
     }
 
-    auto &messageQueue = std::get<ipc::IpcQueue>(result);
     while (true)
     {
-        auto buf = messageQueue.receive();
+        auto buf = messageQueue->receive();
         if (buf.isEmpty())
         {
             continue;

--- a/src/singletons/NativeMessaging.cpp
+++ b/src/singletons/NativeMessaging.cpp
@@ -212,7 +212,7 @@ void NativeMessagingServer::ReceiverThread::handleSelect(
     }
 #endif
 
-    if (type != u"twtich"_s)
+    if (type != u"twitch"_s)
     {
         qCDebug(chatterinoNativeMessage) << "NM unknown channel type";
         return;

--- a/src/singletons/NativeMessaging.cpp
+++ b/src/singletons/NativeMessaging.cpp
@@ -28,101 +28,103 @@ namespace {
 using namespace chatterino;
 using namespace literals;
 
+void handleSelect(const QJsonObject &root)
+{
+    QString type = root["type"_L1].toString();
+    bool attach = root["attach"_L1].toBool();
+    bool attachFullscreen = root["attach_fullscreen"_L1].toBool();
+    QString name = root["name"_L1].toString();
+
+#ifdef USEWINSDK
+    const auto sizeObject = root["size"_L1].toObject();
+    AttachedWindow::GetArgs args = {
+        .winId = root["winId"_L1].toString(),
+        .yOffset = root["yOffset"_L1].toInt(-1),
+        .x = sizeObject["x"_L1].toDouble(-1.0),
+        .pixelRatio = sizeObject["pixelRatio"_L1].toDouble(-1.0),
+        .width = sizeObject["width"_L1].toInt(-1),
+        .height = sizeObject["height"_L1].toInt(-1),
+        .fullscreen = attachFullscreen,
+    };
+
+    qCDebug(chatterinoNativeMessage)
+        << args.x << args.pixelRatio << args.width << args.height << args.winId;
+
+    if (type.isNull() || args.winId.isNull())
+    {
+        qCDebug(chatterinoNativeMessage) << "NM type, name or winId missing";
+        attach = false;
+        attachFullscreen = false;
+        return;
+    }
+#endif
+
+    if (type == "twitch")
+    {
+        postToThread([=] {
+            auto *app = getApp();
+
+            if (!name.isEmpty())
+            {
+                auto channel = app->twitch->getOrAddChannel(name);
+                if (app->twitch->watchingChannel.get() != channel)
+                {
+                    app->twitch->watchingChannel.reset(channel);
+                }
+            }
+
+            if (attach || attachFullscreen)
+            {
+#ifdef USEWINSDK
+                auto *window = AttachedWindow::getForeground(args);
+                if (!name.isEmpty())
+                {
+                    window->setChannel(app->twitch->getOrAddChannel(name));
+                }
+#endif
+            }
+        });
+    }
+    else
+    {
+        qCDebug(chatterinoNativeMessage) << "NM unknown channel type";
+    }
+}
+
+void handleDetach(const QJsonObject &root)
+{
+    QString winId = root["winId"_L1].toString();
+
+    if (winId.isNull())
+    {
+        qCDebug(chatterinoNativeMessage) << "NM winId missing";
+        return;
+    }
+
+#ifdef USEWINSDK
+    postToThread([winId] {
+        qCDebug(chatterinoNativeMessage) << "NW detach";
+        AttachedWindow::detach(winId);
+    });
+#endif
+}
+
 void handleMessage(const QJsonObject &root)
 {
     QString action = root["action"_L1].toString();
 
-    if (action.isNull())
+    if (action == "select")
     {
-        qCDebug(chatterinoNativeMessage) << "NM action was null";
+        handleSelect(root);
+        return;
+    }
+    if (action == "detach")
+    {
+        handleDetach(root);
         return;
     }
 
-    if (action == "select")
-    {
-        QString type = root["type"_L1].toString();
-        bool attach = root["attach"_L1].toBool();
-        bool attachFullscreen = root["attach_fullscreen"_L1].toBool();
-        QString name = root["name"_L1].toString();
-
-#ifdef USEWINSDK
-        const auto sizeObject = root["size"_L1].toObject();
-        AttachedWindow::GetArgs args = {
-            .winId = root["winId"_L1].toString(),
-            .yOffset = root["yOffset"_L1].toInt(-1),
-            .x = sizeObject["x"_L1].toDouble(-1.0),
-            .pixelRatio = sizeObject["pixelRatio"_L1].toDouble(-1.0),
-            .width = sizeObject["width"_L1].toInt(-1),
-            .height = sizeObject["height"_L1].toInt(-1),
-            .fullscreen = attachFullscreen,
-        };
-
-        qCDebug(chatterinoNativeMessage)
-            << args.x << args.pixelRatio << args.width << args.height
-            << args.winId;
-
-        if (type.isNull() || args.winId.isNull())
-        {
-            qCDebug(chatterinoNativeMessage)
-                << "NM type, name or winId missing";
-            attach = false;
-            attachFullscreen = false;
-            return;
-        }
-#endif
-
-        if (type == "twitch")
-        {
-            postToThread([=] {
-                auto *app = getApp();
-
-                if (!name.isEmpty())
-                {
-                    auto channel = app->twitch->getOrAddChannel(name);
-                    if (app->twitch->watchingChannel.get() != channel)
-                    {
-                        app->twitch->watchingChannel.reset(channel);
-                    }
-                }
-
-                if (attach || attachFullscreen)
-                {
-#ifdef USEWINSDK
-                    auto *window = AttachedWindow::getForeground(args);
-                    if (!name.isEmpty())
-                    {
-                        window->setChannel(app->twitch->getOrAddChannel(name));
-                    }
-#endif
-                }
-            });
-        }
-        else
-        {
-            qCDebug(chatterinoNativeMessage) << "NM unknown channel type";
-        }
-    }
-    else if (action == "detach")
-    {
-        QString winId = root["winId"_L1].toString();
-
-        if (winId.isNull())
-        {
-            qCDebug(chatterinoNativeMessage) << "NM winId missing";
-            return;
-        }
-
-#ifdef USEWINSDK
-        postToThread([winId] {
-            qCDebug(chatterinoNativeMessage) << "NW detach";
-            AttachedWindow::detach(winId);
-        });
-#endif
-    }
-    else
-    {
-        qCDebug(chatterinoNativeMessage) << "NM unknown action " + action;
-    }
+    qCDebug(chatterinoNativeMessage) << "NM unknown action" << action;
 }
 
 }  // namespace

--- a/src/singletons/NativeMessaging.hpp
+++ b/src/singletons/NativeMessaging.hpp
@@ -33,9 +33,6 @@ private:
     {
     public:
         void run() override;
-
-    private:
-        void handleMessage(const QJsonObject &root);
     };
 
     ReceiverThread thread;

--- a/src/singletons/NativeMessaging.hpp
+++ b/src/singletons/NativeMessaging.hpp
@@ -16,12 +16,12 @@ std::string &getNmQueueName(Paths &paths);
 
 Atomic<boost::optional<QString>> &nmIpcError();
 
-namespace nm_client {
+namespace nm::client {
 
     void sendMessage(const QByteArray &array);
     void writeToCout(const QByteArray &array);
 
-}  // namespace nm_client
+}  // namespace nm::client
 
 class NativeMessagingServer final
 {

--- a/src/singletons/NativeMessaging.hpp
+++ b/src/singletons/NativeMessaging.hpp
@@ -33,6 +33,11 @@ private:
     {
     public:
         void run() override;
+
+    private:
+        void handleMessage(const QJsonObject &root);
+        void handleSelect(const QJsonObject &root);
+        void handleDetach(const QJsonObject &root);
     };
 
     ReceiverThread thread;

--- a/src/singletons/NativeMessaging.hpp
+++ b/src/singletons/NativeMessaging.hpp
@@ -16,12 +16,12 @@ std::string &getNmQueueName(Paths &paths);
 
 Atomic<boost::optional<QString>> &nmIpcError();
 
-class NativeMessagingClient final
-{
-public:
+namespace nm_client {
+
     void sendMessage(const QByteArray &array);
     void writeToCout(const QByteArray &array);
-};
+
+}  // namespace nm_client
 
 class NativeMessagingServer final
 {

--- a/src/util/IpcQueue.cpp
+++ b/src/util/IpcQueue.cpp
@@ -39,7 +39,6 @@ public:
 
 IpcQueue::IpcQueue(IpcQueuePrivate *priv)
     : private_(priv){};
-IpcQueue::IpcQueue(IpcQueue &&) = default;
 IpcQueue::~IpcQueue() = default;
 
 std::variant<IpcQueue, QString> IpcQueue::tryReplaceOrCreate(

--- a/src/util/IpcQueue.cpp
+++ b/src/util/IpcQueue.cpp
@@ -37,22 +37,18 @@ public:
     boost_ipc::message_queue queue;
 };
 
-IpcQueue::IpcQueue() = default;
+IpcQueue::IpcQueue(IpcQueuePrivate *priv)
+    : private_(priv){};
+IpcQueue::IpcQueue(IpcQueue &&) = default;
 IpcQueue::~IpcQueue() = default;
 
-std::optional<QString> IpcQueue::tryReplaceOrCreate(const char *name,
-                                                    size_t maxMessages,
-                                                    size_t maxMessageSize)
+std::variant<IpcQueue, QString> IpcQueue::tryReplaceOrCreate(
+    const char *name, size_t maxMessages, size_t maxMessageSize)
 {
     try
     {
-        Q_ASSERT_X(this->private_ == nullptr, "IpcQueue::tryReplaceOrCreate",
-                   "The function can be called at most once.");
-
         boost_ipc::message_queue::remove(name);
-        this->private_ = std::make_unique<IpcQueuePrivate>(name, maxMessages,
-                                                           maxMessageSize);
-        return std::nullopt;
+        return IpcQueue(new IpcQueuePrivate(name, maxMessages, maxMessageSize));
     }
     catch (boost_ipc::interprocess_exception &ex)
     {

--- a/src/util/IpcQueue.cpp
+++ b/src/util/IpcQueue.cpp
@@ -1,0 +1,95 @@
+#include "util/IpcQueue.hpp"
+
+#include "common/QLogging.hpp"
+
+#include <boost/interprocess/ipc/message_queue.hpp>
+#include <QByteArray>
+#include <QString>
+#include <QtGlobal>
+
+namespace boost_ipc = boost::interprocess;
+
+namespace chatterino::ipc {
+
+void sendMessage(const char *name, const QByteArray &data)
+{
+    try
+    {
+        boost_ipc::message_queue messageQueue(boost_ipc::open_only, name);
+
+        messageQueue.try_send(data.data(), size_t(data.size()), 1);
+    }
+    catch (boost_ipc::interprocess_exception &ex)
+    {
+        qCDebug(chatterinoNativeMessage)
+            << "Failed to send message:" << ex.what();
+    }
+}
+
+class IpcQueuePrivate
+{
+    IpcQueuePrivate(IpcQueue *q_ptr, const char *name, size_t maxMessages,
+                    size_t maxMessageSize)
+        : q_ptr(q_ptr)
+        , queue_(boost_ipc::open_or_create, name, maxMessages, maxMessageSize)
+    {
+    }
+
+    Q_DECLARE_PUBLIC(IpcQueue)
+    IpcQueue *q_ptr;
+
+    boost_ipc::message_queue queue_;
+};
+
+IpcQueue::IpcQueue() = default;
+IpcQueue::~IpcQueue() = default;
+
+std::optional<QString> IpcQueue::tryReplaceOrCreate(const char *name,
+                                                    size_t maxMessages,
+                                                    size_t maxMessageSize)
+{
+    try
+    {
+        Q_ASSERT_X(this->d_ptr.isNull(), "IpcQueue::tryReplaceOrCreate",
+                   "The function can be called at most once.");
+
+        boost_ipc::message_queue::remove(name);
+        this->d_ptr.reset(
+            new IpcQueuePrivate(this, name, maxMessages, maxMessageSize));
+        return std::nullopt;
+    }
+    catch (boost_ipc::interprocess_exception &ex)
+    {
+        return QString::fromLatin1(ex.what());
+    }
+}
+
+QByteArray IpcQueue::receive()
+{
+    try
+    {
+        Q_D(IpcQueue);
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+        QByteArray buf(static_cast<qsizetype>(d->queue_.get_max_msg_size()),
+                       Qt::Uninitialized);
+#else
+        QByteArray buf;
+        buf.resize(static_cast<qsizetype>(d->queue_.get_max_msg_size()));
+#endif
+        size_t messageSize = 0;
+        unsigned int priority = 0;
+        d->queue_.receive(buf.data(), buf.size(), messageSize, priority);
+
+        buf.truncate(static_cast<qsizetype>(messageSize));
+        return buf;
+    }
+    catch (boost_ipc::interprocess_exception &ex)
+    {
+        qCDebug(chatterinoNativeMessage)
+            << "Failed to receive message:" << ex.what();
+    }
+    return {};
+}
+
+}  // namespace chatterino::ipc

--- a/src/util/IpcQueue.cpp
+++ b/src/util/IpcQueue.cpp
@@ -41,17 +41,20 @@ IpcQueue::IpcQueue(IpcQueuePrivate *priv)
     : private_(priv){};
 IpcQueue::~IpcQueue() = default;
 
-std::variant<IpcQueue, QString> IpcQueue::tryReplaceOrCreate(
+std::pair<std::unique_ptr<IpcQueue>, QString> IpcQueue::tryReplaceOrCreate(
     const char *name, size_t maxMessages, size_t maxMessageSize)
 {
     try
     {
         boost_ipc::message_queue::remove(name);
-        return IpcQueue(new IpcQueuePrivate(name, maxMessages, maxMessageSize));
+        return std::make_pair(
+            std::unique_ptr<IpcQueue>(new IpcQueue(
+                new IpcQueuePrivate(name, maxMessages, maxMessageSize))),
+            QString());
     }
     catch (boost_ipc::interprocess_exception &ex)
     {
-        return QString::fromLatin1(ex.what());
+        return {nullptr, QString::fromLatin1(ex.what())};
     }
 }
 

--- a/src/util/IpcQueue.hpp
+++ b/src/util/IpcQueue.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
-#include <QScopedPointer>
-#include <QtGlobal>
-
+#include <memory>
 #include <optional>
+
+class QByteArray;
+class QString;
 
 namespace chatterino::ipc {
 
@@ -28,8 +29,9 @@ public:
     QByteArray receive();
 
 private:
-    QScopedPointer<IpcQueuePrivate> d_ptr;
-    Q_DECLARE_PRIVATE(IpcQueue)
+    std::unique_ptr<IpcQueuePrivate> private_;
+
+    friend class IpcQueuePrivate;
 };
 
 }  // namespace chatterino::ipc

--- a/src/util/IpcQueue.hpp
+++ b/src/util/IpcQueue.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <memory>
-#include <optional>
+#include <variant>
 
 class QByteArray;
 class QString;
@@ -14,21 +14,20 @@ class IpcQueuePrivate;
 class IpcQueue
 {
 public:
-    IpcQueue();
+    IpcQueue(IpcQueue &&other);
     ~IpcQueue();
 
-    /// This must only be called at most once and before any call to `receive`.
-    std::optional<QString> tryReplaceOrCreate(const char *name,
-                                              size_t maxMessages,
-                                              size_t maxMessageSize);
+    static std::variant<IpcQueue, QString> tryReplaceOrCreate(
+        const char *name, size_t maxMessages, size_t maxMessageSize);
 
     // TODO: use std::expected
     /// Try to receive a message.
-    /// `tryReplaceOrCreate` must have been called before.
     /// In the case of an error, the buffer is empty.
     QByteArray receive();
 
 private:
+    IpcQueue(IpcQueuePrivate *priv);
+
     std::unique_ptr<IpcQueuePrivate> private_;
 
     friend class IpcQueuePrivate;

--- a/src/util/IpcQueue.hpp
+++ b/src/util/IpcQueue.hpp
@@ -14,7 +14,6 @@ class IpcQueuePrivate;
 class IpcQueue
 {
 public:
-    IpcQueue(IpcQueue &&other);
     ~IpcQueue();
 
     static std::variant<IpcQueue, QString> tryReplaceOrCreate(

--- a/src/util/IpcQueue.hpp
+++ b/src/util/IpcQueue.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <memory>
-#include <variant>
+#include <utility>
 
 class QByteArray;
 class QString;
@@ -16,7 +16,7 @@ class IpcQueue
 public:
     ~IpcQueue();
 
-    static std::variant<IpcQueue, QString> tryReplaceOrCreate(
+    static std::pair<std::unique_ptr<IpcQueue>, QString> tryReplaceOrCreate(
         const char *name, size_t maxMessages, size_t maxMessageSize);
 
     // TODO: use std::expected

--- a/src/util/IpcQueue.hpp
+++ b/src/util/IpcQueue.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <QScopedPointer>
+#include <QtGlobal>
+
+#include <optional>
+
+namespace chatterino::ipc {
+
+void sendMessage(const char *name, const QByteArray &data);
+
+class IpcQueuePrivate;
+class IpcQueue
+{
+public:
+    IpcQueue();
+    ~IpcQueue();
+
+    /// This must only be called at most once and before any call to `receive`.
+    std::optional<QString> tryReplaceOrCreate(const char *name,
+                                              size_t maxMessages,
+                                              size_t maxMessageSize);
+
+    // TODO: use std::expected
+    /// Try to receive a message.
+    /// `tryReplaceOrCreate` must have been called before.
+    /// In the case of an error, the buffer is empty.
+    QByteArray receive();
+
+private:
+    QScopedPointer<IpcQueuePrivate> d_ptr;
+    Q_DECLARE_PRIVATE(IpcQueue)
+};
+
+}  // namespace chatterino::ipc

--- a/src/widgets/AttachedWindow.cpp
+++ b/src/widgets/AttachedWindow.cpp
@@ -136,6 +136,13 @@ AttachedWindow *AttachedWindow::get(void *target, const GetArgs &args)
     return window;
 }
 
+#ifdef USEWINSDK
+AttachedWindow *AttachedWindow::getForeground(const GetArgs &args)
+{
+    return AttachedWindow::get(::GetForegroundWindow(), args);
+}
+#endif
+
 void AttachedWindow::detach(const QString &winId)
 {
     for (Item &item : items)

--- a/src/widgets/AttachedWindow.hpp
+++ b/src/widgets/AttachedWindow.hpp
@@ -31,6 +31,9 @@ public:
     virtual ~AttachedWindow() override;
 
     static AttachedWindow *get(void *target_, const GetArgs &args);
+#ifdef USEWINSDK
+    static AttachedWindow *getForeground(const GetArgs &args);
+#endif
     static void detach(const QString &winId);
 
     void setChannel(ChannelPtr channel);


### PR DESCRIPTION
# Description

In order to implement https://github.com/Chatterino/chatterino2/issues/4146, I wanted to first refactor the native-message-handler. The commits can be reviewed on their own. Some high level changes:

* Moved `boost::interprocess` interactions to new class.
* Created dedicated handlers for message types.
* Resolved clang-tidy warnings.
* Added CMake option to debug native messages.
