### PR TITLE
fix: Add check for tall messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,7 +99,7 @@
 - Dev: BREAKING: Replace custom `import()` with normal Lua `require()`. (#5014)
 - Dev: Fixed most compiler warnings. (#5028)
 - Dev: Added the ability to show `ChannelView`s without a `Split`. (#4747)
-- Dev: Channels without any animated elements on screen will skip updates from the GIF timer. (#5042, #5043)
+- Dev: Channels without any animated elements on screen will skip updates from the GIF timer. (#5042, #5043, #5045)
 
 ## 2.4.6
 

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1501,7 +1501,9 @@ void ChannelView::drawMessages(QPainter &painter, const QRect &area)
             ctx.isLastReadMessage = false;
         }
 
-        if (areaContainsY(ctx.y) || areaContainsY(ctx.y + layout->getHeight()))
+        if (areaContainsY(ctx.y) ||
+            areaContainsY(ctx.y + layout->getHeight()) ||
+            (ctx.y < area.y() && layout->getHeight() > area.height()))
         {
             auto paintResult = layout->paint(ctx);
             if (paintResult.hasAnimatedElements)


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

Previously, only the bottom and the top were checked. This PR adds a check for tall messages (taller than the channel-view).

Fixes #5044.