### PR TITLE
Ignore invisible widgets when hit testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Bugfix: Fixed the Quick Switcher (CTRL+K) from sometimes showing up on the wrong window. (#4819)
 - Bugfix: Fixed too much text being copied when copying chat messages. (#4812, #4830, #4839)
 - Bugfix: Fixed empty page being added when showing out of bounds dialog. (#4849)
+- Bugfix: Fixed issue on Windows preventing the title bar to be dragged in the top left corner. (#4873)
 - Dev: Fixed UTF16 encoding of `modes` file for the installer. (#4791)
 - Dev: Temporarily disable High DPI scaling on Qt6 builds on Windows. (#4767)
 - Dev: Tests now run on Ubuntu 22.04 instead of 20.04 to loosen C++ restrictions in tests. (#4774)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - Bugfix: Fixed the Quick Switcher (CTRL+K) from sometimes showing up on the wrong window. (#4819)
 - Bugfix: Fixed too much text being copied when copying chat messages. (#4812, #4830, #4839)
 - Bugfix: Fixed empty page being added when showing out of bounds dialog. (#4849)
-- Bugfix: Fixed issue on Windows preventing the title bar to be dragged in the top left corner. (#4873)
+- Bugfix: Fixed issue on Windows preventing the title bar from being dragged in the top left corner. (#4873)
 - Dev: Fixed UTF16 encoding of `modes` file for the installer. (#4791)
 - Dev: Temporarily disable High DPI scaling on Qt6 builds on Windows. (#4767)
 - Dev: Tests now run on Ubuntu 22.04 instead of 20.04 to loosen C++ restrictions in tests. (#4774)

--- a/src/widgets/BaseWindow.cpp
+++ b/src/widgets/BaseWindow.cpp
@@ -965,16 +965,17 @@ bool BaseWindow::handleNCHITTEST(MSG *msg, long *result)
 
         return true;
     }
-    else if (this->flags_.has(FramelessDraggable))
+
+    if (this->flags_.has(FramelessDraggable))
     {
         *result = 0;
         bool client = false;
 
-        if (auto widget = this->childAt(point))
+        if (auto *widget = this->childAt(point))
         {
             std::function<bool(QWidget *)> recursiveCheckMouseTracking;
             recursiveCheckMouseTracking = [&](QWidget *widget) {
-                if (widget == nullptr)
+                if (widget == nullptr || !widget->isVisible())
                 {
                     return false;
                 }
@@ -1004,6 +1005,8 @@ bool BaseWindow::handleNCHITTEST(MSG *msg, long *result)
 
         return true;
     }
+
+    // don't handle the message
     return false;
 #else
     return false;

--- a/src/widgets/BaseWindow.cpp
+++ b/src/widgets/BaseWindow.cpp
@@ -379,7 +379,7 @@ void BaseWindow::mousePressEvent(QMouseEvent *event)
         {
             std::function<bool(QWidget *)> recursiveCheckMouseTracking;
             recursiveCheckMouseTracking = [&](QWidget *widget) {
-                if (widget == nullptr)
+                if (widget == nullptr || widget->isHidden())
                 {
                     return false;
                 }
@@ -975,7 +975,7 @@ bool BaseWindow::handleNCHITTEST(MSG *msg, long *result)
         {
             std::function<bool(QWidget *)> recursiveCheckMouseTracking;
             recursiveCheckMouseTracking = [&](QWidget *widget) {
-                if (widget == nullptr || !widget->isVisible())
+                if (widget == nullptr || widget->isHidden())
                 {
                     return false;
                 }

--- a/src/widgets/BaseWindow.cpp
+++ b/src/widgets/BaseWindow.cpp
@@ -936,7 +936,7 @@ bool BaseWindow::handleNCHITTEST(MSG *msg, long *result)
 
             for (QWidget *widget : this->ui_.buttons)
             {
-                if (widget->geometry().contains(point))
+                if (widget->isVisible() && widget->geometry().contains(point))
                 {
                     client = true;
                 }

--- a/src/widgets/BaseWindow.cpp
+++ b/src/widgets/BaseWindow.cpp
@@ -934,17 +934,23 @@ bool BaseWindow::handleNCHITTEST(MSG *msg, long *result)
         {
             bool client = false;
 
-            for (QWidget *widget : this->ui_.buttons)
-            {
-                if (widget->isVisible() && widget->geometry().contains(point))
-                {
-                    client = true;
-                }
-            }
-
+            // Check the main layout first, as it's the largest area
             if (this->ui_.layoutBase->geometry().contains(point))
             {
                 client = true;
+            }
+
+            // Check the titlebar buttons
+            if (!client && this->ui_.titlebarBox->geometry().contains(point))
+            {
+                for (QWidget *widget : this->ui_.buttons)
+                {
+                    if (widget->isVisible() &&
+                        widget->geometry().contains(point))
+                    {
+                        client = true;
+                    }
+                }
             }
 
             if (client)


### PR DESCRIPTION
# Description

Randomly found that we're hit testing invisible widgets (the update button). I added a check to frameless popups as well (although I don't think there are invisible widgets currently).

Since I made changes in the main hit testing anyway, I reordered the checks, so the largest area (→ most likely location of the cursor) gets tested first.

Fixes #1967.
