### PR TITLE
Do bounds-checking on more windows

### DIFF
--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -923,8 +923,7 @@ void CommandController::initialize(Settings &, Paths &paths)
             static_cast<QWidget *>(&(getApp()->windows->getMainWindow())),
             currentSplit);
         userPopup->setData(userName, channel);
-        userPopup->moveTo(QCursor::pos(), false,
-                          BaseWindow::BoundsChecker::CursorPosition);
+        userPopup->moveTo(QCursor::pos(), BoundsChecking::CursorPosition);
         userPopup->show();
         return "";
     });

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -87,8 +87,7 @@ void WindowManager::showAccountSelectPopup(QPoint point)
 
     w->refresh();
 
-    w->moveTo(point - QPoint(30, 0), false,
-              BaseWindow::BoundsChecker::CursorPosition);
+    w->moveTo(point - QPoint(30, 0), BoundsChecking::CursorPosition);
     w->show();
     w->setFocus();
 }

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -87,8 +87,8 @@ void WindowManager::showAccountSelectPopup(QPoint point)
 
     w->refresh();
 
-    QPoint buttonPos = point;
-    w->move(buttonPos.x() - 30, buttonPos.y());
+    w->moveTo(point - QPoint(30, 0), false,
+              BaseWindow::BoundsChecker::CursorPosition);
     w->show();
     w->setFocus();
 }

--- a/src/util/InitUpdateButton.cpp
+++ b/src/util/InitUpdateButton.cpp
@@ -24,7 +24,8 @@ void initUpdateButton(Button &button,
             globalPoint.setX(0);
         }
 
-        dialog->move(globalPoint);
+        dialog->moveTo(globalPoint, false,
+                       BaseWindow::BoundsChecker::DesiredPosition);
         dialog->show();
         dialog->raise();
 

--- a/src/util/InitUpdateButton.cpp
+++ b/src/util/InitUpdateButton.cpp
@@ -24,8 +24,7 @@ void initUpdateButton(Button &button,
             globalPoint.setX(0);
         }
 
-        dialog->moveTo(globalPoint, false,
-                       BaseWindow::BoundsChecker::DesiredPosition);
+        dialog->moveTo(globalPoint, BoundsChecking::DesiredPosition);
         dialog->show();
         dialog->raise();
 

--- a/src/widgets/BaseWindow.cpp
+++ b/src/widgets/BaseWindow.cpp
@@ -34,6 +34,55 @@
 
 #include "widgets/helper/TitlebarButton.hpp"
 
+namespace {
+
+void moveWithinScreen(QWidget *window, QPoint point, QPoint origin)
+{
+    // move the widget into the screen geometry if it's not already in there
+    auto *screen = QApplication::screenAt(origin);
+
+    if (screen == nullptr)
+    {
+        screen = QApplication::primaryScreen();
+    }
+    const QRect bounds = screen->availableGeometry();
+
+    bool stickRight = false;
+    bool stickBottom = false;
+
+    const auto w = window->frameGeometry().width();
+    const auto h = window->frameGeometry().height();
+
+    if (point.x() < bounds.left())
+    {
+        point.setX(bounds.left());
+    }
+    if (point.y() < bounds.top())
+    {
+        point.setY(bounds.top());
+    }
+    if (point.x() + w > bounds.right())
+    {
+        stickRight = true;
+        point.setX(bounds.right() - w);
+    }
+    if (point.y() + h > bounds.bottom())
+    {
+        stickBottom = true;
+        point.setY(bounds.bottom() - h);
+    }
+
+    if (stickRight && stickBottom)
+    {
+        const QPoint globalCursorPos = QCursor::pos();
+        point.setY(globalCursorPos.y() - window->height() - 16);
+    }
+
+    window->move(point);
+}
+
+}  // namespace
+
 namespace chatterino {
 
 BaseWindow::BaseWindow(FlagsEnum<Flags> _flags, QWidget *parent)
@@ -503,34 +552,9 @@ void BaseWindow::leaveEvent(QEvent *)
     TooltipWidget::instance()->hide();
 }
 
