### PR TITLE
Replace boost::optional with std::optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Dev: Add a compile-time flag `CHATTERINO_UPDATER` which can be turned off to disable update checks. (#4854)
 - Dev: Add a compile-time flag `USE_SYSTEM_MINIAUDIO` which can be turned on to use the system miniaudio. (#4867)
 - Dev: Update vcpkg to use Qt6. (#4872)
+- Dev: Replace `boost::optional` with `std::optional`. (#4877)
 
 ## 2.4.6
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ int compare(const QString &a, const QString &b);
  * link
  * ^^^ No need to repeat the obvious.
  */
-boost::optional<QRegularExpressionMatch> matchLink(const QString &text);
+std::optional<QRegularExpressionMatch> matchLink(const QString &text);
 ```
 
 # Code

--- a/mocks/include/mocks/Helix.hpp
+++ b/mocks/include/mocks/Helix.hpp
@@ -269,7 +269,7 @@ public:
     // contains a comma
     MOCK_METHOD(void, updateFollowerMode,
                 (QString broadcasterID, QString moderatorID,
-                 boost::optional<int> followerModeDuration,
+                 std::optional<int> followerModeDuration,
                  ResultCallback<HelixChatSettings> successCallback,
                  (FailureCallback<HelixUpdateChatSettingsError, QString>
                       failureCallback)),
@@ -279,7 +279,7 @@ public:
     // contains a comma
     MOCK_METHOD(void, updateNonModeratorChatDelay,
                 (QString broadcasterID, QString moderatorID,
-                 boost::optional<int> nonModeratorChatDelayDuration,
+                 std::optional<int> nonModeratorChatDelayDuration,
                  ResultCallback<HelixChatSettings> successCallback,
                  (FailureCallback<HelixUpdateChatSettingsError, QString>
                       failureCallback)),
@@ -289,7 +289,7 @@ public:
     // contains a comma
     MOCK_METHOD(void, updateSlowMode,
                 (QString broadcasterID, QString moderatorID,
-                 boost::optional<int> slowModeWaitTime,
+                 std::optional<int> slowModeWaitTime,
                  ResultCallback<HelixChatSettings> successCallback,
                  (FailureCallback<HelixUpdateChatSettingsError, QString>
                       failureCallback)),
@@ -321,7 +321,7 @@ public:
     // contains a comma
     MOCK_METHOD(void, banUser,
                 (QString broadcasterID, QString moderatorID, QString userID,
-                 boost::optional<int> duration, QString reason,
+                 std::optional<int> duration, QString reason,
                  ResultCallback<> successCallback,
                  (FailureCallback<HelixBanUserError, QString> failureCallback)),
                 (override));  // /timeout, /ban

--- a/mocks/include/mocks/UserData.hpp
+++ b/mocks/include/mocks/UserData.hpp
@@ -11,9 +11,9 @@ public:
 
     // Get extra data about a user
     // If the user does not have any extra data, return none
-    boost::optional<UserData> getUser(const QString &userID) const override
+    std::optional<UserData> getUser(const QString &userID) const override
     {
-        return boost::none;
+        return std::nullopt;
     }
 
     // Update or insert extra data for the user's color override

--- a/src/PrecompiledHeader.hpp
+++ b/src/PrecompiledHeader.hpp
@@ -2,7 +2,6 @@
 #    include <boost/circular_buffer.hpp>
 #    include <boost/current_function.hpp>
 #    include <boost/foreach.hpp>
-#    include <boost/optional.hpp>
 #    include <boost/signals2.hpp>
 #    include <IrcCommand>
 #    include <IrcConnection>
@@ -117,6 +116,7 @@
 #    include <map>
 #    include <memory>
 #    include <mutex>
+#    include <optional>
 #    include <random>
 #    include <set>
 #    include <string>

--- a/src/common/Args.hpp
+++ b/src/common/Args.hpp
@@ -2,8 +2,9 @@
 
 #include "common/WindowDescriptors.hpp"
 
-#include <boost/optional.hpp>
 #include <QApplication>
+
+#include <optional>
 
 namespace chatterino {
 
@@ -18,12 +19,12 @@ public:
     bool shouldRunBrowserExtensionHost{};
     // Shows a single chat. Used on windows to embed in another application.
     bool isFramelessEmbed{};
-    boost::optional<unsigned long long> parentWindowId{};
+    std::optional<unsigned long long> parentWindowId{};
 
     // Not settings directly
     bool dontSaveSettings{};
     bool dontLoadMainWindow{};
-    boost::optional<WindowLayout> customChannelLayout;
+    std::optional<WindowLayout> customChannelLayout;
     bool verbose{};
 
 private:

--- a/src/common/Channel.cpp
+++ b/src/common/Channel.cpp
@@ -80,7 +80,7 @@ LimitedQueueSnapshot<MessagePtr> Channel::getMessageSnapshot()
 }
 
 void Channel::addMessage(MessagePtr message,
-                         boost::optional<MessageFlags> overridingFlags)
+                         std::optional<MessageFlags> overridingFlags)
 {
     auto app = getApp();
     MessagePtr deleted;

--- a/src/common/Channel.hpp
+++ b/src/common/Channel.hpp
@@ -4,13 +4,13 @@
 #include "controllers/completion/TabCompletionModel.hpp"
 #include "messages/LimitedQueue.hpp"
 
-#include <boost/optional.hpp>
 #include <pajlada/signals/signal.hpp>
 #include <QDate>
 #include <QString>
 #include <QTimer>
 
 #include <memory>
+#include <optional>
 
 namespace chatterino {
 
@@ -52,7 +52,7 @@ public:
     pajlada::Signals::Signal<const QString &, const QString &, const QString &,
                              bool &>
         sendReplySignal;
-    pajlada::Signals::Signal<MessagePtr &, boost::optional<MessageFlags>>
+    pajlada::Signals::Signal<MessagePtr &, std::optional<MessageFlags>>
         messageAppended;
     pajlada::Signals::Signal<std::vector<MessagePtr> &> messagesAddedAtStart;
     pajlada::Signals::Signal<size_t, MessagePtr &> messageReplaced;
@@ -75,9 +75,8 @@ public:
     // overridingFlags can be filled in with flags that should be used instead
     // of the message's flags. This is useful in case a flag is specific to a
     // type of split
-    void addMessage(
-        MessagePtr message,
-        boost::optional<MessageFlags> overridingFlags = boost::none);
+    void addMessage(MessagePtr message,
+                    std::optional<MessageFlags> overridingFlags = std::nullopt);
     void addMessagesAtStart(const std::vector<MessagePtr> &messages_);
 
     /// Inserts the given messages in order by Message::serverReceivedTime.

--- a/src/common/Common.hpp
+++ b/src/common/Common.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <boost/optional.hpp>
 #include <boost/preprocessor.hpp>
 #include <QString>
 #include <QWidget>
 
 #include <memory>
+#include <optional>
 #include <string>
 
 namespace chatterino {

--- a/src/common/Env.cpp
+++ b/src/common/Env.cpp
@@ -44,7 +44,7 @@ namespace {
         return defaultValue;
     }
 
-    boost::optional<QString> readOptionalStringEnv(const char *envName)
+    std::optional<QString> readOptionalStringEnv(const char *envName)
     {
         auto envString = std::getenv(envName);
         if (envString != nullptr)
@@ -52,7 +52,7 @@ namespace {
             return QString(envString);
         }
 
-        return boost::none;
+        return std::nullopt;
     }
 
     uint16_t readPortEnv(const char *envName, uint16_t defaultValue)

--- a/src/common/Env.hpp
+++ b/src/common/Env.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <boost/optional.hpp>
 #include <QString>
+
+#include <optional>
 
 namespace chatterino {
 
@@ -17,7 +18,7 @@ public:
     const QString twitchServerHost;
     const uint16_t twitchServerPort;
     const bool twitchServerSecure;
-    const boost::optional<QString> proxyUrl;
+    const std::optional<QString> proxyUrl;
 };
 
 }  // namespace chatterino

--- a/src/common/SignalVectorModel.hpp
+++ b/src/common/SignalVectorModel.hpp
@@ -2,11 +2,12 @@
 
 #include "common/SignalVector.hpp"
 
-#include <boost/optional.hpp>
 #include <pajlada/signals/signalholder.hpp>
 #include <QAbstractTableModel>
 #include <QMimeData>
 #include <QStandardItem>
+
+#include <optional>
 
 namespace chatterino {
 
@@ -166,7 +167,7 @@ public:
 
             assert(this->rows_[row].original);
             TVectorItem item = this->getItemFromRow(
-                this->rows_[row].items, this->rows_[row].original.get());
+                this->rows_[row].items, this->rows_[row].original.value());
             this->vector_->insert(item, vecRow, this);
         }
 
@@ -262,7 +263,7 @@ public:
 
         TVectorItem item =
             this->getItemFromRow(this->rows_[sourceRow].items,
-                                 this->rows_[sourceRow].original.get());
+                                 this->rows_[sourceRow].original.value());
         this->vector_->removeAt(signalVectorRow);
         this->vector_->insert(
             item, this->getVectorIndexFromModelIndex(destinationChild));
@@ -417,7 +418,7 @@ protected:
 
     struct Row {
         std::vector<QStandardItem *> items;
-        boost::optional<TVectorItem> original;
+        std::optional<TVectorItem> original;
         bool isCustomRow;
 
         Row(std::vector<QStandardItem *> _items, bool _isCustomRow = false)

--- a/src/common/SignalVectorModel.hpp
+++ b/src/common/SignalVectorModel.hpp
@@ -128,7 +128,8 @@ public:
 
     QVariant data(const QModelIndex &index, int role) const override
     {
-        int row = index.row(), column = index.column();
+        int row = index.row();
+        int column = index.column();
         if (row < 0 || column < 0 || row >= this->rows_.size() ||
             column >= this->columnCount_)
         {
@@ -141,7 +142,8 @@ public:
     bool setData(const QModelIndex &index, const QVariant &value,
                  int role) override
     {
-        int row = index.row(), column = index.column();
+        int row = index.row();
+        int column = index.column();
         if (row < 0 || column < 0 || row >= this->rows_.size() ||
             column >= this->columnCount_)
         {

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -114,7 +114,7 @@ bool appendWhisperMessageWordsLocally(const QStringList &words)
     const auto &bttvemotes = app->twitch->getBttvEmotes();
     const auto &ffzemotes = app->twitch->getFfzEmotes();
     auto flags = MessageElementFlags();
-    auto emote = boost::optional<EmotePtr>{};
+    auto emote = std::optional<EmotePtr>{};
     for (int i = 2; i < words.length(); i++)
     {
         {  // Twitch emote
@@ -138,7 +138,7 @@ bool appendWhisperMessageWordsLocally(const QStringList &words)
             }
             if (emote)
             {
-                b.emplace<EmoteElement>(emote.get(), flags);
+                b.emplace<EmoteElement>(*emote, flags);
                 continue;
             }
         }  // bttv/ffz emote
@@ -181,7 +181,7 @@ bool appendWhisperMessageWordsLocally(const QStringList &words)
 
     app->twitch->whispersChannel->addMessage(messagexD);
 
-    auto overrideFlags = boost::optional<MessageFlags>(messagexD->flags);
+    auto overrideFlags = std::optional<MessageFlags>(messagexD->flags);
     overrideFlags->set(MessageFlag::DoNotLog);
 
     if (getSettings()->inlineWhispers &&
@@ -2856,7 +2856,7 @@ void CommandController::initialize(Settings &, Paths &paths)
              formatBanTimeoutError](const auto &targetUser) {
                 getHelix()->banUser(
                     twitchChannel->roomId(), currentUser->getUserId(),
-                    targetUser.id, boost::none, reason,
+                    targetUser.id, std::nullopt, reason,
                     [] {
                         // No response for bans, they're emitted over pubsub/IRC instead
                     },
@@ -2910,7 +2910,7 @@ void CommandController::initialize(Settings &, Paths &paths)
 
         getHelix()->banUser(
             twitchChannel->roomId(), currentUser->getUserId(), target,
-            boost::none, reason,
+            std::nullopt, reason,
             [] {
                 // No response for bans, they're emitted over pubsub/IRC instead
             },

--- a/src/controllers/commands/builtin/twitch/ChatSettings.cpp
+++ b/src/controllers/commands/builtin/twitch/ChatSettings.cpp
@@ -289,7 +289,7 @@ QString slowOff(const CommandContext &ctx)
     }
 
     getHelix()->updateSlowMode(ctx.twitchChannel->roomId(),
-                               currentUser->getUserId(), boost::none,
+                               currentUser->getUserId(), std::nullopt,
                                successCallback, failureCallback(ctx.channel));
 
     return "";
@@ -367,7 +367,7 @@ QString followersOff(const CommandContext &ctx)
     }
 
     getHelix()->updateFollowerMode(
-        ctx.twitchChannel->roomId(), currentUser->getUserId(), boost::none,
+        ctx.twitchChannel->roomId(), currentUser->getUserId(), std::nullopt,
         successCallback, failureCallback(ctx.channel));
 
     return "";

--- a/src/controllers/highlights/HighlightController.cpp
+++ b/src/controllers/highlights/HighlightController.cpp
@@ -23,7 +23,7 @@ auto highlightPhraseCheck(const HighlightPhrase &highlight) -> HighlightCheck
         [highlight](const auto &args, const auto &badges,
                     const auto &senderName, const auto &originalMessage,
                     const auto &flags,
-                    const auto self) -> boost::optional<HighlightResult> {
+                    const auto self) -> std::optional<HighlightResult> {
             (void)args;        // unused
             (void)badges;      // unused
             (void)senderName;  // unused
@@ -32,15 +32,15 @@ auto highlightPhraseCheck(const HighlightPhrase &highlight) -> HighlightCheck
             if (self)
             {
                 // Phrase checks should ignore highlights from the user
-                return boost::none;
+                return std::nullopt;
             }
 
             if (!highlight.isMatch(originalMessage))
             {
-                return boost::none;
+                return std::nullopt;
             }
 
-            boost::optional<QUrl> highlightSoundUrl;
+            std::optional<QUrl> highlightSoundUrl;
             if (highlight.hasCustomSound())
             {
                 highlightSoundUrl = highlight.getSoundUrl();
@@ -62,7 +62,7 @@ void rebuildSubscriptionHighlights(Settings &settings,
         auto highlightSound = settings.enableSubHighlightSound.getValue();
         auto highlightAlert = settings.enableSubHighlightTaskbar.getValue();
         auto highlightSoundUrlValue = settings.subHighlightSoundUrl.getValue();
-        boost::optional<QUrl> highlightSoundUrl;
+        std::optional<QUrl> highlightSoundUrl;
         if (!highlightSoundUrlValue.isEmpty())
         {
             highlightSoundUrl = highlightSoundUrlValue;
@@ -73,7 +73,7 @@ void rebuildSubscriptionHighlights(Settings &settings,
         checks.emplace_back(HighlightCheck{
             [=](const auto &args, const auto &badges, const auto &senderName,
                 const auto &originalMessage, const auto &flags,
-                const auto self) -> boost::optional<HighlightResult> {
+                const auto self) -> std::optional<HighlightResult> {
                 (void)badges;           // unused
                 (void)senderName;       // unused
                 (void)originalMessage;  // unused
@@ -82,7 +82,7 @@ void rebuildSubscriptionHighlights(Settings &settings,
 
                 if (!args.isSubscriptionMessage)
                 {
-                    return boost::none;
+                    return std::nullopt;
                 }
 
                 auto highlightColor =
@@ -108,7 +108,7 @@ void rebuildWhisperHighlights(Settings &settings,
         auto highlightAlert = settings.enableWhisperHighlightTaskbar.getValue();
         auto highlightSoundUrlValue =
             settings.whisperHighlightSoundUrl.getValue();
-        boost::optional<QUrl> highlightSoundUrl;
+        std::optional<QUrl> highlightSoundUrl;
         if (!highlightSoundUrlValue.isEmpty())
         {
             highlightSoundUrl = highlightSoundUrlValue;
@@ -119,7 +119,7 @@ void rebuildWhisperHighlights(Settings &settings,
         checks.emplace_back(HighlightCheck{
             [=](const auto &args, const auto &badges, const auto &senderName,
                 const auto &originalMessage, const auto &flags,
-                const auto self) -> boost::optional<HighlightResult> {
+                const auto self) -> std::optional<HighlightResult> {
                 (void)badges;           // unused
                 (void)senderName;       // unused
                 (void)originalMessage;  // unused
@@ -128,7 +128,7 @@ void rebuildWhisperHighlights(Settings &settings,
 
                 if (!args.isReceivedWhisper)
                 {
-                    return boost::none;
+                    return std::nullopt;
                 }
 
                 return HighlightResult{
@@ -151,7 +151,7 @@ void rebuildReplyThreadHighlight(Settings &settings,
         auto highlightAlert = settings.enableThreadHighlightTaskbar.getValue();
         auto highlightSoundUrlValue =
             settings.threadHighlightSoundUrl.getValue();
-        boost::optional<QUrl> highlightSoundUrl;
+        std::optional<QUrl> highlightSoundUrl;
         if (!highlightSoundUrlValue.isEmpty())
         {
             highlightSoundUrl = highlightSoundUrlValue;
@@ -162,7 +162,7 @@ void rebuildReplyThreadHighlight(Settings &settings,
             [=](const auto & /*args*/, const auto & /*badges*/,
                 const auto & /*senderName*/, const auto & /*originalMessage*/,
                 const auto &flags,
-                const auto self) -> boost::optional<HighlightResult> {
+                const auto self) -> std::optional<HighlightResult> {
                 if (flags.has(MessageFlag::SubscribedThread) && !self)
                 {
                     return HighlightResult{
@@ -175,7 +175,7 @@ void rebuildReplyThreadHighlight(Settings &settings,
                     };
                 }
 
-                return boost::none;
+                return std::nullopt;
             }});
     }
 }
@@ -219,7 +219,7 @@ void rebuildUserHighlights(Settings &settings,
             [showInMentions](
                 const auto &args, const auto &badges, const auto &senderName,
                 const auto &originalMessage, const auto &flags,
-                const auto self) -> boost::optional<HighlightResult> {
+                const auto self) -> std::optional<HighlightResult> {
                 (void)args;             //unused
                 (void)badges;           //unused
                 (void)senderName;       //unused
@@ -228,7 +228,7 @@ void rebuildUserHighlights(Settings &settings,
 
                 if (!self)
                 {
-                    return boost::none;
+                    return std::nullopt;
                 }
 
                 // Highlight color is provided by the ColorProvider and will be updated accordingly
@@ -246,7 +246,7 @@ void rebuildUserHighlights(Settings &settings,
             [highlight](const auto &args, const auto &badges,
                         const auto &senderName, const auto &originalMessage,
                         const auto &flags,
-                        const auto self) -> boost::optional<HighlightResult> {
+                        const auto self) -> std::optional<HighlightResult> {
                 (void)args;             // unused
                 (void)badges;           // unused
                 (void)originalMessage;  // unused
@@ -255,10 +255,10 @@ void rebuildUserHighlights(Settings &settings,
 
                 if (!highlight.isMatch(senderName))
                 {
-                    return boost::none;
+                    return std::nullopt;
                 }
 
-                boost::optional<QUrl> highlightSoundUrl;
+                std::optional<QUrl> highlightSoundUrl;
                 if (highlight.hasCustomSound())
                 {
                     highlightSoundUrl = highlight.getSoundUrl();
@@ -286,7 +286,7 @@ void rebuildBadgeHighlights(Settings &settings,
             [highlight](const auto &args, const auto &badges,
                         const auto &senderName, const auto &originalMessage,
                         const auto &flags,
-                        const auto self) -> boost::optional<HighlightResult> {
+                        const auto self) -> std::optional<HighlightResult> {
                 (void)args;             // unused
                 (void)senderName;       // unused
                 (void)originalMessage;  // unused
@@ -297,7 +297,7 @@ void rebuildBadgeHighlights(Settings &settings,
                 {
                     if (highlight.isMatch(badge))
                     {
-                        boost::optional<QUrl> highlightSoundUrl;
+                        std::optional<QUrl> highlightSoundUrl;
                         if (highlight.hasCustomSound())
                         {
                             highlightSoundUrl = highlight.getSoundUrl();
@@ -313,7 +313,7 @@ void rebuildBadgeHighlights(Settings &settings,
                     }
                 }
 
-                return boost::none;
+                return std::nullopt;
             }});
     }
 }
@@ -323,7 +323,7 @@ void rebuildBadgeHighlights(Settings &settings,
 namespace chatterino {
 
 HighlightResult::HighlightResult(bool _alert, bool _playSound,
-                                 boost::optional<QUrl> _customSoundUrl,
+                                 std::optional<QUrl> _customSoundUrl,
                                  std::shared_ptr<QColor> _color,
                                  bool _showInMentions)
     : alert(_alert)
@@ -337,7 +337,7 @@ HighlightResult::HighlightResult(bool _alert, bool _playSound,
 HighlightResult HighlightResult::emptyResult()
 {
     return {
-        false, false, boost::none, nullptr, false,
+        false, false, std::nullopt, nullptr, false,
     };
 }
 
@@ -395,7 +395,7 @@ std::ostream &operator<<(std::ostream &os, const HighlightResult &result)
     os << "Alert: " << (result.alert ? "Yes" : "No") << ", "
        << "Play sound: " << (result.playSound ? "Yes" : "No") << " ("
        << (result.customSoundUrl
-               ? result.customSoundUrl.get().toString().toStdString()
+               ? result.customSoundUrl->toString().toStdString()
                : "")
        << ")"
        << ", "

--- a/src/controllers/highlights/HighlightController.hpp
+++ b/src/controllers/highlights/HighlightController.hpp
@@ -4,7 +4,6 @@
 #include "common/Singleton.hpp"
 #include "common/UniqueAccess.hpp"
 
-#include <boost/optional.hpp>
 #include <pajlada/settings.hpp>
 #include <pajlada/settings/settinglistener.hpp>
 #include <QColor>
@@ -12,6 +11,7 @@
 
 #include <functional>
 #include <memory>
+#include <optional>
 #include <utility>
 
 namespace chatterino {
@@ -23,7 +23,7 @@ using MessageFlags = FlagsEnum<MessageFlag>;
 
 struct HighlightResult {
     HighlightResult(bool _alert, bool _playSound,
-                    boost::optional<QUrl> _customSoundUrl,
+                    std::optional<QUrl> _customSoundUrl,
                     std::shared_ptr<QColor> _color, bool _showInMentions);
 
     /**
@@ -46,7 +46,7 @@ struct HighlightResult {
      *
      * May only be set if playSound is true
      **/
-    boost::optional<QUrl> customSoundUrl{};
+    std::optional<QUrl> customSoundUrl{};
 
     /**
      * @brief set if highlight should set a background color
@@ -76,7 +76,7 @@ struct HighlightResult {
 };
 
 struct HighlightCheck {
-    using Checker = std::function<boost::optional<HighlightResult>(
+    using Checker = std::function<std::optional<HighlightResult>(
         const MessageParseArgs &args, const std::vector<Badge> &badges,
         const QString &senderName, const QString &originalMessage,
         const MessageFlags &messageFlags, bool self)>;

--- a/src/controllers/hotkeys/HotkeyController.cpp
+++ b/src/controllers/hotkeys/HotkeyController.cpp
@@ -189,8 +189,8 @@ QString HotkeyController::categoryName(HotkeyCategory category) const
     return categoryData.name;
 }
 
-const std::map<HotkeyCategory, HotkeyCategoryData> &
-    HotkeyController::categories() const
+const std::map<HotkeyCategory, HotkeyCategoryData>
+    &HotkeyController::categories() const
 {
     return this->hotkeyCategories_;
 }

--- a/src/controllers/hotkeys/HotkeyController.cpp
+++ b/src/controllers/hotkeys/HotkeyController.cpp
@@ -127,7 +127,7 @@ int HotkeyController::replaceHotkey(QString oldName,
     return this->hotkeys_.append(newHotkey);
 }
 
-boost::optional<HotkeyCategory> HotkeyController::hotkeyCategoryFromName(
+std::optional<HotkeyCategory> HotkeyController::hotkeyCategoryFromName(
     QString categoryName)
 {
     for (const auto &[category, data] : this->categories())
@@ -189,8 +189,8 @@ QString HotkeyController::categoryName(HotkeyCategory category) const
     return categoryData.name;
 }
 
-const std::map<HotkeyCategory, HotkeyCategoryData>
-    &HotkeyController::categories() const
+const std::map<HotkeyCategory, HotkeyCategoryData> &
+    HotkeyController::categories() const
 {
     return this->hotkeyCategories_;
 }

--- a/src/controllers/hotkeys/HotkeyController.hpp
+++ b/src/controllers/hotkeys/HotkeyController.hpp
@@ -4,7 +4,6 @@
 #include "common/Singleton.hpp"
 #include "controllers/hotkeys/HotkeyCategory.hpp"
 
-#include <boost/optional.hpp>
 #include <pajlada/signals/signal.hpp>
 #include <pajlada/signals/signalholder.hpp>
 
@@ -52,8 +51,7 @@ public:
      * @returns the new index in the SignalVector
      **/
     int replaceHotkey(QString oldName, std::shared_ptr<Hotkey> newHotkey);
-    boost::optional<HotkeyCategory> hotkeyCategoryFromName(
-        QString categoryName);
+    std::optional<HotkeyCategory> hotkeyCategoryFromName(QString categoryName);
 
     /**
      * @brief checks if the hotkey is duplicate

--- a/src/controllers/hotkeys/HotkeyHelpers.cpp
+++ b/src/controllers/hotkeys/HotkeyHelpers.cpp
@@ -3,8 +3,9 @@
 #include "controllers/hotkeys/ActionNames.hpp"
 #include "controllers/hotkeys/HotkeyCategory.hpp"
 
-#include <boost/optional/optional.hpp>
 #include <QStringList>
+
+#include <optional>
 
 namespace chatterino {
 
@@ -31,7 +32,7 @@ std::vector<QString> parseHotkeyArguments(QString argumentString)
     return arguments;
 }
 
-boost::optional<ActionDefinition> findHotkeyActionDefinition(
+std::optional<ActionDefinition> findHotkeyActionDefinition(
     HotkeyCategory category, const QString &action)
 {
     auto allActions = actionNames.find(category);

--- a/src/controllers/hotkeys/HotkeyHelpers.hpp
+++ b/src/controllers/hotkeys/HotkeyHelpers.hpp
@@ -2,15 +2,15 @@
 
 #include "controllers/hotkeys/ActionNames.hpp"
 
-#include <boost/optional/optional.hpp>
 #include <QString>
 
+#include <optional>
 #include <vector>
 
 namespace chatterino {
 
 std::vector<QString> parseHotkeyArguments(QString argumentString);
-boost::optional<ActionDefinition> findHotkeyActionDefinition(
+std::optional<ActionDefinition> findHotkeyActionDefinition(
     HotkeyCategory category, const QString &action);
 
 }  // namespace chatterino

--- a/src/controllers/moderationactions/ModerationAction.cpp
+++ b/src/controllers/moderationactions/ModerationAction.cpp
@@ -136,7 +136,7 @@ bool ModerationAction::isImage() const
     return bool(this->image_);
 }
 
-const boost::optional<ImagePtr> &ModerationAction::getImage() const
+const std::optional<ImagePtr> &ModerationAction::getImage() const
 {
     assertInGuiThread();
 

--- a/src/controllers/moderationactions/ModerationAction.hpp
+++ b/src/controllers/moderationactions/ModerationAction.hpp
@@ -2,11 +2,11 @@
 
 #include "util/RapidjsonHelpers.hpp"
 
-#include <boost/optional.hpp>
 #include <pajlada/serialize.hpp>
 #include <QString>
 
 #include <memory>
+#include <optional>
 
 namespace chatterino {
 
@@ -21,13 +21,13 @@ public:
     bool operator==(const ModerationAction &other) const;
 
     bool isImage() const;
-    const boost::optional<ImagePtr> &getImage() const;
+    const std::optional<ImagePtr> &getImage() const;
     const QString &getLine1() const;
     const QString &getLine2() const;
     const QString &getAction() const;
 
 private:
-    mutable boost::optional<ImagePtr> image_;
+    mutable std::optional<ImagePtr> image_;
     QString line1_;
     QString line2_;
     QString action_;

--- a/src/controllers/nicknames/Nickname.hpp
+++ b/src/controllers/nicknames/Nickname.hpp
@@ -3,12 +3,12 @@
 #include "util/RapidjsonHelpers.hpp"
 #include "util/RapidJsonSerializeQString.hpp"
 
-#include <boost/optional.hpp>
 #include <pajlada/serialize.hpp>
 #include <QRegularExpression>
 #include <QString>
 
 #include <memory>
+#include <optional>
 
 namespace chatterino {
 
@@ -59,18 +59,18 @@ public:
         return this->isCaseSensitive_;
     }
 
-    [[nodiscard]] boost::optional<QString> match(
+    [[nodiscard]] std::optional<QString> match(
         const QString &usernameText) const
     {
         if (this->isRegex())
         {
             if (!this->regex_.isValid())
             {
-                return boost::none;
+                return std::nullopt;
             }
             if (this->name().isEmpty())
             {
-                return boost::none;
+                return std::nullopt;
             }
 
             auto workingCopy = usernameText;
@@ -90,7 +90,7 @@ public:
             }
         }
 
-        return boost::none;
+        return std::nullopt;
     }
 
 private:

--- a/src/controllers/userdata/UserData.hpp
+++ b/src/controllers/userdata/UserData.hpp
@@ -3,10 +3,11 @@
 #include "util/RapidjsonHelpers.hpp"
 #include "util/RapidJsonSerializeQString.hpp"
 
-#include <boost/optional.hpp>
 #include <pajlada/serialize.hpp>
 #include <QColor>
 #include <QString>
+
+#include <optional>
 
 namespace chatterino {
 
@@ -15,7 +16,7 @@ namespace chatterino {
 // or a user note that should be displayed with the user
 // Replacement fields should be optional, where none denotes that the field should not be updated for the user
 struct UserData {
-    boost::optional<QColor> color{boost::none};
+    std::optional<QColor> color{std::nullopt};
 
     // TODO: User note?
 };

--- a/src/controllers/userdata/UserDataController.cpp
+++ b/src/controllers/userdata/UserDataController.cpp
@@ -2,6 +2,7 @@
 
 #include "singletons/Paths.hpp"
 #include "util/CombinePath.hpp"
+#include "util/Helpers.hpp"
 
 namespace {
 
@@ -42,15 +43,14 @@ void UserDataController::save()
     this->sm->save();
 }
 
-boost::optional<UserData> UserDataController::getUser(
-    const QString &userID) const
+std::optional<UserData> UserDataController::getUser(const QString &userID) const
 {
     std::shared_lock lock(this->usersMutex);
     auto it = this->users.find(userID);
 
     if (it == this->users.end())
     {
-        return boost::none;
+        return std::nullopt;
     }
 
     return it->second;
@@ -67,8 +67,8 @@ void UserDataController::setUserColor(const QString &userID,
 {
     auto c = this->getUsers();
     auto it = c.find(userID);
-    boost::optional<QColor> finalColor =
-        boost::make_optional(!colorString.isEmpty(), QColor(colorString));
+    std::optional<QColor> finalColor =
+        makeConditionedOptional(!colorString.isEmpty(), QColor(colorString));
     if (it == c.end())
     {
         if (!finalColor)

--- a/src/controllers/userdata/UserDataController.hpp
+++ b/src/controllers/userdata/UserDataController.hpp
@@ -7,11 +7,11 @@
 #include "util/RapidJsonSerializeQString.hpp"
 #include "util/serialize/Container.hpp"
 
-#include <boost/optional.hpp>
 #include <pajlada/settings.hpp>
 #include <QColor>
 #include <QString>
 
+#include <optional>
 #include <shared_mutex>
 #include <unordered_map>
 
@@ -22,7 +22,7 @@ class IUserDataController
 public:
     virtual ~IUserDataController() = default;
 
-    virtual boost::optional<UserData> getUser(const QString &userID) const = 0;
+    virtual std::optional<UserData> getUser(const QString &userID) const = 0;
 
     virtual void setUserColor(const QString &userID,
                               const QString &colorString) = 0;
@@ -35,7 +35,7 @@ public:
 
     // Get extra data about a user
     // If the user does not have any extra data, return none
-    boost::optional<UserData> getUser(const QString &userID) const override;
+    std::optional<UserData> getUser(const QString &userID) const override;
 
     // Update or insert extra data for the user's color override
     void setUserColor(const QString &userID,

--- a/src/messages/Emote.hpp
+++ b/src/messages/Emote.hpp
@@ -3,11 +3,10 @@
 #include "common/Aliases.hpp"
 #include "messages/ImageSet.hpp"
 
-#include <boost/optional.hpp>
-
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <unordered_map>
 
 namespace chatterino {
@@ -24,7 +23,7 @@ struct Emote {
      * If this emote is aliased, this contains
      * the original (base) name of the emote.
      */
-    boost::optional<EmoteName> baseName;
+    std::optional<EmoteName> baseName;
 
     // FOURTF: no solution yet, to be refactored later
     const QString &getCopyString() const

--- a/src/messages/LimitedQueue.hpp
+++ b/src/messages/LimitedQueue.hpp
@@ -3,10 +3,10 @@
 #include "messages/LimitedQueueSnapshot.hpp"
 
 #include <boost/circular_buffer.hpp>
-#include <boost/optional.hpp>
 
 #include <cassert>
 #include <mutex>
+#include <optional>
 #include <shared_mutex>
 #include <vector>
 
@@ -62,13 +62,13 @@ public:
      * @param[in] index the index of the item to fetch
      * @return the item at the index if it's populated, or none if it's not
      */
-    [[nodiscard]] boost::optional<T> get(size_t index) const
+    [[nodiscard]] std::optional<T> get(size_t index) const
     {
         std::shared_lock lock(this->mutex_);
 
         if (index >= this->buffer_.size())
         {
-            return boost::none;
+            return std::nullopt;
         }
 
         return this->buffer_[index];
@@ -79,13 +79,13 @@ public:
      *
      * @return the item at the front of the queue if it's populated, or none the queue is empty
      */
-    [[nodiscard]] boost::optional<T> first() const
+    [[nodiscard]] std::optional<T> first() const
     {
         std::shared_lock lock(this->mutex_);
 
         if (this->buffer_.empty())
         {
-            return boost::none;
+            return std::nullopt;
         }
 
         return this->buffer_.front();
@@ -96,13 +96,13 @@ public:
      *
      * @return the item at the back of the queue if it's populated, or none the queue is empty
      */
-    [[nodiscard]] boost::optional<T> last() const
+    [[nodiscard]] std::optional<T> last() const
     {
         std::shared_lock lock(this->mutex_);
 
         if (this->buffer_.empty())
         {
-            return boost::none;
+            return std::nullopt;
         }
 
         return this->buffer_.back();
@@ -293,14 +293,14 @@ public:
      * 
      * The contents of the LimitedQueue are iterated over from front to back 
      * until the first element that satisfies `pred(item)`. If no item 
-     * satisfies the predicate, or if the queue is empty, then boost::none
+     * satisfies the predicate, or if the queue is empty, then std::nullopt
      * is returned.
      * 
      * @param[in] pred predicate that will be applied to items
-     * @return the first item found or boost::none
+     * @return the first item found or std::nullopt
      */
     template <typename Predicate>
-    [[nodiscard]] boost::optional<T> find(Predicate pred) const
+    [[nodiscard]] std::optional<T> find(Predicate pred) const
     {
         std::shared_lock lock(this->mutex_);
 
@@ -312,7 +312,7 @@ public:
             }
         }
 
-        return boost::none;
+        return std::nullopt;
     }
 
     /**
@@ -320,14 +320,14 @@ public:
      * 
      * The contents of the LimitedQueue are iterated over from back to front 
      * until the first element that satisfies `pred(item)`. If no item 
-     * satisfies the predicate, or if the queue is empty, then boost::none
+     * satisfies the predicate, or if the queue is empty, then std::nullopt
      * is returned.
      * 
      * @param[in] pred predicate that will be applied to items
-     * @return the first item found or boost::none
+     * @return the first item found or std::nullopt
      */
     template <typename Predicate>
-    [[nodiscard]] boost::optional<T> rfind(Predicate pred) const
+    [[nodiscard]] std::optional<T> rfind(Predicate pred) const
     {
         std::shared_lock lock(this->mutex_);
 
@@ -339,7 +339,7 @@ public:
             }
         }
 
-        return boost::none;
+        return std::nullopt;
     }
 
 private:

--- a/src/messages/MessageElement.cpp
+++ b/src/messages/MessageElement.cpp
@@ -788,7 +788,7 @@ void TwitchModerationElement::addToContainer(MessageLayoutContainer &container,
             if (auto image = action.getImage())
             {
                 container.addElement(
-                    (new ImageLayoutElement(*this, image.get(), size))
+                    (new ImageLayoutElement(*this, *image, size))
                         ->setLink(Link(Link::UserAction, action.getAction())));
             }
             else

--- a/src/messages/SharedMessageBuilder.cpp
+++ b/src/messages/SharedMessageBuilder.cpp
@@ -277,4 +277,5 @@ QString SharedMessageBuilder::stylizeUsername(const QString &username,
 
     return usernameText;
 }
+
 }  // namespace chatterino

--- a/src/messages/SharedMessageBuilder.cpp
+++ b/src/messages/SharedMessageBuilder.cpp
@@ -175,7 +175,7 @@ void SharedMessageBuilder::parseHighlights()
 
     if (highlightResult.customSoundUrl)
     {
-        this->highlightSoundUrl_ = highlightResult.customSoundUrl.get();
+        this->highlightSoundUrl_ = *highlightResult.customSoundUrl;
     }
     else
     {

--- a/src/providers/NetworkConfigurationProvider.cpp
+++ b/src/providers/NetworkConfigurationProvider.cpp
@@ -69,7 +69,7 @@ void NetworkConfigurationProvider::applyFromEnv(const Env &env)
 {
     if (env.proxyUrl)
     {
-        applyProxy(env.proxyUrl.get());
+        applyProxy(*env.proxyUrl);
     }
 }
 

--- a/src/providers/bttv/BttvEmotes.cpp
+++ b/src/providers/bttv/BttvEmotes.cpp
@@ -185,7 +185,10 @@ std::optional<EmotePtr> BttvEmotes::emote(const EmoteName &name) const
     auto it = emotes->find(name);
 
     if (it == emotes->end())
+    {
         return std::nullopt;
+    }
+
     return it->second;
 }
 
@@ -203,8 +206,10 @@ void BttvEmotes::loadEmotes()
             auto emotes = this->global_.get();
             auto pair = parseGlobalEmotes(result.parseJsonArray(), *emotes);
             if (pair.first)
+            {
                 this->setEmotes(
                     std::make_shared<EmoteMap>(std::move(pair.second)));
+            }
             return pair.first;
         })
         .execute();
@@ -251,13 +256,18 @@ void BttvEmotes::loadChannel(std::weak_ptr<Channel> channel,
         .onError([channelId, channel, manualRefresh](auto result) {
             auto shared = channel.lock();
             if (!shared)
+            {
                 return;
+            }
+
             if (result.status() == 404)
             {
                 // User does not have any BTTV emotes
                 if (manualRefresh)
+                {
                     shared->addMessage(
                         makeSystemMessage(CHANNEL_HAS_NO_EMOTES));
+                }
             }
             else
             {

--- a/src/providers/bttv/BttvEmotes.cpp
+++ b/src/providers/bttv/BttvEmotes.cpp
@@ -179,13 +179,13 @@ std::shared_ptr<const EmoteMap> BttvEmotes::emotes() const
     return this->global_.get();
 }
 
-boost::optional<EmotePtr> BttvEmotes::emote(const EmoteName &name) const
+std::optional<EmotePtr> BttvEmotes::emote(const EmoteName &name) const
 {
     auto emotes = this->global_.get();
     auto it = emotes->find(name);
 
     if (it == emotes->end())
-        return boost::none;
+        return std::nullopt;
     return it->second;
 }
 
@@ -291,7 +291,7 @@ EmotePtr BttvEmotes::addEmote(
     return emote;
 }
 
-boost::optional<std::pair<EmotePtr, EmotePtr>> BttvEmotes::updateEmote(
+std::optional<std::pair<EmotePtr, EmotePtr>> BttvEmotes::updateEmote(
     const QString &channelDisplayName,
     Atomic<std::shared_ptr<const EmoteMap>> &channelEmoteMap,
     const BttvLiveUpdateEmoteUpdateAddMessage &message)
@@ -305,7 +305,7 @@ boost::optional<std::pair<EmotePtr, EmotePtr>> BttvEmotes::updateEmote(
     {
         // We already copied the map at this point and are now discarding the copy.
         // This is fine, because this case should be really rare.
-        return boost::none;
+        return std::nullopt;
     }
     auto oldEmotePtr = it->second;
     // copy the existing emote, to not change the original one
@@ -316,7 +316,7 @@ boost::optional<std::pair<EmotePtr, EmotePtr>> BttvEmotes::updateEmote(
     if (!updateChannelEmote(emote, channelDisplayName, message.jsonEmote))
     {
         // The emote wasn't actually updated
-        return boost::none;
+        return std::nullopt;
     }
 
     auto name = emote.name;
@@ -327,7 +327,7 @@ boost::optional<std::pair<EmotePtr, EmotePtr>> BttvEmotes::updateEmote(
     return std::make_pair(oldEmotePtr, emotePtr);
 }
 
-boost::optional<EmotePtr> BttvEmotes::removeEmote(
+std::optional<EmotePtr> BttvEmotes::removeEmote(
     Atomic<std::shared_ptr<const EmoteMap>> &channelEmoteMap,
     const BttvLiveUpdateEmoteRemoveMessage &message)
 {
@@ -338,7 +338,7 @@ boost::optional<EmotePtr> BttvEmotes::removeEmote(
     {
         // We already copied the map at this point and are now discarding the copy.
         // This is fine, because this case should be really rare.
-        return boost::none;
+        return std::nullopt;
     }
     auto emote = it->second;
     updatedMap.erase(it);

--- a/src/providers/bttv/BttvEmotes.hpp
+++ b/src/providers/bttv/BttvEmotes.hpp
@@ -3,9 +3,8 @@
 #include "common/Aliases.hpp"
 #include "common/Atomic.hpp"
 
-#include <boost/optional.hpp>
-
 #include <memory>
+#include <optional>
 
 namespace chatterino {
 
@@ -27,7 +26,7 @@ public:
     BttvEmotes();
 
     std::shared_ptr<const EmoteMap> emotes() const;
-    boost::optional<EmotePtr> emote(const EmoteName &name) const;
+    std::optional<EmotePtr> emote(const EmoteName &name) const;
     void loadEmotes();
     void setEmotes(std::shared_ptr<const EmoteMap> emotes);
     static void loadChannel(std::weak_ptr<Channel> channel,
@@ -55,7 +54,7 @@ public:
      *
      * @return pair<old emote, new emote> if any emote was updated.
      */
-    static boost::optional<std::pair<EmotePtr, EmotePtr>> updateEmote(
+    static std::optional<std::pair<EmotePtr, EmotePtr>> updateEmote(
         const QString &channelDisplayName,
         Atomic<std::shared_ptr<const EmoteMap>> &channelEmoteMap,
         const BttvLiveUpdateEmoteUpdateAddMessage &message);
@@ -67,7 +66,7 @@ public:
      *
      * @return The removed emote if any emote was removed.
      */
-    static boost::optional<EmotePtr> removeEmote(
+    static std::optional<EmotePtr> removeEmote(
         Atomic<std::shared_ptr<const EmoteMap>> &channelEmoteMap,
         const BttvLiveUpdateEmoteRemoveMessage &message);
 

--- a/src/providers/chatterino/ChatterinoBadges.cpp
+++ b/src/providers/chatterino/ChatterinoBadges.cpp
@@ -21,7 +21,7 @@ ChatterinoBadges::ChatterinoBadges()
 {
 }
 
-boost::optional<EmotePtr> ChatterinoBadges::getBadge(const UserId &id)
+std::optional<EmotePtr> ChatterinoBadges::getBadge(const UserId &id)
 {
     std::shared_lock lock(this->mutex_);
 
@@ -30,7 +30,7 @@ boost::optional<EmotePtr> ChatterinoBadges::getBadge(const UserId &id)
     {
         return emotes[it->second];
     }
-    return boost::none;
+    return std::nullopt;
 }
 
 void ChatterinoBadges::loadChatterinoBadges()

--- a/src/providers/chatterino/ChatterinoBadges.hpp
+++ b/src/providers/chatterino/ChatterinoBadges.hpp
@@ -4,9 +4,8 @@
 #include "common/Singleton.hpp"
 #include "util/QStringHash.hpp"
 
-#include <boost/optional.hpp>
-
 #include <memory>
+#include <optional>
 #include <shared_mutex>
 #include <unordered_map>
 #include <vector>
@@ -22,7 +21,7 @@ public:
     virtual void initialize(Settings &settings, Paths &paths) override;
     ChatterinoBadges();
 
-    boost::optional<EmotePtr> getBadge(const UserId &id);
+    std::optional<EmotePtr> getBadge(const UserId &id);
 
 private:
     void loadChatterinoBadges();

--- a/src/providers/ffz/FfzBadges.cpp
+++ b/src/providers/ffz/FfzBadges.cpp
@@ -43,7 +43,7 @@ std::vector<FfzBadges::Badge> FfzBadges::getUserBadges(const UserId &id)
     return badges;
 }
 
-boost::optional<FfzBadges::Badge> FfzBadges::getBadge(const int badgeID)
+std::optional<FfzBadges::Badge> FfzBadges::getBadge(const int badgeID)
 {
     auto it = this->badges.find(badgeID);
     if (it != this->badges.end())
@@ -51,7 +51,7 @@ boost::optional<FfzBadges::Badge> FfzBadges::getBadge(const int badgeID)
         return it->second;
     }
 
-    return boost::none;
+    return std::nullopt;
 }
 
 void FfzBadges::load()

--- a/src/providers/ffz/FfzBadges.hpp
+++ b/src/providers/ffz/FfzBadges.hpp
@@ -4,10 +4,10 @@
 #include "common/Singleton.hpp"
 #include "util/QStringHash.hpp"
 
-#include <boost/optional.hpp>
 #include <QColor>
 
 #include <memory>
+#include <optional>
 #include <set>
 #include <shared_mutex>
 #include <unordered_map>
@@ -32,7 +32,7 @@ public:
     std::vector<Badge> getUserBadges(const UserId &id);
 
 private:
-    boost::optional<Badge> getBadge(int badgeID);
+    std::optional<Badge> getBadge(int badgeID);
 
     void load();
 

--- a/src/providers/ffz/FfzEmotes.cpp
+++ b/src/providers/ffz/FfzEmotes.cpp
@@ -119,10 +119,10 @@ namespace {
         return emotes;
     }
 
-    boost::optional<EmotePtr> parseAuthorityBadge(const QJsonObject &badgeUrls,
-                                                  const QString &tooltip)
+    std::optional<EmotePtr> parseAuthorityBadge(const QJsonObject &badgeUrls,
+                                                const QString &tooltip)
     {
-        boost::optional<EmotePtr> authorityBadge;
+        std::optional<EmotePtr> authorityBadge;
 
         if (!badgeUrls.isEmpty())
         {
@@ -173,7 +173,7 @@ std::shared_ptr<const EmoteMap> FfzEmotes::emotes() const
     return this->global_.get();
 }
 
-boost::optional<EmotePtr> FfzEmotes::emote(const EmoteName &name) const
+std::optional<EmotePtr> FfzEmotes::emote(const EmoteName &name) const
 {
     auto emotes = this->global_.get();
     auto it = emotes->find(name);
@@ -181,7 +181,7 @@ boost::optional<EmotePtr> FfzEmotes::emote(const EmoteName &name) const
     {
         return it->second;
     }
-    return boost::none;
+    return std::nullopt;
 }
 
 void FfzEmotes::loadEmotes()
@@ -214,8 +214,8 @@ void FfzEmotes::setEmotes(std::shared_ptr<const EmoteMap> emotes)
 void FfzEmotes::loadChannel(
     std::weak_ptr<Channel> channel, const QString &channelID,
     std::function<void(EmoteMap &&)> emoteCallback,
-    std::function<void(boost::optional<EmotePtr>)> modBadgeCallback,
-    std::function<void(boost::optional<EmotePtr>)> vipBadgeCallback,
+    std::function<void(std::optional<EmotePtr>)> modBadgeCallback,
+    std::function<void(std::optional<EmotePtr>)> vipBadgeCallback,
     bool manualRefresh)
 {
     qCDebug(chatterinoFfzemotes)

--- a/src/providers/ffz/FfzEmotes.hpp
+++ b/src/providers/ffz/FfzEmotes.hpp
@@ -3,9 +3,8 @@
 #include "common/Aliases.hpp"
 #include "common/Atomic.hpp"
 
-#include <boost/optional.hpp>
-
 #include <memory>
+#include <optional>
 
 namespace chatterino {
 
@@ -20,14 +19,14 @@ public:
     FfzEmotes();
 
     std::shared_ptr<const EmoteMap> emotes() const;
-    boost::optional<EmotePtr> emote(const EmoteName &name) const;
+    std::optional<EmotePtr> emote(const EmoteName &name) const;
     void loadEmotes();
     void setEmotes(std::shared_ptr<const EmoteMap> emotes);
     static void loadChannel(
         std::weak_ptr<Channel> channel, const QString &channelId,
         std::function<void(EmoteMap &&)> emoteCallback,
-        std::function<void(boost::optional<EmotePtr>)> modBadgeCallback,
-        std::function<void(boost::optional<EmotePtr>)> vipBadgeCallback,
+        std::function<void(std::optional<EmotePtr>)> modBadgeCallback,
+        std::function<void(std::optional<EmotePtr>)> vipBadgeCallback,
         bool manualRefresh);
 
 private:

--- a/src/providers/seventv/SeventvBadges.cpp
+++ b/src/providers/seventv/SeventvBadges.cpp
@@ -13,7 +13,7 @@
 
 namespace chatterino {
 
-boost::optional<EmotePtr> SeventvBadges::getBadge(const UserId &id) const
+std::optional<EmotePtr> SeventvBadges::getBadge(const UserId &id) const
 {
     std::shared_lock lock(this->mutex_);
 
@@ -22,7 +22,7 @@ boost::optional<EmotePtr> SeventvBadges::getBadge(const UserId &id) const
     {
         return it->second;
     }
-    return boost::none;
+    return std::nullopt;
 }
 
 void SeventvBadges::assignBadgeToUser(const QString &badgeID,

--- a/src/providers/seventv/SeventvBadges.hpp
+++ b/src/providers/seventv/SeventvBadges.hpp
@@ -4,10 +4,10 @@
 #include "common/Singleton.hpp"
 #include "util/QStringHash.hpp"
 
-#include <boost/optional.hpp>
 #include <QJsonObject>
 
 #include <memory>
+#include <optional>
 #include <shared_mutex>
 #include <unordered_map>
 
@@ -20,7 +20,7 @@ class SeventvBadges : public Singleton
 {
 public:
     // Return the badge, if any, that is assigned to the user
-    boost::optional<EmotePtr> getBadge(const UserId &id) const;
+    std::optional<EmotePtr> getBadge(const UserId &id) const;
 
     // Assign the given badge to the user
     void assignBadgeToUser(const QString &badgeID, const UserId &userID);

--- a/src/providers/seventv/SeventvEmotes.cpp
+++ b/src/providers/seventv/SeventvEmotes.cpp
@@ -11,6 +11,7 @@
 #include "providers/seventv/SeventvAPI.hpp"
 #include "providers/twitch/TwitchChannel.hpp"
 #include "singletons/Settings.hpp"
+#include "util/Helpers.hpp"
 
 #include <QJsonArray>
 #include <QJsonDocument>
@@ -109,7 +110,7 @@ CreateEmoteResult createEmote(const QJsonObject &activeEmote,
     auto emote =
         Emote({emoteName, imageSet, tooltip,
                Url{EMOTE_LINK_FORMAT.arg(emoteId.string)}, zeroWidth, emoteId,
-               author, boost::make_optional(aliasedName, baseEmoteName)});
+               author, makeConditionedOptional(aliasedName, baseEmoteName)});
 
     return {emote, emoteId, emoteName, !emote.images.getImage1()->isEmpty()};
 }
@@ -162,7 +163,7 @@ EmotePtr createUpdatedEmote(const EmotePtr &oldEmote,
     bool toNonAliased = oldEmote->baseName.has_value() &&
                         dispatch.emoteName == oldEmote->baseName->string;
 
-    auto baseName = oldEmote->baseName.get_value_or(oldEmote->name);
+    auto baseName = oldEmote->baseName.value_or(oldEmote->name);
     auto emote = std::make_shared<const Emote>(Emote(
         {EmoteName{dispatch.emoteName}, oldEmote->images,
          toNonAliased
@@ -170,7 +171,7 @@ EmotePtr createUpdatedEmote(const EmotePtr &oldEmote,
              : createAliasedTooltip(dispatch.emoteName, baseName.string,
                                     oldEmote->author.string, false),
          oldEmote->homePage, oldEmote->zeroWidth, oldEmote->id,
-         oldEmote->author, boost::make_optional(!toNonAliased, baseName)}));
+         oldEmote->author, makeConditionedOptional(!toNonAliased, baseName)}));
     return emote;
 }
 
@@ -191,15 +192,14 @@ std::shared_ptr<const EmoteMap> SeventvEmotes::globalEmotes() const
     return this->global_.get();
 }
 
-boost::optional<EmotePtr> SeventvEmotes::globalEmote(
-    const EmoteName &name) const
+std::optional<EmotePtr> SeventvEmotes::globalEmote(const EmoteName &name) const
 {
     auto emotes = this->global_.get();
     auto it = emotes->find(name);
 
     if (it == emotes->end())
     {
-        return boost::none;
+        return std::nullopt;
     }
     return it->second;
 }
@@ -328,7 +328,7 @@ void SeventvEmotes::loadChannelEmotes(
         });
 }
 
-boost::optional<EmotePtr> SeventvEmotes::addEmote(
+std::optional<EmotePtr> SeventvEmotes::addEmote(
     Atomic<std::shared_ptr<const EmoteMap>> &map,
     const EmoteAddDispatch &dispatch)
 {
@@ -336,7 +336,7 @@ boost::optional<EmotePtr> SeventvEmotes::addEmote(
     auto emoteData = dispatch.emoteJson["data"].toObject();
     if (emoteData.empty() || !checkEmoteVisibility(emoteData))
     {
-        return boost::none;
+        return std::nullopt;
     }
 
     // This copies the map.
@@ -347,7 +347,7 @@ boost::optional<EmotePtr> SeventvEmotes::addEmote(
         // Incoming emote didn't contain any images, abort
         qCDebug(chatterinoSeventv)
             << "Emote without images:" << dispatch.emoteJson;
-        return boost::none;
+        return std::nullopt;
     }
     auto emote = std::make_shared<const Emote>(std::move(result.emote));
     updatedMap[result.name] = emote;
@@ -356,7 +356,7 @@ boost::optional<EmotePtr> SeventvEmotes::addEmote(
     return emote;
 }
 
-boost::optional<EmotePtr> SeventvEmotes::updateEmote(
+std::optional<EmotePtr> SeventvEmotes::updateEmote(
     Atomic<std::shared_ptr<const EmoteMap>> &map,
     const EmoteUpdateDispatch &dispatch)
 {
@@ -364,7 +364,7 @@ boost::optional<EmotePtr> SeventvEmotes::updateEmote(
     auto oldEmote = oldMap->findEmote(dispatch.emoteName, dispatch.emoteID);
     if (oldEmote == oldMap->end())
     {
-        return boost::none;
+        return std::nullopt;
     }
 
     // This copies the map.
@@ -378,7 +378,7 @@ boost::optional<EmotePtr> SeventvEmotes::updateEmote(
     return emote;
 }
 
-boost::optional<EmotePtr> SeventvEmotes::removeEmote(
+std::optional<EmotePtr> SeventvEmotes::removeEmote(
     Atomic<std::shared_ptr<const EmoteMap>> &map,
     const EmoteRemoveDispatch &dispatch)
 {
@@ -389,7 +389,7 @@ boost::optional<EmotePtr> SeventvEmotes::removeEmote(
     {
         // We already copied the map at this point and are now discarding the copy.
         // This is fine, because this case should be really rare.
-        return boost::none;
+        return std::nullopt;
     }
     auto emote = it->second;
     updatedMap.erase(it);

--- a/src/providers/seventv/SeventvEmotes.hpp
+++ b/src/providers/seventv/SeventvEmotes.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "boost/optional.hpp"
 #include "common/Aliases.hpp"
 #include "common/Atomic.hpp"
 #include "common/FlagsEnum.hpp"
@@ -8,6 +7,7 @@
 #include <QJsonObject>
 
 #include <memory>
+#include <optional>
 
 namespace chatterino {
 
@@ -89,7 +89,7 @@ public:
     SeventvEmotes();
 
     std::shared_ptr<const EmoteMap> globalEmotes() const;
-    boost::optional<EmotePtr> globalEmote(const EmoteName &name) const;
+    std::optional<EmotePtr> globalEmote(const EmoteName &name) const;
     void loadGlobalEmotes();
     void setGlobalEmotes(std::shared_ptr<const EmoteMap> emotes);
     static void loadChannelEmotes(
@@ -104,7 +104,7 @@ public:
      *
      * @return The added emote if an emote was added.
      */
-    static boost::optional<EmotePtr> addEmote(
+    static std::optional<EmotePtr> addEmote(
         Atomic<std::shared_ptr<const EmoteMap>> &map,
         const seventv::eventapi::EmoteAddDispatch &dispatch);
 
@@ -115,7 +115,7 @@ public:
      *
      * @return The updated emote if any emote was updated.
      */
-    static boost::optional<EmotePtr> updateEmote(
+    static std::optional<EmotePtr> updateEmote(
         Atomic<std::shared_ptr<const EmoteMap>> &map,
         const seventv::eventapi::EmoteUpdateDispatch &dispatch);
 
@@ -126,7 +126,7 @@ public:
      *
      * @return The removed emote if any emote was removed.
      */
-    static boost::optional<EmotePtr> removeEmote(
+    static std::optional<EmotePtr> removeEmote(
         Atomic<std::shared_ptr<const EmoteMap>> &map,
         const seventv::eventapi::EmoteRemoveDispatch &dispatch);
 

--- a/src/providers/seventv/eventapi/Message.hpp
+++ b/src/providers/seventv/eventapi/Message.hpp
@@ -2,11 +2,12 @@
 
 #include "providers/seventv/eventapi/Subscription.hpp"
 
-#include <boost/optional.hpp>
 #include <magic_enum.hpp>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QString>
+
+#include <optional>
 
 namespace chatterino::seventv::eventapi {
 
@@ -18,22 +19,22 @@ struct Message {
     Message(QJsonObject _json);
 
     template <class InnerClass>
-    boost::optional<InnerClass> toInner();
+    std::optional<InnerClass> toInner();
 };
 
 template <class InnerClass>
-boost::optional<InnerClass> Message::toInner()
+std::optional<InnerClass> Message::toInner()
 {
     return InnerClass{this->data};
 }
 
-static boost::optional<Message> parseBaseMessage(const QString &blob)
+static std::optional<Message> parseBaseMessage(const QString &blob)
 {
     QJsonDocument jsonDoc(QJsonDocument::fromJson(blob.toUtf8()));
 
     if (jsonDoc.isNull())
     {
-        return boost::none;
+        return std::nullopt;
     }
 
     return Message(jsonDoc.object());

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -914,7 +914,7 @@ void IrcMessageHandler::handleWhisperMessage(Communi::IrcMessage *message)
 
     c->addMessage(_message);
 
-    auto overrideFlags = boost::optional<MessageFlags>(_message->flags);
+    auto overrideFlags = std::optional<MessageFlags>(_message->flags);
     overrideFlags->set(MessageFlag::DoNotTriggerNotification);
     overrideFlags->set(MessageFlag::DoNotLog);
 

--- a/src/providers/twitch/PubSubManager.cpp
+++ b/src/providers/twitch/PubSubManager.cpp
@@ -727,14 +727,14 @@ void PubSub::registerNonce(QString nonce, NonceInfo info)
     this->nonces_[nonce] = std::move(info);
 }
 
-boost::optional<PubSub::NonceInfo> PubSub::findNonceInfo(QString nonce)
+std::optional<PubSub::NonceInfo> PubSub::findNonceInfo(QString nonce)
 {
     // TODO: This should also DELETE the nonceinfo from the map
     auto it = this->nonces_.find(nonce);
 
     if (it == this->nonces_.end())
     {
-        return boost::none;
+        return std::nullopt;
     }
 
     return it->second;

--- a/src/providers/twitch/PubSubManager.hpp
+++ b/src/providers/twitch/PubSubManager.hpp
@@ -5,7 +5,6 @@
 #include "util/ExponentialBackoff.hpp"
 #include "util/QStringHash.hpp"
 
-#include <boost/optional.hpp>
 #include <pajlada/signals/signal.hpp>
 #include <QJsonObject>
 #include <QString>
@@ -15,6 +14,7 @@
 #include <chrono>
 #include <map>
 #include <memory>
+#include <optional>
 #include <thread>
 #include <unordered_map>
 #include <vector>
@@ -188,7 +188,7 @@ private:
     void registerNonce(QString nonce, NonceInfo nonceInfo);
 
     // Find client associated with a nonce
-    boost::optional<NonceInfo> findNonceInfo(QString nonce);
+    std::optional<NonceInfo> findNonceInfo(QString nonce);
 
     std::unordered_map<QString, NonceInfo> nonces_;
 

--- a/src/providers/twitch/TwitchBadges.cpp
+++ b/src/providers/twitch/TwitchBadges.cpp
@@ -149,8 +149,8 @@ void TwitchBadges::loaded()
     }
 }
 
-boost::optional<EmotePtr> TwitchBadges::badge(const QString &set,
-                                              const QString &version) const
+std::optional<EmotePtr> TwitchBadges::badge(const QString &set,
+                                            const QString &version) const
 {
     auto badgeSets = this->badgeSets_.access();
     auto it = badgeSets->find(set);
@@ -162,10 +162,10 @@ boost::optional<EmotePtr> TwitchBadges::badge(const QString &set,
             return it2->second;
         }
     }
-    return boost::none;
+    return std::nullopt;
 }
 
-boost::optional<EmotePtr> TwitchBadges::badge(const QString &set) const
+std::optional<EmotePtr> TwitchBadges::badge(const QString &set) const
 {
     auto badgeSets = this->badgeSets_.access();
     auto it = badgeSets->find(set);
@@ -176,7 +176,7 @@ boost::optional<EmotePtr> TwitchBadges::badge(const QString &set) const
             return it->second.begin()->second;
         }
     }
-    return boost::none;
+    return std::nullopt;
 }
 
 void TwitchBadges::getBadgeIcon(const QString &name, BadgeIconCallback callback)

--- a/src/providers/twitch/TwitchBadges.hpp
+++ b/src/providers/twitch/TwitchBadges.hpp
@@ -3,7 +3,6 @@
 #include "common/UniqueAccess.hpp"
 #include "util/QStringHash.hpp"
 
-#include <boost/optional.hpp>
 #include <pajlada/signals/signal.hpp>
 #include <QIcon>
 #include <QJsonObject>
@@ -11,6 +10,7 @@
 #include <QString>
 
 #include <memory>
+#include <optional>
 #include <queue>
 #include <shared_mutex>
 #include <unordered_map>
@@ -35,10 +35,10 @@ public:
     static TwitchBadges *instance();
 
     // Get badge from name and version
-    boost::optional<EmotePtr> badge(const QString &set,
-                                    const QString &version) const;
+    std::optional<EmotePtr> badge(const QString &set,
+                                  const QString &version) const;
     // Get first matching badge with name, regardless of version
-    boost::optional<EmotePtr> badge(const QString &set) const;
+    std::optional<EmotePtr> badge(const QString &set) const;
 
     void getBadgeIcon(const QString &name, BadgeIconCallback callback);
     void getBadgeIcon(const DisplayBadge &badge, BadgeIconCallback callback);

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -955,10 +955,10 @@ void TwitchChannel::updateSeventvData(const QString &newUserID,
         return;
     }
 
-    std::optional<QString> oldUserID = makeConditionedOptional(
+    const auto oldUserID = makeConditionedOptional(
         !this->seventvUserID_.isEmpty() && this->seventvUserID_ != newUserID,
         this->seventvUserID_);
-    std::optional<QString> oldEmoteSetID =
+    const auto oldEmoteSetID =
         makeConditionedOptional(!this->seventvEmoteSetID_.isEmpty() &&
                                     this->seventvEmoteSetID_ != newEmoteSetID,
                                 this->seventvEmoteSetID_);

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -1251,8 +1251,8 @@ void TwitchChannel::addReplyThread(const std::shared_ptr<MessageThread> &thread)
     this->threads_[thread->rootId()] = thread;
 }
 
-const std::unordered_map<QString, std::weak_ptr<MessageThread>> &
-    TwitchChannel::threads() const
+const std::unordered_map<QString, std::weak_ptr<MessageThread>>
+    &TwitchChannel::threads() const
 {
     return this->threads_;
 }

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -35,6 +35,7 @@
 #include "singletons/Settings.hpp"
 #include "singletons/Toasts.hpp"
 #include "singletons/WindowManager.hpp"
+#include "util/Helpers.hpp"
 #include "util/PostToThread.hpp"
 #include "util/QStringHash.hpp"
 #include "widgets/Window.hpp"
@@ -396,14 +397,14 @@ bool TwitchChannel::isChannelPointRewardKnown(const QString &rewardId)
     return it != pointRewards->end();
 }
 
-boost::optional<ChannelPointReward> TwitchChannel::channelPointReward(
+std::optional<ChannelPointReward> TwitchChannel::channelPointReward(
     const QString &rewardId) const
 {
     auto rewards = this->channelPointRewards_.accessConst();
     auto it = rewards->find(rewardId);
 
     if (it == rewards->end())
-        return boost::none;
+        return std::nullopt;
     return it->second;
 }
 
@@ -751,35 +752,34 @@ SharedAccessGuard<const TwitchChannel::StreamStatus>
     return this->streamStatus_.accessConst();
 }
 
-boost::optional<EmotePtr> TwitchChannel::bttvEmote(const EmoteName &name) const
+std::optional<EmotePtr> TwitchChannel::bttvEmote(const EmoteName &name) const
 {
     auto emotes = this->bttvEmotes_.get();
     auto it = emotes->find(name);
 
     if (it == emotes->end())
-        return boost::none;
+        return std::nullopt;
     return it->second;
 }
 
-boost::optional<EmotePtr> TwitchChannel::ffzEmote(const EmoteName &name) const
+std::optional<EmotePtr> TwitchChannel::ffzEmote(const EmoteName &name) const
 {
     auto emotes = this->ffzEmotes_.get();
     auto it = emotes->find(name);
 
     if (it == emotes->end())
-        return boost::none;
+        return std::nullopt;
     return it->second;
 }
 
-boost::optional<EmotePtr> TwitchChannel::seventvEmote(
-    const EmoteName &name) const
+std::optional<EmotePtr> TwitchChannel::seventvEmote(const EmoteName &name) const
 {
     auto emotes = this->seventvEmotes_.get();
     auto it = emotes->find(name);
 
     if (it == emotes->end())
     {
-        return boost::none;
+        return std::nullopt;
     }
     return it->second;
 }
@@ -865,7 +865,7 @@ void TwitchChannel::removeBttvEmote(
     }
 
     this->addOrReplaceLiveUpdatesAddRemove(false, "BTTV", QString() /*actor*/,
-                                           removed.get()->name.string);
+                                           (*removed)->name.string);
 }
 
 void TwitchChannel::addSeventvEmote(
@@ -904,7 +904,7 @@ void TwitchChannel::removeSeventvEmote(
     }
 
     this->addOrReplaceLiveUpdatesAddRemove(false, "7TV", dispatch.actorName,
-                                           removed.get()->name.string);
+                                           (*removed)->name.string);
 }
 
 void TwitchChannel::updateSeventvUser(
@@ -955,13 +955,13 @@ void TwitchChannel::updateSeventvData(const QString &newUserID,
         return;
     }
 
-    boost::optional<QString> oldUserID = boost::make_optional(
+    std::optional<QString> oldUserID = makeConditionedOptional(
         !this->seventvUserID_.isEmpty() && this->seventvUserID_ != newUserID,
         this->seventvUserID_);
-    boost::optional<QString> oldEmoteSetID =
-        boost::make_optional(!this->seventvEmoteSetID_.isEmpty() &&
-                                 this->seventvEmoteSetID_ != newEmoteSetID,
-                             this->seventvEmoteSetID_);
+    std::optional<QString> oldEmoteSetID =
+        makeConditionedOptional(!this->seventvEmoteSetID_.isEmpty() &&
+                                    this->seventvEmoteSetID_ != newEmoteSetID,
+                                this->seventvEmoteSetID_);
 
     this->seventvUserID_ = newUserID;
     this->seventvEmoteSetID_ = newEmoteSetID;
@@ -974,8 +974,8 @@ void TwitchChannel::updateSeventvData(const QString &newUserID,
             if (oldUserID || oldEmoteSetID)
             {
                 getApp()->twitch->dropSeventvChannel(
-                    oldUserID.get_value_or(QString()),
-                    oldEmoteSetID.get_value_or(QString()));
+                    oldUserID.value_or(QString()),
+                    oldEmoteSetID.value_or(QString()));
             }
         }
     });
@@ -1251,8 +1251,8 @@ void TwitchChannel::addReplyThread(const std::shared_ptr<MessageThread> &thread)
     this->threads_[thread->rootId()] = thread;
 }
 
-const std::unordered_map<QString, std::weak_ptr<MessageThread>>
-    &TwitchChannel::threads() const
+const std::unordered_map<QString, std::weak_ptr<MessageThread>> &
+    TwitchChannel::threads() const
 {
     return this->threads_;
 }
@@ -1538,8 +1538,8 @@ void TwitchChannel::createClip()
         });
 }
 
-boost::optional<EmotePtr> TwitchChannel::twitchBadge(
-    const QString &set, const QString &version) const
+std::optional<EmotePtr> TwitchChannel::twitchBadge(const QString &set,
+                                                   const QString &version) const
 {
     auto badgeSets = this->badgeSets_.access();
     auto it = badgeSets->find(set);
@@ -1551,20 +1551,20 @@ boost::optional<EmotePtr> TwitchChannel::twitchBadge(
             return it2->second;
         }
     }
-    return boost::none;
+    return std::nullopt;
 }
 
-boost::optional<EmotePtr> TwitchChannel::ffzCustomModBadge() const
+std::optional<EmotePtr> TwitchChannel::ffzCustomModBadge() const
 {
     return this->ffzCustomModBadge_.get();
 }
 
-boost::optional<EmotePtr> TwitchChannel::ffzCustomVipBadge() const
+std::optional<EmotePtr> TwitchChannel::ffzCustomVipBadge() const
 {
     return this->ffzCustomVipBadge_.get();
 }
 
-boost::optional<CheerEmote> TwitchChannel::cheerEmote(const QString &string)
+std::optional<CheerEmote> TwitchChannel::cheerEmote(const QString &string)
 {
     auto sets = this->cheerEmoteSets_.access();
     for (const auto &set : *sets)
@@ -1590,7 +1590,7 @@ boost::optional<CheerEmote> TwitchChannel::cheerEmote(const QString &string)
             }
         }
     }
-    return boost::none;
+    return std::nullopt;
 }
 
 void TwitchChannel::updateSevenTVActivity()

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -9,7 +9,6 @@
 #include "providers/twitch/TwitchEmotes.hpp"
 #include "util/QStringHash.hpp"
 
-#include <boost/optional.hpp>
 #include <boost/signals2.hpp>
 #include <pajlada/signals/signalholder.hpp>
 #include <QColor>
@@ -134,9 +133,9 @@ public:
     SharedAccessGuard<const StreamStatus> accessStreamStatus() const;
 
     // Emotes
-    boost::optional<EmotePtr> bttvEmote(const EmoteName &name) const;
-    boost::optional<EmotePtr> ffzEmote(const EmoteName &name) const;
-    boost::optional<EmotePtr> seventvEmote(const EmoteName &name) const;
+    std::optional<EmotePtr> bttvEmote(const EmoteName &name) const;
+    std::optional<EmotePtr> ffzEmote(const EmoteName &name) const;
+    std::optional<EmotePtr> seventvEmote(const EmoteName &name) const;
     std::shared_ptr<const EmoteMap> bttvEmotes() const;
     std::shared_ptr<const EmoteMap> ffzEmotes() const;
     std::shared_ptr<const EmoteMap> seventvEmotes() const;
@@ -172,13 +171,13 @@ public:
                            const QString &newEmoteSetID);
 
     // Badges
-    boost::optional<EmotePtr> ffzCustomModBadge() const;
-    boost::optional<EmotePtr> ffzCustomVipBadge() const;
-    boost::optional<EmotePtr> twitchBadge(const QString &set,
-                                          const QString &version) const;
+    std::optional<EmotePtr> ffzCustomModBadge() const;
+    std::optional<EmotePtr> ffzCustomVipBadge() const;
+    std::optional<EmotePtr> twitchBadge(const QString &set,
+                                        const QString &version) const;
 
     // Cheers
-    boost::optional<CheerEmote> cheerEmote(const QString &string);
+    std::optional<CheerEmote> cheerEmote(const QString &string);
 
     // Replies
     /**
@@ -217,7 +216,7 @@ public:
         channelPointRewardAdded;
     void addChannelPointReward(const ChannelPointReward &reward);
     bool isChannelPointRewardKnown(const QString &rewardId);
-    boost::optional<ChannelPointReward> channelPointReward(
+    std::optional<ChannelPointReward> channelPointReward(
         const QString &rewardId) const;
 
     // Live status
@@ -342,8 +341,8 @@ protected:
     Atomic<std::shared_ptr<const EmoteMap>> bttvEmotes_;
     Atomic<std::shared_ptr<const EmoteMap>> ffzEmotes_;
     Atomic<std::shared_ptr<const EmoteMap>> seventvEmotes_;
-    Atomic<boost::optional<EmotePtr>> ffzCustomModBadge_;
-    Atomic<boost::optional<EmotePtr>> ffzCustomVipBadge_;
+    Atomic<std::optional<EmotePtr>> ffzCustomModBadge_;
+    Atomic<std::optional<EmotePtr>> ffzCustomVipBadge_;
 
 private:
     // Badges

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -229,7 +229,7 @@ MessagePtr TwitchMessageBuilder::build()
         if (reward)
         {
             this->appendChannelPointRewardMessage(
-                reward.get(), this, this->channel->isMod(),
+                *reward, this, this->channel->isMod(),
                 this->channel->isBroadcaster());
         }
     }
@@ -1069,7 +1069,7 @@ Outcome TwitchMessageBuilder::tryAppendEmote(const EmoteName &name)
     const auto &globalSeventvEmotes = app->twitch->getSeventvEmotes();
 
     auto flags = MessageElementFlags();
-    auto emote = boost::optional<EmotePtr>{};
+    auto emote = std::optional<EmotePtr>{};
     bool zeroWidth = false;
 
     // Emote order:
@@ -1124,8 +1124,7 @@ Outcome TwitchMessageBuilder::tryAppendEmote(const EmoteName &name)
                 auto baseEmoteElement = this->releaseBack();
 
                 std::vector<LayeredEmoteElement::Emote> layers = {
-                    {baseEmote, baseEmoteElement->getFlags()},
-                    {emote.get(), flags}};
+                    {baseEmote, baseEmoteElement->getFlags()}, {*emote, flags}};
                 this->emplace<LayeredEmoteElement>(
                     std::move(layers), baseEmoteElement->getFlags() | flags,
                     this->textColor_);
@@ -1135,7 +1134,7 @@ Outcome TwitchMessageBuilder::tryAppendEmote(const EmoteName &name)
             auto asLayered = dynamic_cast<LayeredEmoteElement *>(&this->back());
             if (asLayered)
             {
-                asLayered->addEmoteLayer({emote.get(), flags});
+                asLayered->addEmoteLayer({*emote, flags});
                 asLayered->addFlags(flags);
                 return Success;
             }
@@ -1143,15 +1142,14 @@ Outcome TwitchMessageBuilder::tryAppendEmote(const EmoteName &name)
             // No emote to merge with, just show as regular emote
         }
 
-        this->emplace<EmoteElement>(emote.get(), flags, this->textColor_);
+        this->emplace<EmoteElement>(*emote, flags, this->textColor_);
         return Success;
     }
 
     return Failure;
 }
 
-boost::optional<EmotePtr> TwitchMessageBuilder::getTwitchBadge(
-    const Badge &badge)
+std::optional<EmotePtr> TwitchMessageBuilder::getTwitchBadge(const Badge &badge)
 {
     if (auto channelBadge =
             this->twitchChannel->twitchBadge(badge.key_, badge.value_))
@@ -1165,7 +1163,7 @@ boost::optional<EmotePtr> TwitchMessageBuilder::getTwitchBadge(
         return globalBadge;
     }
 
-    return boost::none;
+    return std::nullopt;
 }
 
 std::unordered_map<QString, QString> TwitchMessageBuilder::parseBadgeInfoTag(
@@ -1248,7 +1246,7 @@ void TwitchMessageBuilder::appendTwitchBadges()
             if (auto customModBadge = this->twitchChannel->ffzCustomModBadge())
             {
                 this->emplace<ModBadgeElement>(
-                        customModBadge.get(),
+                        *customModBadge,
                         MessageElementFlag::BadgeChannelAuthority)
                     ->setTooltip((*customModBadge)->tooltip.string);
                 // early out, since we have to add a custom badge element here
@@ -1260,7 +1258,7 @@ void TwitchMessageBuilder::appendTwitchBadges()
             if (auto customVipBadge = this->twitchChannel->ffzCustomVipBadge())
             {
                 this->emplace<VipBadgeElement>(
-                        customVipBadge.get(),
+                        *customVipBadge,
                         MessageElementFlag::BadgeChannelAuthority)
                     ->setTooltip((*customVipBadge)->tooltip.string);
                 // early out, since we have to add a custom badge element here
@@ -1302,7 +1300,7 @@ void TwitchMessageBuilder::appendTwitchBadges()
             }
         }
 
-        this->emplace<BadgeElement>(badgeEmote.get(), badge.flag_)
+        this->emplace<BadgeElement>(*badgeEmote, badge.flag_)
             ->setTooltip(tooltip);
     }
 

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -228,7 +228,7 @@ MessagePtr TwitchMessageBuilder::build()
             this->args.channelPointRewardId);
         if (reward)
         {
-            this->appendChannelPointRewardMessage(
+            TwitchMessageBuilder::appendChannelPointRewardMessage(
                 *reward, this, this->channel->isMod(),
                 this->channel->isBroadcaster());
         }
@@ -1115,7 +1115,7 @@ Outcome TwitchMessageBuilder::tryAppendEmote(const EmoteName &name)
             !this->isEmpty())
         {
             // Attempt to merge current zero-width emote into any previous emotes
-            auto asEmote = dynamic_cast<EmoteElement *>(&this->back());
+            auto *asEmote = dynamic_cast<EmoteElement *>(&this->back());
             if (asEmote)
             {
                 // Make sure to access asEmote before taking ownership when releasing
@@ -1131,7 +1131,8 @@ Outcome TwitchMessageBuilder::tryAppendEmote(const EmoteName &name)
                 return Success;
             }
 
-            auto asLayered = dynamic_cast<LayeredEmoteElement *>(&this->back());
+            auto *asLayered =
+                dynamic_cast<LayeredEmoteElement *>(&this->back());
             if (asLayered)
             {
                 asLayered->addEmoteLayer({*emote, flags});

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -1150,7 +1150,8 @@ Outcome TwitchMessageBuilder::tryAppendEmote(const EmoteName &name)
     return Failure;
 }
 
-std::optional<EmotePtr> TwitchMessageBuilder::getTwitchBadge(const Badge &badge)
+std::optional<EmotePtr> TwitchMessageBuilder::getTwitchBadge(
+    const Badge &badge) const
 {
     if (auto channelBadge =
             this->twitchChannel->twitchBadge(badge.key_, badge.value_))

--- a/src/providers/twitch/TwitchMessageBuilder.hpp
+++ b/src/providers/twitch/TwitchMessageBuilder.hpp
@@ -4,11 +4,11 @@
 #include "common/Outcome.hpp"
 #include "messages/SharedMessageBuilder.hpp"
 
-#include <boost/optional.hpp>
 #include <IrcMessage>
 #include <QString>
 #include <QVariant>
 
+#include <optional>
 #include <unordered_map>
 
 namespace chatterino {
@@ -108,7 +108,7 @@ private:
 
     void runIgnoreReplaces(std::vector<TwitchEmoteOccurrence> &twitchEmotes);
 
-    boost::optional<EmotePtr> getTwitchBadge(const Badge &badge);
+    std::optional<EmotePtr> getTwitchBadge(const Badge &badge);
     Outcome tryAppendEmote(const EmoteName &name) override;
 
     void addWords(const QStringList &words,

--- a/src/providers/twitch/TwitchMessageBuilder.hpp
+++ b/src/providers/twitch/TwitchMessageBuilder.hpp
@@ -108,7 +108,7 @@ private:
 
     void runIgnoreReplaces(std::vector<TwitchEmoteOccurrence> &twitchEmotes);
 
-    std::optional<EmotePtr> getTwitchBadge(const Badge &badge);
+    std::optional<EmotePtr> getTwitchBadge(const Badge &badge) const;
     Outcome tryAppendEmote(const EmoteName &name) override;
 
     void addWords(const QStringList &words,

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -1741,7 +1741,7 @@ void Helix::updateEmoteMode(
 
 void Helix::updateFollowerMode(
     QString broadcasterID, QString moderatorID,
-    boost::optional<int> followerModeDuration,
+    std::optional<int> followerModeDuration,
     ResultCallback<HelixChatSettings> successCallback,
     FailureCallback<HelixUpdateChatSettingsError, QString> failureCallback)
 {
@@ -1758,7 +1758,7 @@ void Helix::updateFollowerMode(
 
 void Helix::updateNonModeratorChatDelay(
     QString broadcasterID, QString moderatorID,
-    boost::optional<int> nonModeratorChatDelayDuration,
+    std::optional<int> nonModeratorChatDelayDuration,
     ResultCallback<HelixChatSettings> successCallback,
     FailureCallback<HelixUpdateChatSettingsError, QString> failureCallback)
 {
@@ -1777,7 +1777,7 @@ void Helix::updateNonModeratorChatDelay(
 
 void Helix::updateSlowMode(
     QString broadcasterID, QString moderatorID,
-    boost::optional<int> slowModeWaitTime,
+    std::optional<int> slowModeWaitTime,
     ResultCallback<HelixChatSettings> successCallback,
     FailureCallback<HelixUpdateChatSettingsError, QString> failureCallback)
 {
@@ -2138,7 +2138,7 @@ void Helix::fetchModerators(
 // Ban/timeout a user
 // https://dev.twitch.tv/docs/api/reference#ban-user
 void Helix::banUser(QString broadcasterID, QString moderatorID, QString userID,
-                    boost::optional<int> duration, QString reason,
+                    std::optional<int> duration, QString reason,
                     ResultCallback<> successCallback,
                     FailureCallback<HelixBanUserError, QString> failureCallback)
 {
@@ -2890,14 +2890,14 @@ NetworkRequest Helix::makeRequest(const QString &url, const QUrlQuery &urlQuery,
     {
         qCDebug(chatterinoTwitch)
             << "Helix::makeRequest called without a client ID set BabyRage";
-        // return boost::none;
+        // return std::nullopt;
     }
 
     if (this->oauthToken.isEmpty())
     {
         qCDebug(chatterinoTwitch)
             << "Helix::makeRequest called without an oauth token set BabyRage";
-        // return boost::none;
+        // return std::nullopt;
     }
 
     const QString baseUrl("https://api.twitch.tv/helix/");

--- a/src/providers/twitch/api/Helix.hpp
+++ b/src/providers/twitch/api/Helix.hpp
@@ -3,9 +3,9 @@
 #include "common/Aliases.hpp"
 #include "common/NetworkRequest.hpp"
 #include "providers/twitch/TwitchEmotes.hpp"
+#include "util/Helpers.hpp"
 #include "util/QStringHash.hpp"
 
-#include <boost/optional.hpp>
 #include <QDateTime>
 #include <QJsonArray>
 #include <QJsonObject>
@@ -15,6 +15,7 @@
 #include <QUrlQuery>
 
 #include <functional>
+#include <optional>
 #include <unordered_set>
 #include <vector>
 
@@ -277,24 +278,23 @@ struct HelixChannelEmote {
 struct HelixChatSettings {
     const QString broadcasterId;
     const bool emoteMode;
-    // boost::none if disabled
-    const boost::optional<int> followerModeDuration;  // time in minutes
-    const boost::optional<int>
-        nonModeratorChatDelayDuration;            // time in seconds
-    const boost::optional<int> slowModeWaitTime;  // time in seconds
+    // std::nullopt if disabled
+    const std::optional<int> followerModeDuration;           // time in minutes
+    const std::optional<int> nonModeratorChatDelayDuration;  // time in seconds
+    const std::optional<int> slowModeWaitTime;               // time in seconds
     const bool subscriberMode;
     const bool uniqueChatMode;
 
     explicit HelixChatSettings(QJsonObject jsonObject)
         : broadcasterId(jsonObject.value("broadcaster_id").toString())
         , emoteMode(jsonObject.value("emote_mode").toBool())
-        , followerModeDuration(boost::make_optional(
+        , followerModeDuration(makeConditionedOptional(
               jsonObject.value("follower_mode").toBool(),
               jsonObject.value("follower_mode_duration").toInt()))
-        , nonModeratorChatDelayDuration(boost::make_optional(
+        , nonModeratorChatDelayDuration(makeConditionedOptional(
               jsonObject.value("non_moderator_chat_delay").toBool(),
               jsonObject.value("non_moderator_chat_delay_duration").toInt()))
-        , slowModeWaitTime(boost::make_optional(
+        , slowModeWaitTime(makeConditionedOptional(
               jsonObject.value("slow_mode").toBool(),
               jsonObject.value("slow_mode_wait_time").toInt()))
         , subscriberMode(jsonObject.value("subscriber_mode").toBool())
@@ -908,7 +908,7 @@ public:
     // https://dev.twitch.tv/docs/api/reference#update-chat-settings
     virtual void updateFollowerMode(
         QString broadcasterID, QString moderatorID,
-        boost::optional<int> followerModeDuration,
+        std::optional<int> followerModeDuration,
         ResultCallback<HelixChatSettings> successCallback,
         FailureCallback<HelixUpdateChatSettingsError, QString>
             failureCallback) = 0;
@@ -917,7 +917,7 @@ public:
     // https://dev.twitch.tv/docs/api/reference#update-chat-settings
     virtual void updateNonModeratorChatDelay(
         QString broadcasterID, QString moderatorID,
-        boost::optional<int> nonModeratorChatDelayDuration,
+        std::optional<int> nonModeratorChatDelayDuration,
         ResultCallback<HelixChatSettings> successCallback,
         FailureCallback<HelixUpdateChatSettingsError, QString>
             failureCallback) = 0;
@@ -926,7 +926,7 @@ public:
     // https://dev.twitch.tv/docs/api/reference#update-chat-settings
     virtual void updateSlowMode(
         QString broadcasterID, QString moderatorID,
-        boost::optional<int> slowModeWaitTime,
+        std::optional<int> slowModeWaitTime,
         ResultCallback<HelixChatSettings> successCallback,
         FailureCallback<HelixUpdateChatSettingsError, QString>
             failureCallback) = 0;
@@ -951,7 +951,7 @@ public:
     // https://dev.twitch.tv/docs/api/reference#ban-user
     virtual void banUser(
         QString broadcasterID, QString moderatorID, QString userID,
-        boost::optional<int> duration, QString reason,
+        std::optional<int> duration, QString reason,
         ResultCallback<> successCallback,
         FailureCallback<HelixBanUserError, QString> failureCallback) = 0;
 
@@ -1224,7 +1224,7 @@ public:
     // https://dev.twitch.tv/docs/api/reference#update-chat-settings
     void updateFollowerMode(
         QString broadcasterID, QString moderatorID,
-        boost::optional<int> followerModeDuration,
+        std::optional<int> followerModeDuration,
         ResultCallback<HelixChatSettings> successCallback,
         FailureCallback<HelixUpdateChatSettingsError, QString> failureCallback)
         final;
@@ -1233,7 +1233,7 @@ public:
     // https://dev.twitch.tv/docs/api/reference#update-chat-settings
     void updateNonModeratorChatDelay(
         QString broadcasterID, QString moderatorID,
-        boost::optional<int> nonModeratorChatDelayDuration,
+        std::optional<int> nonModeratorChatDelayDuration,
         ResultCallback<HelixChatSettings> successCallback,
         FailureCallback<HelixUpdateChatSettingsError, QString> failureCallback)
         final;
@@ -1241,7 +1241,7 @@ public:
     // Updates the slow mode using
     // https://dev.twitch.tv/docs/api/reference#update-chat-settings
     void updateSlowMode(QString broadcasterID, QString moderatorID,
-                        boost::optional<int> slowModeWaitTime,
+                        std::optional<int> slowModeWaitTime,
                         ResultCallback<HelixChatSettings> successCallback,
                         FailureCallback<HelixUpdateChatSettingsError, QString>
                             failureCallback) final;
@@ -1266,7 +1266,7 @@ public:
     // https://dev.twitch.tv/docs/api/reference#ban-user
     void banUser(
         QString broadcasterID, QString moderatorID, QString userID,
-        boost::optional<int> duration, QString reason,
+        std::optional<int> duration, QString reason,
         ResultCallback<> successCallback,
         FailureCallback<HelixBanUserError, QString> failureCallback) final;
 

--- a/src/providers/twitch/pubsubmessages/Base.hpp
+++ b/src/providers/twitch/pubsubmessages/Base.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
-#include <boost/optional.hpp>
 #include <magic_enum.hpp>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QString>
+
+#include <optional>
 
 namespace chatterino {
 
@@ -27,16 +28,16 @@ struct PubSubMessage {
     PubSubMessage(QJsonObject _object);
 
     template <class InnerClass>
-    boost::optional<InnerClass> toInner();
+    std::optional<InnerClass> toInner();
 };
 
 template <class InnerClass>
-boost::optional<InnerClass> PubSubMessage::toInner()
+std::optional<InnerClass> PubSubMessage::toInner()
 {
     auto dataValue = this->object.value("data");
     if (!dataValue.isObject())
     {
-        return boost::none;
+        return std::nullopt;
     }
 
     auto data = dataValue.toObject();
@@ -44,14 +45,13 @@ boost::optional<InnerClass> PubSubMessage::toInner()
     return InnerClass{this->nonce, data};
 }
 
-static boost::optional<PubSubMessage> parsePubSubBaseMessage(
-    const QString &blob)
+static std::optional<PubSubMessage> parsePubSubBaseMessage(const QString &blob)
 {
     QJsonDocument jsonDoc(QJsonDocument::fromJson(blob.toUtf8()));
 
     if (jsonDoc.isNull())
     {
-        return boost::none;
+        return std::nullopt;
     }
 
     return PubSubMessage(jsonDoc.object());

--- a/src/providers/twitch/pubsubmessages/Message.hpp
+++ b/src/providers/twitch/pubsubmessages/Message.hpp
@@ -2,10 +2,11 @@
 
 #include "common/QLogging.hpp"
 
-#include <boost/optional.hpp>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QString>
+
+#include <optional>
 
 namespace chatterino {
 
@@ -42,15 +43,15 @@ struct PubSubMessageMessage {
     }
 
     template <class InnerClass>
-    boost::optional<InnerClass> toInner() const;
+    std::optional<InnerClass> toInner() const;
 };
 
 template <class InnerClass>
-boost::optional<InnerClass> PubSubMessageMessage::toInner() const
+std::optional<InnerClass> PubSubMessageMessage::toInner() const
 {
     if (this->messageObject.empty())
     {
-        return boost::none;
+        return std::nullopt;
     }
 
     return InnerClass{this->messageObject};

--- a/src/singletons/NativeMessaging.cpp
+++ b/src/singletons/NativeMessaging.cpp
@@ -312,9 +312,9 @@ void NativeMessagingServer::syncChannels(const QJsonArray &twitchChannels)
     this->channelWarmer_ = std::move(updated);
 }
 
-Atomic<boost::optional<QString>> &nmIpcError()
+Atomic<std::optional<QString>> &nmIpcError()
 {
-    static Atomic<boost::optional<QString>> x;
+    static Atomic<std::optional<QString>> x;
     return x;
 }
 

--- a/src/singletons/NativeMessaging.hpp
+++ b/src/singletons/NativeMessaging.hpp
@@ -2,10 +2,10 @@
 
 #include "common/Atomic.hpp"
 
-#include <boost/optional.hpp>
 #include <QString>
 #include <QThread>
 
+#include <optional>
 #include <vector>
 
 namespace chatterino {
@@ -19,7 +19,7 @@ using ChannelPtr = std::shared_ptr<Channel>;
 void registerNmHost(Paths &paths);
 std::string &getNmQueueName(Paths &paths);
 
-Atomic<boost::optional<QString>> &nmIpcError();
+Atomic<std::optional<QString>> &nmIpcError();
 
 namespace nm::client {
 

--- a/src/singletons/Paths.cpp
+++ b/src/singletons/Paths.cpp
@@ -83,7 +83,7 @@ void Paths::initCheckPortable()
 
 void Paths::initRootDirectory()
 {
-    assert(this->portable_.is_initialized());
+    assert(this->portable_.has_value());
 
     // Root path = %APPDATA%/Chatterino or the folder that the executable
     // resides in

--- a/src/singletons/Paths.hpp
+++ b/src/singletons/Paths.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <boost/optional.hpp>
 #include <QString>
+
+#include <optional>
 
 namespace chatterino {
 
@@ -51,7 +52,7 @@ private:
     void initRootDirectory();
     void initSubDirectories();
 
-    boost::optional<bool> portable_;
+    std::optional<bool> portable_;
 
     // Directory for cache files. Same as <appDataDirectory>/Misc
     QString cacheDirectory_;

--- a/src/singletons/Settings.cpp
+++ b/src/singletons/Settings.cpp
@@ -87,7 +87,7 @@ bool Settings::isMutedChannel(const QString &channelName)
     return false;
 }
 
-boost::optional<QString> Settings::matchNickname(const QString &usernameText)
+std::optional<QString> Settings::matchNickname(const QString &usernameText)
 {
     auto nicknames = this->nicknames.readOnly();
 
@@ -99,7 +99,7 @@ boost::optional<QString> Settings::matchNickname(const QString &usernameText)
         }
     }
 
-    return boost::none;
+    return std::nullopt;
 }
 
 void Settings::mute(const QString &channelName)

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -593,7 +593,7 @@ public:
     bool isBlacklistedUser(const QString &username);
     bool isMutedChannel(const QString &channelName);
     bool toggleMutedChannel(const QString &channelName);
-    boost::optional<QString> matchNickname(const QString &username);
+    std::optional<QString> matchNickname(const QString &username);
 
 private:
     void mute(const QString &channelName);

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -24,7 +24,6 @@
 #include "widgets/splits/SplitContainer.hpp"
 #include "widgets/Window.hpp"
 
-#include <boost/optional.hpp>
 #include <QDebug>
 #include <QJsonArray>
 #include <QJsonDocument>
@@ -34,13 +33,14 @@
 #include <QScreen>
 
 #include <chrono>
+#include <optional>
 
 namespace chatterino {
 namespace {
 
-    boost::optional<bool> &shouldMoveOutOfBoundsWindow()
+    std::optional<bool> &shouldMoveOutOfBoundsWindow()
     {
-        static boost::optional<bool> x;
+        static std::optional<bool> x;
         return x;
     }
 

--- a/src/util/Helpers.hpp
+++ b/src/util/Helpers.hpp
@@ -6,6 +6,7 @@
 #include <QStringRef>
 
 #include <cmath>
+#include <optional>
 #include <vector>
 
 namespace chatterino {
@@ -154,5 +155,29 @@ std::vector<T> splitListIntoBatches(const T &list, int batchSize = 100)
 }
 
 bool compareEmoteStrings(const QString &a, const QString &b);
+
+template <class T>
+constexpr std::optional<T> makeConditionedOptional(bool condition,
+                                                   const T &value)
+{
+    if (condition)
+    {
+        return value;
+    }
+
+    return std::nullopt;
+}
+
+template <class T>
+constexpr std::optional<std::decay_t<T>> makeConditionedOptional(bool condition,
+                                                                 T &&value)
+{
+    if (condition)
+    {
+        return std::optional<std::decay_t<T>>(std::forward<T>(value));
+    }
+
+    return std::nullopt;
+}
 
 }  // namespace chatterino

--- a/src/util/NuulsUploader.cpp
+++ b/src/util/NuulsUploader.cpp
@@ -23,7 +23,7 @@
 
 namespace {
 
-boost::optional<QByteArray> convertToPng(QImage image)
+std::optional<QByteArray> convertToPng(QImage image)
 {
     QByteArray imageData;
     QBuffer buf(&imageData);
@@ -31,11 +31,11 @@ boost::optional<QByteArray> convertToPng(QImage image)
     bool success = image.save(&buf, "png");
     if (success)
     {
-        return boost::optional<QByteArray>(imageData);
+        return std::optional<QByteArray>(imageData);
     }
     else
     {
-        return boost::optional<QByteArray>(boost::none);
+        return std::optional<QByteArray>(std::nullopt);
     }
 }
 }  // namespace
@@ -271,10 +271,10 @@ void upload(const QMimeData *source, ChannelPtr channel,
                     return;
                 }
 
-                boost::optional<QByteArray> imageData = convertToPng(img);
+                std::optional<QByteArray> imageData = convertToPng(img);
                 if (imageData)
                 {
-                    RawImageData data = {imageData.get(), "png", localPath};
+                    RawImageData data = {*imageData, "png", localPath};
                     uploadQueue.push(data);
                 }
                 else
@@ -340,10 +340,10 @@ void upload(const QMimeData *source, ChannelPtr channel,
     else
     {  // not PNG, try loading it into QImage and save it to a PNG.
         QImage image = qvariant_cast<QImage>(source->imageData());
-        boost::optional<QByteArray> imageData = convertToPng(image);
+        std::optional<QByteArray> imageData = convertToPng(image);
         if (imageData)
         {
-            uploadImageToNuuls({imageData.get(), "png", ""}, channel,
+            uploadImageToNuuls({*imageData, "png", ""}, channel,
                                outputTextEdit);
         }
         else

--- a/src/util/NuulsUploader.cpp
+++ b/src/util/NuulsUploader.cpp
@@ -274,8 +274,7 @@ void upload(const QMimeData *source, ChannelPtr channel,
                 auto imageData = convertToPng(img);
                 if (imageData)
                 {
-                    RawImageData data = {*imageData, "png", localPath};
-                    uploadQueue.push(data);
+                    uploadQueue.emplace(*imageData, "png", localPath);
                 }
                 else
                 {

--- a/src/util/NuulsUploader.cpp
+++ b/src/util/NuulsUploader.cpp
@@ -274,7 +274,8 @@ void upload(const QMimeData *source, ChannelPtr channel,
                 auto imageData = convertToPng(img);
                 if (imageData)
                 {
-                    uploadQueue.emplace(*imageData, "png", localPath);
+                    RawImageData data = {*imageData, "png", localPath};
+                    uploadQueue.push(data);
                 }
                 else
                 {

--- a/src/util/NuulsUploader.cpp
+++ b/src/util/NuulsUploader.cpp
@@ -23,7 +23,7 @@
 
 namespace {
 
-std::optional<QByteArray> convertToPng(QImage image)
+std::optional<QByteArray> convertToPng(const QImage &image)
 {
     QByteArray imageData;
     QBuffer buf(&imageData);
@@ -31,16 +31,16 @@ std::optional<QByteArray> convertToPng(QImage image)
     bool success = image.save(&buf, "png");
     if (success)
     {
-        return std::optional<QByteArray>(imageData);
+        return imageData;
     }
-    else
-    {
-        return std::optional<QByteArray>(std::nullopt);
-    }
+
+    return std::nullopt;
 }
+
 }  // namespace
 
 namespace chatterino {
+
 // These variables are only used from the main thread.
 static auto uploadMutex = QMutex();
 static std::queue<RawImageData> uploadQueue;
@@ -271,7 +271,7 @@ void upload(const QMimeData *source, ChannelPtr channel,
                     return;
                 }
 
-                std::optional<QByteArray> imageData = convertToPng(img);
+                auto imageData = convertToPng(img);
                 if (imageData)
                 {
                     RawImageData data = {*imageData, "png", localPath};
@@ -339,8 +339,8 @@ void upload(const QMimeData *source, ChannelPtr channel,
 
     else
     {  // not PNG, try loading it into QImage and save it to a PNG.
-        QImage image = qvariant_cast<QImage>(source->imageData());
-        std::optional<QByteArray> imageData = convertToPng(image);
+        auto image = qvariant_cast<QImage>(source->imageData());
+        auto imageData = convertToPng(image);
         if (imageData)
         {
             uploadImageToNuuls({*imageData, "png", ""}, channel,

--- a/src/util/WindowsHelper.cpp
+++ b/src/util/WindowsHelper.cpp
@@ -22,7 +22,7 @@ using GetDpiForMonitor_ = HRESULT(CALLBACK *)(HMONITOR, MONITOR_DPI_TYPE,
                                               UINT *, UINT *);
 
 // TODO: This should be changed to `GetDpiForWindow`.
-boost::optional<UINT> getWindowDpi(HWND hwnd)
+std::optional<UINT> getWindowDpi(HWND hwnd)
 {
     static HINSTANCE shcore = LoadLibrary(L"Shcore.dll");
     if (shcore != nullptr)
@@ -41,7 +41,7 @@ boost::optional<UINT> getWindowDpi(HWND hwnd)
         }
     }
 
-    return boost::none;
+    return std::nullopt;
 }
 
 void flushClipboard()

--- a/src/util/WindowsHelper.hpp
+++ b/src/util/WindowsHelper.hpp
@@ -2,15 +2,16 @@
 
 #ifdef USEWINSDK
 
-#    include <boost/optional.hpp>
 #    include <QString>
 #    include <Windows.h>
+
+#    include <optional>
 
 namespace chatterino {
 
 enum class AssociationQueryType { Protocol, FileExtension };
 
-boost::optional<UINT> getWindowDpi(HWND hwnd);
+std::optional<UINT> getWindowDpi(HWND hwnd);
 void flushClipboard();
 
 bool isRegisteredForStartup();

--- a/src/widgets/AttachedWindow.cpp
+++ b/src/widgets/AttachedWindow.cpp
@@ -273,7 +273,7 @@ void AttachedWindow::updateWindowRect(void *_attachedPtr)
     float scale = 1.f;
     if (auto dpi = getWindowDpi(attached))
     {
-        scale = dpi.get() / 96.f;
+        scale = *dpi / 96.f;
 
         for (auto w : this->ui_.split->findChildren<BaseWidget *>())
         {

--- a/src/widgets/BaseWidget.cpp
+++ b/src/widgets/BaseWidget.cpp
@@ -42,7 +42,7 @@ float BaseWidget::scale() const
 {
     if (this->overrideScale_)
     {
-        return this->overrideScale_.get();
+        return *this->overrideScale_;
     }
     else if (auto baseWidget = dynamic_cast<BaseWidget *>(this->window()))
     {
@@ -65,13 +65,13 @@ void BaseWidget::setScale(float value)
     this->setScaleIndependantSize(this->scaleIndependantSize());
 }
 
-void BaseWidget::setOverrideScale(boost::optional<float> value)
+void BaseWidget::setOverrideScale(std::optional<float> value)
 {
     this->overrideScale_ = value;
     this->setScale(this->scale());
 }
 
-boost::optional<float> BaseWidget::overrideScale() const
+std::optional<float> BaseWidget::overrideScale() const
 {
     return this->overrideScale_;
 }

--- a/src/widgets/BaseWidget.cpp
+++ b/src/widgets/BaseWidget.cpp
@@ -44,14 +44,13 @@ float BaseWidget::scale() const
     {
         return *this->overrideScale_;
     }
-    else if (auto baseWidget = dynamic_cast<BaseWidget *>(this->window()))
+
+    if (auto *baseWidget = dynamic_cast<BaseWidget *>(this->window()))
     {
         return baseWidget->scale_;
     }
-    else
-    {
-        return 1.f;
-    }
+
+    return 1.F;
 }
 
 void BaseWidget::setScale(float value)

--- a/src/widgets/BaseWidget.hpp
+++ b/src/widgets/BaseWidget.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
-#include <boost/optional.hpp>
 #include <pajlada/signals/signal.hpp>
 #include <pajlada/signals/signalholder.hpp>
 #include <QShortcut>
 #include <QWidget>
+
+#include <optional>
 
 namespace chatterino {
 
@@ -22,8 +23,8 @@ public:
     virtual float scale() const;
     pajlada::Signals::Signal<float> scaleChanged;
 
-    boost::optional<float> overrideScale() const;
-    void setOverrideScale(boost::optional<float>);
+    std::optional<float> overrideScale() const;
+    void setOverrideScale(std::optional<float>);
 
     QSize scaleIndependantSize() const;
     int scaleIndependantWidth() const;
@@ -56,7 +57,7 @@ protected:
 
 private:
     float scale_{1.f};
-    boost::optional<float> overrideScale_;
+    std::optional<float> overrideScale_;
     QSize scaleIndependantSize_;
 
     std::vector<BaseWidget *> widgets_;

--- a/src/widgets/BaseWindow.cpp
+++ b/src/widgets/BaseWindow.cpp
@@ -728,7 +728,7 @@ bool BaseWindow::handleSHOWWINDOW(MSG *msg)
 
     if (auto dpi = getWindowDpi(msg->hwnd))
     {
-        float currentScale = (float)dpi.get() / 96.F;
+        float currentScale = (float)dpi.value() / 96.F;
         if (currentScale != this->nativeScale_)
         {
             this->nativeScale_ = currentScale;

--- a/src/widgets/BaseWindow.hpp
+++ b/src/widgets/BaseWindow.hpp
@@ -95,7 +95,7 @@ protected:
 
     void updateScale();
 
-    boost::optional<QColor> overrideBackgroundColor_;
+    std::optional<QColor> overrideBackgroundColor_;
 
 private:
     void init();

--- a/src/widgets/FramelessEmbedWindow.cpp
+++ b/src/widgets/FramelessEmbedWindow.cpp
@@ -70,7 +70,7 @@ void FramelessEmbedWindow::showEvent(QShowEvent *)
     }
 
     if (auto parentHwnd =
-            reinterpret_cast<HWND>(getArgs().parentWindowId.get()))
+            reinterpret_cast<HWND>(getArgs().parentWindowId.value()))
     {
         auto handle = reinterpret_cast<HWND>(this->winId());
         if (!::SetParent(handle, parentHwnd))

--- a/src/widgets/dialogs/BadgePickerDialog.hpp
+++ b/src/widgets/dialogs/BadgePickerDialog.hpp
@@ -2,11 +2,11 @@
 
 #include "util/DisplayBadge.hpp"
 
-#include <boost/optional.hpp>
 #include <QComboBox>
 #include <QDialog>
 
 #include <memory>
+#include <optional>
 
 namespace chatterino {
 
@@ -14,7 +14,7 @@ class BadgePickerDialog : public QDialog,
                           public std::enable_shared_from_this<BadgePickerDialog>
 {
     using QIconPtr = std::shared_ptr<QIcon>;
-    using BadgeOpt = boost::optional<DisplayBadge>;
+    using BadgeOpt = std::optional<DisplayBadge>;
 
 public:
     BadgePickerDialog(QList<DisplayBadge> badges, QWidget *parent = nullptr);

--- a/src/widgets/dialogs/IrcConnectionEditor.hpp
+++ b/src/widgets/dialogs/IrcConnectionEditor.hpp
@@ -3,8 +3,9 @@
 #include "providers/irc/Irc2.hpp"
 #include "widgets/BaseWindow.hpp"
 
-#include <boost/optional.hpp>
 #include <QDialog>
+
+#include <optional>
 
 namespace Ui {
 class IrcConnectionEditor;

--- a/src/widgets/dialogs/ReplyThreadPopup.cpp
+++ b/src/widgets/dialogs/ReplyThreadPopup.cpp
@@ -239,7 +239,7 @@ void ReplyThreadPopup::addMessagesFromThread()
     this->ui_.threadView->setSourceChannel(sourceChannel);
 
     auto overrideFlags =
-        boost::optional<MessageFlags>(this->thread_->root()->flags);
+        std::optional<MessageFlags>(this->thread_->root()->flags);
     overrideFlags->set(MessageFlag::DoNotLog);
 
     this->virtualChannel_->addMessage(this->thread_->root(), overrideFlags);
@@ -247,7 +247,7 @@ void ReplyThreadPopup::addMessagesFromThread()
     {
         if (auto msg = msgRef.lock())
         {
-            auto overrideFlags = boost::optional<MessageFlags>(msg->flags);
+            auto overrideFlags = std::optional<MessageFlags>(msg->flags);
             overrideFlags->set(MessageFlag::DoNotLog);
 
             this->virtualChannel_->addMessage(msg, overrideFlags);
@@ -261,7 +261,7 @@ void ReplyThreadPopup::addMessagesFromThread()
                 if (message->replyThread == this->thread_)
                 {
                     auto overrideFlags =
-                        boost::optional<MessageFlags>(message->flags);
+                        std::optional<MessageFlags>(message->flags);
                     overrideFlags->set(MessageFlag::DoNotLog);
 
                     // same reply thread, add message

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -110,7 +110,7 @@ namespace {
         {
             MessagePtr message = snapshot[i];
 
-            auto overrideFlags = boost::optional<MessageFlags>(message->flags);
+            auto overrideFlags = std::optional<MessageFlags>(message->flags);
             overrideFlags->set(MessageFlag::DoNotLog);
 
             if (checkMessageUserName(userName, message))

--- a/src/widgets/helper/Button.cpp
+++ b/src/widgets/helper/Button.cpp
@@ -36,7 +36,7 @@ Button::Button(BaseWidget *parent)
     this->setMouseTracking(true);
 }
 
-void Button::setMouseEffectColor(boost::optional<QColor> color)
+void Button::setMouseEffectColor(std::optional<QColor> color)
 {
     this->mouseEffectColor_ = std::move(color);
 }
@@ -185,7 +185,7 @@ void Button::fancyPaint(QPainter &painter)
 
     if (this->mouseEffectColor_)
     {
-        c = this->mouseEffectColor_.get();
+        c = *this->mouseEffectColor_;
     }
     else
     {

--- a/src/widgets/helper/Button.hpp
+++ b/src/widgets/helper/Button.hpp
@@ -2,13 +2,14 @@
 
 #include "widgets/BaseWidget.hpp"
 
-#include <boost/optional.hpp>
 #include <QMenu>
 #include <QMouseEvent>
 #include <QPainter>
 #include <QPoint>
 #include <QTimer>
 #include <QWidget>
+
+#include <optional>
 
 namespace chatterino {
 
@@ -31,7 +32,7 @@ public:
 
     Button(BaseWidget *parent = nullptr);
 
-    void setMouseEffectColor(boost::optional<QColor> color);
+    void setMouseEffectColor(std::optional<QColor> color);
     void setPixmap(const QPixmap &pixmap_);
     const QPixmap &getPixmap() const;
 
@@ -94,7 +95,7 @@ private:
     double hoverMultiplier_{0.0};
     QTimer effectTimer_{};
     std::vector<ClickEffect> clickEffects_{};
-    boost::optional<QColor> mouseEffectColor_{};
+    std::optional<QColor> mouseEffectColor_{};
     std::unique_ptr<QMenu> menu_{};
 };
 

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -308,7 +308,9 @@ void ChannelView::pause(PauseReason reason, std::optional<uint> msecs)
         {
             /// If the new time point is newer then we override.
             if (it->second && it->second.value() < timePoint)
+            {
                 it->second = timePoint;
+            }
         }
     }
     else

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -307,9 +307,11 @@ void ChannelView::pause(PauseReason reason, std::optional<uint> msecs)
         else
         {
             /// If the new time point is newer then we override.
-            if (it->second && it->second.value() < timePoint)
+            auto &previousTimePoint = it->second;
+            if (previousTimePoint.has_value() &&
+                previousTimePoint.value() < timePoint)
             {
-                it->second = timePoint;
+                previousTimePoint = timePoint;
             }
         }
     }

--- a/src/widgets/helper/ChannelView.hpp
+++ b/src/widgets/helper/ChannelView.hpp
@@ -93,8 +93,8 @@ public:
 
     void setEnableScrollingToBottom(bool);
     bool getEnableScrollingToBottom() const;
-    void setOverrideFlags(boost::optional<MessageElementFlags> value);
-    const boost::optional<MessageElementFlags> &getOverrideFlags() const;
+    void setOverrideFlags(std::optional<MessageElementFlags> value);
+    const std::optional<MessageElementFlags> &getOverrideFlags() const;
     void updateLastReadMessage();
 
     /**
@@ -112,7 +112,7 @@ public:
     bool pausable() const;
     void setPausable(bool value);
     bool paused() const;
-    void pause(PauseReason reason, boost::optional<uint> msecs = boost::none);
+    void pause(PauseReason reason, std::optional<uint> msecs = std::nullopt);
     void unpause(PauseReason reason);
 
     MessageElementFlags getFlags() const;
@@ -195,7 +195,7 @@ private:
     void initializeSignals();
 
     void messageAppended(MessagePtr &message,
-                         boost::optional<MessageFlags> overridingFlags);
+                         std::optional<MessageFlags> overridingFlags);
     void messageAddedAtStart(std::vector<MessagePtr> &messages);
     void messageRemoveFromStart(MessagePtr &message);
     void messageReplaced(size_t index, MessagePtr &replacement);
@@ -265,15 +265,15 @@ private:
 
     bool pausable_ = false;
     QTimer pauseTimer_;
-    std::unordered_map<PauseReason, boost::optional<SteadyClock::time_point>>
+    std::unordered_map<PauseReason, std::optional<SteadyClock::time_point>>
         pauses_;
-    boost::optional<SteadyClock::time_point> pauseEnd_;
+    std::optional<SteadyClock::time_point> pauseEnd_;
     int pauseScrollMinimumOffset_ = 0;
     int pauseScrollMaximumOffset_ = 0;
     // Keeps track how many message indices we need to offset the selection when we resume scrolling
     uint32_t pauseSelectionOffset_ = 0;
 
-    boost::optional<MessageElementFlags> overrideFlags_;
+    std::optional<MessageElementFlags> overrideFlags_;
     MessageLayoutPtr lastReadMessage_;
 
     ThreadGuard snapshotGuard_;

--- a/src/widgets/helper/SearchPopup.cpp
+++ b/src/widgets/helper/SearchPopup.cpp
@@ -52,7 +52,7 @@ ChannelPtr SearchPopup::filter(const QString &text, const QString &channelName,
         // If all predicates match, add the message to the channel
         if (accept)
         {
-            auto overrideFlags = boost::optional<MessageFlags>(message->flags);
+            auto overrideFlags = std::optional<MessageFlags>(message->flags);
             overrideFlags->set(MessageFlag::DoNotLog);
 
             channel->addMessage(message, overrideFlags);

--- a/tests/src/BttvLiveUpdates.cpp
+++ b/tests/src/BttvLiveUpdates.cpp
@@ -1,9 +1,9 @@
 #include "providers/bttv/BttvLiveUpdates.hpp"
 
-#include <boost/optional.hpp>
 #include <gtest/gtest.h>
 #include <QString>
 
+#include <optional>
 #include <tuple>
 
 using namespace chatterino;
@@ -18,9 +18,9 @@ TEST(BttvLiveUpdates, AllEvents)
     chatterino::BttvLiveUpdates liveUpdates(host);
     liveUpdates.start();
 
-    boost::optional<BttvLiveUpdateEmoteUpdateAddMessage> addMessage;
-    boost::optional<BttvLiveUpdateEmoteUpdateAddMessage> updateMessage;
-    boost::optional<BttvLiveUpdateEmoteRemoveMessage> removeMessage;
+    std::optional<BttvLiveUpdateEmoteUpdateAddMessage> addMessage;
+    std::optional<BttvLiveUpdateEmoteUpdateAddMessage> updateMessage;
+    std::optional<BttvLiveUpdateEmoteRemoveMessage> removeMessage;
 
     std::ignore = liveUpdates.signals_.emoteAdded.connect([&](const auto &m) {
         addMessage = m;

--- a/tests/src/HighlightController.cpp
+++ b/tests/src/HighlightController.cpp
@@ -11,7 +11,6 @@
 #include "singletons/Paths.hpp"
 #include "singletons/Settings.hpp"
 
-#include <boost/optional/optional_io.hpp>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <QDebug>
@@ -268,7 +267,7 @@ TEST_F(HighlightControllerTest, LoggedInAndConfigured)
                 {
                     false,                                  // alert
                     false,                                  // playsound
-                    boost::none,                            // custom sound url
+                    std::nullopt,                           // custom sound url
                     std::make_shared<QColor>("#7fffffff"),  // color
                     false,
                 },
@@ -307,7 +306,7 @@ TEST_F(HighlightControllerTest, LoggedInAndConfigured)
                 {
                     true,                                   // alert
                     false,                                  // playsound
-                    boost::none,                            // custom sound url
+                    std::nullopt,                           // custom sound url
                     std::make_shared<QColor>("#7fe8b7eb"),  // color
                     false,                                  //showInMentions
                 },
@@ -332,7 +331,7 @@ TEST_F(HighlightControllerTest, LoggedInAndConfigured)
                 {
                     true,                                   // alert
                     false,                                  // playsound
-                    boost::none,                            // custom sound url
+                    std::nullopt,                           // custom sound url
                     std::make_shared<QColor>("#7fffffff"),  // color
                     false,                                  //showInMentions
                 },
@@ -358,7 +357,7 @@ TEST_F(HighlightControllerTest, LoggedInAndConfigured)
                 {
                     false,                                  // alert
                     false,                                  // playsound
-                    boost::none,                            // custom sound url
+                    std::nullopt,                           // custom sound url
                     std::make_shared<QColor>("#7fe8b7ec"),  // color
                     true,                                   // showInMentions
                 },
@@ -379,7 +378,7 @@ TEST_F(HighlightControllerTest, LoggedInAndConfigured)
                 {
                     true,                                   // alert
                     false,                                  // playsound
-                    boost::none,                            // custom sound url
+                    std::nullopt,                           // custom sound url
                     std::make_shared<QColor>("#7ff19900"),  // color
                     true,                                   // showInMentions
                 },
@@ -399,7 +398,7 @@ TEST_F(HighlightControllerTest, LoggedInAndConfigured)
                 {
                     true,                                   // alert
                     true,                                   // playsound
-                    boost::none,                            // custom sound url
+                    std::nullopt,                           // custom sound url
                     std::make_shared<QColor>("#7f7f3f49"),  // color
                     true,                                   // showInMentions
                 },
@@ -420,7 +419,7 @@ TEST_F(HighlightControllerTest, LoggedInAndConfigured)
                 {
                     false,                                  // alert
                     false,                                  // playsound
-                    boost::none,                            // custom sound url
+                    std::nullopt,                           // custom sound url
                     std::make_shared<QColor>("#6fffffff"),  // color
                     false,
                 },
@@ -442,9 +441,9 @@ TEST_F(HighlightControllerTest, LoggedInAndConfigured)
                 .state = true,  // state
                 .result =
                     {
-                        false,        // alert
-                        false,        // playsound
-                        boost::none,  // custom sound url
+                        false,         // alert
+                        false,         // playsound
+                        std::nullopt,  // custom sound url
                         std::make_shared<QColor>(
                             HighlightPhrase::
                                 FALLBACK_HIGHLIGHT_COLOR),  // color
@@ -468,9 +467,9 @@ TEST_F(HighlightControllerTest, LoggedInAndConfigured)
                 .state = true,  // state
                 .result =
                     {
-                        true,         // alert
-                        true,         // playsound
-                        boost::none,  // custom sound url
+                        true,          // alert
+                        true,          // playsound
+                        std::nullopt,  // custom sound url
                         std::make_shared<QColor>("#7f7f3f49"),  // color
                         true,  // showInMentions
                     },

--- a/tests/src/InputCompletion.cpp
+++ b/tests/src/InputCompletion.cpp
@@ -13,7 +13,6 @@
 #include "singletons/Settings.hpp"
 #include "widgets/splits/InputCompletionPopup.hpp"
 
-#include <boost/optional/optional_io.hpp>
 #include <gtest/gtest.h>
 #include <QDir>
 #include <QFile>

--- a/tests/src/SeventvEventAPI.cpp
+++ b/tests/src/SeventvEventAPI.cpp
@@ -4,9 +4,10 @@
 #include "providers/seventv/eventapi/Dispatch.hpp"
 #include "providers/seventv/eventapi/Message.hpp"
 
-#include <boost/optional.hpp>
 #include <gtest/gtest.h>
 #include <QString>
+
+#include <optional>
 
 using namespace chatterino;
 using namespace chatterino::seventv::eventapi;
@@ -22,10 +23,10 @@ TEST(SeventvEventAPI, AllEvents)
     SeventvEventAPI eventAPI(host, std::chrono::milliseconds(1000));
     eventAPI.start();
 
-    boost::optional<EmoteAddDispatch> addDispatch;
-    boost::optional<EmoteUpdateDispatch> updateDispatch;
-    boost::optional<EmoteRemoveDispatch> removeDispatch;
-    boost::optional<UserConnectionUpdateDispatch> userDispatch;
+    std::optional<EmoteAddDispatch> addDispatch;
+    std::optional<EmoteUpdateDispatch> updateDispatch;
+    std::optional<EmoteRemoveDispatch> removeDispatch;
+    std::optional<UserConnectionUpdateDispatch> userDispatch;
 
     eventAPI.signals_.emoteAdded.connect([&](const auto &d) {
         addDispatch = d;
@@ -67,9 +68,9 @@ TEST(SeventvEventAPI, AllEvents)
     ASSERT_EQ(rem.emoteID, QString("621d13967cc2d4e1953838ed"));
 
     ASSERT_EQ(userDispatch.has_value(), false);
-    addDispatch = boost::none;
-    updateDispatch = boost::none;
-    removeDispatch = boost::none;
+    addDispatch = std::nullopt;
+    updateDispatch = std::nullopt;
+    removeDispatch = std::nullopt;
 
     eventAPI.subscribeUser(TARGET_USER_ID, "");
     std::this_thread::sleep_for(50ms);

--- a/tools/clang-format-all.sh
+++ b/tools/clang-format-all.sh
@@ -5,4 +5,6 @@ echo
 if [[ $REPLY =~ ^[Yy]$ ]]; then
     find src/ \( -iname "*.hpp" -o -iname "*.cpp" \) -exec clang-format -i {} \;
     find tests/src/ \( -iname "*.hpp" -o -iname "*.cpp" \) -exec clang-format -i {} \;
+    find benchmarks/src/ \( -iname "*.hpp" -o -iname "*.cpp" \) -exec clang-format -i {} \;
+    find mocks/include/ \( -iname "*.hpp" -o -iname "*.cpp" \) -exec clang-format -i {} \;
 fi


### PR DESCRIPTION
# Description

The commits are split up into two parts:
1. The actual replacing of boost::optional with std::optional
2. The small refactors I've done around the code as the replacing took place - there weren't many things I changed, mostly just 

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
