### PR TITLE
Fix websocketpp depending on boost::random 

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1007,6 +1007,7 @@ if (MSVC)
         /wd4505
         /wd4100
         /wd4267
+        # Enable updated '__cplusplus' macro - workaround for CMake#18837
         /Zc:__cplusplus
     )
     # Disable min/max macros from Windows.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1007,6 +1007,7 @@ if (MSVC)
         /wd4505
         /wd4100
         /wd4267
+        /Zc:__cplusplus
     )
     # Disable min/max macros from Windows.h
     target_compile_definitions(${LIBRARY_PROJECT} PUBLIC NOMINMAX)


### PR DESCRIPTION
After boost::random dependency was dropped #4776, vcpkg build started to fail because websocketpp still required it.

Websocketpp fallback to boost polyfill if it cant detect compiler support for C++11 or newer 
https://github.com/zaphoyd/websocketpp/blob/b9aeec6eaf3d5610503439b4fae3581d9aff08e8/websocketpp/common/cpp11.hpp#L48

Detection is based on `__cplusplus` macro, which reports correct values for gcc and clang, but [static and old value for msvc](https://learn.microsoft.com/en-us/cpp/build/reference/zc-cplusplus?view=msvc-170).

This PR adds `/Zc:__cplusplus` compiler option for MSVC, which makes it report actual C++ version instead of `199711L`