-void BaseWindow::moveTo(QPoint point, bool offset, BoundsChecker boundsChecker)
+void BaseWindow::moveTo(QPoint point, BoundsChecking mode)
 {
-    if (offset)
-    {
-        point.rx() += 16;
-        point.ry() += 16;
-    }
-
-    switch (boundsChecker)
-    {
-        case BoundsChecker::Off: {
-            // The bounds checker is off, *just* move the window
-            this->move(point);
-        }
-        break;
-
-        case BoundsChecker::CursorPosition: {
-            // The bounds checker is on, use the cursor position as the origin
-            this->moveWithinScreen(point, QCursor::pos());
-        }
-        break;
-
-        case BoundsChecker::DesiredPosition: {
-            // The bounds checker is on, use the desired position as the origin
-            this->moveWithinScreen(point, point);
-        }
-        break;
-    }
+    moveWindowTo(this, point, mode);
 }
 
 void BaseWindow::resizeEvent(QResizeEvent *)
@@ -584,51 +608,6 @@ void BaseWindow::closeEvent(QCloseEvent *)
 
 void BaseWindow::showEvent(QShowEvent *)
 {
-}
-
-void BaseWindow::moveWithinScreen(QPoint point, QPoint origin)
-{
-    // move the widget into the screen geometry if it's not already in there
-    auto *screen = QApplication::screenAt(origin);
-
-    if (screen == nullptr)
-    {
-        screen = QApplication::primaryScreen();
-    }
-    const QRect bounds = screen->availableGeometry();
-
-    bool stickRight = false;
-    bool stickBottom = false;
-
-    const auto w = this->frameGeometry().width();
-    const auto h = this->frameGeometry().height();
-
-    if (point.x() < bounds.left())
-    {
-        point.setX(bounds.left());
-    }
-    if (point.y() < bounds.top())
-    {
-        point.setY(bounds.top());
-    }
-    if (point.x() + w > bounds.right())
-    {
-        stickRight = true;
-        point.setX(bounds.right() - w);
-    }
-    if (point.y() + h > bounds.bottom())
-    {
-        stickBottom = true;
-        point.setY(bounds.bottom() - h);
-    }
-
-    if (stickRight && stickBottom)
-    {
-        const QPoint globalCursorPos = QCursor::pos();
-        point.setY(globalCursorPos.y() - this->height() - 16);
-    }
-
-    this->move(point);
 }
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
@@ -1072,6 +1051,24 @@ bool BaseWindow::handleNCHITTEST(MSG *msg, long *result)
 #else
     return false;
 #endif
+}
+
+void moveWindowTo(QWidget *window, QPoint point, BoundsChecking mode)
+{
+    switch (mode)
+    {
+        case BoundsChecking::CursorPosition: {
+            // Use the cursor position as the origin
+            moveWithinScreen(window, point, QCursor::pos());
+        }
+        break;
+
+        case BoundsChecking::DesiredPosition: {
+            // Use the desired position as the origin
+            moveWithinScreen(window, point, point);
+        }
+        break;
+    }
 }
 
 }  // namespace chatterino

--- a/src/widgets/BaseWindow.cpp
+++ b/src/widgets/BaseWindow.cpp
@@ -608,6 +608,10 @@ void BaseWindow::closeEvent(QCloseEvent *)
 
 void BaseWindow::showEvent(QShowEvent *)
 {
+    if (this->flags_.has(BoundsCheckOnShow))
+    {
+        this->moveTo(this->pos(), BoundsChecking::CursorPosition);
+    }
 }
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)

