### PR TITLE
Fix signal connection nodiscard warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Dev: Fix clang-tidy `cppcoreguidelines-pro-type-member-init` warnings. (#4426)
 - Dev: Immediate layout for invisible `ChannelView`s is skipped. (#4811)
 - Dev: Refactor `Image` & Image's `Frames`. (#4773)
+- Dev: Clarify signal connection lifetimes where applicable. (#4818)
 
 ## 2.4.5
 

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -193,6 +193,7 @@ int Application::run(QApplication &qtApp)
 
     // We can safely ignore the signal connections since Application will always live longer than
     // everything else, including settings. right?
+    // NOTE: SETTINGS_LIFETIME
     std::ignore =
         getSettings()->moderationActions.delayedItemsChanged.connect([this] {
             this->windows->forceLayoutChannelViews();

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -97,7 +97,9 @@ Application::Application(Settings &_settings, Paths &_paths)
 {
     this->instance = this;
 
-    this->fonts->fontChanged.connect([this]() {
+    // We can safely ignore this signal's connection since the Application will always
+    // be destroyed after fonts
+    std::ignore = this->fonts->fontChanged.connect([this]() {
         this->windows->layoutChannelViews();
     });
 }
@@ -188,16 +190,22 @@ int Application::run(QApplication &qtApp)
             Updates::instance().checkForUpdates();
         },
         false);
-    getSettings()->moderationActions.delayedItemsChanged.connect([this] {
-        this->windows->forceLayoutChannelViews();
-    });
 
-    getSettings()->highlightedMessages.delayedItemsChanged.connect([this] {
-        this->windows->forceLayoutChannelViews();
-    });
-    getSettings()->highlightedUsers.delayedItemsChanged.connect([this] {
-        this->windows->forceLayoutChannelViews();
-    });
+    // We can safely ignore the signal connections since Application will always live longer than
+    // everything else, including settings. right?
+    std::ignore =
+        getSettings()->moderationActions.delayedItemsChanged.connect([this] {
+            this->windows->forceLayoutChannelViews();
+        });
+
+    std::ignore =
+        getSettings()->highlightedMessages.delayedItemsChanged.connect([this] {
+            this->windows->forceLayoutChannelViews();
+        });
+    std::ignore =
+        getSettings()->highlightedUsers.delayedItemsChanged.connect([this] {
+            this->windows->forceLayoutChannelViews();
+        });
 
     getSettings()->removeSpacesBetweenEmotes.connect([this] {
         this->windows->forceLayoutChannelViews();
@@ -279,7 +287,9 @@ void Application::initNm(Paths &paths)
 
 void Application::initPubSub()
 {
-    this->twitch->pubsub->signals_.moderation.chatCleared.connect(
+    // We can safely ignore these signal connections since the twitch object will always
+    // be destroyed before the Application
+    std::ignore = this->twitch->pubsub->signals_.moderation.chatCleared.connect(
         [this](const auto &action) {
             auto chan = this->twitch->getChannelOrEmptyByID(action.roomID);
             if (chan->isEmpty())
@@ -296,7 +306,7 @@ void Application::initPubSub()
             });
         });
 
-    this->twitch->pubsub->signals_.moderation.modeChanged.connect(
+    std::ignore = this->twitch->pubsub->signals_.moderation.modeChanged.connect(
         [this](const auto &action) {
             auto chan = this->twitch->getChannelOrEmptyByID(action.roomID);
             if (chan->isEmpty())
@@ -322,28 +332,29 @@ void Application::initPubSub()
             });
         });
 
-    this->twitch->pubsub->signals_.moderation.moderationStateChanged.connect(
-        [this](const auto &action) {
-            auto chan = this->twitch->getChannelOrEmptyByID(action.roomID);
-            if (chan->isEmpty())
-            {
-                return;
-            }
+    std::ignore =
+        this->twitch->pubsub->signals_.moderation.moderationStateChanged
+            .connect([this](const auto &action) {
+                auto chan = this->twitch->getChannelOrEmptyByID(action.roomID);
+                if (chan->isEmpty())
+                {
+                    return;
+                }
 
-            QString text;
+                QString text;
 
-            text = QString("%1 %2 %3")
-                       .arg(action.source.login,
-                            (action.modded ? "modded" : "unmodded"),
-                            action.target.login);
+                text = QString("%1 %2 %3")
+                           .arg(action.source.login,
+                                (action.modded ? "modded" : "unmodded"),
+                                action.target.login);
 
-            auto msg = makeSystemMessage(text);
-            postToThread([chan, msg] {
-                chan->addMessage(msg);
+                auto msg = makeSystemMessage(text);
+                postToThread([chan, msg] {
+                    chan->addMessage(msg);
+                });
             });
-        });
 
-    this->twitch->pubsub->signals_.moderation.userBanned.connect(
+    std::ignore = this->twitch->pubsub->signals_.moderation.userBanned.connect(
         [&](const auto &action) {
             auto chan = this->twitch->getChannelOrEmptyByID(action.roomID);
 
@@ -358,208 +369,218 @@ void Application::initPubSub()
                 chan->addOrReplaceTimeout(msg.release());
             });
         });
-    this->twitch->pubsub->signals_.moderation.messageDeleted.connect(
-        [&](const auto &action) {
-            auto chan = this->twitch->getChannelOrEmptyByID(action.roomID);
+    std::ignore =
+        this->twitch->pubsub->signals_.moderation.messageDeleted.connect(
+            [&](const auto &action) {
+                auto chan = this->twitch->getChannelOrEmptyByID(action.roomID);
 
-            if (chan->isEmpty() || getSettings()->hideDeletionActions)
-            {
-                return;
-            }
-
-            MessageBuilder msg;
-            TwitchMessageBuilder::deletionMessage(action, &msg);
-            msg->flags.set(MessageFlag::PubSub);
-
-            postToThread([chan, msg = msg.release()] {
-                auto replaced = false;
-                LimitedQueueSnapshot<MessagePtr> snapshot =
-                    chan->getMessageSnapshot();
-                int snapshotLength = snapshot.size();
-
-                // without parens it doesn't build on windows
-                int end = (std::max)(0, snapshotLength - 200);
-
-                for (int i = snapshotLength - 1; i >= end; --i)
+                if (chan->isEmpty() || getSettings()->hideDeletionActions)
                 {
-                    auto &s = snapshot[i];
-                    if (!s->flags.has(MessageFlag::PubSub) &&
-                        s->timeoutUser == msg->timeoutUser)
-                    {
-                        chan->replaceMessage(s, msg);
-                        replaced = true;
-                        break;
-                    }
+                    return;
                 }
-                if (!replaced)
+
+                MessageBuilder msg;
+                TwitchMessageBuilder::deletionMessage(action, &msg);
+                msg->flags.set(MessageFlag::PubSub);
+
+                postToThread([chan, msg = msg.release()] {
+                    auto replaced = false;
+                    LimitedQueueSnapshot<MessagePtr> snapshot =
+                        chan->getMessageSnapshot();
+                    int snapshotLength = snapshot.size();
+
+                    // without parens it doesn't build on windows
+                    int end = (std::max)(0, snapshotLength - 200);
+
+                    for (int i = snapshotLength - 1; i >= end; --i)
+                    {
+                        auto &s = snapshot[i];
+                        if (!s->flags.has(MessageFlag::PubSub) &&
+                            s->timeoutUser == msg->timeoutUser)
+                        {
+                            chan->replaceMessage(s, msg);
+                            replaced = true;
+                            break;
+                        }
+                    }
+                    if (!replaced)
+                    {
+                        chan->addMessage(msg);
+                    }
+                });
+            });
+
+    std::ignore =
+        this->twitch->pubsub->signals_.moderation.userUnbanned.connect(
+            [&](const auto &action) {
+                auto chan = this->twitch->getChannelOrEmptyByID(action.roomID);
+
+                if (chan->isEmpty())
                 {
+                    return;
+                }
+
+                auto msg = MessageBuilder(action).release();
+
+                postToThread([chan, msg] {
                     chan->addMessage(msg);
+                });
+            });
+
+    std::ignore =
+        this->twitch->pubsub->signals_.moderation.autoModMessageCaught.connect(
+            [&](const auto &msg, const QString &channelID) {
+                auto chan = this->twitch->getChannelOrEmptyByID(channelID);
+                if (chan->isEmpty())
+                {
+                    return;
                 }
-            });
-        });
 
-    this->twitch->pubsub->signals_.moderation.userUnbanned.connect(
-        [&](const auto &action) {
-            auto chan = this->twitch->getChannelOrEmptyByID(action.roomID);
-
-            if (chan->isEmpty())
-            {
-                return;
-            }
-
-            auto msg = MessageBuilder(action).release();
-
-            postToThread([chan, msg] {
-                chan->addMessage(msg);
-            });
-        });
-
-    this->twitch->pubsub->signals_.moderation.autoModMessageCaught.connect(
-        [&](const auto &msg, const QString &channelID) {
-            auto chan = this->twitch->getChannelOrEmptyByID(channelID);
-            if (chan->isEmpty())
-            {
-                return;
-            }
-
-            switch (msg.type)
-            {
-                case PubSubAutoModQueueMessage::Type::AutoModCaughtMessage: {
-                    if (msg.status == "PENDING")
-                    {
-                        AutomodAction action(msg.data, channelID);
-                        action.reason = QString("%1 level %2")
-                                            .arg(msg.contentCategory)
-                                            .arg(msg.contentLevel);
-
-                        action.msgID = msg.messageID;
-                        action.message = msg.messageText;
-
-                        // this message also contains per-word automod data, which could be implemented
-
-                        // extract sender data manually because Twitch loves not being consistent
-                        QString senderDisplayName =
-                            msg.senderUserDisplayName;  // Might be transformed later
-                        bool hasLocalizedName = false;
-                        if (!msg.senderUserDisplayName.isEmpty())
+                switch (msg.type)
+                {
+                    case PubSubAutoModQueueMessage::Type::
+                        AutoModCaughtMessage: {
+                        if (msg.status == "PENDING")
                         {
-                            // check for non-ascii display names
-                            if (QString::compare(msg.senderUserDisplayName,
-                                                 msg.senderUserLogin,
-                                                 Qt::CaseInsensitive) != 0)
+                            AutomodAction action(msg.data, channelID);
+                            action.reason = QString("%1 level %2")
+                                                .arg(msg.contentCategory)
+                                                .arg(msg.contentLevel);
+
+                            action.msgID = msg.messageID;
+                            action.message = msg.messageText;
+
+                            // this message also contains per-word automod data, which could be implemented
+
+                            // extract sender data manually because Twitch loves not being consistent
+                            QString senderDisplayName =
+                                msg.senderUserDisplayName;  // Might be transformed later
+                            bool hasLocalizedName = false;
+                            if (!msg.senderUserDisplayName.isEmpty())
                             {
-                                hasLocalizedName = true;
-                            }
-                        }
-                        QColor senderColor = msg.senderUserChatColor;
-                        QString senderColor_;
-                        if (!senderColor.isValid() &&
-                            getSettings()->colorizeNicknames)
-                        {
-                            // color may be not present if user is a grey-name
-                            senderColor = getRandomColor(msg.senderUserID);
-                        }
-
-                        // handle username style based on prefered setting
-                        switch (getSettings()->usernameDisplayMode.getValue())
-                        {
-                            case UsernameDisplayMode::Username: {
-                                if (hasLocalizedName)
+                                // check for non-ascii display names
+                                if (QString::compare(msg.senderUserDisplayName,
+                                                     msg.senderUserLogin,
+                                                     Qt::CaseInsensitive) != 0)
                                 {
-                                    senderDisplayName = msg.senderUserLogin;
+                                    hasLocalizedName = true;
                                 }
-                                break;
                             }
-                            case UsernameDisplayMode::LocalizedName: {
-                                break;
+                            QColor senderColor = msg.senderUserChatColor;
+                            QString senderColor_;
+                            if (!senderColor.isValid() &&
+                                getSettings()->colorizeNicknames)
+                            {
+                                // color may be not present if user is a grey-name
+                                senderColor = getRandomColor(msg.senderUserID);
                             }
-                            case UsernameDisplayMode::
-                                UsernameAndLocalizedName: {
-                                if (hasLocalizedName)
-                                {
-                                    senderDisplayName = QString("%1(%2)").arg(
-                                        msg.senderUserLogin,
-                                        msg.senderUserDisplayName);
-                                }
-                                break;
-                            }
-                        }
 
-                        action.target =
-                            ActionUser{msg.senderUserID, msg.senderUserLogin,
-                                       senderDisplayName, senderColor};
-                        postToThread([chan, action] {
-                            const auto p = makeAutomodMessage(action);
-                            chan->addMessage(p.first);
-                            chan->addMessage(p.second);
-                        });
+                            // handle username style based on prefered setting
+                            switch (
+                                getSettings()->usernameDisplayMode.getValue())
+                            {
+                                case UsernameDisplayMode::Username: {
+                                    if (hasLocalizedName)
+                                    {
+                                        senderDisplayName = msg.senderUserLogin;
+                                    }
+                                    break;
+                                }
+                                case UsernameDisplayMode::LocalizedName: {
+                                    break;
+                                }
+                                case UsernameDisplayMode::
+                                    UsernameAndLocalizedName: {
+                                    if (hasLocalizedName)
+                                    {
+                                        senderDisplayName =
+                                            QString("%1(%2)").arg(
+                                                msg.senderUserLogin,
+                                                msg.senderUserDisplayName);
+                                    }
+                                    break;
+                                }
+                            }
+
+                            action.target = ActionUser{
+                                msg.senderUserID, msg.senderUserLogin,
+                                senderDisplayName, senderColor};
+                            postToThread([chan, action] {
+                                const auto p = makeAutomodMessage(action);
+                                chan->addMessage(p.first);
+                                chan->addMessage(p.second);
+                            });
+                        }
+                        // "ALLOWED" and "DENIED" statuses remain unimplemented
+                        // They are versions of automod_message_(denied|approved) but for mods.
                     }
-                    // "ALLOWED" and "DENIED" statuses remain unimplemented
-                    // They are versions of automod_message_(denied|approved) but for mods.
+                    break;
+
+                    case PubSubAutoModQueueMessage::Type::INVALID:
+                    default: {
+                    }
+                    break;
                 }
-                break;
+            });
 
-                case PubSubAutoModQueueMessage::Type::INVALID:
-                default: {
+    std::ignore =
+        this->twitch->pubsub->signals_.moderation.autoModMessageBlocked.connect(
+            [&](const auto &action) {
+                auto chan = this->twitch->getChannelOrEmptyByID(action.roomID);
+                if (chan->isEmpty())
+                {
+                    return;
                 }
-                break;
-            }
-        });
 
-    this->twitch->pubsub->signals_.moderation.autoModMessageBlocked.connect(
-        [&](const auto &action) {
-            auto chan = this->twitch->getChannelOrEmptyByID(action.roomID);
-            if (chan->isEmpty())
-            {
-                return;
-            }
-
-            postToThread([chan, action] {
-                const auto p = makeAutomodMessage(action);
-                chan->addMessage(p.first);
-                chan->addMessage(p.second);
+                postToThread([chan, action] {
+                    const auto p = makeAutomodMessage(action);
+                    chan->addMessage(p.first);
+                    chan->addMessage(p.second);
+                });
             });
-        });
 
-    this->twitch->pubsub->signals_.moderation.automodUserMessage.connect(
-        [&](const auto &action) {
-            // This condition has been set up to execute isInStreamerMode() as the last thing
-            // as it could end up being expensive.
-            if (getSettings()->streamerModeHideModActions && isInStreamerMode())
-            {
-                return;
-            }
-            auto chan = this->twitch->getChannelOrEmptyByID(action.roomID);
+    std::ignore =
+        this->twitch->pubsub->signals_.moderation.automodUserMessage.connect(
+            [&](const auto &action) {
+                // This condition has been set up to execute isInStreamerMode() as the last thing
+                // as it could end up being expensive.
+                if (getSettings()->streamerModeHideModActions &&
+                    isInStreamerMode())
+                {
+                    return;
+                }
+                auto chan = this->twitch->getChannelOrEmptyByID(action.roomID);
 
-            if (chan->isEmpty())
-            {
-                return;
-            }
+                if (chan->isEmpty())
+                {
+                    return;
+                }
 
-            auto msg = MessageBuilder(action).release();
+                auto msg = MessageBuilder(action).release();
 
-            postToThread([chan, msg] {
-                chan->addMessage(msg);
+                postToThread([chan, msg] {
+                    chan->addMessage(msg);
+                });
+                chan->deleteMessage(msg->id);
             });
-            chan->deleteMessage(msg->id);
-        });
 
-    this->twitch->pubsub->signals_.moderation.automodInfoMessage.connect(
-        [&](const auto &action) {
-            auto chan = this->twitch->getChannelOrEmptyByID(action.roomID);
+    std::ignore =
+        this->twitch->pubsub->signals_.moderation.automodInfoMessage.connect(
+            [&](const auto &action) {
+                auto chan = this->twitch->getChannelOrEmptyByID(action.roomID);
 
-            if (chan->isEmpty())
-            {
-                return;
-            }
+                if (chan->isEmpty())
+                {
+                    return;
+                }
 
-            postToThread([chan, action] {
-                const auto p = makeAutomodInfoMessage(action);
-                chan->addMessage(p);
+                postToThread([chan, action] {
+                    const auto p = makeAutomodInfoMessage(action);
+                    chan->addMessage(p);
+                });
             });
-        });
 
-    this->twitch->pubsub->signals_.pointReward.redeemed.connect(
+    std::ignore = this->twitch->pubsub->signals_.pointReward.redeemed.connect(
         [&](auto &data) {
             QString channelId = data.value("channel_id").toString();
             if (channelId.isEmpty())
@@ -614,7 +635,9 @@ void Application::initBttvLiveUpdates()
         return;
     }
 
-    this->twitch->bttvLiveUpdates->signals_.emoteAdded.connect(
+    // We can safely ignore these signal connections since the twitch object will always
+    // be destroyed before the Application
+    std::ignore = this->twitch->bttvLiveUpdates->signals_.emoteAdded.connect(
         [&](const auto &data) {
             auto chan = this->twitch->getChannelOrEmptyByID(data.channelID);
 
@@ -625,7 +648,7 @@ void Application::initBttvLiveUpdates()
                 }
             });
         });
-    this->twitch->bttvLiveUpdates->signals_.emoteUpdated.connect(
+    std::ignore = this->twitch->bttvLiveUpdates->signals_.emoteUpdated.connect(
         [&](const auto &data) {
             auto chan = this->twitch->getChannelOrEmptyByID(data.channelID);
 
@@ -636,7 +659,7 @@ void Application::initBttvLiveUpdates()
                 }
             });
         });
-    this->twitch->bttvLiveUpdates->signals_.emoteRemoved.connect(
+    std::ignore = this->twitch->bttvLiveUpdates->signals_.emoteRemoved.connect(
         [&](const auto &data) {
             auto chan = this->twitch->getChannelOrEmptyByID(data.channelID);
 
@@ -659,7 +682,9 @@ void Application::initSeventvEventAPI()
         return;
     }
 
-    this->twitch->seventvEventAPI->signals_.emoteAdded.connect(
+    // We can safely ignore these signal connections since the twitch object will always
+    // be destroyed before the Application
+    std::ignore = this->twitch->seventvEventAPI->signals_.emoteAdded.connect(
         [&](const auto &data) {
             postToThread([this, data] {
                 this->twitch->forEachSeventvEmoteSet(
@@ -668,7 +693,7 @@ void Application::initSeventvEventAPI()
                     });
             });
         });
-    this->twitch->seventvEventAPI->signals_.emoteUpdated.connect(
+    std::ignore = this->twitch->seventvEventAPI->signals_.emoteUpdated.connect(
         [&](const auto &data) {
             postToThread([this, data] {
                 this->twitch->forEachSeventvEmoteSet(
@@ -677,7 +702,7 @@ void Application::initSeventvEventAPI()
                     });
             });
         });
-    this->twitch->seventvEventAPI->signals_.emoteRemoved.connect(
+    std::ignore = this->twitch->seventvEventAPI->signals_.emoteRemoved.connect(
         [&](const auto &data) {
             postToThread([this, data] {
                 this->twitch->forEachSeventvEmoteSet(
@@ -686,7 +711,7 @@ void Application::initSeventvEventAPI()
                     });
             });
         });
-    this->twitch->seventvEventAPI->signals_.userUpdated.connect(
+    std::ignore = this->twitch->seventvEventAPI->signals_.userUpdated.connect(
         [&](const auto &data) {
             this->twitch->forEachSeventvUser(data.userID,
                                              [data](TwitchChannel &chan) {

--- a/src/common/Channel.cpp
+++ b/src/common/Channel.cpp
@@ -106,7 +106,7 @@ void Channel::addMessage(MessagePtr message,
 
     if (this->messages_.pushBack(message, deleted))
     {
-        this->messageRemovedFromStart.invoke(deleted);
+        this->messageRemovedFromStart(deleted);
     }
 
     this->messageAppended.invoke(message, overridingFlags);
@@ -350,6 +350,10 @@ std::shared_ptr<Channel> Channel::getEmpty()
 }
 
 void Channel::onConnected()
+{
+}
+
+void Channel::messageRemovedFromStart(const MessagePtr &msg)
 {
 }
 

--- a/src/common/Channel.hpp
+++ b/src/common/Channel.hpp
@@ -52,7 +52,6 @@ public:
     pajlada::Signals::Signal<const QString &, const QString &, const QString &,
                              bool &>
         sendReplySignal;
-    pajlada::Signals::Signal<MessagePtr &> messageRemovedFromStart;
     pajlada::Signals::Signal<MessagePtr &, boost::optional<MessageFlags>>
         messageAppended;
     pajlada::Signals::Signal<std::vector<MessagePtr> &> messagesAddedAtStart;
@@ -114,6 +113,7 @@ public:
 
 protected:
     virtual void onConnected();
+    virtual void messageRemovedFromStart(const MessagePtr &msg);
 
 private:
     const QString name_;

--- a/src/controllers/accounts/AccountController.cpp
+++ b/src/controllers/accounts/AccountController.cpp
@@ -1,4 +1,4 @@
-#include "AccountController.hpp"
+#include "controllers/accounts/AccountController.hpp"
 
 #include "controllers/accounts/Account.hpp"
 #include "controllers/accounts/AccountModel.hpp"
@@ -10,22 +10,27 @@ namespace chatterino {
 AccountController::AccountController()
     : accounts_(SharedPtrElementLess<Account>{})
 {
-    this->twitch.accounts.itemInserted.connect([this](const auto &args) {
-        this->accounts_.insert(std::dynamic_pointer_cast<Account>(args.item));
-    });
+    // These signal connections can safely be ignored since the twitch object
+    // will always be destroyed before the AccountController
+    std::ignore =
+        this->twitch.accounts.itemInserted.connect([this](const auto &args) {
+            this->accounts_.insert(
+                std::dynamic_pointer_cast<Account>(args.item));
+        });
 
-    this->twitch.accounts.itemRemoved.connect([this](const auto &args) {
-        if (args.caller != this)
-        {
-            auto &accs = this->twitch.accounts.raw();
-            auto it = std::find(accs.begin(), accs.end(), args.item);
-            assert(it != accs.end());
+    std::ignore =
+        this->twitch.accounts.itemRemoved.connect([this](const auto &args) {
+            if (args.caller != this)
+            {
+                auto &accs = this->twitch.accounts.raw();
+                auto it = std::find(accs.begin(), accs.end(), args.item);
+                assert(it != accs.end());
 
-            this->accounts_.removeAt(it - accs.begin(), this);
-        }
-    });
+                this->accounts_.removeAt(it - accs.begin(), this);
+            }
+        });
 
-    this->accounts_.itemRemoved.connect([this](const auto &args) {
+    std::ignore = this->accounts_.itemRemoved.connect([this](const auto &args) {
         switch (args.item->getProviderId())
         {
             case ProviderId::Twitch: {

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -587,8 +587,10 @@ void CommandController::initialize(Settings &, Paths &paths)
 
         this->maxSpaces_ = maxSpaces;
     };
-    this->items.itemInserted.connect(addFirstMatchToMap);
-    this->items.itemRemoved.connect(addFirstMatchToMap);
+    // We can safely ignore these signal connections since items will be destroyed
+    // before CommandController
+    std::ignore = this->items.itemInserted.connect(addFirstMatchToMap);
+    std::ignore = this->items.itemRemoved.connect(addFirstMatchToMap);
 
     // Initialize setting manager for commands.json
     auto path = combinePath(paths.settingsDirectory, "commands.json");
@@ -604,7 +606,7 @@ void CommandController::initialize(Settings &, Paths &paths)
 
     // Update the setting when the vector of commands has been updated (most
     // likely from the settings dialog)
-    this->items.delayedItemsChanged.connect([this] {
+    std::ignore = this->items.delayedItemsChanged.connect([this] {
         this->commandsSetting_->setValue(this->items.raw());
     });
 

--- a/src/controllers/notifications/NotificationController.cpp
+++ b/src/controllers/notifications/NotificationController.cpp
@@ -36,9 +36,13 @@ void NotificationController::initialize(Settings &settings, Paths &paths)
         this->channelMap[Platform::Twitch].append(channelName);
     }
 
-    this->channelMap[Platform::Twitch].delayedItemsChanged.connect([this] {
-        this->twitchSetting_.setValue(this->channelMap[Platform::Twitch].raw());
-    });
+    // We can safely ignore this signal connection since channelMap will always be destroyed
+    // before the NotificationController
+    std::ignore =
+        this->channelMap[Platform::Twitch].delayedItemsChanged.connect([this] {
+            this->twitchSetting_.setValue(
+                this->channelMap[Platform::Twitch].raw());
+        });
 
     liveStatusTimer_ = new QTimer();
 

--- a/src/providers/irc/AbstractIrcServer.cpp
+++ b/src/providers/irc/AbstractIrcServer.cpp
@@ -50,7 +50,7 @@ AbstractIrcServer::AbstractIrcServer()
         this->writeConnection_->connectionLost, [this](bool timeout) {
             qCDebug(chatterinoIrc)
                 << "Write connection reconnect requested. Timeout:" << timeout;
-            this->writeConnection_->smartReconnect.invoke();
+            this->writeConnection_->smartReconnect();
         });
 
     // Listen to read connection message signals
@@ -86,7 +86,7 @@ AbstractIrcServer::AbstractIrcServer()
                 this->addGlobalSystemMessage(
                     "Server connection timed out, reconnecting");
             }
-            this->readConnection_->smartReconnect.invoke();
+            this->readConnection_->smartReconnect();
         });
 }
 

--- a/src/providers/irc/Irc2.cpp
+++ b/src/providers/irc/Irc2.cpp
@@ -88,7 +88,9 @@ void IrcServerData::setPassword(const QString &password)
 
 Irc::Irc()
 {
-    this->connections.itemInserted.connect([this](auto &&args) {
+    // We can safely ignore this signal connection since `connections` will always
+    // be destroyed before the Irc object
+    std::ignore = this->connections.itemInserted.connect([this](auto &&args) {
         // make sure only one id can only exist for one server
         assert(this->servers_.find(args.item.id) == this->servers_.end());
 
@@ -117,7 +119,9 @@ Irc::Irc()
         }
     });
 
-    this->connections.itemRemoved.connect([this](auto &&args) {
+    // We can safely ignore this signal connection since `connections` will always
+    // be destroyed before the Irc object
+    std::ignore = this->connections.itemRemoved.connect([this](auto &&args) {
         // restore
         if (auto server = this->servers_.find(args.item.id);
             server != this->servers_.end())
@@ -141,7 +145,9 @@ Irc::Irc()
         }
     });
 
-    this->connections.delayedItemsChanged.connect([this] {
+    // We can safely ignore this signal connection since `connections` will always
+    // be destroyed before the Irc object
+    std::ignore = this->connections.delayedItemsChanged.connect([this] {
         this->save();
     });
 }

--- a/src/providers/irc/IrcConnection2.cpp
+++ b/src/providers/irc/IrcConnection2.cpp
@@ -38,18 +38,6 @@ IrcConnection::IrcConnection(QObject *parent)
             }
         });
 
-    // Schedule a reconnect that won't violate RECONNECT_MIN_INTERVAL
-    this->smartReconnect.connect([this] {
-        if (this->reconnectTimer_.isActive())
-        {
-            return;
-        }
-
-        auto delay = this->reconnectBackoff_.next();
-        qCDebug(chatterinoIrc) << "Reconnecting in" << delay.count() << "ms";
-        this->reconnectTimer_.start(delay);
-    });
-
     this->reconnectTimer_.setSingleShot(true);
     QObject::connect(&this->reconnectTimer_, &QTimer::timeout, [this] {
         if (this->isConnected())
@@ -121,6 +109,19 @@ IrcConnection::~IrcConnection()
 {
     // Prematurely disconnect all QObject connections
     this->disconnect();
+}
+
+void IrcConnection::smartReconnect()
+{
+    if (this->reconnectTimer_.isActive())
+    {
+        // Ignore this reconnect request, we already have a reconnect request queued up
+        return;
+    }
+
+    auto delay = this->reconnectBackoff_.next();
+    qCDebug(chatterinoIrc) << "Reconnecting in" << delay.count() << "ms";
+    this->reconnectTimer_.start(delay);
 }
 
 void IrcConnection::open()

--- a/src/providers/irc/IrcConnection2.hpp
+++ b/src/providers/irc/IrcConnection2.hpp
@@ -20,7 +20,8 @@ public:
     pajlada::Signals::Signal<bool> connectionLost;
 
     // Request a reconnect with a minimum interval between attempts.
-    pajlada::Signals::NoArgSignal smartReconnect;
+    // This won't violate RECONNECT_MIN_INTERVAL
+    void smartReconnect();
 
     virtual void open();
     virtual void close();

--- a/src/providers/twitch/TwitchAccountManager.cpp
+++ b/src/providers/twitch/TwitchAccountManager.cpp
@@ -20,7 +20,9 @@ TwitchAccountManager::TwitchAccountManager()
         currentUser->loadSeventvUserID();
     });
 
-    this->accounts.itemRemoved.connect([this](const auto &acc) {
+    // We can safely ignore this signal connection since accounts will always be removed
+    // before TwitchAccountManager
+    std::ignore = this->accounts.itemRemoved.connect([this](const auto &acc) {
         this->removeUser(acc.item.get());
     });
 }

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -131,18 +131,7 @@ TwitchChannel::TwitchChannel(const QString &name)
         this->loadRecentMessagesReconnect();
     });
 
-    this->messageRemovedFromStart.connect([this](MessagePtr &msg) {
-        if (msg->replyThread)
-        {
-            if (msg->replyThread->liveCount(msg) == 0)
-            {
-                this->threads_.erase(msg->replyThread->rootId());
-            }
-        }
-    });
-
     // timers
-
     QObject::connect(&this->chattersListTimer_, &QTimer::timeout, [this] {
         this->refreshChatters();
     });
@@ -1067,6 +1056,17 @@ bool TwitchChannel::tryReplaceLastLiveUpdateAddOrRemove(
     this->replaceMessage(last, msg);
 
     return true;
+}
+
+void TwitchChannel::messageRemovedFromStart(const MessagePtr &msg)
+{
+    if (msg->replyThread)
+    {
+        if (msg->replyThread->liveCount(msg) == 0)
+        {
+            this->threads_.erase(msg->replyThread->rootId());
+        }
+    }
 }
 
 const QString &TwitchChannel::subscriptionUrl()

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -100,22 +100,6 @@ TwitchChannel::TwitchChannel(const QString &name)
         this->refreshPubSub();
     });
 
-    // room id loaded -> refresh live status
-    // We can safely ignore this signal connection this has no external dependencies - once the signal
-    // is destroyed, it will no longer be able to fire
-    std::ignore = this->roomIdChanged.connect([this]() {
-        this->refreshPubSub();
-        this->refreshBadges();
-        this->refreshCheerEmotes();
-        this->refreshFFZChannelEmotes(false);
-        this->refreshBTTVChannelEmotes(false);
-        this->refreshSevenTVChannelEmotes(false);
-        this->joinBttvChannel();
-        this->listenSevenTVCosmetics();
-        getIApp()->getTwitchLiveController()->add(
-            std::dynamic_pointer_cast<TwitchChannel>(shared_from_this()));
-    });
-
     // We can safely ignore this signal connection this has no external dependencies - once the signal
     // is destroyed, it will no longer be able to fire
     std::ignore = this->connected.connect([this]() {
@@ -533,6 +517,20 @@ void TwitchChannel::showLoginMessage()
     this->addMessage(builder.release());
 }
 
+void TwitchChannel::roomIdChanged()
+{
+    this->refreshPubSub();
+    this->refreshBadges();
+    this->refreshCheerEmotes();
+    this->refreshFFZChannelEmotes(false);
+    this->refreshBTTVChannelEmotes(false);
+    this->refreshSevenTVChannelEmotes(false);
+    this->joinBttvChannel();
+    this->listenSevenTVCosmetics();
+    getIApp()->getTwitchLiveController()->add(
+        std::dynamic_pointer_cast<TwitchChannel>(shared_from_this()));
+}
+
 QString TwitchChannel::prepareMessage(const QString &message) const
 {
     auto app = getApp();
@@ -724,7 +722,7 @@ void TwitchChannel::setRoomId(const QString &id)
     if (*this->roomID_.accessConst() != id)
     {
         *this->roomID_.access() = id;
-        this->roomIdChanged.invoke();
+        this->roomIdChanged();
         this->loadRecentMessages();
     }
 }

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -94,12 +94,16 @@ TwitchChannel::TwitchChannel(const QString &name)
         }));
 
     this->refreshPubSub();
-    this->userStateChanged.connect([this] {
+    // We can safely ignore this signal connection since it's a private signal, meaning
+    // it will only ever be invoked by TwitchChannel itself
+    std::ignore = this->userStateChanged.connect([this] {
         this->refreshPubSub();
     });
 
     // room id loaded -> refresh live status
-    this->roomIdChanged.connect([this]() {
+    // We can safely ignore this signal connection this has no external dependencies - once the signal
+    // is destroyed, it will no longer be able to fire
+    std::ignore = this->roomIdChanged.connect([this]() {
         this->refreshPubSub();
         this->refreshBadges();
         this->refreshCheerEmotes();
@@ -112,7 +116,9 @@ TwitchChannel::TwitchChannel(const QString &name)
             std::dynamic_pointer_cast<TwitchChannel>(shared_from_this()));
     });
 
-    this->connected.connect([this]() {
+    // We can safely ignore this signal connection this has no external dependencies - once the signal
+    // is destroyed, it will no longer be able to fire
+    std::ignore = this->connected.connect([this]() {
         if (this->roomId().isEmpty())
         {
             // If we get a reconnected event when the room id is not set, we

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -191,8 +191,11 @@ public:
     const std::unordered_map<QString, std::weak_ptr<MessageThread>> &threads()
         const;
 
-    // Signals
+private:
     pajlada::Signals::NoArgSignal roomIdChanged;
+
+public:
+    // Only TwitchChannel may invoke this signal
     pajlada::Signals::NoArgSignal userStateChanged;
 
     /**

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -191,10 +191,6 @@ public:
     const std::unordered_map<QString, std::weak_ptr<MessageThread>> &threads()
         const;
 
-private:
-    pajlada::Signals::NoArgSignal roomIdChanged;
-
-public:
     // Only TwitchChannel may invoke this signal
     pajlada::Signals::NoArgSignal userStateChanged;
 
@@ -245,8 +241,6 @@ private:
         QString actualDisplayName;
     } nameOptions;
 
-private:
-    // Methods
     void refreshPubSub();
     void refreshChatters();
     void refreshBadges();
@@ -255,6 +249,11 @@ private:
     void loadRecentMessagesReconnect();
     void cleanUpReplyThreads();
     void showLoginMessage();
+
+    /// roomIdChanged is called whenever this channel's ID has been changed
+    /// This should only happen once per channel, whenever the ID goes from unset to set
+    void roomIdChanged();
+
     /** Joins (subscribes to) a Twitch channel for updates on BTTV. */
     void joinBttvChannel() const;
     /**

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -338,6 +338,8 @@ private:
     std::unordered_map<QString, std::weak_ptr<MessageThread>> threads_;
 
 protected:
+    void messageRemovedFromStart(const MessagePtr &msg) override;
+
     Atomic<std::shared_ptr<const EmoteMap>> bttvEmotes_;
     Atomic<std::shared_ptr<const EmoteMap>> ffzEmotes_;
     Atomic<std::shared_ptr<const EmoteMap>> seventvEmotes_;

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -133,8 +133,7 @@ void TwitchIrcServer::initializeConnection(IrcConnection *connection,
 std::shared_ptr<Channel> TwitchIrcServer::createChannel(
     const QString &channelName)
 {
-    auto channel =
-        std::shared_ptr<TwitchChannel>(new TwitchChannel(channelName));
+    auto channel = std::make_shared<TwitchChannel>(channelName);
     channel->initialize();
 
     // We can safely ignore these signal connections since the TwitchIrcServer is only
@@ -151,7 +150,7 @@ std::shared_ptr<Channel> TwitchIrcServer::createChannel(
             this->onReplySendRequested(channel, msg, replyId, sent);
         });
 
-    return std::shared_ptr<Channel>(channel);
+    return channel;
 }
 
 void TwitchIrcServer::privateMessageReceived(

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -137,11 +137,15 @@ std::shared_ptr<Channel> TwitchIrcServer::createChannel(
         std::shared_ptr<TwitchChannel>(new TwitchChannel(channelName));
     channel->initialize();
 
-    channel->sendMessageSignal.connect(
+    // We can safely ignore these signal connections since the TwitchIrcServer is only
+    // ever destroyed when the full Application state is about to be destroyed, at which point
+    // no Channel's should live
+    // NOTE: CHANNEL_LIFETIME
+    std::ignore = channel->sendMessageSignal.connect(
         [this, channel = channel.get()](auto &chan, auto &msg, bool &sent) {
             this->onMessageSendRequested(channel, msg, sent);
         });
-    channel->sendReplySignal.connect(
+    std::ignore = channel->sendReplySignal.connect(
         [this, channel = channel.get()](auto &chan, auto &msg, auto &replyId,
                                         bool &sent) {
             this->onReplySendRequested(channel, msg, replyId, sent);

--- a/src/singletons/Logging.cpp
+++ b/src/singletons/Logging.cpp
@@ -14,16 +14,21 @@ namespace chatterino {
 
 void Logging::initialize(Settings &settings, Paths & /*paths*/)
 {
-    settings.loggedChannels.delayedItemsChanged.connect([this, &settings]() {
-        this->threadGuard.guard();
+    // We can safely ignore this signal connection since settings are only-ever destroyed
+    // on application exit
+    // NOTE: SETTINGS_LIFETIME
+    std::ignore = settings.loggedChannels.delayedItemsChanged.connect(
+        [this, &settings]() {
+            this->threadGuard.guard();
 
-        this->onlyLogListedChannels.clear();
+            this->onlyLogListedChannels.clear();
 
-        for (const auto &loggedChannel : *settings.loggedChannels.readOnly())
-        {
-            this->onlyLogListedChannels.insert(loggedChannel.channelName());
-        }
-    });
+            for (const auto &loggedChannel :
+                 *settings.loggedChannels.readOnly())
+            {
+                this->onlyLogListedChannels.insert(loggedChannel.channelName());
+            }
+        });
 }
 
 void Logging::addMessage(const QString &channelName, MessagePtr message,

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -344,9 +344,13 @@ void WindowManager::setEmotePopupPos(QPoint pos)
 
 void WindowManager::initialize(Settings &settings, Paths &paths)
 {
+    (void)paths;
     assertInGuiThread();
 
-    getApp()->themes->repaintVisibleChatWidgets_.connect([this] {
+    // We can safely ignore this signal connection since both Themes and WindowManager
+    // share the Application state lifetime
+    // NOTE: APPLICATION_LIFETIME
+    std::ignore = getApp()->themes->repaintVisibleChatWidgets_.connect([this] {
         this->repaintVisibleChatWidgets();
     });
 

--- a/src/util/InitUpdateButton.cpp
+++ b/src/util/InitUpdateButton.cpp
@@ -1,4 +1,4 @@
-#include "InitUpdateButton.hpp"
+#include "util/InitUpdateButton.hpp"
 
 #include "widgets/dialogs/UpdateDialog.hpp"
 #include "widgets/helper/Button.hpp"
@@ -28,7 +28,11 @@ void initUpdateButton(Button &button,
         dialog->show();
         dialog->raise();
 
-        dialog->buttonClicked.connect([&button](auto buttonType) {
+        // We can safely ignore the signal connection because the dialog will always
+        // be destroyed before the button is destroyed, since it is destroyed on focus loss
+        //
+        // The button is either attached to a Notebook, or a Window frame
+        std::ignore = dialog->buttonClicked.connect([&button](auto buttonType) {
             switch (buttonType)
             {
                 case UpdateDialog::Dismiss: {

--- a/src/widgets/AccountSwitchWidget.cpp
+++ b/src/widgets/AccountSwitchWidget.cpp
@@ -20,22 +20,23 @@ AccountSwitchWidget::AccountSwitchWidget(QWidget *parent)
         this->addItem(userName);
     }
 
-    app->accounts->twitch.userListUpdated.connect([=, this]() {
-        this->blockSignals(true);
+    this->managedConnections_.managedConnect(
+        app->accounts->twitch.userListUpdated, [=, this]() {
+            this->blockSignals(true);
 
-        this->clear();
+            this->clear();
 
-        this->addItem(ANONYMOUS_USERNAME_LABEL);
+            this->addItem(ANONYMOUS_USERNAME_LABEL);
 
-        for (const auto &userName : app->accounts->twitch.getUsernames())
-        {
-            this->addItem(userName);
-        }
+            for (const auto &userName : app->accounts->twitch.getUsernames())
+            {
+                this->addItem(userName);
+            }
 
-        this->refreshSelection();
+            this->refreshSelection();
 
-        this->blockSignals(false);
-    });
+            this->blockSignals(false);
+        });
 
     this->refreshSelection();
 

--- a/src/widgets/AccountSwitchWidget.hpp
+++ b/src/widgets/AccountSwitchWidget.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "pajlada/signals/signalholder.hpp"
+
 #include <QListWidget>
 
 namespace chatterino {
@@ -15,6 +17,8 @@ public:
 
 private:
     void refreshSelection();
+
+    pajlada::Signals::SignalHolder managedConnections_;
 };
 
 }  // namespace chatterino

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -246,7 +246,9 @@ EmotePopup::EmotePopup(QWidget *parent)
             MessageElementFlag::Default, MessageElementFlag::AlwaysShow,
             MessageElementFlag::EmoteImages});
         view->setEnableScrollingToBottom(false);
-        view->linkClicked.connect(clicked);
+        // We can safely ignore this signal connection since the ChannelView is deleted
+        // either when the notebook is deleted, or when our main layout is deleted.
+        std::ignore = view->linkClicked.connect(clicked);
 
         if (addToNotebook)
         {

--- a/src/widgets/dialogs/ReplyThreadPopup.cpp
+++ b/src/widgets/dialogs/ReplyThreadPopup.cpp
@@ -84,9 +84,12 @@ ReplyThreadPopup::ReplyThreadPopup(bool closeAutomatically, QWidget *parent,
     this->ui_.threadView->setMinimumSize(400, 100);
     this->ui_.threadView->setSizePolicy(QSizePolicy::Expanding,
                                         QSizePolicy::Expanding);
-    this->ui_.threadView->mouseDown.connect([this](QMouseEvent *) {
-        this->giveFocus(Qt::MouseFocusReason);
-    });
+    // We can safely ignore this signal's connection since threadView will always be deleted before
+    // the ReplyThreadPopup
+    std::ignore =
+        this->ui_.threadView->mouseDown.connect([this](QMouseEvent *) {
+            this->giveFocus(Qt::MouseFocusReason);
+        });
 
     // Create SplitInput with inline replying disabled
     this->ui_.replyInput =
@@ -97,8 +100,10 @@ ReplyThreadPopup::ReplyThreadPopup(bool closeAutomatically, QWidget *parent,
             this->updateInputUI();
         }));
 
-    // clear SplitInput selection when selecting in ChannelView
-    this->ui_.threadView->selectionChanged.connect([this]() {
+    // We can safely ignore this signal's connection since threadView will always be deleted before
+    // the ReplyThreadPopup
+    std::ignore = this->ui_.threadView->selectionChanged.connect([this]() {
+        // clear SplitInput selection when selecting in ChannelView
         if (this->ui_.replyInput->hasSelection())
         {
             this->ui_.replyInput->clearSelection();
@@ -106,7 +111,9 @@ ReplyThreadPopup::ReplyThreadPopup(bool closeAutomatically, QWidget *parent,
     });
 
     // clear ChannelView selection when selecting in SplitInput
-    this->ui_.replyInput->selectionChanged.connect([this]() {
+    // We can safely ignore this signal's connection since replyInput will always be deleted before
+    // the ReplyThreadPopup
+    std::ignore = this->ui_.replyInput->selectionChanged.connect([this]() {
         if (this->ui_.threadView->hasSelection())
         {
             this->ui_.threadView->clearSelection();

--- a/src/widgets/dialogs/SelectChannelDialog.cpp
+++ b/src/widgets/dialogs/SelectChannelDialog.cpp
@@ -170,7 +170,9 @@ SelectChannelDialog::SelectChannelDialog(QWidget *parent)
             view->getTableView()->horizontalHeader()->setSectionHidden(4, true);
             view->getTableView()->horizontalHeader()->setSectionHidden(5, true);
 
-            view->addButtonPressed.connect([] {
+            // We can safely ignore this signal's connection since the button won't be
+            // accessible after this dialog is closed
+            std::ignore = view->addButtonPressed.connect([] {
                 auto unique = IrcServerData{};
                 unique.id = Irc::instance().uniqueId();
 

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -438,8 +438,10 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically, QWidget *parent,
         });
 
         // userstate
-        this->userStateChanged_.connect([this, mod, unmod, vip,
-                                         unvip]() mutable {
+        // We can safely ignore this signal connection since this is a private signal, and
+        // we only connect once
+        std::ignore = this->userStateChanged_.connect([this, mod, unmod, vip,
+                                                       unvip]() mutable {
             TwitchChannel *twitchChannel =
                 dynamic_cast<TwitchChannel *>(this->underlyingChannel_.get());
 
@@ -469,17 +471,22 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically, QWidget *parent,
     {
         auto timeout = moderation.emplace<TimeoutWidget>();
 
-        this->userStateChanged_.connect([this, lineMod, timeout]() mutable {
-            TwitchChannel *twitchChannel =
-                dynamic_cast<TwitchChannel *>(this->underlyingChannel_.get());
+        // We can safely ignore this signal connection since this is a private signal, and
+        // we only connect once
+        std::ignore =
+            this->userStateChanged_.connect([this, lineMod, timeout]() mutable {
+                TwitchChannel *twitchChannel = dynamic_cast<TwitchChannel *>(
+                    this->underlyingChannel_.get());
 
-            bool hasModRights =
-                twitchChannel ? twitchChannel->hasModRights() : false;
-            lineMod->setVisible(hasModRights);
-            timeout->setVisible(hasModRights);
-        });
+                bool hasModRights =
+                    twitchChannel ? twitchChannel->hasModRights() : false;
+                lineMod->setVisible(hasModRights);
+                timeout->setVisible(hasModRights);
+            });
 
-        timeout->buttonClicked.connect([this](auto item) {
+        // We can safely ignore this signal connection since we own the button, and
+        // the button will always be destroyed before the UserInfoPopup
+        std::ignore = timeout->buttonClicked.connect([this](auto item) {
             TimeoutWidget::Action action;
             int arg;
             std::tie(action, arg) = item;

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -227,7 +227,9 @@ void ChannelView::initializeLayout()
 
 void ChannelView::initializeScrollbar()
 {
-    this->scrollBar_->getCurrentValueChanged().connect([this] {
+    // We can safely ignore the scroll bar's signal connection since the scroll bar will
+    // always be destroyed before the ChannelView
+    std::ignore = this->scrollBar_->getCurrentValueChanged().connect([this] {
         if (this->isVisible())
         {
             this->performLayout(true);

--- a/src/widgets/settingspages/AccountsPage.cpp
+++ b/src/widgets/settingspages/AccountsPage.cpp
@@ -33,7 +33,8 @@ AccountsPage::AccountsPage()
     view->getTableView()->horizontalHeader()->setVisible(false);
     view->getTableView()->horizontalHeader()->setStretchLastSection(true);
 
-    view->addButtonPressed.connect([this] {
+    // We can safely ignore this signal connection since we own the view
+    std::ignore = view->addButtonPressed.connect([this] {
         LoginDialog d(this);
         d.exec();
     });

--- a/src/widgets/settingspages/CommandPage.cpp
+++ b/src/widgets/settingspages/CommandPage.cpp
@@ -45,7 +45,8 @@ CommandPage::CommandPage()
     view->setTitles({"Trigger", "Command", "Show In\nMessage Menu"});
     view->getTableView()->horizontalHeader()->setSectionResizeMode(
         1, QHeaderView::Stretch);
-    view->addButtonPressed.connect([] {
+    // We can safely ignore this signal connection since we own the view
+    std::ignore = view->addButtonPressed.connect([] {
         getApp()->commands->items.append(
             Command{"/command", "I made a new command HeyGuys"});
     });

--- a/src/widgets/settingspages/FiltersPage.cpp
+++ b/src/widgets/settingspages/FiltersPage.cpp
@@ -44,7 +44,8 @@ FiltersPage::FiltersPage()
         view->getTableView()->setColumnWidth(2, 125);
     });
 
-    view->addButtonPressed.connect([] {
+    // We can safely ignore this signal connection since we own the view
+    std::ignore = view->addButtonPressed.connect([] {
         ChannelFilterEditorDialog d(
             static_cast<QWidget *>(&(getApp()->windows->getMainWindow())));
         if (d.exec() == QDialog::Accepted)

--- a/src/widgets/settingspages/GeneralPageView.cpp
+++ b/src/widgets/settingspages/GeneralPageView.cpp
@@ -195,13 +195,17 @@ ColorButton *GeneralPageView::addColorButton(
             auto dialog = new ColorPickerDialog(QColor(setting), this);
             dialog->setAttribute(Qt::WA_DeleteOnClose);
             dialog->show();
-            dialog->closed.connect([&setting, colorButton](QColor selected) {
-                if (selected.isValid())
-                {
-                    setting = selected.name(QColor::HexArgb);
-                    colorButton->setColor(selected);
-                }
-            });
+            // We can safely ignore this signal connection, for now, since the
+            // colorButton & setting are never deleted and the signal is deleted
+            // once the dialog is closed
+            std::ignore = dialog->closed.connect(
+                [&setting, colorButton](QColor selected) {
+                    if (selected.isValid())
+                    {
+                        setting = selected.name(QColor::HexArgb);
+                        colorButton->setColor(selected);
+                    }
+                });
         });
 
     this->groups_.back().widgets.push_back({label, {text}});

--- a/src/widgets/settingspages/HighlightingPage.cpp
+++ b/src/widgets/settingspages/HighlightingPage.cpp
@@ -90,7 +90,8 @@ HighlightingPage::HighlightingPage()
                     view->getTableView()->setColumnWidth(0, 400);
                 });
 
-                view->addButtonPressed.connect([] {
+                // We can safely ignore this signal connection since we own the view
+                std::ignore = view->addButtonPressed.connect([] {
                     getSettings()->highlightedMessages.append(HighlightPhrase{
                         "my phrase", true, true, false, false, false, "",
                         *ColorProvider::instance().color(
@@ -141,7 +142,8 @@ HighlightingPage::HighlightingPage()
                     view->getTableView()->setColumnWidth(0, 200);
                 });
 
-                view->addButtonPressed.connect([] {
+                // We can safely ignore this signal connection since we own the view
+                std::ignore = view->addButtonPressed.connect([] {
                     getSettings()->highlightedUsers.append(HighlightPhrase{
                         "highlighted user", true, true, false, false, false, "",
                         *ColorProvider::instance().color(
@@ -182,7 +184,8 @@ HighlightingPage::HighlightingPage()
                     view->getTableView()->setColumnWidth(0, 200);
                 });
 
-                view->addButtonPressed.connect([this] {
+                // We can safely ignore this signal connection since we own the view
+                std::ignore = view->addButtonPressed.connect([this] {
                     auto d = std::make_shared<BadgePickerDialog>(
                         availableBadges, this);
 
@@ -236,7 +239,8 @@ HighlightingPage::HighlightingPage()
                     view->getTableView()->setColumnWidth(0, 200);
                 });
 
-                view->addButtonPressed.connect([] {
+                // We can safely ignore this signal connection since we own the view
+                std::ignore = view->addButtonPressed.connect([] {
                     getSettings()->blacklistedUsers.append(
                         HighlightBlacklistUser{"blacklisted user", false});
                 });
@@ -329,7 +333,10 @@ void HighlightingPage::openColorDialog(const QModelIndex &clicked,
     auto dialog = new ColorPickerDialog(initial, this);
     dialog->setAttribute(Qt::WA_DeleteOnClose);
     dialog->show();
-    dialog->closed.connect([=](auto selected) {
+    // We can safely ignore this signal connection since the view and tab are never deleted
+    // TODO: The QModelIndex clicked is technically not safe to persist here since the model
+    // can be changed between the color dialog being created & the color dialog being closed
+    std::ignore = dialog->closed.connect([=](auto selected) {
         if (selected.isValid())
         {
             view->getModel()->setData(clicked, selected, Qt::DecorationRole);

--- a/src/widgets/settingspages/IgnoresPage.cpp
+++ b/src/widgets/settingspages/IgnoresPage.cpp
@@ -63,7 +63,8 @@ void addPhrasesTab(LayoutCreator<QVBoxLayout> layout)
         view->getTableView()->setColumnWidth(0, 200);
     });
 
-    view->addButtonPressed.connect([] {
+    // We can safely ignore this signal connection since we own the view
+    std::ignore = view->addButtonPressed.connect([] {
         getSettings()->ignoredMessages.append(
             IgnorePhrase{"my pattern", false, false,
                          getSettings()->ignoredPhraseReplace.getValue(), true});

--- a/src/widgets/settingspages/KeyboardSettingsPage.cpp
+++ b/src/widgets/settingspages/KeyboardSettingsPage.cpp
@@ -34,7 +34,8 @@ KeyboardSettingsPage::KeyboardSettingsPage()
     view->getTableView()->horizontalHeader()->setSectionResizeMode(
         1, QHeaderView::Stretch);
 
-    view->addButtonPressed.connect([view, model] {
+    // We can safely ignore this signal connection since we own the view
+    std::ignore = view->addButtonPressed.connect([view, model] {
         EditHotkeyDialog dialog(nullptr);
         bool wasAccepted = dialog.exec() == 1;
 

--- a/src/widgets/settingspages/ModerationPage.cpp
+++ b/src/widgets/settingspages/ModerationPage.cpp
@@ -169,7 +169,8 @@ ModerationPage::ModerationPage()
         view->getTableView()->horizontalHeader()->setSectionResizeMode(
             0, QHeaderView::Stretch);
 
-        view->addButtonPressed.connect([] {
+        // We can safely ignore this signal connection since we own the view
+        std::ignore = view->addButtonPressed.connect([] {
             getSettings()->loggedChannels.append(ChannelLog("channel"));
         });
 
@@ -209,7 +210,8 @@ ModerationPage::ModerationPage()
         view->getTableView()->horizontalHeader()->setSectionResizeMode(
             0, QHeaderView::Stretch);
 
-        view->addButtonPressed.connect([] {
+        // We can safely ignore this signal connection since we own the view
+        std::ignore = view->addButtonPressed.connect([] {
             getSettings()->moderationActions.append(
                 ModerationAction("/timeout {user.name} 300"));
         });

--- a/src/widgets/settingspages/NicknamesPage.cpp
+++ b/src/widgets/settingspages/NicknamesPage.cpp
@@ -36,7 +36,8 @@ NicknamesPage::NicknamesPage()
     view->getTableView()->horizontalHeader()->setSectionResizeMode(
         1, QHeaderView::Stretch);
 
-    view->addButtonPressed.connect([] {
+    // We can safely ignore this signal connection since we own the view
+    std::ignore = view->addButtonPressed.connect([] {
         getSettings()->nicknames.append(
             Nickname{"Username", "Nickname", false, false});
     });

--- a/src/widgets/settingspages/NotificationPage.cpp
+++ b/src/widgets/settingspages/NotificationPage.cpp
@@ -109,7 +109,8 @@ NotificationPage::NotificationPage()
                     view->getTableView()->setColumnWidth(0, 200);
                 });
 
-                view->addButtonPressed.connect([] {
+                // We can safely ignore this signal connection since we own the view
+                std::ignore = view->addButtonPressed.connect([] {
                     getApp()
                         ->notifications->channelMap[Platform::Twitch]
                         .append("channel");

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -231,13 +231,16 @@ SplitHeader::SplitHeader(Split *split)
     this->handleChannelChanged();
     this->updateModerationModeIcon();
 
-    this->split_->focused.connect([this]() {
+    // The lifetime of these signals are tied to the lifetime of the Split.
+    // Since the SplitHeader is owned by the Split, they will always be destroyed
+    // at the same time.
+    std::ignore = this->split_->focused.connect([this]() {
         this->themeChangedEvent();
     });
-    this->split_->focusLost.connect([this]() {
+    std::ignore = this->split_->focusLost.connect([this]() {
         this->themeChangedEvent();
     });
-    this->split_->channelChanged.connect([this]() {
+    std::ignore = this->split_->channelChanged.connect([this]() {
         this->handleChannelChanged();
     });
 

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -260,6 +260,8 @@ SplitHeader::SplitHeader(Split *split)
 
 void SplitHeader::initializeLayout()
 {
+    assert(this->layout() == nullptr);
+
     auto *layout = makeLayout<QHBoxLayout>({
         // space
         makeWidget<BaseWidget>([](auto w) {

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -44,43 +44,45 @@ using namespace chatterino;
 // 5 minutes
 constexpr const uint64_t THUMBNAIL_MAX_AGE_MS = 5ULL * 60 * 1000;
 
-auto formatRoomMode(TwitchChannel &channel) -> QString
+auto formatRoomModeUnclean(
+    const SharedAccessGuard<const TwitchChannel::RoomModes> &modes) -> QString
 {
     QString text;
 
+    if (modes->r9k)
     {
-        auto modes = channel.accessRoomModes();
-
-        if (modes->r9k)
+        text += "r9k, ";
+    }
+    if (modes->slowMode > 0)
+    {
+        text += QString("slow(%1), ").arg(localizeNumbers(modes->slowMode));
+    }
+    if (modes->emoteOnly)
+    {
+        text += "emote, ";
+    }
+    if (modes->submode)
+    {
+        text += "sub, ";
+    }
+    if (modes->followerOnly != -1)
+    {
+        if (modes->followerOnly != 0)
         {
-            text += "r9k, ";
+            text += QString("follow(%1m), ")
+                        .arg(localizeNumbers(modes->followerOnly));
         }
-        if (modes->slowMode > 0)
+        else
         {
-            text += QString("slow(%1), ").arg(localizeNumbers(modes->slowMode));
-        }
-        if (modes->emoteOnly)
-        {
-            text += "emote, ";
-        }
-        if (modes->submode)
-        {
-            text += "sub, ";
-        }
-        if (modes->followerOnly != -1)
-        {
-            if (modes->followerOnly != 0)
-            {
-                text += QString("follow(%1m), ")
-                            .arg(localizeNumbers(modes->followerOnly));
-            }
-            else
-            {
-                text += QString("follow, ");
-            }
+            text += QString("follow, ");
         }
     }
 
+    return text;
+}
+
+void cleanRoomModeText(QString &text, bool hasModRights)
+{
     if (text.length() > 2)
     {
         text = text.mid(0, text.size() - 2);
@@ -97,12 +99,10 @@ auto formatRoomMode(TwitchChannel &channel) -> QString
         }
     }
 
-    if (text.isEmpty() && channel.hasModRights())
+    if (text.isEmpty() && hasModRights)
     {
-        return "none";
+        text = "none";
     }
-
-    return text;
 }
 
 auto formatTooltip(const TwitchChannel::StreamStatus &s, QString thumbnail)
@@ -280,7 +280,6 @@ void SplitHeader::initializeLayout()
         this->modeButton_ = makeWidget<EffectLabel>([&](auto w) {
             w->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
             w->hide();
-            this->initializeModeSignals(*w);
             w->setMenu(this->createChatModeMenu());
         }),
         // moderator
@@ -576,43 +575,23 @@ std::unique_ptr<QMenu> SplitHeader::createChatModeMenu()
 {
     auto menu = std::make_unique<QMenu>();
 
-    auto *setSub = new QAction("Subscriber only", this);
-    auto *setEmote = new QAction("Emote only", this);
-    auto *setSlow = new QAction("Slow", this);
-    auto *setR9k = new QAction("R9K", this);
-    auto *setFollowers = new QAction("Followers only", this);
+    this->modeActionSetSub = new QAction("Subscriber only", this);
+    this->modeActionSetEmote = new QAction("Emote only", this);
+    this->modeActionSetSlow = new QAction("Slow", this);
+    this->modeActionSetR9k = new QAction("R9K", this);
+    this->modeActionSetFollowers = new QAction("Followers only", this);
 
-    setFollowers->setCheckable(true);
-    setSub->setCheckable(true);
-    setEmote->setCheckable(true);
-    setSlow->setCheckable(true);
-    setR9k->setCheckable(true);
+    this->modeActionSetFollowers->setCheckable(true);
+    this->modeActionSetSub->setCheckable(true);
+    this->modeActionSetEmote->setCheckable(true);
+    this->modeActionSetSlow->setCheckable(true);
+    this->modeActionSetR9k->setCheckable(true);
 
-    menu->addAction(setEmote);
-    menu->addAction(setSub);
-    menu->addAction(setSlow);
-    menu->addAction(setR9k);
-    menu->addAction(setFollowers);
-
-    this->managedConnections_.managedConnect(
-        this->modeUpdateRequested_,
-        [this, setSub, setEmote, setSlow, setR9k, setFollowers]() {
-            auto *twitchChannel =
-                dynamic_cast<TwitchChannel *>(this->split_->getChannel().get());
-            if (twitchChannel == nullptr)
-            {
-                this->modeButton_->hide();
-                return;
-            }
-
-            auto roomModes = twitchChannel->accessRoomModes();
-
-            setR9k->setChecked(roomModes->r9k);
-            setSlow->setChecked(roomModes->slowMode > 0);
-            setEmote->setChecked(roomModes->emoteOnly);
-            setSub->setChecked(roomModes->submode);
-            setFollowers->setChecked(roomModes->followerOnly != -1);
-        });
+    menu->addAction(this->modeActionSetEmote);
+    menu->addAction(this->modeActionSetSub);
+    menu->addAction(this->modeActionSetSlow);
+    menu->addAction(this->modeActionSetR9k);
+    menu->addAction(this->modeActionSetFollowers);
 
     auto execCommand = [this](const QString &command) {
         auto text = getApp()->getCommands()->execCommand(
@@ -625,44 +604,44 @@ std::unique_ptr<QMenu> SplitHeader::createChatModeMenu()
         action->setChecked(!action->isChecked());
     };
 
-    QObject::connect(setSub, &QAction::triggered, this,
-                     [setSub, toggle]() mutable {
-                         toggle("/subscribers", setSub);
+    QObject::connect(this->modeActionSetSub, &QAction::triggered, this,
+                     [this, toggle]() mutable {
+                         toggle("/subscribers", this->modeActionSetSub);
                      });
 
-    QObject::connect(setEmote, &QAction::triggered, this,
-                     [setEmote, toggle]() mutable {
-                         toggle("/emoteonly", setEmote);
+    QObject::connect(this->modeActionSetEmote, &QAction::triggered, this,
+                     [this, toggle]() mutable {
+                         toggle("/emoteonly", this->modeActionSetEmote);
                      });
 
-    QObject::connect(
-        setSlow, &QAction::triggered, this, [setSlow, this, execCommand]() {
-            if (!setSlow->isChecked())
-            {
-                execCommand("/slowoff");
-                setSlow->setChecked(false);
-                return;
-            };
-            auto ok = bool();
-            auto seconds =
-                QInputDialog::getInt(this, "", "Seconds:", 10, 0, 500, 1, &ok,
-                                     Qt::FramelessWindowHint);
-            if (ok)
-            {
-                execCommand(QString("/slow %1").arg(seconds));
-            }
-            else
-            {
-                setSlow->setChecked(false);
-            }
-        });
+    QObject::connect(this->modeActionSetSlow, &QAction::triggered, this,
+                     [this, execCommand]() {
+                         if (!this->modeActionSetSlow->isChecked())
+                         {
+                             execCommand("/slowoff");
+                             this->modeActionSetSlow->setChecked(false);
+                             return;
+                         };
+                         auto ok = bool();
+                         auto seconds = QInputDialog::getInt(
+                             this, "", "Seconds:", 10, 0, 500, 1, &ok,
+                             Qt::FramelessWindowHint);
+                         if (ok)
+                         {
+                             execCommand(QString("/slow %1").arg(seconds));
+                         }
+                         else
+                         {
+                             this->modeActionSetSlow->setChecked(false);
+                         }
+                     });
 
-    QObject::connect(setFollowers, &QAction::triggered, this,
-                     [setFollowers, this, execCommand]() {
-                         if (!setFollowers->isChecked())
+    QObject::connect(this->modeActionSetFollowers, &QAction::triggered, this,
+                     [this, execCommand]() {
+                         if (!this->modeActionSetFollowers->isChecked())
                          {
                              execCommand("/followersoff");
-                             setFollowers->setChecked(false);
+                             this->modeActionSetFollowers->setChecked(false);
                              return;
                          };
                          auto ok = bool();
@@ -676,13 +655,13 @@ std::unique_ptr<QMenu> SplitHeader::createChatModeMenu()
                          }
                          else
                          {
-                             setFollowers->setChecked(false);
+                             this->modeActionSetFollowers->setChecked(false);
                          }
                      });
 
-    QObject::connect(setR9k, &QAction::triggered, this,
-                     [setR9k, toggle]() mutable {
-                         toggle("/r9kbeta", setR9k);
+    QObject::connect(this->modeActionSetR9k, &QAction::triggered, this,
+                     [this, toggle]() mutable {
+                         toggle("/r9kbeta", this->modeActionSetR9k);
                      });
 
     return menu;
@@ -690,30 +669,47 @@ std::unique_ptr<QMenu> SplitHeader::createChatModeMenu()
 
 void SplitHeader::updateRoomModes()
 {
-    this->modeUpdateRequested_.invoke();
-}
+    assert(this->modeButton_ != nullptr);
 
-void SplitHeader::initializeModeSignals(EffectLabel &label)
-{
-    this->modeUpdateRequested_.connect([this, &label] {
-        if (auto *twitchChannel =
-                dynamic_cast<TwitchChannel *>(this->split_->getChannel().get()))
+    // Update the mode button
+    if (auto *twitchChannel =
+            dynamic_cast<TwitchChannel *>(this->split_->getChannel().get()))
+    {
+        this->modeButton_->setEnable(twitchChannel->hasModRights());
+
+        QString text;
         {
-            label.setEnable(twitchChannel->hasModRights());
+            auto roomModes = twitchChannel->accessRoomModes();
+            text = formatRoomModeUnclean(roomModes);
 
-            // set the label text
-            auto text = formatRoomMode(*twitchChannel);
+            // Set menu action
+            this->modeActionSetR9k->setChecked(roomModes->r9k);
+            this->modeActionSetSlow->setChecked(roomModes->slowMode > 0);
+            this->modeActionSetEmote->setChecked(roomModes->emoteOnly);
+            this->modeActionSetSub->setChecked(roomModes->submode);
+            this->modeActionSetFollowers->setChecked(roomModes->followerOnly !=
+                                                     -1);
+        }
+        cleanRoomModeText(text, twitchChannel->hasModRights());
 
-            if (!text.isEmpty())
-            {
-                label.getLabel().setText(text);
-                label.show();
-                return;
-            }
+        // set the label text
+
+        if (!text.isEmpty())
+        {
+            this->modeButton_->getLabel().setText(text);
+            this->modeButton_->show();
+        }
+        else
+        {
+            this->modeButton_->hide();
         }
 
-        label.hide();
-    });
+        // Update the mode button menu actions
+    }
+    else
+    {
+        this->modeButton_->hide();
+    }
 }
 
 void SplitHeader::resetThumbnail()

--- a/src/widgets/splits/SplitHeader.hpp
+++ b/src/widgets/splits/SplitHeader.hpp
@@ -32,6 +32,8 @@ public:
 
     void updateChannelText();
     void updateModerationModeIcon();
+    // Invoked when SplitHeader should update anything refering to a TwitchChannel's mode
+    // has changed (e.g. sub mode toggled)
     void updateRoomModes();
 
 protected:
@@ -75,7 +77,14 @@ private:
     // ui
     Button *dropdownButton_{};
     Label *titleLabel_{};
+
     EffectLabel *modeButton_{};
+    QAction *modeActionSetEmote{};
+    QAction *modeActionSetSub{};
+    QAction *modeActionSetSlow{};
+    QAction *modeActionSetR9k{};
+    QAction *modeActionSetFollowers{};
+
     Button *moderationButton_{};
     Button *viewersButton_{};
     Button *addButton_{};
@@ -86,8 +95,8 @@ private:
     bool doubleClicked_{false};
     bool menuVisible_{false};
 
-    // signals
-    pajlada::Signals::NoArgSignal modeUpdateRequested_;
+    // managedConnections_ contains connections for signals that are not managed by us
+    // and don't change when the parent Split changes its underlying channel
     pajlada::Signals::SignalHolder managedConnections_;
     pajlada::Signals::SignalHolder channelConnections_;
     std::vector<boost::signals2::scoped_connection> bSignals_;

--- a/src/widgets/splits/SplitInput.hpp
+++ b/src/widgets/splits/SplitInput.hpp
@@ -91,6 +91,9 @@ protected:
     void addShortcuts() override;
     void initLayout();
     bool eventFilter(QObject *obj, QEvent *event) override;
+#ifdef DEBUG
+    bool keyPressedEventInstalled{};
+#endif
     void installKeyPressedEvent();
     void onCursorPositionChanged();
     void onTextChanged();


### PR DESCRIPTION
# Description

- Fix nodiscard warnings for SplitHeader split connections
- Clean up SplitHeader's mode update code
- SplitHeader: Ensure the layout is only created once
- Clean up SplitInput signal connection handling
- Clean up ReplyThreadPopup signal ignores
- Clean up Application signal connections
- Clean up AccountController signal connections
- Clean up CommandController signal connections
- Clean up NotificationController signal connections
- Clean up Irc2 signal connections
- Change IrcConnection's smartReconnect signal into a function
- Fix signal connections in SelectChannelDialog
- Clean up ChannelView signal connections
- Clean up Split signal connections
- Clean up HighlightingPage signal connections
- Clean up IgnoresPage signal connections
- Clean up ModerationPage signal connections
- Clean up NotificationPage signal connections
- Clean up KeyboardSettingsPage signal connections
- Clean up FiltersPage signal connections
- Clean up GeneralPageView signal connections
- Clean up NicknamesPage signal connections
- Clean up AccountsPage signal connections
- Clean up CommandPage signal connections
- Clean up UserInfoPopup signal connections
- Clean up EmotePopup signal connections
- Clean up TwitchAccountManager signal connections
- Clean up Logging signal connections
- Clean up TwitchIrcServer signal connections
- Mini TwitchIrcServer.cpp refactor :tf:
- Clean up AccountSwitchWidget signal connections when it gets destroyed
- Clean up signal connection in WindowManager
- Clean up InitUpdateButton signal connections
- Clean up some TwitchChannel signal connections
- TwitchChannel/Channel: Convert the `messageRemovedFromStart` signal into a virtual protected function
- TwitchChannel: Refactor roomIdChanged into a function
- random clang-format reformat on TwitchChannel::threads for some reason

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
