### PR TITLE
fix: Fix username tab completion without @

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 - Dev: Refactor `Image` & Image's `Frames`. (#4773)
 - Dev: Add `WindowManager::getLastSelectedWindow()` to replace `getMainWindow()`. (#4816)
 - Dev: Clarify signal connection lifetimes where applicable. (#4818)
-- Dev: Laid the groundwork for advanced input completion strategies. (#4639, #4846)
+- Dev: Laid the groundwork for advanced input completion strategies. (#4639, #4846, #4853)
 
 ## 2.4.5
 

--- a/src/controllers/completion/TabCompletionModel.cpp
+++ b/src/controllers/completion/TabCompletionModel.cpp
@@ -100,7 +100,7 @@ std::unique_ptr<completion::Source> TabCompletionModel::buildSource(
             return this->buildEmoteSource();
         }
         case SourceKind::User: {
-            return this->buildUserSource();
+            return this->buildUserSource(true);  // Completing with @
         }
         case SourceKind::Command: {
             return this->buildCommandSource();
@@ -116,7 +116,8 @@ std::unique_ptr<completion::Source> TabCompletionModel::buildSource(
         case SourceKind::EmoteUserCommand: {
             std::vector<std::unique_ptr<completion::Source>> sources;
             sources.push_back(this->buildEmoteSource());
-            sources.push_back(this->buildUserSource());
+            sources.push_back(
+                this->buildUserSource(false));  // Not completing with @
             sources.push_back(this->buildCommandSource());
 
             return std::make_unique<completion::UnifiedSource>(
@@ -134,10 +135,12 @@ std::unique_ptr<completion::Source> TabCompletionModel::buildEmoteSource() const
         std::make_unique<completion::ClassicTabEmoteStrategy>());
 }
 
-std::unique_ptr<completion::Source> TabCompletionModel::buildUserSource() const
+std::unique_ptr<completion::Source> TabCompletionModel::buildUserSource(
+    bool prependAt) const
 {
     return std::make_unique<completion::UserSource>(
-        &this->channel_, std::make_unique<completion::ClassicUserStrategy>());
+        &this->channel_, std::make_unique<completion::ClassicUserStrategy>(),
+        nullptr, prependAt);
 }
 
 std::unique_ptr<completion::Source> TabCompletionModel::buildCommandSource()

--- a/src/controllers/completion/TabCompletionModel.hpp
+++ b/src/controllers/completion/TabCompletionModel.hpp
@@ -31,10 +31,15 @@ public:
 
 private:
     enum class SourceKind {
+        // Known to be an emote, i.e. started with :
         Emote,
+        // Known to be a username, i.e. started with @
         User,
+        // Known to be a command, i.e. started with / or .
         Command,
+        // Emote or command without : or / .
         EmoteCommand,
+        // Emote, user, or command without :, @, / .
         EmoteUserCommand
     };
 
@@ -54,7 +59,7 @@ private:
     std::unique_ptr<completion::Source> buildSource(SourceKind kind) const;
 
     std::unique_ptr<completion::Source> buildEmoteSource() const;
-    std::unique_ptr<completion::Source> buildUserSource() const;
+    std::unique_ptr<completion::Source> buildUserSource(bool prependAt) const;
     std::unique_ptr<completion::Source> buildCommandSource() const;
 
     Channel &channel_;


### PR DESCRIPTION
## Description

Fixes usernames not being tab-completed without the `@` prefix (and the "Only search for username autocompletion with an @" setting disabled). 

The completion items being returned by the user source always started with an `@`. The candidate for completion of the query `icel` would be `@icelys, ` which is incompatible due to the extra "@".

Fixes #4850