### PR TITLE
Sanitize Links before parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Minor: Added support for opening incognito links under Linux/BSD using XDG. (#4745)
 - Minor: Added accelerators to the right click menu for messages (#4705)
 - Minor: Improved editing hotkeys. (#4628)
+- Minor: Sanitize URLs to not include not recoginized characters (#4778)
 - Minor: Added `/c2-theme-autoreload` command to automatically reload a custom theme. This is useful for when you're developing your own theme. (#4718)
 - Bugfix: Fixed an issue where Subscriptions & Announcements that contained ignored phrases would still appear if the Block option was enabled. (#4748)
 - Bugfix: Increased amount of blocked users loaded from 100 to 1,000. (#4721)

--- a/src/common/LinkParser.cpp
+++ b/src/common/LinkParser.cpp
@@ -9,6 +9,8 @@
 
 namespace {
 
+const QString urlAllowedSpecialCharacters = QStringLiteral("!#&+/:=?@-_.");
+
 QSet<QString> &tlds()
 {
     static QSet<QString> tlds = [] {
@@ -116,8 +118,6 @@ bool startsWithPort(QStringView string)
 // Simple sanitization method to strip characters that are not recognized by RFC 3986
 QString sanitizeUrl(const QString &unparsedString)
 {
-    const QString allowedSpecialCharacters = QString("!#&+/:=?@-_.");
-
     QString sanitizedUrl;
     for (const QChar &c : unparsedString)
     {
@@ -126,7 +126,7 @@ QString sanitizeUrl(const QString &unparsedString)
             sanitizedUrl.append(c);
             continue;
         }
-        for (const QChar sc : allowedSpecialCharacters)
+        for (const QChar sc : urlAllowedSpecialCharacters)
         {
             if (sc == c)
             {

--- a/src/common/LinkParser.cpp
+++ b/src/common/LinkParser.cpp
@@ -116,23 +116,26 @@ bool startsWithPort(QStringView string)
 // For unicode ranges see: https://unicode.org/charts/
 using UnicodeRange = std::pair<ushort, ushort>;
 std::vector<UnicodeRange> emojiRanges = {
-    {U'\U00002700', U'\U000027BF' }, // Dingbats
-    {U'\U00001F60', U'\U0001F64F' }, // Emoticons
-    {U'\U00002600', U'\U000026FF' }, // Miscellaneous Symbols
-    {U'\U00001F30', U'\U0001F5FF' }, // Miscellaneous Symbols and Pictographs
-    {U'\U00001F90', U'\U0001F9FF' }, // Supplemental Symbols and Pictographs
+    {U'\U00002700', U'\U000027BF'},  // Dingbats
+    {U'\U00001F60', U'\U0001F64F'},  // Emoticons
+    {U'\U00002600', U'\U000026FF'},  // Miscellaneous Symbols
+    {U'\U00001F30', U'\U0001F5FF'},  // Miscellaneous Symbols and Pictographs
+    {U'\U00001F90', U'\U0001F9FF'},  // Supplemental Symbols and Pictographs
 };
 
 std::vector<UnicodeRange> alphaNumeric = {
-    { U'\u0041', U'\u005A' }, // Upper alphabet
-    { U'\u0061', U'\u007A' }, //Lower alphabet
-    { U'\u0030', U'\u0039' }, // Numbers
+    {U'\u0041', U'\u005A'},  // Upper alphabet
+    {U'\u0061', U'\u007A'},  //Lower alphabet
+    {U'\u0030', U'\u0039'},  // Numbers
 };
 
-bool isInUnicodeRange(const QChar& ch, std::vector<UnicodeRange> ranges) {
+bool isInUnicodeRange(const QChar &ch, std::vector<UnicodeRange> ranges)
+{
     ushort unicodeValue = ch.unicode();
-    for (const auto& range : ranges) {
-        if (unicodeValue >= range.first && unicodeValue <= range.second) {
+    for (const auto &range : ranges)
+    {
+        if (unicodeValue >= range.first && unicodeValue <= range.second)
+        {
             return true;
         }
     }
@@ -147,7 +150,8 @@ QString sanitizeUrl(const QString &unparsedString)
     QString sanitizedUrl;
     for (const QChar &c : unparsedString)
     {
-        if (isInUnicodeRange(c, alphaNumeric) || isInUnicodeRange(c, emojiRanges))
+        if (isInUnicodeRange(c, alphaNumeric) ||
+            isInUnicodeRange(c, emojiRanges))
         {
             sanitizedUrl.append(c);
             continue;

--- a/src/common/LinkParser.cpp
+++ b/src/common/LinkParser.cpp
@@ -115,13 +115,34 @@ bool startsWithPort(QStringView string)
     return true;
 }
 
+// For emoji ranges see: https://unicode.org/charts/
+using UnicodeRange = std::pair<ushort, ushort>;
+std::vector<UnicodeRange> emojiRanges = {
+    {U'\U00002700', U'\U000027BF' }, // Dingbats
+    {U'\U00001F60', U'\U0001F64F' }, // Emoticons
+    {U'\U00002600', U'\U000026FF' }, // Miscellaneous Symbols
+    {U'\U00001F30', U'\U0001F5FF' }, // Miscellaneous Symbols and Pictographs
+    {U'\U00001F90', U'\U0001F9FF' }, // Supplemental Symbols and Pictographs
+};
+
+bool isEmoji(const QChar& ch) {
+    ushort unicodeValue = ch.unicode();
+    for (const auto& range : emojiRanges) {
+        if (unicodeValue >= range.first && unicodeValue <= range.second) {
+            return true;
+        }
+    }
+    return false;
+}
+
+
 // Simple sanitization method to strip characters that are not recognized by RFC 3986
 QString sanitizeUrl(const QString &unparsedString)
 {
     QString sanitizedUrl;
     for (const QChar &c : unparsedString)
     {
-        if (c.isLetterOrNumber())
+        if (c.isLetterOrNumber() || isEmoji(c))
         {
             sanitizedUrl.append(c);
             continue;

--- a/src/common/LinkParser.cpp
+++ b/src/common/LinkParser.cpp
@@ -116,7 +116,7 @@ bool startsWithPort(QStringView string)
 // Simple sanitization method to strip characters that are not recognized by RFC 3986
 QString sanitizeUrl(const QString &unparsedString)
 {
-    const QString allowedSpecialCharacters = "!#&+/:=?@-_.";
+    const QString allowedSpecialCharacters = QString("!#&+/:=?@-_.");
 
     QString sanitizedUrl;
     for (const QChar &c : unparsedString)

--- a/src/common/LinkParser.cpp
+++ b/src/common/LinkParser.cpp
@@ -119,7 +119,8 @@ QString sanitizeUrl(const QString &unparsedString)
     const QString allowedSpecialCharacters = "!#&+/:=?@-_.";
 
     QString sanitizedUrl;
-    for (const QChar& c : unparsedString) {
+    for (const QChar &c : unparsedString)
+    {
         if (c.isLetterOrNumber())
         {
             sanitizedUrl.append(c);

--- a/tests/src/LinkParser.cpp
+++ b/tests/src/LinkParser.cpp
@@ -25,23 +25,19 @@ struct Case {
     }
 };
 
-
-struct SanitizeCheck
-{
+struct SanitizeCheck {
     QString testValue{};
     QString expectedValue{};
 };
 
 TEST(LinkParser, parseDomainLinks)
 {
-    const QList<SanitizeCheck> sanitizeCases = {
-        { "(twitch.tv)", "twitch.tv"}
-    };
+    const QList<SanitizeCheck> sanitizeCases = {{"(twitch.tv)", "twitch.tv"}};
 
     for (auto &c : sanitizeCases)
     {
         LinkParser p(c.testValue);
-         ASSERT_TRUE(p.result().has_value()) << c.testValue.toStdString();
+        ASSERT_TRUE(p.result().has_value()) << c.testValue.toStdString();
         const auto &r = *p.result();
         ASSERT_EQ(c.expectedValue, r.host);
     }
@@ -151,42 +147,40 @@ TEST(LinkParser, doesntParseInvalidIpv4Links)
 
 TEST(LinkParser, doesntParseInvalidLinks)
 {
-    const QStringList inputs = {
-        "h://foo.com",
-        "spotify:1234",
-        "ftp://chatterino.com",
-        "ftps://chatterino.com",
-        "spotify://chatterino.com",
-        "httpsx://chatterino.com",
-        "https:chatterino.com",
-        "https:/chatterino.com",
-        "http:/chatterino.com",
-        "htp://chatterino.com",
-        "/chatterino.com",
-        "word",
-        ".",
-        "/",
-        "#",
-        ":",
-        "?",
-        "a",
-        "://chatterino.com",
-        "//chatterino.com",
-        "http://pn.",
-        "http://pn./",
-        "https://pn./",
-        "pn./",
-        "pn.",
-        "http/chatterino.com",
-        "http/wiki.chatterino.com",
-        "http:cat.com",
-        "https:cat.com",
-        "http:/cat.com",
-        "http:/cat.com",
-        "https:/cat.com",
-        "%%%%.com",
-        "*.com"
-    };
+    const QStringList inputs = {"h://foo.com",
+                                "spotify:1234",
+                                "ftp://chatterino.com",
+                                "ftps://chatterino.com",
+                                "spotify://chatterino.com",
+                                "httpsx://chatterino.com",
+                                "https:chatterino.com",
+                                "https:/chatterino.com",
+                                "http:/chatterino.com",
+                                "htp://chatterino.com",
+                                "/chatterino.com",
+                                "word",
+                                ".",
+                                "/",
+                                "#",
+                                ":",
+                                "?",
+                                "a",
+                                "://chatterino.com",
+                                "//chatterino.com",
+                                "http://pn.",
+                                "http://pn./",
+                                "https://pn./",
+                                "pn./",
+                                "pn.",
+                                "http/chatterino.com",
+                                "http/wiki.chatterino.com",
+                                "http:cat.com",
+                                "https:cat.com",
+                                "http:/cat.com",
+                                "http:/cat.com",
+                                "https:/cat.com",
+                                "%%%%.com",
+                                "*.com"};
 
     for (const auto &input : inputs)
     {

--- a/tests/src/LinkParser.cpp
+++ b/tests/src/LinkParser.cpp
@@ -34,14 +34,16 @@ struct SanitizeCheck {
 TEST(LinkParser, parseDomainLinks)
 {
     const QList<SanitizeCheck> sanitizeCases = {
-        { "TW❘TCH.tv", "TW❘TCH.tv" "" }, // contains dingbat
-        {"(twitch.tv/foo)", "twitch.tv", "/foo" },
-        {"t🤪w🤪i🤪t🤪c🤪h🤪.tv/foo", "t🤪w🤪i🤪t🤪c🤪h🤪.tv", "/foo" },
-        { "https://🏹.to/bar", "🏹.to", "/bar" },
-        { "😀.com/baz", "😀.com", "/baz" }, // Emoticon
-        { "❀.com/baz", "❀.com", "/baz" }, // Dingbat
-        { "⛑.com/baz", "⛑.com", "/baz" }, // Misc Symbol
-        { "🍀.com/baz", "🍀.com", "/baz" }, // Pictograph
+        {"TW❘TCH.tv", "TW❘TCH.tv"
+                      ""},  // contains dingbat
+        {"(twitch.tv/foo)", "twitch.tv", "/foo"},
+        {"t🤪w🤪i🤪t🤪c🤪h🤪.tv/foo",
+         "t🤪w🤪i🤪t🤪c🤪h🤪.tv", "/foo"},
+        {"https://🏹.to/bar", "🏹.to", "/bar"},
+        {"😀.com/baz", "😀.com", "/baz"},  // Emoticon
+        {"❀.com/baz", "❀.com", "/baz"},  // Dingbat
+        {"⛑.com/baz", "⛑.com", "/baz"},  // Misc Symbol
+        {"🍀.com/baz", "🍀.com", "/baz"},  // Pictograph
     };
 
     for (auto &c : sanitizeCases)
@@ -50,7 +52,8 @@ TEST(LinkParser, parseDomainLinks)
         ASSERT_TRUE(p.result().has_value()) << c.testValue.toStdString();
         const auto &r = *p.result();
         std::ostringstream ss;
-        ss << "Expected: " << c.expectedHost.toStdString() << "\nResult: " << r.host.toString().toStdString();
+        ss << "Expected: " << c.expectedHost.toStdString()
+           << "\nResult: " << r.host.toString().toStdString();
         ASSERT_EQ(c.expectedHost, r.host) << ss.str();
         ASSERT_EQ(c.expectedRest, r.rest) << c.expectedRest.toStdString();
     }
@@ -160,43 +163,44 @@ TEST(LinkParser, doesntParseInvalidIpv4Links)
 
 TEST(LinkParser, doesntParseInvalidLinks)
 {
-    const QStringList inputs = {"h://foo.com",
-                                "spotify:1234",
-                                "ftp://chatterino.com",
-                                "ftps://chatterino.com",
-                                "spotify://chatterino.com",
-                                "httpsx://chatterino.com",
-                                "https:chatterino.com",
-                                "https:/chatterino.com",
-                                "http:/chatterino.com",
-                                "htp://chatterino.com",
-                                "/chatterino.com",
-                                "word",
-                                ".",
-                                "/",
-                                "#",
-                                ":",
-                                "?",
-                                "a",
-                                "://chatterino.com",
-                                "//chatterino.com",
-                                "http://pn.",
-                                "http://pn./",
-                                "https://pn./",
-                                "pn./",
-                                "pn.",
-                                "http/chatterino.com",
-                                "http/wiki.chatterino.com",
-                                "http:cat.com",
-                                "https:cat.com",
-                                "http:/cat.com",
-                                "http:/cat.com",
-                                "https:/cat.com",
-                                "%%%%.com",
-                                "*.com",
-                                "t🤪w🤪i🤪t🤪c🤪h🤪.🤪t🤪v/foo", // Invalid tld
-                                "https։⧸⧸TW❘TCH.tv/a⧸b" // misleading characters: "⧸" and "։"
-                                };
+    const QStringList inputs = {
+        "h://foo.com",
+        "spotify:1234",
+        "ftp://chatterino.com",
+        "ftps://chatterino.com",
+        "spotify://chatterino.com",
+        "httpsx://chatterino.com",
+        "https:chatterino.com",
+        "https:/chatterino.com",
+        "http:/chatterino.com",
+        "htp://chatterino.com",
+        "/chatterino.com",
+        "word",
+        ".",
+        "/",
+        "#",
+        ":",
+        "?",
+        "a",
+        "://chatterino.com",
+        "//chatterino.com",
+        "http://pn.",
+        "http://pn./",
+        "https://pn./",
+        "pn./",
+        "pn.",
+        "http/chatterino.com",
+        "http/wiki.chatterino.com",
+        "http:cat.com",
+        "https:cat.com",
+        "http:/cat.com",
+        "http:/cat.com",
+        "https:/cat.com",
+        "%%%%.com",
+        "*.com",
+        "t🤪w🤪i🤪t🤪c🤪h🤪.🤪t🤪v/foo",  // Invalid tld
+        "https։⧸⧸TW❘TCH.tv/a⧸b"  // misleading characters: "⧸" and "։"
+    };
 
     for (const auto &input : inputs)
     {

--- a/tests/src/LinkParser.cpp
+++ b/tests/src/LinkParser.cpp
@@ -36,7 +36,11 @@ TEST(LinkParser, parseDomainLinks)
     const QList<SanitizeCheck> sanitizeCases = {
         {"(twitch.tv/foo)", "twitch.tv", "/foo" },
         {"t🤪w🤪i🤪t🤪c🤪h🤪.tv/foo", "t🤪w🤪i🤪t🤪c🤪h🤪.tv", "/foo" },
-        { "https://🏹.to/bar", "🏹.to", "/bar" }
+        { "https://🏹.to/bar", "🏹.to", "/bar" },
+        { "😀.com/baz", "😀.com", "/baz" }, // Emoticon
+        { "❀.com/baz", "❀.com", "/baz" }, // Dingbat
+        { "⛑.com/baz", "⛑.com", "/baz" }, // Misc Symbol
+        { "🍀.com/baz", "🍀.com", "/baz" }, // Pictograph
     };
 
     for (auto &c : sanitizeCases)

--- a/tests/src/LinkParser.cpp
+++ b/tests/src/LinkParser.cpp
@@ -27,19 +27,22 @@ struct Case {
 
 struct SanitizeCheck {
     QString testValue{};
-    QString expectedValue{};
+    QString expectedHost{};
+    QString expectedRest{};
 };
 
 TEST(LinkParser, parseDomainLinks)
 {
-    const QList<SanitizeCheck> sanitizeCases = {{"(twitch.tv)", "twitch.tv"}};
+    const QList<SanitizeCheck> sanitizeCases = {
+        {"(twitch.tv/foo)", "twitch.tv", "foo"}};
 
     for (auto &c : sanitizeCases)
     {
         LinkParser p(c.testValue);
         ASSERT_TRUE(p.result().has_value()) << c.testValue.toStdString();
         const auto &r = *p.result();
-        ASSERT_EQ(c.expectedValue, r.host);
+        ASSERT_EQ(c.expectedHost, r.host) << r.host.toStdString();
+        ASSERT_EQ(c.expectedRest, r.rest) << r.rest.toStdString();
     }
 
     const QList<Case> cases = {

--- a/tests/src/LinkParser.cpp
+++ b/tests/src/LinkParser.cpp
@@ -34,6 +34,7 @@ struct SanitizeCheck {
 TEST(LinkParser, parseDomainLinks)
 {
     const QList<SanitizeCheck> sanitizeCases = {
+        { "TW❘TCH.tv", "TW❘TCH.tv" "" }, // contains dingbat
         {"(twitch.tv/foo)", "twitch.tv", "/foo" },
         {"t🤪w🤪i🤪t🤪c🤪h🤪.tv/foo", "t🤪w🤪i🤪t🤪c🤪h🤪.tv", "/foo" },
         { "https://🏹.to/bar", "🏹.to", "/bar" },
@@ -193,7 +194,9 @@ TEST(LinkParser, doesntParseInvalidLinks)
                                 "https:/cat.com",
                                 "%%%%.com",
                                 "*.com",
-                                "t🤪w🤪i🤪t🤪c🤪h🤪.🤪t🤪v/foo"};
+                                "t🤪w🤪i🤪t🤪c🤪h🤪.🤪t🤪v/foo", // Invalid tld
+                                "https։⧸⧸TW❘TCH.tv/a⧸b" // misleading characters: "⧸" and "։"
+                                };
 
     for (const auto &input : inputs)
     {

--- a/tests/src/LinkParser.cpp
+++ b/tests/src/LinkParser.cpp
@@ -34,15 +34,15 @@ struct SanitizeCheck {
 TEST(LinkParser, parseDomainLinks)
 {
     const QList<SanitizeCheck> sanitizeCases = {
-        {"(twitch.tv/foo)", "twitch.tv", "foo"}};
+        {"(twitch.tv/foo)", "twitch.tv", "/foo"}};
 
     for (auto &c : sanitizeCases)
     {
         LinkParser p(c.testValue);
         ASSERT_TRUE(p.result().has_value()) << c.testValue.toStdString();
         const auto &r = *p.result();
-        ASSERT_EQ(c.expectedHost, r.host) << r.host.toStdString();
-        ASSERT_EQ(c.expectedRest, r.rest) << r.rest.toStdString();
+        ASSERT_EQ(c.expectedHost, r.host) << c.expectedHost.toStdString();
+        ASSERT_EQ(c.expectedRest, r.rest) << c.expectedRest.toStdString();
     }
 
     const QList<Case> cases = {

--- a/tests/src/LinkParser.cpp
+++ b/tests/src/LinkParser.cpp
@@ -34,14 +34,19 @@ struct SanitizeCheck {
 TEST(LinkParser, parseDomainLinks)
 {
     const QList<SanitizeCheck> sanitizeCases = {
-        {"(twitch.tv/foo)", "twitch.tv", "/foo"}};
+        {"(twitch.tv/foo)", "twitch.tv", "/foo" },
+        {"t🤪w🤪i🤪t🤪c🤪h🤪.tv/foo", "t🤪w🤪i🤪t🤪c🤪h🤪.tv", "/foo" },
+        { "https://🏹.to/bar", "🏹.to", "/bar" }
+    };
 
     for (auto &c : sanitizeCases)
     {
         LinkParser p(c.testValue);
         ASSERT_TRUE(p.result().has_value()) << c.testValue.toStdString();
         const auto &r = *p.result();
-        ASSERT_EQ(c.expectedHost, r.host) << c.expectedHost.toStdString();
+        std::ostringstream ss;
+        ss << "Expected: " << c.expectedHost.toStdString() << "\nResult: " << r.host.toString().toStdString();
+        ASSERT_EQ(c.expectedHost, r.host) << ss.str();
         ASSERT_EQ(c.expectedRest, r.rest) << c.expectedRest.toStdString();
     }
 
@@ -183,7 +188,8 @@ TEST(LinkParser, doesntParseInvalidLinks)
                                 "http:/cat.com",
                                 "https:/cat.com",
                                 "%%%%.com",
-                                "*.com"};
+                                "*.com",
+                                "t🤪w🤪i🤪t🤪c🤪h🤪.🤪t🤪v/foo"};
 
     for (const auto &input : inputs)
     {

--- a/tests/src/LinkParser.cpp
+++ b/tests/src/LinkParser.cpp
@@ -25,8 +25,27 @@ struct Case {
     }
 };
 
+
+struct SanitizeCheck
+{
+    QString testValue{};
+    QString expectedValue{};
+};
+
 TEST(LinkParser, parseDomainLinks)
 {
+    const QList<SanitizeCheck> sanitizeCases = {
+        { "(twitch.tv)", "twitch.tv"}
+    };
+
+    for (auto &c : sanitizeCases)
+    {
+        LinkParser p(c.testValue);
+         ASSERT_TRUE(p.result().has_value()) << c.testValue.toStdString();
+        const auto &r = *p.result();
+        ASSERT_EQ(c.expectedValue, r.host);
+    }
+
     const QList<Case> cases = {
         {"https://", "chatterino.com"},
         {"http://", "chatterino.com"},
@@ -165,6 +184,8 @@ TEST(LinkParser, doesntParseInvalidLinks)
         "http:/cat.com",
         "http:/cat.com",
         "https:/cat.com",
+        "%%%%.com",
+        "*.com"
     };
 
     for (const auto &input : inputs)


### PR DESCRIPTION
# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
Attempts to close #4769.

Actual sanitation of the URLs and removing characters depending on where they are in the URL (host, protocol, etc.) is complicated, but I tried to keep in line with [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986) and removing characters that should not be recognized. I created this list `!#&+/:=?@-_.` plus alphanumeric characters. All possible URLs are broader than allowed here, but this should cover the best practices and 99% of URLs. Other characters can easily be added. I added a few tests to cover the scenarios outlined in the issue, but I will add more if needed.