### PR TITLE
fix: ReplyThreadPopup now requires a split as its parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - Bugfix: Fixed support for Windows 11 Snap layouts. (#4994)
 - Bugfix: Fixed some windows appearing between screens. (#4797)
 - Bugfix: Fixed a crash that could occur when using certain features in a Usercard after closing the split from which it was created. (#5034)
+- Bugfix: Fixed a crash that could occur when using certain features in a Reply popup after closing the split from which it was created. (#5036)
 - Bugfix: Fixed a bug on Wayland where tooltips would spawn as separate windows instead of behaving like tooltips. (#4998)
 - Bugfix: Fixes to section deletion in text input fields. (#5013)
 - Bugfix: Show user text input within watch streak notices. (#5029)

--- a/src/widgets/dialogs/ReplyThreadPopup.cpp
+++ b/src/widgets/dialogs/ReplyThreadPopup.cpp
@@ -24,11 +24,12 @@ const QString TEXT_TITLE("Reply Thread - @%1 in #%2");
 
 namespace chatterino {
 
-ReplyThreadPopup::ReplyThreadPopup(bool closeAutomatically, QWidget *parent,
-                                   Split *split)
-    : DraggablePopup(closeAutomatically, parent)
+ReplyThreadPopup::ReplyThreadPopup(bool closeAutomatically, Split *split)
+    : DraggablePopup(closeAutomatically, split)
     , split_(split)
 {
+    assert(split != nullptr);
+
     this->setWindowTitle(QStringLiteral("Reply Thread"));
 
     HotkeyController::HotkeyMap actions{

--- a/src/widgets/dialogs/ReplyThreadPopup.hpp
+++ b/src/widgets/dialogs/ReplyThreadPopup.hpp
@@ -20,7 +20,11 @@ class ReplyThreadPopup final : public DraggablePopup
     Q_OBJECT
 
 public:
-    ReplyThreadPopup(bool closeAutomatically, QWidget *parent, Split *split);
+    /**
+     * @param closeAutomatically Decides whether the popup should close when it loses focus
+     * @param split Will be used as the popup's parent. Must not be null
+     */
+    explicit ReplyThreadPopup(bool closeAutomatically, Split *split);
 
     void setThread(std::shared_ptr<MessageThread> thread);
     void giveFocus(Qt::FocusReason reason);

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -2917,10 +2917,8 @@ void ChannelView::showReplyThreadPopup(const MessagePtr &message)
         return;
     }
 
-    auto *popupParent =
-        static_cast<QWidget *>(&(getApp()->windows->getMainWindow()));
-    auto *popup = new ReplyThreadPopup(getSettings()->autoCloseThreadPopup,
-                                       popupParent, this->split_);
+    auto *popup =
+        new ReplyThreadPopup(getSettings()->autoCloseThreadPopup, this->split_);
 
     popup->setThread(message->replyThread);
 


### PR DESCRIPTION
# Description

Fixes the problem described in #4747 in a different way

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
