### PR TITLE
refactor: ChannelView

### DIFF
--- a/src/messages/layouts/MessageLayout.hpp
+++ b/src/messages/layouts/MessageLayout.hpp
@@ -60,7 +60,11 @@ public:
     void deleteBuffer();
     void deleteCache();
 
-    // Elements
+    /**
+     * Returns a raw pointer to the element at the given point
+     *
+     * If no element is found at the given point, this returns a null pointer
+     */
     const MessageLayoutElement *getElementAt(QPoint point);
 
     /**

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -1251,10 +1251,26 @@ void TwitchChannel::addReplyThread(const std::shared_ptr<MessageThread> &thread)
     this->threads_[thread->rootId()] = thread;
 }
 
-const std::unordered_map<QString, std::weak_ptr<MessageThread>>
-    &TwitchChannel::threads() const
+const std::unordered_map<QString, std::weak_ptr<MessageThread>> &
+    TwitchChannel::threads() const
 {
     return this->threads_;
+}
+
+std::shared_ptr<MessageThread> TwitchChannel::getOrCreateThread(
+    const MessagePtr &message)
+{
+    assert(message != nullptr);
+
+    auto threadIt = this->threads_.find(message->id);
+    if (threadIt != this->threads_.end() && !threadIt->second.expired())
+    {
+        return threadIt->second.lock();
+    }
+
+    auto thread = std::make_shared<MessageThread>(message);
+    this->addReplyThread(thread);
+    return thread;
 }
 
 void TwitchChannel::cleanUpReplyThreads()

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -190,6 +190,12 @@ public:
     const std::unordered_map<QString, std::weak_ptr<MessageThread>> &threads()
         const;
 
+    /**
+     * Get the thread for the given message
+     * If no thread can be found for the message, create one
+     */
+    std::shared_ptr<MessageThread> getOrCreateThread(const MessagePtr &message);
+
     // Only TwitchChannel may invoke this signal
     pajlada::Signals::NoArgSignal userStateChanged;
 

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -2069,7 +2069,8 @@ void ChannelView::mouseReleaseEvent(QMouseEvent *event)
 
             return;
         }
