### PR TITLE
fix: Avoid duplicate scale in settings dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@
 - Dev: Refactor Args to be less of a singleton. (#5041)
 - Dev: Channels without any animated elements on screen will skip updates from the GIF timer. (#5042, #5043, #5045)
 - Dev: Autogenerate docs/plugin-meta.lua. (#5055)
+- Dev: Removed duplicate scale in settings dialog. (#5069)
 
 ## 2.4.6
 

--- a/src/widgets/dialogs/SettingsDialog.cpp
+++ b/src/widgets/dialogs/SettingsDialog.cpp
@@ -52,7 +52,6 @@ SettingsDialog::SettingsDialog(QWidget *parent)
     this->initUi();
     this->addTabs();
     this->overrideBackgroundColor_ = QColor("#111111");
-    this->scaleChangedEvent(this->scale());  // execute twice to width of item
 
     this->addShortcuts();
     this->signalHolder_.managedConnect(getApp()->hotkeys->onItemsUpdated,
@@ -128,6 +127,8 @@ void SettingsDialog::initUi()
         .setLayoutType<QVBoxLayout>()
         .withoutMargin()
         .assign(&this->ui_.tabContainer);
+    this->ui_.tabContainerContainer->setFixedWidth(
+        static_cast<int>(150 * this->dpi_));
 
     // right side (pages)
     centerBox.emplace<QStackedLayout>()
@@ -257,6 +258,7 @@ void SettingsDialog::addTab(std::function<SettingsPage *()> page,
                             SettingsTabId id, Qt::Alignment alignment)
 {
     auto tab = new SettingsDialogTab(this, std::move(page), name, iconPath, id);
+    tab->setFixedHeight(static_cast<int>(30 * this->dpi_));
 
     this->ui_.tabContainer->addWidget(tab, 0, alignment);
     this->tabs_.push_back(tab);
@@ -390,7 +392,11 @@ void SettingsDialog::scaleChangedEvent(float newDpi)
     this->setStyleSheet(styleSheet);
 
     if (this->ui_.tabContainerContainer)
+    {
         this->ui_.tabContainerContainer->setFixedWidth(int(150 * newDpi));
+    }
+
+    this->dpi_ = newDpi;
 }
 
 void SettingsDialog::themeChangedEvent()

--- a/src/widgets/dialogs/SettingsDialog.hpp
+++ b/src/widgets/dialogs/SettingsDialog.hpp
@@ -77,6 +77,7 @@ private:
     std::vector<SettingsDialogTab *> tabs_;
     SettingsDialogTab *selectedTab_{};
     SettingsDialogTab *lastSelectedByUser_{};
+    float dpi_ = 1.0F;
 
     friend class SettingsDialogTab;
 };


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

Running the scale twice invalidated some of the layout. For me, this took about 800ms in debug mode. We can avoid this by setting the fixed widths and heights directly when the elements are created. It's still slow to open, but not as slow. Initializing the general page is the main issue. This takes about 1.1s for me in debug mode.