### PR TITLE
Remove comment for incorrect Twitch response

### DIFF
--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -2867,7 +2867,6 @@ void Helix::sendShoutout(
                 break;
 
                 case 500: {
-                    // Helix returns 500 when user is not mod,
                     if (message.isEmpty())
                     {
                         failureCallback(Error::Unknown,


### PR DESCRIPTION
# Description

When originally implementing /shoutout, when the user was not a mod Helix would return a 500 with no additional information, at some point this was resolved so this comment can be removed. https://github.com/twitchdev/issues/issues/779#issuecomment-1687039069

500 handling is kept b/c something could break, might as well keep it. 