### PR TITLE
refactor: debug count and popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - Dev: Replace `boost::optional` with `std::optional`. (#4877)
 - Dev: Improve performance by reducing repaints caused by selections. (#4889)
 - Dev: Removed direct dependency on Qt 5 compatibility module. (#4906)
+- Dev: Refactor `DebugCount` and add copy button to debug popup. (#4921)
 
 ## 2.4.6
 

--- a/src/messages/Image.cpp
+++ b/src/messages/Image.cpp
@@ -108,7 +108,7 @@ namespace detail {
         {
             auto sz = frame.image.size();
             auto area = sz.width() * sz.height();
-            auto memory = area * frame.image.depth();
+            auto memory = area * frame.image.depth() / 8;
 
             usage += memory;
         }

--- a/src/messages/Image.cpp
+++ b/src/messages/Image.cpp
@@ -608,6 +608,13 @@ ImageExpirationPool::ImageExpirationPool()
     this->freeTimer_->start(
         std::chrono::duration_cast<std::chrono::milliseconds>(
             IMAGE_POOL_CLEANUP_INTERVAL));
+
+    // configure all debug counts used by images
+    DebugCount::configure("image bytes", DebugCount::Flag::DataSize);
+    DebugCount::configure("image bytes (ever loaded)",
+                          DebugCount::Flag::DataSize);
+    DebugCount::configure("image bytes (ever unloaded)",
+                          DebugCount::Flag::DataSize);
 }
 
 ImageExpirationPool &ImageExpirationPool::instance()

--- a/src/util/DebugCount.cpp
+++ b/src/util/DebugCount.cpp
@@ -85,13 +85,28 @@ void DebugCount::decrease(const QString &name, const int64_t &amount)
 
 QString DebugCount::getDebugText()
 {
+#if QT_VERSION > QT_VERSION_CHECK(5, 13, 0)
+    static const QLocale locale(QLocale::English);
+#else
+    static QLocale locale(QLocale::English);
+#endif
+
     auto counts = COUNTS.access();
-    QLocale locale;
 
     QString text;
     for (const auto &[key, count] : *counts)
     {
-        text += key % ": " % locale.toString(count.value) % '\n';
+        QString formatted;
+        if (count.flags.has(Flag::DataSize))
+        {
+            formatted = locale.formattedDataSize(count.value);
+        }
+        else
+        {
+            formatted = locale.toString(static_cast<qlonglong>(count.value));
+        }
+
+        text += key % ": " % formatted % '\n';
     }
     return text;
 }

--- a/src/util/DebugCount.cpp
+++ b/src/util/DebugCount.cpp
@@ -2,6 +2,7 @@
 
 #include "common/UniqueAccess.hpp"
 
+#include <QLocale>
 #include <QStringBuilder>
 
 #include <map>
@@ -85,11 +86,12 @@ void DebugCount::decrease(const QString &name, const int64_t &amount)
 QString DebugCount::getDebugText()
 {
     auto counts = COUNTS.access();
+    QLocale locale;
 
     QString text;
     for (const auto &[key, count] : *counts)
     {
-        text += key % ": " % QString::number(count.value) % '\n';
+        text += key % ": " % locale.toString(count.value) % '\n';
     }
     return text;
 }

--- a/src/util/DebugCount.cpp
+++ b/src/util/DebugCount.cpp
@@ -2,7 +2,7 @@
 
 #include "common/UniqueAccess.hpp"
 
-#include <QMap>
+#include <map>
 
 namespace {
 
@@ -14,7 +14,7 @@ struct Count {
 };
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-UniqueAccess<QMap<QString, Count>> COUNTS;
+UniqueAccess<std::map<QString, Count>> COUNTS;
 
 }  // namespace
 
@@ -27,11 +27,11 @@ void DebugCount::configure(const QString &name, Flags flags)
     auto it = counts->find(name);
     if (it == counts->end())
     {
-        counts->insert(name, {.flags = flags});
+        counts->emplace(name, Count{.flags = flags});
     }
     else
     {
-        it.value().flags = flags;
+        it->second.flags = flags;
     }
 }
 
@@ -42,11 +42,11 @@ void DebugCount::set(const QString &name, const int64_t &amount)
     auto it = counts->find(name);
     if (it == counts->end())
     {
-        counts->insert(name, {amount});
+        counts->emplace(name, Count{amount});
     }
     else
     {
-        it.value().value = amount;
+        it->second.value = amount;
     }
 }
 
@@ -57,11 +57,11 @@ void DebugCount::increase(const QString &name, const int64_t &amount)
     auto it = counts->find(name);
     if (it == counts->end())
     {
-        counts->insert(name, {amount});
+        counts->emplace(name, Count{amount});
     }
     else
     {
-        it.value().value += amount;
+        it->second.value += amount;
     }
 }
 
@@ -72,11 +72,11 @@ void DebugCount::decrease(const QString &name, const int64_t &amount)
     auto it = counts->find(name);
     if (it == counts->end())
     {
-        counts->insert(name, {-amount});
+        counts->emplace(name, Count{-amount});
     }
     else
     {
-        it.value().value -= amount;
+        it->second.value -= amount;
     }
 }
 
