### PR TITLE
Fix selection rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Bugfix: Fixed selection of tabs after closing a tab when using "Live Tabs Only". (#4770)
 - Bugfix: Fixed input in reply thread popup losing focus when dragging. (#4815)
 - Bugfix: Fixed the Quick Switcher (CTRL+K) from sometimes showing up on the wrong window. (#4819)
-- Bugfix: Fixed too much text being copied when copying chat messages. (#4812)
+- Bugfix: Fixed too much text being copied when copying chat messages. (#4812, #4830)
 - Dev: Fixed UTF16 encoding of `modes` file for the installer. (#4791)
 - Dev: Temporarily disable High DPI scaling on Qt6 builds on Windows. (#4767)
 - Dev: Tests now run on Ubuntu 22.04 instead of 20.04 to loosen C++ restrictions in tests. (#4774)

--- a/src/messages/Selection.hpp
+++ b/src/messages/Selection.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <tuple>
 #include <utility>
@@ -8,11 +9,11 @@ namespace chatterino {
 
 struct SelectionItem {
     size_t messageIndex{0};
-    int charIndex{0};
+    size_t charIndex{0};
 
     SelectionItem() = default;
 
-    SelectionItem(size_t _messageIndex, int _charIndex)
+    SelectionItem(size_t _messageIndex, size_t _charIndex)
         : messageIndex(_messageIndex)
         , charIndex(_charIndex)
     {

--- a/src/messages/Selection.hpp
+++ b/src/messages/Selection.hpp
@@ -7,12 +7,12 @@
 namespace chatterino {
 
 struct SelectionItem {
-    uint32_t messageIndex{0};
-    uint32_t charIndex{0};
+    size_t messageIndex{0};
+    int charIndex{0};
 
     SelectionItem() = default;
 
-    SelectionItem(uint32_t _messageIndex, uint32_t _charIndex)
+    SelectionItem(size_t _messageIndex, int _charIndex)
         : messageIndex(_messageIndex)
         , charIndex(_charIndex)
     {
@@ -73,7 +73,7 @@ struct Selection {
     }
 
     // Shift all message selection indices `offset` back
-    void shiftMessageIndex(uint32_t offset)
+    void shiftMessageIndex(size_t offset)
     {
         if (offset > this->selectionMin.messageIndex)
         {

--- a/src/messages/layouts/MessageLayout.cpp
+++ b/src/messages/layouts/MessageLayout.cpp
@@ -424,7 +424,7 @@ const MessageLayoutElement *MessageLayout::getElementAt(QPoint point)
     return this->container_.getElementAt(point);
 }
 
-int MessageLayout::getLastCharacterIndex() const
+size_t MessageLayout::getLastCharacterIndex() const
 {
     return this->container_.getLastCharacterIndex();
 }

--- a/src/messages/layouts/MessageLayout.cpp
+++ b/src/messages/layouts/MessageLayout.cpp
@@ -143,7 +143,7 @@ void MessageLayout::actuallyLayout(int width, MessageElementFlags flags)
     bool hideSimilar = getSettings()->hideSimilar;
     bool hideReplies = !flags.has(MessageElementFlag::RepliedMessage);
 
-    this->container_.begin(width, this->scale_, messageFlags);
+    this->container_.beginLayout(width, this->scale_, messageFlags);
 
     for (const auto &element : this->message_->elements)
     {
@@ -184,7 +184,7 @@ void MessageLayout::actuallyLayout(int width, MessageElementFlags flags)
         this->deleteBuffer();
     }
 
-    this->container_.end();
+    this->container_.endLayout();
     this->height_ = this->container_.getHeight();
 
     // collapsed state

--- a/src/messages/layouts/MessageLayout.cpp
+++ b/src/messages/layouts/MessageLayout.cpp
@@ -429,12 +429,12 @@ size_t MessageLayout::getLastCharacterIndex() const
     return this->container_.getLastCharacterIndex();
 }
 
-int MessageLayout::getFirstMessageCharacterIndex() const
+size_t MessageLayout::getFirstMessageCharacterIndex() const
 {
     return this->container_.getFirstMessageCharacterIndex();
 }
 
-int MessageLayout::getSelectionIndex(QPoint position)
+size_t MessageLayout::getSelectionIndex(QPoint position) const
 {
     return this->container_.getSelectionIndex(position);
 }

--- a/src/messages/layouts/MessageLayout.hpp
+++ b/src/messages/layouts/MessageLayout.hpp
@@ -62,9 +62,23 @@ public:
 
     // Elements
     const MessageLayoutElement *getElementAt(QPoint point);
+
+    /**
+     * Get the index of the last character in this message's container
+     * This is the sum of all the characters in `elements_`
+     */
     size_t getLastCharacterIndex() const;
-    int getFirstMessageCharacterIndex() const;
-    int getSelectionIndex(QPoint position);
+
+    /**
+     * Get the index of the first visible character in this message's container
+     * This is not always 0 in case there elements that are skipped
+     */
+    size_t getFirstMessageCharacterIndex() const;
+
+    /**
+     * Get the character index at the given position, in the context of selections
+     */
+    size_t getSelectionIndex(QPoint position) const;
     void addSelectionText(QString &str, uint32_t from = 0,
                           uint32_t to = UINT32_MAX,
                           CopyMode copymode = CopyMode::Everything);

--- a/src/messages/layouts/MessageLayout.hpp
+++ b/src/messages/layouts/MessageLayout.hpp
@@ -62,7 +62,7 @@ public:
 
     // Elements
     const MessageLayoutElement *getElementAt(QPoint point);
-    int getLastCharacterIndex() const;
+    size_t getLastCharacterIndex() const;
     int getFirstMessageCharacterIndex() const;
     int getSelectionIndex(QPoint position);
     void addSelectionText(QString &str, uint32_t from = 0,

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -634,7 +634,7 @@ void MessageLayoutContainer::paintSelection(QPainter &painter,
 }
 
 // selection
-int MessageLayoutContainer::getSelectionIndex(QPoint point)
+size_t MessageLayoutContainer::getSelectionIndex(QPoint point) const
 {
     if (this->elements_.empty())
     {
@@ -660,7 +660,7 @@ int MessageLayoutContainer::getSelectionIndex(QPoint point)
     auto lineEnd =
         line == this->lines_.end() ? this->elements_.size() : line->startIndex;
 
-    int index = 0;
+    size_t index = 0;
 
     for (auto i = 0; i < lineEnd; i++)
     {
@@ -704,16 +704,17 @@ size_t MessageLayoutContainer::getLastCharacterIndex() const
     return this->lines_.back().endCharIndex;
 }
 
-int MessageLayoutContainer::getFirstMessageCharacterIndex() const
+size_t MessageLayoutContainer::getFirstMessageCharacterIndex() const
 {
-    static FlagsEnum<MessageElementFlag> skippedFlags;
-    skippedFlags.set(MessageElementFlag::RepliedMessage);
-    skippedFlags.set(MessageElementFlag::Timestamp);
-    skippedFlags.set(MessageElementFlag::Badges);
-    skippedFlags.set(MessageElementFlag::Username);
+    static const FlagsEnum<MessageElementFlag> skippedFlags{
+        MessageElementFlag::RepliedMessage,
+        MessageElementFlag::Timestamp,
+        MessageElementFlag::Badges,
+        MessageElementFlag::Username,
+    };
 
     // Get the index of the first character of the real message
-    int index = 0;
+    size_t index = 0;
     for (const auto &element : this->elements_)
     {
         if (element->getFlags().hasAny(skippedFlags))

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -538,15 +538,15 @@ void MessageLayoutContainer::paintSelection(QPainter &painter,
                                             const Selection &selection,
                                             const int yOffset)
 {
-    auto *app = getApp();
-    QColor selectionColor = app->themes->messages.selection;
-
     if (selection.selectionMin.messageIndex > messageIndex ||
         selection.selectionMax.messageIndex < messageIndex)
     {
         // This message is not part of the selection, don't draw anything
         return;
     }
+
+    auto *app = getApp();
+    QColor selectionColor = app->themes->messages.selection;
 
     const auto paintLineRect = [&](const Line &line, int left, int right) {
         QRect rect = line.rect;

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -394,7 +394,7 @@ void MessageLayoutContainer::breakLine()
         this->lines_.back().endCharIndex = this->charIndex_;
     }
     this->lines_.push_back({
-        .startIndex = (int)lineStart_,
+        .startIndex = lineStart_,
         .endIndex = 0,
         .startCharIndex = this->charIndex_,
         .endCharIndex = 0,

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -428,7 +428,7 @@ void MessageLayoutContainer::breakLine()
     this->line_++;
 }
 
-bool MessageLayoutContainer::atStartOfLine()
+bool MessageLayoutContainer::atStartOfLine() const
 {
     return this->lineStart_ == this->elements_.size();
 }
@@ -523,9 +523,9 @@ bool MessageLayoutContainer::isCollapsed() const
     return this->isCollapsed_;
 }
 
-MessageLayoutElement *MessageLayoutContainer::getElementAt(QPoint point)
+MessageLayoutElement *MessageLayoutContainer::getElementAt(QPoint point) const
 {
-    for (std::unique_ptr<MessageLayoutElement> &element : this->elements_)
+    for (const auto &element : this->elements_)
     {
         if (element->getRect().contains(point))
         {
@@ -727,12 +727,13 @@ size_t MessageLayoutContainer::getFirstMessageCharacterIndex() const
 }
 
 void MessageLayoutContainer::addSelectionText(QString &str, uint32_t from,
-                                              uint32_t to, CopyMode copymode)
+                                              uint32_t to,
+                                              CopyMode copymode) const
 {
     uint32_t index = 0;
     bool first = true;
 
-    for (auto &element : this->elements_)
+    for (const auto &element : this->elements_)
     {
         if (copymode != CopyMode::Everything &&
             element->getCreator().getFlags().has(

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -408,7 +408,7 @@ void MessageLayoutContainer::breakLine()
     this->lineStart_ = this->elements_.size();
     //    this->currentX = (int)(this->scale * 8);
 
-    if (this->canCollapse() && line_ + 1 >= MAX_UNCOLLAPSED_LINES)
+    if (this->canCollapse() && this->line_ + 1 >= MAX_UNCOLLAPSED_LINES)
     {
         this->canAddMessages_ = false;
         return;

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -12,11 +12,18 @@
 #include "util/Helpers.hpp"
 
 #include <QDebug>
+#include <QMargins>
 #include <QPainter>
 
 #define COMPACT_EMOTES_OFFSET 4
 #define MAX_UNCOLLAPSED_LINES \
     (getSettings()->collpseMessagesMinLines.getValue())
+
+namespace {
+
+constexpr const QMargins MARGIN{4, 8, 4, 8};
+
+}  // namespace
 
 namespace chatterino {
 
@@ -155,7 +162,7 @@ void MessageLayoutContainer::addElement(MessageLayoutElement *element,
     // top margin
     if (this->elements_.empty())
     {
-        this->currentY_ = int(this->margin.top * this->scale_);
+        this->currentY_ = int(MARGIN.top() * this->scale_);
     }
 
     int elementLineHeight = element->getRect().height();
@@ -181,7 +188,7 @@ void MessageLayoutContainer::addElement(MessageLayoutElement *element,
         element->getCreator().getFlags().hasNone(
             {MessageElementFlag::TwitchEmoteImage}))
     {
-        yOffset -= (this->margin.top * this->scale_);
+        yOffset -= (MARGIN.top() * this->scale_);
     }
 
     if (getSettings()->removeSpacesBetweenEmotes &&
@@ -358,8 +365,8 @@ void MessageLayoutContainer::breakLine()
 
     if (this->flags_.has(MessageFlag::Centered) && this->elements_.size() > 0)
     {
-        const int marginOffset = int(this->margin.left * this->scale_) +
-                                 int(this->margin.right * this->scale_);
+        const int marginOffset = int(MARGIN.left() * this->scale_) +
+                                 int(MARGIN.right() * this->scale_);
         xOffset = (width_ - marginOffset -
                    this->elements_.at(this->elements_.size() - 1)
                        ->getRect()
@@ -384,7 +391,7 @@ void MessageLayoutContainer::breakLine()
 
         element->setPosition(
             QPoint(element->getRect().x() + xOffset +
-                       int(this->margin.left * this->scale_),
+                       int(MARGIN.left() * this->scale_),
                    element->getRect().y() + this->lineHeight_ + yExtra));
     }
 
@@ -417,7 +424,7 @@ void MessageLayoutContainer::breakLine()
 
     this->currentX_ = 0;
     this->currentY_ += this->lineHeight_;
-    this->height_ = this->currentY_ + int(this->margin.bottom * this->scale_);
+    this->height_ = this->currentY_ + int(MARGIN.bottom() * this->scale_);
     this->lineHeight_ = 0;
     this->line_++;
 }
@@ -434,8 +441,8 @@ bool MessageLayoutContainer::fitsInLine(int width) const
 
 int MessageLayoutContainer::remainingWidth() const
 {
-    return (this->width_ - int(this->margin.left * this->scale_) -
-            int(this->margin.right * this->scale_) -
+    return (this->width_ - int(MARGIN.left() * this->scale_) -
+            int(MARGIN.right() * this->scale_) -
             (this->line_ + 1 == MAX_UNCOLLAPSED_LINES ? this->dotdotdotWidth_
                                                       : 0)) -
            this->currentX_;

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -73,13 +73,13 @@ void MessageLayoutContainer::addElement(MessageLayoutElement *element)
         this->breakLine();
     }
 
-    this->_addElement(element);
+    this->addElement(element, false, -2);
 }
 
 void MessageLayoutContainer::addElementNoLineBreak(
     MessageLayoutElement *element)
 {
-    this->_addElement(element);
+    this->addElement(element, false, -2);
 }
 
 bool MessageLayoutContainer::canAddElements() const
@@ -87,8 +87,9 @@ bool MessageLayoutContainer::canAddElements() const
     return this->canAddMessages_;
 }
 
-void MessageLayoutContainer::_addElement(MessageLayoutElement *element,
-                                         bool forceAdd, int prevIndex)
+void MessageLayoutContainer::addElement(MessageLayoutElement *element,
+                                        const bool forceAdd,
+                                        const int prevIndex)
 {
     if (!this->canAddElements() && !forceAdd)
     {
@@ -328,13 +329,13 @@ void MessageLayoutContainer::reorderRTL(int firstTextIndex)
     // manually do the first call with -1 as previous index
     if (this->canAddElements())
     {
-        this->_addElement(this->elements_[correctSequence[0]].get(), false, -1);
+        this->addElement(this->elements_[correctSequence[0]].get(), false, -1);
     }
 
     for (int i = 1; i < correctSequence.size() && this->canAddElements(); i++)
     {
-        this->_addElement(this->elements_[correctSequence[i]].get(), false,
-                          correctSequence[i - 1]);
+        this->addElement(this->elements_[correctSequence[i]].get(), false,
+                         correctSequence[i - 1]);
     }
 }
 
@@ -464,7 +465,7 @@ void MessageLayoutContainer::end()
                     QPoint(prevPos.x() + this->dotdotdotWidth_, prevPos.y()));
             }
         }
-        this->_addElement(element, true);
+        this->addElement(element, true, -2);
         this->isCollapsed_ = true;
     }
 

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -48,8 +48,18 @@ float MessageLayoutContainer::getScale() const
 void MessageLayoutContainer::beginLayout(int width, float scale,
                                          MessageFlags flags)
 {
-    this->clear();
+    this->elements_.clear();
+    this->lines_.clear();
+
+    this->line_ = 0;
+    this->currentX_ = 0;
+    this->currentY_ = 0;
+    this->lineStart_ = 0;
+    this->lineHeight_ = 0;
+    this->charIndex_ = 0;
+
     this->width_ = width;
+    this->height_ = 0;
     this->scale_ = scale;
     this->flags_ = flags;
     auto mediumFontMetrics =
@@ -60,20 +70,6 @@ void MessageLayoutContainer::beginLayout(int width, float scale,
     this->canAddMessages_ = true;
     this->isCollapsed_ = false;
     this->wasPrevReversed_ = false;
-}
-
-void MessageLayoutContainer::clear()
-{
-    this->elements_.clear();
-    this->lines_.clear();
-
-    this->height_ = 0;
-    this->line_ = 0;
-    this->currentX_ = 0;
-    this->currentY_ = 0;
-    this->lineStart_ = 0;
-    this->lineHeight_ = 0;
-    this->charIndex_ = 0;
 }
 
 void MessageLayoutContainer::addElement(MessageLayoutElement *element)

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -533,6 +533,23 @@ MessageLayoutElement *MessageLayoutContainer::getElementAt(QPoint point)
 void MessageLayoutContainer::paintElements(QPainter &painter,
                                            const MessagePaintContext &ctx)
 {
+#ifdef FOURTF
+    static constexpr std::array<QColor, 5> lineColors{
+        QColor{255, 0, 0, 60},    // RED
+        QColor{0, 255, 0, 60},    // GREEN
+        QColor{0, 0, 255, 60},    // BLUE
+        QColor{255, 0, 255, 60},  // PINk
+        QColor{0, 255, 255, 60},  // CYAN
+    };
+
+    int lineNum = 0;
+    for (const auto &line : this->lines_)
+    {
+        const auto &color = lineColors[lineNum++ % 5];
+        painter.fillRect(line.rect, color);
+    }
+#endif
+
     for (const std::unique_ptr<MessageLayoutElement> &element : this->elements_)
     {
 #ifdef FOURTF

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -45,7 +45,8 @@ float MessageLayoutContainer::getScale() const
 }
 
 // methods
-void MessageLayoutContainer::begin(int width, float scale, MessageFlags flags)
+void MessageLayoutContainer::beginLayout(int width, float scale,
+                                         MessageFlags flags)
 {
     this->clear();
     this->width_ = width;
@@ -450,7 +451,7 @@ int MessageLayoutContainer::remainingWidth() const
            this->currentX_;
 }
 
-void MessageLayoutContainer::end()
+void MessageLayoutContainer::endLayout()
 {
     if (!this->canAddElements())
     {

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -694,13 +694,13 @@ int MessageLayoutContainer::getSelectionIndex(QPoint point)
     return index;
 }
 
-// fourtf: no idea if this is acurate LOL
-int MessageLayoutContainer::getLastCharacterIndex() const
+size_t MessageLayoutContainer::getLastCharacterIndex() const
 {
     if (this->lines_.empty())
     {
         return 0;
     }
+
     return this->lines_.back().endCharIndex;
 }
 

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -427,9 +427,9 @@ bool MessageLayoutContainer::atStartOfLine()
     return this->lineStart_ == this->elements_.size();
 }
 
-bool MessageLayoutContainer::fitsInLine(int _width)
+bool MessageLayoutContainer::fitsInLine(int width) const
 {
-    return _width <= this->remainingWidth();
+    return width <= this->remainingWidth();
 }
 
 int MessageLayoutContainer::remainingWidth() const

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -541,10 +541,10 @@ void MessageLayoutContainer::paintSelection(QPainter &painter,
     auto *app = getApp();
     QColor selectionColor = app->themes->messages.selection;
 
-    // don't draw anything
     if (selection.selectionMin.messageIndex > messageIndex ||
         selection.selectionMax.messageIndex < messageIndex)
     {
+        // This message is not part of the selection, don't draw anything
         return;
     }
 

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -457,7 +457,7 @@ void MessageLayoutContainer::end()
         if (this->first == FirstWord::RTL)
         {
             // Shift all elements in the next line to the left
-            for (int i = this->lines_.back().startIndex;
+            for (auto i = this->lines_.back().startIndex;
                  i < this->elements_.size(); i++)
             {
                 QPoint prevPos = this->elements_[i]->getRect().topLeft();
@@ -636,7 +636,7 @@ void MessageLayoutContainer::paintSelection(QPainter &painter,
             int r = this->elements_[line.endIndex - 1]->getRect().right();
 
             int index = line.startCharIndex;
-            for (int i = line.startIndex; i < line.endIndex; i++)
+            for (auto i = line.startIndex; i < line.endIndex; i++)
             {
                 int indexCount = this->elements_[i]->getSelectionIndexCount();
                 if (index + indexCount <= selection.selectionMin.charIndex)
@@ -654,7 +654,7 @@ void MessageLayoutContainer::paintSelection(QPainter &painter,
                 {
                     returnAfter = true;
                     index = line.startCharIndex;
-                    for (int elementIdx = line.startIndex;
+                    for (auto elementIdx = line.startIndex;
                          elementIdx < line.endIndex; elementIdx++)
                     {
                         int c = this->elements_[elementIdx]
@@ -734,7 +734,7 @@ void MessageLayoutContainer::paintSelection(QPainter &painter,
         // find the right end of the selection
         int r = this->elements_[line.endIndex - 1]->getRect().right();
 
-        for (int i = line.startIndex; i < line.endIndex; i++)
+        for (auto i = line.startIndex; i < line.endIndex; i++)
         {
             int c = this->elements_[i]->getSelectionIndexCount();
 
@@ -774,18 +774,18 @@ int MessageLayoutContainer::getSelectionIndex(QPoint point)
         }
     }
 
-    int lineStart = line == this->lines_.end() ? this->lines_.back().startIndex
-                                               : line->startIndex;
+    auto lineStart = line == this->lines_.end() ? this->lines_.back().startIndex
+                                                : line->startIndex;
     if (line != this->lines_.end())
     {
         line++;
     }
-    int lineEnd =
+    auto lineEnd =
         line == this->lines_.end() ? this->elements_.size() : line->startIndex;
 
     int index = 0;
 
-    for (int i = 0; i < lineEnd; i++)
+    for (auto i = 0; i < lineEnd; i++)
     {
         auto &&element = this->elements_[i];
 

--- a/src/messages/layouts/MessageLayoutContainer.hpp
+++ b/src/messages/layouts/MessageLayoutContainer.hpp
@@ -98,13 +98,13 @@ private:
          * In the context of selections, the index of the first character on this line
          * The first line's startCharIndex will always be 0
          */
-        int startCharIndex{};
+        size_t startCharIndex{};
 
         /**
          * In the context of selections, the index of the last character on this line
          * The last line's startCharIndex will always be the sum of all characters in this message
          */
-        int endCharIndex{};
+        size_t endCharIndex{};
 
         /**
          * The rectangle that covers all elements on this line
@@ -154,7 +154,11 @@ private:
     int height_ = 0;
     int currentX_ = 0;
     int currentY_ = 0;
-    int charIndex_ = 0;
+    /**
+     * charIndex_ is the selection-contexted index of where we currently are in our message
+     * At the end, this will always be equal to the sum of `elements_` getSelectionIndexCount()
+     */
+    size_t charIndex_ = 0;
     size_t lineStart_ = 0;
     int lineHeight_ = 0;
     int spaceWidth_ = 4;

--- a/src/messages/layouts/MessageLayoutContainer.hpp
+++ b/src/messages/layouts/MessageLayoutContainer.hpp
@@ -106,13 +106,13 @@ private:
          * The index of the first message element on this line
          * Points into `elements_`
          */
-        int startIndex{};
+        size_t startIndex{};
 
         /**
          * The index of the last message element on this line
          * Points into `elements_`
          */
-        int endIndex{};
+        size_t endIndex{};
 
         /**
          * In the context of selections, the index of the first character on this line

--- a/src/messages/layouts/MessageLayoutContainer.hpp
+++ b/src/messages/layouts/MessageLayoutContainer.hpp
@@ -26,12 +26,32 @@ struct MessageLayoutContainer {
 
     FirstWord first = FirstWord::Neutral;
 
+    /**
+     * Returns the height of this message
+     */
     int getHeight() const;
+
+    /**
+     * Returns the width of this message
+     */
     int getWidth() const;
+
+    /**
+     * Returns the scale of this message
+     */
     float getScale() const;
 
-    // methods
+    /**
+     * Begin the layout process of this message
+     *
+     * This will reset all line calculations, and will be considered incomplete
+     * until the accompanying end function has been called
+     */
     void begin(int width_, float scale_, MessageFlags flags_);
+
+    /**
+     * Finish the layout process of this message
+     */
     void end();
 
     void clear();

--- a/src/messages/layouts/MessageLayoutContainer.hpp
+++ b/src/messages/layouts/MessageLayoutContainer.hpp
@@ -20,31 +20,6 @@ class MessageLayoutElement;
 struct Selection;
 struct MessagePaintContext;
 
-struct Margin {
-    int top;
-    int right;
-    int bottom;
-    int left;
-
-    Margin()
-        : Margin(0)
-    {
-    }
-
-    Margin(int value)
-        : Margin(value, value, value, value)
-    {
-    }
-
-    Margin(int _top, int _right, int _bottom, int _left)
-        : top(_top)
-        , right(_right)
-        , bottom(_bottom)
-        , left(_left)
-    {
-    }
-};
-
 struct MessageLayoutContainer {
     MessageLayoutContainer() = default;
 
@@ -165,8 +140,6 @@ private:
      **/
     void paintSelectionRect(QPainter &painter, const Line &line, int left,
                             int right, int yOffset, const QColor &color) const;
-
-    const Margin margin = {4, 8, 4, 8};
 
     // variables
     float scale_ = 1.F;

--- a/src/messages/layouts/MessageLayoutContainer.hpp
+++ b/src/messages/layouts/MessageLayoutContainer.hpp
@@ -54,7 +54,6 @@ struct MessageLayoutContainer {
      */
     void endLayout();
 
-    bool canAddElements() const;
     void addElement(MessageLayoutElement *element);
     void addElementNoLineBreak(MessageLayoutElement *element);
     void breakLine();
@@ -143,6 +142,11 @@ private:
          */
         QRect rect;
     };
+
+    /**
+     * canAddElements returns true if it's possible to add more elements to this message
+     */
+    bool canAddElements() const;
 
     // helpers
     /*

--- a/src/messages/layouts/MessageLayoutContainer.hpp
+++ b/src/messages/layouts/MessageLayoutContainer.hpp
@@ -135,7 +135,7 @@ private:
 
     // helpers
     /*
-    _addElement is called at two stages. first stage is the normal one where we want to add message layout elements to the container.
+    addElement is called at two stages. first stage is the normal one where we want to add message layout elements to the container.
     If we detect an RTL word in the message, reorderRTL will be called, which is the second stage, where we call _addElement
     again for each layout element, but in the correct order this time, without adding the elemnt to the this->element_ vector.
     Due to compact emote logic, we need the previous element to check if we should change the spacing or not.
@@ -144,8 +144,8 @@ private:
     In stage one we don't need that and we pass -2 to indicate stage one (i.e. adding mode)
     In stage two, we pass -1 for the first element, and the index of the oredered privous element for the rest.
     */
-    void _addElement(MessageLayoutElement *element, bool forceAdd = false,
-                     int prevIndex = -2);
+    void addElement(MessageLayoutElement *element, bool forceAdd,
+                    int prevIndex);
     bool canCollapse();
 
     /**
@@ -164,7 +164,7 @@ private:
     const Margin margin = {4, 8, 4, 8};
 
     // variables
-    float scale_ = 1.f;
+    float scale_ = 1.F;
     int width_ = 0;
     MessageFlags flags_{};
     /**

--- a/src/messages/layouts/MessageLayoutContainer.hpp
+++ b/src/messages/layouts/MessageLayoutContainer.hpp
@@ -72,14 +72,22 @@ struct MessageLayoutContainer {
     void paintSelection(QPainter &painter, size_t messageIndex,
                         const Selection &selection, int yOffset);
 
-    // selection
-    int getSelectionIndex(QPoint point);
+    /**
+     * Get the character index at the given position, in the context of selections
+     */
+    size_t getSelectionIndex(QPoint point) const;
+
     /**
      * Get the index of the last character in this message
      * This is the sum of all the characters in `elements_`
      */
     size_t getLastCharacterIndex() const;
-    int getFirstMessageCharacterIndex() const;
+
+    /**
+     * Get the index of the first visible character in this message
+     * This is not always 0 in case there elements that are skipped
+     */
+    size_t getFirstMessageCharacterIndex() const;
     void addSelectionText(QString &str, uint32_t from, uint32_t to,
                           CopyMode copymode);
 

--- a/src/messages/layouts/MessageLayoutContainer.hpp
+++ b/src/messages/layouts/MessageLayoutContainer.hpp
@@ -77,6 +77,17 @@ struct MessageLayoutContainer {
     // painting
     void paintElements(QPainter &painter, const MessagePaintContext &ctx);
     void paintAnimatedElements(QPainter &painter, int yOffset);
+
+    /**
+     * Paint the selection for this container
+     * This container contains one or more message elements
+     *
+     * @param painter The painter we draw everything to
+     * @param messageIndex This container's message index in the context of
+     *                     the layout we're being painted in
+     * @param selection The selection we need to paint
+     * @param yOffset The extra offset added to Y for everything that's painted
+     */
     void paintSelection(QPainter &painter, size_t messageIndex,
                         const Selection &selection, int yOffset);
 

--- a/src/messages/layouts/MessageLayoutContainer.hpp
+++ b/src/messages/layouts/MessageLayoutContainer.hpp
@@ -124,6 +124,19 @@ private:
                      int prevIndex = -2);
     bool canCollapse();
 
+    /**
+     * Paint a selection rectangle over the given line
+     *
+     * @param painter The painter we draw everything to
+     * @param line The line whose rect we use as the base top & bottom of the rect to paint
+     * @param left The left coordinates of the rect to paint
+     * @param right The right coordinates of the rect to paint
+     * @param yOffset Extra offset for line's top & bottom
+     * @param color Color of the selection
+     **/
+    void paintSelectionRect(QPainter &painter, const Line &line, int left,
+                            int right, int yOffset, const QColor &color) const;
+
     const Margin margin = {4, 8, 4, 8};
 
     // variables

--- a/src/messages/layouts/MessageLayoutContainer.hpp
+++ b/src/messages/layouts/MessageLayoutContainer.hpp
@@ -167,7 +167,12 @@ private:
     float scale_ = 1.f;
     int width_ = 0;
     MessageFlags flags_{};
-    int line_ = 0;
+    /**
+     * line_ is the current line index we are adding
+     * This is not the number of lines this message contains, since this will stop
+     * incrementing if the message is collapsed
+     */
+    size_t line_{};
     int height_ = 0;
     int currentX_ = 0;
     int currentY_ = 0;
@@ -182,6 +187,7 @@ private:
     bool wasPrevReversed_ = false;
 
     std::vector<std::unique_ptr<MessageLayoutElement>> elements_;
+
     /**
      * A list of lines covering this message
      * A message that spans 3 lines in a view will have 3 elements in lines_

--- a/src/messages/layouts/MessageLayoutContainer.hpp
+++ b/src/messages/layouts/MessageLayoutContainer.hpp
@@ -27,21 +27,6 @@ struct MessageLayoutContainer {
     FirstWord first = FirstWord::Neutral;
 
     /**
-     * Returns the height of this message
-     */
-    int getHeight() const;
-
-    /**
-     * Returns the width of this message
-     */
-    int getWidth() const;
-
-    /**
-     * Returns the scale of this message
-     */
-    float getScale() const;
-
-    /**
      * Begin the layout process of this message
      *
      * This will reset all line calculations, and will be considered incomplete
@@ -73,6 +58,84 @@ struct MessageLayoutContainer {
     void breakLine();
 
     /**
+     * Paint the elements in this message
+     */
+    void paintElements(QPainter &painter, const MessagePaintContext &ctx) const;
+
+    /**
+     * Paint the animated elements in this message
+     */
+    void paintAnimatedElements(QPainter &painter, int yOffset) const;
+
+    /**
+     * Paint the selection for this container
+     * This container contains one or more message elements
+     *
+     * @param painter The painter we draw everything to
+     * @param messageIndex This container's message index in the context of
+     *                     the layout we're being painted in
+     * @param selection The selection we need to paint
+     * @param yOffset The extra offset added to Y for everything that's painted
+     */
+    void paintSelection(QPainter &painter, size_t messageIndex,
+                        const Selection &selection, int yOffset) const;
+
+    /**
+     * Add text from this message into the `str` parameter
+     *
+     * @param[out] str The string where we append our selected text to
+     * @param from The character index from which we collecting our selected text
+     * @param to The character index where we stop collecting our selected text
+     * @param copymode Decides what from the message gets added to the selected text
+     */
+    void addSelectionText(QString &str, uint32_t from, uint32_t to,
+                          CopyMode copymode) const;
+
+    /**
+     * Returns a raw pointer to the element at the given coordinates
+     *
+     * If no element is found at the given point, this returns a null pointer
+     */
+    MessageLayoutElement *getElementAt(QPoint point) const;
+
+    /**
+     * Get the character index at the given position, in the context of selections
+     */
+    size_t getSelectionIndex(QPoint point) const;
+
+    /**
+     * Get the index of the first visible character in this message
+     * This is not always 0 in case there elements that are skipped
+     */
+    size_t getFirstMessageCharacterIndex() const;
+
+    /**
+     * Get the index of the last character in this message
+     * This is the sum of all the characters in `elements_`
+     */
+    size_t getLastCharacterIndex() const;
+
+    /**
+     * Returns the width of this message
+     */
+    int getWidth() const;
+
+    /**
+     * Returns the height of this message
+     */
+    int getHeight() const;
+
+    /**
+     * Returns the scale of this message
+     */
+    float getScale() const;
+
+    /**
+     * Returns true if this message is collapsed
+     */
+    bool isCollapsed() const;
+
+    /**
      * Return true if we are at the start of a new line
      */
     bool atStartOfLine() const;
@@ -88,69 +151,6 @@ struct MessageLayoutContainer {
      * Returns the remaining width of this line until we will need to start a new line
      */
     int remainingWidth() const;
-
-    /**
-     * Returns a raw pointer to the element at the given coordinates
-     *
-     * If no element is found at the given point, this returns a null pointer
-     */
-    MessageLayoutElement *getElementAt(QPoint point) const;
-
-    /**
-     * Paint the elements in this message
-     */
-    void paintElements(QPainter &painter, const MessagePaintContext &ctx);
-
-    /**
-     * Paint the animated elements in this message
-     */
-    void paintAnimatedElements(QPainter &painter, int yOffset);
-
-    /**
-     * Paint the selection for this container
-     * This container contains one or more message elements
-     *
-     * @param painter The painter we draw everything to
-     * @param messageIndex This container's message index in the context of
-     *                     the layout we're being painted in
-     * @param selection The selection we need to paint
-     * @param yOffset The extra offset added to Y for everything that's painted
-     */
-    void paintSelection(QPainter &painter, size_t messageIndex,
-                        const Selection &selection, int yOffset);
-
-    /**
-     * Get the character index at the given position, in the context of selections
-     */
-    size_t getSelectionIndex(QPoint point) const;
-
-    /**
-     * Get the index of the last character in this message
-     * This is the sum of all the characters in `elements_`
-     */
-    size_t getLastCharacterIndex() const;
-
-    /**
-     * Get the index of the first visible character in this message
-     * This is not always 0 in case there elements that are skipped
-     */
-    size_t getFirstMessageCharacterIndex() const;
-
-    /**
-     * Add text from this message into the `str` parameter
-     *
-     * @param[out] str The string where we append our selected text to
-     * @param from The character index from which we collecting our selected text
-     * @param to The character index where we stop collecting our selected text
-     * @param copymode Decides what from the message gets added to the selected text
-     */
-    void addSelectionText(QString &str, uint32_t from, uint32_t to,
-                          CopyMode copymode) const;
-
-    /**
-     * Returns true if this message is collapsed
-     */
-    bool isCollapsed() const;
 
 private:
     struct Line {
@@ -185,12 +185,6 @@ private:
         QRect rect;
     };
 
-    /**
-     * canAddElements returns true if it's possible to add more elements to this message
-     */
-    bool canAddElements() const;
-
-    // helpers
     /*
     addElement is called at two stages. first stage is the normal one where we want to add message layout elements to the container.
     If we detect an RTL word in the message, reorderRTL will be called, which is the second stage, where we call _addElement
@@ -203,7 +197,6 @@ private:
     */
     void addElement(MessageLayoutElement *element, bool forceAdd,
                     int prevIndex);
-    bool canCollapse();
 
     // this method is called when a message has an RTL word
     // we need to reorder the words to be shown properly
@@ -241,6 +234,18 @@ private:
      */
     void paintSelectionEnd(QPainter &painter, size_t lineIndex,
                            const Selection &selection, int yOffset) const;
+
+    /**
+     * canAddElements returns true if it's possible to add more elements to this message
+     */
+    bool canAddElements() const;
+
+    /**
+     * Return true if this message can collapse
+     *
+     * TODO: comment this better :-)
+     */
+    bool canCollapse() const;
 
     // variables
     float scale_ = 1.F;

--- a/src/messages/layouts/MessageLayoutContainer.hpp
+++ b/src/messages/layouts/MessageLayoutContainer.hpp
@@ -47,12 +47,12 @@ struct MessageLayoutContainer {
      * This will reset all line calculations, and will be considered incomplete
      * until the accompanying end function has been called
      */
-    void begin(int width_, float scale_, MessageFlags flags_);
+    void beginLayout(int width_, float scale_, MessageFlags flags_);
 
     /**
      * Finish the layout process of this message
      */
-    void end();
+    void endLayout();
 
     void clear();
     bool canAddElements() const;

--- a/src/messages/layouts/MessageLayoutContainer.hpp
+++ b/src/messages/layouts/MessageLayoutContainer.hpp
@@ -74,7 +74,11 @@ struct MessageLayoutContainer {
 
     // selection
     int getSelectionIndex(QPoint point);
-    int getLastCharacterIndex() const;
+    /**
+     * Get the index of the last character in this message
+     * This is the sum of all the characters in `elements_`
+     */
+    size_t getLastCharacterIndex() const;
     int getFirstMessageCharacterIndex() const;
     void addSelectionText(QString &str, uint32_t from, uint32_t to,
                           CopyMode copymode);

--- a/src/messages/layouts/MessageLayoutContainer.hpp
+++ b/src/messages/layouts/MessageLayoutContainer.hpp
@@ -25,7 +25,6 @@ struct MessageLayoutContainer {
     MessageLayoutContainer() = default;
 
     FirstWord first = FirstWord::Neutral;
-    bool containsRTL = false;
 
     int getHeight() const;
     int getWidth() const;
@@ -198,6 +197,12 @@ private:
     bool canAddMessages_ = true;
     bool isCollapsed_ = false;
     bool wasPrevReversed_ = false;
+
+    /**
+     * containsRTL indicates whether or not any of the text in this message
+     * contains any right-to-left characters (e.g. arabic)
+     */
+    bool containsRTL = false;
 
     std::vector<std::unique_ptr<MessageLayoutElement>> elements_;
 

--- a/src/messages/layouts/MessageLayoutContainer.hpp
+++ b/src/messages/layouts/MessageLayoutContainer.hpp
@@ -65,7 +65,12 @@ struct MessageLayoutContainer {
     void addElementNoLineBreak(MessageLayoutElement *element);
     void breakLine();
     bool atStartOfLine();
-    bool fitsInLine(int width_);
+    /**
+     * Check whether an additional `width` would fit in the current line
+     *
+     * Returns true if it does fit, false if not
+     */
+    bool fitsInLine(int width) const;
     int remainingWidth() const;
     // this method is called when a message has an RTL word
     // we need to reorder the words to be shown properly

--- a/src/messages/layouts/MessageLayoutContainer.hpp
+++ b/src/messages/layouts/MessageLayoutContainer.hpp
@@ -92,14 +92,14 @@ struct MessageLayoutContainer {
                           CopyMode copymode) const;
 
     /**
-     * Returns a raw pointer to the element at the given coordinates
+     * Returns a raw pointer to the element at the given point
      *
      * If no element is found at the given point, this returns a null pointer
      */
     MessageLayoutElement *getElementAt(QPoint point) const;
 
     /**
-     * Get the character index at the given position, in the context of selections
+     * Get the character index at the given point, in the context of selections
      */
     size_t getSelectionIndex(QPoint point) const;
 

--- a/src/messages/layouts/MessageLayoutContainer.hpp
+++ b/src/messages/layouts/MessageLayoutContainer.hpp
@@ -102,10 +102,34 @@ struct MessageLayoutContainer {
 
 private:
     struct Line {
+        /**
+         * The index of the first message element on this line
+         * Points into `elements_`
+         */
         int startIndex{};
+
+        /**
+         * The index of the last message element on this line
+         * Points into `elements_`
+         */
         int endIndex{};
+
+        /**
+         * In the context of selections, the index of the first character on this line
+         * The first line's startCharIndex will always be 0
+         */
         int startCharIndex{};
+
+        /**
+         * In the context of selections, the index of the last character on this line
+         * The last line's startCharIndex will always be the sum of all characters in this message
+         */
         int endCharIndex{};
+
+        /**
+         * The rectangle that covers all elements on this line
+         * This rectangle will always take up 100% of the view's width
+         */
         QRect rect;
     };
 
@@ -158,6 +182,11 @@ private:
     bool wasPrevReversed_ = false;
 
     std::vector<std::unique_ptr<MessageLayoutElement>> elements_;
+    /**
+     * A list of lines covering this message
+     * A message that spans 3 lines in a view will have 3 elements in lines_
+     * These lines hold no relation to the elements that are in this
+     */
     std::vector<Line> lines_;
 };
 

--- a/src/messages/layouts/MessageLayoutContainer.hpp
+++ b/src/messages/layouts/MessageLayoutContainer.hpp
@@ -54,7 +54,6 @@ struct MessageLayoutContainer {
      */
     void endLayout();
 
-    void clear();
     bool canAddElements() const;
     void addElement(MessageLayoutElement *element);
     void addElementNoLineBreak(MessageLayoutElement *element);

--- a/src/messages/layouts/MessageLayoutContainer.hpp
+++ b/src/messages/layouts/MessageLayoutContainer.hpp
@@ -7,6 +7,7 @@
 #include <QRect>
 
 #include <memory>
+#include <optional>
 #include <vector>
 
 class QPainter;
@@ -140,6 +141,24 @@ private:
      **/
     void paintSelectionRect(QPainter &painter, const Line &line, int left,
                             int right, int yOffset, const QColor &color) const;
+
+    /**
+     * Paint the selection start
+     *
+     * Returns a line index if this message should also paint the selection end
+     */
+    std::optional<size_t> paintSelectionStart(QPainter &painter,
+                                              size_t messageIndex,
+                                              const Selection &selection,
+                                              int yOffset) const;
+
+    /**
+     * Paint the selection end
+     *
+     * @param lineIndex The index of the line to start painting at
+     */
+    void paintSelectionEnd(QPainter &painter, size_t lineIndex,
+                           const Selection &selection, int yOffset) const;
 
     // variables
     float scale_ = 1.F;

--- a/src/messages/layouts/MessageLayoutContainer.hpp
+++ b/src/messages/layouts/MessageLayoutContainer.hpp
@@ -54,26 +54,56 @@ struct MessageLayoutContainer {
      */
     void endLayout();
 
+    /**
+     * Add the given `element` to this message.
+     *
+     * This will also prepend a line break if the element
+     * does not fit in the current line
+     */
     void addElement(MessageLayoutElement *element);
+
+    /**
+     * Add the given `element` to this message
+     */
     void addElementNoLineBreak(MessageLayoutElement *element);
+
+    /**
+     * Break the current line
+     */
     void breakLine();
-    bool atStartOfLine();
+
+    /**
+     * Return true if we are at the start of a new line
+     */
+    bool atStartOfLine() const;
+
     /**
      * Check whether an additional `width` would fit in the current line
      *
      * Returns true if it does fit, false if not
      */
     bool fitsInLine(int width) const;
-    int remainingWidth() const;
-    // this method is called when a message has an RTL word
-    // we need to reorder the words to be shown properly
-    // however we don't we to reorder non-text elements like badges, timestamps, username
-    // firstTextIndex is the index of the first text element that we need to start the reordering from
-    void reorderRTL(int firstTextIndex);
-    MessageLayoutElement *getElementAt(QPoint point);
 
-    // painting
+    /**
+     * Returns the remaining width of this line until we will need to start a new line
+     */
+    int remainingWidth() const;
+
+    /**
+     * Returns a raw pointer to the element at the given coordinates
+     *
+     * If no element is found at the given point, this returns a null pointer
+     */
+    MessageLayoutElement *getElementAt(QPoint point) const;
+
+    /**
+     * Paint the elements in this message
+     */
     void paintElements(QPainter &painter, const MessagePaintContext &ctx);
+
+    /**
+     * Paint the animated elements in this message
+     */
     void paintAnimatedElements(QPainter &painter, int yOffset);
 
     /**
@@ -105,9 +135,21 @@ struct MessageLayoutContainer {
      * This is not always 0 in case there elements that are skipped
      */
     size_t getFirstMessageCharacterIndex() const;
-    void addSelectionText(QString &str, uint32_t from, uint32_t to,
-                          CopyMode copymode);
 
+    /**
+     * Add text from this message into the `str` parameter
+     *
+     * @param[out] str The string where we append our selected text to
+     * @param from The character index from which we collecting our selected text
+     * @param to The character index where we stop collecting our selected text
+     * @param copymode Decides what from the message gets added to the selected text
+     */
+    void addSelectionText(QString &str, uint32_t from, uint32_t to,
+                          CopyMode copymode) const;
+
+    /**
+     * Returns true if this message is collapsed
+     */
     bool isCollapsed() const;
 
 private:
@@ -162,6 +204,12 @@ private:
     void addElement(MessageLayoutElement *element, bool forceAdd,
                     int prevIndex);
     bool canCollapse();
+
+    // this method is called when a message has an RTL word
+    // we need to reorder the words to be shown properly
+    // however we don't we to reorder non-text elements like badges, timestamps, username
+    // firstTextIndex is the index of the first text element that we need to start the reordering from
+    void reorderRTL(int firstTextIndex);
 
     /**
      * Paint a selection rectangle over the given line

--- a/src/messages/layouts/MessageLayoutContainer.hpp
+++ b/src/messages/layouts/MessageLayoutContainer.hpp
@@ -105,7 +105,8 @@ struct MessageLayoutContainer {
 
     /**
      * Get the index of the first visible character in this message
-     * This is not always 0 in case there elements that are skipped
+     *
+     * This can be non-zero if there are elements in this message that are skipped
      */
     size_t getFirstMessageCharacterIndex() const;
 

--- a/src/messages/layouts/MessageLayoutElement.cpp
+++ b/src/messages/layouts/MessageLayoutElement.cpp
@@ -60,12 +60,12 @@ bool MessageLayoutElement::hasTrailingSpace() const
     return this->trailingSpace;
 }
 
-int MessageLayoutElement::getLine() const
+size_t MessageLayoutElement::getLine() const
 {
     return this->line_;
 }
 
-void MessageLayoutElement::setLine(int line)
+void MessageLayoutElement::setLine(size_t line)
 {
     this->line_ = line;
 }

--- a/src/messages/layouts/MessageLayoutElement.cpp
+++ b/src/messages/layouts/MessageLayoutElement.cpp
@@ -132,7 +132,7 @@ void ImageLayoutElement::addCopyTextToString(QString &str, uint32_t from,
     }
 }
 
-int ImageLayoutElement::getSelectionIndexCount() const
+size_t ImageLayoutElement::getSelectionIndexCount() const
 {
     return this->trailingSpace ? 2 : 1;
 }
@@ -176,7 +176,7 @@ int ImageLayoutElement::getMouseOverIndex(const QPoint &abs) const
     return 0;
 }
 
-int ImageLayoutElement::getXFromIndex(int index)
+int ImageLayoutElement::getXFromIndex(size_t index)
 {
     if (index <= 0)
     {
@@ -224,7 +224,7 @@ void LayeredImageLayoutElement::addCopyTextToString(QString &str, uint32_t from,
     }
 }
 
-int LayeredImageLayoutElement::getSelectionIndexCount() const
+size_t LayeredImageLayoutElement::getSelectionIndexCount() const
 {
     return this->trailingSpace ? 2 : 1;
 }
@@ -304,7 +304,7 @@ int LayeredImageLayoutElement::getMouseOverIndex(const QPoint &abs) const
     return 0;
 }
 
-int LayeredImageLayoutElement::getXFromIndex(int index)
+int LayeredImageLayoutElement::getXFromIndex(size_t index)
 {
     if (index <= 0)
     {
@@ -422,7 +422,7 @@ void TextLayoutElement::addCopyTextToString(QString &str, uint32_t from,
     }
 }
 
-int TextLayoutElement::getSelectionIndexCount() const
+size_t TextLayoutElement::getSelectionIndexCount() const
 {
     return this->getText().length() + (this->trailingSpace ? 1 : 0);
 }
@@ -489,7 +489,7 @@ int TextLayoutElement::getMouseOverIndex(const QPoint &abs) const
     return this->getSelectionIndexCount() - (this->hasTrailingSpace() ? 1 : 0);
 }
 
-int TextLayoutElement::getXFromIndex(int index)
+int TextLayoutElement::getXFromIndex(size_t index)
 {
     auto app = getApp();
 
@@ -532,7 +532,7 @@ void TextIconLayoutElement::addCopyTextToString(QString &str, uint32_t from,
 {
 }
 
-int TextIconLayoutElement::getSelectionIndexCount() const
+size_t TextIconLayoutElement::getSelectionIndexCount() const
 {
     return this->trailingSpace ? 2 : 1;
 }
@@ -576,7 +576,7 @@ int TextIconLayoutElement::getMouseOverIndex(const QPoint &abs) const
     return 0;
 }
 
-int TextIconLayoutElement::getXFromIndex(int index)
+int TextIconLayoutElement::getXFromIndex(size_t index)
 {
     if (index <= 0)
     {
@@ -649,7 +649,7 @@ int ReplyCurveLayoutElement::getMouseOverIndex(const QPoint &abs) const
     return 0;
 }
 
-int ReplyCurveLayoutElement::getXFromIndex(int index)
+int ReplyCurveLayoutElement::getXFromIndex(size_t index)
 {
     if (index <= 0)
     {
@@ -664,7 +664,7 @@ void ReplyCurveLayoutElement::addCopyTextToString(QString &str, uint32_t from,
 {
 }
 
-int ReplyCurveLayoutElement::getSelectionIndexCount() const
+size_t ReplyCurveLayoutElement::getSelectionIndexCount() const
 {
     return 1;
 }

--- a/src/messages/layouts/MessageLayoutElement.hpp
+++ b/src/messages/layouts/MessageLayoutElement.hpp
@@ -49,12 +49,12 @@ public:
 
     virtual void addCopyTextToString(QString &str, uint32_t from = 0,
                                      uint32_t to = UINT32_MAX) const = 0;
-    virtual int getSelectionIndexCount() const = 0;
+    virtual size_t getSelectionIndexCount() const = 0;
     virtual void paint(QPainter &painter,
                        const MessageColors &messageColors) = 0;
     virtual void paintAnimated(QPainter &painter, int yOffset) = 0;
     virtual int getMouseOverIndex(const QPoint &abs) const = 0;
-    virtual int getXFromIndex(int index) = 0;
+    virtual int getXFromIndex(size_t index) = 0;
 
     const Link &getLink() const;
     const QString &getText() const;
@@ -84,11 +84,11 @@ public:
 protected:
     void addCopyTextToString(QString &str, uint32_t from = 0,
                              uint32_t to = UINT32_MAX) const override;
-    int getSelectionIndexCount() const override;
+    size_t getSelectionIndexCount() const override;
     void paint(QPainter &painter, const MessageColors &messageColors) override;
     void paintAnimated(QPainter &painter, int yOffset) override;
     int getMouseOverIndex(const QPoint &abs) const override;
-    int getXFromIndex(int index) override;
+    int getXFromIndex(size_t index) override;
 
     ImagePtr image_;
 };
@@ -103,11 +103,11 @@ public:
 protected:
     void addCopyTextToString(QString &str, uint32_t from = 0,
                              uint32_t to = UINT32_MAX) const override;
-    int getSelectionIndexCount() const override;
+    size_t getSelectionIndexCount() const override;
     void paint(QPainter &painter, const MessageColors &messageColors) override;
     void paintAnimated(QPainter &painter, int yOffset) override;
     int getMouseOverIndex(const QPoint &abs) const override;
-    int getXFromIndex(int index) override;
+    int getXFromIndex(size_t index) override;
 
     std::vector<ImagePtr> images_;
     std::vector<QSize> sizes_;
@@ -156,11 +156,11 @@ public:
 protected:
     void addCopyTextToString(QString &str, uint32_t from = 0,
                              uint32_t to = UINT32_MAX) const override;
-    int getSelectionIndexCount() const override;
+    size_t getSelectionIndexCount() const override;
     void paint(QPainter &painter, const MessageColors &messageColors) override;
     void paintAnimated(QPainter &painter, int yOffset) override;
     int getMouseOverIndex(const QPoint &abs) const override;
-    int getXFromIndex(int index) override;
+    int getXFromIndex(size_t index) override;
 
     QColor color_;
     FontStyle style_;
@@ -180,11 +180,11 @@ public:
 protected:
     void addCopyTextToString(QString &str, uint32_t from = 0,
                              uint32_t to = UINT32_MAX) const override;
-    int getSelectionIndexCount() const override;
+    size_t getSelectionIndexCount() const override;
     void paint(QPainter &painter, const MessageColors &messageColors) override;
     void paintAnimated(QPainter &painter, int yOffset) override;
     int getMouseOverIndex(const QPoint &abs) const override;
-    int getXFromIndex(int index) override;
+    int getXFromIndex(size_t index) override;
 
 private:
     float scale;
@@ -202,10 +202,10 @@ protected:
     void paint(QPainter &painter, const MessageColors &messageColors) override;
     void paintAnimated(QPainter &painter, int yOffset) override;
     int getMouseOverIndex(const QPoint &abs) const override;
-    int getXFromIndex(int index) override;
+    int getXFromIndex(size_t index) override;
     void addCopyTextToString(QString &str, uint32_t from = 0,
                              uint32_t to = UINT32_MAX) const override;
-    int getSelectionIndexCount() const override;
+    size_t getSelectionIndexCount() const override;
 
 private:
     const QPen pen_;

--- a/src/messages/layouts/MessageLayoutElement.hpp
+++ b/src/messages/layouts/MessageLayoutElement.hpp
@@ -40,8 +40,8 @@ public:
     MessageElement &getCreator() const;
     void setPosition(QPoint point);
     bool hasTrailingSpace() const;
-    int getLine() const;
-    void setLine(int line);
+    size_t getLine() const;
+    void setLine(size_t line);
 
     MessageLayoutElement *setTrailingSpace(bool value);
     MessageLayoutElement *setLink(const Link &link_);
@@ -68,7 +68,10 @@ private:
     QRect rect_;
     Link link_;
     MessageElement &creator_;
-    int line_{};
+    /**
+     * The line of the container this element is laid out at
+     */
+    size_t line_{};
 };
 
 // IMAGE

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1519,7 +1519,7 @@ void ChannelView::mouseMoveEvent(QMouseEvent *event)
     if (this->isLeftMouseDown_)
     {
         // this->pause(PauseReason::Selecting, 300);
-        int index = layout->getSelectionIndex(relativePos);
+        auto index = layout->getSelectionIndex(relativePos);
 
         this->setSelection(this->selection_.start,
                            SelectionItem(messageIndex, index));


### PR DESCRIPTION
# Description

After 3265df76619e689e9a738517732fe930fbe2b590, the selection rendering was off. Selecting the trailing newline of a message (upwards) would render the whole last line of a message to be selected. However, when copying the text, only the trailing newline of the message would be included.

This PR refactors the rendering of the selection to be a bit more readable and to reduce `sign-compare` warnings in the code (see https://github.com/Chatterino/chatterino2/issues/4825). In addition, a special case for the newline is added to be consistent with rendering the selection of the "trailing newline" (downwards).

Even though the selection is now correctly rendered, this might not be the exact behavior one would expect. Not including the trailing newline might be desired. Feel free to discuss this here and I can potentially adjust the behavior.