### PR TITLE
Encode `modes` file in UTF8

### DIFF
--- a/.CI/build-installer.ps1
+++ b/.CI/build-installer.ps1
@@ -15,11 +15,11 @@ if ($isTagged) {
     # This is a release.
     # Make sure, any existing `modes` file is overwritten for the user,
     # for example when updating from nightly to stable.
-    Write-Output "" > Chatterino2/modes;
+    Write-Output "" | Out-File Chatterino2/modes -Encoding ASCII;
     $installerBaseName = "Chatterino.Installer";
 }
 else {
-    Write-Output nightly > Chatterino2/modes;
+    Write-Output nightly | Out-File Chatterino2/modes -Encoding ASCII;
     $defines = "/DIS_NIGHTLY=1";
     $installerBaseName = "Chatterino.Nightly.Installer";
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unversioned
 
-- Bugfix: Fixed UTF16 encoding of `modes` file for the installer. (#4791)
+- Dev: Fixed UTF16 encoding of `modes` file for the installer. (#4791)
 
 ## 2.4.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+- Bugfix: Fixed UTF16 encoding of `modes` file for the installer. (#4791)
+
 ## 2.4.5
 
 - Major: AutoMod term management messages (e.g. testaccount added "noob" as a blocked term on AutoMod.) are now hidden in Streamer Mode if you have the "Hide moderation actions" setting enabled. (#4758)


### PR DESCRIPTION
# Description

I noticed that PowerShell 5 (which is the version used in CI) encodes files using UTF16-LE when doing `echo foo > xd`. This doesn't happen in PowerShell 7 which I used for local testing. For the built installer, that shouldn't change anything, since it ignores lines that contain junk and the release `modes` file is empty.

Since using `Out-File` with `-Encoding Utf8` will result in a file encoded in UTF8 with BOM, I used `ASCII` (which is fine here).
