### PR TITLE
Add `WindowManager::getLastSelectedWindow()` to replace `getMainWindow()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Dev: Fix clang-tidy `cppcoreguidelines-pro-type-member-init` warnings. (#4426)
 - Dev: Immediate layout for invisible `ChannelView`s is skipped. (#4811)
 - Dev: Refactor `Image` & Image's `Frames`. (#4773)
+- Dev: Add `WindowManager::getLastSelectedWindow()` to replace `getMainWindow()`. (#4816)
 
 ## 2.4.5
 

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -246,6 +246,10 @@ Window &WindowManager::getMainWindow()
 Window *WindowManager::getLastSelectedWindow() const
 {
     assertInGuiThread();
+    if (this->selectedWindow_ == nullptr)
+    {
+        return this->mainWindow_;
+    }
 
     return this->selectedWindow_;
 }

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -243,11 +243,11 @@ Window &WindowManager::getMainWindow()
     return *this->mainWindow_;
 }
 
-Window &WindowManager::getSelectedWindow()
+Window *WindowManager::getLastSelectedWindow() const
 {
     assertInGuiThread();
 
-    return *this->selectedWindow_;
+    return this->selectedWindow_;
 }
 
 Window &WindowManager::createWindow(WindowType type, bool show, QWidget *parent)

--- a/src/singletons/WindowManager.hpp
+++ b/src/singletons/WindowManager.hpp
@@ -67,8 +67,10 @@ public:
     Window &getMainWindow();
 
     // Returns a pointer to the last selected window.
-    // This may be null if the application was not focused since the start.
-    // This does not account for the window being unfocused.
+    // Edge cases:
+    //  - If the application was not focused since the start, this will return a pointer to the main window.
+    //  - If the window was closed this points to the main window.
+    //  - If the window was unfocused since being selected, this function will still return it.
     Window *getLastSelectedWindow() const;
 
     Window &createWindow(WindowType type, bool show = true,

--- a/src/singletons/WindowManager.hpp
+++ b/src/singletons/WindowManager.hpp
@@ -65,7 +65,12 @@ public:
     void repaintGifEmotes();
 
     Window &getMainWindow();
-    Window &getSelectedWindow();
+
+    // Returns a pointer to the last selected window.
+    // This may be null if the application was not focused since the start.
+    // This does not account for the window being unfocused.
+    Window *getLastSelectedWindow() const;
+
     Window &createWindow(WindowType type, bool show = true,
                          QWidget *parent = nullptr);
 
@@ -153,6 +158,8 @@ private:
 
     QTimer *saveTimer;
     QTimer miscUpdateTimer_;
+
+    friend class Window;  // this is for selectedWindow_
 };
 
 }  // namespace chatterino

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -144,6 +144,11 @@ void Window::closeEvent(QCloseEvent *)
         app->windows->closeAll();
     }
 
+    // Ensure selectedWindow_ is never an invalid pointer.
+    // WindowManager will return the main window if no window is pointed to by
+    // `selectedWindow_`.
+    getApp()->windows->selectedWindow_ = nullptr;
+
     this->closed.invoke();
 
     if (this->type_ == WindowType::Main)

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -103,8 +103,10 @@ bool Window::event(QEvent *event)
 {
     switch (event->type())
     {
-        case QEvent::WindowActivate:
+        case QEvent::WindowActivate: {
+            getApp()->windows->selectedWindow_ = this;
             break;
+        }
 
         case QEvent::WindowDeactivate: {
             auto page = this->notebook_->getOrAddSelectedPage();


### PR DESCRIPTION
# Description

This is needed to fix `/clearmessages`. I will replace all usages of `getMainWindow()` in another PR.

Here is a simple fix for `/clearmesages` which can be used to test this.

Fixes #3353. Required to finally close issue #2406. <!-- intended to not trigger keyword -->

<details>
<summary>Patch</summary>

```patch
diff --git a/src/controllers/commands/CommandController.cpp b/src/controllers/commands/CommandController.cpp
index 9ce784ba..68eb2939 100644
--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -1377,18 +1377,25 @@ void CommandController::initialize(Settings &, Paths &paths)
         return "";
     });
 
-    this->registerCommand("/clearmessages", [](const auto & /*words*/,
-                                               ChannelPtr channel) {
-        auto *currentPage = dynamic_cast<SplitContainer *>(
-            getApp()->windows->getMainWindow().getNotebook().getSelectedPage());
+    this->registerCommand(
+        "/clearmessages",
+        [](const auto & /*words*/, ChannelPtr channel) -> QString {
+            auto *win = getApp()->windows->getLastSelectedWindow();
+            if (win == nullptr)
+            {
+                return "";
+            }
 
-        if (auto split = currentPage->getSelectedSplit())
-        {
-            split->getChannelView().clearMessages();
-        }
+            auto *currentPage = dynamic_cast<SplitContainer *>(
+                win->getNotebook().getSelectedPage());
 
-        return "";
-    });
+            if (auto *split = currentPage->getSelectedSplit())
+            {
+                split->getChannelView().clearMessages();
+            }
+
+            return "";
+        });
 
     this->registerCommand("/settitle", [](const QStringList &words,
                                           ChannelPtr channel) {
```

</details>