### PR TITLE
Move clang-tidy to its own CI job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,6 @@ jobs:
             plugins: false
             skip-artifact: false
             skip-crashpad: false
-            clang-tidy-review: false
           # Ubuntu 22.04, Qt 5.15
           - os: ubuntu-22.04
             qt-version: 5.15.2
@@ -45,7 +44,6 @@ jobs:
             plugins: false
             skip-artifact: false
             skip-crashpad: false
-            clang-tidy-review: true
           # Ubuntu 22.04, Qt 6.2.4 - tests LTO & plugins
           - os: ubuntu-22.04
             qt-version: 6.2.4
@@ -53,7 +51,6 @@ jobs:
             plugins: true
             skip-artifact: false
             skip-crashpad: false
-            clang-tidy-review: false
           # macOS
           - os: macos-latest
             qt-version: 5.15.2
@@ -61,7 +58,6 @@ jobs:
             plugins: false
             skip-artifact: false
             skip-crashpad: false
-            clang-tidy-review: false
           # Windows
           - os: windows-latest
             qt-version: 6.5.0
@@ -69,7 +65,6 @@ jobs:
             plugins: false
             skip-artifact: false
             skip-crashpad: false
-            clang-tidy-review: false
           # Windows 7/8
           - os: windows-latest
             qt-version: 5.15.2
@@ -77,7 +72,6 @@ jobs:
             plugins: false
             skip-artifact: false
             skip-crashpad: true
-            clang-tidy-review: false
 
       fail-fast: false
 
@@ -328,38 +322,6 @@ jobs:
             ..
           make -j"$(nproc)"
         shell: bash
