### PR TITLE
fix: button hover state-change not visible in some cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 - Bugfix: Show user text input within watch streak notices. (#5029)
 - Bugfix: Fixed avatar in usercard and moderation button triggering when releasing the mouse outside their area. (#5052)
 - Bugfix: Fixed moderator-only topics being subscribed to for non-moderators. (#5056)
+- Bugfix: Fixed a bug where buttons would remain in a hovered state after leaving them. (#5077)
 - Dev: Run miniaudio in a separate thread, and simplify it to not manage the device ourselves. There's a chance the simplification is a bad idea. (#4978)
 - Dev: Change clang-format from v14 to v16. (#4929)
 - Dev: Fixed UTF16 encoding of `modes` file for the installer. (#4791)

--- a/src/widgets/helper/Button.cpp
+++ b/src/widgets/helper/Button.cpp
@@ -222,12 +222,20 @@ void Button::enterEvent(QEnterEvent * /*event*/)
 void Button::enterEvent(QEvent * /*event*/)
 #endif
 {
-    this->mouseOver_ = true;
+    if (!this->mouseOver_)
+    {
+        this->mouseOver_ = true;
+        this->update();
+    }
 }
 
-void Button::leaveEvent(QEvent *)
+void Button::leaveEvent(QEvent * /*event*/)
 {
-    this->mouseOver_ = false;
+    if (this->mouseOver_)
+    {
+        this->mouseOver_ = false;
+        this->update();
+    }
 }
 
 void Button::mousePressEvent(QMouseEvent *event)


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

I noticed this for quite some time, but there doesn't seem to be an issue. If you hover really fast over some buttons, you'll see them remain in a hovered state:

https://github.com/Chatterino/chatterino2/assets/19953266/2c5f0c19-c83c-4e8d-822c-74a2c3e52006

This PR fixes that.

