### PR TITLE
fix: Avoid unnecessary `NotebookTab` updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@
 - Dev: Refactor Args to be less of a singleton. (#5041)
 - Dev: Channels without any animated elements on screen will skip updates from the GIF timer. (#5042, #5043, #5045)
 - Dev: Autogenerate docs/plugin-meta.lua. (#5055)
+- Dev: Fix `NotebookTab` emitting updates for every message. (#5068)
 
 ## 2.4.6
 

--- a/src/widgets/helper/NotebookTab.cpp
+++ b/src/widgets/helper/NotebookTab.cpp
@@ -346,17 +346,25 @@ bool NotebookTab::isLive() const
 
 void NotebookTab::setHighlightState(HighlightState newHighlightStyle)
 {
-    if (this->isSelected() || (!this->highlightEnabled_ &&
-                               newHighlightStyle == HighlightState::NewMessage))
+    if (this->isSelected())
     {
         return;
     }
-    if (this->highlightState_ != HighlightState::Highlighted)
-    {
-        this->highlightState_ = newHighlightStyle;
 
-        this->update();
+    if (!this->highlightEnabled_ &&
+        newHighlightStyle == HighlightState::NewMessage)
+    {
+        return;
     }
+
+    if (this->highlightState_ == newHighlightStyle ||
+        this->highlightState_ == HighlightState::Highlighted)
+    {
+        return;
+    }
+
+    this->highlightState_ = newHighlightStyle;
+    this->update();
 }
 
 void NotebookTab::setHighlightsEnabled(const bool &newVal)

--- a/tests/src/NotebookTab.cpp
+++ b/tests/src/NotebookTab.cpp
@@ -91,8 +91,7 @@ TEST_F(NotebookTabFixture, UpgradeHighlightState)
 /// The highlight state must stay as NewMessage when called twice
 TEST_F(NotebookTabFixture, SameHighlightStateNewMessage)
 {
-    // XXX: This only updates the state once, so it should only update once
-    EXPECT_CALL(this->tab, update).Times(Exactly(2));
+    EXPECT_CALL(this->tab, update).Times(Exactly(1));
     EXPECT_EQ(this->tab.highlightState(), HighlightState::None);
     this->tab.setHighlightState(HighlightState::NewMessage);
     EXPECT_EQ(this->tab.highlightState(), HighlightState::NewMessage);


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

`NotebookTab::setHighlightState` wasn't checking if the state changed at all, causing an `update()` for (almost) every message sent (this would also cause some of the parents to repaint like `BaseWindow`).