### PR TITLE
Display all parsed elements when parsing emojis in replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Bugfix: Fixed too much text being copied when copying chat messages. (#4812, #4830, #4839)
 - Bugfix: Fixed empty page being added when showing out of bounds dialog. (#4849)
 - Bugfix: Fixed issue on Windows preventing the title bar from being dragged in the top left corner. (#4873)
-- Bugfix: Fixed emojis getting lost in replies. (#4875)
+- Bugfix: Fixed an issue where reply context didn't render correctly if an emoji was touching text. (#4875)
 - Dev: Fixed UTF16 encoding of `modes` file for the installer. (#4791)
 - Dev: Temporarily disable High DPI scaling on Qt6 builds on Windows. (#4767)
 - Dev: Tests now run on Ubuntu 22.04 instead of 20.04 to loosen C++ restrictions in tests. (#4774)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Bugfix: Fixed too much text being copied when copying chat messages. (#4812, #4830, #4839)
 - Bugfix: Fixed empty page being added when showing out of bounds dialog. (#4849)
 - Bugfix: Fixed issue on Windows preventing the title bar from being dragged in the top left corner. (#4873)
+- Bugfix: Fixed emojis getting lost in replies. (#4875)
 - Dev: Fixed UTF16 encoding of `modes` file for the installer. (#4791)
 - Dev: Temporarily disable High DPI scaling on Qt6 builds on Windows. (#4767)
 - Dev: Tests now run on Ubuntu 22.04 instead of 20.04 to loosen C++ restrictions in tests. (#4774)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -458,6 +458,7 @@ set(SOURCE_FILES
         util/Twitch.cpp
         util/Twitch.hpp
         util/TypeName.hpp
+        util/Variant.hpp
         util/WidgetHelpers.cpp
         util/WidgetHelpers.hpp
         util/WindowsHelper.cpp

--- a/src/util/Variant.hpp
+++ b/src/util/Variant.hpp
@@ -20,4 +20,9 @@ struct Overloaded : Ts... {
     using Ts::operator()...;
 };
 
+// Technically, we shouldn't need this, as we're on C++ 20,
+// but not all of our compilers support CTAD for aggregates yet.
+template <class... Ts>
+Overloaded(Ts...) -> Overloaded<Ts...>;
+
 }  // namespace chatterino::variant

--- a/src/util/Variant.hpp
+++ b/src/util/Variant.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+namespace chatterino::variant {
+
+/// Compile-time safe visitor for std and boost variants.
+///
+/// From https://en.cppreference.com/w/cpp/utility/variant/visit
+///
+/// Usage:
+///
+/// ```
+/// std::variant<int, double> v;
+/// std::visit(variant::Overloaded{
+///     [](double) { qDebug() << "double"; },
+///     [](int) { qDebug() << "int"; }
+/// }, v);
+/// ```
+template <class... Ts>
+struct Overloaded : Ts... {
+    using Ts::operator()...;
+};
+
+}  // namespace chatterino::variant


### PR DESCRIPTION
# Description

Previously, only the first parsed element was used. This also adds a helper for Boost's and `std`'s `apply_visitor`/`visit`, which ensures all alternative types from the variants are handled.

Fixes #4874.
