### PR TITLE
Fixed subscriptions and announcements not being blockable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Bugfix: Fixed highlights sometimes not working after changing sound device, or switching users in your operating system. (#4729)
 - Bugfix: Fixed key bindings not showing in context menus on Mac. (#4722)
 - Bugfix: Fixed tab completion rarely completing the wrong word. (#4735)
+- Bugfix: Fixed subscriptions and announcements not being blockable (#4748)
 - Dev: Added command to set Qt's logging filter/rules at runtime (`/c2-set-logging-rules`). (#4637)
 - Dev: Added the ability to see & load custom themes from the Themes directory. No stable promises are made of this feature, changes might be made that breaks custom themes without notice. (#4570)
 - Dev: Added test cases for emote and tab completion. (#4644)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 - Bugfix: Fixed highlights sometimes not working after changing sound device, or switching users in your operating system. (#4729)
 - Bugfix: Fixed key bindings not showing in context menus on Mac. (#4722)
 - Bugfix: Fixed tab completion rarely completing the wrong word. (#4735)
-- Bugfix: Fixed subscriptions and announcements not being blockable (#4748)
+- Bugfix: Fixed an issue where Subscriptions & Announcements that contained ignored phrases would still appear if the Block option was enabled. (#4748)
 - Dev: Added command to set Qt's logging filter/rules at runtime (`/c2-set-logging-rules`). (#4637)
 - Dev: Added the ability to see & load custom themes from the Themes directory. No stable promises are made of this feature, changes might be made that breaks custom themes without notice. (#4570)
 - Dev: Added test cases for emote and tab completion. (#4644)

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -894,10 +894,10 @@ std::vector<MessagePtr> IrcMessageHandler::parseUserNoticeMessage(
     }
 
     if (isIgnoredMessage({
-            /*.message = */ content,
-            /*.twitchUserID = */ tags.value("user-id").toString(),
-            /*.isMod = */ channel->isMod(),
-            /*.isBroadcaster = */ channel->isBroadcaster(),
+            .message = content,
+            .twitchUserID = tags.value("user-id").toString(),
+            .isMod = channel->isMod(),
+            .isBroadcaster = channel->isBroadcaster(),
         }))
     {
         return {};
@@ -966,10 +966,10 @@ void IrcMessageHandler::handleUserNoticeMessage(Communi::IrcMessage *message,
 
     auto chn = server.getChannelOrEmpty(target);
     if (isIgnoredMessage({
-            /*.message = */ content,
-            /*.twitchUserID = */ tags.value("user-id").toString(),
-            /*.isMod = */ chn->isMod(),
-            /*.isBroadcaster = */ chn->isBroadcaster(),
+            .message = content,
+            .twitchUserID = tags.value("user-id").toString(),
+            .isMod = chn->isMod(),
+            .isBroadcaster = chn->isBroadcaster(),
         }))
     {
         return;


### PR DESCRIPTION
# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
This adds a previously missing check for blocked users and blocked phrases in USERNOTICEs, both in the recent messages copy (`parseUserNoticeMessage`) and the normal one (`handleUserNoticeMessage`). Deduplicating the code was out of scope for this PR.

Closes #3412