### PR TITLE
Fix input in reply thread popup losing focus when dragging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Bugfix: Fixed a data race when disconnecting from Twitch PubSub. (#4771)
 - Bugfix: Fixed `/shoutout` command not working with usernames starting with @'s (e.g. `/shoutout @forsen`). (#4800)
 - Bugfix: Fixed selection of tabs after closing a tab when using "Live Tabs Only". (#4770)
+- Bugfix: Fixed input in reply thread popup losing focus when dragging. (#4815)
 - Dev: Fixed UTF16 encoding of `modes` file for the installer. (#4791)
 - Dev: Temporarily disable High DPI scaling on Qt6 builds on Windows. (#4767)
 - Dev: Tests now run on Ubuntu 22.04 instead of 20.04 to loosen C++ restrictions in tests. (#4774)

--- a/src/widgets/dialogs/ReplyThreadPopup.cpp
+++ b/src/widgets/dialogs/ReplyThreadPopup.cpp
@@ -1,4 +1,4 @@
-#include "ReplyThreadPopup.hpp"
+#include "widgets/dialogs/ReplyThreadPopup.hpp"
 
 #include "Application.hpp"
 #include "common/Channel.hpp"

--- a/src/widgets/dialogs/ReplyThreadPopup.cpp
+++ b/src/widgets/dialogs/ReplyThreadPopup.cpp
@@ -149,7 +149,7 @@ ReplyThreadPopup::ReplyThreadPopup(bool closeAutomatically, QWidget *parent,
                                  }
                              });
             hbox->addWidget(this->ui_.notificationCheckbox, 1);
-            this->ui_.notificationCheckbox->setFocusPolicy(Qt::ClickFocus);
+            this->ui_.notificationCheckbox->setFocusPolicy(Qt::NoFocus);
         }
 
         if (closeAutomatically)


### PR DESCRIPTION
# Description

When dragging the reply thread popup and the notification checkbox is shown, the input in the dialog would lose focus (at least on Windows). Changing the focus policy of the checkbox from `ClickFocus` to `NoFocus` resolves that. This means that the checkbox can never be toggled with the keyboard. However, this doesn't change much, since you had to click on the checkbox before in order to toggle it with the keyboard.
