### PR TITLE
Check VCRT and show installed/shipped version

### DIFF
--- a/.CI/build-installer.ps1
+++ b/.CI/build-installer.ps1
@@ -43,7 +43,7 @@ ISCC `
     /DWORKING_DIR="$($pwd.Path)\" `
     /DINSTALLER_BASE_NAME="$installerBaseName" `
     /DSHIPPED_VCRT_BUILD="$($VCRTVersion.FileBuildPart)" `
-    /DSHIPPED_VCRT_VERSION="'$($VCRTVersion.FileVersion)'" `
+    /DSHIPPED_VCRT_VERSION="$($VCRTVersion.FileDescription)" `
     $defines `
     /O. `
     "$PSScriptRoot\chatterino-installer.iss";

--- a/.CI/build-installer.ps1
+++ b/.CI/build-installer.ps1
@@ -36,10 +36,14 @@ if ($null -eq $Env:VCToolsRedistDir) {
 }
 Copy-Item "$Env:VCToolsRedistDir\vc_redist.x64.exe" .;
 
+$VCRTVersion = (Get-Item "$Env:VCToolsRedistDir\vc_redist.x64.exe").VersionInfo;
+
 # Build the installer
 ISCC `
     /DWORKING_DIR="$($pwd.Path)\" `
     /DINSTALLER_BASE_NAME="$installerBaseName" `
+    /DSHIPPED_VCRT_BUILD="$($VCRTVersion.FileBuildPart)" `
+    /DSHIPPED_VCRT_VERSION="'$($VCRTVersion.FileVersion)'" `
     $defines `
     /O. `
     "$PSScriptRoot\chatterino-installer.iss";

--- a/.CI/chatterino-installer.iss
+++ b/.CI/chatterino-installer.iss
@@ -19,7 +19,7 @@
 #endif
 ; Set to the string representation of the VCRT version
 #ifndef SHIPPED_VCRT_VERSION
-#define SHIPPED_VCRT_VERSION '?'
+#define SHIPPED_VCRT_VERSION ?
 #endif
 
 [Setup]
@@ -66,7 +66,7 @@ SetupWindowTitle=Setup - %1 (Nightly)
 
 [Tasks]
 ; Only show this option if the VCRT can be updated.
-Name: "vcredist"; Description: "Install the required Visual C++ 2022 Redistributable ({code:VCRTDescription})"; Check: NeedsNewVCRT();
+Name: "vcredist"; Description: "Install the required {#SHIPPED_VCRT_VERSION} ({code:VCRTDescription})"; Check: NeedsNewVCRT();
 ; GroupDescription: "{cm:AdditionalIcons}"; 
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; Flags: unchecked
 Name: "freshinstall"; Description: "Fresh install (delete old settings/logs)"; Flags: unchecked
@@ -112,14 +112,12 @@ end;
 function VCRTDescription(Param: String): String;
 var
   VCRTVersion: Variant;
-  ShippedVersion: String;
 begin
   VCRTVersion := GetVCRT;
-  ShippedVersion := {#SHIPPED_VCRT_VERSION};
   if VarIsNull(VCRTVersion) then
     Result := 'none is installed'
   else
-    Result := VCRTVersion + ' is installed, but this installer ships v' + ShippedVersion;
+    Result := VCRTVersion + ' is installed';
 end;
 
 // Checks if a new VCRT is needed by comparing the builds.

--- a/.CI/chatterino-installer.iss
+++ b/.CI/chatterino-installer.iss
@@ -13,6 +13,15 @@
 #define WORKING_DIR ""
 #endif
 
+; Set to the build part of the VCRT version
+#ifndef SHIPPED_VCRT_BUILD
+#define SHIPPED_VCRT_BUILD 0
+#endif
+; Set to the string representation of the VCRT version
+#ifndef SHIPPED_VCRT_VERSION
+#define SHIPPED_VCRT_VERSION '?'
+#endif
+
 [Setup]
 ; NOTE: The value of AppId uniquely identifies this application. Do not use the same AppId value in installers for other applications.
 ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
@@ -56,7 +65,8 @@ SetupWindowTitle=Setup - %1 (Nightly)
 #endif
 
 [Tasks]
-Name: "vcredist"; Description: "Install the required Visual C++ 2015/2017/2019/2022 Redistributable";
+; Only show this option if the VCRT can be updated.
+Name: "vcredist"; Description: "Install the required Visual C++ 2022 Redistributable ({code:VCRTDescription})"; Check: NeedsNewVCRT();
 ; GroupDescription: "{cm:AdditionalIcons}"; 
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; Flags: unchecked
 Name: "freshinstall"; Description: "Fresh install (delete old settings/logs)"; Flags: unchecked
@@ -85,3 +95,42 @@ Type: filesandordirs; Name: "{userappdata}\Chatterino2"; Tasks: freshinstall
 [UninstallDelete]
 ; Delete cache on uninstall
 Type: filesandordirs; Name: "{userappdata}\Chatterino2\Cache"
+
+[Code]
+// Get the VCRT version as a string. Null if the version could not be found.
+function GetVCRT(): Variant;
+var
+  VCRTVersion: String;
+begin
+  Result := Null;
+  if RegQueryStringValue(HKEY_LOCAL_MACHINE, 'SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64', 'Version', VCRTVersion) then
+    Result := VCRTVersion;
+end;
+
+// Gets a description about the VCRT installed vs shipped.
+// This doesn't compare the versions.
+function VCRTDescription(Param: String): String;
+var
+  VCRTVersion: Variant;
+  ShippedVersion: String;
+begin
+  VCRTVersion := GetVCRT;
+  ShippedVersion := {#SHIPPED_VCRT_VERSION};
+  if VarIsNull(VCRTVersion) then
+    Result := 'none is installed'
+  else
+    Result := VCRTVersion + ' is installed, but this installer ships v' + ShippedVersion;
+end;
+
+// Checks if a new VCRT is needed by comparing the builds.
+function NeedsNewVCRT(): Boolean;
+var
+  VCRTBuild: Cardinal;
+begin
+  Result := True;
+  if RegQueryDWordValue(HKEY_LOCAL_MACHINE, 'SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64', 'Bld', VCRTBuild) then
+  begin
+    if VCRTBuild >= {#SHIPPED_VCRT_BUILD} then
+        Result := False;
+  end;
+end;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Minor: Migrate to the new Get Channel Followers Helix endpoint, fixing follower count not showing up in usercards. (#4809)
 - Minor: The account switcher is now styled to match your theme. (#4817)
 - Minor: Add an invisible resize handle to the bottom of frameless user info popups and reply thread popups. (#4795)
+- Minor: The installer now checks for the VC Runtime version and shows more info when it's outdated. (#4847)
 - Bugfix: Trimmed custom streamlink paths on all platforms making sure you don't accidentally add spaces at the beginning or end of its path. (#4834)
 - Bugfix: Fixed a performance issue when displaying replies to certain messages. (#4807)
 - Bugfix: Fixed a data race when disconnecting from Twitch PubSub. (#4771)


### PR DESCRIPTION
# Description

* If the installed VCRT is old enough, the task to install it will be hidden.
* If the version is too low, the installer now shows the installed and shipped version.

For testing, you can change `Bld` to a lower number in `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64` and/or rename it (or `Version`) to simulate the case where it's not installed.

---

Aside: The installer currently doesn't have the option to specify the installation directory. I'm not sure if that's intentional. `DisableDirPage=false` can be added to show the page.
