### PR TITLE
Add the Changelog Category Check workflow

### DIFF
--- a/.github/workflows/changelog-category-check.yml
+++ b/.github/workflows/changelog-category-check.yml
@@ -1,0 +1,33 @@
+---
+name: Changelog Category Check
+
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  changelog-category-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        id: label-checker
+        with:
+          result-encoding: "string"
+          script: |
+            const response = await github.rest.issues.listLabelsOnIssue({
+              issue_number: context.payload.pull_request.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            });
+            if (new Set(response.data.map(label => label.name)).has("skip-changelog-checker")) {
+              return "skip";
+            }
+            return "";
+
+      - uses: pajlads/changelog-checker@v1.0.0
+        if: steps.label-checker.outputs.result != 'skip'


### PR DESCRIPTION
This ensures the changelog entry added, if any, is under the Unreleased category

This action can be skipped with the `skip-changelog-check` label

# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
