### PR TITLE
feat: add `--safe-mode` command line option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Minor: Add menu actions to reply directly to a message or the original thread root. (#4923)
 - Minor: The `/reply` command now replies to the latest message of the user. (#4919)
 - Minor: All sound capabilities can now be disabled by setting your "Sound backend" setting to "Null" and restarting Chatterino. (#4978)
+- Minor: Add --safe-mode command line option. (#4985)
 - Bugfix: Fixed an issue where certain emojis did not send to Twitch chat correctly. (#4840)
 - Bugfix: Fixed capitalized channel names in log inclusion list not being logged. (#4848)
 - Bugfix: Trimmed custom streamlink paths on all platforms making sure you don't accidentally add spaces at the beginning or end of its path. (#4834)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Minor: Add menu actions to reply directly to a message or the original thread root. (#4923)
 - Minor: The `/reply` command now replies to the latest message of the user. (#4919)
 - Minor: All sound capabilities can now be disabled by setting your "Sound backend" setting to "Null" and restarting Chatterino. (#4978)
-- Minor: Add --safe-mode command line option. (#4985)
+- Minor: Add `--safe-mode` command line option that can be used for troubleshooting when Chatterino is misbehaving or is misconfigured. It disables hiding the settings button & prevents plugins from loading. (#4985)
 - Bugfix: Fixed an issue where certain emojis did not send to Twitch chat correctly. (#4840)
 - Bugfix: Fixed capitalized channel names in log inclusion list not being logged. (#4848)
 - Bugfix: Trimmed custom streamlink paths on all platforms making sure you don't accidentally add spaces at the beginning or end of its path. (#4834)

--- a/src/common/Args.cpp
+++ b/src/common/Args.cpp
@@ -38,6 +38,9 @@ Args::Args(const QApplication &app)
                                       "Attaches to the Console on windows, "
                                       "allowing you to see debug output."});
     crashRecoveryOption.setFlags(QCommandLineOption::HiddenFromHelp);
+    QCommandLineOption safeModeOption(
+        "safe-mode", "Starts Chatterino without loading Plugins and always "
+                     "show the settings button.");
 
     parser.addOptions({
         {{"V", "version"}, "Displays version information."},
@@ -45,6 +48,7 @@ Args::Args(const QApplication &app)
         parentWindowOption,
         parentWindowIdOption,
         verboseOption,
+        safeModeOption,
     });
     parser.addOption(QCommandLineOption(
         {"c", "channels"},
@@ -88,6 +92,10 @@ Args::Args(const QApplication &app)
         this->dontLoadMainWindow = true;
 
         this->parentWindowId = parser.value(parentWindowIdOption).toULongLong();
+    }
+    if (parser.isSet(safeModeOption))
+    {
+        this->safeMode = true;
     }
 }
 

--- a/src/common/Args.hpp
+++ b/src/common/Args.hpp
@@ -26,6 +26,7 @@ public:
     bool dontLoadMainWindow{};
     std::optional<WindowLayout> customChannelLayout;
     bool verbose{};
+    bool safeMode{};
 
 private:
     void applyCustomChannelLayout(const QString &argValue);

--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -1,6 +1,7 @@
 #include "widgets/Notebook.hpp"
 
 #include "Application.hpp"
+#include "common/Args.hpp"
 #include "common/QLogging.hpp"
 #include "controllers/hotkeys/HotkeyCategory.hpp"
 #include "controllers/hotkeys/HotkeyController.hpp"
@@ -1344,13 +1345,22 @@ void SplitNotebook::addCustomButtons()
     // settings
     auto settingsBtn = this->addCustomButton();
 
-    settingsBtn->setVisible(!getSettings()->hidePreferencesButton.getValue());
+    // This is to ensure you can't lock yourself out of the settings
+    if (getArgs().safeMode)
+    {
+        settingsBtn->setVisible(true);
+    }
+    else
+    {
+        settingsBtn->setVisible(
+            !getSettings()->hidePreferencesButton.getValue());
 
-    getSettings()->hidePreferencesButton.connect(
-        [settingsBtn](bool hide, auto) {
-            settingsBtn->setVisible(!hide);
-        },
-        this->signalHolder_);
+        getSettings()->hidePreferencesButton.connect(
+            [settingsBtn](bool hide, auto) {
+                settingsBtn->setVisible(!hide);
+            },
+            this->signalHolder_);
+    }
 
     settingsBtn->setIcon(NotebookButton::Settings);
 

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -1,6 +1,7 @@
 #include "widgets/Window.hpp"
 
 #include "Application.hpp"
+#include "common/Args.hpp"
 #include "common/Credentials.hpp"
 #include "common/Modes.hpp"
 #include "common/QLogging.hpp"
@@ -735,6 +736,11 @@ void Window::onAccountSelected()
         windowTitle += " - " + user->getUserName();
     }
 #endif
+
+    if (getArgs().safeMode)
+    {
+        windowTitle += " (safe mode)";
+    }
 
     this->setWindowTitle(windowTitle);
 

--- a/src/widgets/settingspages/PluginsPage.cpp
+++ b/src/widgets/settingspages/PluginsPage.cpp
@@ -2,6 +2,7 @@
 #    include "widgets/settingspages/PluginsPage.hpp"
 
 #    include "Application.hpp"
+#    include "common/Args.hpp"
 #    include "controllers/plugins/PluginController.hpp"
 #    include "singletons/Paths.hpp"
 #    include "singletons/Settings.hpp"
@@ -52,6 +53,15 @@ PluginsPage::PluginsPage()
             this->rebuildContent();
         });
         groupLayout->addRow(box);
+        if (getArgs().safeMode)
+        {
+            box->setEnabled(false);
+            auto *disabledLabel = new QLabel(this);
+            disabledLabel->setText("Plugins will not be fully loaded because "
+                                   "Chatterino is in safe mode. You can still "
+                                   "enable and disable them.");
+            groupLayout->addRow(disabledLabel);
+        }
     }
 
     this->rebuildContent();
@@ -177,6 +187,10 @@ void PluginsPage::rebuildContent()
                              this->rebuildContent();
                          });
         pluginEntry->addRow(reloadButton);
+        if (getArgs().safeMode)
+        {
+            reloadButton->setEnabled(false);
+        }
     }
 }
 


### PR DESCRIPTION
# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
This adds an option that disables plugins (if they were enabled at build time) and forces the preferences icon to show. Original idea was to also disable custom themes, however pajlada decided that is not needed. Should we decide to theme the settings, adding that will be needed.