### PR TITLE
conan: Update Boost to 1.83 & OpenSSL to 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - Dev: Temporarily disable High DPI scaling on Qt6 builds on Windows. (#4767)
 - Dev: Tests now run on Ubuntu 22.04 instead of 20.04 to loosen C++ restrictions in tests. (#4774)
 - Dev: Do a pretty major refactor of the Settings classes. List settings (e.g. highlights) are most heavily modified, and should have an extra eye kept on them. (#4775)
+- Dev: conan: Update Boost to 1.83 & OpenSSL to 3.2.0. (#5007)
 - Dev: Remove `boost::noncopyable` use & `boost_random` dependency. (#4776)
 - Dev: Fix clang-tidy `cppcoreguidelines-pro-type-member-init` warnings. (#4426)
 - Dev: Immediate layout for invisible `ChannelView`s is skipped. (#4811)

--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from os import path
 
 class Chatterino(ConanFile):
     name = "Chatterino"
-    requires = "boost/1.81.0"
+    requires = "boost/1.83.0"
     settings = "os", "compiler", "build_type", "arch"
     default_options = {
         "with_benchmark": False,

--- a/conanfile.py
+++ b/conanfile.py
@@ -24,7 +24,7 @@ class Chatterino(ConanFile):
             self.requires("benchmark/1.7.1")
 
         if self.options.get_safe("with_openssl3", False):
-            self.requires("openssl/3.1.0")
+            self.requires("openssl/3.2.0")
         else:
             self.requires("openssl/1.1.1t")
 


### PR DESCRIPTION
# Description

These are used in the Windows build
