### PR TITLE
refactor: Use override instead of virtual where possible

### DIFF
--- a/src/common/SignalVectorModel.hpp
+++ b/src/common/SignalVectorModel.hpp
@@ -101,7 +101,7 @@ public:
         return this;
     }
 
-    virtual ~SignalVectorModel()
+    ~SignalVectorModel() override
     {
         for (Row &row : this->rows_)
         {

--- a/src/controllers/accounts/AccountController.hpp
+++ b/src/controllers/accounts/AccountController.hpp
@@ -21,7 +21,7 @@ public:
 
     AccountModel *createModel(QObject *parent);
 
-    virtual void initialize(Settings &settings, Paths &paths) override;
+    void initialize(Settings &settings, Paths &paths) override;
 
     TwitchAccountManager twitch;
 

--- a/src/controllers/accounts/AccountModel.hpp
+++ b/src/controllers/accounts/AccountModel.hpp
@@ -17,21 +17,20 @@ public:
 
 protected:
     // turn a vector item into a model row
-    virtual std::shared_ptr<Account> getItemFromRow(
+    std::shared_ptr<Account> getItemFromRow(
         std::vector<QStandardItem *> &row,
         const std::shared_ptr<Account> &original) override;
 
     // turns a row in the model into a vector item
-    virtual void getRowFromItem(const std::shared_ptr<Account> &item,
-                                std::vector<QStandardItem *> &row) override;
+    void getRowFromItem(const std::shared_ptr<Account> &item,
+                        std::vector<QStandardItem *> &row) override;
 
-    virtual int beforeInsert(const std::shared_ptr<Account> &item,
-                             std::vector<QStandardItem *> &row,
-                             int proposedIndex) override;
+    int beforeInsert(const std::shared_ptr<Account> &item,
+                     std::vector<QStandardItem *> &row,
+                     int proposedIndex) override;
 
-    virtual void afterRemoved(const std::shared_ptr<Account> &item,
-                              std::vector<QStandardItem *> &row,
-                              int index) override;
+    void afterRemoved(const std::shared_ptr<Account> &item,
+                      std::vector<QStandardItem *> &row, int index) override;
 
     friend class AccountController;
 

--- a/src/controllers/commands/CommandController.hpp
+++ b/src/controllers/commands/CommandController.hpp
@@ -33,8 +33,8 @@ public:
                         bool dryRun);
     QStringList getDefaultChatterinoCommandList();
 
-    virtual void initialize(Settings &, Paths &paths) override;
-    virtual void save() override;
+    void initialize(Settings &, Paths &paths) override;
+    void save() override;
 
     CommandModel *createModel(QObject *parent);
 

--- a/src/controllers/commands/CommandModel.hpp
+++ b/src/controllers/commands/CommandModel.hpp
@@ -22,12 +22,12 @@ class CommandModel : public SignalVectorModel<Command>
 
 protected:
     // turn a vector item into a model row
-    virtual Command getItemFromRow(std::vector<QStandardItem *> &row,
-                                   const Command &command) override;
+    Command getItemFromRow(std::vector<QStandardItem *> &row,
+                           const Command &command) override;
 
     // turns a row in the model into a vector item
-    virtual void getRowFromItem(const Command &item,
-                                std::vector<QStandardItem *> &row) override;
+    void getRowFromItem(const Command &item,
+                        std::vector<QStandardItem *> &row) override;
 
     friend class CommandController;
 };

--- a/src/controllers/filters/FilterModel.hpp
+++ b/src/controllers/filters/FilterModel.hpp
@@ -16,13 +16,12 @@ public:
 
 protected:
     // turn a vector item into a model row
-    virtual FilterRecordPtr getItemFromRow(
-        std::vector<QStandardItem *> &row,
-        const FilterRecordPtr &original) override;
+    FilterRecordPtr getItemFromRow(std::vector<QStandardItem *> &row,
+                                   const FilterRecordPtr &original) override;
 
     // turns a row in the model into a vector item
-    virtual void getRowFromItem(const FilterRecordPtr &item,
-                                std::vector<QStandardItem *> &row) override;
+    void getRowFromItem(const FilterRecordPtr &item,
+                        std::vector<QStandardItem *> &row) override;
 };
 
 }  // namespace chatterino

--- a/src/controllers/highlights/BadgeHighlightModel.hpp
+++ b/src/controllers/highlights/BadgeHighlightModel.hpp
@@ -25,12 +25,11 @@ public:
 
 protected:
     // vector into model row
-    virtual HighlightBadge getItemFromRow(
-        std::vector<QStandardItem *> &row,
-        const HighlightBadge &original) override;
+    HighlightBadge getItemFromRow(std::vector<QStandardItem *> &row,
+                                  const HighlightBadge &original) override;
 
-    virtual void getRowFromItem(const HighlightBadge &item,
-                                std::vector<QStandardItem *> &row) override;
+    void getRowFromItem(const HighlightBadge &item,
+                        std::vector<QStandardItem *> &row) override;
 };
 
 }  // namespace chatterino

--- a/src/controllers/highlights/HighlightBlacklistModel.hpp
+++ b/src/controllers/highlights/HighlightBlacklistModel.hpp
@@ -21,13 +21,13 @@ public:
 
 protected:
     // turn a vector item into a model row
