### PR TITLE
fix: avoid crash from channelPointRewardAdded callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Bugfix: Fixed double-click text selection moving its position with each new message. (#4898)
 - Bugfix: Fixed an issue where notifications on Windows would contain no or an old avatar. (#4899)
 - Bugfix: Fixed a crash when clicking `More messages below` button in a usercard and closing it quickly. (#4933)
+- Bugfix: Fixed occasional crash for channel point redemptions with text input. (#4942)
 - Dev: Change clang-format from v14 to v16. (#4929)
 - Dev: Fixed UTF16 encoding of `modes` file for the installer. (#4791)
 - Dev: Temporarily disable High DPI scaling on Qt6 builds on Windows. (#4767)

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -1251,7 +1251,8 @@ void IrcMessageHandler::addMessage(Communi::IrcMessage *message,
     if (const auto it = tags.find("custom-reward-id"); it != tags.end())
     {
         const auto rewardId = it.value().toString();
-        if (!rewardId.isEmpty() && !channel->isChannelPointRewardKnown(rewardId))
+        if (!rewardId.isEmpty() &&
+            !channel->isChannelPointRewardKnown(rewardId))
         {
             // Need to wait for pubsub reward notification
             auto *rewardClone = new QString(rewardId);

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -1251,7 +1251,7 @@ void IrcMessageHandler::addMessage(Communi::IrcMessage *message,
     if (const auto it = tags.find("custom-reward-id"); it != tags.end())
     {
         const auto rewardId = it.value().toString();
-        if (!channel->isChannelPointRewardKnown(rewardId))
+        if (!rewardId.isEmpty() && !channel->isChannelPointRewardKnown(rewardId))
         {
             // Need to wait for pubsub reward notification
             auto *rewardClone = new QString(rewardId);

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -1254,20 +1254,27 @@ void IrcMessageHandler::addMessage(Communi::IrcMessage *message,
         if (!channel->isChannelPointRewardKnown(rewardId))
         {
             // Need to wait for pubsub reward notification
+            auto *rewardClone = new QString(rewardId);
+            auto *targetClone = new QString(target);
+            auto *contentClone = new QString(originalContent);
             auto *clone = message->clone();
             qCDebug(chatterinoTwitch) << "TwitchChannel reward added ADD "
                                          "callback since reward is not known:"
                                       << rewardId;
             channel->channelPointRewardAdded.connect(
-                [=, this, &server](ChannelPointReward reward) {
+                [&, rewardClone, clone, targetClone,
+                 contentClone](const auto reward) {
                     qCDebug(chatterinoTwitch)
                         << "TwitchChannel reward added callback:" << reward.id
-                        << "-" << rewardId;
-                    if (reward.id == rewardId)
+                        << "-" << *rewardClone;
+                    if (reward.id == *rewardClone)
                     {
-                        this->addMessage(clone, target, originalContent, server,
-                                         isSub, isAction);
+                        this->addMessage(clone, *targetClone, *contentClone,
+                                         server, false, false);
                         clone->deleteLater();
+                        delete rewardClone;
+                        delete targetClone;
+                        delete contentClone;
                         return true;
                     }
                     return false;


### PR DESCRIPTION
Closes #2432 
Closes #3942 

# Problem

It is possible for `channelPointRewardAdded` connections to be created that have a long lifetime (take this as a given, I explain how this happens in the "Follow-up" section). Upon callback lambda invocation, the captured variables will be released. However, if the invocation is unrelated to the desired `rewardId`, releasing the captured variables will cause a seg fault when a matching invocation occurs later on. (Technically this matching invocation will take the form of empty reward ids because of the earlier variable destruction)


# Solution

Clone objects used in lambda scope to avoid early destruction (also ensure `reward` is properly copied for each signal connection)


# Follow-up

While this PR avoids a common crash, there are remaining edge cases to be tackled in future PRs.

1. ~~It is possible that `channelPointRewardAdded` is invoked before a signal connection is made in `IrcMessageHandler` (when `isChannelPointRewardKnown` yields false). This is the scenario I described [before](https://github.com/Chatterino/chatterino2/issues/3942#issuecomment-1248397260). When this happens, now the first redemption associated with the reward will never be posted to chat (and the cloned objects are not freed). To solve this, there should be a mutex that prevents `channelPointRewardAdded.invoke` when we are in the `!channel->isChannelPointRewardKnown(rewardId)` block (and after acquiring the mutex, we should check `isChannelPointRewardKnown` once more)~~ Scratch this, I assumed multiple threads were at play

2. It is possible that the pubsub socket is not connected when the text redemption occurs. As a result, a signal connection will be made, but `invoke` would not be called. Again, the cloned objects would not be freed (until the next redemption for the same reward occurs, while pubsub is connected). So, we ought to implement a timeout where if x seconds pass without signal invocation, we release the message regardless. 
