### PR TITLE
fix: Commands now completable when not starting with /

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 - Dev: Refactor `Image` & Image's `Frames`. (#4773)
 - Dev: Add `WindowManager::getLastSelectedWindow()` to replace `getMainWindow()`. (#4816)
 - Dev: Clarify signal connection lifetimes where applicable. (#4818)
-- Dev: Laid the groundwork for advanced input completion strategies. (#4639)
+- Dev: Laid the groundwork for advanced input completion strategies. (#4639, #4846)
 
 ## 2.4.5
 

--- a/src/controllers/completion/TabCompletionModel.hpp
+++ b/src/controllers/completion/TabCompletionModel.hpp
@@ -30,7 +30,13 @@ public:
     void updateResults(const QString &query, bool isFirstWord = false);
 
 private:
-    enum class SourceKind { Emote, User, Command, EmoteAndUser };
+    enum class SourceKind {
+        Emote,
+        User,
+        Command,
+        EmoteCommand,
+        EmoteUserCommand
+    };
 
     /// @brief Updates the internal completion source based on the current query.
     /// The completion source will only change if the deduced completion kind
@@ -46,6 +52,10 @@ private:
     std::optional<SourceKind> deduceSourceKind(const QString &query) const;
 
     std::unique_ptr<completion::Source> buildSource(SourceKind kind) const;
+
+    std::unique_ptr<completion::Source> buildEmoteSource() const;
+    std::unique_ptr<completion::Source> buildUserSource() const;
+    std::unique_ptr<completion::Source> buildCommandSource() const;
 
     Channel &channel_;
     std::unique_ptr<completion::Source> source_{};

--- a/src/controllers/completion/sources/CommandSource.cpp
+++ b/src/controllers/completion/sources/CommandSource.cpp
@@ -14,11 +14,17 @@ namespace {
     {
         if (command.startsWith('/') || command.startsWith('.'))
         {
-            out.push_back({command.mid(1), command.at(0)});
+            out.push_back({
+                .name = command.mid(1),
+                .prefix = command.at(0),
+            });
         }
         else
         {
-            out.push_back({command, '/'});
+            out.push_back({
+                .name = command,
+                .prefix = "",
+            });
         }
     }
 

--- a/src/controllers/completion/sources/CommandSource.hpp
+++ b/src/controllers/completion/sources/CommandSource.hpp
@@ -13,7 +13,7 @@ namespace chatterino::completion {
 
 struct CommandItem {
     QString name{};
-    QChar prefix{};
+    QString prefix{};
 };
 
 class CommandSource : public Source

--- a/src/controllers/completion/sources/UnifiedSource.hpp
+++ b/src/controllers/completion/sources/UnifiedSource.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "common/Channel.hpp"
+#include "controllers/completion/sources/CommandSource.hpp"
 #include "controllers/completion/sources/EmoteSource.hpp"
 #include "controllers/completion/sources/Source.hpp"
 #include "controllers/completion/sources/UserSource.hpp"
@@ -13,20 +14,9 @@ namespace chatterino::completion {
 class UnifiedSource : public Source
 {
 public:
-    using ActionCallback = std::function<void(const QString &)>;
-
-    /// @brief Initializes a unified completion source for the given channel.
-    /// Resolves both emotes and usernames for autocompletion.
-    /// @param channel Channel to initialize emotes and users from. Must be a
-    /// TwitchChannel or completion is a no-op.
-    /// @param emoteStrategy Strategy for selecting emotes
-    /// @param userStrategy Strategy for selecting users
-    /// @param callback ActionCallback to invoke upon InputCompletionItem selection.
-    /// See InputCompletionItem::action(). Can be nullptr.
-    UnifiedSource(const Channel *channel,
-                  std::unique_ptr<EmoteSource::EmoteStrategy> emoteStrategy,
-                  std::unique_ptr<UserSource::UserStrategy> userStrategy,
-                  ActionCallback callback = nullptr);
+    /// @brief Initializes a unified completion source.
+    /// @param sources Vector of sources to unify
+    UnifiedSource(std::vector<std::unique_ptr<Source>> sources);
 
     void update(const QString &query) override;
     void addToListModel(GenericListModel &model,
@@ -35,8 +25,7 @@ public:
                          bool isFirstWord = false) const override;
 
 private:
-    EmoteSource emoteSource_;
-    UserSource usersSource_;
+    std::vector<std::unique_ptr<Source>> sources_;
 };
 
 }  // namespace chatterino::completion

--- a/src/controllers/completion/strategies/CommandStrategy.cpp
+++ b/src/controllers/completion/strategies/CommandStrategy.cpp
@@ -2,6 +2,16 @@
 
 namespace chatterino::completion {
 
+QString normalizeQuery(const QString &query)
+{
+    if (query.startsWith('/') || query.startsWith('.'))
+    {
+        return query.mid(1);
+    }
+
+    return query;
+}
+
 CommandStrategy::CommandStrategy(bool startsWithOnly)
     : startsWithOnly_(startsWithOnly)
 {
@@ -11,11 +21,7 @@ void CommandStrategy::apply(const std::vector<CommandItem> &items,
                             std::vector<CommandItem> &output,
                             const QString &query) const
 {
-    QString normalizedQuery = query;
-    if (normalizedQuery.startsWith('/') || normalizedQuery.startsWith('.'))
-    {
-        normalizedQuery = normalizedQuery.mid(1);
-    }
+    QString normalizedQuery = normalizeQuery(query);
 
     if (startsWithOnly_)
     {


### PR DESCRIPTION
## Description

Fixes a regression introduced in #4639. When we can't determine the kind of item being tab-completed, we now consider emotes, usernames, and commands.

Fixes #4842

Truthfully I didn't even know you could create a command without a slash 😅 

## Implementation

This fix was a bit more complicated than I had expected due to the `userCompletionOnlyWithAt` setting. When we can't deduce the kind of item being completed, depending on this setting, we either:

1. Complete emotes, usernames, and commands (setting disabled)
2. Complete emotes and commands (setting enabled)

To reduce code duplication, I modified `UnifiedSource` to accept a vector of sources to combine instead of being hardcoded to just combine emotes and usernames.