### PR TITLE
Cleanup Windows helpers

### DIFF
--- a/src/util/WindowsHelper.cpp
+++ b/src/util/WindowsHelper.cpp
@@ -1,4 +1,6 @@
-#include "WindowsHelper.hpp"
+#include "util/WindowsHelper.hpp"
+
+#include "common/Literals.hpp"
 
 #include <QApplication>
 #include <QClipboard>
@@ -8,23 +10,18 @@
 #ifdef USEWINSDK
 
 #    include <Ole2.h>
+#    include <ShellScalingApi.h>
 #    include <Shlwapi.h>
 #    include <VersionHelpers.h>
 
 namespace chatterino {
 
-typedef enum MONITOR_DPI_TYPE {
-    MDT_EFFECTIVE_DPI = 0,
-    MDT_ANGULAR_DPI = 1,
-    MDT_RAW_DPI = 2,
-    MDT_DEFAULT = MDT_EFFECTIVE_DPI
-} MONITOR_DPI_TYPE;
+using namespace literals;
 
-typedef HRESULT(CALLBACK *GetDpiForMonitor_)(HMONITOR, MONITOR_DPI_TYPE, UINT *,
-                                             UINT *);
-typedef HRESULT(CALLBACK *AssocQueryString_)(ASSOCF, ASSOCSTR, LPCWSTR, LPCWSTR,
-                                             LPWSTR, DWORD *);
+using GetDpiForMonitor_ = HRESULT CALLBACK (*)(HMONITOR, MONITOR_DPI_TYPE,
+                                               UINT *, UINT *);
 
+// TODO: This should be changed to `GetDpiForWindow`.
 boost::optional<UINT> getWindowDpi(HWND hwnd)
 {
     static HINSTANCE shcore = LoadLibrary(L"Shcore.dll");
@@ -36,8 +33,8 @@ boost::optional<UINT> getWindowDpi(HWND hwnd)
             HMONITOR monitor =
                 MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
 
-            UINT xScale, yScale;
-
+            UINT xScale = 96;
+            UINT yScale = 96;
             getDpiForMonitor(monitor, MDT_DEFAULT, &xScale, &yScale);
 
             return xScale;
@@ -55,19 +52,19 @@ void flushClipboard()
     }
 }
 
-constexpr const char *runKey =
-    "HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Run";
+const QString RUN_KEY =
+    uR"(HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run)"_s;
 
 bool isRegisteredForStartup()
 {
-    QSettings settings(runKey, QSettings::NativeFormat);
+    QSettings settings(RUN_KEY, QSettings::NativeFormat);
 
     return !settings.value("Chatterino").toString().isEmpty();
 }
 
 void setRegisteredForStartup(bool isRegistered)
 {
-    QSettings settings(runKey, QSettings::NativeFormat);
+    QSettings settings(RUN_KEY, QSettings::NativeFormat);
 
     if (isRegistered)
     {
@@ -85,19 +82,6 @@ void setRegisteredForStartup(bool isRegistered)
 
 QString getAssociatedExecutable(AssociationQueryType queryType, LPCWSTR query)
 {
-    static HINSTANCE shlwapi = LoadLibrary(L"shlwapi");
-    if (shlwapi == nullptr)
-    {
-        return QString();
-    }
-
-    static auto assocQueryString =
-        AssocQueryString_(GetProcAddress(shlwapi, "AssocQueryStringW"));
-    if (assocQueryString == nullptr)
-    {
-        return QString();
-    }
-
     // always error out instead of returning a truncated string when the
     // buffer is too small - avoids race condition when the user changes their
     // default browser between calls to AssocQueryString
@@ -112,28 +96,28 @@ QString getAssociatedExecutable(AssociationQueryType queryType, LPCWSTR query)
         }
         else
         {
-            return QString();
+            return {};
         }
     }
 
     DWORD resultSize = 0;
-    if (FAILED(assocQueryString(flags, ASSOCSTR_EXECUTABLE, query, nullptr,
-                                nullptr, &resultSize)))
+    if (FAILED(AssocQueryStringW(flags, ASSOCSTR_EXECUTABLE, query, nullptr,
+                                 nullptr, &resultSize)))
     {
-        return QString();
+        return {};
     }
 
     if (resultSize <= 1)
     {
         // resultSize includes the null terminator. if resultSize is 1, the
         // returned value would be the empty string.
-        return QString();
+        return {};
     }
 
     QString result;
-    auto buf = new wchar_t[resultSize];
-    if (SUCCEEDED(assocQueryString(flags, ASSOCSTR_EXECUTABLE, query, nullptr,
-                                   buf, &resultSize)))
+    auto *buf = new wchar_t[resultSize];
+    if (SUCCEEDED(AssocQueryStringW(flags, ASSOCSTR_EXECUTABLE, query, nullptr,
+                                    buf, &resultSize)))
     {
         // QString::fromWCharArray expects the length in characters *not
         // including* the null terminator, but AssocQueryStringW calculates

--- a/src/util/WindowsHelper.cpp
+++ b/src/util/WindowsHelper.cpp
@@ -1,11 +1,13 @@
 #include "WindowsHelper.hpp"
 
-#include <QCoreApplication>
+#include <QApplication>
+#include <QClipboard>
 #include <QFileInfo>
 #include <QSettings>
 
 #ifdef USEWINSDK
 
+#    include <Ole2.h>
 #    include <Shlwapi.h>
 #    include <VersionHelpers.h>
 
@@ -45,18 +47,11 @@ boost::optional<UINT> getWindowDpi(HWND hwnd)
     return boost::none;
 }
 
-typedef HRESULT(CALLBACK *OleFlushClipboard_)();
-
 void flushClipboard()
 {
-    static HINSTANCE ole32 = LoadLibrary(L"Ole32.dll");
-    if (ole32 != nullptr)
+    if (QApplication::clipboard()->ownsClipboard())
     {
-        if (auto oleFlushClipboard =
-                OleFlushClipboard_(GetProcAddress(ole32, "OleFlushClipboard")))
-        {
-            oleFlushClipboard();
-        }
+        OleFlushClipboard();
     }
 }
 

--- a/src/util/WindowsHelper.cpp
+++ b/src/util/WindowsHelper.cpp
@@ -18,8 +18,8 @@ namespace chatterino {
 
 using namespace literals;
 
-using GetDpiForMonitor_ = HRESULT CALLBACK (*)(HMONITOR, MONITOR_DPI_TYPE,
-                                               UINT *, UINT *);
+using GetDpiForMonitor_ = HRESULT(CALLBACK *)(HMONITOR, MONITOR_DPI_TYPE,
+                                              UINT *, UINT *);
 
 // TODO: This should be changed to `GetDpiForWindow`.
 boost::optional<UINT> getWindowDpi(HWND hwnd)


### PR DESCRIPTION
# Description

This fixes an issue where `OleFlushClipboard` was called when not owning the clipboard (causes an exception) and cleans up the `WindowsHelper` code. I was too scared to make the change from `GetDpiForMonitor` to `GetDpiForWindow` (which is the preferred API), so I added a `TODO`.