-    virtual HighlightBlacklistUser getItemFromRow(
+    HighlightBlacklistUser getItemFromRow(
         std::vector<QStandardItem *> &row,
         const HighlightBlacklistUser &original) override;
 
     // turns a row in the model into a vector item
-    virtual void getRowFromItem(const HighlightBlacklistUser &item,
-                                std::vector<QStandardItem *> &row) override;
+    void getRowFromItem(const HighlightBlacklistUser &item,
+                        std::vector<QStandardItem *> &row) override;
 };
 
 }  // namespace chatterino

--- a/src/controllers/highlights/HighlightModel.hpp
+++ b/src/controllers/highlights/HighlightModel.hpp
@@ -42,19 +42,18 @@ public:
 
 protected:
     // turn a vector item into a model row
-    virtual HighlightPhrase getItemFromRow(
-        std::vector<QStandardItem *> &row,
-        const HighlightPhrase &original) override;
+    HighlightPhrase getItemFromRow(std::vector<QStandardItem *> &row,
+                                   const HighlightPhrase &original) override;
 
     // turns a row in the model into a vector item
-    virtual void getRowFromItem(const HighlightPhrase &item,
-                                std::vector<QStandardItem *> &row) override;
+    void getRowFromItem(const HighlightPhrase &item,
+                        std::vector<QStandardItem *> &row) override;
 
-    virtual void afterInit() override;
+    void afterInit() override;
 
-    virtual void customRowSetData(const std::vector<QStandardItem *> &row,
-                                  int column, const QVariant &value, int role,
-                                  int rowIndex) override;
+    void customRowSetData(const std::vector<QStandardItem *> &row, int column,
+                          const QVariant &value, int role,
+                          int rowIndex) override;
 };
 
 }  // namespace chatterino

--- a/src/controllers/highlights/UserHighlightModel.hpp
+++ b/src/controllers/highlights/UserHighlightModel.hpp
@@ -16,18 +16,17 @@ public:
 
 protected:
     // vector into model row
-    virtual HighlightPhrase getItemFromRow(
-        std::vector<QStandardItem *> &row,
-        const HighlightPhrase &original) override;
+    HighlightPhrase getItemFromRow(std::vector<QStandardItem *> &row,
+                                   const HighlightPhrase &original) override;
 
-    virtual void getRowFromItem(const HighlightPhrase &item,
-                                std::vector<QStandardItem *> &row) override;
+    void getRowFromItem(const HighlightPhrase &item,
+                        std::vector<QStandardItem *> &row) override;
 
-    virtual void afterInit() override;
+    void afterInit() override;
 
-    virtual void customRowSetData(const std::vector<QStandardItem *> &row,
-                                  int column, const QVariant &value, int role,
-                                  int rowIndex) override;
+    void customRowSetData(const std::vector<QStandardItem *> &row, int column,
+                          const QVariant &value, int role,
+                          int rowIndex) override;
 };
 
 }  // namespace chatterino

--- a/src/controllers/hotkeys/HotkeyModel.hpp
+++ b/src/controllers/hotkeys/HotkeyModel.hpp
@@ -17,21 +17,20 @@ public:
 
 protected:
     // turn a vector item into a model row
-    virtual std::shared_ptr<Hotkey> getItemFromRow(
+    std::shared_ptr<Hotkey> getItemFromRow(
         std::vector<QStandardItem *> &row,
         const std::shared_ptr<Hotkey> &original) override;
 
     // turns a row in the model into a vector item
-    virtual void getRowFromItem(const std::shared_ptr<Hotkey> &item,
-                                std::vector<QStandardItem *> &row) override;
+    void getRowFromItem(const std::shared_ptr<Hotkey> &item,
+                        std::vector<QStandardItem *> &row) override;
 
-    virtual int beforeInsert(const std::shared_ptr<Hotkey> &item,
-                             std::vector<QStandardItem *> &row,
-                             int proposedIndex) override;
+    int beforeInsert(const std::shared_ptr<Hotkey> &item,
+                     std::vector<QStandardItem *> &row,
+                     int proposedIndex) override;
 
-    virtual void afterRemoved(const std::shared_ptr<Hotkey> &item,
-                              std::vector<QStandardItem *> &row,
-                              int index) override;
+    void afterRemoved(const std::shared_ptr<Hotkey> &item,
+                      std::vector<QStandardItem *> &row, int index) override;
 
     friend class HotkeyController;
 

--- a/src/controllers/ignores/IgnoreModel.hpp
+++ b/src/controllers/ignores/IgnoreModel.hpp
@@ -15,12 +15,12 @@ public:
 
 protected:
     // turn a vector item into a model row
-    virtual IgnorePhrase getItemFromRow(std::vector<QStandardItem *> &row,
-                                        const IgnorePhrase &original) override;
+    IgnorePhrase getItemFromRow(std::vector<QStandardItem *> &row,
+                                const IgnorePhrase &original) override;
 
     // turns a row in the model into a vector item
-    virtual void getRowFromItem(const IgnorePhrase &item,
-                                std::vector<QStandardItem *> &row) override;
+    void getRowFromItem(const IgnorePhrase &item,
+                        std::vector<QStandardItem *> &row) override;
 };
 
 }  // namespace chatterino

--- a/src/controllers/moderationactions/ModerationActionModel.hpp
+++ b/src/controllers/moderationactions/ModerationActionModel.hpp
@@ -15,13 +15,12 @@ public:
 
 protected:
     // turn a vector item into a model row
