### PR TITLE
Release v2.4.6

### DIFF
--- a/.CI/chatterino-installer.iss
+++ b/.CI/chatterino-installer.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Chatterino"
-#define MyAppVersion "2.4.5"
+#define MyAppVersion "2.4.6"
 #define MyAppPublisher "Chatterino Team"
 #define MyAppURL "https://www.chatterino.com"
 #define MyAppExeName "chatterino.exe"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - "bugfix-release/*"
   pull_request:
   workflow_dispatch:
   merge_group:
@@ -14,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  C2_ENABLE_LTO: ${{ github.ref == 'refs/heads/master' }}
+  C2_ENABLE_LTO: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/bugfix-release/') }}
   CHATTERINO_REQUIRE_CLEAN_GIT: On
   C2_BUILD_WITH_QT6: Off
   # Last known good conan version
@@ -27,13 +28,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, macos-latest]
-        qt-version: [5.15.2, 6.5.0]
-        force-lto: [false]
-        plugins: [false]
-        skip-artifact: [false]
-        skip-crashpad: [false]
-        clang-tidy-review: [false]
         include:
           # Ubuntu 20.04, Qt 5.12
           - os: ubuntu-20.04
@@ -56,6 +50,22 @@ jobs:
             qt-version: 6.2.4
             force-lto: true
             plugins: true
+            skip-artifact: false
+            skip-crashpad: false
+            clang-tidy-review: false
+          # macOS
+          - os: macos-latest
+            qt-version: 6.5.3
+            force-lto: false
+            plugins: false
+            skip-artifact: false
+            skip-crashpad: false
+            clang-tidy-review: false
+          # Windows
+          - os: windows-latest
+            qt-version: 6.5.3
+            force-lto: false
+            plugins: false
             skip-artifact: false
             skip-crashpad: false
             clang-tidy-review: false
@@ -395,7 +405,7 @@ jobs:
   create-release:
     needs: build
     runs-on: ubuntu-latest
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/master')
+    if: (github.event_name == 'push' && (github.ref == 'refs/heads/master'))
 
     steps:
       - uses: actions/checkout@v3
@@ -409,27 +419,15 @@ jobs:
           path: release-artifacts/
 
       - uses: actions/download-artifact@v3
-        name: Windows Qt6.5.0
+        name: Windows Qt6.5.3
         with:
-          name: chatterino-windows-x86-64-Qt-6.5.0.zip
+          name: chatterino-windows-x86-64-Qt-6.5.3.zip
           path: release-artifacts/
 
       - uses: actions/download-artifact@v3
-        name: Windows Qt6.5.0 symbols
+        name: Windows Qt6.5.3 symbols
         with:
-          name: chatterino-windows-x86-64-Qt-6.5.0-symbols.pdb.7z
-          path: release-artifacts/
-
-      - uses: actions/download-artifact@v3
-        name: Windows Qt5.15.2
-        with:
-          name: chatterino-windows-x86-64-Qt-5.15.2.zip
-          path: release-artifacts/
-
-      - uses: actions/download-artifact@v3
-        name: Windows Qt5.15 symbols
-        with:
-          name: chatterino-windows-x86-64-Qt-5.15.2-symbols.pdb.7z
+          name: chatterino-windows-x86-64-Qt-6.5.3-symbols.pdb.7z
           path: release-artifacts/
 
       - uses: actions/download-artifact@v3
@@ -451,9 +449,9 @@ jobs:
           path: release-artifacts/
 
       - uses: actions/download-artifact@v3
-        name: macOS x86_64 Qt5.15.2 dmg
+        name: macOS x86_64 Qt6.5.3 dmg
         with:
-          name: chatterino-macos-Qt-5.15.2.dmg
+          name: chatterino-macos-Qt-6.5.3.dmg
           path: release-artifacts/
 
       - name: Copy flatpakref
@@ -465,12 +463,7 @@ jobs:
         run: |
           ls -l
           # Rename the macos build to indicate that it's for macOS 10.15 users
-          mv chatterino-macos-Qt-5.15.2.dmg Chatterino-macOS-10.15.dmg
-
-          # Mark all Qt6 builds as EXPERIMENTAL
-          mv Chatterino-ubuntu-22.04-x86_64.deb EXPERIMENTAL-Chatterino-ubuntu-22.04-Qt-6.2.4.deb
-          mv chatterino-windows-x86-64-Qt-6.5.0.zip EXPERIMENTAL-chatterino-windows-x86-64-Qt-6.5.0.zip
-          mv chatterino-Qt-6.5.0.pdb.7z EXPERIMENTAL-chatterino-Qt-6.5.0.pdb.7z
+          mv chatterino-macos-Qt-6.5.3.dmg Chatterino-macOS-10.15.dmg
         working-directory: release-artifacts
         shell: bash
 

--- a/.github/workflows/create-installer.yml
+++ b/.github/workflows/create-installer.yml
@@ -5,7 +5,9 @@ on:
     workflows: ["Build"]
     types: [completed]
     # make sure this only runs on the default branch
-    branches: [master]
+    branches:
+      - master
+      - "bugfix-release/*"
   workflow_dispatch:
 
 jobs:
@@ -15,9 +17,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     strategy:
       matrix:
-        qt-version: [5.15.2, 6.5.0]
-    env:
-      VARIANT_SUFFIX: ${{ startsWith(matrix.qt-version, '6.') && '.EXPERIMENTAL-Qt6' || '' }}
+        qt-version: ["6.5.3"]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -52,5 +52,5 @@ jobs:
       - name: Upload installer
         uses: actions/upload-artifact@v3
         with:
