### PR TITLE
fix: QuickSwitcherPopup now pops up in the selected window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Bugfix: Fixed `/shoutout` command not working with usernames starting with @'s (e.g. `/shoutout @forsen`). (#4800)
 - Bugfix: Fixed selection of tabs after closing a tab when using "Live Tabs Only". (#4770)
 - Bugfix: Fixed input in reply thread popup losing focus when dragging. (#4815)
+- Bugfix: Fixed the Quick Switcher (CTRL+K) from sometimes showing up on the wrong window. (#4819)
 - Dev: Fixed UTF16 encoding of `modes` file for the installer. (#4791)
 - Dev: Temporarily disable High DPI scaling on Qt6 builds on Windows. (#4767)
 - Dev: Tests now run on Ubuntu 22.04 instead of 20.04 to loosen C++ restrictions in tests. (#4774)

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -485,9 +485,8 @@ void Window::addShortcuts()
              return "";
          }},
         {"openQuickSwitcher",
-         [](std::vector<QString>) -> QString {
-             auto quickSwitcher =
-                 new QuickSwitcherPopup(&getApp()->windows->getMainWindow());
+         [this](std::vector<QString>) -> QString {
+             auto *quickSwitcher = new QuickSwitcherPopup(this);
              quickSwitcher->show();
              return "";
          }},

--- a/src/widgets/dialogs/switcher/NewTabItem.cpp
+++ b/src/widgets/dialogs/switcher/NewTabItem.cpp
@@ -12,16 +12,17 @@
 
 namespace chatterino {
 
-NewTabItem::NewTabItem(const QString &channelName)
+NewTabItem::NewTabItem(Window *window_, const QString &channelName)
     : AbstractSwitcherItem(QIcon(":/switcher/plus.svg"))
     , channelName_(channelName)
     , text_(QString(TEXT_FORMAT).arg(channelName))
+    , window(window_)
 {
 }
 
 void NewTabItem::action()
 {
-    auto &nb = getApp()->windows->getMainWindow().getNotebook();
+    auto &nb = this->window->getNotebook();
     SplitContainer *container = nb.addPage(true);
 
     Split *split = new Split(container);

--- a/src/widgets/dialogs/switcher/NewTabItem.hpp
+++ b/src/widgets/dialogs/switcher/NewTabItem.hpp
@@ -4,6 +4,8 @@
 
 namespace chatterino {
 
+class Window;
+
 class NewTabItem : public AbstractSwitcherItem
 {
 public:
@@ -13,7 +15,7 @@ public:
      *
      * @param   channelName name of channel to open
      */
-    NewTabItem(const QString &channelName);
+    NewTabItem(Window *window_, const QString &channelName);
 
     /**
      * @brief   Open the channel passed in the constructor in a new tab.
@@ -27,6 +29,7 @@ private:
     static constexpr const char *TEXT_FORMAT = "Open channel \"%1\" in new tab";
     QString channelName_;
     QString text_;
+    Window *window{};
 };
 
 }  // namespace chatterino

--- a/src/widgets/dialogs/switcher/QuickSwitcherPopup.cpp
+++ b/src/widgets/dialogs/switcher/QuickSwitcherPopup.cpp
@@ -18,11 +18,11 @@
 namespace chatterino {
 
 namespace {
-    QList<SplitContainer *> openPages()
+    QList<SplitContainer *> openPages(Window *window)
     {
         QList<SplitContainer *> pages;
 
-        auto &nb = getApp()->windows->getMainWindow().getNotebook();
+        auto &nb = window->getNotebook();
         for (int i = 0; i < nb.getPageCount(); ++i)
         {
             pages.append(static_cast<SplitContainer *>(nb.getPageAt(i)));
@@ -34,11 +34,12 @@ namespace {
 
 const QSize QuickSwitcherPopup::MINIMUM_SIZE(500, 300);
 
-QuickSwitcherPopup::QuickSwitcherPopup(QWidget *parent)
+QuickSwitcherPopup::QuickSwitcherPopup(Window *parent)
     : BasePopup({BaseWindow::Flags::Frameless, BaseWindow::Flags::TopMost,
                  BaseWindow::DisableLayoutSave},
                 parent)
     , switcherModel_(this)
+    , window(parent)
 {
     this->setWindowFlag(Qt::Dialog);
     this->setActionOnFocusLoss(BaseWindow::ActionOnFocusLoss::Delete);
@@ -86,7 +87,7 @@ void QuickSwitcherPopup::updateSuggestions(const QString &text)
     this->switcherModel_.clear();
 
     // Add items for navigating to different splits
-    for (auto *sc : openPages())
+    for (auto *sc : openPages(this->window))
     {
         const QString &tabTitle = sc->getTab()->getTitle();
         const auto splits = sc->getSplits();

--- a/src/widgets/dialogs/switcher/QuickSwitcherPopup.cpp
+++ b/src/widgets/dialogs/switcher/QuickSwitcherPopup.cpp
@@ -15,22 +15,26 @@
 #include "widgets/splits/SplitContainer.hpp"
 #include "widgets/Window.hpp"
 
-namespace chatterino {
-
 namespace {
-    QList<SplitContainer *> openPages(Window *window)
+
+using namespace chatterino;
+
+QList<SplitContainer *> openPages(Window *window)
+{
+    QList<SplitContainer *> pages;
+
+    auto &nb = window->getNotebook();
+    for (int i = 0; i < nb.getPageCount(); ++i)
     {
-        QList<SplitContainer *> pages;
-
-        auto &nb = window->getNotebook();
-        for (int i = 0; i < nb.getPageCount(); ++i)
-        {
-            pages.append(static_cast<SplitContainer *>(nb.getPageAt(i)));
-        }
-
-        return pages;
+        pages.append(static_cast<SplitContainer *>(nb.getPageAt(i)));
     }
+
+    return pages;
+}
+
 }  // namespace
+
+namespace chatterino {
 
 const QSize QuickSwitcherPopup::MINIMUM_SIZE(500, 300);
 

--- a/src/widgets/dialogs/switcher/QuickSwitcherPopup.cpp
+++ b/src/widgets/dialogs/switcher/QuickSwitcherPopup.cpp
@@ -36,8 +36,6 @@ QList<SplitContainer *> openPages(Window *window)
 
 namespace chatterino {
 
-const QSize QuickSwitcherPopup::MINIMUM_SIZE(500, 300);
-
 QuickSwitcherPopup::QuickSwitcherPopup(Window *parent)
     : BasePopup({BaseWindow::Flags::Frameless, BaseWindow::Flags::TopMost,
                  BaseWindow::DisableLayoutSave},

--- a/src/widgets/dialogs/switcher/QuickSwitcherPopup.cpp
+++ b/src/widgets/dialogs/switcher/QuickSwitcherPopup.cpp
@@ -122,7 +122,7 @@ void QuickSwitcherPopup::updateSuggestions(const QString &text)
     // Add item for opening a channel in a new tab or new popup
     if (!text.isEmpty())
     {
-        auto newTabItem = std::make_unique<NewTabItem>(text);
+        auto newTabItem = std::make_unique<NewTabItem>(this->window, text);
         this->switcherModel_.addItem(std::move(newTabItem));
 
         auto newPopupItem = std::make_unique<NewPopupItem>(text);

--- a/src/widgets/dialogs/switcher/QuickSwitcherPopup.hpp
+++ b/src/widgets/dialogs/switcher/QuickSwitcherPopup.hpp
@@ -10,6 +10,7 @@
 namespace chatterino {
 
 class GenericListView;
+class Window;
 
 class QuickSwitcherPopup : public BasePopup
 {
@@ -17,10 +18,10 @@ public:
     /**
      * @brief   Construct a new QuickSwitcherPopup.
      *
-     * @param   parent  Parent widget of the popup. The popup will be placed
-     *                  in the center of the parent widget.
+     * @param   parent  Parent window of the popup. The popup will be placed
+     *                  in the center of the window.
      */
-    explicit QuickSwitcherPopup(QWidget *parent = nullptr);
+    explicit QuickSwitcherPopup(Window *parent);
 
 protected:
     virtual void themeChangedEvent() override;
@@ -37,6 +38,8 @@ private:
     } ui_;
 
     QuickSwitcherModel switcherModel_;
+
+    Window *window{};
 
     void initWidgets();
 };

--- a/src/widgets/dialogs/switcher/QuickSwitcherPopup.hpp
+++ b/src/widgets/dialogs/switcher/QuickSwitcherPopup.hpp
@@ -24,7 +24,7 @@ public:
     explicit QuickSwitcherPopup(Window *parent);
 
 protected:
-    virtual void themeChangedEvent() override;
+    void themeChangedEvent() override;
 
 public slots:
     void updateSuggestions(const QString &text);

--- a/src/widgets/dialogs/switcher/QuickSwitcherPopup.hpp
+++ b/src/widgets/dialogs/switcher/QuickSwitcherPopup.hpp
@@ -30,7 +30,7 @@ public slots:
     void updateSuggestions(const QString &text);
 
 private:
-    static const QSize MINIMUM_SIZE;
+    constexpr static const QSize MINIMUM_SIZE{500, 300};
 
     struct {
         QLineEdit *searchEdit{};


### PR DESCRIPTION
# Description

- fix: QuickSwitcherPopup now pops up in the selected window
- QuickSwitcherPopup: reduce indentation anon namespace
- QuickSwitcherPopup: constexpr the minimum size
- QuickSwitcherPopup: remove redundant virtual from `themeChangedEvent`

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
