### PR TITLE
refactor: Remove `Outcome` from network requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 - Dev: Refactor `ChannelView`, removing a bunch of clang-tidy warnings. (#4926)
 - Dev: Refactor `IrcMessageHandler`, removing a bunch of clang-tidy warnings & changing its public API. (#4927)
 - Dev: `Details` file properties tab is now populated on Windows. (#4912)
+- Dev: Removed `Outcome` from network requests. (#4959)
 
 ## 2.4.6
 

--- a/src/common/NetworkCommon.hpp
+++ b/src/common/NetworkCommon.hpp
@@ -9,10 +9,9 @@ class QNetworkReply;
 
 namespace chatterino {
 
-class Outcome;
 class NetworkResult;
 
-using NetworkSuccessCallback = std::function<Outcome(NetworkResult)>;
+using NetworkSuccessCallback = std::function<void(NetworkResult)>;
 using NetworkErrorCallback = std::function<void(NetworkResult)>;
 using NetworkReplyCreatedCallback = std::function<void(QNetworkReply *)>;
 using NetworkFinallyCallback = std::function<void()>;

--- a/src/common/NetworkPrivate.cpp
+++ b/src/common/NetworkPrivate.cpp
@@ -2,7 +2,6 @@
 
 #include "common/NetworkManager.hpp"
 #include "common/NetworkResult.hpp"
-#include "common/Outcome.hpp"
 #include "common/QLogging.hpp"
 #include "debug/AssertInGuiThread.hpp"
 #include "singletons/Paths.hpp"

--- a/src/controllers/notifications/NotificationController.cpp
+++ b/src/controllers/notifications/NotificationController.cpp
@@ -1,8 +1,6 @@
 #include "controllers/notifications/NotificationController.hpp"
 
 #include "Application.hpp"
-#include "common/NetworkRequest.hpp"
-#include "common/Outcome.hpp"
 #include "common/QLogging.hpp"
 #include "controllers/notifications/NotificationModel.hpp"
 #include "controllers/sound/SoundController.hpp"

--- a/src/messages/Image.cpp
+++ b/src/messages/Image.cpp
@@ -4,7 +4,6 @@
 #include "common/Common.hpp"
 #include "common/NetworkRequest.hpp"
 #include "common/NetworkResult.hpp"
-#include "common/Outcome.hpp"
 #include "common/QLogging.hpp"
 #include "debug/AssertInGuiThread.hpp"
 #include "debug/Benchmark.hpp"
@@ -502,11 +501,11 @@ void Image::actuallyLoad()
     NetworkRequest(this->url().string)
         .concurrent()
         .cache()
-        .onSuccess([weak](auto result) -> Outcome {
+        .onSuccess([weak](auto result) {
             auto shared = weak.lock();
             if (!shared)
             {
-                return Failure;
+                return;
             }
 
             auto data = result.getData();
@@ -521,14 +520,14 @@ void Image::actuallyLoad()
                 qCDebug(chatterinoImage)
                     << "Error: image cant be read " << shared->url().string;
                 shared->empty_ = true;
-                return Failure;
+                return;
             }
 
             const auto size = reader.size();
             if (size.isEmpty())
             {
                 shared->empty_ = true;
-                return Failure;
+                return;
             }
 
             // returns 1 for non-animated formats
@@ -538,7 +537,7 @@ void Image::actuallyLoad()
                     << "Error: image has less than 1 frame "
                     << shared->url().string << ": " << reader.errorString();
                 shared->empty_ = true;
-                return Failure;
+                return;
             }
 
             // use "double" to prevent int overflows
@@ -549,7 +548,7 @@ void Image::actuallyLoad()
                 qCDebug(chatterinoImage) << "image too large in RAM";
 
                 shared->empty_ = true;
-                return Failure;
+                return;
             }
 
             auto parsed = detail::readFrames(reader, shared->url());
@@ -562,8 +561,6 @@ void Image::actuallyLoad()
                             std::forward<decltype(frames)>(frames));
                     }
                 }));
-
-            return Success;
         })
         .onError([weak](auto /*result*/) {
             auto shared = weak.lock();

--- a/src/providers/IvrApi.cpp
+++ b/src/providers/IvrApi.cpp
@@ -1,7 +1,6 @@
 #include "IvrApi.hpp"
 
 #include "common/NetworkResult.hpp"
-#include "common/Outcome.hpp"
 #include "common/QLogging.hpp"
 
 #include <QUrlQuery>
@@ -18,12 +17,10 @@ void IvrApi::getSubage(QString userName, QString channelName,
 
     this->makeRequest(
             QString("twitch/subage/%1/%2").arg(userName).arg(channelName), {})
-        .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
+        .onSuccess([successCallback, failureCallback](auto result) {
             auto root = result.parseJson();
 
             successCallback(root);
-
-            return Success;
         })
         .onError([failureCallback](auto result) {
             qCWarning(chatterinoIvr)
@@ -42,12 +39,10 @@ void IvrApi::getBulkEmoteSets(QString emoteSetList,
     urlQuery.addQueryItem("set_id", emoteSetList);
 
     this->makeRequest("twitch/emotes/sets", urlQuery)
-        .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
+        .onSuccess([successCallback, failureCallback](auto result) {
             auto root = result.parseJsonArray();
 
             successCallback(root);
-
-            return Success;
         })
         .onError([failureCallback](auto result) {
             qCWarning(chatterinoIvr)

--- a/src/providers/LinkResolver.cpp
+++ b/src/providers/LinkResolver.cpp
@@ -3,7 +3,6 @@
 #include "common/Env.hpp"
 #include "common/NetworkRequest.hpp"
 #include "common/NetworkResult.hpp"
-#include "common/Outcome.hpp"
 #include "messages/Image.hpp"
 #include "messages/Link.hpp"
 #include "singletons/Settings.hpp"
@@ -27,8 +26,7 @@ void LinkResolver::getLinkInfo(
                        QUrl::toPercentEncoding(url, "", "/:"))))
         .caller(caller)
         .timeout(30000)
-        .onSuccess([successCallback,
-                    url](NetworkResult result) mutable -> Outcome {
+        .onSuccess([successCallback, url](NetworkResult result) mutable {
             auto root = result.parseJson();
             auto statusCode = root.value("status").toInt();
             QString response;
@@ -54,8 +52,6 @@ void LinkResolver::getLinkInfo(
             }
             successCallback(QUrl::fromPercentEncoding(response.toUtf8()),
                             Link(Link::Url, linkString), thumbnail);
-
-            return Success;
         })
         .onError([successCallback, url](auto /*result*/) {
             successCallback("No link info found", Link(Link::Url, url),

--- a/src/providers/bttv/BttvEmotes.cpp
+++ b/src/providers/bttv/BttvEmotes.cpp
@@ -2,6 +2,7 @@
 
 #include "common/NetworkRequest.hpp"
 #include "common/NetworkResult.hpp"
+#include "common/Outcome.hpp"
 #include "common/QLogging.hpp"
 #include "messages/Emote.hpp"
 #include "messages/Image.hpp"
@@ -202,7 +203,7 @@ void BttvEmotes::loadEmotes()
 
     NetworkRequest(QString(globalEmoteApiUrl))
         .timeout(30000)
-        .onSuccess([this](auto result) -> Outcome {
+        .onSuccess([this](auto result) {
             auto emotes = this->global_.get();
             auto pair = parseGlobalEmotes(result.parseJsonArray(), *emotes);
             if (pair.first)
@@ -210,7 +211,6 @@ void BttvEmotes::loadEmotes()
                 this->setEmotes(
                     std::make_shared<EmoteMap>(std::move(pair.second)));
             }
-            return pair.first;
         })
         .execute();
 }
@@ -229,7 +229,7 @@ void BttvEmotes::loadChannel(std::weak_ptr<Channel> channel,
     NetworkRequest(QString(bttvChannelEmoteApiUrl) + channelId)
         .timeout(20000)
         .onSuccess([callback = std::move(callback), channel, channelDisplayName,
-                    manualRefresh](auto result) -> Outcome {
+                    manualRefresh](auto result) {
             auto pair =
                 parseChannelEmotes(result.parseJson(), channelDisplayName);
             bool hasEmotes = false;
@@ -251,7 +251,6 @@ void BttvEmotes::loadChannel(std::weak_ptr<Channel> channel,
                         makeSystemMessage(CHANNEL_HAS_NO_EMOTES));
                 }
             }
-            return pair.first;
         })
         .onError([channelId, channel, manualRefresh](auto result) {
             auto shared = channel.lock();

--- a/src/providers/chatterino/ChatterinoBadges.cpp
+++ b/src/providers/chatterino/ChatterinoBadges.cpp
@@ -2,7 +2,6 @@
 
 #include "common/NetworkRequest.hpp"
 #include "common/NetworkResult.hpp"
-#include "common/Outcome.hpp"
 #include "messages/Emote.hpp"
 
 #include <QJsonArray>
@@ -39,7 +38,7 @@ void ChatterinoBadges::loadChatterinoBadges()
 
     NetworkRequest(url)
         .concurrent()
-        .onSuccess([this](auto result) -> Outcome {
+        .onSuccess([this](auto result) {
             auto jsonRoot = result.parseJson();
 
             std::unique_lock lock(this->mutex_);
@@ -64,8 +63,6 @@ void ChatterinoBadges::loadChatterinoBadges()
                 }
                 ++index;
             }
-
-            return Success;
         })
         .execute();
 }

--- a/src/providers/ffz/FfzBadges.cpp
+++ b/src/providers/ffz/FfzBadges.cpp
@@ -2,7 +2,6 @@
 
 #include "common/NetworkRequest.hpp"
 #include "common/NetworkResult.hpp"
-#include "common/Outcome.hpp"
 #include "messages/Emote.hpp"
 #include "providers/ffz/FfzUtil.hpp"
 
@@ -59,7 +58,7 @@ void FfzBadges::load()
     static QUrl url("https://api.frankerfacez.com/v1/badges/ids");
 
     NetworkRequest(url)
-        .onSuccess([this](auto result) -> Outcome {
+        .onSuccess([this](auto result) {
             std::unique_lock lock(this->mutex_);
 
             auto jsonRoot = result.parseJson();
@@ -103,8 +102,6 @@ void FfzBadges::load()
                     }
                 }
             }
-
-            return Success;
         })
         .execute();
 }

--- a/src/providers/ffz/FfzEmotes.cpp
+++ b/src/providers/ffz/FfzEmotes.cpp
@@ -2,7 +2,6 @@
 
 #include "common/NetworkRequest.hpp"
 #include "common/NetworkResult.hpp"
-#include "common/Outcome.hpp"
 #include "common/QLogging.hpp"
 #include "messages/Emote.hpp"
 #include "messages/Image.hpp"
@@ -197,11 +196,9 @@ void FfzEmotes::loadEmotes()
     NetworkRequest(url)
 
         .timeout(30000)
-        .onSuccess([this](auto result) -> Outcome {
+        .onSuccess([this](auto result) {
             auto parsedSet = parseGlobalEmotes(result.parseJson());
             this->setEmotes(std::make_shared<EmoteMap>(std::move(parsedSet)));
-
-            return Success;
         })
         .execute();
 }
@@ -227,7 +224,7 @@ void FfzEmotes::loadChannel(
         .onSuccess([emoteCallback = std::move(emoteCallback),
                     modBadgeCallback = std::move(modBadgeCallback),
                     vipBadgeCallback = std::move(vipBadgeCallback), channel,
-                    manualRefresh](const auto &result) -> Outcome {
+                    manualRefresh](const auto &result) {
             const auto json = result.parseJson();
 
             auto emoteMap = parseChannelEmotes(json);
@@ -254,8 +251,6 @@ void FfzEmotes::loadChannel(
                         makeSystemMessage(CHANNEL_HAS_NO_EMOTES));
                 }
             }
-
-            return Success;
         })
         .onError([channelID, channel, manualRefresh](const auto &result) {
             auto shared = channel.lock();

--- a/src/providers/recentmessages/Api.cpp
+++ b/src/providers/recentmessages/Api.cpp
@@ -26,11 +26,11 @@ void load(const QString &channelName, std::weak_ptr<Channel> channelPtr,
     const auto url = constructRecentMessagesUrl(channelName);
 
     NetworkRequest(url)
-        .onSuccess([channelPtr, onLoaded](const auto &result) -> Outcome {
+        .onSuccess([channelPtr, onLoaded](const auto &result) {
             auto shared = channelPtr.lock();
             if (!shared)
             {
-                return Failure;
+                return;
             }
 
             qCDebug(LOG) << "Successfully loaded recent messages for"
@@ -65,8 +65,6 @@ void load(const QString &channelName, std::weak_ptr<Channel> channelPtr,
 
                 onLoaded(messages);
             });
-
-            return Success;
         })
         .onError([channelPtr, onError](const NetworkResult &result) {
             auto shared = channelPtr.lock();

--- a/src/providers/seventv/SeventvAPI.cpp
+++ b/src/providers/seventv/SeventvAPI.cpp
@@ -3,7 +3,6 @@
 #include "common/Literals.hpp"
 #include "common/NetworkRequest.hpp"
 #include "common/NetworkResult.hpp"
-#include "common/Outcome.hpp"
 
 namespace {
 
@@ -24,12 +23,11 @@ void SeventvAPI::getUserByTwitchID(
 {
     NetworkRequest(API_URL_USER.arg(twitchID), NetworkRequestType::Get)
         .timeout(20000)
-        .onSuccess([callback = std::move(onSuccess)](
-                       const NetworkResult &result) -> Outcome {
-            auto json = result.parseJson();
-            callback(json);
-            return Success;
-        })
+        .onSuccess(
+            [callback = std::move(onSuccess)](const NetworkResult &result) {
+                auto json = result.parseJson();
+                callback(json);
+            })
         .onError([callback = std::move(onError)](const NetworkResult &result) {
             callback(result);
         })
@@ -42,12 +40,11 @@ void SeventvAPI::getEmoteSet(const QString &emoteSet,
 {
     NetworkRequest(API_URL_EMOTE_SET.arg(emoteSet), NetworkRequestType::Get)
         .timeout(25000)
-        .onSuccess([callback = std::move(onSuccess)](
-                       const NetworkResult &result) -> Outcome {
-            auto json = result.parseJson();
-            callback(json);
-            return Success;
-        })
+        .onSuccess(
+            [callback = std::move(onSuccess)](const NetworkResult &result) {
+                auto json = result.parseJson();
+                callback(json);
+            })
         .onError([callback = std::move(onError)](const NetworkResult &result) {
             callback(result);
         })
@@ -72,9 +69,8 @@ void SeventvAPI::updatePresence(const QString &twitchChannelID,
                    NetworkRequestType::Post)
         .json(payload)
         .timeout(10000)
-        .onSuccess([callback = std::move(onSuccess)](const auto &) -> Outcome {
+        .onSuccess([callback = std::move(onSuccess)](const auto &) {
             callback();
-            return Success;
         })
         .onError([callback = std::move(onError)](const NetworkResult &result) {
             callback(result);

--- a/src/providers/twitch/TwitchAccount.cpp
+++ b/src/providers/twitch/TwitchAccount.cpp
@@ -4,7 +4,6 @@
 #include "common/Channel.hpp"
 #include "common/Env.hpp"
 #include "common/NetworkResult.hpp"
-#include "common/Outcome.hpp"
 #include "common/QLogging.hpp"
 #include "controllers/accounts/AccountController.hpp"
 #include "debug/AssertInGuiThread.hpp"
@@ -500,7 +499,6 @@ void TwitchAccount::loadSeventvUserID()
             {
                 this->seventvUserID_ = id;
             }
-            return Success;
         },
         [](const auto &result) {
             qCDebug(chatterinoSeventv)

--- a/src/providers/twitch/TwitchBadges.cpp
+++ b/src/providers/twitch/TwitchBadges.cpp
@@ -2,7 +2,6 @@
 
 #include "common/NetworkRequest.hpp"
 #include "common/NetworkResult.hpp"
-#include "common/Outcome.hpp"
 #include "common/QLogging.hpp"
 #include "messages/Emote.hpp"
 #include "messages/Image.hpp"
@@ -238,7 +237,7 @@ void TwitchBadges::loadEmoteImage(const QString &name, ImagePtr image,
     NetworkRequest(image->url().string)
         .concurrent()
         .cache()
-        .onSuccess([this, name, callback](auto result) -> Outcome {
+        .onSuccess([this, name, callback](auto result) {
             auto data = result.getData();
 
             // const cast since we are only reading from it
@@ -248,18 +247,18 @@ void TwitchBadges::loadEmoteImage(const QString &name, ImagePtr image,
 
             if (!reader.canRead() || reader.size().isEmpty())
             {
-                return Failure;
+                return;
             }
 
             QImage image = reader.read();
             if (image.isNull())
             {
-                return Failure;
+                return;
             }
 
             if (reader.imageCount() <= 0)
             {
-                return Failure;
+                return;
             }
 
             auto icon = std::make_shared<QIcon>(QPixmap::fromImage(image));
@@ -270,8 +269,6 @@ void TwitchBadges::loadEmoteImage(const QString &name, ImagePtr image,
             }
 
             callback(name, icon);
-
-            return Success;
         })
         .execute();
 }

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -1381,11 +1381,11 @@ void TwitchChannel::refreshCheerEmotes()
     getHelix()->getCheermotes(
         this->roomId(),
         [this, weak = weakOf<Channel>(this)](
-            const std::vector<HelixCheermoteSet> &cheermoteSets) -> Outcome {
+            const std::vector<HelixCheermoteSet> &cheermoteSets) {
             auto shared = weak.lock();
             if (!shared)
             {
-                return Failure;
+                return;
             }
 
             std::vector<CheerEmoteSet> emoteSets;
@@ -1444,12 +1444,9 @@ void TwitchChannel::refreshCheerEmotes()
             }
 
             *this->cheerEmoteSets_.access() = std::move(emoteSets);
-
-            return Success;
         },
         [] {
             // Failure
-            return Failure;
         });
 }
 
@@ -1656,11 +1653,10 @@ void TwitchChannel::updateSevenTVActivity()
                 std::dynamic_pointer_cast<TwitchChannel>(chan.lock());
             if (!self)
             {
-                return Success;
+                return;
             }
             self->nextSeventvActivity_ =
                 QDateTime::currentDateTimeUtc().addSecs(60);
-            return Success;
         },
         [](const auto &result) {
             qCDebug(chatterinoSeventv)

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -5,7 +5,6 @@
 #include "common/Channel.hpp"
 #include "common/ChannelChatters.hpp"
 #include "common/Common.hpp"
-#include "common/Outcome.hpp"
 #include "common/UniqueAccess.hpp"
 #include "providers/twitch/TwitchEmotes.hpp"
 #include "util/QStringHash.hpp"

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -3,7 +3,6 @@
 #include "common/Literals.hpp"
 #include "common/NetworkRequest.hpp"
 #include "common/NetworkResult.hpp"
-#include "common/Outcome.hpp"
 #include "common/QLogging.hpp"
 #include "util/CancellationToken.hpp"
 
@@ -57,14 +56,14 @@ void Helix::fetchUsers(QStringList userIds, QStringList userLogins,
 
     // TODO: set on success and on error
     this->makeGet("users", urlQuery)
-        .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
+        .onSuccess([successCallback, failureCallback](auto result) {
             auto root = result.parseJson();
             auto data = root.value("data");
 
             if (!data.isArray())
             {
                 failureCallback();
-                return Failure;
+                return;
             }
 
             std::vector<HelixUser> users;
@@ -75,8 +74,6 @@ void Helix::fetchUsers(QStringList userIds, QStringList userLogins,
             }
 
             successCallback(users);
-
-            return Success;
         })
         .onError([failureCallback](auto /*result*/) {
             // TODO: make better xd
@@ -138,15 +135,14 @@ void Helix::getChannelFollowers(
 
     // TODO: set on success and on error
     this->makeGet("channels/followers", urlQuery)
-        .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
+        .onSuccess([successCallback, failureCallback](auto result) {
             auto root = result.parseJson();
             if (root.empty())
             {
                 failureCallback("Bad JSON response");
-                return Failure;
+                return;
             }
             successCallback(HelixGetChannelFollowersResponse(root));
-            return Success;
         })
         .onError([failureCallback](auto result) {
             auto root = result.parseJson();
@@ -182,14 +178,14 @@ void Helix::fetchStreams(
 
     // TODO: set on success and on error
     this->makeGet("streams", urlQuery)
-        .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
+        .onSuccess([successCallback, failureCallback](auto result) {
             auto root = result.parseJson();
             auto data = root.value("data");
 
             if (!data.isArray())
             {
                 failureCallback();
-                return Failure;
+                return;
             }
 
             std::vector<HelixStream> streams;
@@ -200,8 +196,6 @@ void Helix::fetchStreams(
             }
 
             successCallback(streams);
-
-            return Success;
         })
         .onError([failureCallback](auto /*result*/) {
             // TODO: make better xd
@@ -275,14 +269,14 @@ void Helix::fetchGames(QStringList gameIds, QStringList gameNames,
 
     // TODO: set on success and on error
     this->makeGet("games", urlQuery)
-        .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
+        .onSuccess([successCallback, failureCallback](auto result) {
             auto root = result.parseJson();
             auto data = root.value("data");
 
             if (!data.isArray())
             {
                 failureCallback();
-                return Failure;
+                return;
             }
 
             std::vector<HelixGame> games;
@@ -293,8 +287,6 @@ void Helix::fetchGames(QStringList gameIds, QStringList gameNames,
             }
 
             successCallback(games);
-
-            return Success;
         })
         .onError([failureCallback](auto /*result*/) {
             // TODO: make better xd
@@ -311,14 +303,14 @@ void Helix::searchGames(QString gameName,
     urlQuery.addQueryItem("query", gameName);
 
     this->makeGet("search/categories", urlQuery)
-        .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
+        .onSuccess([successCallback, failureCallback](auto result) {
             auto root = result.parseJson();
             auto data = root.value("data");
 
             if (!data.isArray())
             {
                 failureCallback();
-                return Failure;
+                return;
             }
 
             std::vector<HelixGame> games;
@@ -329,8 +321,6 @@ void Helix::searchGames(QString gameName,
             }
 
             successCallback(games);
-
-            return Success;
         })
         .onError([failureCallback](auto /*result*/) {
             // TODO: make better xd
@@ -369,20 +359,19 @@ void Helix::createClip(QString channelId,
 
     this->makePost("clips", urlQuery)
         .header("Content-Type", "application/json")
-        .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
+        .onSuccess([successCallback, failureCallback](auto result) {
             auto root = result.parseJson();
             auto data = root.value("data");
 
             if (!data.isArray())
             {
                 failureCallback(HelixClipError::Unknown);
-                return Failure;
+                return;
             }
 
             HelixClip clip(data.toArray()[0].toObject());
 
             successCallback(clip);
-            return Success;
         })
         .onError([failureCallback](auto result) {
             switch (result.status().value_or(0))
@@ -425,14 +414,14 @@ void Helix::fetchChannels(
     }
 
     this->makeGet("channels", urlQuery)
-        .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
+        .onSuccess([successCallback, failureCallback](auto result) {
             auto root = result.parseJson();
             auto data = root.value("data");
 
             if (!data.isArray())
             {
                 failureCallback();
-                return Failure;
+                return;
             }
 
             std::vector<HelixChannel> channels;
@@ -443,7 +432,6 @@ void Helix::fetchChannels(
             }
 
             successCallback(channels);
-            return Success;
         })
         .onError([failureCallback](auto /*result*/) {
             failureCallback();
@@ -459,20 +447,19 @@ void Helix::getChannel(QString broadcasterId,
     urlQuery.addQueryItem("broadcaster_id", broadcasterId);
 
     this->makeGet("channels", urlQuery)
-        .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
+        .onSuccess([successCallback, failureCallback](auto result) {
             auto root = result.parseJson();
             auto data = root.value("data");
 
             if (!data.isArray())
             {
                 failureCallback();
-                return Failure;
+                return;
             }
 
             HelixChannel channel(data.toArray()[0].toObject());
 
             successCallback(channel);
-            return Success;
         })
         .onError([failureCallback](auto /*result*/) {
             failureCallback();
@@ -495,20 +482,19 @@ void Helix::createStreamMarker(
 
     this->makePost("streams/markers", QUrlQuery())
         .json(payload)
-        .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
+        .onSuccess([successCallback, failureCallback](auto result) {
             auto root = result.parseJson();
             auto data = root.value("data");
 
             if (!data.isArray())
             {
                 failureCallback(HelixStreamMarkerError::Unknown);
-                return Failure;
+                return;
             }
 
             HelixStreamMarker streamMarker(data.toArray()[0].toObject());
 
             successCallback(streamMarker);
-            return Success;
         })
         .onError([failureCallback](NetworkResult result) {
             switch (result.status().value_or(0))
@@ -597,9 +583,8 @@ void Helix::blockUser(QString targetUserId, const QObject *caller,
 
     this->makePut("users/blocks", urlQuery)
         .caller(caller)
-        .onSuccess([successCallback](auto /*result*/) -> Outcome {
+        .onSuccess([successCallback](auto /*result*/) {
             successCallback();
-            return Success;
         })
         .onError([failureCallback](auto /*result*/) {
             // TODO: make better xd
@@ -617,9 +602,8 @@ void Helix::unblockUser(QString targetUserId, const QObject *caller,
 
     this->makeDelete("users/blocks", urlQuery)
         .caller(caller)
-        .onSuccess([successCallback](auto /*result*/) -> Outcome {
+        .onSuccess([successCallback](auto /*result*/) {
             successCallback();
-            return Success;
         })
         .onError([failureCallback](auto /*result*/) {
             // TODO: make better xd
@@ -657,9 +641,8 @@ void Helix::updateChannel(QString broadcasterId, QString gameId,
     urlQuery.addQueryItem("broadcaster_id", broadcasterId);
     this->makePatch("channels", urlQuery)
         .json(obj)
-        .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
+        .onSuccess([successCallback, failureCallback](auto result) {
             successCallback(result);
-            return Success;
         })
         .onError([failureCallback](NetworkResult result) {
             failureCallback();
@@ -680,9 +663,8 @@ void Helix::manageAutoModMessages(
 
     this->makePost("moderation/automod/message", QUrlQuery())
         .json(payload)
-        .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
+        .onSuccess([successCallback, failureCallback](auto result) {
             successCallback();
-            return Success;
         })
         .onError([failureCallback, msgID, action](NetworkResult result) {
             switch (result.status().value_or(0))
@@ -736,14 +718,14 @@ void Helix::getCheermotes(
     urlQuery.addQueryItem("broadcaster_id", broadcasterId);
 
     this->makeGet("bits/cheermotes", urlQuery)
-        .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
+        .onSuccess([successCallback, failureCallback](auto result) {
             auto root = result.parseJson();
             auto data = root.value("data");
 
             if (!data.isArray())
             {
                 failureCallback();
-                return Failure;
+                return;
             }
 
             std::vector<HelixCheermoteSet> cheermoteSets;
@@ -754,7 +736,6 @@ void Helix::getCheermotes(
             }
 
             successCallback(cheermoteSets);
-            return Success;
         })
         .onError([broadcasterId, failureCallback](NetworkResult result) {
             qCDebug(chatterinoTwitch)
@@ -774,21 +755,19 @@ void Helix::getEmoteSetData(QString emoteSetId,
     urlQuery.addQueryItem("emote_set_id", emoteSetId);
 
     this->makeGet("chat/emotes/set", urlQuery)
-        .onSuccess([successCallback, failureCallback,
-                    emoteSetId](auto result) -> Outcome {
+        .onSuccess([successCallback, failureCallback, emoteSetId](auto result) {
             QJsonObject root = result.parseJson();
             auto data = root.value("data");
 
             if (!data.isArray() || data.toArray().isEmpty())
             {
                 failureCallback();
-                return Failure;
+                return;
             }
 
             HelixEmoteSetData emoteSetData(data.toArray()[0].toObject());
 
             successCallback(emoteSetData);
-            return Success;
         })
         .onError([failureCallback](NetworkResult result) {
             // TODO: make better xd
@@ -806,15 +785,14 @@ void Helix::getChannelEmotes(
     urlQuery.addQueryItem("broadcaster_id", broadcasterId);
 
     this->makeGet("chat/emotes", urlQuery)
-        .onSuccess([successCallback,
-                    failureCallback](NetworkResult result) -> Outcome {
+        .onSuccess([successCallback, failureCallback](NetworkResult result) {
             QJsonObject root = result.parseJson();
             auto data = root.value("data");
 
             if (!data.isArray())
             {
                 failureCallback();
-                return Failure;
+                return;
             }
 
             std::vector<HelixChannelEmote> channelEmotes;
@@ -825,7 +803,6 @@ void Helix::getChannelEmotes(
             }
 
             successCallback(channelEmotes);
-            return Success;
         })
         .onError([failureCallback](auto result) {
             // TODO: make better xd
@@ -847,7 +824,7 @@ void Helix::updateUserChatColor(
 
     this->makePut("chat/color", QUrlQuery())
         .json(payload)
-        .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
+        .onSuccess([successCallback, failureCallback](auto result) {
             auto obj = result.parseJson();
             if (result.status() != 204)
             {
@@ -858,7 +835,6 @@ void Helix::updateUserChatColor(
             }
 
             successCallback();
-            return Success;
         })
         .onError([failureCallback](const auto &result) -> void {
             if (!result.status())
@@ -931,7 +907,7 @@ void Helix::deleteChatMessages(
     }
 
     this->makeDelete("moderation/chat", urlQuery)
-        .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
+        .onSuccess([successCallback, failureCallback](auto result) {
             if (result.status() != 204)
             {
                 qCWarning(chatterinoTwitch)
@@ -941,7 +917,6 @@ void Helix::deleteChatMessages(
             }
 
             successCallback();
-            return Success;
         })
         .onError([failureCallback](const auto &result) -> void {
             if (!result.status())
@@ -1016,7 +991,7 @@ void Helix::addChannelModerator(
     urlQuery.addQueryItem("user_id", userID);
 
     this->makePost("moderation/moderators", urlQuery)
-        .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
+        .onSuccess([successCallback, failureCallback](auto result) {
             if (result.status() != 204)
             {
                 qCWarning(chatterinoTwitch)
@@ -1026,7 +1001,6 @@ void Helix::addChannelModerator(
             }
 
             successCallback();
-            return Success;
         })
         .onError([failureCallback](const auto &result) -> void {
             if (!result.status())
@@ -1111,7 +1085,7 @@ void Helix::removeChannelModerator(
     urlQuery.addQueryItem("user_id", userID);
 
     this->makeDelete("moderation/moderators", urlQuery)
-        .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
+        .onSuccess([successCallback, failureCallback](auto result) {
             if (result.status() != 204)
             {
                 qCWarning(chatterinoTwitch)
@@ -1121,7 +1095,6 @@ void Helix::removeChannelModerator(
             }
 
             successCallback();
-            return Success;
         })
         .onError([failureCallback](const auto &result) -> void {
             if (!result.status())
@@ -1205,7 +1178,7 @@ void Helix::sendChatAnnouncement(
 
     this->makePost("chat/announcements", urlQuery)
         .json(body)
-        .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
+        .onSuccess([successCallback, failureCallback](auto result) {
             if (result.status() != 204)
             {
                 qCWarning(chatterinoTwitch)
@@ -1215,7 +1188,6 @@ void Helix::sendChatAnnouncement(
             }
 
             successCallback();
-            return Success;
         })
         .onError([failureCallback](const auto &result) -> void {
             if (!result.status())
@@ -1281,7 +1253,7 @@ void Helix::addChannelVIP(
     urlQuery.addQueryItem("user_id", userID);
 
     this->makePost("channels/vips", urlQuery)
-        .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
+        .onSuccess([successCallback, failureCallback](auto result) {
             if (result.status() != 204)
             {
                 qCWarning(chatterinoTwitch)
@@ -1291,7 +1263,6 @@ void Helix::addChannelVIP(
             }
 
             successCallback();
-            return Success;
         })
         .onError([failureCallback](const auto &result) -> void {
             if (!result.status())
@@ -1366,7 +1337,7 @@ void Helix::removeChannelVIP(
     urlQuery.addQueryItem("user_id", userID);
 
     this->makeDelete("channels/vips", urlQuery)
-        .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
+        .onSuccess([successCallback, failureCallback](auto result) {
             if (result.status() != 204)
             {
                 qCWarning(chatterinoTwitch)
@@ -1376,7 +1347,6 @@ void Helix::removeChannelVIP(
             }
 
             successCallback();
-            return Success;
         })
         .onError([failureCallback](const auto &result) -> void {
             if (!result.status())
@@ -1462,7 +1432,7 @@ void Helix::unbanUser(
     urlQuery.addQueryItem("user_id", userID);
 
     this->makeDelete("moderation/bans", urlQuery)
-        .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
+        .onSuccess([successCallback, failureCallback](auto result) {
             if (result.status() != 204)
             {
                 qCWarning(chatterinoTwitch)
@@ -1472,7 +1442,6 @@ void Helix::unbanUser(
             }
 
             successCallback();
-            return Success;
         })
         .onError([failureCallback](const auto &result) -> void {
             if (!result.status())
@@ -1574,11 +1543,9 @@ void Helix::startRaid(
     urlQuery.addQueryItem("to_broadcaster_id", toBroadcasterID);
 
     this->makePost("raids", urlQuery)
-        .onSuccess(
-            [successCallback, failureCallback](auto /*result*/) -> Outcome {
-                successCallback();
-                return Success;
-            })
+        .onSuccess([successCallback, failureCallback](auto /*result*/) {
+            successCallback();
+        })
         .onError([failureCallback](const auto &result) -> void {
             if (!result.status())
             {
@@ -1660,7 +1627,7 @@ void Helix::cancelRaid(
     urlQuery.addQueryItem("broadcaster_id", broadcasterID);
 
     this->makeDelete("raids", urlQuery)
-        .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
+        .onSuccess([successCallback, failureCallback](auto result) {
             if (result.status() != 204)
             {
                 qCWarning(chatterinoTwitch)
@@ -1670,7 +1637,6 @@ void Helix::cancelRaid(
             }
 
             successCallback();
-            return Success;
         })
         .onError([failureCallback](const auto &result) -> void {
             if (!result.status())
@@ -1828,7 +1794,7 @@ void Helix::updateChatSettings(
 
     this->makePatch("chat/settings", urlQuery)
         .json(payload)
-        .onSuccess([successCallback](auto result) -> Outcome {
+        .onSuccess([successCallback](auto result) {
             if (result.status() != 200)
             {
                 qCWarning(chatterinoTwitch)
@@ -1838,7 +1804,6 @@ void Helix::updateChatSettings(
             auto response = result.parseJson();
             successCallback(HelixChatSettings(
                 response.value("data").toArray().first().toObject()));
-            return Success;
         })
         .onError([failureCallback](const auto &result) -> void {
             if (!result.status())
@@ -1957,7 +1922,7 @@ void Helix::fetchChatters(
     }
 
     this->makeGet("chat/chatters", urlQuery)
-        .onSuccess([successCallback](auto result) -> Outcome {
+        .onSuccess([successCallback](auto result) {
             if (result.status() != 200)
             {
                 qCWarning(chatterinoTwitch)
@@ -1967,7 +1932,6 @@ void Helix::fetchChatters(
 
             auto response = result.parseJson();
             successCallback(HelixChatters(response));
-            return Success;
         })
         .onError([failureCallback](const auto &result) -> void {
             if (!result.status())
@@ -2072,7 +2036,7 @@ void Helix::fetchModerators(
     }
 
     this->makeGet("moderation/moderators", urlQuery)
-        .onSuccess([successCallback](auto result) -> Outcome {
+        .onSuccess([successCallback](auto result) {
             if (result.status() != 200)
             {
                 qCWarning(chatterinoTwitch)
@@ -2082,7 +2046,6 @@ void Helix::fetchModerators(
 
             auto response = result.parseJson();
             successCallback(HelixModerators(response));
-            return Success;
         })
         .onError([failureCallback](const auto &result) -> void {
             if (!result.status())
@@ -2164,7 +2127,7 @@ void Helix::banUser(QString broadcasterID, QString moderatorID, QString userID,
 
     this->makePost("moderation/bans", urlQuery)
         .json(payload)
-        .onSuccess([successCallback](auto result) -> Outcome {
+        .onSuccess([successCallback](auto result) {
             if (result.status() != 200)
             {
                 qCWarning(chatterinoTwitch)
@@ -2173,7 +2136,6 @@ void Helix::banUser(QString broadcasterID, QString moderatorID, QString userID,
             }
             // we don't care about the response
             successCallback();
-            return Success;
         })
         .onError([failureCallback](const auto &result) -> void {
             if (!result.status())
@@ -2267,7 +2229,7 @@ void Helix::sendWhisper(
 
     this->makePost("whispers", urlQuery)
         .json(payload)
-        .onSuccess([successCallback](auto result) -> Outcome {
+        .onSuccess([successCallback](auto result) {
             if (result.status() != 204)
             {
                 qCWarning(chatterinoTwitch)
@@ -2276,7 +2238,6 @@ void Helix::sendWhisper(
             }
             // we don't care about the response
             successCallback();
-            return Success;
         })
         .onError([failureCallback](const auto &result) -> void {
             if (!result.status())
@@ -2416,7 +2377,7 @@ void Helix::getChannelVIPs(
 
     this->makeGet("channels/vips", urlQuery)
         .header("Content-Type", "application/json")
-        .onSuccess([successCallback](auto result) -> Outcome {
+        .onSuccess([successCallback](auto result) {
             if (result.status() != 200)
             {
                 qCWarning(chatterinoTwitch)
@@ -2433,7 +2394,6 @@ void Helix::getChannelVIPs(
             }
 
             successCallback(channelVips);
-            return Success;
         })
         .onError([failureCallback](const auto &result) -> void {
             if (!result.status())
@@ -2509,18 +2469,17 @@ void Helix::startCommercial(
 
     this->makePost("channels/commercial", QUrlQuery())
         .json(payload)
-        .onSuccess([successCallback, failureCallback](auto result) -> Outcome {
+        .onSuccess([successCallback, failureCallback](auto result) {
             auto obj = result.parseJson();
             if (obj.isEmpty())
             {
                 failureCallback(
                     Error::Unknown,
                     "Twitch didn't send any information about this error.");
-                return Failure;
+                return;
             }
 
             successCallback(HelixStartCommercialResponse(obj));
-            return Success;
         })
         .onError([failureCallback](const auto &result) -> void {
             if (!result.status())
@@ -2605,7 +2564,7 @@ void Helix::getGlobalBadges(
     using Error = HelixGetGlobalBadgesError;
 
     this->makeGet("chat/badges/global", QUrlQuery())
-        .onSuccess([successCallback](auto result) -> Outcome {
+        .onSuccess([successCallback](auto result) {
             if (result.status() != 200)
             {
                 qCWarning(chatterinoTwitch)
@@ -2615,7 +2574,6 @@ void Helix::getGlobalBadges(
 
             auto response = result.parseJson();
             successCallback(HelixGlobalBadges(response));
-            return Success;
         })
         .onError([failureCallback](const auto &result) -> void {
             if (!result.status())
@@ -2658,7 +2616,7 @@ void Helix::getChannelBadges(
     urlQuery.addQueryItem("broadcaster_id", broadcasterID);
 
     this->makeGet("chat/badges", urlQuery)
-        .onSuccess([successCallback](auto result) -> Outcome {
+        .onSuccess([successCallback](auto result) {
             if (result.status() != 200)
             {
                 qCWarning(chatterinoTwitch)
@@ -2668,7 +2626,6 @@ void Helix::getChannelBadges(
 
             auto response = result.parseJson();
             successCallback(HelixChannelBadges(response));
-            return Success;
         })
         .onError([failureCallback](const auto &result) -> void {
             if (!result.status())
@@ -2717,7 +2674,7 @@ void Helix::updateShieldMode(
 
     this->makePut("moderation/shield_mode", urlQuery)
         .json(payload)
-        .onSuccess([successCallback](auto result) -> Outcome {
+        .onSuccess([successCallback](auto result) {
             if (result.status() != 200)
             {
                 qCWarning(chatterinoTwitch)
@@ -2728,7 +2685,6 @@ void Helix::updateShieldMode(
             const auto response = result.parseJson();
             successCallback(
                 HelixShieldModeStatus(response["data"][0].toObject()));
-            return Success;
         })
         .onError([failureCallback](const auto &result) -> void {
             if (!result.status())
@@ -2790,7 +2746,7 @@ void Helix::sendShoutout(
 
     this->makePost("chat/shoutouts", urlQuery)
         .header("Content-Type", "application/json")
-        .onSuccess([successCallback](NetworkResult result) -> Outcome {
+        .onSuccess([successCallback](NetworkResult result) {
             if (result.status() != 204)
             {
                 qCWarning(chatterinoTwitch)
@@ -2799,7 +2755,6 @@ void Helix::sendShoutout(
             }
 
             successCallback();
-            return Success;
         })
         .onError([failureCallback](const NetworkResult &result) -> void {
             if (!result.status())
@@ -2944,33 +2899,33 @@ void Helix::paginate(const QString &url, const QUrlQuery &baseQuery,
                      CancellationToken &&cancellationToken)
 {
     auto onSuccess =
-        std::make_shared<std::function<Outcome(NetworkResult)>>(nullptr);
+        std::make_shared<std::function<void(NetworkResult)>>(nullptr);
     // This is the actual callback passed to NetworkRequest.
     // It wraps the shared-ptr.
-    auto onSuccessCb = [onSuccess](const auto &res) -> Outcome {
+    auto onSuccessCb = [onSuccess](const auto &res) {
         return (*onSuccess)(res);
     };
 
     *onSuccess = [this, onPage = std::move(onPage), onError, onSuccessCb,
                   url{url}, baseQuery{baseQuery},
-                  cancellationToken = std::move(cancellationToken)](
-                     const NetworkResult &res) -> Outcome {
+                  cancellationToken =
+                      std::move(cancellationToken)](const NetworkResult &res) {
         if (cancellationToken.isCancelled())
         {
-            return Success;
+            return;
         }
 
         const auto json = res.parseJson();
         if (!onPage(json))
         {
             // The consumer doesn't want any more pages
-            return Success;
+            return;
         }
 
         auto cursor = json["pagination"_L1]["cursor"_L1].toString();
         if (cursor.isEmpty())
         {
-            return Success;
+            return;
         }
 
         auto query = baseQuery;
@@ -2981,8 +2936,6 @@ void Helix::paginate(const QString &url, const QUrlQuery &baseQuery,
             .onSuccess(onSuccessCb)
             .onError(onError)
             .execute();
-
-        return Success;
     };
 
     this->makeGet(url, baseQuery)

--- a/src/singletons/Updates.cpp
+++ b/src/singletons/Updates.cpp
@@ -3,7 +3,6 @@
 #include "common/Modes.hpp"
 #include "common/NetworkRequest.hpp"
 #include "common/NetworkResult.hpp"
-#include "common/Outcome.hpp"
 #include "common/QLogging.hpp"
 #include "common/Version.hpp"
 #include "Settings.hpp"
@@ -122,7 +121,7 @@ void Updates::installUpdates()
                     box->raise();
                 });
             })
-            .onSuccess([this](auto result) -> Outcome {
+            .onSuccess([this](auto result) {
                 if (result.status() != 200)
                 {
                     auto *box = new QMessageBox(
@@ -132,7 +131,7 @@ void Updates::installUpdates()
                             .arg(result.formatError()));
                     box->setAttribute(Qt::WA_DeleteOnClose);
                     box->exec();
-                    return Failure;
+                    return;
                 }
 
                 QByteArray object = result.getData();
@@ -145,7 +144,7 @@ void Updates::installUpdates()
                 if (file.write(object) == -1)
                 {
                     this->setStatus_(WriteFileFailed);
-                    return Failure;
+                    return;
                 }
                 file.flush();
                 file.close();
@@ -156,7 +155,6 @@ void Updates::installUpdates()
                     {filename, "restart"});
 
                 QApplication::exit(0);
-                return Success;
             })
             .execute();
         this->setStatus_(Downloading);
@@ -183,7 +181,7 @@ void Updates::installUpdates()
                 box->setAttribute(Qt::WA_DeleteOnClose);
                 box->exec();
             })
-            .onSuccess([this](auto result) -> Outcome {
+            .onSuccess([this](auto result) {
                 if (result.status() != 200)
                 {
                     auto *box = new QMessageBox(
@@ -193,7 +191,7 @@ void Updates::installUpdates()
                             .arg(result.formatError()));
                     box->setAttribute(Qt::WA_DeleteOnClose);
                     box->exec();
-                    return Failure;
+                    return;
                 }
 
                 QByteArray object = result.getData();
@@ -216,7 +214,7 @@ void Updates::installUpdates()
                     box->exec();
 
                     QDesktopServices::openUrl(this->updateExe_);
-                    return Failure;
+                    return;
                 }
                 file.flush();
                 file.close();
@@ -239,8 +237,6 @@ void Updates::installUpdates()
 
                     QDesktopServices::openUrl(this->updateExe_);
                 }
-
-                return Success;
             })
             .execute();
         this->setStatus_(Downloading);
@@ -279,7 +275,7 @@ void Updates::checkForUpdates()
 
     NetworkRequest(url)
         .timeout(60000)
-        .onSuccess([this](auto result) -> Outcome {
+        .onSuccess([this](auto result) {
             const auto object = result.parseJson();
             /// Version available on every platform
             auto version = object["version"];
@@ -289,7 +285,7 @@ void Updates::checkForUpdates()
                 this->setStatus_(SearchFailed);
                 qCDebug(chatterinoUpdate)
                     << "error checking version - missing 'version'" << object;
-                return Failure;
+                return;
             }
 
 #    if defined Q_OS_WIN || defined Q_OS_MACOS
@@ -300,7 +296,7 @@ void Updates::checkForUpdates()
                 this->setStatus_(SearchFailed);
                 qCDebug(chatterinoUpdate)
                     << "error checking version - missing 'updateexe'" << object;
-                return Failure;
+                return;
             }
             this->updateExe_ = updateExeUrl.toString();
 
@@ -313,7 +309,7 @@ void Updates::checkForUpdates()
                 qCDebug(chatterinoUpdate)
                     << "error checking version - missing 'portable_download'"
                     << object;
-                return Failure;
+                return;
             }
             this->updatePortable_ = portableUrl.toString();
 #        endif
@@ -325,7 +321,7 @@ void Updates::checkForUpdates()
                 this->updateGuideLink_ = updateGuide.toString();
             }
 #    else
-            return Failure;
+            return;
 #    endif
 
             /// Current version
@@ -342,7 +338,6 @@ void Updates::checkForUpdates()
             {
                 this->setStatus_(NoUpdateAvailable);
             }
-            return Failure;
         })
         .execute();
     this->setStatus_(Searching);

--- a/src/util/NuulsUploader.cpp
+++ b/src/util/NuulsUploader.cpp
@@ -156,7 +156,7 @@ void uploadImageToNuuls(RawImageData imageData, ChannelPtr channel,
         .headerList(extraHeaders)
         .multiPart(payload)
         .onSuccess([&textEdit, channel,
-                    originalFilePath](NetworkResult result) -> Outcome {
+                    originalFilePath](NetworkResult result) {
             QString link = getSettings()->imageUploaderLink.getValue().isEmpty()
                                ? result.getData()
                                : getLinkFromResponse(
@@ -202,8 +202,6 @@ void uploadImageToNuuls(RawImageData imageData, ChannelPtr channel,
             }
 
             logToFile(originalFilePath, link, deletionLink, channel);
-
-            return Success;
         })
         .onError([channel](NetworkResult result) -> bool {
             auto errorMessage =

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -804,7 +804,7 @@ void SplitHeader::updateChannelText()
             {
                 NetworkRequest(url, NetworkRequestType::Get)
                     .caller(this)
-                    .onSuccess([this](auto result) -> Outcome {
+                    .onSuccess([this](auto result) {
                         // NOTE: We do not follow the redirects, so we need to make sure we only treat code 200 as a valid image
                         if (result.status() == 200)
                         {
@@ -816,7 +816,6 @@ void SplitHeader::updateChannelText()
                             this->thumbnail_.clear();
                         }
                         this->updateChannelText();
-                        return Success;
                     })
                     .execute();
                 this->lastThumbnail_.restart();

--- a/tests/src/NetworkRequest.cpp
+++ b/tests/src/NetworkRequest.cpp
@@ -2,7 +2,6 @@
 
 #include "common/NetworkManager.hpp"
 #include "common/NetworkResult.hpp"
-#include "common/Outcome.hpp"
 
 #include <gtest/gtest.h>
 #include <QCoreApplication>
@@ -83,12 +82,10 @@ TEST(NetworkRequest, Success)
         RequestWaiter waiter;
 
         NetworkRequest(url)
-            .onSuccess(
-                [code, &waiter, url](const NetworkResult &result) -> Outcome {
-                    EXPECT_EQ(result.status(), code);
-                    waiter.requestDone();
-                    return Success;
-                })
+            .onSuccess([code, &waiter, url](const NetworkResult &result) {
+                EXPECT_EQ(result.status(), code);
+                waiter.requestDone();
+            })
             .onError([&](const NetworkResult & /*result*/) {
                 // The codes should *not* throw an error
                 EXPECT_TRUE(false);
@@ -143,13 +140,11 @@ TEST(NetworkRequest, Error)
         RequestWaiter waiter;
 
         NetworkRequest(url)
-            .onSuccess(
-                [&waiter, url](const NetworkResult & /*result*/) -> Outcome {
-                    // The codes should throw an error
-                    EXPECT_TRUE(false);
-                    waiter.requestDone();
-                    return Success;
-                })
+            .onSuccess([&waiter, url](const NetworkResult & /*result*/) {
+                // The codes should throw an error
+                EXPECT_TRUE(false);
+                waiter.requestDone();
+            })
             .onError([code, &waiter, url](const NetworkResult &result) {
                 EXPECT_EQ(result.status(), code);
 
@@ -201,11 +196,10 @@ TEST(NetworkRequest, TimeoutTimingOut)
 
     NetworkRequest(url)
         .timeout(1000)
-        .onSuccess([&waiter](const NetworkResult & /*result*/) -> Outcome {
+        .onSuccess([&waiter](const NetworkResult & /*result*/) {
             // The timeout should throw an error
             EXPECT_TRUE(false);
             waiter.requestDone();
-            return Success;
         })
         .onError([&waiter, url](const NetworkResult &result) {
             qDebug() << QTime::currentTime().toString()
@@ -232,11 +226,10 @@ TEST(NetworkRequest, TimeoutNotTimingOut)
 
     NetworkRequest(url)
         .timeout(3000)
-        .onSuccess([&waiter, url](const NetworkResult &result) -> Outcome {
+        .onSuccess([&waiter, url](const NetworkResult &result) {
             EXPECT_EQ(result.status(), 200);
 
             waiter.requestDone();
-            return Success;
         })
         .onError([&waiter, url](const NetworkResult & /*result*/) {
             // The timeout should *not* throw an error
@@ -263,9 +256,8 @@ TEST(NetworkRequest, FinallyCallbackOnTimeout)
 
     NetworkRequest(url)
         .timeout(1000)
-        .onSuccess([&](const NetworkResult & /*result*/) -> Outcome {
+        .onSuccess([&](const NetworkResult & /*result*/) {
             onSuccessCalled = true;
-            return Success;
         })
         .onError([&](const NetworkResult &result) {
             onErrorCalled = true;


### PR DESCRIPTION
# Description

As explained in the issue, the return value was never used.

Closes #4909.
