### PR TITLE
Fix qtkeychain include for Qt6 users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Dev: Clarify signal connection lifetimes where applicable. (#4818)
 - Dev: Laid the groundwork for advanced input completion strategies. (#4639, #4846, #4853)
 - Dev: Fixed flickering when running with Direct2D on Windows. (#4851)
+- Dev: Fix qtkeychain include for Qt6 users. (#4863)
 - Dev: Add a compile-time flag `CHATTERINO_UPDATER` which can be turned off to disable update checks. (#4854)
 
 ## 2.4.6

--- a/src/common/Credentials.cpp
+++ b/src/common/Credentials.cpp
@@ -11,7 +11,11 @@
 
 #ifndef NO_QTKEYCHAIN
 #    ifdef CMAKE_BUILD
-#        include "qt5keychain/keychain.h"
+#        if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#            include "qt6keychain/keychain.h"
+#        else
+#            include "qt5keychain/keychain.h"
+#        endif
 #    else
 #        include "keychain.h"
 #    endif


### PR DESCRIPTION
# Description

AUR used to patch this with https://aur.archlinux.org/cgit/aur.git/tree/0001-qt6-qtkeychain.patch?h=chatterino2-git but with this PR it should no longer be necessary

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
