### PR TITLE
fix: restore focus of last split when restoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 - Bugfix: Fixed avatar in usercard and moderation button triggering when releasing the mouse outside their area. (#5052)
 - Bugfix: Fixed moderator-only topics being subscribed to for non-moderators. (#5056)
 - Bugfix: Fixed a bug where buttons would remain in a hovered state after leaving them. (#5077)
+- Bugfix: Fixed splits not retaining their focus after minimizing. (#5080)
 - Dev: Run miniaudio in a separate thread, and simplify it to not manage the device ourselves. There's a chance the simplification is a bad idea. (#4978)
 - Dev: Change clang-format from v14 to v16. (#4929)
 - Dev: Fixed UTF16 encoding of `modes` file for the installer. (#4791)

--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -1332,13 +1332,19 @@ SplitNotebook::SplitNotebook(Window *parent)
         });
 }
 
-void SplitNotebook::showEvent(QShowEvent *)
+void SplitNotebook::showEvent(QShowEvent * /*event*/)
 {
-    if (auto page = this->getSelectedPage())
+    if (auto *page = this->getSelectedPage())
     {
-        if (auto split = page->findChild<Split *>())
+        auto *split = page->getSelectedSplit();
+        if (!split)
         {
-            split->setFocus(Qt::FocusReason::OtherFocusReason);
+            split = page->findChild<Split *>();
+        }
+
+        if (split)
+        {
+            split->setFocus(Qt::OtherFocusReason);
         }
     }
 }


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

Fixes #5015. Previously, the first `Split` inside the Notebook was focused. Now, if there is a selected split, this one is used, if not the behavior remains the same.