### PR TITLE
Set `QT_ENABLE_HIGHDPI_SCALING` to `0` on Qt 6 on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unversioned
 
 - Dev: Fixed UTF16 encoding of `modes` file for the installer. (#4791)
+- Dev: Temporarily disable High DPI scaling on Qt6 builds on Windows. (#4767)
 
 ## 2.4.5
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,6 +24,11 @@ using namespace chatterino;
 
 int main(int argc, char **argv)
 {
+    // TODO: This is a temporary fix (see #4552).
+#if defined(Q_OS_WINDOWS) && QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    qputenv("QT_ENABLE_HIGHDPI_SCALING", "0");
+#endif
+
     QApplication a(argc, argv);
 
     QCoreApplication::setApplicationName("chatterino");


### PR DESCRIPTION
# Description

See #4552. This is a temporary fix, as [`QT_ENABLE_HIGHDPI_SCALING`](https://doc.qt.io/qt-6/highdpi.html#environment-variable-reference) is described as "This variable is intended for testing purposes only, and we do not recommend setting it on a permanent basis.".