-
-      - name: clang-tidy review
-        if: matrix.clang-tidy-review && github.event_name == 'pull_request'
-        timeout-minutes: 10
-        uses: ZedThree/clang-tidy-review@v0.14.0
-        with:
-          build_dir: build-clang-tidy
-          config_file: ".clang-tidy"
-          split_workflow: true
-          exclude: "lib/*"
-          cmake_command: >-
-            cmake -S. -Bbuild-clang-tidy 
-            -DCMAKE_BUILD_TYPE=Release 
-            -DPAJLADA_SETTINGS_USE_BOOST_FILESYSTEM=On 
-            -DUSE_PRECOMPILED_HEADERS=OFF 
-            -DCMAKE_EXPORT_COMPILE_COMMANDS=On 
-            -DCHATTERINO_LTO=Off 
-            -DCHATTERINO_PLUGINS=On 
-            -DBUILD_WITH_QT6=Off
-            -DBUILD_TESTS=On
-            -DBUILD_BENCHMARKS=On
-          apt_packages: >-
-            qttools5-dev, qt5-image-formats-plugins, libqt5svg5-dev, 
-            libsecret-1-dev,
-            libboost-dev, libboost-system-dev, libboost-filesystem-dev,
-            libssl-dev,
-            rapidjson-dev,
-            libbenchmark-dev
-
-      - name: clang-tidy-review upload
-        if: matrix.clang-tidy-review && github.event_name == 'pull_request'
-        uses: ZedThree/clang-tidy-review/upload@v0.14.0
 
       - name: Package - AppImage (Ubuntu)
         if: startsWith(matrix.os, 'ubuntu-20.04') && !matrix.skip-artifact

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,0 +1,148 @@
+---
+name: clang-tidy
+
+on:
+  pull_request:
+
+concurrency:
+  group: clang-tidy-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CHATTERINO_REQUIRE_CLEAN_GIT: On
+  C2_BUILD_WITH_QT6: Off
+
+jobs:
+  build:
+    name: "clang-tidy ${{ matrix.os }}, Qt ${{ matrix.qt-version }})"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          # Ubuntu 22.04, Qt 5.15
+          - os: ubuntu-22.04
+            qt-version: 5.15.2
+            plugins: false
+
+      fail-fast: false
+
+    steps:
+      - name: Enable plugin support
+        if: matrix.plugins
+        run: |
+          echo "C2_PLUGINS=ON" >> "$GITHUB_ENV"
+        shell: bash
+
+      - name: Set BUILD_WITH_QT6
+        if: startsWith(matrix.qt-version, '6.')
+        run: |
+          echo "C2_BUILD_WITH_QT6=ON" >> "$GITHUB_ENV"
+        shell: bash
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0 # allows for tags access
+
+      - name: Install Qt5
+        if: startsWith(matrix.qt-version, '5.')
+        uses: jurplel/install-qt-action@v3.3.0
+        with:
+          cache: true
+          cache-key-prefix: ${{ runner.os }}-QtCache-${{ matrix.qt-version }}-v2
+          version: ${{ matrix.qt-version }}
+
+      - name: Install Qt 6.5.3 imageformats
+        if: startsWith(matrix.qt-version, '6.')
+        uses: jurplel/install-qt-action@v3.3.0
+        with:
+          cache: false
+          modules: qtimageformats
+          set-env: false
+          version: 6.5.3
+          extra: --noarchives
+
+      - name: Install Qt6
+        if: startsWith(matrix.qt-version, '6.')
+        uses: jurplel/install-qt-action@v3.3.0
+        with:
+          cache: true
+          cache-key-prefix: ${{ runner.os }}-QtCache-${{ matrix.qt-version }}-v2
+          modules: qt5compat qtimageformats
+          version: ${{ matrix.qt-version }}
+
+      # LINUX
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install \
+              cmake \
+              virtualenv \
+              rapidjson-dev \
+              libfuse2 \
+              libssl-dev \
+              libboost-dev \
+              libxcb-randr0-dev \
+              libboost-system-dev \
+              libboost-filesystem-dev \
+              libpulse-dev \
+              libxkbcommon-x11-0 \
+              build-essential \
+              libgl1-mesa-dev \
+              libxcb-icccm4 \
+              libxcb-image0 \
+              libxcb-keysyms1 \
+              libxcb-render-util0 \
+              libxcb-xinerama0
+
+      - name: Apply Qt5 patches
+        if: startsWith(matrix.qt-version, '5.')
+        run: |
+          patch "$Qt5_DIR/include/QtConcurrent/qtconcurrentthreadengine.h" .patches/qt5-on-newer-gcc.patch
+        shell: bash
+
+      - name: Build
+        run: |
+          mkdir build
+          cd build
+          CXXFLAGS=-fno-sized-deallocation cmake \
+            -DCMAKE_INSTALL_PREFIX=appdir/usr/ \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DPAJLADA_SETTINGS_USE_BOOST_FILESYSTEM=On \
+            -DUSE_PRECOMPILED_HEADERS=OFF \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=On \
+            -DCHATTERINO_LTO="$C2_ENABLE_LTO" \
+            -DCHATTERINO_PLUGINS="$C2_PLUGINS" \
+            -DBUILD_WITH_QT6="$C2_BUILD_WITH_QT6" \
+            ..
+        shell: bash
+
+      - name: clang-tidy review
+        timeout-minutes: 20
+        uses: ZedThree/clang-tidy-review@v0.14.0
+        with:
+          build_dir: build-clang-tidy
+          config_file: ".clang-tidy"
+          split_workflow: true
+          exclude: "lib/*"
+          cmake_command: >-
+            cmake -S. -Bbuild-clang-tidy 
+            -DCMAKE_BUILD_TYPE=Release 
+            -DPAJLADA_SETTINGS_USE_BOOST_FILESYSTEM=On 
+            -DUSE_PRECOMPILED_HEADERS=OFF 
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=On 
+            -DCHATTERINO_LTO=Off 
+            -DCHATTERINO_PLUGINS=On 
+            -DBUILD_WITH_QT6=Off
+            -DBUILD_TESTS=On
+            -DBUILD_BENCHMARKS=On
+          apt_packages: >-
+            qttools5-dev, qt5-image-formats-plugins, libqt5svg5-dev, 
+            libsecret-1-dev,
+            libboost-dev, libboost-system-dev, libboost-filesystem-dev,
+            libssl-dev,
+            rapidjson-dev,
+            libbenchmark-dev
+
+      - name: clang-tidy-review upload
+        uses: ZedThree/clang-tidy-review/upload@v0.14.0

--- a/.github/workflows/post-clang-tidy-review.yml
+++ b/.github/workflows/post-clang-tidy-review.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Only when a build succeeds
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - uses: ZedThree/clang-tidy-review/post@v0.14.0

--- a/.github/workflows/post-clang-tidy-review.yml
+++ b/.github/workflows/post-clang-tidy-review.yml
@@ -3,7 +3,7 @@ name: Post clang-tidy review comments
 
 on:
   workflow_run:
-    workflows: ["Build"]
+    workflows: ["clang-tidy"]
     types:
       - completed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
 - Dev: `Details` file properties tab is now populated on Windows. (#4912)
 - Dev: Removed `Outcome` from network requests. (#4959)
 - Dev: Added Tests for Windows and MacOS in CI. (#4970)
+- Dev: Move `clang-tidy` checker to its own CI job. (#4996)
 - Dev: Refactored the Image Uploader feature. (#4971)
 - Dev: Fixed deadlock and use-after-free in tests. (#4981)
 


### PR DESCRIPTION
# Description

This gives a bit more flexibility in ignoring it, its timeout, and repeating failures

The implementaion is the same as before, it runs on the same platform, except:
 - timeout has been increased from 10m to 20m
 - the build doesn't work, only cmake is ran
