### PR TITLE
fix: Remove tab completion caching of source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 - Dev: Refactor `Image` & Image's `Frames`. (#4773)
 - Dev: Add `WindowManager::getLastSelectedWindow()` to replace `getMainWindow()`. (#4816)
 - Dev: Clarify signal connection lifetimes where applicable. (#4818)
-- Dev: Laid the groundwork for advanced input completion strategies. (#4639, #4846, #4853)
+- Dev: Laid the groundwork for advanced input completion strategies. (#4639, #4846, #4853, #4893)
 - Dev: Fixed flickering when running with Direct2D on Windows. (#4851)
 - Dev: Fix qtkeychain include for Qt6 users. (#4863)
 - Dev: Add a compile-time flag `CHATTERINO_UPDATER` which can be turned off to disable update checks. (#4854)

--- a/src/controllers/completion/TabCompletionModel.cpp
+++ b/src/controllers/completion/TabCompletionModel.cpp
@@ -39,18 +39,11 @@ void TabCompletionModel::updateSourceFromQuery(const QString &query)
     if (!deducedKind)
     {
         // unable to determine what kind of completion is occurring
-        this->sourceKind_ = std::nullopt;
         this->source_ = nullptr;
         return;
     }
 
-    if (this->sourceKind_ == *deducedKind)
-    {
-        // Source already properly configured
-        return;
-    }
-
-    this->sourceKind_ = *deducedKind;
+    // Build source for new query
     this->source_ = this->buildSource(*deducedKind);
 }
 

--- a/src/controllers/completion/TabCompletionModel.hpp
+++ b/src/controllers/completion/TabCompletionModel.hpp
@@ -64,7 +64,6 @@ private:
 
     Channel &channel_;
     std::unique_ptr<completion::Source> source_{};
-    std::optional<SourceKind> sourceKind_{};
 };
 
 }  // namespace chatterino


### PR DESCRIPTION
## Description

We were being a little too clever and trying to cache the emote source for later reuse. Unfortunately, when a new user chats for the first time, their username would not be included in the available completion list until they type something else before attempting a completion again.

The same goes for emotes added via the EventAPI.

Fixes #4878
Fixes #4892