### PR TITLE
streamlink: trim custom paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Minor: Migrate to the new Get Channel Followers Helix endpoint, fixing follower count not showing up in usercards. (#4809)
 - Minor: The account switcher is now styled to match your theme. (#4817)
 - Minor: Add an invisible resize handle to the bottom of frameless user info popups and reply thread popups. (#4795)
-- Bugfix: Fixed trailing whitespace in custom streamlink paths not being trimmed on Windows. (#4834)
+- Bugfix: Trimmed custom streamlink paths on all platforms making sure you don't accidentally add spaces at the beginning or end of its path. (#4834)
 - Bugfix: Fixed a performance issue when displaying replies to certain messages. (#4807)
 - Bugfix: Fixed a data race when disconnecting from Twitch PubSub. (#4771)
 - Bugfix: Fixed `/shoutout` command not working with usernames starting with @'s (e.g. `/shoutout @forsen`). (#4800)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Minor: Migrate to the new Get Channel Followers Helix endpoint, fixing follower count not showing up in usercards. (#4809)
 - Minor: The account switcher is now styled to match your theme. (#4817)
 - Minor: Add an invisible resize handle to the bottom of frameless user info popups and reply thread popups. (#4795)
+- Bugfix: Fixed trailing whitespace in custom streamlink paths not being trimmed on Windows. (#4834)
 - Bugfix: Fixed a performance issue when displaying replies to certain messages. (#4807)
 - Bugfix: Fixed a data race when disconnecting from Twitch PubSub. (#4771)
 - Bugfix: Fixed `/shoutout` command not working with usernames starting with @'s (e.g. `/shoutout @forsen`). (#4800)

--- a/src/util/StreamLink.cpp
+++ b/src/util/StreamLink.cpp
@@ -81,7 +81,7 @@ namespace {
             if (getSettings()->streamlinkUseCustomPath)
             {
 #ifdef _WIN32
-                QString path = getSettings()->streamlinkPath;
+                const QString path = getSettings()->streamlinkPath;
                 return path.trimmed() + "/" + getBinaryName();
 #else
                 return getSettings()->streamlinkPath + "/" + getBinaryName();

--- a/src/util/StreamLink.cpp
+++ b/src/util/StreamLink.cpp
@@ -75,22 +75,16 @@ namespace {
 
     QProcess *createStreamlinkProcess()
     {
-        auto p = new QProcess;
+        auto *p = new QProcess;
 
-        const QString path = [] {
+        const QString path = []() -> QString {
             if (getSettings()->streamlinkUseCustomPath)
             {
-#ifdef _WIN32
                 const QString path = getSettings()->streamlinkPath;
                 return path.trimmed() + "/" + getBinaryName();
-#else
-                return getSettings()->streamlinkPath + "/" + getBinaryName();
-#endif
             }
-            else
-            {
-                return QString{getBinaryName()};
-            }
+
+            return {getBinaryName()};
         }();
 
         if (Version::instance().isFlatpak())

--- a/src/util/StreamLink.cpp
+++ b/src/util/StreamLink.cpp
@@ -80,7 +80,12 @@ namespace {
         const QString path = [] {
             if (getSettings()->streamlinkUseCustomPath)
             {
+#ifdef _WIN32
+                QString path = getSettings()->streamlinkPath;
+                return path.trimmed() + "/" + getBinaryName();
+#else
                 return getSettings()->streamlinkPath + "/" + getBinaryName();
+#endif
             }
             else
             {


### PR DESCRIPTION
Windows paths can't have trailing whitespace, currently having trailing whitespace in the path will result in the path not being found