### PR TITLE
fix: some buttons triggering when releasing mouse outside

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 - Bugfix: Fixed a bug on Wayland where tooltips would spawn as separate windows instead of behaving like tooltips. (#4998, #5040)
 - Bugfix: Fixes to section deletion in text input fields. (#5013)
 - Bugfix: Show user text input within watch streak notices. (#5029)
+- Bugfix: Fixed avatar in usercard and moderation button triggering when releasing the mouse outside their area. (#5052)
 - Dev: Run miniaudio in a separate thread, and simplify it to not manage the device ourselves. There's a chance the simplification is a bad idea. (#4978)
 - Dev: Change clang-format from v14 to v16. (#4929)
 - Dev: Fixed UTF16 encoding of `modes` file for the installer. (#4791)

--- a/src/widgets/helper/Button.cpp
+++ b/src/widgets/helper/Button.cpp
@@ -261,17 +261,26 @@ void Button::mousePressEvent(QMouseEvent *event)
 void Button::mouseReleaseEvent(QMouseEvent *event)
 {
     if (!this->enabled_)
+    {
         return;
+    }
+
+    bool isInside = this->rect().contains(event->pos());
 
     if (event->button() == Qt::LeftButton)
     {
         this->mouseDown_ = false;
 
-        if (this->rect().contains(event->pos()))
+        if (isInside)
+        {
             emit leftClicked();
+        }
     }
 
-    emit clicked(event->button());
+    if (isInside)
+    {
+        emit clicked(event->button());
+    }
 }
 
 void Button::mouseMoveEvent(QMouseEvent *event)


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

`Button::clicked` was emitted when the mouse was released outside the area of the button. This isn't expected. The avatar in usercards and the moderation button both used this. 