### PR TITLE
Use custom frame for main window only

### DIFF
--- a/src/widgets/BasePopup.cpp
+++ b/src/widgets/BasePopup.cpp
@@ -6,9 +6,9 @@
 
 namespace chatterino {
 
-BasePopup::BasePopup(FlagsEnum<Flags> _flags, QWidget *parent,
+BasePopup::BasePopup(FlagsEnum<Flags> flags_, QWidget *parent,
                      bool addDialogFlag)
-    : BaseWindow(addDialogFlag ? _flags | Dialog : _flags, parent)
+    : BaseWindow(addDialogFlag ? flags_ | Dialog : flags_, parent)
 {
 }
 

--- a/src/widgets/BasePopup.cpp
+++ b/src/widgets/BasePopup.cpp
@@ -6,8 +6,9 @@
 
 namespace chatterino {
 
-BasePopup::BasePopup(FlagsEnum<Flags> _flags, QWidget *parent)
-    : BaseWindow(_flags | Dialog, parent)
+BasePopup::BasePopup(FlagsEnum<Flags> _flags, QWidget *parent,
+                     bool addDialogFlag)
+    : BaseWindow(addDialogFlag ? _flags | Dialog : _flags, parent)
 {
 }
 

--- a/src/widgets/BasePopup.hpp
+++ b/src/widgets/BasePopup.hpp
@@ -11,7 +11,7 @@ class BasePopup : public BaseWindow
 {
 public:
     explicit BasePopup(FlagsEnum<BaseWindow::Flags> flags_ = None,
-                       QWidget *parent = nullptr);
+                       QWidget *parent = nullptr, bool addDialogFlag = true);
 
 protected:
     void keyPressEvent(QKeyEvent *e) override;

--- a/src/widgets/DraggablePopup.cpp
+++ b/src/widgets/DraggablePopup.cpp
@@ -15,18 +15,13 @@ namespace {
 #ifdef Q_OS_LINUX
     FlagsEnum<BaseWindow::Flags> popupFlags{
         BaseWindow::Dialog,
-        BaseWindow::EnableCustomFrame,
     };
     FlagsEnum<BaseWindow::Flags> popupFlagsCloseAutomatically{
         BaseWindow::Dialog,
-        BaseWindow::EnableCustomFrame,
     };
 #else
-    FlagsEnum<BaseWindow::Flags> popupFlags{
-        BaseWindow::EnableCustomFrame,
-    };
+    FlagsEnum<BaseWindow::Flags> popupFlags{};
     FlagsEnum<BaseWindow::Flags> popupFlagsCloseAutomatically{
-        BaseWindow::EnableCustomFrame,
         BaseWindow::Frameless,
         BaseWindow::FramelessDraggable,
     };

--- a/src/widgets/dialogs/ColorPickerDialog.cpp
+++ b/src/widgets/dialogs/ColorPickerDialog.cpp
@@ -13,8 +13,7 @@
 namespace chatterino {
 
 ColorPickerDialog::ColorPickerDialog(const QColor &initial, QWidget *parent)
-    : BasePopup({BaseWindow::EnableCustomFrame, BaseWindow::DisableLayoutSave},
-                parent)
+    : BasePopup({BaseWindow::DisableLayoutSave}, parent)
     , color_()
     , dialogConfirmed_(false)
 {

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -201,7 +201,7 @@ EmoteMap filterEmoteMap(const QString &text,
 namespace chatterino {
 
 EmotePopup::EmotePopup(QWidget *parent)
-    : BasePopup(BaseWindow::EnableCustomFrame, parent)
+    : BasePopup({}, parent, false)
     , search_(new QLineEdit())
     , notebook_(new Notebook(this))
 {

--- a/src/widgets/dialogs/SelectChannelDialog.cpp
+++ b/src/widgets/dialogs/SelectChannelDialog.cpp
@@ -31,8 +31,7 @@
 namespace chatterino {
 
 SelectChannelDialog::SelectChannelDialog(QWidget *parent)
-    : BaseWindow({BaseWindow::Flags::EnableCustomFrame,
-                  BaseWindow::Flags::Dialog, BaseWindow::DisableLayoutSave},
+    : BaseWindow({BaseWindow::Flags::Dialog, BaseWindow::DisableLayoutSave},
                  parent)
     , selectedChannel_(Channel::getEmpty())
 {

--- a/src/widgets/dialogs/UpdateDialog.cpp
+++ b/src/widgets/dialogs/UpdateDialog.cpp
@@ -12,7 +12,7 @@ namespace chatterino {
 
 UpdateDialog::UpdateDialog()
     : BaseWindow({BaseWindow::Frameless, BaseWindow::TopMost,
-                  BaseWindow::EnableCustomFrame, BaseWindow::DisableLayoutSave})
+                  BaseWindow::DisableLayoutSave})
 {
     auto layout =
         LayoutCreator<UpdateDialog>(this).setLayoutType<QVBoxLayout>();

--- a/src/widgets/dialogs/WelcomeDialog.cpp
+++ b/src/widgets/dialogs/WelcomeDialog.cpp
@@ -3,7 +3,7 @@
 namespace chatterino {
 
 WelcomeDialog::WelcomeDialog()
-    : BaseWindow({BaseWindow::EnableCustomFrame, BaseWindow::DisableLayoutSave})
+    : BaseWindow(BaseWindow::DisableLayoutSave)
 {
     this->setWindowTitle("Chatterino quick setup");
 }

--- a/src/widgets/settingspages/AboutPage.cpp
+++ b/src/widgets/settingspages/AboutPage.cpp
@@ -227,7 +227,7 @@ void AboutPage::addLicense(QFormLayout *form, const QString &name,
     auto *b = new QLabel("<a href=\"" + licenseLink + "\">show license</a>");
     QObject::connect(
         b, &QLabel::linkActivated, [parent = this, name, licenseLink] {
-            auto window =
+            auto *window =
                 new BasePopup({BaseWindow::DisableLayoutSave}, parent);
             window->setWindowTitle("Chatterino - License for " + name);
             window->setAttribute(Qt::WA_DeleteOnClose);

--- a/src/widgets/settingspages/AboutPage.cpp
+++ b/src/widgets/settingspages/AboutPage.cpp
@@ -227,9 +227,8 @@ void AboutPage::addLicense(QFormLayout *form, const QString &name,
     auto *b = new QLabel("<a href=\"" + licenseLink + "\">show license</a>");
     QObject::connect(
         b, &QLabel::linkActivated, [parent = this, name, licenseLink] {
-            auto window = new BasePopup({BaseWindow::Flags::EnableCustomFrame,
-                                         BaseWindow::DisableLayoutSave},
-                                        parent);
+            auto window =
+                new BasePopup({BaseWindow::DisableLayoutSave}, parent);
             window->setWindowTitle("Chatterino - License for " + name);
             window->setAttribute(Qt::WA_DeleteOnClose);
             auto layout = new QVBoxLayout();

--- a/src/widgets/splits/InputCompletionPopup.cpp
+++ b/src/widgets/splits/InputCompletionPopup.cpp
@@ -10,8 +10,8 @@
 namespace chatterino {
 
 InputCompletionPopup::InputCompletionPopup(QWidget *parent)
-    : BasePopup({BasePopup::EnableCustomFrame, BasePopup::Frameless,
-                 BasePopup::DontFocus, BaseWindow::DisableLayoutSave},
+    : BasePopup({BasePopup::Frameless, BasePopup::DontFocus,
+                 BaseWindow::DisableLayoutSave},
                 parent)
     , model_(this)
 {

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -192,8 +192,7 @@ namespace {
     void showTutorialVideo(QWidget *parent, const QString &source,
                            const QString &title, const QString &description)
     {
-        auto window =
-            new BasePopup(BaseWindow::Flags::EnableCustomFrame, parent);
+        auto window = new BasePopup({}, parent);
         window->setWindowTitle("Chatterino - " + title);
         window->setAttribute(Qt::WA_DeleteOnClose);
         auto layout = new QVBoxLayout();

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -192,7 +192,7 @@ namespace {
     void showTutorialVideo(QWidget *parent, const QString &source,
                            const QString &title, const QString &description)
     {
-        auto window = new BasePopup({}, parent);
+        auto *window = new BasePopup({}, parent);
         window->setWindowTitle("Chatterino - " + title);
         window->setAttribute(Qt::WA_DeleteOnClose);
         auto layout = new QVBoxLayout();


### PR DESCRIPTION
We use custom frame to draw extra controls in title bar on Windows. Currently few windows beside main window also use `BaseWindow::EnableCustomFrame` flag. This PR removes use of custom frame outside of `Window.cpp`, so only main chatterino window and popup chats are left.

Since Qt6.4 system theme and user preferred colors are used for title bars by default. 

other changes: 
- `BasePopup` is always enabling [Qt::Dialog](https://doc.qt.io/qt-6/qt.html#WindowType-enum) flag, which removes minimize/maximize buttons. This is undesired for `EmotePopup`, so i added bool to disable that behavior for that single window. This is possibly breaking change for Linux WMs, so needs test, didn't want to ifdef right away.