### PR TITLE
Fix: dont select mod buttons at triple click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Bugfix: Fixed a crash when clicking `More messages below` button in a usercard and closing it quickly. (#4933)
 - Bugfix: Fixed thread popup window missing messages for nested threads. (#4923)
 - Bugfix: Fixed an occasional crash for channel point redemptions with text input. (#4949)
+- Bugfix: Fixed triple click on message also selecting moderation buttons. (#4961)
 - Dev: Change clang-format from v14 to v16. (#4929)
 - Dev: Fixed UTF16 encoding of `modes` file for the installer. (#4791)
 - Dev: Temporarily disable High DPI scaling on Qt6 builds on Windows. (#4767)

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -430,10 +430,8 @@ size_t MessageLayoutContainer::getSelectionIndex(QPoint point) const
 size_t MessageLayoutContainer::getFirstMessageCharacterIndex() const
 {
     static const FlagsEnum<MessageElementFlag> skippedFlags{
-        MessageElementFlag::RepliedMessage,
-        MessageElementFlag::Timestamp,
-        MessageElementFlag::ModeratorTools,
-        MessageElementFlag::Badges,
+        MessageElementFlag::RepliedMessage, MessageElementFlag::Timestamp,
+        MessageElementFlag::ModeratorTools, MessageElementFlag::Badges,
         MessageElementFlag::Username,
     };
 

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -432,6 +432,7 @@ size_t MessageLayoutContainer::getFirstMessageCharacterIndex() const
     static const FlagsEnum<MessageElementFlag> skippedFlags{
         MessageElementFlag::RepliedMessage,
         MessageElementFlag::Timestamp,
+        MessageElementFlag::ModeratorTools,
         MessageElementFlag::Badges,
         MessageElementFlag::Username,
     };


### PR DESCRIPTION
Moderation buttons were not skipped in `getFirstMessageCharacterIndex()` causing triple click to select them,
issue visible on #4960 videos 