### PR TITLE
perf: Only update regions with animated elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,7 +99,7 @@
 - Dev: BREAKING: Replace custom `import()` with normal Lua `require()`. (#5014)
 - Dev: Fixed most compiler warnings. (#5028)
 - Dev: Added the ability to show `ChannelView`s without a `Split`. (#4747)
-- Dev: Channels without any animated elements on screen will skip updates from the GIF timer. (#5042)
+- Dev: Channels without any animated elements on screen will skip updates from the GIF timer. (#5042, #5043)
 
 ## 2.4.6
 

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -350,6 +350,10 @@ ChannelView::ChannelView(InternalCtor /*tag*/, QWidget *parent, Split *split,
     auto curve = QEasingCurve();
     curve.setCustomType(highlightEasingFunction);
     this->highlightAnimation_.setEasingCurve(curve);
+    QObject::connect(&this->highlightAnimation_,
+                     &QVariantAnimation::valueChanged, this, [this] {
+                         this->queueUpdate();
+                     });
 
     this->messageColors_.applyTheme(getTheme());
     this->messagePreferences_.connectSettings(getSettings(),

--- a/src/widgets/helper/ChannelView.hpp
+++ b/src/widgets/helper/ChannelView.hpp
@@ -275,7 +275,7 @@ private:
     bool lastMessageHasAlternateBackgroundReverse_ = true;
 
     /// Tracks the area of animated elements in the last full repaint.
-    /// If this is empty (QRect::isEmpty()), at least one animated element is shown.
+    /// If this is empty (QRect::isEmpty()), no animated element is shown.
     QRect animationArea_;
 
     bool pausable_ = false;

--- a/src/widgets/helper/ChannelView.hpp
+++ b/src/widgets/helper/ChannelView.hpp
@@ -96,6 +96,7 @@ public:
                          size_t messagesLimit = 1000);
 
     void queueUpdate();
+    void queueUpdate(const QRect &area);
     Scrollbar &getScrollBar();
 
     QString getSelectedText();
@@ -232,7 +233,7 @@ private:
     void updateScrollbar(const LimitedQueueSnapshot<MessageLayoutPtr> &messages,
                          bool causedByScrollbar, bool causedByShow);
 
-    void drawMessages(QPainter &painter);
+    void drawMessages(QPainter &painter, const QRect &area);
     void setSelection(const SelectionItem &start, const SelectionItem &end);
     void setSelection(const Selection &newSelection);
     void selectWholeMessage(MessageLayout *layout, int &messageIndex);
@@ -273,8 +274,9 @@ private:
     bool lastMessageHasAlternateBackground_ = false;
     bool lastMessageHasAlternateBackgroundReverse_ = true;
 
-    /// Tracks if this view has painted any animated element in the last #paintEvent().
-    bool anyAnimationShown_ = false;
+    /// Tracks the area of animated elements in the last full repaint.
+    /// If this is empty (QRect::isEmpty()), at least one animated element is shown.
+    QRect animationArea_;
 
     bool pausable_ = false;
     QTimer pauseTimer_;


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

Continuation of #5042.

This PR selectively updates the area in a channel-view that contains animated elements. The area of animated elements is calculated on every full repaint (see comment).

While testing, I noticed go-to-message not working, as it didn't update the widget (pretty sure this was broken if animated emotes were turned off).

You can flip the `#ifdef` to show the updated area.