### PR TITLE
Fix log files unlocking when closing chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Bugfix: Fixed the input completion popup from disappearing when clicking on it on Windows and macOS. (#4876)
 - Bugfix: Fixed double-click text selection moving its position with each new message. (#4898)
 - Bugfix: Fixed an issue where notifications on Windows would contain no or an old avatar. (#4899)
+- Bugfix: Fixed log files being locked longer than needed. (#4928)
 - Dev: Fixed UTF16 encoding of `modes` file for the installer. (#4791)
 - Dev: Temporarily disable High DPI scaling on Qt6 builds on Windows. (#4767)
 - Dev: Tests now run on Ubuntu 22.04 instead of 20.04 to loosen C++ restrictions in tests. (#4774)

--- a/src/common/Channel.cpp
+++ b/src/common/Channel.cpp
@@ -78,7 +78,7 @@ bool Channel::hasMessages() const
     return !this->messages_.empty();
 }
 
-QString &Channel::logFolderName()
+const QString &Channel::logFolderName()
 {
     return this->logFolderName_;
 }

--- a/src/common/Channel.cpp
+++ b/src/common/Channel.cpp
@@ -93,7 +93,8 @@ void Channel::addMessage(MessagePtr message,
 {
     MessagePtr deleted;
 
-    if (!overridingFlags || !overridingFlags->has(MessageFlag::DoNotLog))
+    if (getSettings()->enableLogging &&
+        (!overridingFlags || !overridingFlags->has(MessageFlag::DoNotLog)))
     {
         if (!this->isLogInitialized_)
         {

--- a/src/common/Channel.hpp
+++ b/src/common/Channel.hpp
@@ -104,6 +104,7 @@ public:
     virtual bool shouldIgnoreHighlights() const;
     virtual bool canReconnect() const;
     virtual void reconnect();
+    virtual QString &logFolderName();
 
     static std::shared_ptr<Channel> getEmpty();
 
@@ -118,6 +119,8 @@ private:
     const QString name_;
     LimitedQueue<MessagePtr> messages_;
     Type type_;
+    bool isLogInitialized_{false};
+    QString logFolderName_;
     QTimer clearCompletionModelTimer_;
 };
 

--- a/src/common/Channel.hpp
+++ b/src/common/Channel.hpp
@@ -104,7 +104,7 @@ public:
     virtual bool shouldIgnoreHighlights() const;
     virtual bool canReconnect() const;
     virtual void reconnect();
-    virtual QString &logFolderName();
+    virtual const QString &logFolderName();
 
     static std::shared_ptr<Channel> getEmpty();
 

--- a/src/providers/irc/IrcChannel2.cpp
+++ b/src/providers/irc/IrcChannel2.cpp
@@ -105,7 +105,7 @@ bool IrcChannel::canReconnect() const
     return true;
 }
 
-QString &IrcChannel::logFolderName()
+const QString &IrcChannel::logFolderName()
 {
     return this->logFolderName_;
 }

--- a/src/providers/irc/IrcChannel2.cpp
+++ b/src/providers/irc/IrcChannel2.cpp
@@ -1,5 +1,6 @@
 #include "IrcChannel2.hpp"
 
+#include "Application.hpp"
 #include "debug/AssertInGuiThread.hpp"
 #include "messages/Message.hpp"
 #include "messages/MessageBuilder.hpp"
@@ -7,6 +8,7 @@
 #include "providers/irc/IrcCommands.hpp"
 #include "providers/irc/IrcMessageBuilder.hpp"
 #include "providers/irc/IrcServer.hpp"
+#include "singletons/Logging.hpp"
 #include "util/Helpers.hpp"
 
 namespace chatterino {
@@ -15,7 +17,13 @@ IrcChannel::IrcChannel(const QString &name, IrcServer *server)
     : Channel(name, Channel::Type::Irc)
     , ChannelChatters(*static_cast<Channel *>(this))
     , server_(server)
+    , logFolderName_(QString("irc-%1").arg(server->userFriendlyIdentifier()))
 {
+}
+
+IrcChannel::~IrcChannel()
+{
+    getApp()->logging->removeChannel(this->getName(), this->logFolderName());
 }
 
 void IrcChannel::sendMessage(const QString &message)
@@ -95,6 +103,11 @@ void IrcChannel::setServer(IrcServer *server)
 bool IrcChannel::canReconnect() const
 {
     return true;
+}
+
+QString &IrcChannel::logFolderName()
+{
+    return this->logFolderName_;
 }
 
 void IrcChannel::reconnect()

--- a/src/providers/irc/IrcChannel2.hpp
+++ b/src/providers/irc/IrcChannel2.hpp
@@ -12,6 +12,7 @@ class IrcChannel final : public Channel, public ChannelChatters
 {
 public:
     explicit IrcChannel(const QString &name, IrcServer *server);
+    ~IrcChannel();
 
     void sendMessage(const QString &message) override;
 
@@ -20,12 +21,14 @@ public:
 
     // Channel methods
     bool canReconnect() const override;
+    QString &logFolderName() override;
     void reconnect() override;
 
 private:
     void setServer(IrcServer *server);
 
     IrcServer *server_;
+    QString logFolderName_;
 
     friend class Irc;
 };

--- a/src/providers/irc/IrcChannel2.hpp
+++ b/src/providers/irc/IrcChannel2.hpp
@@ -21,7 +21,7 @@ public:
 
     // Channel methods
     bool canReconnect() const override;
-    QString &logFolderName() override;
+    const QString &logFolderName() override;
     void reconnect() override;
 
 private:

--- a/src/providers/irc/IrcChannel2.hpp
+++ b/src/providers/irc/IrcChannel2.hpp
@@ -12,7 +12,7 @@ class IrcChannel final : public Channel, public ChannelChatters
 {
 public:
     explicit IrcChannel(const QString &name, IrcServer *server);
-    ~IrcChannel();
+    ~IrcChannel() override;
 
     void sendMessage(const QString &message) override;
 

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -1253,8 +1253,8 @@ void TwitchChannel::addReplyThread(const std::shared_ptr<MessageThread> &thread)
     this->threads_[thread->rootId()] = thread;
 }
 
-const std::unordered_map<QString, std::weak_ptr<MessageThread>> &
-    TwitchChannel::threads() const
+const std::unordered_map<QString, std::weak_ptr<MessageThread>>
+    &TwitchChannel::threads() const
 {
     return this->threads_;
 }

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -32,6 +32,7 @@
 #include "providers/twitch/TwitchIrcServer.hpp"
 #include "providers/twitch/TwitchMessageBuilder.hpp"
 #include "singletons/Emotes.hpp"
+#include "singletons/Logging.hpp"
 #include "singletons/Settings.hpp"
 #include "singletons/Toasts.hpp"
 #include "singletons/WindowManager.hpp"
@@ -237,6 +238,7 @@ TwitchChannel::~TwitchChannel()
         getApp()->twitch->seventvEventAPI->unsubscribeTwitchChannel(
             this->roomId());
     }
+    getApp()->logging->removeChannel(this->getName(), this->logFolderName());
 }
 
 void TwitchChannel::initialize()
@@ -1251,8 +1253,8 @@ void TwitchChannel::addReplyThread(const std::shared_ptr<MessageThread> &thread)
     this->threads_[thread->rootId()] = thread;
 }
 
-const std::unordered_map<QString, std::weak_ptr<MessageThread>>
-    &TwitchChannel::threads() const
+const std::unordered_map<QString, std::weak_ptr<MessageThread>> &
+    TwitchChannel::threads() const
 {
     return this->threads_;
 }

--- a/src/singletons/Logging.cpp
+++ b/src/singletons/Logging.cpp
@@ -43,7 +43,7 @@ void Logging::addMessage(const QString &channelName, MessagePtr message,
 
     this->loggingChannels_.at(platformName)
         .at(channelName)
-        ->addMessage(message);
+        ->addMessage(std::move(message));
 }
 
 void Logging::addChannel(const QString &channelName,
@@ -60,8 +60,7 @@ void Logging::addChannel(const QString &channelName,
     {
         auto channel = new LoggingChannel(channelName, platformName);
         this->loggingChannels_.at(platformName)
-            .emplace(channelName,
-                     std::unique_ptr<LoggingChannel>(std::move(channel)));
+            .emplace(channelName, std::unique_ptr<LoggingChannel>(channel));
     }
 }
 

--- a/src/singletons/Logging.cpp
+++ b/src/singletons/Logging.cpp
@@ -33,11 +33,6 @@ void Logging::addMessage(const QString &channelName, MessagePtr message,
 {
     this->threadGuard.guard();
 
-    if (!getSettings()->enableLogging)
-    {
-        return;
-    }
-
     if (getSettings()->onlyLogListedChannels)
     {
         if (!this->onlyLogListedChannels.contains(channelName))

--- a/src/singletons/Logging.hpp
+++ b/src/singletons/Logging.hpp
@@ -6,8 +6,8 @@
 
 #include <QString>
 
-#include <map>
 #include <memory>
+#include <unordered_map>
 #include <unordered_set>
 
 namespace chatterino {
@@ -28,12 +28,15 @@ public:
 
     void addMessage(const QString &channelName, MessagePtr message,
                     const QString &platformName);
+    void addChannel(const QString &channelName, const QString &platformName);
+    void removeChannel(const QString &channelName, const QString &platformName);
 
 private:
     using PlatformName = QString;
     using ChannelName = QString;
-    std::map<PlatformName,
-             std::map<ChannelName, std::unique_ptr<LoggingChannel>>>
+    std::unordered_map<
+        PlatformName,
+        std::unordered_map<ChannelName, std::unique_ptr<LoggingChannel>>>
         loggingChannels_;
 
     // Keeps the value of the `loggedChannels` settings


### PR DESCRIPTION
### Issue
Currently log files are never unlocked, to clear logs of closed chat user needs to close chatterino.

### Cause

`LogginChannel` [destructor](https://github.com/Chatterino/chatterino2/blob/master/src/singletons/helper/LoggingChannel.cpp#L49-L53) is never called, because channels are currently never removed from map in `Logging` singleton 

### Fix
- add `Logging::removeChannel` method and call it when `TwitchChannel` or `IrcChannel2` are destructed, which happens when last split of given channel is closed

### Other changes
- move channelPlatform QString creation away from `Channel::addMessage` (frequent code path) to constructor made `logFolderName_`
- add virtual `Channel::logFolderName()` and override it for IRC channels
- move map inserting logic from `Logging::addMessage` to its own `Logging::addChannel`, and call it once per `Channel` instance
- remove unused imports 
- change `loggingChannels_` from map to unordered_map