### PR TITLE
Fixed `/shoutout` command not working with usernames starting with @'s (e.g. `/shoutout @forsen`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unversioned
 
 - Bugfix: Fixed a data race when disconnecting from Twitch PubSub. (#4771)
+- Bugfix: Fixed `/shoutout` command not working with usernames starting with @'s (e.g. `/shoutout @forsen`). (#4800)
 - Dev: Fixed UTF16 encoding of `modes` file for the installer. (#4791)
 - Dev: Temporarily disable High DPI scaling on Qt6 builds on Windows. (#4767)
 - Dev: Tests now run on Ubuntu 22.04 instead of 20.04 to loosen C++ restrictions in tests. (#4774)

--- a/src/controllers/commands/builtin/twitch/Shoutout.cpp
+++ b/src/controllers/commands/builtin/twitch/Shoutout.cpp
@@ -7,6 +7,7 @@
 #include "providers/twitch/api/Helix.hpp"
 #include "providers/twitch/TwitchAccount.hpp"
 #include "providers/twitch/TwitchChannel.hpp"
+#include "util/Twitch.hpp"
 
 namespace chatterino::commands {
 
@@ -39,7 +40,8 @@ QString sendShoutout(const CommandContext &ctx)
         return "";
     }
 
-    const auto target = words->at(1);
+    auto target = words->at(1);
+    stripChannelName(target);
 
     using Error = HelixSendShoutoutError;
 


### PR DESCRIPTION
# Description

Tested, confirmed it works as expected

Fixes #4799 

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
