### PR TITLE
perf: Only update ChannelView for GIFs if visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@
 - Dev: Load less message history upon reconnects. (#5001)
 - Dev: BREAKING: Replace custom `import()` with normal Lua `require()`. (#5014)
 - Dev: Fixed most compiler warnings. (#5028)
+- Dev: Only update visible ChannelViews for GIF repaints. (#5033)
 
 ## 2.4.6
 

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -392,7 +392,10 @@ void ChannelView::initializeSignals()
 
     this->signalHolder_.managedConnect(getApp()->windows->gifRepaintRequested,
                                        [&] {
-                                           this->queueUpdate();
+                                           if (this->isVisible())
+                                           {
+                                               this->queueUpdate();
+                                           }
                                        });
 
     this->signalHolder_.managedConnect(


### PR DESCRIPTION
## Description

On every `gifRepaintRequested` invocation (e.g. every `GIFTimer` tick), we currently update *every* ChannelView, even those in tabs that aren't active. The number of repaints every 20ms scaled with the number of open tabs. 

This PR only calls `update` on a ChannelView if the ChannelView is visible.