-    virtual ModerationAction getItemFromRow(
-        std::vector<QStandardItem *> &row,
-        const ModerationAction &original) override;
+    ModerationAction getItemFromRow(std::vector<QStandardItem *> &row,
+                                    const ModerationAction &original) override;
 
     // turns a row in the model into a vector item
-    virtual void getRowFromItem(const ModerationAction &item,
-                                std::vector<QStandardItem *> &row) override;
+    void getRowFromItem(const ModerationAction &item,
+                        std::vector<QStandardItem *> &row) override;
 
     friend class HighlightController;
 };

--- a/src/controllers/notifications/NotificationController.hpp
+++ b/src/controllers/notifications/NotificationController.hpp
@@ -20,7 +20,7 @@ enum class Platform : uint8_t {
 class NotificationController final : public Singleton, private QObject
 {
 public:
-    virtual void initialize(Settings &settings, Paths &paths) override;
+    void initialize(Settings &settings, Paths &paths) override;
 
     bool isChannelNotified(const QString &channelName, Platform p);
     void updateChannelNotification(const QString &channelName, Platform p);

--- a/src/controllers/notifications/NotificationModel.hpp
+++ b/src/controllers/notifications/NotificationModel.hpp
@@ -14,12 +14,12 @@ class NotificationModel : public SignalVectorModel<QString>
 
 protected:
     // turn a vector item into a model row
-    virtual QString getItemFromRow(std::vector<QStandardItem *> &row,
-                                   const QString &original) override;
+    QString getItemFromRow(std::vector<QStandardItem *> &row,
+                           const QString &original) override;
 
     // turns a row in the model into a vector item
-    virtual void getRowFromItem(const QString &item,
-                                std::vector<QStandardItem *> &row) override;
+    void getRowFromItem(const QString &item,
+                        std::vector<QStandardItem *> &row) override;
 
     friend class NotificationController;
 };

--- a/src/controllers/pings/MutedChannelModel.hpp
+++ b/src/controllers/pings/MutedChannelModel.hpp
@@ -12,12 +12,12 @@ class MutedChannelModel : public SignalVectorModel<QString>
 
 protected:
     // turn a vector item into a model row
-    virtual QString getItemFromRow(std::vector<QStandardItem *> &row,
-                                   const QString &original) override;
+    QString getItemFromRow(std::vector<QStandardItem *> &row,
+                           const QString &original) override;
 
     // turns a row in the model into a vector item
-    virtual void getRowFromItem(const QString &item,
-                                std::vector<QStandardItem *> &row) override;
+    void getRowFromItem(const QString &item,
+                        std::vector<QStandardItem *> &row) override;
 };
 
 }  // namespace chatterino

