### PR TITLE
fix: prevent channelPointRewardAdded invocation while connecting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Bugfix: Fixed tooltips appearing too large and/or away from the cursor. (#4920)
 - Bugfix: Fixed a crash when clicking `More messages below` button in a usercard and closing it quickly. (#4933)
 - Bugfix: Fixed occasional crash for channel point redemptions with text input. (#4942)
+- Bugfix: Fixed first redemption of a channel points reward not appearing in rare cases. (#4943)
 - Dev: Change clang-format from v14 to v16. (#4929)
 - Dev: Fixed UTF16 encoding of `modes` file for the installer. (#4791)
 - Dev: Temporarily disable High DPI scaling on Qt6 builds on Windows. (#4767)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Bugfix: Fixed double-click text selection moving its position with each new message. (#4898)
 - Bugfix: Fixed an issue where notifications on Windows would contain no or an old avatar. (#4899)
 - Bugfix: Fixed a crash when clicking `More messages below` button in a usercard and closing it quickly. (#4933)
+- Bugfix: Fixed occasional crash for channel point redemptions with text input. (#4942)
 - Dev: Change clang-format from v14 to v16. (#4929)
 - Dev: Fixed UTF16 encoding of `modes` file for the installer. (#4791)
 - Dev: Temporarily disable High DPI scaling on Qt6 builds on Windows. (#4767)

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -1251,7 +1251,8 @@ void IrcMessageHandler::addMessage(Communi::IrcMessage *message,
     if (const auto it = tags.find("custom-reward-id"); it != tags.end())
     {
         const auto rewardId = it.value().toString();
-        if (!rewardId.isEmpty() && !channel->isChannelPointRewardKnown(rewardId))
+        if (!rewardId.isEmpty() &&
+            !channel->isChannelPointRewardKnown(rewardId))
         {
             // Need to wait for pubsub reward notification
             auto *rewardClone = new QString(rewardId);

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -1251,7 +1251,7 @@ void IrcMessageHandler::addMessage(Communi::IrcMessage *message,
     if (const auto it = tags.find("custom-reward-id"); it != tags.end())
     {
         const auto rewardId = it.value().toString();
-        if (!channel->isChannelPointRewardKnown(rewardId))
+        if (!rewardId.isEmpty() && !channel->isChannelPointRewardKnown(rewardId))
         {
             // Need to wait for pubsub reward notification
             auto *rewardClone = new QString(rewardId);

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -1254,20 +1254,27 @@ void IrcMessageHandler::addMessage(Communi::IrcMessage *message,
         if (!channel->isChannelPointRewardKnown(rewardId))
         {
             // Need to wait for pubsub reward notification
+            auto *rewardClone = new QString(rewardId);
+            auto *targetClone = new QString(target);
+            auto *contentClone = new QString(originalContent);
             auto *clone = message->clone();
             qCDebug(chatterinoTwitch) << "TwitchChannel reward added ADD "
                                          "callback since reward is not known:"
                                       << rewardId;
             channel->channelPointRewardAdded.connect(
-                [=, this, &server](ChannelPointReward reward) {
+                [&, rewardClone, clone, targetClone,
+                 contentClone](const auto reward) {
                     qCDebug(chatterinoTwitch)
                         << "TwitchChannel reward added callback:" << reward.id
-                        << "-" << rewardId;
-                    if (reward.id == rewardId)
+                        << "-" << *rewardClone;
+                    if (reward.id == *rewardClone)
                     {
-                        this->addMessage(clone, target, originalContent, server,
-                                         isSub, isAction);
+                        this->addMessage(clone, *targetClone, *contentClone,
+                                         server, false, false);
                         clone->deleteLater();
+                        delete rewardClone;
+                        delete targetClone;
+                        delete contentClone;
                         return true;
                     }
                     return false;

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -377,6 +377,7 @@ void TwitchChannel::addChannelPointReward(const ChannelPointReward &reward)
         // This only attempts to prevent a crash when invoking the signal.
         try
         {
+            std::unique_lock lock(this->rewardAddedMutex);
             this->channelPointRewardAdded.invoke(reward);
         }
         catch (const std::bad_function_call &)

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -18,6 +18,7 @@
 #include <atomic>
 #include <mutex>
 #include <optional>
+#include <shared_mutex>
 #include <unordered_map>
 
 namespace chatterino {
@@ -218,6 +219,7 @@ public:
     pajlada::Signals::NoArgSignal roomModesChanged;
 
     // Channel point rewards
+    std::shared_mutex rewardAddedMutex;
     pajlada::Signals::SelfDisconnectingSignal<ChannelPointReward>
         channelPointRewardAdded;
     void addChannelPointReward(const ChannelPointReward &reward);


### PR DESCRIPTION
Follow-up PR 1/2 for #4942 - implements the mutex outlined in https://github.com/Chatterino/chatterino2/issues/3942#issuecomment-1248397260
