### PR TITLE
refactor: common/Credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@
 - Dev: Removed direct dependency on Qt 5 compatibility module. (#4906)
 - Dev: Refactor `Emoji`'s EmojiMap into a vector. (#4980)
 - Dev: Refactor `DebugCount` and add copy button to debug popup. (#4921)
-- Dev: Refactor `common/Credentials`. (#4921)
+- Dev: Refactor `common/Credentials`. (#4979)
 - Dev: Changed lifetime of context menus. (#4924)
 - Dev: Refactor `ChannelView`, removing a bunch of clang-tidy warnings. (#4926)
 - Dev: Refactor `IrcMessageHandler`, removing a bunch of clang-tidy warnings & changing its public API. (#4927)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 - Dev: Improve performance of selecting text. (#4889, #4911)
 - Dev: Removed direct dependency on Qt 5 compatibility module. (#4906)
 - Dev: Refactor `DebugCount` and add copy button to debug popup. (#4921)
+- Dev: Refactor `common/Credentials`. (#4921)
 - Dev: Changed lifetime of context menus. (#4924)
 - Dev: Refactor `ChannelView`, removing a bunch of clang-tidy warnings. (#4926)
 - Dev: Refactor `IrcMessageHandler`, removing a bunch of clang-tidy warnings & changing its public API. (#4927)

--- a/src/common/Credentials.cpp
+++ b/src/common/Credentials.cpp
@@ -5,6 +5,7 @@
 #include "singletons/Settings.hpp"
 #include "util/CombinePath.hpp"
 #include "util/Overloaded.hpp"
+#include "util/Variant.hpp"
 
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -111,13 +112,6 @@ std::queue<Job> &jobQueue()
     return jobs;
 }
 
-template <class... Ts>
-struct overloaded : Ts... {
-    using Ts::operator()...;
-};
-template <class... Ts>
-overloaded(Ts...) -> overloaded<Ts...>;
-
 void runNextJob()
 {
 #ifndef NO_QTKEYCHAIN
@@ -130,7 +124,7 @@ void runNextJob()
         auto &&item = queue.front();
 
         std::visit(
-            overloaded{
+            variant::Overloaded{
                 [](const SetJob &set) {
                     auto *job = new QKeychain::WritePasswordJob("chatterino");
                     job->setAutoDelete(true);

--- a/src/common/Credentials.cpp
+++ b/src/common/Credentials.cpp
@@ -177,6 +177,7 @@ Credentials::Credentials()
 {
 }
 
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 void Credentials::get(const QString &provider, const QString &name_,
                       QObject *receiver,
                       std::function<void(const QString &)> &&onLoaded)
@@ -209,6 +210,7 @@ void Credentials::get(const QString &provider, const QString &name_,
     }
 }
 
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 void Credentials::set(const QString &provider, const QString &name_,
                       const QString &credential)
 {
@@ -235,6 +237,7 @@ void Credentials::set(const QString &provider, const QString &name_,
     }
 }
 
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 void Credentials::erase(const QString &provider, const QString &name_)
 {
     assertInGuiThread();

--- a/src/common/Credentials.cpp
+++ b/src/common/Credentials.cpp
@@ -126,7 +126,7 @@ void runNextJob()
         if (item.which() == 0)  // set job
         {
             auto set = boost::get<SetJob>(item);
-            auto job = new QKeychain::WritePasswordJob("chatterino");
+            auto *job = new QKeychain::WritePasswordJob("chatterino");
             job->setAutoDelete(true);
             job->setKey(set.name);
             job->setTextData(set.credential);
@@ -138,7 +138,7 @@ void runNextJob()
         else  // erase job
         {
             auto erase = boost::get<EraseJob>(item);
-            auto job = new QKeychain::DeletePasswordJob("chatterino");
+            auto *job = new QKeychain::DeletePasswordJob("chatterino");
             job->setAutoDelete(true);
             job->setKey(erase.name);
             QObject::connect(job, &QKeychain::Job::finished, qApp, [](auto) {
@@ -189,7 +189,7 @@ void Credentials::get(const QString &provider, const QString &name_,
     {
 #ifndef NO_QTKEYCHAIN
         // if NO_QTKEYCHAIN is set, then this code is never used either way
-        auto job = new QKeychain::ReadPasswordJob("chatterino");
+        auto *job = new QKeychain::ReadPasswordJob("chatterino");
         job->setAutoDelete(true);
         job->setKey(name);
         QObject::connect(

--- a/src/common/Credentials.cpp
+++ b/src/common/Credentials.cpp
@@ -6,8 +6,10 @@
 #include "util/CombinePath.hpp"
 #include "util/Overloaded.hpp"
 
+#include <boost/variant.hpp>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QSaveFile>
 
 #ifndef NO_QTKEYCHAIN
 #    ifdef CMAKE_BUILD
@@ -20,8 +22,6 @@
 #        include "keychain.h"
 #    endif
 #endif
-#include <boost/variant.hpp>
-#include <QSaveFile>
 
 #define FORMAT_NAME                                                  \
     ([&] {                                                           \

--- a/src/common/Credentials.cpp
+++ b/src/common/Credentials.cpp
@@ -171,10 +171,6 @@ Credentials &Credentials::instance()
     return creds;
 }
 
-Credentials::Credentials()
-{
-}
-
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 void Credentials::get(const QString &provider, const QString &name_,
                       QObject *receiver,

--- a/src/common/Credentials.cpp
+++ b/src/common/Credentials.cpp
@@ -42,14 +42,12 @@ bool useKeyring()
     {
         return false;
     }
-    else
-    {
+
 #ifdef Q_OS_LINUX
-        return getSettings()->useKeyring;
+    return getSettings()->useKeyring;
 #else
-        return true;
+    return true;
 #endif
-    }
 }
 
 // Insecure storage:

--- a/src/common/Credentials.cpp
+++ b/src/common/Credentials.cpp
@@ -1,4 +1,4 @@
-#include "Credentials.hpp"
+#include "common/Credentials.hpp"
 
 #include "debug/AssertInGuiThread.hpp"
 #include "singletons/Paths.hpp"

--- a/src/common/Credentials.hpp
+++ b/src/common/Credentials.hpp
@@ -19,7 +19,7 @@ public:
     void erase(const QString &provider, const QString &name);
 
 private:
-    Credentials();
+    Credentials() = default;
 };
 
 }  // namespace chatterino


### PR DESCRIPTION


# Description

- Include full path
- Sort includes
- Move anon namespace out of chatterino namespace
- Use auto * where possible
- disable convert-member-function-to-static check
- no else after return
- Remove empty constructor
- Use std::variant instead of boost::variant

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
