### PR TITLE
Update magic_enum from v0.9.3 to v0.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 - Dev: Add a compile-time flag `CHATTERINO_UPDATER` which can be turned off to disable update checks. (#4854)
 - Dev: Add a compile-time flag `USE_SYSTEM_MINIAUDIO` which can be turned on to use the system miniaudio. (#4867)
 - Dev: Update vcpkg to use Qt6. (#4872)
+- Dev: Update `magic_enum` to v0.9.5. (#4992)
 - Dev: Replace `boost::optional` with `std::optional`. (#4877)
 - Dev: Improve performance of selecting text. (#4889, #4911)
 - Dev: Removed direct dependency on Qt 5 compatibility module. (#4906)

--- a/benchmarks/.clang-format
+++ b/benchmarks/.clang-format
@@ -32,9 +32,6 @@ IncludeCategories:
   # Project includes
   - Regex: '^"[a-zA-Z\._-]+(/[a-zA-Z0-9\._-]+)*"$'
     Priority: 1
-  # Third party library includes
-  - Regex: '<[[:alnum:].]+/[a-zA-Z0-9\._\/-]+>'
-    Priority: 3
   # Qt includes
   - Regex: '^<Q[a-zA-Z0-9\._\/-]+>$'
     Priority: 3
@@ -42,12 +39,12 @@ IncludeCategories:
   # LibCommuni includes
   - Regex: "^<Irc[a-zA-Z]+>$"
     Priority: 3
-  # Misc libraries
-  - Regex: '^<[a-zA-Z_0-9]+\.h(pp)?>$'
-    Priority: 3
   # Standard library includes
   - Regex: "^<[a-zA-Z_]+>$"
     Priority: 4
+  # Third party library includes
+  - Regex: "^<([a-zA-Z_0-9-]+/)*[a-zA-Z_0-9-]+.h(pp)?>$"
+    Priority: 3
 NamespaceIndentation: Inner
 PointerBindsToType: false
 SpacesBeforeTrailingComments: 2

--- a/cmake/FindMagicEnum.cmake
+++ b/cmake/FindMagicEnum.cmake
@@ -1,6 +1,6 @@
 include(FindPackageHandleStandardArgs)
 
-find_path(MagicEnum_INCLUDE_DIR magic_enum.hpp HINTS ${CMAKE_SOURCE_DIR}/lib/magic_enum/include)
+find_path(MagicEnum_INCLUDE_DIR magic_enum/magic_enum.hpp HINTS ${CMAKE_SOURCE_DIR}/lib/magic_enum/include)
 
 find_package_handle_standard_args(MagicEnum DEFAULT_MSG MagicEnum_INCLUDE_DIR)
 

--- a/mocks/.clang-format
+++ b/mocks/.clang-format
@@ -32,9 +32,6 @@ IncludeCategories:
   # Project includes
   - Regex: '^"[a-zA-Z\._-]+(/[a-zA-Z0-9\._-]+)*"$'
     Priority: 1
-  # Third party library includes
-  - Regex: '<[[:alnum:].]+/[a-zA-Z0-9\._\/-]+>'
-    Priority: 3
   # Qt includes
   - Regex: '^<Q[a-zA-Z0-9\._\/-]+>$'
     Priority: 3
@@ -42,12 +39,12 @@ IncludeCategories:
   # LibCommuni includes
   - Regex: "^<Irc[a-zA-Z]+>$"
     Priority: 3
-  # Misc libraries
-  - Regex: '^<[a-zA-Z_0-9]+\.h(pp)?>$'
-    Priority: 3
   # Standard library includes
   - Regex: "^<[a-zA-Z_]+>$"
     Priority: 4
+  # Third party library includes
+  - Regex: "^<([a-zA-Z_0-9-]+/)*[a-zA-Z_0-9-]+.h(pp)?>$"
+    Priority: 3
 NamespaceIndentation: Inner
 PointerBindsToType: false
 SpacesBeforeTrailingComments: 2

--- a/src/.clang-format
+++ b/src/.clang-format
@@ -32,9 +32,6 @@ IncludeCategories:
   # Project includes
   - Regex: '^"[a-zA-Z\._-]+(/[a-zA-Z0-9\._-]+)*"$'
     Priority: 1
-  # Third party library includes
-  - Regex: '<[[:alnum:].]+/[a-zA-Z0-9\._\/-]+>'
-    Priority: 3
   # Qt includes
   - Regex: '^<Q[a-zA-Z0-9\._\/-]+>$'
     Priority: 3
@@ -42,12 +39,12 @@ IncludeCategories:
   # LibCommuni includes
   - Regex: "^<Irc[a-zA-Z]+>$"
     Priority: 3
-  # Misc libraries
-  - Regex: '^<[a-zA-Z_0-9]+\.h(pp)?>$'
-    Priority: 3
   # Standard library includes
   - Regex: "^<[a-zA-Z_]+>$"
     Priority: 4
+  # Third party library includes
+  - Regex: "^<([a-zA-Z_0-9-]+/)*[a-zA-Z_0-9-]+.h(pp)?>$"
+    Priority: 3
 NamespaceIndentation: Inner
 PointerBindsToType: false
 SpacesBeforeTrailingComments: 2

--- a/src/common/ChatterinoSetting.hpp
+++ b/src/common/ChatterinoSetting.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 #include <pajlada/settings.hpp>
 #include <QString>
 

--- a/src/controllers/plugins/LuaUtilities.hpp
+++ b/src/controllers/plugins/LuaUtilities.hpp
@@ -4,7 +4,7 @@
 
 #    include <lua.h>
 #    include <lualib.h>
-#    include <magic_enum.hpp>
+#    include <magic_enum/magic_enum.hpp>
 #    include <QList>
 
 #    include <string>

--- a/src/controllers/plugins/Plugin.cpp
+++ b/src/controllers/plugins/Plugin.cpp
@@ -4,7 +4,7 @@
 #    include "controllers/commands/CommandController.hpp"
 
 #    include <lua.h>
-#    include <magic_enum.hpp>
+#    include <magic_enum/magic_enum.hpp>
 #    include <QJsonArray>
 #    include <QJsonObject>
 

--- a/src/providers/seventv/SeventvCosmetics.hpp
+++ b/src/providers/seventv/SeventvCosmetics.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 namespace chatterino::seventv {
 

--- a/src/providers/seventv/eventapi/Message.hpp
+++ b/src/providers/seventv/eventapi/Message.hpp
@@ -2,7 +2,7 @@
 
 #include "providers/seventv/eventapi/Subscription.hpp"
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QString>

--- a/src/providers/seventv/eventapi/Subscription.hpp
+++ b/src/providers/seventv/eventapi/Subscription.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 #include <QByteArray>
 #include <QHash>
 #include <QJsonObject>

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -6,7 +6,7 @@
 #include "common/QLogging.hpp"
 #include "util/CancellationToken.hpp"
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 #include <QJsonDocument>
 
 namespace {

--- a/src/providers/twitch/pubsubmessages/AutoMod.hpp
+++ b/src/providers/twitch/pubsubmessages/AutoMod.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 #include <QColor>
 #include <QJsonObject>
 #include <QString>

--- a/src/providers/twitch/pubsubmessages/Base.hpp
+++ b/src/providers/twitch/pubsubmessages/Base.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QString>

--- a/src/providers/twitch/pubsubmessages/ChannelPoints.hpp
+++ b/src/providers/twitch/pubsubmessages/ChannelPoints.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 #include <QJsonObject>
 #include <QString>
 

--- a/src/providers/twitch/pubsubmessages/ChatModeratorAction.hpp
+++ b/src/providers/twitch/pubsubmessages/ChatModeratorAction.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 #include <QJsonObject>
 #include <QString>
 

--- a/src/providers/twitch/pubsubmessages/Whisper.hpp
+++ b/src/providers/twitch/pubsubmessages/Whisper.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 #include <QColor>
 #include <QJsonObject>
 #include <QString>

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -21,7 +21,7 @@
 #include "widgets/settingspages/GeneralPageView.hpp"
 #include "widgets/splits/SplitInput.hpp"
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 #include <QDesktopServices>
 #include <QFileDialog>
 #include <QFontDialog>

--- a/tests/.clang-format
+++ b/tests/.clang-format
@@ -32,9 +32,6 @@ IncludeCategories:
   # Project includes
   - Regex: '^"[a-zA-Z\._-]+(/[a-zA-Z0-9\._-]+)*"$'
     Priority: 1
-  # Third party library includes
-  - Regex: '<[[:alnum:].]+/[a-zA-Z0-9\._\/-]+>'
-    Priority: 3
   # Qt includes
   - Regex: '^<Q[a-zA-Z0-9\._\/-]+>$'
     Priority: 3
@@ -42,12 +39,12 @@ IncludeCategories:
   # LibCommuni includes
   - Regex: "^<Irc[a-zA-Z]+>$"
     Priority: 3
-  # Misc libraries
-  - Regex: '^<[a-zA-Z_0-9]+\.h(pp)?>$'
-    Priority: 3
   # Standard library includes
   - Regex: "^<[a-zA-Z_]+>$"
     Priority: 4
+  # Third party library includes
+  - Regex: "^<([a-zA-Z_0-9-]+/)*[a-zA-Z_0-9-]+.h(pp)?>$"
+    Priority: 3
 NamespaceIndentation: Inner
 PointerBindsToType: false
 SpacesBeforeTrailingComments: 2


### PR DESCRIPTION
# Description

- Update `magic_enum` from v0.9.3 to v0.9.5
- Fix include path for magic enum
- Update .clang-format to ensure magic enum is caught as a third party library

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
