### PR TITLE
chore: Add a 10m timeout to the clang-tidy CI job

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -63,3 +63,6 @@ CheckOptions:
   # Lua state
   - key: readability-identifier-naming.LocalPointerIgnoredRegexp
     value: ^L$
+
+  - key: misc-const-correctness.AnalyzeValues
+    value: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -331,6 +331,7 @@ jobs:
 
       - name: clang-tidy review
         if: matrix.clang-tidy-review && github.event_name == 'pull_request'
+        timeout-minutes: 10
         uses: ZedThree/clang-tidy-review@v0.14.0
         with:
           build_dir: build-clang-tidy


### PR DESCRIPTION
# Description

Add a 10m timeout to the clang-tidy job

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
