### PR TITLE
refactor: Logging (chat logger)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@
 - Dev: Refactor `Emoji`'s EmojiMap into a vector. (#4980)
 - Dev: Refactor `DebugCount` and add copy button to debug popup. (#4921)
 - Dev: Refactor `common/Credentials`. (#4979)
+- Dev: Refactor chat logger. (#5058)
 - Dev: Changed lifetime of context menus. (#4924)
 - Dev: Renamed `tools` directory to `scripts`. (#5035)
 - Dev: Refactor `ChannelView`, removing a bunch of clang-tidy warnings. (#4926)

--- a/mocks/include/mocks/EmptyApplication.hpp
+++ b/mocks/include/mocks/EmptyApplication.hpp
@@ -75,6 +75,12 @@ public:
         return nullptr;
     }
 
+    Logging *getChatLogger() override
+    {
+        assert(!"getChatLogger was called without being initialized");
+        return nullptr;
+    }
+
     ChatterinoBadges *getChatterinoBadges() override
     {
         return nullptr;

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -128,10 +128,10 @@ Application::Application(Settings &_settings, Paths &_paths, const Args &_args)
     , userData(&this->emplace<UserDataController>())
     , sound(&this->emplace<ISoundController>(makeSoundController(_settings)))
     , twitchLiveController(&this->emplace<TwitchLiveController>())
+    , logging(new Logging(_settings))
 #ifdef CHATTERINO_HAVE_PLUGINS
     , plugins(&this->emplace<PluginController>())
 #endif
-    , logging(new Logging(_settings))
 {
     Application::instance = this;
 

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -131,7 +131,7 @@ Application::Application(Settings &_settings, Paths &_paths, const Args &_args)
 #ifdef CHATTERINO_HAVE_PLUGINS
     , plugins(&this->emplace<PluginController>())
 #endif
-    , logging(&this->emplace<Logging>())
+    , logging(new Logging(_settings))
 {
     this->instance = this;
 
@@ -141,6 +141,8 @@ Application::Application(Settings &_settings, Paths &_paths, const Args &_args)
         this->windows->layoutChannelViews();
     });
 }
+
+Application::~Application() = default;
 
 void Application::initialize(Settings &settings, Paths &paths)
 {
@@ -310,6 +312,11 @@ ITwitchLiveController *Application::getTwitchLiveController()
 ITwitchIrcServer *Application::getTwitch()
 {
     return this->twitch;
+}
+
+Logging *Application::getChatLogger()
+{
+    return this->logging.get();
 }
 
 void Application::save()

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -133,7 +133,7 @@ Application::Application(Settings &_settings, Paths &_paths, const Args &_args)
 #endif
     , logging(new Logging(_settings))
 {
-    this->instance = this;
+    Application::instance = this;
 
     // We can safely ignore this signal's connection since the Application will always
     // be destroyed after fonts

--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -68,6 +68,7 @@ public:
     virtual HighlightController *getHighlights() = 0;
     virtual NotificationController *getNotifications() = 0;
     virtual ITwitchIrcServer *getTwitch() = 0;
+    virtual Logging *getChatLogger() = 0;
     virtual ChatterinoBadges *getChatterinoBadges() = 0;
     virtual FfzBadges *getFfzBadges() = 0;
     virtual SeventvBadges *getSeventvBadges() = 0;
@@ -89,6 +90,12 @@ public:
     static Application *instance;
 
     Application(Settings &_settings, Paths &_paths, const Args &_args);
+    ~Application() override;
+
+    Application(const Application &) = delete;
+    Application(Application &&) = delete;
+    Application &operator=(const Application &) = delete;
+    Application &operator=(Application &&) = delete;
 
     void initialize(Settings &settings, Paths &paths);
     void load();
@@ -121,13 +128,12 @@ public:
 
 private:
     TwitchLiveController *const twitchLiveController{};
+    const std::unique_ptr<Logging> logging;
 
 public:
 #ifdef CHATTERINO_HAVE_PLUGINS
     PluginController *const plugins{};
 #endif
-
-    /*[[deprecated]]*/ Logging *const logging{};
 
     const Args &getArgs() override
     {
@@ -175,6 +181,7 @@ public:
         return this->highlights;
     }
     ITwitchIrcServer *getTwitch() override;
+    Logging *getChatLogger() override;
     ChatterinoBadges *getChatterinoBadges() override
     {
         return this->chatterinoBadges;

--- a/src/common/Channel.cpp
+++ b/src/common/Channel.cpp
@@ -101,7 +101,8 @@ void Channel::addMessage(MessagePtr message,
         {
             channelPlatform = "twitch";
         }
-        app->logging->addMessage(this->name_, message, channelPlatform);
+        getIApp()->getChatLogger()->addMessage(this->name_, message,
+                                               channelPlatform);
     }
 
     if (this->messages_.pushBack(message, deleted))

--- a/src/singletons/Logging.cpp
+++ b/src/singletons/Logging.cpp
@@ -12,7 +12,7 @@
 
 namespace chatterino {
 
-void Logging::initialize(Settings &settings, Paths & /*paths*/)
+Logging::Logging(Settings &settings)
 {
     // We can safely ignore this signal connection since settings are only-ever destroyed
     // on application exit

--- a/src/singletons/Logging.hpp
+++ b/src/singletons/Logging.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "common/Singleton.hpp"
 #include "util/QStringHash.hpp"
 #include "util/ThreadGuard.hpp"
 
@@ -12,19 +11,15 @@
 
 namespace chatterino {
 
-class Paths;
+class Settings;
 struct Message;
 using MessagePtr = std::shared_ptr<const Message>;
 class LoggingChannel;
 
-class Logging : public Singleton
+class Logging
 {
-    Paths *pathManager = nullptr;
-
 public:
-    Logging() = default;
-
-    void initialize(Settings &settings, Paths &paths) override;
+    Logging(Settings &settings);
 
     void addMessage(const QString &channelName, MessagePtr message,
                     const QString &platformName);


### PR DESCRIPTION
It's no longer a singleton

It's now a `unique_ptr` that dies together with the Application

<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