-        else if (foundElement)
+
+        if (foundElement)
         {
             const MessageLayoutElement *hoverLayoutElement =
                 layout->getElementAt(relativePos);
@@ -2078,14 +2079,14 @@ void ChannelView::mouseReleaseEvent(QMouseEvent *event)
             {
                 return;
             }
-            else if (hoverLayoutElement->getFlags().has(
-                         MessageElementFlag::Username))
+            if (hoverLayoutElement->getFlags().has(
+                    MessageElementFlag::Username))
             {
                 openTwitchUsercard(this->channel_->getName(),
                                    hoverLayoutElement->getLink().value);
                 return;
             }
-            else if (hoverLayoutElement->getLink().isUrl() == false)
+            if (hoverLayoutElement->getLink().isUrl() == false)
             {
                 return;
             }
@@ -2889,12 +2890,10 @@ void ChannelView::setInputReply(const MessagePtr &message)
             {
                 return threadIt->second.lock();
             }
-            else
-            {
-                auto thread = std::make_shared<MessageThread>(message);
-                tc->addReplyThread(thread);
-                return thread;
-            }
+
+            auto thread = std::make_shared<MessageThread>(message);
+            tc->addReplyThread(thread);
+            return thread;
         };
 
         if (auto tc =

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1529,13 +1529,15 @@ void ChannelView::drawMessages(QPainter &painter)
 
 void ChannelView::wheelEvent(QWheelEvent *event)
 {
-    if (!event->angleDelta().y())
+    if (event->angleDelta().y() == 0)
     {
+        // Ignore any scrolls where no vertical scrolling has taken place
         return;
     }
 
-    if (event->modifiers() & Qt::ControlModifier)
+    if ((event->modifiers() & Qt::ControlModifier) != 0)
     {
+        // Ignore any scrolls where ctrl is held down - it is used for zoom
         event->ignore();
         return;
     }

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -733,7 +733,7 @@ void ChannelView::setChannel(ChannelPtr underlyingChannel)
         [this](std::vector<MessagePtr> &messages) {
             std::vector<MessagePtr> filtered;
             std::copy_if(messages.begin(), messages.end(),
-                         std::back_inserter(filtered), [this](MessagePtr msg) {
+                         std::back_inserter(filtered), [this](const auto &msg) {
                              return this->shouldIncludeMessage(msg);
                          });
 
@@ -743,7 +743,7 @@ void ChannelView::setChannel(ChannelPtr underlyingChannel)
 
     this->channelConnections_.managedConnect(
         underlyingChannel->messageReplaced,
-        [this](size_t index, MessagePtr replacement) {
+        [this](auto index, const auto &replacement) {
             if (this->shouldIncludeMessage(replacement))
                 this->channel_->replaceMessage(index, replacement);
         });
@@ -753,7 +753,7 @@ void ChannelView::setChannel(ChannelPtr underlyingChannel)
             std::vector<MessagePtr> filtered;
             filtered.reserve(messages.size());
             std::copy_if(messages.begin(), messages.end(),
-                         std::back_inserter(filtered), [this](MessagePtr msg) {
+                         std::back_inserter(filtered), [this](const auto &msg) {
                              return this->shouldIncludeMessage(msg);
                          });
             this->channel_->fillInMissingMessages(filtered);
@@ -1595,14 +1595,14 @@ void ChannelView::mouseMoveEvent(QMouseEvent *event)
             }
             else if (layeredEmoteElement)
             {
-                auto &layeredEmotes = layeredEmoteElement->getEmotes();
+                const auto &layeredEmotes = layeredEmoteElement->getEmotes();
                 // Should never be empty but ensure it
                 if (!layeredEmotes.empty())
                 {
                     std::vector<TooltipEntry> entries;
                     entries.reserve(layeredEmotes.size());
 
-                    auto &emoteTooltips =
+                    const auto &emoteTooltips =
                         layeredEmoteElement->getEmoteTooltips();
 
                     // Someone performing some tomfoolery could put an emote with tens,
@@ -2496,14 +2496,14 @@ void ChannelView::mouseDoubleClickEvent(QMouseEvent *event)
 
     if (getSettings()->linksDoubleClickOnly)
     {
-        auto &link = hoverLayoutElement->getLink();
+        const auto &link = hoverLayoutElement->getLink();
         this->handleLinkClick(event, link, layout.get());
     }
 }
 
 void ChannelView::hideEvent(QHideEvent * /*event*/)
 {
-    for (auto &layout : this->messagesOnScreen_)
+    for (const auto &layout : this->messagesOnScreen_)
     {
         layout->deleteBuffer();
     }

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1648,7 +1648,8 @@ void ChannelView::mouseMoveEvent(QMouseEvent *event)
     if (float pauseTime = getSettings()->pauseOnHoverDuration;
         pauseTime > 0.001F)
     {
-        this->pause(PauseReason::Mouse, uint(pauseTime * 1000.F));
+        this->pause(PauseReason::Mouse,
+                    static_cast<uint32_t>(pauseTime * 1000.F));
     }
     else if (pauseTime < -0.5F)
     {

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1076,7 +1076,7 @@ void ChannelView::updateLastReadMessage()
     this->update();
 }
 
-void ChannelView::resizeEvent(QResizeEvent *)
+void ChannelView::resizeEvent(QResizeEvent * /*event*/)
 {
     this->scrollBar_->setGeometry(this->width() - this->scrollBar_->width(), 0,
                                   this->scrollBar_->width(), this->height());
@@ -1479,7 +1479,7 @@ void ChannelView::enterEvent(QEvent * /*event*/)
 {
 }
 
-void ChannelView::leaveEvent(QEvent *)
+void ChannelView::leaveEvent(QEvent * /*event*/)
 {
     TooltipWidget::instance()->hide();
 
@@ -2502,7 +2502,7 @@ void ChannelView::mouseDoubleClickEvent(QMouseEvent *event)
     }
 }
 
-void ChannelView::hideEvent(QHideEvent *)
+void ChannelView::hideEvent(QHideEvent * /*event*/)
 {
     for (auto &layout : this->messagesOnScreen_)
     {

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -184,9 +184,18 @@ ChannelView::ChannelView(BaseWidget *parent, Split *split, Context context,
 
     this->pauseTimer_.setSingleShot(true);
     QObject::connect(&this->pauseTimer_, &QTimer::timeout, this, [this] {
-        /// remove elements that are finite
+        // remove elements that are finite
         for (auto it = this->pauses_.begin(); it != this->pauses_.end();)
-            it = it->second ? this->pauses_.erase(it) : ++it;
+        {
+            if (it->second)
+            {
+                it = this->pauses_.erase(it);
+            }
+            else
+            {
+                it = ++it;
+            }
+        }
 
         this->updatePauses();
     });

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -878,14 +878,18 @@ void ChannelView::setChannel(ChannelPtr underlyingChannel)
                          });
 
             if (!filtered.empty())
+            {
                 this->channel_->addMessagesAtStart(filtered);
+            }
         });
 
     this->channelConnections_.managedConnect(
         underlyingChannel->messageReplaced,
         [this](auto index, const auto &replacement) {
             if (this->shouldIncludeMessage(replacement))
+            {
                 this->channel_->replaceMessage(index, replacement);
+            }
         });
 
     this->channelConnections_.managedConnect(
@@ -1001,7 +1005,9 @@ bool ChannelView::shouldIncludeMessage(const MessagePtr &m) const
         if (getSettings()->excludeUserMessagesFromFilter &&
             getApp()->accounts->twitch.getCurrent()->getUserName().compare(
                 m->loginName, Qt::CaseInsensitive) == 0)
+        {
             return true;
+        }
 
         return this->channelFilters_->filter(m, this->underlyingChannel_);
     }
@@ -1112,7 +1118,9 @@ void ChannelView::messageAddedAtStart(std::vector<MessagePtr> &messages)
 
         // alternate color
         if (!this->lastMessageHasAlternateBackgroundReverse_)
+        {
             layout->flags.set(MessageLayoutFlag::AlternateBackground);
+        }
         this->lastMessageHasAlternateBackgroundReverse_ =
             !this->lastMessageHasAlternateBackgroundReverse_;
 
@@ -1124,9 +1132,13 @@ void ChannelView::messageAddedAtStart(std::vector<MessagePtr> &messages)
     if (!addedMessages.empty())
     {
         if (this->scrollBar_->isAtBottom())
+        {
             this->scrollBar_->scrollToBottom();
+        }
         else
+        {
             this->scrollBar_->offset(qreal(addedMessages.size()));
+        }
         this->scrollBar_->offsetMaximum(qreal(addedMessages.size()));
     }
 
@@ -1285,7 +1297,9 @@ MessageElementFlags ChannelView::getFlags() const
     }
 
     if (this->sourceChannel_ == app->twitch->mentionsChannel)
+    {
         flags.set(MessageElementFlag::ChannelName);
+    }
 
     if (this->context_ == Context::ReplyThread ||
         getSettings()->hideReplyContext)
@@ -1811,7 +1825,9 @@ void ChannelView::mouseMoveEvent(QMouseEvent *event)
                                           ImagePtr thumbnail) {
                         auto shared = weakLayout.lock();
                         if (!shared)
+                        {
                             return;
+                        }
                         element->setTooltip(tooltipText);
                         element->setThumbnail(thumbnail);
                     });
@@ -1900,13 +1916,17 @@ void ChannelView::mousePressEvent(QMouseEvent *event)
     {
         case Qt::LeftButton: {
             if (this->isScrolling_)
+            {
                 this->disableScrolling();
+            }
 
             this->lastLeftPressPosition_ = event->screenPos();
             this->isLeftMouseDown_ = true;
 
             if (layout->flags.has(MessageLayoutFlag::Collapsed))
+            {
                 return;
+            }
 
             if (getSettings()->linksDoubleClickOnly.getValue())
             {
@@ -1921,7 +1941,9 @@ void ChannelView::mousePressEvent(QMouseEvent *event)
 
         case Qt::RightButton: {
             if (this->isScrolling_)
+            {
                 this->disableScrolling();
+            }
 
             this->lastRightPressPosition_ = event->screenPos();
             this->isRightMouseDown_ = true;
@@ -1941,13 +1963,19 @@ void ChannelView::mousePressEvent(QMouseEvent *event)
             else
             {
                 if (this->isScrolling_)
+                {
                     this->disableScrolling();
+                }
                 else if (hoverLayoutElement != nullptr &&
                          hoverLayoutElement->getFlags().has(
                              MessageElementFlag::Username))
+                {
                     break;
+                }
                 else if (this->scrollBar_->isVisible())
+                {
                     this->enableScrolling(event->screenPos());
+                }
             }
         }
         break;
@@ -2030,9 +2058,13 @@ void ChannelView::mouseReleaseEvent(QMouseEvent *event)
         if (this->isScrolling_ && this->scrollBar_->isVisible())
         {
             if (event->screenPos() == this->lastMiddlePressPosition_)
+            {
                 this->enableScrolling(event->screenPos());
+            }
             else
+            {
                 this->disableScrolling();
+            }
 
             return;
         }
@@ -2606,9 +2638,13 @@ void ChannelView::handleLinkClick(QMouseEvent *event, const Link &link,
 
         case Link::Url: {
             if (getSettings()->openLinksIncognito && supportsIncognitoLinks())
+            {
                 openLinkIncognito(link.value);
+            }
             else
+            {
                 QDesktopServices::openUrl(QUrl(link.value));
+            }
         }
         break;
 
@@ -2764,7 +2800,9 @@ bool ChannelView::tryGetMessageAt(QPoint p,
 int ChannelView::getLayoutWidth() const
 {
     if (this->scrollBar_->isVisible())
+    {
         return int(this->width() - SCROLLBAR_PADDING * this->scale());
+    }
 
     return this->width();
 }
@@ -2787,7 +2825,9 @@ void ChannelView::enableScrolling(const QPointF &scrollStart)
     this->scrollTimer_.start();
 
     if (!QGuiApplication::overrideCursor())
+    {
         QGuiApplication::setOverrideCursor(this->cursors_.neutral);
+    }
 }
 
 void ChannelView::disableScrolling()

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1,4 +1,4 @@
-#include "ChannelView.hpp"
+#include "widgets/helper/ChannelView.hpp"
 
 #include "Application.hpp"
 #include "common/Common.hpp"

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -187,8 +187,9 @@ ChannelView::ChannelView(BaseWidget *parent, Split *split, Context context,
     this->clickTimer_->setInterval(500);
 
     this->scrollTimer_.setInterval(20);
-    QObject::connect(&this->scrollTimer_, &QTimer::timeout, this,
-                     &ChannelView::scrollUpdateRequested);
+    QObject::connect(&this->scrollTimer_, &QTimer::timeout, this, [this] {
+        this->scrollUpdateRequested();
+    });
 
     // TODO: Figure out if we need this, and if so, why
     // StrongFocus means we can focus this event through clicking it

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -979,11 +979,11 @@ void ChannelView::setFilters(const QList<QUuid> &ids)
     this->channelFilters_ = std::make_shared<FilterSet>(ids);
 }
 
-const QList<QUuid> ChannelView::getFilterIds() const
+QList<QUuid> ChannelView::getFilterIds() const
 {
     if (!this->channelFilters_)
     {
-        return QList<QUuid>();
+        return {};
     }
 
     return this->channelFilters_->filterIds();

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -820,7 +820,7 @@ bool ChannelView::showScrollbarHighlights() const
     return this->channel_->getType() != Channel::Type::TwitchMentions;
 }
 
-void ChannelView::setChannel(ChannelPtr underlyingChannel)
+void ChannelView::setChannel(const ChannelPtr &underlyingChannel)
 {
     /// Clear connections from the last channel
     this->channelConnections_.clear();

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -67,6 +67,12 @@
 #define CHAT_HOVER_PAUSE_DURATION 1000
 #define TOOLTIP_EMOTE_ENTRIES_LIMIT 7
 
+namespace {
+
+constexpr int SCROLLBAR_PADDING = 8;
+
+}  // namespace
+
 namespace chatterino {
 namespace {
     void addEmoteContextMenuItems(const Emote &emote,
@@ -2729,7 +2735,7 @@ bool ChannelView::tryGetMessageAt(QPoint p,
 int ChannelView::getLayoutWidth() const
 {
     if (this->scrollBar_->isVisible())
-        return int(this->width() - scrollbarPadding * this->scale());
+        return int(this->width() - SCROLLBAR_PADDING * this->scale());
 
     return this->width();
 }

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -555,7 +555,7 @@ void ChannelView::scaleChangedEvent(float scale)
     {
         auto factor = this->qtFontScale();
 #ifdef Q_OS_MACOS
-        factor = scale * 80.f /
+        factor = scale * 80.F /
                  std::max<float>(
                      0.01, this->logicalDpiX() * this->devicePixelRatioF());
 #endif
@@ -1646,11 +1646,11 @@ void ChannelView::mouseMoveEvent(QMouseEvent *event)
 {
     /// Pause on hover
     if (float pauseTime = getSettings()->pauseOnHoverDuration;
-        pauseTime > 0.001f)
+        pauseTime > 0.001F)
     {
-        this->pause(PauseReason::Mouse, uint(pauseTime * 1000.f));
+        this->pause(PauseReason::Mouse, uint(pauseTime * 1000.F));
     }
-    else if (pauseTime < -0.5f)
+    else if (pauseTime < -0.5F)
     {
         this->pause(PauseReason::Mouse);
     }
@@ -2006,7 +2006,7 @@ void ChannelView::mouseReleaseEvent(QMouseEvent *event)
             this->isDoubleClick_ = false;
             // Was actually not a wanted triple-click
             if (fabsf(distanceBetweenPoints(this->lastDoubleClickPosition_,
-                                            event->screenPos())) > 10.f)
+                                            event->screenPos())) > 10.F)
             {
                 this->clickTimer_.stop();
                 return;
@@ -2017,7 +2017,7 @@ void ChannelView::mouseReleaseEvent(QMouseEvent *event)
             this->isLeftMouseDown_ = false;
 
             if (fabsf(distanceBetweenPoints(this->lastLeftPressPosition_,
-                                            event->screenPos())) > 15.f)
+                                            event->screenPos())) > 15.F)
             {
                 return;
             }
@@ -2025,7 +2025,7 @@ void ChannelView::mouseReleaseEvent(QMouseEvent *event)
             // Triple-clicking a message selects the whole message
             if (foundElement && this->clickTimer_.isActive() &&
                 (fabsf(distanceBetweenPoints(this->lastDoubleClickPosition_,
-                                             event->screenPos())) < 10.f))
+                                             event->screenPos())) < 10.F))
             {
                 this->selectWholeMessage(layout.get(), messageIndex);
                 return;
@@ -2043,7 +2043,7 @@ void ChannelView::mouseReleaseEvent(QMouseEvent *event)
             this->isRightMouseDown_ = false;
 
             if (fabsf(distanceBetweenPoints(this->lastRightPressPosition_,
-                                            event->screenPos())) > 15.f)
+                                            event->screenPos())) > 15.F)
             {
                 return;
             }

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -791,7 +791,7 @@ bool ChannelView::getEnableScrollingToBottom() const
 
 void ChannelView::setOverrideFlags(std::optional<MessageElementFlags> value)
 {
-    this->overrideFlags_ = std::move(value);
+    this->overrideFlags_ = value;
 }
 
 const std::optional<MessageElementFlags> &ChannelView::getOverrideFlags() const
@@ -912,7 +912,7 @@ void ChannelView::setChannel(ChannelPtr underlyingChannel)
         this->channel_->messageAppended,
         [this](MessagePtr &message,
                std::optional<MessageFlags> overridingFlags) {
-            this->messageAppended(message, std::move(overridingFlags));
+            this->messageAppended(message, overridingFlags);
         });
 
     this->channelConnections_.managedConnect(

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -317,7 +317,7 @@ ChannelView::ChannelView(BaseWidget *parent, Split *split, Context context,
     // don't have a SplitInput like the SearchPopup or EmotePopup.
     // See SplitInput::installKeyPressedEvent for the copy event
     // from views with a SplitInput.
-    auto shortcut = new QShortcut(QKeySequence::StandardKey::Copy, this);
+    auto *shortcut = new QShortcut(QKeySequence::StandardKey::Copy, this);
     QObject::connect(shortcut, &QShortcut::activated, [this] {
         this->copySelectedText();
     });
@@ -963,10 +963,12 @@ void ChannelView::setChannel(ChannelPtr underlyingChannel)
     this->queueUpdate();
 
     // Notifications
-    if (auto tc = dynamic_cast<TwitchChannel *>(underlyingChannel.get()))
+    auto *twitchChannel =
+        dynamic_cast<TwitchChannel *>(underlyingChannel.get());
+    if (twitchChannel != nullptr)
     {
         this->channelConnections_.managedConnect(
-            tc->streamStatusChanged, [this]() {
+            twitchChannel->streamStatusChanged, [this]() {
                 this->liveStatusChanged.invoke();
             });
     }
@@ -1248,7 +1250,7 @@ void ChannelView::setSelection(const SelectionItem &start,
 
 MessageElementFlags ChannelView::getFlags() const
 {
-    auto app = getApp();
+    auto *app = getApp();
 
     if (this->overrideFlags_)
     {
@@ -1257,12 +1259,11 @@ MessageElementFlags ChannelView::getFlags() const
 
     MessageElementFlags flags = app->windows->getWordFlags();
 
-    Split *split = dynamic_cast<Split *>(this->parentWidget());
+    auto *split = dynamic_cast<Split *>(this->parentWidget());
 
     if (split == nullptr)
     {
-        SearchPopup *searchPopup =
-            dynamic_cast<SearchPopup *>(this->parentWidget());
+        auto *searchPopup = dynamic_cast<SearchPopup *>(this->parentWidget());
         if (searchPopup != nullptr)
         {
             split = dynamic_cast<Split *>(searchPopup->parentWidget());
@@ -1640,7 +1641,7 @@ void ChannelView::mouseMoveEvent(QMouseEvent *event)
         this->pause(PauseReason::Mouse);
     }
 
-    auto tooltipWidget = TooltipWidget::instance();
+    auto *tooltipWidget = TooltipWidget::instance();
     std::shared_ptr<MessageLayout> layout;
     QPoint relativePos;
     int messageIndex;
@@ -1698,10 +1699,10 @@ void ChannelView::mouseMoveEvent(QMouseEvent *event)
         return;
     }
 
-    auto element = &hoverLayoutElement->getCreator();
+    auto *element = &hoverLayoutElement->getCreator();
     bool isLinkValid = hoverLayoutElement->getLink().isValid();
-    auto emoteElement = dynamic_cast<const EmoteElement *>(element);
-    auto layeredEmoteElement =
+    const auto *emoteElement = dynamic_cast<const EmoteElement *>(element);
+    const auto *layeredEmoteElement =
         dynamic_cast<const LayeredEmoteElement *>(element);
     bool isNotEmote = emoteElement == nullptr && layeredEmoteElement == nullptr;
 
@@ -1712,7 +1713,7 @@ void ChannelView::mouseMoveEvent(QMouseEvent *event)
     }
     else
     {
-        auto badgeElement = dynamic_cast<const BadgeElement *>(element);
+        const auto *badgeElement = dynamic_cast<const BadgeElement *>(element);
 
         if (badgeElement || emoteElement || layeredEmoteElement)
         {
@@ -2119,7 +2120,7 @@ void ChannelView::handleMouseClick(QMouseEvent *event,
             if ((this->context_ == Context::None) &&
                 (hoveredElement != nullptr))
             {
-                auto split = dynamic_cast<Split *>(this->parentWidget());
+                auto *split = dynamic_cast<Split *>(this->parentWidget());
                 auto insertText = [=](QString text) {
                     if (split)
                     {
@@ -2615,11 +2616,11 @@ void ChannelView::handleLinkClick(QMouseEvent *event, const Link &link,
             QString value = link.value;
 
             ChannelPtr channel = this->underlyingChannel_;
-            SearchPopup *searchPopup =
+            auto *searchPopup =
                 dynamic_cast<SearchPopup *>(this->parentWidget());
             if (searchPopup != nullptr)
             {
-                Split *split =
+                auto *split =
                     dynamic_cast<Split *>(searchPopup->parentWidget());
                 if (split != nullptr)
                 {
@@ -2826,7 +2827,7 @@ void ChannelView::scrollUpdateRequested()
     }
 
     // "Good" feeling multiplier found by trial-and-error
-    const qreal multiplier = qreal(0.02);
+    const qreal multiplier(0.02);
     this->scrollBar_->offset(multiplier * offset);
 }
 
@@ -2887,10 +2888,10 @@ void ChannelView::showReplyThreadPopup(const MessagePtr &message)
         return;
     }
 
-    auto popupParent =
+    auto *popupParent =
         static_cast<QWidget *>(&(getApp()->windows->getMainWindow()));
-    auto popup = new ReplyThreadPopup(getSettings()->autoCloseThreadPopup,
-                                      popupParent, this->split_);
+    auto *popup = new ReplyThreadPopup(getSettings()->autoCloseThreadPopup,
+                                       popupParent, this->split_);
 
     popup->setThread(message->replyThread);
 

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -221,6 +221,30 @@ void addLinkContextMenuItems(const MessageLayoutElement *hoveredElement,
     menu.addSeparator();
 }
 
+void addHiddenContextMenuItems(const MessageLayoutElement * /*hoveredElement*/,
+                               MessageLayoutPtr layout, QMouseEvent *event,
+                               QMenu &menu)
+{
+    if (!layout)
+    {
+        return;
+    }
+
+    if (event->modifiers() != Qt::ShiftModifier)
+    {
+        // NOTE: We currently require the modifier to be ONLY shift - we might want to check if shift is among the modifiers instead
+        return;
+    }
+
+    if (!layout->getMessage()->id.isEmpty())
+    {
+        menu.addAction("Copy message &ID",
+                       [messageID = layout->getMessage()->id] {
+                           crossPlatformCopy(messageID);
+                       });
+    }
+}
+
 // Current function: https://www.desmos.com/calculator/vdyamchjwh
 qreal highlightEasingFunction(qreal progress)
 {
@@ -2231,7 +2255,7 @@ void ChannelView::addContextMenuItems(
     this->addTwitchLinkContextMenuItems(hoveredElement, layout, event, *menu);
 
     // Add hidden options (e.g. copy message ID) if the user held down Shift
-    this->addHiddenContextMenuItems(hoveredElement, layout, event, *menu);
+    addHiddenContextMenuItems(hoveredElement, layout, event, *menu);
 
     // Add executable command options
     this->addCommandExecutionContextMenuItems(hoveredElement, layout, event,
@@ -2388,30 +2412,6 @@ void ChannelView::addTwitchLinkContextMenuItems(
             this->openChannelIn.invoke(twitchUsername,
                                        FromTwitchLinkOpenChannelIn::Streamlink);
         });
-    }
-}
-
-void ChannelView::addHiddenContextMenuItems(
-    const MessageLayoutElement * /*hoveredElement*/, MessageLayoutPtr layout,
-    QMouseEvent *event, QMenu &menu)
-{
-    if (!layout)
-    {
-        return;
-    }
-
-    if (event->modifiers() != Qt::ShiftModifier)
-    {
-        // NOTE: We currently require the modifier to be ONLY shift - we might want to check if shift is among the modifiers instead
-        return;
-    }
-
-    if (!layout->getMessage()->id.isEmpty())
-    {
-        menu.addAction("Copy message &ID",
-                       [messageID = layout->getMessage()->id] {
-                           crossPlatformCopy(messageID);
-                       });
     }
 }
 

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -182,9 +182,8 @@ ChannelView::ChannelView(BaseWidget *parent, Split *split, Context context,
         this->copySelectedText();
     });
 
-    this->clickTimer_ = new QTimer(this);
-    this->clickTimer_->setSingleShot(true);
-    this->clickTimer_->setInterval(500);
+    this->clickTimer_.setSingleShot(true);
+    this->clickTimer_.setInterval(500);
 
     this->scrollTimer_.setInterval(20);
     QObject::connect(&this->scrollTimer_, &QTimer::timeout, this, [this] {
@@ -1840,7 +1839,7 @@ void ChannelView::mouseReleaseEvent(QMouseEvent *event)
             if (fabsf(distanceBetweenPoints(this->lastDoubleClickPosition_,
                                             event->screenPos())) > 10.f)
             {
-                this->clickTimer_->stop();
+                this->clickTimer_.stop();
                 return;
             }
         }
@@ -1855,7 +1854,7 @@ void ChannelView::mouseReleaseEvent(QMouseEvent *event)
             }
 
             // Triple-clicking a message selects the whole message
-            if (foundElement && this->clickTimer_->isActive() &&
+            if (foundElement && this->clickTimer_.isActive() &&
                 (fabsf(distanceBetweenPoints(this->lastDoubleClickPosition_,
                                              event->screenPos())) < 10.f))
             {
@@ -2473,7 +2472,7 @@ void ChannelView::mouseDoubleClickEvent(QMouseEvent *event)
 
     this->isDoubleClick_ = true;
     this->lastDoubleClickPosition_ = event->screenPos();
-    this->clickTimer_->start();
+    this->clickTimer_.start();
 
     // message under cursor is collapsed
     if (layout->flags.has(MessageLayoutFlag::Collapsed))

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -2747,16 +2747,16 @@ void ChannelView::handleLinkClick(QMouseEvent *event, const Link &link,
         case Link::JumpToMessage: {
             if (this->context_ == Context::Search)
             {
-                if (auto search =
-                        dynamic_cast<SearchPopup *>(this->parentWidget()))
+                auto *search =
+                    dynamic_cast<SearchPopup *>(this->parentWidget());
+                if (search != nullptr)
                 {
                     search->goToMessageId(link.value);
                 }
+                return;
             }
-            else
-            {
-                this->scrollToMessageId(link.value);
-            }
+
+            this->scrollToMessageId(link.value);
         }
         break;
 

--- a/src/widgets/helper/ChannelView.hpp
+++ b/src/widgets/helper/ChannelView.hpp
@@ -346,7 +346,6 @@ private:
     MessageColors messageColors_;
     MessagePreferences messagePreferences_;
 
-private slots:
     void scrollUpdateRequested();
 };
 

--- a/src/widgets/helper/ChannelView.hpp
+++ b/src/widgets/helper/ChannelView.hpp
@@ -121,7 +121,7 @@ public:
     void setChannel(ChannelPtr channel_);
 
     void setFilters(const QList<QUuid> &ids);
-    const QList<QUuid> getFilterIds() const;
+    QList<QUuid> getFilterIds() const;
     FilterSetPtr getFilterSet() const;
 
     ChannelPtr sourceChannel() const;

--- a/src/widgets/helper/ChannelView.hpp
+++ b/src/widgets/helper/ChannelView.hpp
@@ -224,9 +224,6 @@ private:
     void addTwitchLinkContextMenuItems(
         const MessageLayoutElement *hoveredElement, MessageLayoutPtr layout,
         QMouseEvent *event, QMenu &menu);
-    void addHiddenContextMenuItems(const MessageLayoutElement *hoveredElement,
-                                   MessageLayoutPtr layout, QMouseEvent *event,
-                                   QMenu &menu);
     void addCommandExecutionContextMenuItems(
         const MessageLayoutElement *hoveredElement, MessageLayoutPtr layout,
         QMouseEvent *event, QMenu &menu);

--- a/src/widgets/helper/ChannelView.hpp
+++ b/src/widgets/helper/ChannelView.hpp
@@ -346,9 +346,6 @@ private:
     MessageColors messageColors_;
     MessagePreferences messagePreferences_;
 
-    static constexpr int leftPadding = 8;
-    static constexpr int scrollbarPadding = 8;
-
 private slots:
     void scrollUpdateRequested();
 };

--- a/src/widgets/helper/ChannelView.hpp
+++ b/src/widgets/helper/ChannelView.hpp
@@ -218,12 +218,6 @@ private:
                           MessageLayoutPtr layout);
     void addContextMenuItems(const MessageLayoutElement *hoveredElement,
                              MessageLayoutPtr layout, QMouseEvent *event);
-    void addImageContextMenuItems(const MessageLayoutElement *hoveredElement,
-                                  MessageLayoutPtr layout, QMouseEvent *event,
-                                  QMenu &menu);
-    void addLinkContextMenuItems(const MessageLayoutElement *hoveredElement,
-                                 MessageLayoutPtr layout, QMouseEvent *event,
-                                 QMenu &menu);
     void addMessageContextMenuItems(const MessageLayoutElement *hoveredElement,
                                     MessageLayoutPtr layout, QMouseEvent *event,
                                     QMenu &menu);

--- a/src/widgets/helper/ChannelView.hpp
+++ b/src/widgets/helper/ChannelView.hpp
@@ -163,9 +163,9 @@ protected:
     void themeChangedEvent() override;
     void scaleChangedEvent(float scale) override;
 
-    void resizeEvent(QResizeEvent *) override;
+    void resizeEvent(QResizeEvent * /*event*/) override;
 
-    void paintEvent(QPaintEvent *) override;
+    void paintEvent(QPaintEvent * /*event*/) override;
     void wheelEvent(QWheelEvent *event) override;
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
@@ -173,14 +173,14 @@ protected:
 #else
     void enterEvent(QEvent * /*event*/) override;
 #endif
-    void leaveEvent(QEvent *) override;
+    void leaveEvent(QEvent * /*event*/) override;
 
     void mouseMoveEvent(QMouseEvent *event) override;
     void mousePressEvent(QMouseEvent *event) override;
     void mouseReleaseEvent(QMouseEvent *event) override;
     void mouseDoubleClickEvent(QMouseEvent *event) override;
 
-    void hideEvent(QHideEvent *) override;
+    void hideEvent(QHideEvent * /*event*/) override;
     void showEvent(QShowEvent *event) override;
 
     void handleLinkClick(QMouseEvent *event, const Link &link,

--- a/src/widgets/helper/ChannelView.hpp
+++ b/src/widgets/helper/ChannelView.hpp
@@ -350,12 +350,6 @@ private:
     static constexpr int scrollbarPadding = 8;
 
 private slots:
-    void wordFlagsChanged()
-    {
-        queueLayout();
-        update();
-    }
-
     void scrollUpdateRequested();
 };
 

--- a/src/widgets/helper/ChannelView.hpp
+++ b/src/widgets/helper/ChannelView.hpp
@@ -219,15 +219,12 @@ private:
                           MessageLayoutPtr layout);
     void addContextMenuItems(const MessageLayoutElement *hoveredElement,
                              MessageLayoutPtr layout, QMouseEvent *event);
-    void addMessageContextMenuItems(const MessageLayoutElement *hoveredElement,
-                                    MessageLayoutPtr layout, QMouseEvent *event,
-                                    QMenu &menu);
+    void addMessageContextMenuItems(QMenu *menu,
+                                    const MessageLayoutPtr &layout);
     void addTwitchLinkContextMenuItems(
-        const MessageLayoutElement *hoveredElement, MessageLayoutPtr layout,
-        QMouseEvent *event, QMenu &menu);
-    void addCommandExecutionContextMenuItems(
-        const MessageLayoutElement *hoveredElement, MessageLayoutPtr layout,
-        QMouseEvent *event, QMenu &menu);
+        QMenu *menu, const MessageLayoutElement *hoveredElement);
+    void addCommandExecutionContextMenuItems(QMenu *menu,
+                                             const MessageLayoutPtr &layout);
 
     int getLayoutWidth() const;
     void updatePauses();

--- a/src/widgets/helper/ChannelView.hpp
+++ b/src/widgets/helper/ChannelView.hpp
@@ -112,7 +112,8 @@ public:
     bool pausable() const;
     void setPausable(bool value);
     bool paused() const;
-    void pause(PauseReason reason, std::optional<uint> msecs = std::nullopt);
+    void pause(PauseReason reason,
+               std::optional<uint32_t> msecs = std::nullopt);
     void unpause(PauseReason reason);
 
     MessageElementFlags getFlags() const;

--- a/src/widgets/helper/ChannelView.hpp
+++ b/src/widgets/helper/ChannelView.hpp
@@ -212,9 +212,6 @@ private:
     void setSelection(const SelectionItem &start, const SelectionItem &end);
     void setSelection(const Selection &newSelection);
     void selectWholeMessage(MessageLayout *layout, int &messageIndex);
-    std::pair<size_t, size_t> getWordBounds(MessageLayout *layout,
-                                            const MessageLayoutElement *element,
-                                            const QPoint &relativePos);
 
     void handleMouseClick(QMouseEvent *event,
                           const MessageLayoutElement *hoveredElement,

--- a/src/widgets/helper/ChannelView.hpp
+++ b/src/widgets/helper/ChannelView.hpp
@@ -311,7 +311,7 @@ private:
     QPointF lastLeftPressPosition_;
     QPointF lastRightPressPosition_;
     QPointF lastDoubleClickPosition_;
-    QTimer *clickTimer_;
+    QTimer clickTimer_;
 
     bool isScrolling_ = false;
     QPointF lastMiddlePressPosition_;

--- a/src/widgets/helper/ChannelView.hpp
+++ b/src/widgets/helper/ChannelView.hpp
@@ -119,7 +119,7 @@ public:
     MessageElementFlags getFlags() const;
 
     ChannelPtr channel();
-    void setChannel(ChannelPtr channel_);
+    void setChannel(const ChannelPtr &underlyingChannel);
 
     void setFilters(const QList<QUuid> &ids);
     QList<QUuid> getFilterIds() const;


### PR DESCRIPTION

# Description

- comment getElementAt function
- Use relative-to-src include
- Remove unused wordFlagsChanged slot
- Refactor padding variables
- Make scrollUpdateRequest a normal function instead of a slot
- add missing parameter names
- Make clickTimer_ a value instead of a pointer
- Add const to auto & where possible
- move static functions to the better namespace
- Make getWordBounds return a pair of the bounds instead of accepting it by reference
- Clean up pause timer function
- Make addImageContextMenuItems & addLinkContextMenuItems static
- Make addHiddenContextMenuItems static
- auto * where possible
- Remove const in return value
- add braces where possible
- Use capital F when making a float literal
- use uint32_t instead of uint in pauses
- No else after return
- Remove pessimistic move
- Make setChannel const &sharedptr
- Be more explicit about scroll events we ignore
- Refactor menu item add functions
- JumpToMessage logic
- Refactor thread creation

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
