### PR TITLE
ci: Use clang-format 16

### DIFF
--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -23,10 +23,14 @@ jobs:
         run: sudo apt-get update
 
       - name: Install clang-format
-        run: sudo apt-get -y install clang-format dos2unix
+        run: sudo apt-get -y install dos2unix
 
       - name: Check formatting
-        run: ./tools/check-format.sh
+        uses: DoozyX/clang-format-lint-action@v0.16.2
+        with:
+          source: "./src ./tests/src ./benchmarks/src ./mocks/include"
+          extensions: "hpp,cpp"
+          clangFormatVersion: 16
 
       - name: Check line-endings
         run: ./tools/check-line-endings.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Bugfix: Fixed the input completion popup from disappearing when clicking on it on Windows and macOS. (#4876)
 - Bugfix: Fixed double-click text selection moving its position with each new message. (#4898)
 - Bugfix: Fixed an issue where notifications on Windows would contain no or an old avatar. (#4899)
+- Dev: Change clang-format from v14 to v16. (#4929)
 - Dev: Fixed UTF16 encoding of `modes` file for the installer. (#4791)
 - Dev: Temporarily disable High DPI scaling on Qt6 builds on Windows. (#4767)
 - Dev: Tests now run on Ubuntu 22.04 instead of 20.04 to loosen C++ restrictions in tests. (#4774)

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The code is formatted using clang format in Qt Creator. [.clang-format](src/.cla
 
 ### Get it automated with QT Creator + Beautifier + Clang Format
 
-1. Download LLVM: https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.5/LLVM-15.0.5-win64.exe
+1. Download LLVM: https://github.com/llvm/llvm-project/releases/download/llvmorg-16.0.6/LLVM-16.0.6-win64.exe
 2. During the installation, make sure to add it to your path
 3. In QT Creator, select `Help` > `About Plugins` > `C++` > `Beautifier` to enable the plugin
 4. Restart QT Creator

--- a/src/controllers/hotkeys/HotkeyController.cpp
+++ b/src/controllers/hotkeys/HotkeyController.cpp
@@ -189,8 +189,8 @@ QString HotkeyController::categoryName(HotkeyCategory category) const
     return categoryData.name;
 }
 
-const std::map<HotkeyCategory, HotkeyCategoryData>
-    &HotkeyController::categories() const
+const std::map<HotkeyCategory, HotkeyCategoryData> &
+    HotkeyController::categories() const
 {
     return this->hotkeyCategories_;
 }

--- a/src/controllers/hotkeys/HotkeyController.hpp
+++ b/src/controllers/hotkeys/HotkeyController.hpp
@@ -81,8 +81,8 @@ public:
     /**
      * @returns a const map with the HotkeyCategory enum as its key, and HotkeyCategoryData as the value.
      **/
-    [[nodiscard]] const std::map<HotkeyCategory, HotkeyCategoryData>
-        &categories() const;
+    [[nodiscard]] const std::map<HotkeyCategory, HotkeyCategoryData> &
+        categories() const;
 
     pajlada::Signals::NoArgSignal onItemsUpdated;
 

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -1251,8 +1251,8 @@ void TwitchChannel::addReplyThread(const std::shared_ptr<MessageThread> &thread)
     this->threads_[thread->rootId()] = thread;
 }
 
-const std::unordered_map<QString, std::weak_ptr<MessageThread>>
-    &TwitchChannel::threads() const
+const std::unordered_map<QString, std::weak_ptr<MessageThread>> &
+    TwitchChannel::threads() const
 {
     return this->threads_;
 }

--- a/src/widgets/splits/SplitContainer.cpp
+++ b/src/widgets/splits/SplitContainer.cpp
@@ -973,8 +973,8 @@ qreal SplitContainer::Node::getVerticalFlex() const
     return this->flexV_;
 }
 
-const std::vector<std::unique_ptr<SplitContainer::Node>>
-    &SplitContainer::Node::getChildren()
+const std::vector<std::unique_ptr<SplitContainer::Node>> &
+    SplitContainer::Node::getChildren()
 {
     return this->children_;
 }


### PR DESCRIPTION
# Description

We now use https://github.com/DoozyX/clang-format-lint-action for running clang-format instead, since it allows us to change which clang-format version to use easier.

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
