### PR TITLE
Update Nightly to 2.4.6 and get qt6-related-changes from 2.4.6

### DIFF
--- a/.CI/chatterino-installer.iss
+++ b/.CI/chatterino-installer.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Chatterino"
-#define MyAppVersion "2.4.5"
+#define MyAppVersion "2.4.6"
 #define MyAppPublisher "Chatterino Team"
 #define MyAppURL "https://www.chatterino.com"
 #define MyAppExeName "chatterino.exe"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - master
+      - "bugfix-release/*"
+      - "release/*"
   pull_request:
   workflow_dispatch:
   merge_group:
@@ -14,7 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  C2_ENABLE_LTO: ${{ github.ref == 'refs/heads/master' }}
+  C2_ENABLE_LTO: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/bugfix-release/') || startsWith(github.ref, 'refs/heads/release/') }}
   CHATTERINO_REQUIRE_CLEAN_GIT: On
   C2_BUILD_WITH_QT6: Off
   # Last known good conan version
@@ -27,13 +29,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, macos-latest]
-        qt-version: [5.15.2, 6.5.0]
-        force-lto: [false]
-        plugins: [false]
-        skip-artifact: [false]
-        skip-crashpad: [false]
-        clang-tidy-review: [false]
         include:
           # Ubuntu 20.04, Qt 5.12
           - os: ubuntu-20.04
@@ -59,12 +54,28 @@ jobs:
             skip-artifact: false
             skip-crashpad: false
             clang-tidy-review: false
-          # Test for disabling crashpad on Windows
+          # macOS
+          - os: macos-latest
+            qt-version: 5.15.2
+            force-lto: false
+            plugins: false
+            skip-artifact: false
+            skip-crashpad: false
+            clang-tidy-review: false
+          # Windows
+          - os: windows-latest
+            qt-version: 6.5.0
+            force-lto: false
+            plugins: false
+            skip-artifact: false
+            skip-crashpad: false
+            clang-tidy-review: false
+          # Windows 7/8
           - os: windows-latest
             qt-version: 5.15.2
             force-lto: false
             plugins: false
-            skip-artifact: true
+            skip-artifact: false
             skip-crashpad: true
             clang-tidy-review: false
 
@@ -113,6 +124,26 @@ jobs:
           cache: true
           cache-key-prefix: ${{ runner.os }}-QtCache-${{ matrix.qt-version }}-v2
           version: ${{ matrix.qt-version }}
+
+      - name: Install Qt 6.5.3 imageformats
+        if: startsWith(matrix.qt-version, '6.')
+        uses: jurplel/install-qt-action@v3.3.0
+        with:
+          cache: false
+          modules: qtimageformats
+          set-env: false
+          version: 6.5.3
+          extra: --noarchives
+
+      - name: Find Qt 6.5.3 Path
+        if: startsWith(matrix.qt-version, '6.') && startsWith(matrix.os, 'windows')
+        shell: pwsh
+        id: find-good-imageformats
+        run: |
+          cd "$Env:RUNNER_WORKSPACE/Qt/6.5.3"
+          cd (Get-ChildItem)[0].Name
+          cd plugins/imageformats
+          echo "PLUGIN_PATH=$(pwd)" | Out-File -Path "$Env:GITHUB_OUTPUT" -Encoding ASCII
 
       - name: Install Qt6
         if: startsWith(matrix.qt-version, '6.')
@@ -213,13 +244,24 @@ jobs:
           cp bin/crashpad/crashpad_handler.exe Chatterino2/crashpad/crashpad_handler.exe
           7z a bin/chatterino-Qt-${{ matrix.qt-version }}.pdb.7z bin/chatterino.pdb
 
-      - name: Package (windows)
+      - name: Prepare build dir (windows)
         if: startsWith(matrix.os, 'windows')
         run: |
           cd build
           windeployqt bin/chatterino.exe --release --no-compiler-runtime --no-translations --no-opengl-sw --dir Chatterino2/
           cp bin/chatterino.exe Chatterino2/
           echo nightly > Chatterino2/modes
+
+      - name: Fix Qt6 (windows)
+        if: startsWith(matrix.qt-version, '6.') && startsWith(matrix.os, 'windows')
+        working-directory: build
+        run: |
+          cp ${{ steps.find-good-imageformats.outputs.PLUGIN_PATH }}/qwebp.dll Chatterino2/imageformats/qwebp.dll
+
+      - name: Package (windows)
+        if: startsWith(matrix.os, 'windows')
+        working-directory: build
+        run: |
           7z a chatterino-windows-x86-64-Qt-${{ matrix.qt-version }}.zip Chatterino2/
 
       - name: Upload artifact (Windows - binary)
@@ -467,10 +509,10 @@ jobs:
           # Rename the macos build to indicate that it's for macOS 10.15 users
           mv chatterino-macos-Qt-5.15.2.dmg Chatterino-macOS-10.15.dmg
 
-          # Mark all Qt6 builds as EXPERIMENTAL
           mv Chatterino-ubuntu-22.04-x86_64.deb EXPERIMENTAL-Chatterino-ubuntu-22.04-Qt-6.2.4.deb
