### PR TITLE
Fix to interpret logger channel names as lowercase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Minor: The account switcher is now styled to match your theme. (#4817)
 - Minor: Add an invisible resize handle to the bottom of frameless user info popups and reply thread popups. (#4795)
 - Minor: The installer now checks for the VC Runtime version and shows more info when it's outdated. (#4847)
-- Bugfix: Fixed capitalized channel names in log inclusion list not being logged. (#4835)
+- Bugfix: Fixed capitalized channel names in log inclusion list not being logged. (#4848)
 - Bugfix: Trimmed custom streamlink paths on all platforms making sure you don't accidentally add spaces at the beginning or end of its path. (#4834)
 - Bugfix: Fixed a performance issue when displaying replies to certain messages. (#4807)
 - Bugfix: Fixed a data race when disconnecting from Twitch PubSub. (#4771)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Minor: Migrate to the new Get Channel Followers Helix endpoint, fixing follower count not showing up in usercards. (#4809)
 - Minor: The account switcher is now styled to match your theme. (#4817)
 - Minor: Add an invisible resize handle to the bottom of frameless user info popups and reply thread popups. (#4795)
+- Bugfix: Fixed capitalized channel names in log inclusion list not logged. (#4835)
 - Bugfix: Trimmed custom streamlink paths on all platforms making sure you don't accidentally add spaces at the beginning or end of its path. (#4834)
 - Bugfix: Fixed a performance issue when displaying replies to certain messages. (#4807)
 - Bugfix: Fixed a data race when disconnecting from Twitch PubSub. (#4771)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Minor: Migrate to the new Get Channel Followers Helix endpoint, fixing follower count not showing up in usercards. (#4809)
 - Minor: The account switcher is now styled to match your theme. (#4817)
 - Minor: Add an invisible resize handle to the bottom of frameless user info popups and reply thread popups. (#4795)
-- Bugfix: Fixed capitalized channel names in log inclusion list not logged. (#4835)
+- Bugfix: Fixed capitalized channel names in log inclusion list not being logged. (#4835)
 - Bugfix: Trimmed custom streamlink paths on all platforms making sure you don't accidentally add spaces at the beginning or end of its path. (#4834)
 - Bugfix: Fixed a performance issue when displaying replies to certain messages. (#4807)
 - Bugfix: Fixed a data race when disconnecting from Twitch PubSub. (#4771)

--- a/src/controllers/logging/ChannelLog.cpp
+++ b/src/controllers/logging/ChannelLog.cpp
@@ -9,7 +9,8 @@ ChannelLog::ChannelLog(QString channelName)
 
 QString ChannelLog::channelName() const
 {
-    return this->channelName_;
+    QString lowercaseChannelName_ = this->channelName_.toLower();
+    return lowercaseChannelName_;
 }
 
 QString ChannelLog::toString() const

--- a/src/controllers/logging/ChannelLog.cpp
+++ b/src/controllers/logging/ChannelLog.cpp
@@ -9,8 +9,7 @@ ChannelLog::ChannelLog(QString channelName)
 
 QString ChannelLog::channelName() const
 {
-    QString lowercaseChannelName = this->channelName_.toLower();
-    return lowercaseChannelName;
+    return this->channelName_.toLower();
 }
 
 QString ChannelLog::toString() const

--- a/src/controllers/logging/ChannelLog.cpp
+++ b/src/controllers/logging/ChannelLog.cpp
@@ -9,8 +9,8 @@ ChannelLog::ChannelLog(QString channelName)
 
 QString ChannelLog::channelName() const
 {
-    QString lowercaseChannelName_ = this->channelName_.toLower();
-    return lowercaseChannelName_;
+    QString lowercaseChannelName = this->channelName_.toLower();
+    return lowercaseChannelName;
 }
 
 QString ChannelLog::toString() const


### PR DESCRIPTION
# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->

Fixes the issue (https://github.com/Chatterino/chatterino2/issues/4835) where logging channels with capitalization wouldn't work, by making channel names lowercase.

I tested the original exe file without my changes and then tested an exe file with my changes and it works.