--- a/src/widgets/BaseWindow.hpp
+++ b/src/widgets/BaseWindow.hpp
@@ -37,14 +37,15 @@ class BaseWindow : public BaseWidget
 public:
     enum Flags {
         None = 0,
-        EnableCustomFrame = 1,
-        Frameless = 2,
-        TopMost = 4,
-        DisableCustomScaling = 8,
-        FramelessDraggable = 16,
-        DontFocus = 32,
-        Dialog = 64,
-        DisableLayoutSave = 128,
+        EnableCustomFrame = 1 << 0,
+        Frameless = 1 << 1,
+        TopMost = 1 << 2,
+        DisableCustomScaling = 1 << 3,
+        FramelessDraggable = 1 << 4,
+        DontFocus = 1 << 5,
+        Dialog = 1 << 6,
+        DisableLayoutSave = 1 << 7,
+        BoundsCheckOnShow = 1 << 8,
     };
 
     enum ActionOnFocusLoss { Nothing, Delete, Close, Hide };

--- a/src/widgets/BaseWindow.hpp
+++ b/src/widgets/BaseWindow.hpp
@@ -19,6 +19,17 @@ class EffectLabel;
 class TitleBarButton;
 enum class TitleBarButtonStyle;
 
+enum class BoundsChecking {
+    // Attempt to keep the window within bounds of the screen the cursor is on
+    CursorPosition,
+
+    // Attempt to keep the window within bounds of the screen the desired position is on
+    DesiredPosition,
+};
+
+/// Move the `window` to `point` and do bounds-checking to ensure that it stays on exactly one screen.
+void moveWindowTo(QWidget *window, QPoint point, BoundsChecking mode);
+
 class BaseWindow : public BaseWidget
 {
     Q_OBJECT
@@ -34,17 +45,6 @@ public:
         DontFocus = 32,
         Dialog = 64,
         DisableLayoutSave = 128,
-    };
-
-    enum class BoundsChecker {
-        // Don't attempt to do any "stay in screen" stuff, just move me!
-        Off,
-
-        // Attempt to keep the window within bounds of the screen the cursor is on
-        CursorPosition,
-
-        // Attempt to keep the window within bounds of the screen the desired position is on
-        DesiredPosition,
     };
 
     enum ActionOnFocusLoss { Nothing, Delete, Close, Hide };
@@ -65,7 +65,8 @@ public:
     void setActionOnFocusLoss(ActionOnFocusLoss value);
     ActionOnFocusLoss getActionOnFocusLoss() const;
 
-    void moveTo(QPoint point, bool offset, BoundsChecker boundsChecker);
+    /// Move this window to `point` and do bounds-checking to ensure that it stays on the current screen.
+    void moveTo(QPoint point, BoundsChecking mode);
 
     float scale() const override;
     float qtFontScale() const;
@@ -109,11 +110,6 @@ protected:
 
 private:
     void init();
-
-    /**
-     *
-     **/
-    void moveWithinScreen(QPoint point, QPoint origin);
 
     void calcButtonsSizes();
     void drawCustomWindowFrame(QPainter &painter);

