### PR TITLE
fix: Split input sometimes not accepting focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Bugfix: Fixed capitalized channel names in log inclusion list not being logged. (#4848)
 - Bugfix: Trimmed custom streamlink paths on all platforms making sure you don't accidentally add spaces at the beginning or end of its path. (#4834)
 - Bugfix: Fixed a performance issue when displaying replies to certain messages. (#4807)
+- Bugfix: Fixed an issue where certain parts of the split input wouldn't focus the split when clicked. (#4958)
 - Bugfix: Fixed a data race when disconnecting from Twitch PubSub. (#4771)
 - Bugfix: Fixed `/shoutout` command not working with usernames starting with @'s (e.g. `/shoutout @forsen`). (#4800)
 - Bugfix: Fixed Usercard popup not floating on tiling WMs on Linux when "Automatically close user popup when it loses focus" setting is enabled. (#3511)

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -691,6 +691,8 @@ void SplitInput::installKeyPressedEvent()
 
 void SplitInput::mousePressEvent(QMouseEvent *event)
 {
+    this->giveFocus(Qt::MouseFocusReason);
+
     if (this->hidden)
     {
         BaseWidget::mousePressEvent(event);


### PR DESCRIPTION
# Description

When clicking between the Split Input & the Split chat, there was a pixel or two where focus was not being granted to the split. This PR fixes that by adding a `giveFocus` call to the `mousePress` event.
<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
