### PR TITLE
refactor: Change lifetime of context menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Bugfix: Fixed the input completion popup from disappearing when clicking on it on Windows and macOS. (#4876)
 - Bugfix: Fixed double-click text selection moving its position with each new message. (#4898)
 - Bugfix: Fixed an issue where notifications on Windows would contain no or an old avatar. (#4899)
+- Bugfix: Fixed memory leak when creating context menus. (#4924)
 - Dev: Fixed UTF16 encoding of `modes` file for the installer. (#4791)
 - Dev: Temporarily disable High DPI scaling on Qt6 builds on Windows. (#4767)
 - Dev: Tests now run on Ubuntu 22.04 instead of 20.04 to loosen C++ restrictions in tests. (#4774)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@
 - Bugfix: Fixed the input completion popup from disappearing when clicking on it on Windows and macOS. (#4876)
 - Bugfix: Fixed double-click text selection moving its position with each new message. (#4898)
 - Bugfix: Fixed an issue where notifications on Windows would contain no or an old avatar. (#4899)
-- Bugfix: Fixed memory leak when creating context menus. (#4924)
 - Dev: Fixed UTF16 encoding of `modes` file for the installer. (#4791)
 - Dev: Temporarily disable High DPI scaling on Qt6 builds on Windows. (#4767)
 - Dev: Tests now run on Ubuntu 22.04 instead of 20.04 to loosen C++ restrictions in tests. (#4774)
@@ -45,6 +44,7 @@
 - Dev: Improve performance by reducing repaints caused by selections. (#4889)
 - Dev: Removed direct dependency on Qt 5 compatibility module. (#4906)
 - Dev: Refactor `DebugCount` and add copy button to debug popup. (#4921)
+- Dev: Changed lifetime of context menus. (#4924)
 
 ## 2.4.6
 

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -279,6 +279,7 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically, QWidget *parent,
                         }
 
                         auto *menu = new QMenu(this);
+                        menu->setAttribute(Qt::WA_DeleteOnClose);
 
                         auto avatarUrl = this->avatarUrl_;
 

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -278,15 +278,7 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically, QWidget *parent,
                             return;
                         }
 
-                        static QMenu *previousMenu = nullptr;
-                        if (previousMenu != nullptr)
-                        {
-                            previousMenu->deleteLater();
-                            previousMenu = nullptr;
-                        }
-
-                        auto menu = new QMenu;
-                        previousMenu = menu;
+                        auto *menu = new QMenu(this);
 
                         auto avatarUrl = this->avatarUrl_;
 

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -73,18 +73,12 @@ namespace {
                                   MessageElementFlags creatorFlags, QMenu &menu)
     {
         auto *openAction = menu.addAction("&Open");
-        auto openMenu = new QMenu;
+        auto *openMenu = new QMenu(&menu);
         openAction->setMenu(openMenu);
 
         auto *copyAction = menu.addAction("&Copy");
-        auto copyMenu = new QMenu;
+        auto *copyMenu = new QMenu(&menu);
         copyAction->setMenu(copyMenu);
-
-        // see if the QMenu actually gets destroyed
-        QObject::connect(openMenu, &QMenu::destroyed, [] {
-            QMessageBox(QMessageBox::Information, "xD", "the menu got deleted")
-                .exec();
-        });
 
         // Add copy and open links for 1x, 2x, 3x
         auto addImageLink = [&](const ImagePtr &image, char scale) {
@@ -2416,7 +2410,7 @@ void ChannelView::addCommandExecutionContextMenuItems(
 
     menu.addSeparator();
     auto *executeAction = menu.addAction("&Execute command");
-    auto cmdMenu = new QMenu;
+    auto *cmdMenu = new QMenu(&menu);
     executeAction->setMenu(cmdMenu);
 
     for (auto &cmd : cmds)

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -2093,15 +2093,7 @@ void ChannelView::addContextMenuItems(
     const MessageLayoutElement *hoveredElement, MessageLayoutPtr layout,
     QMouseEvent *event)
 {
-    static QMenu *previousMenu = nullptr;
-    if (previousMenu != nullptr)
-    {
-        previousMenu->deleteLater();
-        previousMenu = nullptr;
-    }
-
-    auto menu = new QMenu;
-    previousMenu = menu;
+    auto *menu = new QMenu(this);
 
     // Add image options if the element clicked contains an image (e.g. a badge or an emote)
     this->addImageContextMenuItems(hoveredElement, layout, event, *menu);

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -2094,6 +2094,7 @@ void ChannelView::addContextMenuItems(
     QMouseEvent *event)
 {
     auto *menu = new QMenu(this);
+    menu->setAttribute(Qt::WA_DeleteOnClose);
 
     // Add image options if the element clicked contains an image (e.g. a badge or an emote)
     this->addImageContextMenuItems(hoveredElement, layout, event, *menu);


### PR DESCRIPTION
# Description

I saw that dialog code and couldn't unsee it. This memory leak is really tiny, so almost not worth a changelog entry.

When looking at the menu code, I found the weird `previousMenu` construction(s). They aren't needed, so I replaced them.