### PR TITLE
Split log line generation from message search text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Minor: Message input is now focused when clicking on emotes. (#4719)
 - Minor: Changed viewer list to chatter list to more match Twitch's terminology. (#4732)
-- Minor: Nicknames are now taken into consideration when searching for messages. (#4663)
+- Minor: Nicknames are now taken into consideration when searching for messages. (#4663, #4742)
 - Minor: Add an icon showing when streamer mode is enabled (#4410, #4690)
 - Minor: Added `/shoutout <username>` commands to shoutout specified user. (#4638)
 - Minor: Improved editing hotkeys. (#4628)
@@ -31,7 +31,6 @@
 - Bugfix: Fixed highlights sometimes not working after changing sound device, or switching users in your operating system. (#4729)
 - Bugfix: Fixed key bindings not showing in context menus on Mac. (#4722)
 - Bugfix: Fixed tab completion rarely completing the wrong word. (#4735)
-- Bugfix: Fixed duplicate username in logs (#4742)
 - Dev: Added command to set Qt's logging filter/rules at runtime (`/c2-set-logging-rules`). (#4637)
 - Dev: Added the ability to see & load custom themes from the Themes directory. No stable promises are made of this feature, changes might be made that breaks custom themes without notice. (#4570)
 - Dev: Added test cases for emote and tab completion. (#4644)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Bugfix: Fixed highlights sometimes not working after changing sound device, or switching users in your operating system. (#4729)
 - Bugfix: Fixed key bindings not showing in context menus on Mac. (#4722)
 - Bugfix: Fixed tab completion rarely completing the wrong word. (#4735)
+- Bugfix: Fixed duplicate username in logs (#4742)
 - Dev: Added command to set Qt's logging filter/rules at runtime (`/c2-set-logging-rules`). (#4637)
 - Dev: Added the ability to see & load custom themes from the Themes directory. No stable promises are made of this feature, changes might be made that breaks custom themes without notice. (#4570)
 - Dev: Added test cases for emote and tab completion. (#4644)

--- a/src/singletons/helper/LoggingChannel.cpp
+++ b/src/singletons/helper/LoggingChannel.cpp
@@ -114,8 +114,15 @@ void LoggingChannel::addMessage(MessagePtr message)
     }
     else
     {
-        messageText = message->localizedName + " " + message->loginName + ": " +
-                      message->messageText;
+        if (message->localizedName.isEmpty())
+        {
+            messageText = message->loginName + ": " + message->messageText;
+        }
+        else
+        {
+            messageText = message->localizedName + " " + message->loginName +
+                          ": " + message->messageText;
+        }
     }
 
     if ((message->flags.has(MessageFlag::ReplyMessage) &&

--- a/src/singletons/helper/LoggingChannel.cpp
+++ b/src/singletons/helper/LoggingChannel.cpp
@@ -105,20 +105,32 @@ void LoggingChannel::addMessage(MessagePtr message)
     str.append(now.toString("HH:mm:ss"));
     str.append("] ");
 
-    QString messageSearchText = message->searchText;
+    QString messageText;
+    if (message->loginName.isEmpty())
+    {
+        // This accounts for any messages not explicitly sent by a user, like
+        // system messages, parts of announcements, subs etc.
+        messageText = message->messageText;
+    }
+    else
+    {
+        messageText = message->localizedName + " " + message->loginName + ": " +
+                      message->messageText;
+    }
+
     if ((message->flags.has(MessageFlag::ReplyMessage) &&
          getSettings()->stripReplyMention) &&
         !getSettings()->hideReplyContext)
     {
-        qsizetype colonIndex = messageSearchText.indexOf(':');
+        qsizetype colonIndex = messageText.indexOf(':');
         if (colonIndex != -1)
         {
             QString rootMessageChatter =
                 message->replyThread->root()->loginName;
-            messageSearchText.insert(colonIndex + 1, " @" + rootMessageChatter);
+            messageText.insert(colonIndex + 1, " @" + rootMessageChatter);
         }
     }
-    str.append(messageSearchText);
+    str.append(messageText);
     str.append(endline);
 
     this->appendLine(str);


### PR DESCRIPTION
# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
Closes #4697

The line string is now generated in logging code and search text isn't used.