### PR TITLE
Fix empty page added when showing OOB dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Bugfix: Fixed input in reply thread popup losing focus when dragging. (#4815)
 - Bugfix: Fixed the Quick Switcher (CTRL+K) from sometimes showing up on the wrong window. (#4819)
 - Bugfix: Fixed too much text being copied when copying chat messages. (#4812, #4830, #4839)
+- Bugfix: Fixed empty page being added when showing out of bounds dialog. (#4849)
 - Dev: Fixed UTF16 encoding of `modes` file for the installer. (#4791)
 - Dev: Temporarily disable High DPI scaling on Qt6 builds on Windows. (#4767)
 - Dev: Tests now run on Ubuntu 22.04 instead of 20.04 to loosen C++ restrictions in tests. (#4774)

--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -1440,6 +1440,11 @@ SplitContainer *SplitNotebook::getOrAddSelectedPage()
     return this->addPage();
 }
 
+SplitContainer *SplitNotebook::getSelectedPage()
+{
+    return dynamic_cast<SplitContainer *>(Notebook::getSelectedPage());
+}
+
 void SplitNotebook::select(QWidget *page, bool focusPage)
 {
     // If there's a previously selected page, go through its splits and

--- a/src/widgets/Notebook.hpp
+++ b/src/widgets/Notebook.hpp
@@ -209,6 +209,8 @@ public:
 
     SplitContainer *addPage(bool select = false);
     SplitContainer *getOrAddSelectedPage();
+    /// Returns `nullptr` when no page is selected.
+    SplitContainer *getSelectedPage();
     void select(QWidget *page, bool focusPage = true) override;
     void themeChangedEvent() override;
 

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -109,7 +109,7 @@ bool Window::event(QEvent *event)
         }
 
         case QEvent::WindowDeactivate: {
-            auto page = this->notebook_->getOrAddSelectedPage();
+            auto *page = this->notebook_->getSelectedPage();
 
             if (page != nullptr)
             {
@@ -119,12 +119,8 @@ bool Window::event(QEvent *event)
                 {
                     split->updateLastReadMessage();
                 }
-            }
 
-            if (SplitContainer *container =
-                    dynamic_cast<SplitContainer *>(page))
-            {
-                container->hideResizeHandles();
+                page->hideResizeHandles();
             }
         }
         break;


### PR DESCRIPTION
# Description

This is a fun kind-of-but-not-really concurrency problem. The dialog is shown by using [`QDialog::exec`](https://doc.qt.io/qt-6/qdialog.html#exec), which creates an additional event-loop. This event-loop will handle the dialog events. One event happens when the dialog is activated/shown, which deactivates the last active window. Since the window is created before the dialog is shown, it gets deactivated. Deactivating the main window will cause `Window::event` to be called, which adds a page, since there are no pages at that point.

Technically, the fix could also move the window creation, but the handler for `QEvent::WindowDeactivate` doesn't need to call `getOrAddSelectedPage` in the first place.

Fixes #3571.