-          path: build/${{ steps.build-installer.outputs.C2_INSTALLER_BASE_NAME }}${{ env.VARIANT_SUFFIX }}.exe
-          name: ${{ steps.build-installer.outputs.C2_INSTALLER_BASE_NAME }}${{ env.VARIANT_SUFFIX }}.exe
+          path: build/${{ steps.build-installer.outputs.C2_INSTALLER_BASE_NAME }}.exe
+          name: ${{ steps.build-installer.outputs.C2_INSTALLER_BASE_NAME }}.exe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## 2.4.6
 
 - Bugfix: Update Qt version, fixing a security issue with webp loading (see https://www.qt.io/blog/two-qt-security-advisorys-gdi-font-engine-webp-image-format) (#4843)
+- Dev: Temporarily disable High DPI scaling on Qt6 builds on Windows. (#4767)
 
 ## 2.4.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unversioned
 
+## 2.4.6
+
+- Bugfix: Update Qt version, fixing a security issue with webp loading (see https://www.qt.io/blog/two-qt-security-advisorys-gdi-font-engine-webp-image-format). (#4843)
+
 ## 2.4.5
 
 - Major: AutoMod term management messages (e.g. testaccount added "noob" as a blocked term on AutoMod.) are now hidden in Streamer Mode if you have the "Hide moderation actions" setting enabled. (#4758)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 2.4.6
 
-- Bugfix: Update Qt version, fixing a security issue with webp loading (see https://www.qt.io/blog/two-qt-security-advisorys-gdi-font-engine-webp-image-format). (#4843)
+- Bugfix: Update Qt version, fixing a security issue with webp loading (see https://www.qt.io/blog/two-qt-security-advisorys-gdi-font-engine-webp-image-format) (#4843)
 
 ## 2.4.5
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ list(APPEND CMAKE_MODULE_PATH
     "${CMAKE_SOURCE_DIR}/cmake/sanitizers-cmake/cmake"
     )
 
-project(chatterino VERSION 2.4.5)
+project(chatterino VERSION 2.4.6)
 
 option(BUILD_APP "Build Chatterino" ON)
 option(BUILD_TESTS "Build the tests for Chatterino" OFF)

--- a/resources/com.chatterino.chatterino.appdata.xml
+++ b/resources/com.chatterino.chatterino.appdata.xml
@@ -32,6 +32,9 @@
         <binary>chatterino</binary>
     </provides>
     <releases>
+        <release version="2.4.6" date="2023-09-28">
+            <url>https://github.com/Chatterino/chatterino2/releases/tag/v2.4.6</url>
+        </release>
         <release version="2.4.5" date="2023-08-26">
             <url>https://github.com/Chatterino/chatterino2/releases/tag/v2.4.5</url>
         </release>

--- a/src/common/Version.hpp
+++ b/src/common/Version.hpp
@@ -24,7 +24,7 @@
  *  - 2.4.0-alpha.2
  *  - 2.4.0-alpha
  **/
-#define CHATTERINO_VERSION "2.4.5"
+#define CHATTERINO_VERSION "2.4.6"
 
 #if defined(Q_OS_WIN)
 #    define CHATTERINO_OS "win"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,6 +24,11 @@ using namespace chatterino;
 
 int main(int argc, char **argv)
 {
+    // TODO: This is a temporary fix (see #4552).
+#if defined(Q_OS_WINDOWS) && QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    qputenv("QT_ENABLE_HIGHDPI_SCALING", "0");
+#endif
+
     QApplication a(argc, argv);
 
     QCoreApplication::setApplicationName("chatterino");


### PR DESCRIPTION
# Description

This PR aims to prepare a new release of Chatterino which only updates the version of Qt used for the main Windows build.
This build is based on the v2.4.5 release since the changes in master right now are not considered stable.

I want to merge this into the `bugfix-release/v2.4.6` branch, but since it's not a protected branch CI jobs won't run, so I'll target that branch after CI has built and testing has been done

This PR has removed Qt5 builds.

# Checklist for making a release

## In the release PR

- [x] Updated version code in `src/common/Version.hpp`
- [x] Updated version code in `CMakeLists.txt`  
       This can only be "whole versions", so if you're releasing `2.4.0-beta` you'll need to condense it to `2.4.0`
- [x] Add a new release at the top of of the `releases` key in `resources/com.chatterino.chatterino.appdata.xml`  
       This cannot use dash to denote a pre-release identifier, you have to use a tilde instead.

- [x] Updated version code in `.CI/chatterino-installer.iss`
- [x] Update the changelog `## Unreleased` section to the new version `CHANGELOG.md`  
       Make sure to leave the `## Unreleased` line unchanged for easier merges

## After the PR has been merged

- [ ] Tag the release
- [ ] Manually run the [create-installer](https://github.com/Chatterino/chatterino2/actions/workflows/create-installer.yml) workflow.  
       This is only necessary if the tag was created after the CI in the main branch finished.
- [ ] ~~Start a manual [Launchpad import](https://code.launchpad.net/~pajlada/chatterino/+git/chatterino) - scroll down & click Import Now~~  
       **Not necessary as the PPA build uses system qtimageformats plugins, which have been patched in Ubuntu**

 - [ ] ~~Make a PPA release to [this repo](https://git.launchpad.net/~pajlada/+git/chatterino-packaging/) with the `debchange` command.  
       `debchange -v 2.4.0` then add the changelog entries  
       `debchange --release` then change the distro to be `unstable`~~
       **Not necessary as the PPA build uses system qtimageformats plugins, which have been patched in Ubuntu**


<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
