### PR TITLE
Fixed too much text being copied when copying chat messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Bugfix: Fixed Usercard popup not floating on tiling WMs on Linux when "Automatically close user popup when it loses focus" setting is enabled. (#3511)
 - Bugfix: Fixed selection of tabs after closing a tab when using "Live Tabs Only". (#4770)
 - Bugfix: Fixed input in reply thread popup losing focus when dragging. (#4815)
-- Bugfix: Fixed too much text being copied when selecting text. (#4812)
+- Bugfix: Fixed too much text being copied when copying chat messages. (#4812)
 - Dev: Fixed UTF16 encoding of `modes` file for the installer. (#4791)
 - Dev: Temporarily disable High DPI scaling on Qt6 builds on Windows. (#4767)
 - Dev: Tests now run on Ubuntu 22.04 instead of 20.04 to loosen C++ restrictions in tests. (#4774)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Bugfix: Fixed Usercard popup not floating on tiling WMs on Linux when "Automatically close user popup when it loses focus" setting is enabled. (#3511)
 - Bugfix: Fixed selection of tabs after closing a tab when using "Live Tabs Only". (#4770)
 - Bugfix: Fixed input in reply thread popup losing focus when dragging. (#4815)
+- Bugfix: Fixed too much text being copied when selecting text. (#4812)
 - Dev: Fixed UTF16 encoding of `modes` file for the installer. (#4791)
 - Dev: Temporarily disable High DPI scaling on Qt6 builds on Windows. (#4767)
 - Dev: Tests now run on Ubuntu 22.04 instead of 20.04 to loosen C++ restrictions in tests. (#4774)

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -478,6 +478,11 @@ void MessageLayoutContainer::end()
         this->lines_.back().endIndex = this->elements_.size();
         this->lines_.back().endCharIndex = this->charIndex_;
     }
+
+    if (!this->elements_.empty())
+    {
+        this->elements_.back()->setTrailingSpace(false);
+    }
 }
 
 bool MessageLayoutContainer::canCollapse()
@@ -849,7 +854,7 @@ void MessageLayoutContainer::addSelectionText(QString &str, uint32_t from,
                 element->addCopyTextToString(str, from - index, to - index);
                 first = false;
 
-                if (index + indexCount > to)
+                if (index + indexCount >= to)
                 {
                     break;
                 }
@@ -857,7 +862,7 @@ void MessageLayoutContainer::addSelectionText(QString &str, uint32_t from,
         }
         else
         {
-            if (index + indexCount > to)
+            if (index + indexCount >= to)
             {
                 element->addCopyTextToString(str, 0, to - index);
                 break;

--- a/src/messages/layouts/MessageLayoutElement.cpp
+++ b/src/messages/layouts/MessageLayoutElement.cpp
@@ -125,9 +125,9 @@ void ImageLayoutElement::addCopyTextToString(QString &str, uint32_t from,
     {
         str += emoteElement->getEmote()->getCopyString();
         str = TwitchEmotes::cleanUpEmoteCode(str);
-        if (this->hasTrailingSpace())
+        if (this->hasTrailingSpace() && to >= 2)
         {
-            str += " ";
+            str += ' ';
         }
     }
 }
@@ -217,9 +217,9 @@ void LayeredImageLayoutElement::addCopyTextToString(QString &str, uint32_t from,
     {
         // cleaning is taken care in call
         str += layeredEmoteElement->getCleanCopyString();
-        if (this->hasTrailingSpace())
+        if (this->hasTrailingSpace() && to >= 2)
         {
-            str += " ";
+            str += ' ';
         }
     }
 }
@@ -416,9 +416,9 @@ void TextLayoutElement::addCopyTextToString(QString &str, uint32_t from,
 {
     str += this->getText().mid(from, to - from);
 
-    if (this->hasTrailingSpace())
+    if (this->hasTrailingSpace() && to > this->getText().length())
     {
-        str += " ";
+        str += ' ';
     }
 }
 

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -609,6 +609,11 @@ QString ChannelView::getSelectedText()
                       : layout->getLastCharacterIndex() + 1;
 
         layout->addSelectionText(result, from, to);
+
+        if (msg != indexEnd)
+        {
+            result += '\n';
+        }
     }
 
     return result;


### PR DESCRIPTION
# Description

This is a continuation of #3080. The same approach is used. 

Because of the reply button being in every message, setting `hasTrailingSpace` on the last element (even the last text element) when building as mentioned in https://github.com/Chatterino/chatterino2/pull/3080#issuecomment-893014909 doesn't work. 
Instead, `hasTrailingSpace` is set on the last _layout_ element. With the button enabled, a trailing space is copied (as that space is visually selected). Without the button, no trailing space is copied. When selecting multiple lines, having no delimiter after a message is bad, so a newline is added (over a space to distinguish lines).

Fixes #2449.

Additionally, this fixes the issue of copying emotes when they're not selected (e.g. in `a 🅰` with `a ` selected, Chatterino would copy `a 🅰 `).
