### PR TITLE
fix: avoid reward redemption crash via buffer refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Bugfix: Fixed tooltips appearing too large and/or away from the cursor. (#4920)
 - Bugfix: Fixed a crash when clicking `More messages below` button in a usercard and closing it quickly. (#4933)
 - Bugfix: Fixed thread popup window missing messages for nested threads. (#4923)
+- Bugfix: Fixed an occasional crash for channel point redemptions with text input. (#4949)
 - Dev: Change clang-format from v14 to v16. (#4929)
 - Dev: Fixed UTF16 encoding of `modes` file for the installer. (#4791)
 - Dev: Temporarily disable High DPI scaling on Qt6 builds on Windows. (#4767)

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -1,6 +1,7 @@
 #include "providers/twitch/IrcMessageHandler.hpp"
 
 #include "Application.hpp"
+#include "common/Common.hpp"
 #include "common/Literals.hpp"
 #include "common/QLogging.hpp"
 #include "controllers/accounts/AccountController.hpp"
@@ -1298,7 +1299,7 @@ void IrcMessageHandler::addMessage(Communi::IrcMessage *message,
                                          "callback since reward is not known:"
                                       << rewardId;
             channel->waitingRedemptions.push_back(
-                {rewardId, originalContent, QPointer(message->clone())});
+                {rewardId, originalContent, {message->clone(), {}}});
             return;
         }
         args.channelPointRewardId = rewardId;

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -692,7 +692,7 @@ void IrcMessageHandler::handlePrivMessage(Communi::IrcPrivateMessage *message,
     // https://mm2pl.github.io/emoji_rfc.pdf for more details
 
     this->addMessage(
-        message, message->target(),
+        message, channelOrEmptyByTarget(message->target(), server),
         message->content().replace(COMBINED_FIXER, ZERO_WIDTH_JOINER), server,
         false, message->isAction());
 
@@ -1002,7 +1002,7 @@ void IrcMessageHandler::handleUserNoticeMessage(Communi::IrcMessage *message,
         // Messages are not required, so they might be empty
         if (!content.isEmpty())
         {
-            this->addMessage(message, target, content, server, true, false);
+            this->addMessage(message, chn, content, server, true, false);
         }
     }
 
@@ -1261,13 +1261,11 @@ void IrcMessageHandler::setSimilarityFlags(const MessagePtr &message,
 }
 
 void IrcMessageHandler::addMessage(Communi::IrcMessage *message,
-                                   const QString &target,
+                                   const ChannelPtr &chan,
                                    const QString &originalContent,
                                    TwitchIrcServer &server, bool isSub,
                                    bool isAction)
 {
-    auto chan = channelOrEmptyByTarget(target, server);
-
     if (chan->isEmpty())
     {
         return;
@@ -1307,7 +1305,7 @@ void IrcMessageHandler::addMessage(Communi::IrcMessage *message,
     QString content = originalContent;
     int messageOffset = stripLeadingReplyMention(tags, content);
 
-    TwitchMessageBuilder builder(chan.get(), message, args, content, isAction);
+    TwitchMessageBuilder builder(channel, message, args, content, isAction);
     builder.setMessageOffset(messageOffset);
 
     if (const auto it = tags.find("reply-thread-parent-msg-id");

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -1298,8 +1298,7 @@ void IrcMessageHandler::addMessage(Communi::IrcMessage *message,
             qCDebug(chatterinoTwitch) << "TwitchChannel reward added ADD "
                                          "callback since reward is not known:"
                                       << rewardId;
-            channel->waitingRedemptions.push_back(
-                {rewardId, originalContent, {message->clone(), {}}});
+            channel->addQueuedRedemption(rewardId, originalContent, message);
             return;
         }
         args.channelPointRewardId = rewardId;

--- a/src/providers/twitch/IrcMessageHandler.hpp
+++ b/src/providers/twitch/IrcMessageHandler.hpp
@@ -55,7 +55,7 @@ public:
     void handleJoinMessage(Communi::IrcMessage *message);
     void handlePartMessage(Communi::IrcMessage *message);
 
-    void addMessage(Communi::IrcMessage *message, const QString &target,
+    void addMessage(Communi::IrcMessage *message, const ChannelPtr &chan,
                     const QString &originalContent, TwitchIrcServer &server,
                     bool isSub, bool isAction);
 

--- a/src/providers/twitch/IrcMessageHandler.hpp
+++ b/src/providers/twitch/IrcMessageHandler.hpp
@@ -55,15 +55,15 @@ public:
     void handleJoinMessage(Communi::IrcMessage *message);
     void handlePartMessage(Communi::IrcMessage *message);
 
+    void addMessage(Communi::IrcMessage *message, const QString &target,
+                    const QString &originalContent, TwitchIrcServer &server,
+                    bool isSub, bool isAction);
+
 private:
     static float similarity(const MessagePtr &msg,
                             const LimitedQueueSnapshot<MessagePtr> &messages);
     static void setSimilarityFlags(const MessagePtr &message,
                                    const ChannelPtr &channel);
-
-    void addMessage(Communi::IrcMessage *message, const QString &target,
-                    const QString &originalContent, TwitchIrcServer &server,
-                    bool isSub, bool isAction);
 };
 
 }  // namespace chatterino

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -391,7 +391,7 @@ void TwitchChannel::addChannelPointReward(const ChannelPointReward &reward)
                 if (reward.id == msg.rewardID)
                 {
                     IrcMessageHandler::instance().addMessage(
-                        msg.message.get(), "#" + channelName,
+                        msg.message.get(), shared_from_this(),
                         msg.originalContent, *server, false, false);
                     return true;
                 }

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -386,17 +386,17 @@ void TwitchChannel::addChannelPointReward(const ChannelPointReward &reward)
 
         auto *server = getApp()->twitch;
         auto it = std::remove_if(
-                this->waitingRedemptions_.begin(), this->waitingRedemptions_.end(),
-                [&](const QueuedRedemption &msg) {
-                    if (reward.id == msg.rewardID)
-                    {
-                        IrcMessageHandler::instance().addMessage(
-                                msg.message.get(), "#" + channelName,
-                                msg.originalContent, *server, false, false);
-                        return true;
-                    }
-                    return false;
-                });
+            this->waitingRedemptions_.begin(), this->waitingRedemptions_.end(),
+            [&](const QueuedRedemption &msg) {
+                if (reward.id == msg.rewardID)
+                {
+                    IrcMessageHandler::instance().addMessage(
+                        msg.message.get(), "#" + channelName,
+                        msg.originalContent, *server, false, false);
+                    return true;
+                }
+                return false;
+            });
         this->waitingRedemptions_.erase(it, this->waitingRedemptions_.end());
     }
 }

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -380,7 +380,7 @@ void TwitchChannel::addChannelPointReward(const ChannelPointReward &reward)
         auto it = std::remove_if(
             this->waitingRedemptions.begin(), this->waitingRedemptions.end(),
             [&](const QueuedRedemption &msg) {
-                if (reward.id == msg.rewardId)
+                if (reward.id == msg.rewardID)
                 {
                     IrcMessageHandler::instance().addMessage(
                         msg.message, "#" + channelName, msg.originalContent,

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -88,8 +88,6 @@ TwitchChannel::TwitchChannel(const QString &name)
 {
     qCDebug(chatterinoTwitch) << "[TwitchChannel" << name << "] Opened";
 
-    this->waitingRedemptions_.set_capacity(MAX_QUEUED_REDEMPTIONS);
-
     this->bSignals_.emplace_back(
         getApp()->accounts->twitch.currentUserChanged.connect([this] {
             this->setMod(false);

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -379,7 +379,7 @@ void TwitchChannel::addChannelPointReward(const ChannelPointReward &reward)
         auto *server = getApp()->twitch;
         auto it = std::remove_if(
             this->waitingRedemptions.begin(), this->waitingRedemptions.end(),
-            [=, &channelName, &server](const QueuedRedemption &msg) {
+            [&](const QueuedRedemption &msg) {
                 if (reward.id == msg.rewardId)
                 {
                     IrcMessageHandler::instance().addMessage(

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -383,8 +383,8 @@ void TwitchChannel::addChannelPointReward(const ChannelPointReward &reward)
                 if (reward.id == msg.rewardID)
                 {
                     IrcMessageHandler::instance().addMessage(
-                        msg.message, "#" + channelName, msg.originalContent,
-                        *server, false, false);
+                        msg.message.get(), "#" + channelName,
+                        msg.originalContent, *server, false, false);
                     return true;
                 }
                 return false;

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -354,8 +354,11 @@ void TwitchChannel::addQueuedRedemption(const QString &rewardId,
                                         const QString &originalContent,
                                         Communi::IrcMessage *message)
 {
-    this->waitingRedemptions_.push_back(
-        {rewardId, originalContent, {message->clone(), {}}});
+    this->waitingRedemptions_.push_back({
+        rewardId,
+        originalContent,
+        {message->clone(), {}},
+    });
 }
 
 void TwitchChannel::addChannelPointReward(const ChannelPointReward &reward)

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -9,6 +9,7 @@
 #include "providers/twitch/TwitchEmotes.hpp"
 #include "util/QStringHash.hpp"
 
+#include <boost/circular_buffer/space_optimized.hpp>
 #include <boost/signals2.hpp>
 #include <pajlada/signals/signalholder.hpp>
 #include <QColor>
@@ -101,6 +102,12 @@ public:
          * 0 = slow mode off
          **/
         int slowMode = 0;
+    };
+
+    struct QueuedRedemption {
+        QString rewardId;
+        QString originalContent;
+        QPointer<Communi::IrcMessage> message;
     };
 
     explicit TwitchChannel(const QString &channelName);
@@ -218,8 +225,7 @@ public:
     pajlada::Signals::NoArgSignal roomModesChanged;
 
     // Channel point rewards
-    pajlada::Signals::SelfDisconnectingSignal<ChannelPointReward>
-        channelPointRewardAdded;
+    boost::circular_buffer_space_optimized<QueuedRedemption> waitingRedemptions;
     void addChannelPointReward(const ChannelPointReward &reward);
     bool isChannelPointRewardKnown(const QString &rewardId);
     std::optional<ChannelPointReward> channelPointReward(

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -107,7 +107,7 @@ public:
     };
 
     struct QueuedRedemption {
-        QString rewardId;
+        QString rewardID;
         QString originalContent;
         QPointer<Communi::IrcMessage> message;
     };

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -373,7 +373,7 @@ private:
     UniqueAccess<std::vector<CheerEmoteSet>> cheerEmoteSets_;
     UniqueAccess<std::map<QString, ChannelPointReward>> channelPointRewards_;
     boost::circular_buffer_space_optimized<QueuedRedemption>
-        waitingRedemptions_;
+        waitingRedemptions_{MAX_QUEUED_REDEMPTIONS};
 
     bool mod_ = false;
     bool vip_ = false;

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -15,6 +15,7 @@
 #include <pajlada/signals/signalholder.hpp>
 #include <QColor>
 #include <QElapsedTimer>
+#include <QPointer>
 #include <QRegularExpression>
 
 #include <atomic>

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -368,7 +368,8 @@ private:
         badgeSets_;  // "subscribers": { "0": ... "3": ... "6": ...
     UniqueAccess<std::vector<CheerEmoteSet>> cheerEmoteSets_;
     UniqueAccess<std::map<QString, ChannelPointReward>> channelPointRewards_;
-    boost::circular_buffer_space_optimized<QueuedRedemption> waitingRedemptions_;
+    boost::circular_buffer_space_optimized<QueuedRedemption>
+        waitingRedemptions_;
 
     bool mod_ = false;
     bool vip_ = false;

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -10,6 +10,7 @@
 #include "providers/twitch/TwitchEmotes.hpp"
 #include "util/QStringHash.hpp"
 
+#include <boost/circular_buffer/space_optimized.hpp>
 #include <boost/signals2.hpp>
 #include <IrcMessage>
 #include <pajlada/signals/signalholder.hpp>
@@ -367,7 +368,7 @@ private:
         badgeSets_;  // "subscribers": { "0": ... "3": ... "6": ...
     UniqueAccess<std::vector<CheerEmoteSet>> cheerEmoteSets_;
     UniqueAccess<std::map<QString, ChannelPointReward>> channelPointRewards_;
-    std::list<QueuedRedemption> waitingRedemptions_;
+    boost::circular_buffer_space_optimized<QueuedRedemption> waitingRedemptions_;
 
     bool mod_ = false;
     bool vip_ = false;

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -11,6 +11,7 @@
 
 #include <boost/circular_buffer/space_optimized.hpp>
 #include <boost/signals2.hpp>
+#include <IrcMessage>
 #include <pajlada/signals/signalholder.hpp>
 #include <QColor>
 #include <QElapsedTimer>

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -4,6 +4,7 @@
 #include "common/Atomic.hpp"
 #include "common/Channel.hpp"
 #include "common/ChannelChatters.hpp"
+#include "common/Common.hpp"
 #include "common/Outcome.hpp"
 #include "common/UniqueAccess.hpp"
 #include "providers/twitch/TwitchEmotes.hpp"
@@ -15,7 +16,6 @@
 #include <pajlada/signals/signalholder.hpp>
 #include <QColor>
 #include <QElapsedTimer>
-#include <QPointer>
 #include <QRegularExpression>
 
 #include <atomic>
@@ -109,7 +109,7 @@ public:
     struct QueuedRedemption {
         QString rewardID;
         QString originalContent;
-        QPointer<Communi::IrcMessage> message;
+        QObjectPtr<Communi::IrcMessage> message;
     };
 
     explicit TwitchChannel(const QString &channelName);

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -226,6 +226,10 @@ public:
     void addQueuedRedemption(const QString &rewardId,
                              const QString &originalContent,
                              Communi::IrcMessage *message);
+    /**
+     * A rich & hydrated redemption from PubSub has arrived, add it to the channel.
+     * This will look at queued up partial messages, and if one is found it will add the queued up partial messages fully hydrated.
+     **/
     void addChannelPointReward(const ChannelPointReward &reward);
     bool isChannelPointRewardKnown(const QString &rewardId);
     std::optional<ChannelPointReward> channelPointReward(


### PR DESCRIPTION
Closes #2432
Closes #3942

Supersedes #4942

Inspired by https://github.com/Chatterino/chatterino2/pull/4943#pullrequestreview-1713956782

Rewrites self-destructing signal usage (that suffered from inadequate value forwarding & use-after-free) with buffer approach that holds redemptions without a corresponding reward until a relevant pubsub message arrives