--- a/src/providers/chatterino/ChatterinoBadges.hpp
+++ b/src/providers/chatterino/ChatterinoBadges.hpp
@@ -18,7 +18,7 @@ using EmotePtr = std::shared_ptr<const Emote>;
 class ChatterinoBadges : public Singleton
 {
 public:
-    virtual void initialize(Settings &settings, Paths &paths) override;
+    void initialize(Settings &settings, Paths &paths) override;
     ChatterinoBadges();
 
     std::optional<EmotePtr> getBadge(const UserId &id);

--- a/src/providers/ffz/FfzBadges.hpp
+++ b/src/providers/ffz/FfzBadges.hpp
@@ -21,7 +21,7 @@ using EmotePtr = std::shared_ptr<const Emote>;
 class FfzBadges : public Singleton
 {
 public:
-    virtual void initialize(Settings &settings, Paths &paths) override;
+    void initialize(Settings &settings, Paths &paths) override;
     FfzBadges() = default;
 
     struct Badge {

--- a/src/providers/irc/AbstractIrcServer.hpp
+++ b/src/providers/irc/AbstractIrcServer.hpp
@@ -22,7 +22,7 @@ class AbstractIrcServer : public QObject
 public:
     enum ConnectionType { Read = 1, Write = 2, Both = 3 };
 
-    virtual ~AbstractIrcServer() = default;
+    ~AbstractIrcServer() override = default;
 
     // initializeIrc must be called from the derived class
     // this allows us to initialize the abstract IRC server based on the derived class's parameters

--- a/src/providers/irc/Irc2.cpp
+++ b/src/providers/irc/Irc2.cpp
@@ -18,6 +18,7 @@
 namespace chatterino {
 
 namespace {
+
     QString configPath()
     {
         return combinePath(getPaths()->settingsDirectory, "irc.json");
@@ -33,7 +34,7 @@ namespace {
 
         // turn a vector item into a model row
         IrcServerData getItemFromRow(std::vector<QStandardItem *> &row,
-                                     const IrcServerData &original)
+                                     const IrcServerData &original) override
         {
             return IrcServerData{
                 row[0]->data(Qt::EditRole).toString(),      // host
@@ -50,7 +51,7 @@ namespace {
 
         // turns a row in the model into a vector item
         void getRowFromItem(const IrcServerData &item,
-                            std::vector<QStandardItem *> &row)
+                            std::vector<QStandardItem *> &row) override
         {
             setStringItem(row[0], item.host, false);
             setStringItem(row[1], QString::number(item.port));
@@ -60,6 +61,7 @@ namespace {
             setStringItem(row[5], item.real);
         }
     };
+
 }  // namespace
 
 inline QString escape(QString str)

--- a/src/providers/irc/IrcChannel2.hpp
+++ b/src/providers/irc/IrcChannel2.hpp
@@ -8,7 +8,7 @@ namespace chatterino {
 class Irc;
 class IrcServer;
 
-class IrcChannel : public Channel, public ChannelChatters
+class IrcChannel final : public Channel, public ChannelChatters
 {
 public:
     explicit IrcChannel(const QString &name, IrcServer *server);
@@ -19,8 +19,8 @@ public:
     IrcServer *server();
 
     // Channel methods
-    virtual bool canReconnect() const override;
-    virtual void reconnect() override;
+    bool canReconnect() const override;
+    void reconnect() override;
 
 private:
     void setServer(IrcServer *server);

--- a/src/providers/twitch/TwitchAccount.hpp
+++ b/src/providers/twitch/TwitchAccount.hpp
@@ -52,7 +52,7 @@ public:
     TwitchAccount(const QString &username, const QString &oauthToken_,
                   const QString &oauthClient_, const QString &_userID);
 
-    virtual QString toString() const override;
+    QString toString() const override;
 
     const QString &getUserName() const;
     const QString &getOAuthToken() const;

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -109,17 +109,17 @@ public:
     void initialize();
 
     // Channel methods
-    virtual bool isEmpty() const override;
-    virtual bool canSendMessage() const override;
-    virtual void sendMessage(const QString &message) override;
-    virtual void sendReply(const QString &message, const QString &replyId);
-    virtual bool isMod() const override;
+    bool isEmpty() const override;
+    bool canSendMessage() const override;
+    void sendMessage(const QString &message) override;
+    void sendReply(const QString &message, const QString &replyId);
+    bool isMod() const override;
     bool isVip() const;
     bool isStaff() const;
-    virtual bool isBroadcaster() const override;
-    virtual bool hasHighRateLimit() const override;
-    virtual bool canReconnect() const override;
-    virtual void reconnect() override;
+    bool isBroadcaster() const override;
+    bool hasHighRateLimit() const override;
+    bool canReconnect() const override;
+    void reconnect() override;
     void createClip();
 
     // Data
@@ -127,7 +127,7 @@ public:
     const QString &channelUrl();
     const QString &popoutPlayerUrl();
     int chatterCount();
-    virtual bool isLive() const override;
+    bool isLive() const override;
     QString roomId() const;
     SharedAccessGuard<const RoomModes> accessRoomModes() const;
     SharedAccessGuard<const StreamStatus> accessStreamStatus() const;

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -67,7 +67,7 @@ struct HelixStream;
 
 class TwitchIrcServer;
 
-class TwitchChannel : public Channel, public ChannelChatters
+class TwitchChannel final : public Channel, public ChannelChatters
 {
 public:
     struct StreamStatus {
@@ -140,9 +140,9 @@ public:
     std::shared_ptr<const EmoteMap> ffzEmotes() const;
     std::shared_ptr<const EmoteMap> seventvEmotes() const;
 
-    virtual void refreshBTTVChannelEmotes(bool manualRefresh);
-    virtual void refreshFFZChannelEmotes(bool manualRefresh);
-    virtual void refreshSevenTVChannelEmotes(bool manualRefresh);
+    void refreshBTTVChannelEmotes(bool manualRefresh);
+    void refreshFFZChannelEmotes(bool manualRefresh);
+    void refreshSevenTVChannelEmotes(bool manualRefresh);
 
     const QString &seventvUserID() const;
     const QString &seventvEmoteSetID() const;

--- a/src/providers/twitch/TwitchIrcServer.hpp
+++ b/src/providers/twitch/TwitchIrcServer.hpp
@@ -42,9 +42,9 @@ class TwitchIrcServer final : public AbstractIrcServer,
 {
 public:
     TwitchIrcServer();
-    virtual ~TwitchIrcServer() override = default;
+    ~TwitchIrcServer() override = default;
 
-    virtual void initialize(Settings &settings, Paths &paths) override;
+    void initialize(Settings &settings, Paths &paths) override;
 
     void forEachChannelAndSpecialChannels(std::function<void(ChannelPtr)> func);
 
@@ -89,23 +89,19 @@ public:
     const IndirectChannel &getWatchingChannel() const override;
 
 protected:
-    virtual void initializeConnection(IrcConnection *connection,
-                                      ConnectionType type) override;
-    virtual std::shared_ptr<Channel> createChannel(
-        const QString &channelName) override;
+    void initializeConnection(IrcConnection *connection,
+                              ConnectionType type) override;
+    std::shared_ptr<Channel> createChannel(const QString &channelName) override;
 
-    virtual void privateMessageReceived(
-        Communi::IrcPrivateMessage *message) override;
-    virtual void readConnectionMessageReceived(
-        Communi::IrcMessage *message) override;
-    virtual void writeConnectionMessageReceived(
-        Communi::IrcMessage *message) override;
+    void privateMessageReceived(Communi::IrcPrivateMessage *message) override;
+    void readConnectionMessageReceived(Communi::IrcMessage *message) override;
+    void writeConnectionMessageReceived(Communi::IrcMessage *message) override;
 
-    virtual std::shared_ptr<Channel> getCustomChannel(
+    std::shared_ptr<Channel> getCustomChannel(
         const QString &channelname) override;
 
-    virtual QString cleanChannelName(const QString &dirtyChannelName) override;
-    virtual bool hasSeparateWriteConnection() const override;
+    QString cleanChannelName(const QString &dirtyChannelName) override;
+    bool hasSeparateWriteConnection() const override;
 
 private:
     void onMessageSendRequested(TwitchChannel *channel, const QString &message,

--- a/src/singletons/Emotes.hpp
+++ b/src/singletons/Emotes.hpp
@@ -25,7 +25,7 @@ class Emotes final : public IEmotes, public Singleton
 public:
     Emotes();
 
-    virtual void initialize(Settings &settings, Paths &paths) override;
+    void initialize(Settings &settings, Paths &paths) override;
 
     bool isIgnoredEmote(const QString &emote);
 

--- a/src/singletons/Fonts.hpp
+++ b/src/singletons/Fonts.hpp
@@ -43,7 +43,7 @@ class Fonts final : public Singleton
 public:
     Fonts();
 
-    virtual void initialize(Settings &settings, Paths &paths) override;
+    void initialize(Settings &settings, Paths &paths) override;
 
     // font data gets set in createFontData(...)
 

--- a/src/singletons/Logging.hpp
+++ b/src/singletons/Logging.hpp
@@ -24,7 +24,7 @@ class Logging : public Singleton
 public:
     Logging() = default;
 
-    virtual void initialize(Settings &settings, Paths &paths) override;
+    void initialize(Settings &settings, Paths &paths) override;
 
     void addMessage(const QString &channelName, MessagePtr message,
                     const QString &platformName);

--- a/src/singletons/WindowManager.hpp
+++ b/src/singletons/WindowManager.hpp
@@ -93,8 +93,8 @@ public:
     QPoint emotePopupPos();
     void setEmotePopupPos(QPoint pos);
 
-    virtual void initialize(Settings &settings, Paths &paths) override;
-    virtual void save() override;
+    void initialize(Settings &settings, Paths &paths) override;
+    void save() override;
     void closeAll();
 
     int getGeneration() const;

--- a/src/util/PostToThread.hpp
+++ b/src/util/PostToThread.hpp
@@ -17,8 +17,8 @@ class LambdaRunnable : public QRunnable
 {
 public:
     LambdaRunnable(std::function<void()> action)
+        : action_(std::move(action))
     {
-        this->action_ = std::move(action);
     }
 
     void run() override

--- a/src/util/PostToThread.hpp
+++ b/src/util/PostToThread.hpp
@@ -21,7 +21,7 @@ public:
         this->action_ = std::move(action);
     }
 
-    void run()
+    void run() override
     {
         this->action_();
     }

--- a/src/widgets/AttachedWindow.hpp
+++ b/src/widgets/AttachedWindow.hpp
@@ -28,7 +28,7 @@ public:
         bool fullscreen = false;
     };
 
-    virtual ~AttachedWindow() override;
+    ~AttachedWindow() override;
 
     static AttachedWindow *get(void *target_, const GetArgs &args);
 #ifdef USEWINSDK
@@ -39,7 +39,7 @@ public:
     void setChannel(ChannelPtr channel);
 
 protected:
-    virtual void showEvent(QShowEvent *) override;
+    void showEvent(QShowEvent *) override;
     //    virtual void nativeEvent(const QByteArray &eventType, void *message,
     //    long *result) override;
 

--- a/src/widgets/BaseWidget.hpp
+++ b/src/widgets/BaseWidget.hpp
@@ -37,8 +37,8 @@ public:
     float qtFontScale() const;
 
 protected:
-    virtual void childEvent(QChildEvent *) override;
-    virtual void showEvent(QShowEvent *) override;
+    void childEvent(QChildEvent *) override;
+    void showEvent(QShowEvent *) override;
 
     virtual void scaleChangedEvent(float newScale);
     virtual void themeChangedEvent();

--- a/src/widgets/BaseWindow.hpp
+++ b/src/widgets/BaseWindow.hpp
@@ -72,20 +72,20 @@ protected:
     bool nativeEvent(const QByteArray &eventType, void *message,
                      long *result) override;
 #endif
-    virtual void scaleChangedEvent(float) override;
+    void scaleChangedEvent(float) override;
 
-    virtual void paintEvent(QPaintEvent *) override;
+    void paintEvent(QPaintEvent *) override;
 
-    virtual void changeEvent(QEvent *) override;
-    virtual void leaveEvent(QEvent *) override;
-    virtual void resizeEvent(QResizeEvent *) override;
-    virtual void moveEvent(QMoveEvent *) override;
-    virtual void closeEvent(QCloseEvent *) override;
-    virtual void showEvent(QShowEvent *) override;
+    void changeEvent(QEvent *) override;
+    void leaveEvent(QEvent *) override;
+    void resizeEvent(QResizeEvent *) override;
+    void moveEvent(QMoveEvent *) override;
+    void closeEvent(QCloseEvent *) override;
+    void showEvent(QShowEvent *) override;
 
-    virtual void themeChangedEvent() override;
-    virtual bool event(QEvent *event) override;
-    virtual void wheelEvent(QWheelEvent *event) override;
+    void themeChangedEvent() override;
+    bool event(QEvent *event) override;
+    void wheelEvent(QWheelEvent *event) override;
 
     void mousePressEvent(QMouseEvent *event) override;
     void mouseReleaseEvent(QMouseEvent *event) override;

--- a/src/widgets/Label.hpp
+++ b/src/widgets/Label.hpp
@@ -28,11 +28,11 @@ public:
     void setHasOffset(bool hasOffset);
 
 protected:
-    virtual void scaleChangedEvent(float scale_) override;
-    virtual void paintEvent(QPaintEvent *) override;
+    void scaleChangedEvent(float scale_) override;
+    void paintEvent(QPaintEvent *) override;
 
-    virtual QSize sizeHint() const override;
-    virtual QSize minimumSizeHint() const override;
+    QSize sizeHint() const override;
+    QSize minimumSizeHint() const override;
 
 private:
     void updateSize();

--- a/src/widgets/Notebook.hpp
+++ b/src/widgets/Notebook.hpp
@@ -124,10 +124,10 @@ public:
     void refresh();
 
 protected:
-    virtual void scaleChangedEvent(float scale_) override;
-    virtual void resizeEvent(QResizeEvent *) override;
-    virtual void mousePressEvent(QMouseEvent *event) override;
-    virtual void paintEvent(QPaintEvent *) override;
+    void scaleChangedEvent(float scale_) override;
+    void resizeEvent(QResizeEvent *) override;
+    void mousePressEvent(QMouseEvent *event) override;
+    void paintEvent(QPaintEvent *) override;
 
     NotebookButton *getAddButton();
     NotebookButton *addCustomButton();

--- a/src/widgets/dialogs/ColorPickerDialog.hpp
+++ b/src/widgets/dialogs/ColorPickerDialog.hpp
@@ -37,7 +37,7 @@ public:
      */
     ColorPickerDialog(const QColor &initial, QWidget *parent);
 
-    ~ColorPickerDialog();
+    ~ColorPickerDialog() override;
 
     /**
      * @brief Return the final color selected by the user.

--- a/src/widgets/dialogs/IrcConnectionEditor.hpp
+++ b/src/widgets/dialogs/IrcConnectionEditor.hpp
@@ -22,7 +22,7 @@ class IrcConnectionEditor : public QDialog
 public:
     explicit IrcConnectionEditor(const IrcServerData &data, bool isAdd = false,
                                  QWidget *parent = nullptr);
-    ~IrcConnectionEditor();
+    ~IrcConnectionEditor() override;
 
     IrcServerData data();
 

--- a/src/widgets/dialogs/SelectChannelDialog.hpp
+++ b/src/widgets/dialogs/SelectChannelDialog.hpp
@@ -27,8 +27,8 @@ public:
     pajlada::Signals::NoArgSignal closed;
 
 protected:
-    virtual void closeEvent(QCloseEvent *) override;
-    virtual void themeChangedEvent() override;
+    void closeEvent(QCloseEvent *) override;
+    void themeChangedEvent() override;
 
 private:
     class EventFilter : public QObject
@@ -37,7 +37,7 @@ private:
         SelectChannelDialog *dialog;
 
     protected:
-        virtual bool eventFilter(QObject *watched, QEvent *event) override;
+        bool eventFilter(QObject *watched, QEvent *event) override;
     };
 
     struct {

--- a/src/widgets/dialogs/SettingsDialog.hpp
+++ b/src/widgets/dialogs/SettingsDialog.hpp
@@ -42,9 +42,9 @@ public:
                                SettingsDialogPreference::NoPreference);
 
 protected:
-    virtual void scaleChangedEvent(float newDpi) override;
-    virtual void themeChangedEvent() override;
-    virtual void showEvent(QShowEvent *) override;
+    void scaleChangedEvent(float newDpi) override;
+    void themeChangedEvent() override;
+    void showEvent(QShowEvent *) override;
 
 private:
     void refresh();

--- a/src/widgets/dialogs/UserInfoPopup.hpp
+++ b/src/widgets/dialogs/UserInfoPopup.hpp
@@ -30,8 +30,8 @@ public:
                  const ChannelPtr &openingChannel);
 
 protected:
-    virtual void themeChangedEvent() override;
-    virtual void scaleChangedEvent(float scale) override;
+    void themeChangedEvent() override;
+    void scaleChangedEvent(float scale) override;
 
 private:
     void installEvents();

--- a/src/widgets/dialogs/switcher/NewPopupItem.hpp
+++ b/src/widgets/dialogs/switcher/NewPopupItem.hpp
@@ -18,10 +18,10 @@ public:
     /**
      * @brief   Open the channel passed in the constructor in a new popup.
      */
-    virtual void action() override;
+    void action() override;
 
-    virtual void paint(QPainter *painter, const QRect &rect) const override;
-    virtual QSize sizeHint(const QRect &rect) const override;
+    void paint(QPainter *painter, const QRect &rect) const override;
+    QSize sizeHint(const QRect &rect) const override;
 
 private:
     static constexpr const char *TEXT_FORMAT =

--- a/src/widgets/dialogs/switcher/NewTabItem.hpp
+++ b/src/widgets/dialogs/switcher/NewTabItem.hpp
@@ -20,10 +20,10 @@ public:
     /**
      * @brief   Open the channel passed in the constructor in a new tab.
      */
-    virtual void action() override;
+    void action() override;
 
-    virtual void paint(QPainter *painter, const QRect &rect) const override;
-    virtual QSize sizeHint(const QRect &rect) const override;
+    void paint(QPainter *painter, const QRect &rect) const override;
+    QSize sizeHint(const QRect &rect) const override;
 
 private:
     static constexpr const char *TEXT_FORMAT = "Open channel \"%1\" in new tab";

--- a/src/widgets/dialogs/switcher/SwitchSplitItem.hpp
+++ b/src/widgets/dialogs/switcher/SwitchSplitItem.hpp
@@ -16,10 +16,10 @@ class SwitchSplitItem : public AbstractSwitcherItem
 public:
     SwitchSplitItem(SplitContainer *container, Split *split = nullptr);
 
-    virtual void action() override;
+    void action() override;
 
-    virtual void paint(QPainter *painter, const QRect &rect) const override;
-    virtual QSize sizeHint(const QRect &rect) const override;
+    void paint(QPainter *painter, const QRect &rect) const override;
+    QSize sizeHint(const QRect &rect) const override;
 
 private:
     SplitContainer *container_{};

--- a/src/widgets/helper/Button.hpp
+++ b/src/widgets/helper/Button.hpp
@@ -69,10 +69,10 @@ protected:
 #else
     void enterEvent(QEvent * /*event*/) override;
 #endif
-    virtual void leaveEvent(QEvent *) override;
-    virtual void mousePressEvent(QMouseEvent *event) override;
-    virtual void mouseReleaseEvent(QMouseEvent *event) override;
-    virtual void mouseMoveEvent(QMouseEvent *event) override;
+    void leaveEvent(QEvent *) override;
+    void mousePressEvent(QMouseEvent *event) override;
+    void mouseReleaseEvent(QMouseEvent *event) override;
+    void mouseMoveEvent(QMouseEvent *event) override;
 
     void fancyPaint(QPainter &painter);
 

--- a/src/widgets/helper/ComboBoxItemDelegate.hpp
+++ b/src/widgets/helper/ComboBoxItemDelegate.hpp
@@ -12,14 +12,14 @@ class ComboBoxItemDelegate : public QStyledItemDelegate
 
 public:
     ComboBoxItemDelegate(QObject *parent = nullptr);
-    ~ComboBoxItemDelegate();
+    ~ComboBoxItemDelegate() override;
 
-    virtual QWidget *createEditor(QWidget *parent,
-                                  const QStyleOptionViewItem &option,
-                                  const QModelIndex &index) const;
-    virtual void setEditorData(QWidget *editor, const QModelIndex &index) const;
-    virtual void setModelData(QWidget *editor, QAbstractItemModel *model,
-                              const QModelIndex &index) const;
+    QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option,
+                          const QModelIndex &index) const override;
+    void setEditorData(QWidget *editor,
+                       const QModelIndex &index) const override;
+    void setModelData(QWidget *editor, QAbstractItemModel *model,
+                      const QModelIndex &index) const override;
 };
 
 }  // namespace chatterino

--- a/src/widgets/helper/Line.hpp
+++ b/src/widgets/helper/Line.hpp
@@ -23,7 +23,7 @@ public:
         }
     }
 
-    virtual void paintEvent(QPaintEvent *)
+    void paintEvent(QPaintEvent *) override
     {
         QPainter painter(this);
 

--- a/src/widgets/helper/NotebookButton.hpp
+++ b/src/widgets/helper/NotebookButton.hpp
@@ -21,15 +21,15 @@ public:
     Icon getIcon() const;
 
 protected:
-    virtual void themeChangedEvent() override;
-    virtual void paintEvent(QPaintEvent *) override;
-    virtual void mouseReleaseEvent(QMouseEvent *) override;
-    virtual void dragEnterEvent(QDragEnterEvent *) override;
-    virtual void dragLeaveEvent(QDragLeaveEvent *) override;
-    virtual void dropEvent(QDropEvent *) override;
+    void themeChangedEvent() override;
+    void paintEvent(QPaintEvent *) override;
+    void mouseReleaseEvent(QMouseEvent *) override;
+    void dragEnterEvent(QDragEnterEvent *) override;
+    void dragLeaveEvent(QDragLeaveEvent *) override;
+    void dropEvent(QDropEvent *) override;
 
-    virtual void hideEvent(QHideEvent *) override;
-    virtual void showEvent(QShowEvent *) override;
+    void hideEvent(QHideEvent *) override;
+    void showEvent(QShowEvent *) override;
 
 signals:
     void leftClicked();

--- a/src/widgets/helper/NotebookTab.hpp
+++ b/src/widgets/helper/NotebookTab.hpp
@@ -65,24 +65,24 @@ public:
     int normalTabWidth();
 
 protected:
-    virtual void themeChangedEvent() override;
+    void themeChangedEvent() override;
 
-    virtual void paintEvent(QPaintEvent *) override;
+    void paintEvent(QPaintEvent *) override;
 
-    virtual void mousePressEvent(QMouseEvent *event) override;
-    virtual void mouseReleaseEvent(QMouseEvent *event) override;
-    virtual void mouseDoubleClickEvent(QMouseEvent *event) override;
+    void mousePressEvent(QMouseEvent *event) override;
+    void mouseReleaseEvent(QMouseEvent *event) override;
+    void mouseDoubleClickEvent(QMouseEvent *event) override;
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     void enterEvent(QEnterEvent *event) override;
 #else
     void enterEvent(QEvent *event) override;
 #endif
-    virtual void leaveEvent(QEvent *) override;
+    void leaveEvent(QEvent *) override;
 
-    virtual void dragEnterEvent(QDragEnterEvent *event) override;
+    void dragEnterEvent(QDragEnterEvent *event) override;
 
-    virtual void mouseMoveEvent(QMouseEvent *event) override;
-    virtual void wheelEvent(QWheelEvent *event) override;
+    void mouseMoveEvent(QMouseEvent *event) override;
+    void wheelEvent(QWheelEvent *event) override;
 
 private:
     void showRenameDialog();

--- a/src/widgets/helper/QColorPicker.hpp
+++ b/src/widgets/helper/QColorPicker.hpp
@@ -91,7 +91,7 @@ class QColorLuminancePicker : public QWidget
     Q_OBJECT
 public:
     QColorLuminancePicker(QWidget *parent = 0);
-    ~QColorLuminancePicker();
+    ~QColorLuminancePicker() override;
 
 public slots:
     void setCol(int h, int s, int v);

--- a/src/widgets/helper/QColorPicker.hpp
+++ b/src/widgets/helper/QColorPicker.hpp
@@ -56,7 +56,7 @@ class QColorPicker : public QFrame
     Q_OBJECT
 public:
     QColorPicker(QWidget *parent);
-    ~QColorPicker();
+    ~QColorPicker() override;
     void setCrossVisible(bool visible);
 
 public slots:

--- a/src/widgets/helper/SettingsDialogTab.hpp
+++ b/src/widgets/helper/SettingsDialogTab.hpp
@@ -40,8 +40,8 @@ signals:
     void selectedChanged(bool);
 
 private:
-    void paintEvent(QPaintEvent *);
-    void mousePressEvent(QMouseEvent *event);
+    void paintEvent(QPaintEvent *) override;
+    void mousePressEvent(QMouseEvent *event) override;
 
     struct {
         QString labelText;

--- a/src/widgets/helper/SignalLabel.hpp
+++ b/src/widgets/helper/SignalLabel.hpp
@@ -13,7 +13,7 @@ class SignalLabel : public QLabel
 
 public:
     explicit SignalLabel(QWidget *parent = nullptr, Qt::WindowFlags f = {});
-    virtual ~SignalLabel() override = default;
+    ~SignalLabel() override = default;
 
 signals:
     void mouseDoubleClick(QMouseEvent *ev);

--- a/src/widgets/listview/GenericItemDelegate.hpp
+++ b/src/widgets/listview/GenericItemDelegate.hpp
@@ -10,7 +10,7 @@ class SwitcherItemDelegate : public QStyledItemDelegate
 
 public:
     SwitcherItemDelegate(QObject *parent = nullptr);
-    ~SwitcherItemDelegate();
+    ~SwitcherItemDelegate() override;
 
     void paint(QPainter *painter, const QStyleOptionViewItem &option,
                const QModelIndex &index) const override;

--- a/src/widgets/listview/GenericListView.hpp
+++ b/src/widgets/listview/GenericListView.hpp
@@ -16,7 +16,7 @@ class GenericListView : public QListView
 public:
     GenericListView();
 
-    virtual void setModel(QAbstractItemModel *model) override;
+    void setModel(QAbstractItemModel *model) override;
     void setModel(GenericListModel *);
     void setInvokeActionOnTab(bool);
     bool eventFilter(QObject *watched, QEvent *event) override;

--- a/src/widgets/settingspages/GeneralPage.hpp
+++ b/src/widgets/settingspages/GeneralPage.hpp
@@ -19,7 +19,7 @@ class GeneralPage : public SettingsPage
 public:
     GeneralPage();
 
-    bool filterElements(const QString &query);
+    bool filterElements(const QString &query) override;
 
 private:
     void initLayout(GeneralPageView &layout);

--- a/src/widgets/splits/InputCompletionItem.hpp
+++ b/src/widgets/splits/InputCompletionItem.hpp
@@ -19,10 +19,9 @@ public:
                         ActionCallback action);
 
     // GenericListItem interface
-public:
-    virtual void action() override;
-    virtual void paint(QPainter *painter, const QRect &rect) const override;
-    virtual QSize sizeHint(const QRect &rect) const override;
+    void action() override;
+    void paint(QPainter *painter, const QRect &rect) const override;
+    QSize sizeHint(const QRect &rect) const override;
 
 private:
     EmotePtr emote_;


### PR DESCRIPTION
# Description

This PR fixes most warnings from the clang-tidy `cppcoreguidelines-explicit-virtualfunctions` check

1. For base classes implementing virtual functions, just use virtual
2. For derived classes overriding a base class virtual function, just use override since override implies virtual

Part of #4915

## Unrelated change(s)

Irc2: Add some newlines to let the anon namespace breathe
LambdaRunnable: Initialize action_ in member initializer list
IrcChannel: Made the class final
TwitchChannel: Made the class final

## How to review

Most changes are just removing virtual & the reformatting that comes with it.
TwitchChannel had 3 virtual functions that were never overwritten, `refresh{BTTV,FFZ,SevenTV}ChannelEmotes`. I removed virtual complete there.
Made `LambdaRunnable`'s `run` function override - it was not override or virtual before, but run is most likely meant to override `QRunnable`'s `run` function.
Made `GeneralPage`'s `filterElements` function override
`ComboBoxItemDelegate` now uses override instead of virtual, since they override functions from `QStyledItemDelegate`