### PR TITLE
Style account switcher to match the current theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unversioned
 
 - Minor: Migrate to the new Get Channel Followers Helix endpoint, fixing follower count not showing up in usercards. (#4809)
+- Minor: The account switcher is now styled to match your theme. (#4817)
 - Bugfix: Fixed a performance issue when displaying replies to certain messages. (#4807)
 - Bugfix: Fixed a data race when disconnecting from Twitch PubSub. (#4771)
 - Bugfix: Fixed `/shoutout` command not working with usernames starting with @'s (e.g. `/shoutout @forsen`). (#4800)

--- a/src/widgets/AccountSwitchPopup.cpp
+++ b/src/widgets/AccountSwitchPopup.cpp
@@ -1,5 +1,7 @@
 #include "widgets/AccountSwitchPopup.hpp"
 
+#include "common/Literals.hpp"
+#include "singletons/Theme.hpp"
 #include "widgets/AccountSwitchWidget.hpp"
 #include "widgets/dialogs/SettingsDialog.hpp"
 
@@ -8,6 +10,8 @@
 #include <QPushButton>
 
 namespace chatterino {
+
+using namespace literals;
 
 AccountSwitchPopup::AccountSwitchPopup(QWidget *parent)
     : BaseWindow({BaseWindow::TopMost, BaseWindow::Frameless,
@@ -39,6 +43,48 @@ AccountSwitchPopup::AccountSwitchPopup(QWidget *parent)
     this->getLayoutContainer()->setLayout(vbox);
 
     this->setScaleIndependantSize(200, 200);
+    this->themeChangedEvent();
+}
+
+void AccountSwitchPopup::themeChangedEvent()
+{
+    BaseWindow::themeChangedEvent();
+
+    auto *t = getTheme();
+    auto color = [](const QColor &c) {
+        return c.name(QColor::HexArgb);
+    };
+    this->setStyleSheet(uR"(
+        QListView {
+            color: %1;
+            background: %2;
+        }
+        QListView::item:hover {
+            background: %3;
+        }
+        QListView::item:selected {
+            background: %4;
+        }
+
+        QPushButton {
+            background: %5;
+            color: %1;
+        }
+        QPushButton:hover {
+            background: %3;
+        }
+        QPushButton:pressed {
+            background: %6;
+        }
+
+        chatterino--AccountSwitchPopup {
+            background: %7;
+        }
+    )"_s.arg(color(t->window.text), color(t->splits.header.background),
+             color(t->splits.header.focusedBackground), color(t->accent),
+             color(t->tabs.regular.backgrounds.regular),
+             color(t->tabs.selected.backgrounds.regular),
+             color(t->window.background)));
 }
 
 void AccountSwitchPopup::refresh()

--- a/src/widgets/AccountSwitchPopup.hpp
+++ b/src/widgets/AccountSwitchPopup.hpp
@@ -21,6 +21,8 @@ protected:
     void focusOutEvent(QFocusEvent *event) final;
     void paintEvent(QPaintEvent *event) override;
 
+    void themeChangedEvent() override;
+
 private:
     struct {
         AccountSwitchWidget *accountSwitchWidget = nullptr;


### PR DESCRIPTION
# Description

This PR adds better support for themes in the account switcher.

| | White | Light | Dark | Black |
| ---|---|---|---|---|
|Before | ![chatterino_2023-09-15_12-52-57](https://github.com/Chatterino/chatterino2/assets/19953266/a7519a2a-488a-41d6-9be3-36c8abd5ec0c) | ![chatterino_2023-09-15_12-53-01](https://github.com/Chatterino/chatterino2/assets/19953266/98ad93df-491f-43bd-8d29-19d547fd13c4) | ![chatterino_2023-09-15_12-53-06](https://github.com/Chatterino/chatterino2/assets/19953266/197e16d8-24e7-442a-85c9-5aca6ee65141) | ![chatterino_2023-09-15_12-53-10](https://github.com/Chatterino/chatterino2/assets/19953266/45d1c306-d1d8-4cbd-8e11-ca258ce743d2) |
| After | ![chatterino_2023-09-15_12-51-37](https://github.com/Chatterino/chatterino2/assets/19953266/e41b73c3-f78f-4e48-b32e-b3a1819c275c) | ![chatterino_2023-09-15_12-51-43](https://github.com/Chatterino/chatterino2/assets/19953266/a7d1294d-9ea1-4774-9d56-f1a7554e7d90) | ![chatterino_2023-09-15_12-51-47](https://github.com/Chatterino/chatterino2/assets/19953266/ee1774ff-9813-453f-987c-300ef93bc851) | ![chatterino_2023-09-15_12-51-54](https://github.com/Chatterino/chatterino2/assets/19953266/6e3b46a6-efc4-4fc8-be04-97803d81066b)

