### PR TITLE
Don't download non-existant qt 5.15 debug symbols for Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -466,12 +466,6 @@ jobs:
           path: release-artifacts/
 
       - uses: actions/download-artifact@v3
-        name: Windows Qt5.15 symbols
-        with:
-          name: chatterino-windows-x86-64-Qt-5.15.2-symbols.pdb.7z
-          path: release-artifacts/
-
-      - uses: actions/download-artifact@v3
         name: Linux Qt5.12.12 AppImage
         with:
           name: Chatterino-x86_64-5.12.12.AppImage


### PR DESCRIPTION
# Description

thanks @Wissididom

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
