### PR TITLE
Bugfix: Fixed a crash when clicking `More messages below` button in a usercard and closing it quickly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Bugfix: Fixed the input completion popup from disappearing when clicking on it on Windows and macOS. (#4876)
 - Bugfix: Fixed double-click text selection moving its position with each new message. (#4898)
 - Bugfix: Fixed an issue where notifications on Windows would contain no or an old avatar. (#4899)
+- Bugfix: Fixed a crash when clicking `More messages below` button in a usercard and closing it quickly. (#4933)
 - Dev: Change clang-format from v14 to v16. (#4929)
 - Dev: Fixed UTF16 encoding of `modes` file for the installer. (#4791)
 - Dev: Temporarily disable High DPI scaling on Qt6 builds on Windows. (#4767)

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -351,7 +351,7 @@ void ChannelView::initializeLayout()
 
     QObject::connect(
         this->goToBottom_, &EffectLabel::leftClicked, this, [this] {
-            QTimer::singleShot(180, [this] {
+            QTimer::singleShot(180, this, [this] {
                 this->scrollBar_->scrollToBottom(
                     getSettings()->enableSmoothScrollingNewMessages.getValue());
             });


### PR DESCRIPTION
# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->

Just use a better QTimer::singleShot variant.
Fixes #4932.