### PR TITLE
Show historic timeouts and bans in usercard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Bugfix: Fixed crash that could occurr when closing the usercard too quickly after blocking or unblocking a user. (#4711)
 - Bugfix: Fixed highlights sometimes not working after changing sound device, or switching users in your operating system. (#4729)
 - Bugfix: Fixed key bindings not showing in context menus on Mac. (#4722)
+- Bugfix: Fixed timeouts from history messages not behaving consistently. (#4760)
 - Bugfix: Fixed tab completion rarely completing the wrong word. (#4735)
 - Bugfix: Fixed an issue where Subscriptions & Announcements that contained ignored phrases would still appear if the Block option was enabled. (#4748)
 - Dev: Added command to set Qt's logging filter/rules at runtime (`/c2-set-logging-rules`). (#4637)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -397,6 +397,7 @@ set(SOURCE_FILES
         util/AttachToConsole.cpp
         util/AttachToConsole.hpp
         util/CancellationToken.hpp
+        util/ChannelHelpers.hpp
         util/Clipboard.cpp
         util/Clipboard.hpp
         util/ConcurrentMap.hpp

--- a/src/common/Channel.cpp
+++ b/src/common/Channel.cpp
@@ -10,6 +10,7 @@
 #include "singletons/Logging.hpp"
 #include "singletons/Settings.hpp"
 #include "singletons/WindowManager.hpp"
+#include "util/ChannelHelpers.hpp"
 
 #include <QJsonArray>
 #include <QJsonDocument>
@@ -113,95 +114,15 @@ void Channel::addMessage(MessagePtr message,
 
 void Channel::addOrReplaceTimeout(MessagePtr message)
 {
-    LimitedQueueSnapshot<MessagePtr> snapshot = this->getMessageSnapshot();
-    int snapshotLength = snapshot.size();
-
-    int end = std::max(0, snapshotLength - 20);
-
-    bool addMessage = true;
-
-    QTime minimumTime = QTime::currentTime().addSecs(-5);
-
-    auto timeoutStackStyle = static_cast<TimeoutStackStyle>(
-        getSettings()->timeoutStackStyle.getValue());
-
-    for (int i = snapshotLength - 1; i >= end; --i)
-    {
-        auto &s = snapshot[i];
-
-        if (s->parseTime < minimumTime)
-        {
-            break;
-        }
-
-        if (s->flags.has(MessageFlag::Untimeout) &&
-            s->timeoutUser == message->timeoutUser)
-        {
-            break;
-        }
-
-        if (timeoutStackStyle == TimeoutStackStyle::DontStackBeyondUserMessage)
-        {
-            if (s->loginName == message->timeoutUser &&
-                s->flags.hasNone({MessageFlag::Disabled, MessageFlag::Timeout,
-                                  MessageFlag::Untimeout}))
-            {
-                break;
-            }
-        }
-
-        if (s->flags.has(MessageFlag::Timeout) &&
-            s->timeoutUser == message->timeoutUser)
-        {
-            if (message->flags.has(MessageFlag::PubSub) &&
-                !s->flags.has(MessageFlag::PubSub))
-            {
-                this->replaceMessage(s, message);
-                addMessage = false;
-                break;
-            }
-            if (!message->flags.has(MessageFlag::PubSub) &&
-                s->flags.has(MessageFlag::PubSub))
-            {
-                addMessage = timeoutStackStyle == TimeoutStackStyle::DontStack;
-                break;
-            }
-
-            int count = s->count + 1;
-
-            MessageBuilder replacement(timeoutMessage, message->timeoutUser,
-                                       message->loginName, message->searchText,
-                                       count);
-
-            replacement->timeoutUser = message->timeoutUser;
-            replacement->count = count;
-            replacement->flags = message->flags;
-
-            this->replaceMessage(s, replacement.release());
-
-            addMessage = false;
-            break;
-        }
-    }
-
-    // disable the messages from the user
-    for (int i = 0; i < snapshotLength; i++)
-    {
-        auto &s = snapshot[i];
-        if (s->loginName == message->timeoutUser &&
-            s->flags.hasNone({MessageFlag::Timeout, MessageFlag::Untimeout,
-                              MessageFlag::Whisper}))
-        {
-            // FOURTF: disabled for now
-            // PAJLADA: Shitty solution described in Message.hpp
-            s->flags.set(MessageFlag::Disabled);
-        }
-    }
-
-    if (addMessage)
-    {
-        this->addMessage(message);
-    }
+    addOrReplaceChannelTimeout(
+        this->getMessageSnapshot(), std::move(message),
+        [this](auto /*idx*/, auto msg, auto replacement) {
+            this->replaceMessage(msg, replacement);
+        },
+        [this](auto msg) {
+            this->addMessage(msg);
+        },
+        true);
 
     // XXX: Might need the following line
     // WindowManager::instance().repaintVisibleChatWidgets(this);

--- a/src/common/Channel.cpp
+++ b/src/common/Channel.cpp
@@ -115,7 +115,7 @@ void Channel::addMessage(MessagePtr message,
 void Channel::addOrReplaceTimeout(MessagePtr message)
 {
     addOrReplaceChannelTimeout(
-        this->getMessageSnapshot(), std::move(message),
+        this->getMessageSnapshot(), std::move(message), QTime::currentTime(),
         [this](auto /*idx*/, auto msg, auto replacement) {
             this->replaceMessage(msg, replacement);
         },

--- a/src/providers/recentmessages/Impl.hpp
+++ b/src/providers/recentmessages/Impl.hpp
@@ -13,12 +13,6 @@
 
 namespace chatterino::recentmessages::detail {
 
-// convertClearchatToNotice takes a Communi::IrcMessage that is a CLEARCHAT
-// command and converts it to a readable NOTICE message. This has
-// historically been done in the Recent Messages API, but this functionality
-// has been moved to Chatterino instead.
-Communi::IrcMessage *convertClearchatToNotice(Communi::IrcMessage *message);
-
 // Parse the IRC messages returned in JSON form into Communi messages
 std::vector<Communi::IrcMessage *> parseRecentMessages(
     const QJsonObject &jsonRoot);

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -433,6 +433,7 @@ std::vector<MessagePtr> IrcMessageHandler::parseMessageWithReply(
         {
             addOrReplaceChannelTimeout(
                 otherLoaded, std::move(clearChat.message),
+                calculateMessageTime(message).time(),
                 [&](auto idx, auto /*msg*/, auto &&replacement) {
                     replacement->flags.set(MessageFlag::RecentMessage);
                     otherLoaded[idx] = replacement;

--- a/src/providers/twitch/IrcMessageHandler.hpp
+++ b/src/providers/twitch/IrcMessageHandler.hpp
@@ -16,6 +16,11 @@ using MessagePtr = std::shared_ptr<const Message>;
 class TwitchChannel;
 class TwitchMessageBuilder;
 
+struct ClearChatMessage {
+    MessagePtr message;
+    bool disableAllMessages;
+};
+
 class IrcMessageHandler
 {
     IrcMessageHandler() = default;
@@ -29,7 +34,7 @@ public:
 
     std::vector<MessagePtr> parseMessageWithReply(
         Channel *channel, Communi::IrcMessage *message,
-        const std::vector<MessagePtr> &otherLoaded);
+        std::vector<MessagePtr> &otherLoaded);
 
     // parsePrivMessage arses a single IRC PRIVMSG into 0-1 Chatterino messages
     std::vector<MessagePtr> parsePrivMessage(
@@ -38,6 +43,8 @@ public:
                            TwitchIrcServer &server);
 
     void handleRoomStateMessage(Communi::IrcMessage *message);
+    std::optional<ClearChatMessage> parseClearChatMessage(
+        Communi::IrcMessage *message);
     void handleClearChatMessage(Communi::IrcMessage *message);
     void handleClearMessageMessage(Communi::IrcMessage *message);
     void handleUserStateMessage(Communi::IrcMessage *message);

--- a/src/providers/twitch/IrcMessageHandler.hpp
+++ b/src/providers/twitch/IrcMessageHandler.hpp
@@ -4,6 +4,7 @@
 
 #include <IrcMessage>
 
+#include <optional>
 #include <vector>
 
 namespace chatterino {

--- a/src/util/ChannelHelpers.hpp
+++ b/src/util/ChannelHelpers.hpp
@@ -3,6 +3,7 @@
 #include "common/Channel.hpp"
 #include "messages/Message.hpp"
 #include "messages/MessageBuilder.hpp"
+#include "singletons/Settings.hpp"
 
 namespace chatterino {
 

--- a/src/util/ChannelHelpers.hpp
+++ b/src/util/ChannelHelpers.hpp
@@ -19,6 +19,12 @@ void addOrReplaceChannelTimeout(const Buf &buffer, MessagePtr message,
                                 Replace replaceMessage, Add addMessage,
                                 bool disableUserMessages)
 {
+    // NOTE: This function uses the CURRENT time & the messages PARSE time to figure out whether they should be replaced
+    // This works as expected for incoming messages, but not for historic messages.
+    // This has never worked before, but would be nice in the future.
+    // For this to work, we need to make sure *all* messages have a "server received time".
+    // The currently do not.
+
     size_t snapshotLength = buffer.size();
 
     size_t end = std::max<size_t>(0, snapshotLength - 20);

--- a/src/util/ChannelHelpers.hpp
+++ b/src/util/ChannelHelpers.hpp
@@ -97,16 +97,19 @@ void addOrReplaceChannelTimeout(const Buf &buffer, MessagePtr message,
     }
 
     // disable the messages from the user
-    for (size_t i = 0; i < snapshotLength && disableUserMessages; i++)
+    if (disableUserMessages)
     {
-        auto &s = buffer[i];
-        if (s->loginName == message->timeoutUser &&
-            s->flags.hasNone({MessageFlag::Timeout, MessageFlag::Untimeout,
-                              MessageFlag::Whisper}))
+        for (size_t i = 0; i < snapshotLength; i++)
         {
-            // FOURTF: disabled for now
-            // PAJLADA: Shitty solution described in Message.hpp
-            s->flags.set(MessageFlag::Disabled);
+            auto &s = buffer[i];
+            if (s->loginName == message->timeoutUser &&
+                s->flags.hasNone({MessageFlag::Timeout, MessageFlag::Untimeout,
+                                  MessageFlag::Whisper}))
+            {
+                // FOURTF: disabled for now
+                // PAJLADA: Shitty solution described in Message.hpp
+                s->flags.set(MessageFlag::Disabled);
+            }
         }
     }
 

--- a/src/util/ChannelHelpers.hpp
+++ b/src/util/ChannelHelpers.hpp
@@ -1,0 +1,112 @@
+#pragma once
+
+#include "common/Channel.hpp"
+#include "messages/Message.hpp"
+#include "messages/MessageBuilder.hpp"
+
+namespace chatterino {
+
+/// Adds a timeout or replaces a previous one sent in the last 20 messages and in the last 5s.
+/// This function accepts any buffer to store the messsages in.
+/// @param replaceMessage A function of type `void (int index, MessagePtr toReplace, MessagePtr replacement)`
+///                       - replace `buffer[i]` (=toReplace) with `replacement`
+/// @param addMessage A function of type `void (MessagePtr message)`
+///                   - adds the `message`.
+/// @param disableUserMessages If set, disables all message by the timed out user.
+template <typename Buf, typename Replace, typename Add>
+void addOrReplaceChannelTimeout(const Buf &buffer, MessagePtr message,
+                                Replace replaceMessage, Add addMessage,
+                                bool disableUserMessages)
+{
+    size_t snapshotLength = buffer.size();
+
+    size_t end = std::max<size_t>(0, snapshotLength - 20);
+
+    bool shouldAddMessage = true;
+
+    QTime minimumTime = QTime::currentTime().addSecs(-5);
+
+    auto timeoutStackStyle = static_cast<TimeoutStackStyle>(
+        getSettings()->timeoutStackStyle.getValue());
+
+    for (size_t i = snapshotLength - 1; i >= end; --i)
+    {
+        const MessagePtr &s = buffer[i];
+
+        if (s->parseTime < minimumTime)
+        {
+            break;
+        }
+
+        if (s->flags.has(MessageFlag::Untimeout) &&
+            s->timeoutUser == message->timeoutUser)
+        {
+            break;
+        }
+
+        if (timeoutStackStyle == TimeoutStackStyle::DontStackBeyondUserMessage)
+        {
+            if (s->loginName == message->timeoutUser &&
+                s->flags.hasNone({MessageFlag::Disabled, MessageFlag::Timeout,
+                                  MessageFlag::Untimeout}))
+            {
+                break;
+            }
+        }
+
+        if (s->flags.has(MessageFlag::Timeout) &&
+            s->timeoutUser == message->timeoutUser)
+        {
+            if (message->flags.has(MessageFlag::PubSub) &&
+                !s->flags.has(MessageFlag::PubSub))
+            {
+                replaceMessage(i, s, message);
+                shouldAddMessage = false;
+                break;
+            }
+            if (!message->flags.has(MessageFlag::PubSub) &&
+                s->flags.has(MessageFlag::PubSub))
+            {
+                shouldAddMessage =
+                    timeoutStackStyle == TimeoutStackStyle::DontStack;
+                break;
+            }
+
+            uint32_t count = s->count + 1;
+
+            MessageBuilder replacement(timeoutMessage, message->timeoutUser,
+                                       message->loginName, message->searchText,
+                                       count);
+
+            replacement->timeoutUser = message->timeoutUser;
+            replacement->count = count;
+            replacement->flags = message->flags;
+
+            replaceMessage(i, s, replacement.release());
+
+            shouldAddMessage = false;
+            break;
+        }
+    }
+
+    // disable the messages from the user
+    for (size_t i = 0; i < snapshotLength && disableUserMessages; i++)
+    {
+        auto &s = buffer[i];
+        if (s->loginName == message->timeoutUser &&
+            s->flags.hasNone({MessageFlag::Timeout, MessageFlag::Untimeout,
+                              MessageFlag::Whisper}))
+        {
+            // FOURTF: disabled for now
+            // PAJLADA: Shitty solution described in Message.hpp
+            s->flags.set(MessageFlag::Disabled);
+        }
+    }
+
+    if (shouldAddMessage)
+    {
+        addMessage(message);
+    }
+}
+
+}  // namespace chatterino

--- a/src/util/ChannelHelpers.hpp
+++ b/src/util/ChannelHelpers.hpp
@@ -16,8 +16,8 @@ namespace chatterino {
 /// @param disableUserMessages If set, disables all message by the timed out user.
 template <typename Buf, typename Replace, typename Add>
 void addOrReplaceChannelTimeout(const Buf &buffer, MessagePtr message,
-                                Replace replaceMessage, Add addMessage,
-                                bool disableUserMessages)
+                                QTime now, Replace replaceMessage,
+                                Add addMessage, bool disableUserMessages)
 {
     // NOTE: This function uses the CURRENT time & the messages PARSE time to figure out whether they should be replaced
     // This works as expected for incoming messages, but not for historic messages.
@@ -31,7 +31,7 @@ void addOrReplaceChannelTimeout(const Buf &buffer, MessagePtr message,
 
     bool shouldAddMessage = true;
 
-    QTime minimumTime = QTime::currentTime().addSecs(-5);
+    QTime minimumTime = now.addSecs(-5);
 
     auto timeoutStackStyle = static_cast<TimeoutStackStyle>(
         getSettings()->timeoutStackStyle.getValue());

--- a/src/util/ChannelHelpers.hpp
+++ b/src/util/ChannelHelpers.hpp
@@ -19,15 +19,14 @@ void addOrReplaceChannelTimeout(const Buf &buffer, MessagePtr message,
                                 QTime now, Replace replaceMessage,
                                 Add addMessage, bool disableUserMessages)
 {
-    // NOTE: This function uses the CURRENT time & the messages PARSE time to figure out whether they should be replaced
+    // NOTE: This function uses the messages PARSE time to figure out whether they should be replaced
     // This works as expected for incoming messages, but not for historic messages.
     // This has never worked before, but would be nice in the future.
     // For this to work, we need to make sure *all* messages have a "server received time".
-    // The currently do not.
 
-    size_t snapshotLength = buffer.size();
+    auto snapshotLength = static_cast<qsizetype>(buffer.size());
 
-    size_t end = std::max<size_t>(0, snapshotLength - 20);
+    auto end = std::max<qsizetype>(0, snapshotLength - 20);
 
     bool shouldAddMessage = true;
 
@@ -36,7 +35,7 @@ void addOrReplaceChannelTimeout(const Buf &buffer, MessagePtr message,
     auto timeoutStackStyle = static_cast<TimeoutStackStyle>(
         getSettings()->timeoutStackStyle.getValue());
 
-    for (size_t i = snapshotLength - 1; i >= end; --i)
+    for (auto i = snapshotLength - 1; i >= end; --i)
     {
         const MessagePtr &s = buffer[i];
 
@@ -99,7 +98,7 @@ void addOrReplaceChannelTimeout(const Buf &buffer, MessagePtr message,
     // disable the messages from the user
     if (disableUserMessages)
     {
-        for (size_t i = 0; i < snapshotLength; i++)
+        for (qsizetype i = 0; i < snapshotLength; i++)
         {
             auto &s = buffer[i];
             if (s->loginName == message->timeoutUser &&


### PR DESCRIPTION
# Description

This PR fixes timeouts and bans of users not being shown in their usercard and timeouts not stacking. Previously, `CLEARCHAT`s were converted to `NOTICE`s. This was removed and `CLEARCHAT`s are handled.

The fix is a bit more involved, as the `addOrReplaceMessage` logic now adapts to any buffer. I wasn't very sure where to put the shared logic, so I chose `ChannelHelpers` (analogous to `IrcHelpers`).

Fixes #3030.