@@ -85,9 +85,9 @@ QString DebugCount::getDebugText()
     auto counts = COUNTS.access();
 
     QString text;
-    for (auto it = counts->begin(); it != counts->end(); it++)
+    for (const auto &[key, count] : *counts)
     {
-        text += it.key() + ": " + QString::number(it.value().value) + "\n";
+        text += key + ": " + QString::number(count.value) + "\n";
     }
     return text;
 }

--- a/src/util/DebugCount.cpp
+++ b/src/util/DebugCount.cpp
@@ -9,7 +9,8 @@ namespace {
 using namespace chatterino;
 
 struct Count {
-    int64_t value;
+    int64_t value = 0;
+    DebugCount::Flags flags = DebugCount::Flag::None;
 };
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
@@ -18,6 +19,21 @@ UniqueAccess<QMap<QString, Count>> COUNTS;
 }  // namespace
 
 namespace chatterino {
+
+void DebugCount::configure(const QString &name, Flags flags)
+{
+    auto counts = COUNTS.access();
+
+    auto it = counts->find(name);
+    if (it == counts->end())
+    {
+        counts->insert(name, {.flags = flags});
+    }
+    else
+    {
+        it.value().flags = flags;
+    }
+}
 
 void DebugCount::set(const QString &name, const int64_t &amount)
 {

--- a/src/util/DebugCount.cpp
+++ b/src/util/DebugCount.cpp
@@ -2,6 +2,8 @@
 
 #include "common/UniqueAccess.hpp"
 
+#include <QStringBuilder>
+
 #include <map>
 
 namespace {
@@ -87,7 +89,7 @@ QString DebugCount::getDebugText()
     QString text;
     for (const auto &[key, count] : *counts)
     {
-        text += key + ": " + QString::number(count.value) + "\n";
+        text += key % ": " % QString::number(count.value) % '\n';
     }
     return text;
 }

--- a/src/util/DebugCount.cpp
+++ b/src/util/DebugCount.cpp
@@ -1,7 +1,79 @@
-#include "DebugCount.hpp"
+#include "util/DebugCount.hpp"
+
+#include "common/UniqueAccess.hpp"
+
+#include <QMap>
+
+namespace {
+
+using namespace chatterino;
+
+struct Count {
+    int64_t value;
+};
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+UniqueAccess<QMap<QString, Count>> COUNTS;
+
+}  // namespace
 
 namespace chatterino {
 
-UniqueAccess<QMap<QString, int64_t>> DebugCount::counts_;
+void DebugCount::set(const QString &name, const int64_t &amount)
+{
+    auto counts = COUNTS.access();
+
+    auto it = counts->find(name);
+    if (it == counts->end())
+    {
+        counts->insert(name, {amount});
+    }
+    else
+    {
+        it.value().value = amount;
+    }
+}
+
+void DebugCount::increase(const QString &name, const int64_t &amount)
+{
+    auto counts = COUNTS.access();
+
+    auto it = counts->find(name);
+    if (it == counts->end())
+    {
+        counts->insert(name, {amount});
+    }
+    else
+    {
+        it.value().value += amount;
+    }
+}
+
+void DebugCount::decrease(const QString &name, const int64_t &amount)
+{
+    auto counts = COUNTS.access();
+
+    auto it = counts->find(name);
+    if (it == counts->end())
+    {
+        counts->insert(name, {-amount});
+    }
+    else
+    {
+        it.value().value -= amount;
+    }
+}
+
+QString DebugCount::getDebugText()
+{
+    auto counts = COUNTS.access();
+
+    QString text;
+    for (auto it = counts->begin(); it != counts->end(); it++)
+    {
+        text += it.key() + ": " + QString::number(it.value().value) + "\n";
+    }
+    return text;
+}
 
 }  // namespace chatterino

--- a/src/util/DebugCount.hpp
+++ b/src/util/DebugCount.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "common/FlagsEnum.hpp"
+
 #include <QString>
 
 namespace chatterino {
@@ -7,6 +9,13 @@ namespace chatterino {
 class DebugCount
 {
 public:
+    enum class Flag : uint16_t {
+        None = 0,
+    };
+    using Flags = FlagsEnum<Flag>;
+
+    static void configure(const QString &name, Flags flags);
+
     static void set(const QString &name, const int64_t &amount);
 
     static void increase(const QString &name, const int64_t &amount);

--- a/src/util/DebugCount.hpp
+++ b/src/util/DebugCount.hpp
@@ -11,6 +11,8 @@ class DebugCount
 public:
     enum class Flag : uint16_t {
         None = 0,
+        /// The value is a data size in bytes
+        DataSize = 1 << 0,
     };
     using Flags = FlagsEnum<Flag>;
 

--- a/src/util/DebugCount.hpp
+++ b/src/util/DebugCount.hpp
@@ -1,111 +1,27 @@
 #pragma once
 
-#include "common/UniqueAccess.hpp"
-
-#include <QMap>
 #include <QString>
-
-#include <mutex>
-#include <typeinfo>
 
 namespace chatterino {
 
 class DebugCount
 {
 public:
+    static void set(const QString &name, const int64_t &amount);
+
+    static void increase(const QString &name, const int64_t &amount);
     static void increase(const QString &name)
     {
-        auto counts = counts_.access();
-
-        auto it = counts->find(name);
-        if (it == counts->end())
-        {
-            counts->insert(name, 1);
-        }
-        else
-        {
-            reinterpret_cast<int64_t &>(it.value())++;
-        }
+        DebugCount::increase(name, 1);
     }
 
-    static void set(const QString &name, const int64_t &amount)
-    {
-        auto counts = counts_.access();
-
-        auto it = counts->find(name);
-        if (it == counts->end())
-        {
-            counts->insert(name, amount);
-        }
-        else
-        {
-            reinterpret_cast<int64_t &>(it.value()) = amount;
-        }
-    }
-
-    static void increase(const QString &name, const int64_t &amount)
-    {
-        auto counts = counts_.access();
-
-        auto it = counts->find(name);
-        if (it == counts->end())
-        {
-            counts->insert(name, amount);
-        }
-        else
-        {
-            reinterpret_cast<int64_t &>(it.value()) += amount;
-        }
-    }
-
+    static void decrease(const QString &name, const int64_t &amount);
     static void decrease(const QString &name)
     {
-        auto counts = counts_.access();
-
-        auto it = counts->find(name);
-        if (it == counts->end())
-        {
-            counts->insert(name, -1);
-        }
-        else
-        {
-            reinterpret_cast<int64_t &>(it.value())--;
-        }
-    }
-    static void decrease(const QString &name, const int64_t &amount)
-    {
-        auto counts = counts_.access();
-
-        auto it = counts->find(name);
-        if (it == counts->end())
-        {
-            counts->insert(name, -amount);
-        }
-        else
-        {
-            reinterpret_cast<int64_t &>(it.value()) -= amount;
-        }
+        DebugCount::decrease(name, 1);
     }
 
-    static QString getDebugText()
-    {
-        auto counts = counts_.access();
-
-        QString text;
-        for (auto it = counts->begin(); it != counts->end(); it++)
-        {
-            text += it.key() + ": " + QString::number(it.value()) + "\n";
-        }
-        return text;
-    }
-
-    QString toString()
-    {
-        return "";
-    }
-
-private:
-    static UniqueAccess<QMap<QString, int64_t>> counts_;
+    static QString getDebugText();
 };
 
 }  // namespace chatterino

--- a/src/widgets/helper/DebugPopup.cpp
+++ b/src/widgets/helper/DebugPopup.cpp
@@ -1,29 +1,40 @@
-#include "DebugPopup.hpp"
+#include "widgets/helper/DebugPopup.hpp"
 
+#include "common/Literals.hpp"
+#include "util/Clipboard.hpp"
 #include "util/DebugCount.hpp"
 
 #include <QFontDatabase>
-#include <QHBoxLayout>
 #include <QLabel>
+#include <QPushButton>
 #include <QTimer>
+#include <QVBoxLayout>
 
 namespace chatterino {
 
+using namespace literals;
+
 DebugPopup::DebugPopup()
 {
-    auto *layout = new QHBoxLayout(this);
+    auto *layout = new QVBoxLayout(this);
     auto *text = new QLabel(this);
     auto *timer = new QTimer(this);
+    auto *copyButton = new QPushButton(u"&Copy"_s);
 
-    timer->setInterval(300);
     QObject::connect(timer, &QTimer::timeout, [text] {
         text->setText(DebugCount::getDebugText());
     });
-    timer->start();
+    timer->start(300);
+    text->setText(DebugCount::getDebugText());
 
     text->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
 
     layout->addWidget(text);
+    layout->addWidget(copyButton, 1);
+
+    QObject::connect(copyButton, &QPushButton::clicked, this, [text] {
+        crossPlatformCopy(text->text());
+    });
 }
 
 }  // namespace chatterino


### PR DESCRIPTION
# Description

This PR refactors the debug count/-popup to be able to format large numbers and data sizes properly. The following changes were made in the commits:

* Moved implementation of the methods to the `cpp` file.
* Added `DebugCount::Flag(s)` and `DebugCount::configure(name, flags)`.
* Moved from `QMap` to `std::map` (order is important here).
* Used `QStringBuilder` for concatenations.
* Used `QLocale` for formatting (adds separators).
* Added `DebugCount::Flag::DataSize` for data sizes in bytes (and fixed language to English).
* Used `DataSize` for image sizes (maybe this should be moved somewhere else?).
* Added copy button to popup.
* Fixed Image usage reporting being eight times too large (could be another PR, but honestly it's four characters).

| Before | After |
| --- | --- |
| ![before](https://github.com/Chatterino/chatterino2/assets/19953266/0df90542-4414-49b1-b138-3097eeab6462) | ![after](https://github.com/Chatterino/chatterino2/assets/19953266/057c4317-6457-4df4-9229-a87140e05da8) |

