### PR TITLE
Fix flickering when running with Direct2D

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Dev: Add `WindowManager::getLastSelectedWindow()` to replace `getMainWindow()`. (#4816)
 - Dev: Clarify signal connection lifetimes where applicable. (#4818)
 - Dev: Laid the groundwork for advanced input completion strategies. (#4639, #4846)
+- Dev: Fixed flickering when running with Direct2D on Windows. (#4851)
 
 ## 2.4.5
 

--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -1117,7 +1117,6 @@ void Notebook::setTabLocation(NotebookTabLocation location)
 
 void Notebook::paintEvent(QPaintEvent *event)
 {
-    BaseWidget::paintEvent(event);
     auto scale = this->scale();
 
     QPainter painter(this);

--- a/src/widgets/helper/Button.cpp
+++ b/src/widgets/helper/Button.cpp
@@ -133,7 +133,11 @@ void Button::setMenu(std::unique_ptr<QMenu> menu)
 void Button::paintEvent(QPaintEvent *)
 {
     QPainter painter(this);
+    this->paintButton(painter);
+}
 
+void Button::paintButton(QPainter &painter)
+{
     painter.setRenderHint(QPainter::SmoothPixmapTransform);
 
     if (!this->pixmap_.isNull())

--- a/src/widgets/helper/Button.hpp
+++ b/src/widgets/helper/Button.hpp
@@ -56,7 +56,13 @@ signals:
     void leftMousePress();
 
 protected:
-    virtual void paintEvent(QPaintEvent *) override;
+    void paintEvent(QPaintEvent * /*event*/) override;
+
+    /// Paint this button.
+    /// This is intended for child classes that may want to paint the overlay.
+    /// This function should be used after rendering the custom button,
+    /// because the painter's state will be modified by this function.
+    void paintButton(QPainter &painter);
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     void enterEvent(QEnterEvent * /*event*/) override;
 #else

--- a/src/widgets/helper/NotebookButton.cpp
+++ b/src/widgets/helper/NotebookButton.cpp
@@ -138,7 +138,7 @@ void NotebookButton::paintEvent(QPaintEvent *event)
         default:;
     }
 
-    Button::paintEvent(event);
+    this->paintButton(painter);
 }
 
 void NotebookButton::mouseReleaseEvent(QMouseEvent *event)

--- a/src/widgets/helper/TitlebarButton.cpp
+++ b/src/widgets/helper/TitlebarButton.cpp
@@ -121,8 +121,7 @@ void TitleBarButton::paintEvent(QPaintEvent *event)
         default:;
     }
 
-    Button::paintEvent(event);
-    //    this->fancyPaint(painter);
+    this->paintButton(painter);
 }
 
 }  // namespace chatterino


### PR DESCRIPTION
# Description

When running with Direct2D on Windows, Chatterino would flicker and print warnings that `EndDraw` failed with `D2DERR_POP_CALL_DID_NOT_MATCH_PUSH`. This was because derived buttons (titlebar & notebook) would call `Button::paintEvent` in their `paintEvent` - creating two painters for a paint device at a time (not permitted - [see `QPainter::begin`](https://doc.qt.io/qt-6/qpainter.html#begin)). This PR fixes that.

The only other "issues" I had with Direct2D was [an exception leaking through the driver](https://forums.developer.nvidia.com/t/poco-notfoundexception-thrown-in-driver-version-531-18/245285) and that text rendering isn't as crisp.
