### PR TITLE
Fix input completion tests on Qt6 & run tests on 22.04

### DIFF
--- a/.docker/Dockerfile-ubuntu-20.04-base
+++ b/.docker/Dockerfile-ubuntu-20.04-base
@@ -1,0 +1,38 @@
+FROM ubuntu:20.04
+
+ENV TZ=UTC
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN apt-get update && apt-get -y install --no-install-recommends \
+        cmake \
+        virtualenv \
+        rapidjson-dev \
+        libfuse2 \
+        libssl-dev \
+        libboost-dev \
+        libxcb-randr0-dev \
+        libboost-system-dev \
+        libboost-filesystem-dev \
+        libpulse-dev \
+        libxkbcommon-x11-0 \
+        build-essential \
+        libgl1-mesa-dev \
+        libxcb-icccm4 \
+        libxcb-image0 \
+        libxcb-keysyms1 \
+        libxcb-render-util0 \
+        libxcb-xinerama0
+
+RUN apt-get -y install \
+        git \
+        lsb-release \
+        python3-pip && \
+        apt-get clean all
+
+# Install Qt as we do in CI
+
+RUN pip3 install -U pip && \
+        pip3 install aqtinstall && \
+        aqt install-qt linux desktop 5.12.12 && \
+        mkdir -p /opt/qt512 && \
+        mv /5.12.12/gcc_64/* /opt/qt512

--- a/.docker/Dockerfile-ubuntu-20.04-build
+++ b/.docker/Dockerfile-ubuntu-20.04-build
@@ -1,41 +1,4 @@
-FROM ubuntu:20.04
-
-ENV TZ=UTC
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-
-RUN apt-get update && apt-get -y install --no-install-recommends \
-        cmake \
-        virtualenv \
-        rapidjson-dev \
-        libfuse2 \
-        libssl-dev \
-        libboost-dev \
-        libxcb-randr0-dev \
-        libboost-system-dev \
-        libboost-filesystem-dev \
-        libpulse-dev \
-        libxkbcommon-x11-0 \
-        build-essential \
-        libgl1-mesa-dev \
-        libxcb-icccm4 \
-        libxcb-image0 \
-        libxcb-keysyms1 \
-        libxcb-render-util0 \
-        libxcb-xinerama0
-
-RUN apt-get -y install \
-        git \
-        lsb-release \
-        python3-pip && \
-        apt-get clean all
-
-# Install Qt as we do in CI
-
-RUN pip3 install -U pip && \
-        pip3 install aqtinstall && \
-        aqt install-qt linux desktop 5.12.12 && \
-        mkdir -p /opt/qt512 && \
-        mv /5.12.12/gcc_64/* /opt/qt512
+FROM chatterino-ubuntu-20.04-base
 
 ADD . /src
 

--- a/.docker/Dockerfile-ubuntu-22.04-base
+++ b/.docker/Dockerfile-ubuntu-22.04-base
@@ -1,0 +1,44 @@
+FROM ubuntu:22.04
+
+ENV TZ=UTC
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN apt-get update && apt-get -y install --no-install-recommends \
+        cmake \
+        virtualenv \
+        rapidjson-dev \
+        libfuse2 \
+        libssl-dev \
+        libboost-dev \
+        libxcb-randr0-dev \
+        libboost-system-dev \
+        libboost-filesystem-dev \
+        libpulse-dev \
+        libxkbcommon-x11-0 \
+        build-essential \
+        libgl1-mesa-dev \
+        libxcb-icccm4 \
+        libxcb-image0 \
+        libxcb-keysyms1 \
+        libxcb-render-util0 \
+        libxcb-xinerama0 \
+        libfontconfig
+
+RUN apt-get -y install \
+        git \
+        lsb-release \
+        python3-pip && \
+        apt-get clean all
+
+# Install Qt as we do in CI
+
+RUN pip3 install -U pip && \
+        pip3 install aqtinstall && \
+        aqt install-qt linux desktop 5.15.2 && \
+        mkdir -p /opt/qt515 && \
+        mv /5.15.2/gcc_64/* /opt/qt515
+
+ADD ./.patches /tmp/.patches
+
+# Apply Qt patches
+RUN patch "/opt/qt515/include/QtConcurrent/qtconcurrentthreadengine.h" /tmp/.patches/qt5-on-newer-gcc.patch

--- a/.docker/Dockerfile-ubuntu-22.04-test
+++ b/.docker/Dockerfile-ubuntu-22.04-test
@@ -7,11 +7,18 @@ RUN mkdir /src/build
 # cmake
 RUN cd /src/build && \
         CXXFLAGS=-fno-sized-deallocation cmake \
-        -DCMAKE_INSTALL_PREFIX=appdir/usr/ \
         -DCMAKE_PREFIX_PATH=/opt/qt515/lib/cmake \
+        -DUSE_PRECOMPILED_HEADERS=OFF \
         -DBUILD_WITH_QTKEYCHAIN=OFF \
+        -DBUILD_TESTS=ON \
         ..
 
 # build
 RUN cd /src/build && \
         make -j8
+
+ENV QT_QPA_PLATFORM=minimal
+ENV QT_PLUGIN_PATH=/opt/qt515/plugins
+
+# test
+CMD /src/build/bin/chatterino-test

--- a/.docker/README.md
+++ b/.docker/README.md
@@ -6,6 +6,8 @@
 
 To build, from the repo root
 
+1. Build a docker image that contains all the dependencies necessary to build Chatterino on Ubuntu 20.04  
+   `docker buildx build -t chatterino-ubuntu-20.04-base -f .docker/Dockerfile-ubuntu-20.04-base .`
 1. Build a docker image that contains all the build artifacts and source from building Chatterino on Ubuntu 20.04  
    `docker buildx build -t chatterino-ubuntu-20.04-build -f .docker/Dockerfile-ubuntu-20.04-build .`
 1. Build a docker image that uses the above-built image & packages it into a .deb file  
@@ -20,6 +22,8 @@ To extract the final package, you can run the following command:
 
 To build, from the repo root
 
+1. Build a docker image that contains all the dependencies necessary to build Chatterino on Ubuntu 22.04  
+   `docker buildx build -t chatterino-ubuntu-22.04-base -f .docker/Dockerfile-ubuntu-22.04-base .`
 1. Build a docker image that contains all the build artifacts and source from building Chatterino on Ubuntu 22.04  
    `docker buildx build -t chatterino-ubuntu-22.04-build -f .docker/Dockerfile-ubuntu-22.04-build .`
 1. Build a docker image that uses the above-built image & packages it into a .deb file  
@@ -29,3 +33,10 @@ To extract the final package, you can run the following command:
 `docker run -v $PWD:/opt/mount --rm -it chatterino-ubuntu-22.04-package bash -c "cp /src/build/Chatterino-x86_64.deb /opt/mount/"`
 
 NOTE: The AppImage from Ubuntu 22.04 is broken. Approach with caution
+
+#### Testing
+
+1. Build a docker image builds the chatterino tests  
+   `docker buildx build -t chatterino-ubuntu-22.04-test -f .docker/Dockerfile-ubuntu-22.04-test .`
+1. Run the tests  
+   `docker run --rm --network=host chatterino-ubuntu-22.04-test`

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,9 +20,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: "ubuntu-20.04"
+          - os: "ubuntu-22.04"
             qt-version: "5.15.2"
-          - os: "ubuntu-20.04"
+          - os: "ubuntu-22.04"
             qt-version: "5.12.12"
           - os: "ubuntu-22.04"
             qt-version: "6.2.4"
@@ -43,6 +43,12 @@ jobs:
           cache-key-prefix: ${{ runner.os }}-QtCache-${{ matrix.qt-version }}-v2
           modules: ${{ env.QT_MODULES }}
           version: ${{ matrix.qt-version }}
+
+      - name: Apply Qt patches (Ubuntu)
+        if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.qt-version, '5.')
+        run: |
+          patch "$Qt5_DIR/include/QtConcurrent/qtconcurrentthreadengine.h" .patches/qt5-on-newer-gcc.patch
+        shell: bash
 
       # LINUX
       - name: Install dependencies (Ubuntu)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Dev: Fixed UTF16 encoding of `modes` file for the installer. (#4791)
 - Dev: Temporarily disable High DPI scaling on Qt6 builds on Windows. (#4767)
+- Dev: Tests now run on Ubuntu 22.04 instead of 20.04 to loosen C++ restrictions in tests. (#4774)
 
 ## 2.4.5
 

--- a/tests/src/InputCompletion.cpp
+++ b/tests/src/InputCompletion.cpp
@@ -20,6 +20,8 @@
 #include <QString>
 #include <QTemporaryDir>
 
+#include <span>
+
 namespace {
 
 using namespace chatterino;
@@ -224,6 +226,25 @@ protected:
     }
 };
 
+void containsRoughly(std::span<detail::CompletionEmote> span,
+                     std::set<QString> values)
+{
+    for (const auto &v : values)
+    {
+        bool found = false;
+        for (const auto &actualValue : span)
+        {
+            if (actualValue.displayName == v)
+            {
+                found = true;
+                break;
+            }
+        }
+
+        ASSERT_TRUE(found) << qPrintable(v) << " was not found in the span";
+    }
+}
+
 TEST_F(InputCompletionTest, EmoteNameFiltering)
 {
     // The completion doesn't guarantee an ordering for a specific category of emotes.
@@ -238,12 +259,11 @@ TEST_F(InputCompletionTest, EmoteNameFiltering)
     ASSERT_EQ(completion[1].displayName, "FeelsBadMan");
     ASSERT_EQ(completion[2].displayName, "FeelsGoodMan");
 
+    // all these matches are Twitch global emotes
     completion = queryEmoteCompletion(":)");
     ASSERT_EQ(completion.size(), 3);
     ASSERT_EQ(completion[0].displayName, ":)");  // Exact match with : prefix
-    // all these matches are Twitch global emotes
-    ASSERT_EQ(completion[1].displayName, ":-)");
-    ASSERT_EQ(completion[2].displayName, "B-)");
+    containsRoughly({completion.begin() + 1, 2}, {":-)", "B-)"});
 
     completion = queryEmoteCompletion(":cat");
     ASSERT_TRUE(completion.size() >= 2);


### PR DESCRIPTION
# Description

- Tests: Fix InputCompletion tests in Qt6

This is achieved by not checking exact order for certain completion tests

- GitHub actions now run all tests in Ubuntu 22.04 - this is done to be able to use more modern features in tests
  We will still support Ubuntu 20.04 in the actual main project

- Update dockerfiles to match this new reality

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