--- a/src/widgets/dialogs/ColorPickerDialog.cpp
+++ b/src/widgets/dialogs/ColorPickerDialog.cpp
@@ -13,8 +13,13 @@
 namespace chatterino {
 
 ColorPickerDialog::ColorPickerDialog(const QColor &initial, QWidget *parent)
-    : BasePopup({BaseWindow::EnableCustomFrame, BaseWindow::DisableLayoutSave},
-                parent)
+    : BasePopup(
+          {
+              BaseWindow::EnableCustomFrame,
+              BaseWindow::DisableLayoutSave,
+              BaseWindow::BoundsCheckOnShow,
+          },
+          parent)
     , color_()
     , dialogConfirmed_(false)
 {

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -207,8 +207,8 @@ EmotePopup::EmotePopup(QWidget *parent)
     , notebook_(new Notebook(this))
 {
     // this->setStayInScreenRect(true);
-    this->moveTo(getApp()->windows->emotePopupPos(), false,
-                 BaseWindow::BoundsChecker::DesiredPosition);
+    this->moveTo(getApp()->windows->emotePopupPos(),
+                 BoundsChecking::DesiredPosition);
 
     auto *layout = new QVBoxLayout();
     this->getLayoutContainer()->setLayout(layout);

--- a/src/widgets/dialogs/QualityPopup.cpp
+++ b/src/widgets/dialogs/QualityPopup.cpp
@@ -9,8 +9,12 @@
 namespace chatterino {
 
 QualityPopup::QualityPopup(const QString &channelURL, QStringList options)
-    : BasePopup({BaseWindow::DisableLayoutSave},
-                static_cast<QWidget *>(&(getApp()->windows->getMainWindow())))
+    : BasePopup(
+          {
+              BaseWindow::DisableLayoutSave,
+              BaseWindow::BoundsCheckOnShow,
+          },
+          static_cast<QWidget *>(&(getApp()->windows->getMainWindow())))
     , channelURL_(channelURL)
 {
     this->ui_.selector = new QComboBox(this);

--- a/src/widgets/dialogs/SelectChannelDialog.cpp
+++ b/src/widgets/dialogs/SelectChannelDialog.cpp
@@ -31,9 +31,14 @@
 namespace chatterino {
 
 SelectChannelDialog::SelectChannelDialog(QWidget *parent)
-    : BaseWindow({BaseWindow::Flags::EnableCustomFrame,
-                  BaseWindow::Flags::Dialog, BaseWindow::DisableLayoutSave},
-                 parent)
+    : BaseWindow(
+          {
+              BaseWindow::Flags::EnableCustomFrame,
+              BaseWindow::Flags::Dialog,
+              BaseWindow::DisableLayoutSave,
+              BaseWindow::BoundsCheckOnShow,
+          },
+          parent)
     , selectedChannel_(Channel::getEmpty())
 {
     this->setWindowTitle("Select a channel to join");

--- a/src/widgets/dialogs/SettingsDialog.cpp
+++ b/src/widgets/dialogs/SettingsDialog.cpp
@@ -6,6 +6,7 @@
 #include "controllers/hotkeys/HotkeyController.hpp"
 #include "singletons/Settings.hpp"
 #include "util/LayoutCreator.hpp"
+#include "widgets/BaseWindow.hpp"
 #include "widgets/helper/Button.hpp"
 #include "widgets/helper/SettingsDialogTab.hpp"
 #include "widgets/settingspages/AboutPage.hpp"
@@ -29,9 +30,14 @@
 namespace chatterino {
 
 SettingsDialog::SettingsDialog(QWidget *parent)
-    : BaseWindow({BaseWindow::Flags::DisableCustomScaling,
-                  BaseWindow::Flags::Dialog, BaseWindow::DisableLayoutSave},
-                 parent)
+    : BaseWindow(
+          {
+              BaseWindow::Flags::DisableCustomScaling,
+              BaseWindow::Flags::Dialog,
+              BaseWindow::DisableLayoutSave,
+              BaseWindow::BoundsCheckOnShow,
+          },
+          parent)
 {
     this->setObjectName("SettingsDialog");
     this->setWindowTitle("Chatterino Settings");
@@ -380,9 +386,10 @@ void SettingsDialog::themeChangedEvent()
     this->setPalette(palette);
 }
 
-void SettingsDialog::showEvent(QShowEvent *)
+void SettingsDialog::showEvent(QShowEvent *e)
 {
     this->ui_.search->setText("");
+    BaseWindow::showEvent(e);
 }
 
 ///// Widget creation helpers

--- a/src/widgets/dialogs/switcher/QuickSwitcherPopup.cpp
+++ b/src/widgets/dialogs/switcher/QuickSwitcherPopup.cpp
@@ -35,9 +35,14 @@ namespace {
 const QSize QuickSwitcherPopup::MINIMUM_SIZE(500, 300);
 
 QuickSwitcherPopup::QuickSwitcherPopup(QWidget *parent)
-    : BasePopup({BaseWindow::Flags::Frameless, BaseWindow::Flags::TopMost,
-                 BaseWindow::DisableLayoutSave},
-                parent)
+    : BasePopup(
+          {
+              BaseWindow::Frameless,
+              BaseWindow::TopMost,
+              BaseWindow::DisableLayoutSave,
+              BaseWindow::BoundsCheckOnShow,
+          },
+          parent)
     , switcherModel_(this)
 {
     this->setWindowFlag(Qt::Dialog);

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1810,8 +1810,8 @@ void ChannelView::mouseMoveEvent(QMouseEvent *event)
             }
         }
 
-        tooltipWidget->moveTo(event->globalPos(), true,
-                              BaseWindow::BoundsChecker::CursorPosition);
+        tooltipWidget->moveTo(event->globalPos() + QPoint(16, 16),
+                              BoundsChecking::CursorPosition);
         tooltipWidget->setWordWrap(isLinkValid);
         tooltipWidget->show();
     }
@@ -2665,8 +2665,7 @@ void ChannelView::showUserInfoPopup(const QString &userName,
     userPopup->setData(userName, contextChannel, openingChannel);
 
     QPoint offset(userPopup->width() / 3, userPopup->height() / 5);
-    userPopup->moveTo(QCursor::pos() - offset, false,
-                      BaseWindow::BoundsChecker::CursorPosition);
+    userPopup->moveTo(QCursor::pos() - offset, BoundsChecking::CursorPosition);
     userPopup->show();
 }
 
@@ -3020,8 +3019,7 @@ void ChannelView::showReplyThreadPopup(const MessagePtr &message)
 
     QPoint offset(int(150 * this->scale()), int(70 * this->scale()));
     popup->show();
-    popup->moveTo(QCursor::pos() - offset, false,
-                  BaseWindow::BoundsChecker::CursorPosition);
+    popup->moveTo(QCursor::pos() - offset, BoundsChecking::CursorPosition);
     popup->giveFocus(Qt::MouseFocusReason);
 }
 

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -3019,8 +3019,9 @@ void ChannelView::showReplyThreadPopup(const MessagePtr &message)
     popup->setThread(message->replyThread);
 
     QPoint offset(int(150 * this->scale()), int(70 * this->scale()));
-    popup->move(QCursor::pos() - offset);
     popup->show();
+    popup->moveTo(QCursor::pos() - offset, false,
+                  BaseWindow::BoundsChecker::CursorPosition);
     popup->giveFocus(Qt::MouseFocusReason);
 }
 

--- a/src/widgets/helper/SearchPopup.cpp
+++ b/src/widgets/helper/SearchPopup.cpp
@@ -63,7 +63,12 @@ ChannelPtr SearchPopup::filter(const QString &text, const QString &channelName,
 }
 
 SearchPopup::SearchPopup(QWidget *parent, Split *split)
-    : BasePopup({BaseWindow::DisableLayoutSave}, parent)
+    : BasePopup(
+          {
+              BaseWindow::DisableLayoutSave,
+              BaseWindow::BoundsCheckOnShow,
+          },
+          parent)
     , split_(split)
 {
     this->initLayout();
@@ -180,9 +185,10 @@ void SearchPopup::updateWindowTitle()
     this->setWindowTitle("Searching in " + historyName + " history");
 }
 
-void SearchPopup::showEvent(QShowEvent *)
+void SearchPopup::showEvent(QShowEvent *e)
 {
     this->search();
+    BaseWindow::showEvent(e);
 }
 
 bool SearchPopup::eventFilter(QObject *object, QEvent *event)

--- a/src/widgets/settingspages/AboutPage.cpp
+++ b/src/widgets/settingspages/AboutPage.cpp
@@ -227,9 +227,13 @@ void AboutPage::addLicense(QFormLayout *form, const QString &name,
     auto *b = new QLabel("<a href=\"" + licenseLink + "\">show license</a>");
     QObject::connect(
         b, &QLabel::linkActivated, [parent = this, name, licenseLink] {
-            auto window = new BasePopup({BaseWindow::Flags::EnableCustomFrame,
-                                         BaseWindow::DisableLayoutSave},
-                                        parent);
+            auto *window = new BasePopup(
+                {
+                    BaseWindow::EnableCustomFrame,
+                    BaseWindow::DisableLayoutSave,
+                    BaseWindow::BoundsCheckOnShow,
+                },
+                parent);
             window->setWindowTitle("Chatterino - License for " + name);
             window->setAttribute(Qt::WA_DeleteOnClose);
             auto layout = new QVBoxLayout();

--- a/src/widgets/settingspages/FiltersPage.cpp
+++ b/src/widgets/settingspages/FiltersPage.cpp
@@ -44,9 +44,8 @@ FiltersPage::FiltersPage()
         view->getTableView()->setColumnWidth(2, 125);
     });
 
-    view->addButtonPressed.connect([] {
-        ChannelFilterEditorDialog d(
-            static_cast<QWidget *>(&(getApp()->windows->getMainWindow())));
+    view->addButtonPressed.connect([this] {
+        ChannelFilterEditorDialog d(this->window());
         if (d.exec() == QDialog::Accepted)
         {
             getSettings()->filterRecords.append(

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -192,8 +192,12 @@ namespace {
     void showTutorialVideo(QWidget *parent, const QString &source,
                            const QString &title, const QString &description)
     {
-        auto window =
-            new BasePopup(BaseWindow::Flags::EnableCustomFrame, parent);
+        auto *window = new BasePopup(
+            {
+                BaseWindow::EnableCustomFrame,
+                BaseWindow::BoundsCheckOnShow,
+            },
+            parent);
         window->setWindowTitle("Chatterino - " + title);
         window->setAttribute(Qt::WA_DeleteOnClose);
         auto layout = new QVBoxLayout();

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -1122,7 +1122,8 @@ void Split::showViewerList()
     viewerDock->resize(
         0.5 * this->width(),
         this->height() - this->header_->height() - this->input_->height());
-    viewerDock->move(0, this->header_->height());
+    moveWindowTo(viewerDock, {0, this->header_->height()},
+                 BoundsChecking::DesiredPosition);
 
     auto multiWidget = new QWidget(viewerDock);
     auto *dockVbox = new QVBoxLayout();

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -955,7 +955,7 @@ void SplitHeader::enterEvent(QEvent *event)
         auto pos = this->mapToGlobal(this->rect().bottomLeft()) +
                    QPoint((this->width() - tooltip->width()) / 2, 1);
 
-        tooltip->moveTo(pos, false, BaseWindow::BoundsChecker::CursorPosition);
+        tooltip->moveTo(pos, BoundsChecking::CursorPosition);
         tooltip->show();
     }
 


### PR DESCRIPTION
# Description

This is a continuation of #4740.

* Bounds checking can be done on _any_ window now.
* `BaseWindow`s can opt in to bounds-checking when they're shown (old behavior). This will prefer the monitor the cursor is on.
* `ChannelFilterEditorDialog` now has the settings window as its parent (causing it to open there instead of the main window). 

The following windows are now bounds-checked:

* `AccountSwitchPopup`
* `UpdateDialog`
* `SelectChannelDialog`
* `SettingsDialog`
* `QuickSwitcherPopup`
* `ReplyThreadPopup`
* `SearchPopup`
* `QualityPopup`
* `ColorPickerDialog`
* Viewer list
* Tutorial popup
* License popup

The following windows are **not** bounds-checked:

* `FramelessEmbedWindow`
* `AttachedWindow` (does its own positioning)
* `NotificationPopup` (never constructed)
* `WelcomeDialog` (never constructed)
* `InputCompletionPopup` (it's supposed to be in the middle above the split input)

Fixes #4790.
