### PR TITLE
Allow customization of whisper colors in settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Minor: Updated the flatpakref link included with nightly builds to point to up-to-date flathub-beta builds. (#5008)
 - Minor: Add a new completion API for experimental plugins feature. (#5000)
 - Minor: Re-enabled _Restart on crash_ option on Windows. (#5012)
+- Minor: The whisper highlight color can now be configured through the settings. (#5053)
 - Bugfix: Fixed an issue where certain emojis did not send to Twitch chat correctly. (#4840)
 - Bugfix: Fixed capitalized channel names in log inclusion list not being logged. (#4848)
 - Bugfix: Trimmed custom streamlink paths on all platforms making sure you don't accidentally add spaces at the beginning or end of its path. (#4834)

--- a/src/controllers/highlights/HighlightModel.cpp
+++ b/src/controllers/highlights/HighlightModel.cpp
@@ -98,9 +98,8 @@ void HighlightModel::afterInit()
         QUrl(getSettings()->whisperHighlightSoundUrl.getValue());
     setFilePathItem(whisperRow[Column::SoundPath], whisperSound, false);
 
-    //    auto whisperColor = ColorProvider::instance().color(ColorType::Whisper);
-    //    setColorItem(whisperRow[Column::Color], *whisperColor, false);
-    whisperRow[Column::Color]->setFlags(Qt::ItemFlag::NoItemFlags);
+    auto whisperColor = ColorProvider::instance().color(ColorType::Whisper);
+    setColorItem(whisperRow[Column::Color], *whisperColor, false);
 
     this->insertCustomRow(whisperRow, HighlightRowIndexes::WhisperRow);
 
@@ -463,48 +462,47 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
             // Custom color
             if (role == Qt::DecorationRole)
             {
-                auto colorName = value.value<QColor>().name(QColor::HexArgb);
+                const auto setColor = [&](auto &setting, ColorType ty) {
+                    auto color = value.value<QColor>();
+                    setting.setValue(color.name(QColor::HexArgb));
+                    const_cast<ColorProvider &>(ColorProvider::instance())
+                        .updateColor(ty, color);
+                };
+
                 if (rowIndex == HighlightRowIndexes::SelfHighlightRow)
                 {
-                    getSettings()->selfHighlightColor.setValue(colorName);
+                    setColor(getSettings()->selfHighlightColor,
+                             ColorType::SelfHighlight);
                 }
-                //                else if (rowIndex == HighlightRowIndexes::WhisperRow)
-                //                {
-                //                    getSettings()->whisperHighlightColor.setValue(colorName);
-                //                }
+                else if (rowIndex == HighlightRowIndexes::WhisperRow)
+                {
+                    setColor(getSettings()->whisperHighlightColor,
+                             ColorType::Whisper);
+                }
                 else if (rowIndex == HighlightRowIndexes::SubRow)
                 {
-                    getSettings()->subHighlightColor.setValue(colorName);
+                    setColor(getSettings()->subHighlightColor,
+                             ColorType::Subscription);
                 }
                 else if (rowIndex == HighlightRowIndexes::RedeemedRow)
                 {
-                    getSettings()->redeemedHighlightColor.setValue(colorName);
-                    const_cast<ColorProvider &>(ColorProvider::instance())
-                        .updateColor(ColorType::RedeemedHighlight,
-                                     QColor(colorName));
+                    setColor(getSettings()->redeemedHighlightColor,
+                             ColorType::RedeemedHighlight);
                 }
                 else if (rowIndex == HighlightRowIndexes::FirstMessageRow)
                 {
-                    getSettings()->firstMessageHighlightColor.setValue(
-                        colorName);
-                    const_cast<ColorProvider &>(ColorProvider::instance())
-                        .updateColor(ColorType::FirstMessageHighlight,
-                                     QColor(colorName));
+                    setColor(getSettings()->firstMessageHighlightColor,
+                             ColorType::FirstMessageHighlight);
                 }
                 else if (rowIndex == HighlightRowIndexes::ElevatedMessageRow)
                 {
-                    getSettings()->elevatedMessageHighlightColor.setValue(
-                        colorName);
-                    const_cast<ColorProvider &>(ColorProvider::instance())
-                        .updateColor(ColorType::ElevatedMessageHighlight,
-                                     QColor(colorName));
+                    setColor(getSettings()->elevatedMessageHighlightColor,
+                             ColorType::ElevatedMessageHighlight);
                 }
                 else if (rowIndex == HighlightRowIndexes::ThreadMessageRow)
                 {
-                    getSettings()->threadHighlightColor.setValue(colorName);
-                    const_cast<ColorProvider &>(ColorProvider::instance())
-                        .updateColor(ColorType::ThreadMessageHighlight,
-                                     QColor(colorName));
+                    setColor(getSettings()->threadHighlightColor,
+                             ColorType::ThreadMessageHighlight);
                 }
             }
         }

--- a/src/widgets/settingspages/HighlightingPage.cpp
+++ b/src/widgets/settingspages/HighlightingPage.cpp
@@ -340,28 +340,6 @@ void HighlightingPage::openColorDialog(const QModelIndex &clicked,
         if (selected.isValid())
         {
             view->getModel()->setData(clicked, selected, Qt::DecorationRole);
-
-            if (tab == HighlightTab::Messages)
-            {
-                /*
-                 * For preset highlights in the "Messages" tab, we need to
-                 * manually update the color map.
-                 */
-                auto instance = ColorProvider::instance();
-                switch (clicked.row())
-                {
-                    case 0:
-                        instance.updateColor(ColorType::SelfHighlight,
-                                             selected);
-                        break;
-                    case 1:
-                        instance.updateColor(ColorType::Whisper, selected);
-                        break;
-                    case 2:
-                        instance.updateColor(ColorType::Subscription, selected);
-                        break;
-                }
-            }
         }
     });
 }


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

Whisper highlights could be configured by manually changing the setting. This PR adds the option to do this through the UI. #1922 mentioned some bug that I couldn't find.

Fixes #1922.