-          mv chatterino-windows-x86-64-Qt-6.5.0.zip EXPERIMENTAL-chatterino-windows-x86-64-Qt-6.5.0.zip
-          mv chatterino-Qt-6.5.0.pdb.7z EXPERIMENTAL-chatterino-Qt-6.5.0.pdb.7z
+
+          # Mark all Windows Qt5 builds as old
+          mv chatterino-windows-x86-64-Qt-5.15.2.zip chatterino-windows-old-x86-64-Qt-5.15.2.zip
         working-directory: release-artifacts
         shell: bash
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -215,16 +215,13 @@ jobs:
       - name: Build (Windows)
         if: startsWith(matrix.os, 'windows')
         shell: pwsh
-        env:
-          # Enable PCH on Windows when crashpad is enabled
-          C2_WINDOWS_USE_PCH: ${{ matrix.skip-crashpad && 'OFF' || 'ON' }}
         run: |
           cd build
           cmake `
               -G"NMake Makefiles" `
               -DCMAKE_BUILD_TYPE=RelWithDebInfo `
               -DCMAKE_TOOLCHAIN_FILE="conan_toolchain.cmake" `
-              -DUSE_PRECOMPILED_HEADERS=${{ env.C2_WINDOWS_USE_PCH }} `
+              -DUSE_PRECOMPILED_HEADERS=ON `
               -DBUILD_WITH_CRASHPAD="$Env:C2_ENABLE_CRASHPAD" `
               -DCHATTERINO_LTO="$Env:C2_ENABLE_LTO" `
               -DCHATTERINO_PLUGINS="$Env:C2_PLUGINS" `

--- a/.github/workflows/create-installer.yml
+++ b/.github/workflows/create-installer.yml
@@ -5,7 +5,10 @@ on:
     workflows: ["Build"]
     types: [completed]
     # make sure this only runs on the default branch
-    branches: [master]
+    branches:
+      - master
+      - "bugfix-release/*"
+      - "release/*"
   workflow_dispatch:
 
 jobs:
@@ -15,9 +18,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     strategy:
       matrix:
-        qt-version: [5.15.2, 6.5.0]
-    env:
-      VARIANT_SUFFIX: ${{ startsWith(matrix.qt-version, '6.') && '.EXPERIMENTAL-Qt6' || '' }}
+        qt-version: ["6.5.0"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -28,6 +29,7 @@ jobs:
         with:
           workflow: build.yml
           name: chatterino-windows-x86-64-Qt-${{ matrix.qt-version }}.zip
+          commit: ${{ github.sha }}
           path: build/
 
       - name: Unzip
@@ -52,5 +54,5 @@ jobs:
       - name: Upload installer
         uses: actions/upload-artifact@v3
         with:
-          path: build/${{ steps.build-installer.outputs.C2_INSTALLER_BASE_NAME }}${{ env.VARIANT_SUFFIX }}.exe
-          name: ${{ steps.build-installer.outputs.C2_INSTALLER_BASE_NAME }}${{ env.VARIANT_SUFFIX }}.exe
+          path: build/${{ steps.build-installer.outputs.C2_INSTALLER_BASE_NAME }}.exe
+          name: ${{ steps.build-installer.outputs.C2_INSTALLER_BASE_NAME }}.exe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@
 - Dev: Laid the groundwork for advanced input completion strategies. (#4639, #4846)
 - Dev: Fixed flickering when running with Direct2D on Windows. (#4851)
 
+## 2.4.6
+
+- Minor: Migrate to the new Get Channel Followers Helix endpoint, fixing follower count not showing up in usercards. (#4809)
+- Bugfix: Update Qt version, fixing a security issue with webp loading (see https://www.qt.io/blog/two-qt-security-advisorys-gdi-font-engine-webp-image-format) (#4843)
+- Dev: Temporarily disable High DPI scaling on Qt6 builds on Windows. (#4767)
+
 ## 2.4.5
 
 - Major: AutoMod term management messages (e.g. testaccount added "noob" as a blocked term on AutoMod.) are now hidden in Streamer Mode if you have the "Hide moderation actions" setting enabled. (#4758)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ list(APPEND CMAKE_MODULE_PATH
     "${CMAKE_SOURCE_DIR}/cmake/sanitizers-cmake/cmake"
     )
 
-project(chatterino VERSION 2.4.5)
+project(chatterino VERSION 2.4.6)
 
 option(BUILD_APP "Build Chatterino" ON)
 option(BUILD_TESTS "Build the tests for Chatterino" OFF)

--- a/resources/com.chatterino.chatterino.appdata.xml
+++ b/resources/com.chatterino.chatterino.appdata.xml
@@ -32,6 +32,9 @@
         <binary>chatterino</binary>
     </provides>
     <releases>
+        <release version="2.4.6" date="2023-09-30">
+            <url>https://github.com/Chatterino/chatterino2/releases/tag/v2.4.6</url>
+        </release>
         <release version="2.4.5" date="2023-08-26">
             <url>https://github.com/Chatterino/chatterino2/releases/tag/v2.4.5</url>
         </release>

--- a/src/common/Version.hpp
+++ b/src/common/Version.hpp
@@ -24,7 +24,7 @@
  *  - 2.4.0-alpha.2
  *  - 2.4.0-alpha
  **/
-#define CHATTERINO_VERSION "2.4.5"
+#define CHATTERINO_VERSION "2.4.6"
 
 #if defined(Q_OS_WIN)
 #    define CHATTERINO_OS "win"


### PR DESCRIPTION
# Description

This cherry-picks changes from v2.4.6 (the security release), making sure nightly build users also get the same security fixes.
This means nightly will also be for windows 10 and above users now - we'll continue distributing an older build but it is unsafe.

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
