### PR TITLE
Add `author.id` variable for filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Minor: Migrate to the new Get Channel Followers Helix endpoint, fixing follower count not showing up in usercards. (#4809)
 - Minor: The account switcher is now styled to match your theme. (#4817)
 - Minor: Add an invisible resize handle to the bottom of frameless user info popups and reply thread popups. (#4795)
+- Minor: Add `author.id` filter variable (#4841)
 - Bugfix: Trimmed custom streamlink paths on all platforms making sure you don't accidentally add spaces at the beginning or end of its path. (#4834)
 - Bugfix: Fixed a performance issue when displaying replies to certain messages. (#4807)
 - Bugfix: Fixed a data race when disconnecting from Twitch PubSub. (#4771)

--- a/src/controllers/filters/lang/Filter.cpp
+++ b/src/controllers/filters/lang/Filter.cpp
@@ -26,6 +26,7 @@ ContextMap buildContextMap(const MessagePtr &m, chatterino::Channel *channel)
      * author.badges
      * author.color
      * author.name
+     * author.id
      * author.no_color
      * author.subbed
      * author.sub_length
@@ -81,6 +82,7 @@ ContextMap buildContextMap(const MessagePtr &m, chatterino::Channel *channel)
         {"author.badges", std::move(badges)},
         {"author.color", m->usernameColor},
         {"author.name", m->displayName},
+        {"author.id", m->id},
         {"author.no_color", !m->usernameColor.isValid()},
         {"author.subbed", subscribed},
         {"author.sub_length", subLength},

--- a/src/controllers/filters/lang/Filter.hpp
+++ b/src/controllers/filters/lang/Filter.hpp
@@ -26,6 +26,7 @@ static const QMap<QString, Type> MESSAGE_TYPING_CONTEXT = {
     {"author.badges", Type::StringList},
     {"author.color", Type::Color},
     {"author.name", Type::String},
+    {"author.id", Type::String},
     {"author.no_color", Type::Bool},
     {"author.subbed", Type::Bool},
     {"author.sub_length", Type::Int},

--- a/src/controllers/filters/lang/Tokenizer.hpp
+++ b/src/controllers/filters/lang/Tokenizer.hpp
@@ -12,6 +12,7 @@ static const QMap<QString, QString> validIdentifiersMap = {
     {"author.badges", "author badges"},
     {"author.color", "author color"},
     {"author.name", "author name"},
+    {"author.id", "author id"}
     {"author.no_color", "author has no color?"},
     {"author.subbed", "author subscribed?"},
     {"author.sub_length", "author sub length"},

--- a/src/controllers/filters/lang/Tokenizer.hpp
+++ b/src/controllers/filters/lang/Tokenizer.hpp
@@ -12,7 +12,7 @@ static const QMap<QString, QString> validIdentifiersMap = {
     {"author.badges", "author badges"},
     {"author.color", "author color"},
     {"author.name", "author name"},
-    {"author.id", "author id"}
+    {"author.id", "author id"},
     {"author.no_color", "author has no color?"},
     {"author.subbed", "author subscribed?"},
     {"author.sub_length", "author sub length"},


### PR DESCRIPTION
# Description

This PR adds the `author.id` variable for use in filters. The use of this variable would be especially useful to deal with name changes

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
