### PR TITLE
refactor: fix clang-tidy auto*, const&, and curly braces

### DIFF
--- a/scripts/check-clang-tidy.sh
+++ b/scripts/check-clang-tidy.sh
@@ -4,23 +4,9 @@ set -eu
 
 clang-tidy --version
 
-# clang-tidy --checks '-*,readability-braces-around-statements' src/RunGui.cpp
-while read -r file; do
-    echo "Running clang-tidy on $file"
-    clang-tidy --quiet "$@" "$file"
-done < <(find src/ -type f \( -iname "*.hpp" -o -iname "*.cpp" \))
-
-while read -r file; do
-    echo "Running clang-tidy on $file"
-    clang-tidy --quiet "$@" "$file"
-done < <(find tests/src/ -type f \( -iname "*.hpp" -o -iname "*.cpp" \))
-
-while read -r file; do
-    echo "Running clang-tidy on $file"
-    clang-tidy --quiet "$@" "$file"
-done < <(find benchmarks/src/ -type f \( -iname "*.hpp" -o -iname "*.cpp" \))
-
-while read -r file; do
-    echo "Running clang-tidy on $file"
-    clang-tidy --quiet "$@" "$file"
-done < <(find mocks/include/ -type f \( -iname "*.hpp" -o -iname "*.cpp" \))
+find \
+    src/ \
+    tests/src/ \
+    benchmarks/src/ \
+    mocks/include/ \
+    -type f \( -name "*.hpp" -o -name "*.cpp" \) -print0 | parallel -0 -j16 -I {} clang-tidy --quiet "$@" "{}"

--- a/scripts/check-clang-tidy.sh
+++ b/scripts/check-clang-tidy.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -eu
+
+clang-tidy --version
+
+# clang-tidy --checks '-*,readability-braces-around-statements' src/RunGui.cpp
+while read -r file; do
+    echo "Running clang-tidy on $file"
+    clang-tidy --quiet "$@" "$file"
+done < <(find src/ -type f \( -iname "*.hpp" -o -iname "*.cpp" \))
+
+while read -r file; do
+    echo "Running clang-tidy on $file"
+    clang-tidy --quiet "$@" "$file"
+done < <(find tests/src/ -type f \( -iname "*.hpp" -o -iname "*.cpp" \))
+
+while read -r file; do
+    echo "Running clang-tidy on $file"
+    clang-tidy --quiet "$@" "$file"
+done < <(find benchmarks/src/ -type f \( -iname "*.hpp" -o -iname "*.cpp" \))
+
+while read -r file; do
+    echo "Running clang-tidy on $file"
+    clang-tidy --quiet "$@" "$file"
+done < <(find mocks/include/ -type f \( -iname "*.hpp" -o -iname "*.cpp" \))

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -162,9 +162,9 @@ void Application::initialize(Settings &settings, Paths &paths)
         getSettings()->currentVersion.getValue() != "" &&
         getSettings()->currentVersion.getValue() != CHATTERINO_VERSION)
     {
-        auto box = new QMessageBox(QMessageBox::Information, "Chatterino 2",
-                                   "Show changelog?",
-                                   QMessageBox::Yes | QMessageBox::No);
+        auto *box = new QMessageBox(QMessageBox::Information, "Chatterino 2",
+                                    "Show changelog?",
+                                    QMessageBox::Yes | QMessageBox::No);
         box->setAttribute(Qt::WA_DeleteOnClose);
         if (box->exec() == QMessageBox::Yes)
         {
@@ -193,10 +193,10 @@ void Application::initialize(Settings &settings, Paths &paths)
 #ifndef Q_OS_WIN
     if (!this->args_.isFramelessEmbed && this->args_.crashRecovery)
     {
-        if (auto selected =
+        if (auto *selected =
                 this->windows->getMainWindow().getNotebook().getSelectedPage())
         {
-            if (auto container = dynamic_cast<SplitContainer *>(selected))
+            if (auto *container = dynamic_cast<SplitContainer *>(selected))
             {
                 for (auto &&split : container->getSplits())
                 {
@@ -459,7 +459,7 @@ void Application::initPubSub()
 
                 for (int i = snapshotLength - 1; i >= end; --i)
                 {
-                    auto &s = snapshot[i];
+                    const auto &s = snapshot[i];
                     if (!s->flags.has(MessageFlag::PubSub) &&
                         s->timeoutUser == msg->timeoutUser)
                     {
@@ -749,7 +749,7 @@ void Application::initPubSub()
             auto reward = ChannelPointReward(data);
 
             postToThread([chan, reward] {
-                if (auto channel = dynamic_cast<TwitchChannel *>(chan.get()))
+                if (auto *channel = dynamic_cast<TwitchChannel *>(chan.get()))
                 {
                     channel->addChannelPointReward(reward);
                 }

--- a/src/common/Args.cpp
+++ b/src/common/Args.cpp
@@ -198,7 +198,9 @@ void Args::applyCustomChannelLayout(const QString &argValue)
         for (const WindowDescriptor &window : configLayout.windows_)
         {
             if (window.type_ != WindowType::Main)
+            {
                 continue;
+            }
 
             return window.geometry_;
         }
@@ -212,7 +214,9 @@ void Args::applyCustomChannelLayout(const QString &argValue)
     for (const QString &channelArg : channelArgList)
     {
         if (channelArg.isEmpty())
+        {
             continue;
+        }
 
         // Twitch is default platform
         QString platform = "t";

--- a/src/common/Channel.cpp
+++ b/src/common/Channel.cpp
@@ -82,7 +82,7 @@ LimitedQueueSnapshot<MessagePtr> Channel::getMessageSnapshot()
 void Channel::addMessage(MessagePtr message,
                          std::optional<MessageFlags> overridingFlags)
 {
-    auto app = getApp();
+    auto *app = getApp();
     MessagePtr deleted;
 
     if (!overridingFlags || !overridingFlags->has(MessageFlag::DoNotLog))
@@ -135,7 +135,7 @@ void Channel::disableAllMessages()
     int snapshotLength = snapshot.size();
     for (int i = 0; i < snapshotLength; i++)
     {
-        auto &message = snapshot[i];
+        const auto &message = snapshot[i];
         if (message->flags.hasAny({MessageFlag::System, MessageFlag::Timeout,
                                    MessageFlag::Whisper}))
         {
@@ -179,7 +179,7 @@ void Channel::fillInMissingMessages(const std::vector<MessagePtr> &messages)
     existingMessageIds.reserve(snapshot.size());
 
     // First, collect the ids of every message already present in the channel
-    for (auto &msg : snapshot)
+    for (const auto &msg : snapshot)
     {
         if (msg->flags.has(MessageFlag::System) || msg->id.isEmpty())
         {
@@ -196,7 +196,7 @@ void Channel::fillInMissingMessages(const std::vector<MessagePtr> &messages)
     // being able to insert just-loaded historical messages at the end
     // in the correct place.
     auto lastMsg = snapshot[snapshot.size() - 1];
-    for (auto &msg : messages)
+    for (const auto &msg : messages)
     {
         // check if message already exists
         if (existingMessageIds.count(msg->id) != 0)
@@ -208,7 +208,7 @@ void Channel::fillInMissingMessages(const std::vector<MessagePtr> &messages)
         anyInserted = true;
 
         bool insertedFlag = false;
-        for (auto &snapshotMsg : snapshot)
+        for (const auto &snapshotMsg : snapshot)
         {
             if (snapshotMsg->flags.has(MessageFlag::System))
             {

--- a/src/common/ChatterSet.cpp
+++ b/src/common/ChatterSet.cpp
@@ -27,11 +27,15 @@ void ChatterSet::updateOnlineChatters(
     for (auto &&chatter : lowerCaseUsernames)
     {
         if (this->items.exists(chatter))
+        {
             tmp.put(chatter, this->items.get(chatter));
 
-        // Less chatters than the limit => try to preserve as many as possible.
+            // Less chatters than the limit => try to preserve as many as possible.
+        }
         else if (lowerCaseUsernames.size() < chatterLimit)
+        {
             tmp.put(chatter, chatter);
+        }
     }
 
     this->items = std::move(tmp);
@@ -50,7 +54,9 @@ std::vector<QString> ChatterSet::filterByPrefix(const QString &prefix) const
     for (auto &&item : this->items)
     {
         if (item.first.startsWith(lowerPrefix))
+        {
             result.push_back(item.second);
+        }
     }
 
     return result;

--- a/src/common/FlagsEnum.hpp
+++ b/src/common/FlagsEnum.hpp
@@ -56,9 +56,13 @@ public:
     void set(T flag, bool value)
     {
         if (value)
+        {
             this->set(flag);
+        }
         else
+        {
             this->unset(flag);
+        }
     }
 
     bool has(T flag) const

--- a/src/common/SignalVectorModel.hpp
+++ b/src/common/SignalVectorModel.hpp
@@ -308,10 +308,12 @@ public:
         for (auto &&x : list)
         {
             if (x.row() != list.first().row())
+            {
                 return nullptr;
+            }
         }
 
-        auto data = new QMimeData;
+        auto *data = new QMimeData;
         data->setData("chatterino_row_id", QByteArray::number(list[0].row()));
         return data;
     }

--- a/src/controllers/accounts/AccountController.cpp
+++ b/src/controllers/accounts/AccountController.cpp
@@ -22,7 +22,7 @@ AccountController::AccountController()
         this->twitch.accounts.itemRemoved.connect([this](const auto &args) {
             if (args.caller != this)
             {
-                auto &accs = this->twitch.accounts.raw();
+                const auto &accs = this->twitch.accounts.raw();
                 auto it = std::find(accs.begin(), accs.end(), args.item);
                 assert(it != accs.end());
 

--- a/src/controllers/commands/builtin/twitch/Shoutout.cpp
+++ b/src/controllers/commands/builtin/twitch/Shoutout.cpp
@@ -15,7 +15,7 @@ QString sendShoutout(const CommandContext &ctx)
 {
     auto *twitchChannel = ctx.twitchChannel;
     auto channel = ctx.channel;
-    auto words = &ctx.words;
+    const auto *words = &ctx.words;
 
     if (twitchChannel == nullptr)
     {

--- a/src/controllers/filters/FilterSet.cpp
+++ b/src/controllers/filters/FilterSet.cpp
@@ -19,7 +19,9 @@ FilterSet::FilterSet(const QList<QUuid> &filterIds)
     for (const auto &f : *filters)
     {
         if (filterIds.contains(f->getId()))
+        {
             this->filters_.insert(f->getId(), f);
+        }
     }
 
     this->listener_ =
@@ -36,13 +38,17 @@ FilterSet::~FilterSet()
 bool FilterSet::filter(const MessagePtr &m, ChannelPtr channel) const
 {
     if (this->filters_.size() == 0)
+    {
         return true;
+    }
 
     filters::ContextMap context = filters::buildContextMap(m, channel.get());
     for (const auto &f : this->filters_.values())
     {
         if (!f->valid() || !f->filter(context))
+        {
             return false;
+        }
     }
 
     return true;

--- a/src/controllers/filters/lang/Tokenizer.cpp
+++ b/src/controllers/filters/lang/Tokenizer.cpp
@@ -105,7 +105,9 @@ QString Tokenizer::current() const
 QString Tokenizer::preview() const
 {
     if (this->hasNext())
+    {
         return this->tokens_.at(this->i_);
+    }
     return "";
 }
 
@@ -172,51 +174,97 @@ const QStringList Tokenizer::allTokens()
 TokenType Tokenizer::tokenize(const QString &text)
 {
     if (text == "&&")
+    {
         return TokenType::AND;
+    }
     else if (text == "||")
+    {
         return TokenType::OR;
+    }
     else if (text == "(")
+    {
         return TokenType::LP;
+    }
     else if (text == ")")
+    {
         return TokenType::RP;
+    }
     else if (text == "{")
+    {
         return TokenType::LIST_START;
+    }
     else if (text == "}")
+    {
         return TokenType::LIST_END;
+    }
     else if (text == ",")
+    {
         return TokenType::COMMA;
+    }
     else if (text == "+")
+    {
         return TokenType::PLUS;
+    }
     else if (text == "-")
+    {
         return TokenType::MINUS;
+    }
     else if (text == "*")
+    {
         return TokenType::MULTIPLY;
+    }
     else if (text == "/")
+    {
         return TokenType::DIVIDE;
+    }
     else if (text == "==")
+    {
         return TokenType::EQ;
+    }
     else if (text == "!=")
+    {
         return TokenType::NEQ;
+    }
     else if (text == "%")
+    {
         return TokenType::MOD;
+    }
     else if (text == "<")
+    {
         return TokenType::LT;
+    }
     else if (text == ">")
+    {
         return TokenType::GT;
+    }
     else if (text == "<=")
+    {
         return TokenType::LTE;
+    }
     else if (text == ">=")
+    {
         return TokenType::GTE;
+    }
     else if (text == "contains")
+    {
         return TokenType::CONTAINS;
+    }
     else if (text == "startswith")
+    {
         return TokenType::STARTS_WITH;
+    }
     else if (text == "endswith")
+    {
         return TokenType::ENDS_WITH;
+    }
     else if (text == "match")
+    {
         return TokenType::MATCH;
+    }
     else if (text == "!")
+    {
         return TokenType::NOT;
+    }
     else
     {
         if ((text.startsWith("r\"") || text.startsWith("ri\"")) &&
@@ -226,14 +274,20 @@ TokenType Tokenizer::tokenize(const QString &text)
         }
 
         if (text.front() == '"' && text.back() == '"')
+        {
             return TokenType::STRING;
+        }
 
         if (validIdentifiersMap.keys().contains(text))
+        {
             return TokenType::IDENTIFIER;
+        }
 
         bool flag;
         if (text.toInt(&flag); flag)
+        {
             return TokenType::INT;
+        }
     }
 
     return TokenType::NONE;

--- a/src/controllers/filters/lang/expressions/BinaryOperation.cpp
+++ b/src/controllers/filters/lang/expressions/BinaryOperation.cpp
@@ -69,27 +69,39 @@ QVariant BinaryOperation::execute(const ContextMap &context) const
             return 0;
         case MINUS:
             if (convertVariantTypes(left, right, QMetaType::Int))
+            {
                 return left.toInt() - right.toInt();
+            }
             return 0;
         case MULTIPLY:
             if (convertVariantTypes(left, right, QMetaType::Int))
+            {
                 return left.toInt() * right.toInt();
+            }
             return 0;
         case DIVIDE:
             if (convertVariantTypes(left, right, QMetaType::Int))
+            {
                 return left.toInt() / right.toInt();
+            }
             return 0;
         case MOD:
             if (convertVariantTypes(left, right, QMetaType::Int))
+            {
                 return left.toInt() % right.toInt();
+            }
             return 0;
         case OR:
             if (convertVariantTypes(left, right, QMetaType::Bool))
+            {
                 return left.toBool() || right.toBool();
+            }
             return false;
         case AND:
             if (convertVariantTypes(left, right, QMetaType::Bool))
+            {
                 return left.toBool() && right.toBool();
+            }
             return false;
         case EQ:
             if (variantTypesMatch(left, right, QMetaType::QString))
@@ -107,19 +119,27 @@ QVariant BinaryOperation::execute(const ContextMap &context) const
             return !looselyCompareVariants(left, right);
         case LT:
             if (convertVariantTypes(left, right, QMetaType::Int))
+            {
                 return left.toInt() < right.toInt();
+            }
             return false;
         case GT:
             if (convertVariantTypes(left, right, QMetaType::Int))
+            {
                 return left.toInt() > right.toInt();
+            }
             return false;
         case LTE:
             if (convertVariantTypes(left, right, QMetaType::Int))
+            {
                 return left.toInt() <= right.toInt();
+            }
             return false;
         case GTE:
             if (convertVariantTypes(left, right, QMetaType::Int))
+            {
                 return left.toInt() >= right.toInt();
+            }
             return false;
         case CONTAINS:
             if (variantIs(left, QMetaType::QStringList) &&
@@ -215,22 +235,30 @@ QVariant BinaryOperation::execute(const ContextMap &context) const
 
                     // list must be two items
                     if (list.size() != 2)
+                    {
                         return false;
+                    }
 
                     // list must be a regular expression and an int
                     if (variantIsNot(list.at(0),
                                      QMetaType::QRegularExpression) ||
                         variantIsNot(list.at(1), QMetaType::Int))
+                    {
                         return false;
+                    }
 
                     auto match =
                         list.at(0).toRegularExpression().match(matching);
 
                     // if matched, return nth capture group. Otherwise, return ""
                     if (match.hasMatch())
+                    {
                         return match.captured(list.at(1).toInt());
+                    }
                     else
+                    {
                         return "";
+                    }
                 }
                 default:
                     return false;
@@ -263,9 +291,13 @@ PossibleType BinaryOperation::synthesizeType(const TypingContext &context) const
     {
         case PLUS:
             if (left == Type::String)
+            {
                 return TypeClass{Type::String};  // String concatenation
+            }
             else if (left == Type::Int && right == Type::Int)
+            {
                 return TypeClass{Type::Int};
+            }
 
             return IllTyped{this, "Can only add Ints or concatenate a String"};
         case MINUS:
@@ -273,13 +305,17 @@ PossibleType BinaryOperation::synthesizeType(const TypingContext &context) const
         case DIVIDE:
         case MOD:
             if (left == Type::Int && right == Type::Int)
+            {
                 return TypeClass{Type::Int};
+            }
 
             return IllTyped{this, "Can only perform operation with Ints"};
         case OR:
         case AND:
             if (left == Type::Bool && right == Type::Bool)
+            {
                 return TypeClass{Type::Bool};
+            }
 
             return IllTyped{this,
                             "Can only perform logical operations with Bools"};
@@ -292,37 +328,53 @@ PossibleType BinaryOperation::synthesizeType(const TypingContext &context) const
         case LTE:
         case GTE:
             if (left == Type::Int && right == Type::Int)
+            {
                 return TypeClass{Type::Bool};
+            }
 
             return IllTyped{this, "Can only perform comparisons with Ints"};
         case STARTS_WITH:
         case ENDS_WITH:
             if (isList(left))
+            {
                 return TypeClass{Type::Bool};
+            }
             if (left == Type::String && right == Type::String)
+            {
                 return TypeClass{Type::Bool};
+            }
 
             return IllTyped{
                 this,
                 "Can only perform starts/ends with a List or two Strings"};
         case CONTAINS:
             if (isList(left) || left == Type::Map)
+            {
                 return TypeClass{Type::Bool};
+            }
             if (left == Type::String && right == Type::String)
+            {
                 return TypeClass{Type::Bool};
+            }
 
             return IllTyped{
                 this,
                 "Can only perform contains with a List, a Map, or two Strings"};
         case MATCH: {
             if (left != Type::String)
+            {
                 return IllTyped{this,
                                 "Left argument of match must be a String"};
+            }
 
             if (right == Type::RegularExpression)
+            {
                 return TypeClass{Type::Bool};
-            if (right == Type::MatchingSpecifier)  // group capturing
+            }
+            if (right == Type::MatchingSpecifier)
+            {  // group capturing
                 return TypeClass{Type::String};
+            }
 
             return IllTyped{this, "Can only match on a RegularExpression or a "
                                   "MatchingSpecifier"};

--- a/src/controllers/highlights/HighlightBadge.hpp
+++ b/src/controllers/highlights/HighlightBadge.hpp
@@ -123,7 +123,9 @@ struct Deserialize<chatterino::HighlightBadge> {
 
         auto _color = QColor(encodedColor);
         if (!_color.isValid())
+        {
             _color = chatterino::HighlightBadge::FALLBACK_HIGHLIGHT_COLOR;
+        }
 
         return chatterino::HighlightBadge(_name, _displayName, _showInMentions,
                                           _hasAlert, _hasSound, _soundUrl,

--- a/src/controllers/highlights/HighlightPhrase.hpp
+++ b/src/controllers/highlights/HighlightPhrase.hpp
@@ -164,7 +164,9 @@ struct Deserialize<chatterino::HighlightPhrase> {
 
         auto _color = QColor(encodedColor);
         if (!_color.isValid())
+        {
             _color = chatterino::HighlightPhrase::FALLBACK_HIGHLIGHT_COLOR;
+        }
 
         return chatterino::HighlightPhrase(_pattern, _showInMentions, _hasAlert,
                                            _hasSound, _isRegex,

--- a/src/controllers/hotkeys/HotkeyController.cpp
+++ b/src/controllers/hotkeys/HotkeyController.cpp
@@ -66,7 +66,7 @@ std::vector<QShortcut *> HotkeyController::shortcutsForCategory(
             continue;
         }
         auto createShortcutFromKeySeq = [&](QKeySequence qs) {
-            auto s = new QShortcut(qs, parent);
+            auto *s = new QShortcut(qs, parent);
             s->setContext(hotkey->getContext());
             auto functionPointer = target->second;
             QObject::connect(s, &QShortcut::activated, parent,
@@ -101,7 +101,7 @@ void HotkeyController::save()
 
 std::shared_ptr<Hotkey> HotkeyController::getHotkeyByName(QString name)
 {
-    for (auto &hotkey : this->hotkeys_)
+    for (const auto &hotkey : this->hotkeys_)
     {
         if (hotkey->name() == name)
         {
@@ -115,7 +115,7 @@ int HotkeyController::replaceHotkey(QString oldName,
                                     std::shared_ptr<Hotkey> newHotkey)
 {
     int i = 0;
-    for (auto &hotkey : this->hotkeys_)
+    for (const auto &hotkey : this->hotkeys_)
     {
         if (hotkey->name() == oldName)
         {
@@ -544,7 +544,7 @@ void HotkeyController::tryAddDefault(std::set<QString> &addedHotkeys,
 void HotkeyController::showHotkeyError(const std::shared_ptr<Hotkey> &hotkey,
                                        QString warning)
 {
-    auto msgBox = new QMessageBox(
+    auto *msgBox = new QMessageBox(
         QMessageBox::Icon::Warning, "Hotkey error",
         QString(
             "There was an error while executing your hotkey named \"%1\": \n%2")

--- a/src/controllers/moderationactions/ModerationAction.cpp
+++ b/src/controllers/moderationactions/ModerationAction.cpp
@@ -143,11 +143,15 @@ const std::optional<ImagePtr> &ModerationAction::getImage() const
     if (this->imageToLoad_ != 0)
     {
         if (this->imageToLoad_ == 1)
+        {
             this->image_ =
                 Image::fromResourcePixmap(getResources().buttons.ban);
+        }
         else if (this->imageToLoad_ == 2)
+        {
             this->image_ =
                 Image::fromResourcePixmap(getResources().buttons.trashCan);
+        }
     }
 
     return this->image_;

--- a/src/controllers/notifications/NotificationController.cpp
+++ b/src/controllers/notifications/NotificationController.cpp
@@ -225,7 +225,7 @@ void NotificationController::removeFakeChannel(const QString channelName)
 
         for (int i = snapshotLength - 1; i >= end; --i)
         {
-            auto &s = snapshot[i];
+            const auto &s = snapshot[i];
 
             if (s->messageText == liveMessageSearchText)
             {

--- a/src/messages/Emote.cpp
+++ b/src/messages/Emote.cpp
@@ -20,7 +20,9 @@ EmotePtr cachedOrMakeEmotePtr(Emote &&emote, const EmoteMap &cache)
     // reuse old shared_ptr if nothing changed
     auto it = cache.find(emote.name);
     if (it != cache.end() && *it->second == emote)
+    {
         return it->second;
+    }
 
     return std::make_shared<Emote>(std::move(emote));
 }

--- a/src/messages/Image.cpp
+++ b/src/messages/Image.cpp
@@ -208,7 +208,9 @@ namespace detail {
                 // https://github.com/SevenTV/chatterino7/issues/46#issuecomment-1010595231
                 int duration = reader.nextImageDelay();
                 if (duration <= 10)
+                {
                     duration = 100;
+                }
                 duration = std::max(20, duration);
                 frames.push_back(Frame<QImage>{std::move(image), duration});
             }

--- a/src/messages/ImageSet.cpp
+++ b/src/messages/ImageSet.cpp
@@ -66,9 +66,13 @@ const std::shared_ptr<Image> &getImagePriv(const ImageSet &set, float scale)
     int quality = 1;
 
     if (scale > 2.001f)
+    {
         quality = 3;
+    }
     else if (scale > 1.001f)
+    {
         quality = 2;
+    }
 
     if (!set.getImage3()->isEmpty() && quality == 3)
     {
@@ -92,17 +96,27 @@ const ImagePtr &ImageSet::getImageOrLoaded(float scale) const
 
     // prefer other image if selected image is not loaded yet
     if (result->loaded())
+    {
         return result;
+    }
     else if (this->imageX3_ && !this->imageX3_->isEmpty() &&
              this->imageX3_->loaded())
+    {
         return this->imageX3_;
+    }
     else if (this->imageX2_ && !this->imageX2_->isEmpty() &&
              this->imageX2_->loaded())
+    {
         return this->imageX2_;
+    }
     else if (this->imageX1_->loaded())
+    {
         return this->imageX1_;
+    }
     else
+    {
         return result;
+    }
 }
 
 const ImagePtr &ImageSet::getImage(float scale) const

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -637,11 +637,11 @@ void MessageBuilder::addLink(const ParsedLink &parsedLink)
     auto linkElement = Link(Link::Url, matchedLink);
 
     auto textColor = MessageColor(MessageColor::Link);
-    auto linkMELowercase =
+    auto *linkMELowercase =
         this->emplace<TextElement>(lowercaseLinkString,
                                    MessageElementFlag::LowercaseLink, textColor)
             ->setLink(linkElement);
-    auto linkMEOriginal =
+    auto *linkMEOriginal =
         this->emplace<TextElement>(origLink, MessageElementFlag::OriginalLink,
                                    textColor)
             ->setLink(linkElement);

--- a/src/messages/MessageElement.cpp
+++ b/src/messages/MessageElement.cpp
@@ -212,7 +212,9 @@ void EmoteElement::addToContainer(MessageLayoutContainer &container,
             auto image =
                 this->emote_->images.getImageOrLoaded(container.getScale());
             if (image->isEmpty())
+            {
                 return;
+            }
 
             auto emoteScale = getSettings()->emoteScale.getValue();
 
@@ -420,7 +422,9 @@ void BadgeElement::addToContainer(MessageLayoutContainer &container,
         auto image =
             this->emote_->images.getImageOrLoaded(container.getScale());
         if (image->isEmpty())
+        {
             return;
+        }
 
         auto size = QSize(int(container.getScale() * image->width()),
                           int(container.getScale() * image->height()));
@@ -437,7 +441,7 @@ EmotePtr BadgeElement::getEmote() const
 MessageLayoutElement *BadgeElement::makeImageLayoutElement(
     const ImagePtr &image, const QSize &size)
 {
-    auto element =
+    auto *element =
         (new ImageLayoutElement(*this, image, size))->setLink(this->getLink());
 
     return element;
@@ -455,9 +459,9 @@ MessageLayoutElement *ModBadgeElement::makeImageLayoutElement(
 {
     static const QColor modBadgeBackgroundColor("#34AE0A");
 
-    auto element = (new ImageWithBackgroundLayoutElement(
-                        *this, image, size, modBadgeBackgroundColor))
-                       ->setLink(this->getLink());
+    auto *element = (new ImageWithBackgroundLayoutElement(
+                         *this, image, size, modBadgeBackgroundColor))
+                        ->setLink(this->getLink());
 
     return element;
 }
@@ -472,7 +476,7 @@ VipBadgeElement::VipBadgeElement(const EmotePtr &data,
 MessageLayoutElement *VipBadgeElement::makeImageLayoutElement(
     const ImagePtr &image, const QSize &size)
 {
-    auto element =
+    auto *element =
         (new ImageLayoutElement(*this, image, size))->setLink(this->getLink());
 
     return element;
@@ -489,7 +493,7 @@ FfzBadgeElement::FfzBadgeElement(const EmotePtr &data,
 MessageLayoutElement *FfzBadgeElement::makeImageLayoutElement(
     const ImagePtr &image, const QSize &size)
 {
-    auto element =
+    auto *element =
         (new ImageWithBackgroundLayoutElement(*this, image, size, this->color))
             ->setLink(this->getLink());
 
@@ -513,7 +517,7 @@ TextElement::TextElement(const QString &text, MessageElementFlags flags,
 void TextElement::addToContainer(MessageLayoutContainer &container,
                                  MessageElementFlags flags)
 {
-    auto app = getApp();
+    auto *app = getApp();
 
     if (flags.hasAny(this->getFlags()))
     {
@@ -527,10 +531,10 @@ void TextElement::addToContainer(MessageLayoutContainer &container,
                 auto color = this->color_.getColor(*app->themes);
                 app->themes->normalizeColor(color);
 
-                auto e = (new TextLayoutElement(
-                              *this, text, QSize(width, metrics.height()),
-                              color, this->style_, container.getScale()))
-                             ->setLink(this->getLink());
+                auto *e = (new TextLayoutElement(
+                               *this, text, QSize(width, metrics.height()),
+                               color, this->style_, container.getScale()))
+                              ->setLink(this->getLink());
                 e->setTrailingSpace(hasTrailingSpace);
                 e->setText(text);
 
@@ -596,14 +600,18 @@ void TextElement::addToContainer(MessageLayoutContainer &container,
                     width = charWidth;
 
                     if (isSurrogate)
+                    {
                         i++;
+                    }
                     continue;
                 }
 
                 width += charWidth;
 
                 if (isSurrogate)
+                {
                     i++;
+                }
             }
             //add the final piece of wrapped text
             container.addElementNoLineBreak(getTextLayoutElement(
@@ -629,7 +637,7 @@ SingleLineTextElement::SingleLineTextElement(const QString &text,
 void SingleLineTextElement::addToContainer(MessageLayoutContainer &container,
                                            MessageElementFlags flags)
 {
-    auto app = getApp();
+    auto *app = getApp();
 
     if (flags.hasAny(this->getFlags()))
     {
@@ -641,10 +649,10 @@ void SingleLineTextElement::addToContainer(MessageLayoutContainer &container,
             auto color = this->color_.getColor(*app->themes);
             app->themes->normalizeColor(color);
 
-            auto e = (new TextLayoutElement(
-                          *this, text, QSize(width, metrics.height()), color,
-                          this->style_, container.getScale()))
-                         ->setLink(this->getLink());
+            auto *e = (new TextLayoutElement(
+                           *this, text, QSize(width, metrics.height()), color,
+                           this->style_, container.getScale()))
+                          ->setLink(this->getLink());
             e->setTrailingSpace(hasTrailingSpace);
             e->setText(text);
 
@@ -837,7 +845,9 @@ void ScalingImageElement::addToContainer(MessageLayoutContainer &container,
         const auto &image =
             this->images_.getImageOrLoaded(container.getScale());
         if (image->isEmpty())
+        {
             return;
+        }
 
         auto size = QSize(image->width() * container.getScale(),
                           image->height() * container.getScale());

--- a/src/messages/layouts/MessageLayout.cpp
+++ b/src/messages/layouts/MessageLayout.cpp
@@ -78,7 +78,7 @@ bool MessageLayout::layout(int width, float scale, MessageElementFlags flags)
 {
     //    BenchmarkGuard benchmark("MessageLayout::layout()");
 
-    auto app = getApp();
+    auto *app = getApp();
 
     bool layoutRequired = false;
 

--- a/src/messages/layouts/MessageLayoutElement.cpp
+++ b/src/messages/layouts/MessageLayoutElement.cpp
@@ -433,7 +433,7 @@ size_t TextLayoutElement::getSelectionIndexCount() const
 void TextLayoutElement::paint(QPainter &painter,
                               const MessageColors & /*messageColors*/)
 {
-    auto app = getApp();
+    auto *app = getApp();
     QString text = this->getText();
     if (text.isRightToLeft() || this->reversedNeutral)
     {
@@ -461,7 +461,7 @@ int TextLayoutElement::getMouseOverIndex(const QPoint &abs) const
         return 0;
     }
 
-    auto app = getApp();
+    auto *app = getApp();
 
     auto metrics = app->fonts->getFontMetrics(this->style_, this->scale_);
     auto x = this->getRect().left();
@@ -495,7 +495,7 @@ int TextLayoutElement::getMouseOverIndex(const QPoint &abs) const
 
 int TextLayoutElement::getXFromIndex(size_t index)
 {
-    auto app = getApp();
+    auto *app = getApp();
 
     QFontMetrics metrics =
         app->fonts->getFontMetrics(this->style_, this->scale_);

--- a/src/providers/irc/AbstractIrcServer.cpp
+++ b/src/providers/irc/AbstractIrcServer.cpp
@@ -391,7 +391,7 @@ QString AbstractIrcServer::cleanChannelName(const QString &dirtyChannelName)
 
 void AbstractIrcServer::addFakeMessage(const QString &data)
 {
-    auto fakeMessage = Communi::IrcMessage::fromData(
+    auto *fakeMessage = Communi::IrcMessage::fromData(
         data.toUtf8(), this->readConnection_.get());
 
     if (fakeMessage->command() == "PRIVMSG")

--- a/src/providers/irc/Irc2.cpp
+++ b/src/providers/irc/Irc2.cpp
@@ -104,10 +104,16 @@ Irc::Irc()
 
             // set server of abandoned channels
             for (auto weak : ab->second)
+            {
                 if (auto shared = weak.lock())
-                    if (auto ircChannel =
+                {
+                    if (auto *ircChannel =
                             dynamic_cast<IrcChannel *>(shared.get()))
+                    {
                         ircChannel->setServer(server.get());
+                    }
+                }
+            }
 
             // add new server with abandoned channels
             this->servers_.emplace(args.item.id, std::move(server));
@@ -132,10 +138,16 @@ Irc::Irc()
 
             // set server of abandoned servers to nullptr
             for (auto weak : abandoned)
+            {
                 if (auto shared = weak.lock())
-                    if (auto ircChannel =
+                {
+                    if (auto *ircChannel =
                             dynamic_cast<IrcChannel *>(shared.get()))
+                    {
                         ircChannel->setServer(nullptr);
+                    }
+                }
+            }
 
             this->abandonedChannels_[args.item.id] = abandoned;
             this->servers_.erase(server);
@@ -156,7 +168,7 @@ Irc::Irc()
 
 QAbstractTableModel *Irc::newConnectionModel(QObject *parent)
 {
-    auto model = new Model(parent);
+    auto *model = new Model(parent);
     model->initialize(&this->connections);
     return model;
 }
@@ -234,7 +246,9 @@ void Irc::save()
 void Irc::load()
 {
     if (this->loaded_)
+    {
         return;
+    }
     this->loaded_ = true;
 
     QString config = configPath();

--- a/src/providers/irc/IrcChannel2.cpp
+++ b/src/providers/irc/IrcChannel2.cpp
@@ -100,7 +100,9 @@ bool IrcChannel::canReconnect() const
 void IrcChannel::reconnect()
 {
     if (this->server())
+    {
         this->server()->connect();
+    }
 }
 
 }  // namespace chatterino

--- a/src/providers/irc/IrcServer.cpp
+++ b/src/providers/irc/IrcServer.cpp
@@ -261,7 +261,7 @@ void IrcServer::readConnectionMessageReceived(Communi::IrcMessage *message)
     switch (message->type())
     {
         case Communi::IrcMessage::Join: {
-            auto x = static_cast<Communi::IrcJoinMessage *>(message);
+            auto *x = static_cast<Communi::IrcJoinMessage *>(message);
 
             if (auto it = this->channels.find(x->channel());
                 it != this->channels.end())
@@ -274,9 +274,11 @@ void IrcServer::readConnectionMessageReceived(Communi::IrcMessage *message)
                     }
                     else
                     {
-                        if (auto c =
+                        if (auto *c =
                                 dynamic_cast<ChannelChatters *>(shared.get()))
+                        {
                             c->addJoinedUser(x->nick());
+                        }
                     }
                 }
             }
@@ -284,7 +286,7 @@ void IrcServer::readConnectionMessageReceived(Communi::IrcMessage *message)
         }
 
         case Communi::IrcMessage::Part: {
-            auto x = static_cast<Communi::IrcPartMessage *>(message);
+            auto *x = static_cast<Communi::IrcPartMessage *>(message);
 
             if (auto it = this->channels.find(x->channel());
                 it != this->channels.end())
@@ -297,9 +299,11 @@ void IrcServer::readConnectionMessageReceived(Communi::IrcMessage *message)
                     }
                     else
                     {
-                        if (auto c =
+                        if (auto *c =
                                 dynamic_cast<ChannelChatters *>(shared.get()))
+                        {
                             c->addPartedUser(x->nick());
+                        }
                     }
                 }
             }
@@ -327,7 +331,9 @@ void IrcServer::readConnectionMessageReceived(Communi::IrcMessage *message)
                 for (auto &&weak : this->channels)
                 {
                     if (auto shared = weak.lock())
+                    {
                         shared->addMessage(msg);
+                    }
                 }
             };
     }

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -442,7 +442,9 @@ std::optional<ChannelPointReward> TwitchChannel::channelPointReward(
     auto it = rewards->find(rewardId);
 
     if (it == rewards->end())
+    {
         return std::nullopt;
+    }
     return it->second;
 }
 
@@ -572,7 +574,7 @@ void TwitchChannel::roomIdChanged()
 
 QString TwitchChannel::prepareMessage(const QString &message) const
 {
-    auto app = getApp();
+    auto *app = getApp();
     QString parsedMessage = app->emotes->emojis.replaceShortCodes(message);
 
     parsedMessage = parsedMessage.simplified();
@@ -618,7 +620,7 @@ QString TwitchChannel::prepareMessage(const QString &message) const
 
 void TwitchChannel::sendMessage(const QString &message)
 {
-    auto app = getApp();
+    auto *app = getApp();
     if (!app->accounts->twitch.isLoggedIn())
     {
         if (!message.isEmpty())
@@ -652,7 +654,7 @@ void TwitchChannel::sendMessage(const QString &message)
 
 void TwitchChannel::sendReply(const QString &message, const QString &replyId)
 {
-    auto app = getApp();
+    auto *app = getApp();
     if (!app->accounts->twitch.isLoggedIn())
     {
         if (!message.isEmpty())
@@ -803,7 +805,9 @@ std::optional<EmotePtr> TwitchChannel::bttvEmote(const EmoteName &name) const
     auto it = emotes->find(name);
 
     if (it == emotes->end())
+    {
         return std::nullopt;
+    }
     return it->second;
 }
 
@@ -813,7 +817,9 @@ std::optional<EmotePtr> TwitchChannel::ffzEmote(const EmoteName &name) const
     auto it = emotes->find(name);
 
     if (it == emotes->end())
+    {
         return std::nullopt;
+    }
     return it->second;
 }
 
@@ -1181,11 +1187,15 @@ void TwitchChannel::loadRecentMessages()
         [weak](const auto &messages) {
             auto shared = weak.lock();
             if (!shared)
+            {
                 return;
+            }
 
-            auto tc = dynamic_cast<TwitchChannel *>(shared.get());
+            auto *tc = dynamic_cast<TwitchChannel *>(shared.get());
             if (!tc)
+            {
                 return;
+            }
 
             tc->addMessagesAtStart(messages);
             tc->loadingRecentMessages_.clear();
@@ -1208,11 +1218,15 @@ void TwitchChannel::loadRecentMessages()
         [weak]() {
             auto shared = weak.lock();
             if (!shared)
+            {
                 return;
+            }
 
-            auto tc = dynamic_cast<TwitchChannel *>(shared.get());
+            auto *tc = dynamic_cast<TwitchChannel *>(shared.get());
             if (!tc)
+            {
                 return;
+            }
 
             tc->loadingRecentMessages_.clear();
         },
@@ -1253,11 +1267,15 @@ void TwitchChannel::loadRecentMessagesReconnect()
         [weak](const auto &messages) {
             auto shared = weak.lock();
             if (!shared)
+            {
                 return;
+            }
 
-            auto tc = dynamic_cast<TwitchChannel *>(shared.get());
+            auto *tc = dynamic_cast<TwitchChannel *>(shared.get());
             if (!tc)
+            {
                 return;
+            }
 
             tc->fillInMissingMessages(messages);
             tc->loadingRecentMessages_.clear();
@@ -1265,11 +1283,15 @@ void TwitchChannel::loadRecentMessagesReconnect()
         [weak]() {
             auto shared = weak.lock();
             if (!shared)
+            {
                 return;
+            }
 
-            auto tc = dynamic_cast<TwitchChannel *>(shared.get());
+            auto *tc = dynamic_cast<TwitchChannel *>(shared.get());
             if (!tc)
+            {
                 return;
+            }
 
             tc->loadingRecentMessages_.clear();
         },

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -395,11 +395,15 @@ std::shared_ptr<Channel> TwitchIrcServer::getChannelOrEmptyByID(
     {
         auto channel = weakChannel.lock();
         if (!channel)
+        {
             continue;
+        }
 
         auto twitchChannel = std::dynamic_pointer_cast<TwitchChannel>(channel);
         if (!twitchChannel)
+        {
             continue;
+        }
 
         if (twitchChannel->roomId() == channelId &&
             twitchChannel->getName().count(':') < 2)
@@ -414,9 +418,13 @@ std::shared_ptr<Channel> TwitchIrcServer::getChannelOrEmptyByID(
 QString TwitchIrcServer::cleanChannelName(const QString &dirtyChannelName)
 {
     if (dirtyChannelName.startsWith('#'))
+    {
         return dirtyChannelName.mid(1).toLower();
+    }
     else
+    {
         return dirtyChannelName.toLower();
+    }
 }
 
 bool TwitchIrcServer::hasSeparateWriteConnection() const

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -1233,7 +1233,9 @@ std::unordered_map<QString, QString> TwitchMessageBuilder::parseBadgeInfoTag(
 
     auto infoIt = tags.constFind("badge-info");
     if (infoIt == tags.end())
+    {
         return infoMap;
+    }
 
     auto info = infoIt.value().toString().split(',', Qt::SkipEmptyParts);
 
@@ -1651,7 +1653,7 @@ void TwitchMessageBuilder::listOfUsersSystemMessage(QString prefix,
     builder->emplace<TextElement>(prefix, MessageElementFlag::Text,
                                   MessageColor::System);
     bool isFirst = true;
-    auto tc = dynamic_cast<TwitchChannel *>(channel);
+    auto *tc = dynamic_cast<TwitchChannel *>(channel);
     for (const QString &username : users)
     {
         if (!isFirst)

--- a/src/singletons/Logging.cpp
+++ b/src/singletons/Logging.cpp
@@ -52,7 +52,7 @@ void Logging::addMessage(const QString &channelName, MessagePtr message,
     auto platIt = this->loggingChannels_.find(platformName);
     if (platIt == this->loggingChannels_.end())
     {
-        auto channel = new LoggingChannel(channelName, platformName);
+        auto *channel = new LoggingChannel(channelName, platformName);
         channel->addMessage(message);
         auto map = std::map<QString, std::unique_ptr<LoggingChannel>>();
         this->loggingChannels_[platformName] = std::move(map);
@@ -63,7 +63,7 @@ void Logging::addMessage(const QString &channelName, MessagePtr message,
     auto chanIt = platIt->second.find(channelName);
     if (chanIt == platIt->second.end())
     {
-        auto channel = new LoggingChannel(channelName, platformName);
+        auto *channel = new LoggingChannel(channelName, platformName);
         channel->addMessage(message);
         platIt->second.emplace(channelName, std::move(channel));
     }

--- a/src/singletons/Settings.cpp
+++ b/src/singletons/Settings.cpp
@@ -54,7 +54,9 @@ bool Settings::isHighlightedUser(const QString &username)
     for (const auto &highlightedUser : *items)
     {
         if (highlightedUser.isMatch(username))
+        {
             return true;
+        }
     }
 
     return false;
@@ -67,7 +69,9 @@ bool Settings::isBlacklistedUser(const QString &username)
     for (const auto &blacklistedUser : *items)
     {
         if (blacklistedUser.isMatch(username))
+        {
             return true;
+        }
     }
 
     return false;
@@ -208,7 +212,7 @@ void Settings::saveSnapshot()
         }
 
         rapidjson::Value key(setting->getPath().c_str(), a);
-        auto curVal = setting->unmarshalJSON();
+        auto *curVal = setting->unmarshalJSON();
         if (curVal == nullptr)
         {
             continue;

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -97,7 +97,7 @@ WindowManager::WindowManager()
 {
     qCDebug(chatterinoWindowmanager) << "init WindowManager";
 
-    auto settings = getSettings();
+    auto *settings = getSettings();
 
     this->wordFlagsListener_.addSetting(settings->showTimestamps);
     this->wordFlagsListener_.addSetting(settings->showBadgesGlobalAuthority);
@@ -135,7 +135,7 @@ MessageElementFlags WindowManager::getWordFlags()
 void WindowManager::updateWordTypeMask()
 {
     using MEF = MessageElementFlag;
-    auto settings = getSettings();
+    auto *settings = getSettings();
 
     // text
     auto flags = MessageElementFlags(MEF::Text);
@@ -630,7 +630,7 @@ void WindowManager::encodeChannel(IndirectChannel channel, QJsonObject &obj)
         }
         break;
         case Channel::Type::Irc: {
-            if (auto ircChannel =
+            if (auto *ircChannel =
                     dynamic_cast<IrcChannel *>(channel.get().get()))
             {
                 obj.insert("type", "irc");
@@ -664,7 +664,7 @@ IndirectChannel WindowManager::decodeChannel(const SplitDescriptor &descriptor)
 {
     assertInGuiThread();
 
-    auto app = getApp();
+    auto *app = getApp();
 
     if (descriptor.type_ == "twitch")
     {

--- a/src/singletons/helper/GifTimer.cpp
+++ b/src/singletons/helper/GifTimer.cpp
@@ -13,15 +13,21 @@ void GIFTimer::initialize()
 
     getSettings()->animateEmotes.connect([this](bool enabled, auto) {
         if (enabled)
+        {
             this->timer.start();
+        }
         else
+        {
             this->timer.stop();
+        }
     });
 
     QObject::connect(&this->timer, &QTimer::timeout, [this] {
         if (getSettings()->animationsWhenFocused &&
             qApp->activeWindow() == nullptr)
+        {
             return;
+        }
 
         this->position_ += GIF_FRAME_LENGTH;
         this->signal.invoke();

--- a/src/util/Clipboard.cpp
+++ b/src/util/Clipboard.cpp
@@ -7,7 +7,7 @@ namespace chatterino {
 
 void crossPlatformCopy(const QString &text)
 {
-    auto clipboard = QApplication::clipboard();
+    auto *clipboard = QApplication::clipboard();
 
     clipboard->setText(text);
 

--- a/src/util/InitUpdateButton.cpp
+++ b/src/util/InitUpdateButton.cpp
@@ -12,7 +12,7 @@ void initUpdateButton(Button &button,
 
     // show update prompt when clicking the button
     QObject::connect(&button, &Button::leftClicked, [&button] {
-        auto dialog = new UpdateDialog();
+        auto *dialog = new UpdateDialog();
         dialog->setActionOnFocusLoss(BaseWindow::Delete);
 
         auto globalPoint = button.mapToGlobal(
@@ -54,9 +54,9 @@ void initUpdateButton(Button &button,
     auto updateChange = [&button](auto) {
         button.setVisible(Updates::instance().shouldShowUpdateButton());
 
-        auto imageUrl = Updates::instance().isError()
-                            ? ":/buttons/updateError.png"
-                            : ":/buttons/update.png";
+        const auto *imageUrl = Updates::instance().isError()
+                                   ? ":/buttons/updateError.png"
+                                   : ":/buttons/update.png";
         button.setPixmap(QPixmap(imageUrl));
     };
 

--- a/src/util/LayoutHelper.cpp
+++ b/src/util/LayoutHelper.cpp
@@ -7,14 +7,14 @@ namespace chatterino {
 
 QWidget *wrapLayout(QLayout *layout)
 {
-    auto widget = new QWidget;
+    auto *widget = new QWidget;
     widget->setLayout(layout);
     return widget;
 }
 
 QScrollArea *makeScrollArea(WidgetOrLayout item)
 {
-    auto area = new QScrollArea();
+    auto *area = new QScrollArea();
 
     switch (item.which())
     {

--- a/src/util/LayoutHelper.hpp
+++ b/src/util/LayoutHelper.hpp
@@ -19,7 +19,7 @@ T *makeLayout(std::initializer_list<LayoutItem> items)
 {
     auto t = new T;
 
-    for (auto &item : items)
+    for (const auto &item : items)
     {
         switch (item.which())
         {

--- a/src/util/PersistSignalVector.hpp
+++ b/src/util/PersistSignalVector.hpp
@@ -13,7 +13,9 @@ inline void persist(SignalVector<T> &vec, const std::string &name)
     auto setting = std::make_unique<ChatterinoSetting<std::vector<T>>>(name);
 
     for (auto &&item : setting->getValue())
+    {
         vec.append(item);
+    }
 
     vec.delayedItemsChanged.connect([setting = setting.get(), vec = &vec] {
         setting->setValue(vec->raw());

--- a/src/util/SplitCommand.cpp
+++ b/src/util/SplitCommand.cpp
@@ -70,7 +70,9 @@ QStringList chatterino::splitCommand(QStringView command)
         if (quoteCount)
         {
             if (quoteCount == 1)
+            {
                 inQuote = !inQuote;
+            }
             quoteCount = 0;
         }
         if (!inQuote && command.at(i).isSpace())
@@ -87,7 +89,9 @@ QStringList chatterino::splitCommand(QStringView command)
         }
     }
     if (!tmp.isEmpty())
+    {
         args += tmp;
+    }
 
     return args;
 }

--- a/src/widgets/AccountSwitchPopup.cpp
+++ b/src/widgets/AccountSwitchPopup.cpp
@@ -29,8 +29,8 @@ AccountSwitchPopup::AccountSwitchPopup(QWidget *parent)
     this->ui_.accountSwitchWidget->setFocusPolicy(Qt::NoFocus);
     vbox->addWidget(this->ui_.accountSwitchWidget);
 
-    auto hbox = new QHBoxLayout();
-    auto manageAccountsButton = new QPushButton(this);
+    auto *hbox = new QHBoxLayout();
+    auto *manageAccountsButton = new QPushButton(this);
     manageAccountsButton->setText("Manage Accounts");
     manageAccountsButton->setFocusPolicy(Qt::NoFocus);
     hbox->addWidget(manageAccountsButton);

--- a/src/widgets/AccountSwitchWidget.cpp
+++ b/src/widgets/AccountSwitchWidget.cpp
@@ -11,7 +11,7 @@ namespace chatterino {
 AccountSwitchWidget::AccountSwitchWidget(QWidget *parent)
     : QListWidget(parent)
 {
-    auto app = getApp();
+    auto *app = getApp();
 
     this->addItem(ANONYMOUS_USERNAME_LABEL);
 
@@ -69,7 +69,7 @@ void AccountSwitchWidget::refreshSelection()
     // Select the currently logged in user
     if (this->count() > 0)
     {
-        auto app = getApp();
+        auto *app = getApp();
 
         auto currentUser = app->accounts->twitch.getCurrent();
 

--- a/src/widgets/BaseWidget.cpp
+++ b/src/widgets/BaseWidget.cpp
@@ -28,7 +28,7 @@ BaseWidget::BaseWidget(QWidget *parent, Qt::WindowFlags f)
 }
 void BaseWidget::clearShortcuts()
 {
-    for (auto shortcut : this->shortcuts_)
+    for (auto *shortcut : this->shortcuts_)
     {
         shortcut->setKey(QKeySequence());
         shortcut->removeEventFilter(this);
@@ -122,7 +122,7 @@ void BaseWidget::setScaleIndependantHeight(int value)
 
 float BaseWidget::qtFontScale() const
 {
-    if (auto window = dynamic_cast<BaseWindow *>(this->window()))
+    if (auto *window = dynamic_cast<BaseWindow *>(this->window()))
     {
         // ensure no div by 0
         return this->scale() / std::max<float>(0.01f, window->nativeScale_);
@@ -138,7 +138,7 @@ void BaseWidget::childEvent(QChildEvent *event)
     if (event->added())
     {
         // add element if it's a basewidget
-        if (auto widget = dynamic_cast<BaseWidget *>(event->child()))
+        if (auto *widget = dynamic_cast<BaseWidget *>(event->child()))
         {
             this->widgets_.push_back(widget);
         }

--- a/src/widgets/BaseWindow.cpp
+++ b/src/widgets/BaseWindow.cpp
@@ -373,7 +373,7 @@ void BaseWindow::mousePressEvent(QMouseEvent *event)
     if (this->flags_.has(FramelessDraggable))
     {
         this->movingRelativePos = event->localPos();
-        if (auto widget =
+        if (auto *widget =
                 this->childAt(event->localPos().x(), event->localPos().y()))
         {
             std::function<bool(QWidget *)> recursiveCheckMouseTracking;
@@ -735,7 +735,7 @@ void BaseWindow::updateScale()
 
     this->setScale(scale);
 
-    for (auto child : this->findChildren<BaseWidget *>())
+    for (auto *child : this->findChildren<BaseWidget *>())
     {
         child->setScale(scale);
     }

--- a/src/widgets/FramelessEmbedWindow.cpp
+++ b/src/widgets/FramelessEmbedWindow.cpp
@@ -19,7 +19,7 @@ FramelessEmbedWindow::FramelessEmbedWindow()
     : BaseWindow({BaseWindow::Frameless, BaseWindow::DisableLayoutSave})
 {
     this->split_ = new Split((QWidget *)nullptr);
-    auto layout = new QHBoxLayout;
+    auto *layout = new QHBoxLayout;
     layout->setContentsMargins(0, 0, 0, 0);
     layout->addWidget(this->split_);
 

--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -785,7 +785,9 @@ void Notebook::performLayout(bool animated)
         }
 
         if (this->visibleButtonCount() > 0)
+        {
             y = tabHeight + lineThickness;  // account for divider line
+        }
 
         int totalButtonWidths = x;
         const int top = y + tabSpacer;  // add margin
@@ -829,7 +831,9 @@ void Notebook::performLayout(bool animated)
                 }
 
                 if (isLastColumn && largestWidth + x < totalButtonWidths)
+                {
                     largestWidth = totalButtonWidths - x;
+                }
 
                 for (int i = tabStart; i < tabEnd; i++)
                 {
@@ -877,7 +881,7 @@ void Notebook::performLayout(bool animated)
         for (auto btnIt = this->customButtons_.rbegin();
              btnIt != this->customButtons_.rend(); ++btnIt)
         {
-            auto btn = *btnIt;
+            auto *btn = *btnIt;
             if (!btn->isVisible())
             {
                 continue;
@@ -889,7 +893,9 @@ void Notebook::performLayout(bool animated)
         }
 
         if (this->visibleButtonCount() > 0)
+        {
             y = tabHeight + lineThickness;  // account for divider line
+        }
 
         int consumedButtonWidths = right - x;
         const int top = y + tabSpacer;  // add margin
@@ -936,7 +942,9 @@ void Notebook::performLayout(bool animated)
 
                 if (isLastColumn &&
                     largestWidth + distanceFromRight < consumedButtonWidths)
+                {
                     largestWidth = consumedButtonWidths - distanceFromRight;
+                }
 
                 x -= largestWidth + lineThickness;
 
@@ -1288,7 +1296,7 @@ SplitNotebook::SplitNotebook(Window *parent)
         getApp()->windows->selectSplit, [this](Split *split) {
             for (auto &&item : this->items())
             {
-                if (auto sc = dynamic_cast<SplitContainer *>(item.page))
+                if (auto *sc = dynamic_cast<SplitContainer *>(item.page))
                 {
                     auto &&splits = sc->getSplits();
                     if (std::find(splits.begin(), splits.end(), split) !=
@@ -1312,7 +1320,7 @@ SplitNotebook::SplitNotebook(Window *parent)
         [this](const MessagePtr &message) {
             for (auto &&item : this->items())
             {
-                if (auto sc = dynamic_cast<SplitContainer *>(item.page))
+                if (auto *sc = dynamic_cast<SplitContainer *>(item.page))
                 {
                     for (auto *split : sc->getSplits())
                     {
@@ -1352,7 +1360,7 @@ void SplitNotebook::showEvent(QShowEvent * /*event*/)
 void SplitNotebook::addCustomButtons()
 {
     // settings
-    auto settingsBtn = this->addCustomButton();
+    auto *settingsBtn = this->addCustomButton();
 
     // This is to ensure you can't lock yourself out of the settings
     if (getApp()->getArgs().safeMode)
@@ -1378,7 +1386,7 @@ void SplitNotebook::addCustomButtons()
     });
 
     // account
-    auto userBtn = this->addCustomButton();
+    auto *userBtn = this->addCustomButton();
     userBtn->setVisible(!getSettings()->hideUserButton.getValue());
     getSettings()->hideUserButton.connect(
         [userBtn](bool hide, auto) {
@@ -1393,7 +1401,7 @@ void SplitNotebook::addCustomButtons()
     });
 
     // updates
-    auto updateBtn = this->addCustomButton();
+    auto *updateBtn = this->addCustomButton();
 
     initUpdateButton(*updateBtn, this->signalHolder_);
 
@@ -1439,8 +1447,8 @@ void SplitNotebook::themeChangedEvent()
 
 SplitContainer *SplitNotebook::addPage(bool select)
 {
-    auto container = new SplitContainer(this);
-    auto tab = Notebook::addPage(container, QString(), select);
+    auto *container = new SplitContainer(this);
+    auto *tab = Notebook::addPage(container, QString(), select);
     container->setTab(tab);
     tab->setParent(this);
     return container;

--- a/src/widgets/TooltipWidget.cpp
+++ b/src/widgets/TooltipWidget.cpp
@@ -119,9 +119,9 @@ void TooltipWidget::set(const std::vector<TooltipEntry> &entries,
 
     for (int i = 0; i < entries.size(); ++i)
     {
-        if (auto entryWidget = this->entryAt(i))
+        if (auto *entryWidget = this->entryAt(i))
         {
-            auto &entry = entries[i];
+            const auto &entry = entries[i];
             entryWidget->setImage(entry.image);
             entryWidget->setText(entry.text);
             entryWidget->setImageScale(entry.customWidth, entry.customHeight);
@@ -306,7 +306,7 @@ void TooltipWidget::setWordWrap(bool wrap)
 {
     for (int i = 0; i < this->visibleEntries_; ++i)
     {
-        auto entry = this->entryAt(i);
+        auto *entry = this->entryAt(i);
         if (entry)
         {
             entry->setWordWrap(wrap);

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -136,7 +136,7 @@ void Window::closeEvent(QCloseEvent *)
 {
     if (this->type_ == WindowType::Main)
     {
-        auto app = getApp();
+        auto *app = getApp();
         app->windows->save();
         app->windows->closeAll();
     }
@@ -171,9 +171,13 @@ void Window::addLayout()
 void Window::addCustomTitlebarButtons()
 {
     if (!this->hasCustomWindowFrame())
+    {
         return;
+    }
     if (this->type_ != WindowType::Main)
+    {
         return;
+    }
 
     // settings
     this->addTitleBarButton(TitleBarButtonStyle::Settings, [this] {
@@ -181,7 +185,7 @@ void Window::addCustomTitlebarButtons()
     });
 
     // updates
-    auto update = this->addTitleBarButton(TitleBarButtonStyle::None, [] {});
+    auto *update = this->addTitleBarButton(TitleBarButtonStyle::None, [] {});
 
     initUpdateButton(*update, this->signalHolder_);
 
@@ -384,10 +388,10 @@ void Window::addShortcuts()
              }
              if (arguments.at(0) == "split")
              {
-                 if (auto page = dynamic_cast<SplitContainer *>(
+                 if (auto *page = dynamic_cast<SplitContainer *>(
                          this->notebook_->getSelectedPage()))
                  {
-                     if (auto split = page->getSelectedSplit())
+                     if (auto *split = page->getSelectedSplit())
                      {
                          split->popup();
                      }
@@ -395,7 +399,7 @@ void Window::addShortcuts()
              }
              else if (arguments.at(0) == "window")
              {
-                 if (auto page = dynamic_cast<SplitContainer *>(
+                 if (auto *page = dynamic_cast<SplitContainer *>(
                          this->notebook_->getSelectedPage()))
                  {
                      page->popup();

--- a/src/widgets/dialogs/BadgePickerDialog.cpp
+++ b/src/widgets/dialogs/BadgePickerDialog.cpp
@@ -14,8 +14,8 @@ BadgePickerDialog::BadgePickerDialog(QList<DisplayBadge> badges,
     : QDialog(parent)
 {
     this->dropdown_ = new QComboBox;
-    auto vbox = new QVBoxLayout(this);
-    auto buttonBox =
+    auto *vbox = new QVBoxLayout(this);
+    auto *buttonBox =
         new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
 
     vbox->addWidget(this->dropdown_);
@@ -61,7 +61,9 @@ BadgePickerDialog::BadgePickerDialog(QList<DisplayBadge> badges,
         badges,
         [&dropdown = this->dropdown_](QString identifier, const QIconPtr icon) {
             if (!dropdown)
+            {
                 return;
+            }
 
             int index = dropdown->findData(identifier);
             if (index != -1)

--- a/src/widgets/dialogs/ChannelFilterEditorDialog.cpp
+++ b/src/widgets/dialogs/ChannelFilterEditorDialog.cpp
@@ -21,16 +21,16 @@ namespace {
 ChannelFilterEditorDialog::ChannelFilterEditorDialog(QWidget *parent)
     : QDialog(parent)
 {
-    auto vbox = new QVBoxLayout(this);
-    auto filterVbox = new QVBoxLayout;
-    auto buttonBox = new QHBoxLayout;
-    auto okButton = new QPushButton("Ok");
-    auto cancelButton = new QPushButton("Cancel");
+    auto *vbox = new QVBoxLayout(this);
+    auto *filterVbox = new QVBoxLayout;
+    auto *buttonBox = new QHBoxLayout;
+    auto *okButton = new QPushButton("Ok");
+    auto *cancelButton = new QPushButton("Cancel");
 
     okButton->setDefault(true);
     cancelButton->setDefault(false);
 
-    auto helpLabel =
+    auto *helpLabel =
         new QLabel(QString("<a href='%1'><span "
                            "style='color:#99f'>variable help</span></a>")
                        .arg("https://wiki.chatterino.com/Filters/#variables"));
@@ -55,16 +55,16 @@ ChannelFilterEditorDialog::ChannelFilterEditorDialog(QWidget *parent)
         Qt::Dialog | Qt::MSWindowsFixedSizeDialogHint);
     this->setWindowTitle("Channel Filter Creator");
 
-    auto titleInput = new QLineEdit;
+    auto *titleInput = new QLineEdit;
     titleInput->setPlaceholderText("Filter name");
     titleInput->setText("My filter");
 
     this->titleInput_ = titleInput;
     filterVbox->addWidget(titleInput);
 
-    auto left = new ChannelFilterEditorDialog::ValueSpecifier;
-    auto right = new ChannelFilterEditorDialog::ValueSpecifier;
-    auto exp =
+    auto *left = new ChannelFilterEditorDialog::ValueSpecifier;
+    auto *right = new ChannelFilterEditorDialog::ValueSpecifier;
+    auto *exp =
         new ChannelFilterEditorDialog::BinaryOperationSpecifier(left, right);
 
     this->expressionSpecifier_ = exp;

--- a/src/widgets/dialogs/IrcConnectionEditor.hpp
+++ b/src/widgets/dialogs/IrcConnectionEditor.hpp
@@ -5,11 +5,11 @@
 
 #include <QDialog>
 
-#include <optional>
-
 namespace Ui {
+
 class IrcConnectionEditor;
-}
+
+}  // namespace Ui
 
 namespace chatterino {
 
@@ -22,6 +22,10 @@ class IrcConnectionEditor : public QDialog
 public:
     explicit IrcConnectionEditor(const IrcServerData &data, bool isAdd = false,
                                  QWidget *parent = nullptr);
+    IrcConnectionEditor(const IrcConnectionEditor &) = delete;
+    IrcConnectionEditor(IrcConnectionEditor &&) = delete;
+    IrcConnectionEditor &operator=(const IrcConnectionEditor &) = delete;
+    IrcConnectionEditor &operator=(IrcConnectionEditor &&) = delete;
     ~IrcConnectionEditor() override;
 
     IrcServerData data();

--- a/src/widgets/dialogs/SelectChannelDialog.cpp
+++ b/src/widgets/dialogs/SelectChannelDialog.cpp
@@ -171,7 +171,7 @@ SelectChannelDialog::SelectChannelDialog(QWidget *parent)
         QWidget::setTabOrder(live_btn.getElement(), automod_btn.getElement());
 
         // tab
-        auto tab = notebook->addPage(obj.getElement());
+        auto *tab = notebook->addPage(obj.getElement());
         tab->setCustomTitle("Twitch");
     }
 
@@ -181,7 +181,7 @@ SelectChannelDialog::SelectChannelDialog(QWidget *parent)
         auto outerBox = obj.setLayoutType<QFormLayout>();
 
         {
-            auto view = this->ui_.irc.servers =
+            auto *view = this->ui_.irc.servers =
                 new EditableModelView(Irc::instance().newConnectionModel(this));
 
             view->setTitles({"host", "port", "ssl", "user", "nick", "real",
@@ -199,7 +199,7 @@ SelectChannelDialog::SelectChannelDialog(QWidget *parent)
                 auto unique = IrcServerData{};
                 unique.id = Irc::instance().uniqueId();
 
-                auto editor = new IrcConnectionEditor(unique);
+                auto *editor = new IrcConnectionEditor(unique);
                 if (editor->exec() == QDialog::Accepted)
                 {
                     Irc::instance().connections.append(editor->data());
@@ -209,7 +209,7 @@ SelectChannelDialog::SelectChannelDialog(QWidget *parent)
             QObject::connect(
                 view->getTableView(), &QTableView::doubleClicked,
                 [](const QModelIndex &index) {
-                    auto editor = new IrcConnectionEditor(
+                    auto *editor = new IrcConnectionEditor(
                         Irc::instance().connections.raw()[size_t(index.row())]);
 
                     if (editor->exec() == QDialog::Accepted)
@@ -235,7 +235,7 @@ SelectChannelDialog::SelectChannelDialog(QWidget *parent)
 
         outerBox->addRow("Channel: #", this->ui_.irc.channel = new QLineEdit);
 
-        auto tab = notebook->addPage(obj.getElement());
+        auto *tab = notebook->addPage(obj.getElement());
         tab->setCustomTitle("Irc (Beta)");
 
         if (!getSettings()->enableExperimentalIrc)
@@ -338,10 +338,10 @@ void SelectChannelDialog::setSelectedChannel(IndirectChannel _channel)
             this->ui_.notebook->selectIndex(TAB_IRC);
             this->ui_.irc.channel->setText(_channel.get()->getName());
 
-            if (auto ircChannel =
+            if (auto *ircChannel =
                     dynamic_cast<IrcChannel *>(_channel.get().get()))
             {
-                if (auto server = ircChannel->server())
+                if (auto *server = ircChannel->server())
                 {
                     int i = 0;
                     for (auto &&conn : Irc::instance().connections)
@@ -375,7 +375,7 @@ IndirectChannel SelectChannelDialog::getSelectedChannel() const
         return this->selectedChannel_;
     }
 
-    auto app = getApp();
+    auto *app = getApp();
 
     switch (this->ui_.notebook->getSelectedIndex())
     {

--- a/src/widgets/dialogs/SelectChannelFiltersDialog.cpp
+++ b/src/widgets/dialogs/SelectChannelFiltersDialog.cpp
@@ -15,16 +15,16 @@ SelectChannelFiltersDialog::SelectChannelFiltersDialog(
     const QList<QUuid> &previousSelection, QWidget *parent)
     : QDialog(parent)
 {
-    auto vbox = new QVBoxLayout(this);
-    auto itemVbox = new QVBoxLayout;
-    auto buttonBox = new QHBoxLayout;
-    auto okButton = new QPushButton("Ok");
-    auto cancelButton = new QPushButton("Cancel");
+    auto *vbox = new QVBoxLayout(this);
+    auto *itemVbox = new QVBoxLayout;
+    auto *buttonBox = new QHBoxLayout;
+    auto *okButton = new QPushButton("Ok");
+    auto *cancelButton = new QPushButton("Cancel");
 
-    auto scrollAreaContent = new QWidget;
+    auto *scrollAreaContent = new QWidget;
     scrollAreaContent->setLayout(itemVbox);
 
-    auto scrollArea = new QScrollArea;
+    auto *scrollArea = new QScrollArea;
     scrollArea->setWidgetResizable(true);
     scrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     scrollArea->setWidget(scrollAreaContent);
@@ -53,14 +53,14 @@ SelectChannelFiltersDialog::SelectChannelFiltersDialog(
 
     if (availableFilters->size() == 0)
     {
-        auto text = new QLabel("No filters defined");
+        auto *text = new QLabel("No filters defined");
         itemVbox->addWidget(text);
     }
     else
     {
         for (const auto &f : *availableFilters)
         {
-            auto checkbox = new QCheckBox(f->getName(), this);
+            auto *checkbox = new QCheckBox(f->getName(), this);
             bool alreadySelected = previousSelection.contains(f->getId());
             checkbox->setCheckState(alreadySelected
                                         ? Qt::CheckState::Checked

--- a/src/widgets/dialogs/SettingsDialog.cpp
+++ b/src/widgets/dialogs/SettingsDialog.cpp
@@ -190,8 +190,8 @@ void SettingsDialog::filterElements(const QString &text)
 
     for (int i = 0; i < this->ui_.tabContainer->count(); i++)
     {
-        auto item = this->ui_.tabContainer->itemAt(i);
-        if (auto x = dynamic_cast<QSpacerItem *>(item); x)
+        auto *item = this->ui_.tabContainer->itemAt(i);
+        if (auto *x = dynamic_cast<QSpacerItem *>(item); x)
         {
             x->changeSize(10, shouldShowSpace ? int(16 * this->scale()) : 0);
             shouldShowSpace = false;
@@ -257,7 +257,8 @@ void SettingsDialog::addTab(std::function<SettingsPage *()> page,
                             const QString &name, const QString &iconPath,
                             SettingsTabId id, Qt::Alignment alignment)
 {
-    auto tab = new SettingsDialogTab(this, std::move(page), name, iconPath, id);
+    auto *tab =
+        new SettingsDialogTab(this, std::move(page), name, iconPath, id);
     tab->setFixedHeight(static_cast<int>(30 * this->dpi_));
 
     this->ui_.tabContainer->addWidget(tab, 0, alignment);
@@ -274,8 +275,12 @@ void SettingsDialog::selectTab(SettingsDialogTab *tab, bool byUser)
     // add page if it's not been added yet
     [&] {
         for (int i = 0; i < this->ui_.pageStack->count(); i++)
+        {
             if (this->ui_.pageStack->itemAt(i)->widget() == tab->page())
+            {
                 return;
+            }
+        }
 
         this->ui_.pageStack->addWidget(tab->page());
     }();
@@ -301,10 +306,12 @@ void SettingsDialog::selectTab(SettingsDialogTab *tab, bool byUser)
 
 void SettingsDialog::selectTab(SettingsTabId id)
 {
-    auto t = this->tab(id);
+    auto *t = this->tab(id);
     assert(t);
     if (!t)
+    {
         return;
+    }
 
     this->selectTab(t);
 }
@@ -312,8 +319,12 @@ void SettingsDialog::selectTab(SettingsTabId id)
 SettingsDialogTab *SettingsDialog::tab(SettingsTabId id)
 {
     for (auto &&tab : this->tabs_)
+    {
         if (tab->id() == id)
+        {
             return tab;
+        }
+    }
 
     assert(false);
     return nullptr;
@@ -325,7 +336,9 @@ void SettingsDialog::showDialog(QWidget *parent,
     static SettingsDialog *instance = new SettingsDialog(parent);
     static bool hasShownBefore = false;
     if (hasShownBefore)
+    {
         instance->refresh();
+    }
     hasShownBefore = true;
 
     switch (preferredTab)
@@ -335,10 +348,10 @@ void SettingsDialog::showDialog(QWidget *parent,
             break;
 
         case SettingsDialogPreference::ModerationActions:
-            if (auto tab = instance->tab(SettingsTabId::Moderation))
+            if (auto *tab = instance->tab(SettingsTabId::Moderation))
             {
                 instance->selectTab(tab);
-                if (auto page = dynamic_cast<ModerationPage *>(tab->page()))
+                if (auto *page = dynamic_cast<ModerationPage *>(tab->page()))
                 {
                     page->selectModerationActions();
                 }

--- a/src/widgets/dialogs/UpdateDialog.cpp
+++ b/src/widgets/dialogs/UpdateDialog.cpp
@@ -21,9 +21,9 @@ UpdateDialog::UpdateDialog()
         .assign(&this->ui_.label);
 
     auto buttons = layout.emplace<QDialogButtonBox>();
-    auto install = buttons->addButton("Install", QDialogButtonBox::AcceptRole);
+    auto *install = buttons->addButton("Install", QDialogButtonBox::AcceptRole);
     this->ui_.installButton = install;
-    auto dismiss = buttons->addButton("Dismiss", QDialogButtonBox::RejectRole);
+    auto *dismiss = buttons->addButton("Dismiss", QDialogButtonBox::RejectRole);
 
     QObject::connect(install, &QPushButton::clicked, this, [this] {
         Updates::instance().installUpdates();

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -75,7 +75,9 @@ namespace {
     bool checkMessageUserName(const QString &userName, MessagePtr message)
     {
         if (message->flags.has(MessageFlag::Whisper))
+        {
             return false;
+        }
 
         bool isSubscription = message->flags.has(MessageFlag::Subscription) &&
                               message->loginName.isEmpty() &&
@@ -296,12 +298,12 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically, Split *split)
                         menu->addAction(
                             "Open channel in a new popup window", this,
                             [loginName] {
-                                auto app = getApp();
+                                auto *app = getApp();
                                 auto &window = app->windows->createWindow(
                                     WindowType::Popup, true);
-                                auto split = window.getNotebook()
-                                                 .getOrAddSelectedPage()
-                                                 ->appendNewSplit(false);
+                                auto *split = window.getNotebook()
+                                                  .getOrAddSelectedPage()
+                                                  ->appendNewSplit(false);
                                 split->setChannel(app->twitch->getOrAddChannel(
                                     loginName.toLower()));
                             });
@@ -771,7 +773,9 @@ void UserInfoPopup::updateLatestMessages()
             this->underlyingChannel_->messageAppended.connect(
                 [this, hasMessages](auto message, auto) {
                     if (!checkMessageUserName(this->userName_, message))
+                    {
                         return;
+                    }
 
                     if (hasMessages)
                     {
@@ -961,7 +965,7 @@ void UserInfoPopup::updateUserData()
 void UserInfoPopup::loadAvatar(const QUrl &url)
 {
     QNetworkRequest req(url);
-    static auto manager = new QNetworkAccessManager();
+    static auto *manager = new QNetworkAccessManager();
     auto *reply = manager->get(req);
 
     QObject::connect(reply, &QNetworkReply::finished, this, [=, this] {

--- a/src/widgets/helper/Button.cpp
+++ b/src/widgets/helper/Button.cpp
@@ -16,10 +16,14 @@ namespace {
                       const QSize &size) -> QPixmap
     {
         if (resized.size() == size)
+        {
             return resized;
+        }
         else
+        {
             return current.scaled(size, Qt::IgnoreAspectRatio,
                                   Qt::SmoothTransformation);
+        }
     }
 
 }  // namespace
@@ -92,11 +96,17 @@ bool Button::getEnableMargin() const
 qreal Button::getCurrentDimAmount() const
 {
     if (this->dimPixmap_ == Dim::None || this->mouseOver_)
+    {
         return 1;
+    }
     else if (this->dimPixmap_ == Dim::Some)
+    {
         return 0.7;
+    }
     else
+    {
         return 0.15;
+    }
 }
 
 void Button::setBorderColor(const QColor &color)
@@ -114,7 +124,9 @@ const QColor &Button::getBorderColor() const
 void Button::setMenu(std::unique_ptr<QMenu> menu)
 {
     if (this->menu_)
+    {
         this->menu_.release()->deleteLater();
+    }
 
     this->menu_ = std::move(menu);
 
@@ -362,7 +374,9 @@ void Button::onMouseEffectTimeout()
 void Button::showMenu()
 {
     if (!this->menu_)
+    {
         return;
+    }
 
     auto menuSizeHint = this->menu_->sizeHint();
     auto point = this->mapToGlobal(

--- a/src/widgets/helper/ComboBoxItemDelegate.cpp
+++ b/src/widgets/helper/ComboBoxItemDelegate.cpp
@@ -56,10 +56,14 @@ void ComboBoxItemDelegate::setModelData(QWidget *editor,
                                         const QModelIndex &index) const
 {
     if (QComboBox *cb = qobject_cast<QComboBox *>(editor))
+    {
         // save the current text of the combo box as the current value of the
         // item
         model->setData(index, cb->currentText(), Qt::EditRole);
+    }
     else
+    {
         QStyledItemDelegate::setModelData(editor, model, index);
+    }
 }
 }  // namespace chatterino

--- a/src/widgets/helper/EditableModelView.cpp
+++ b/src/widgets/helper/EditableModelView.cpp
@@ -53,12 +53,16 @@ EditableModelView::EditableModelView(QAbstractTableModel *model, bool movable)
         // Remove rows backwards so indices don't shift.
         std::vector<int> rows;
         for (auto &&index : selected)
+        {
             rows.push_back(index.row());
+        }
 
         std::sort(rows.begin(), rows.end(), std::greater{});
 
         for (auto &&row : rows)
+        {
             model_->removeRow(row);
+        }
     });
 
     if (movable)
@@ -135,7 +139,7 @@ void EditableModelView::addCustomButton(QWidget *widget)
 
 void EditableModelView::addRegexHelpLink()
 {
-    auto regexHelpLabel =
+    auto *regexHelpLabel =
         new QLabel("<a href='"
                    "https://chatterino.com/help/regex'>"
                    "<span style='color:#99f'>regex info</span></a>");
@@ -152,7 +156,9 @@ void EditableModelView::moveRow(int dir)
         (row = selected.at(0).row()) + dir >=
             this->model_->rowCount(QModelIndex()) ||
         row + dir < 0)
+    {
         return;
+    }
 
     model_->moveRows(model_->index(row, 0), row, selected.size(),
                      model_->index(row + dir, 0), row + dir);

--- a/src/widgets/helper/NotebookButton.cpp
+++ b/src/widgets/helper/NotebookButton.cpp
@@ -158,13 +158,15 @@ void NotebookButton::mouseReleaseEvent(QMouseEvent *event)
 void NotebookButton::dragEnterEvent(QDragEnterEvent *event)
 {
     if (!event->mimeData()->hasFormat("chatterino/split"))
+    {
         return;
+    }
 
     event->acceptProposedAction();
 
-    auto e = new QMouseEvent(QMouseEvent::MouseButtonPress,
-                             QPointF(this->width() / 2, this->height() / 2),
-                             Qt::LeftButton, Qt::LeftButton, {});
+    auto *e = new QMouseEvent(QMouseEvent::MouseButtonPress,
+                              QPointF(this->width() / 2, this->height() / 2),
+                              Qt::LeftButton, Qt::LeftButton, {});
     Button::mousePressEvent(e);
     delete e;
 }
@@ -174,9 +176,9 @@ void NotebookButton::dragLeaveEvent(QDragLeaveEvent *)
     this->mouseDown_ = true;
     this->update();
 
-    auto e = new QMouseEvent(QMouseEvent::MouseButtonRelease,
-                             QPointF(this->width() / 2, this->height() / 2),
-                             Qt::LeftButton, Qt::LeftButton, {});
+    auto *e = new QMouseEvent(QMouseEvent::MouseButtonRelease,
+                              QPointF(this->width() / 2, this->height() / 2),
+                              Qt::LeftButton, Qt::LeftButton, {});
     Button::mouseReleaseEvent(e);
     delete e;
 }

--- a/src/widgets/helper/NotebookTab.cpp
+++ b/src/widgets/helper/NotebookTab.cpp
@@ -99,7 +99,7 @@ NotebookTab::NotebookTab(Notebook *notebook)
     this->menu_.addAction(
         "Popup Tab",
         [this]() {
-            if (auto container = dynamic_cast<SplitContainer *>(this->page))
+            if (auto *container = dynamic_cast<SplitContainer *>(this->page))
             {
                 container->popup();
             }
@@ -124,11 +124,11 @@ NotebookTab::NotebookTab(Notebook *notebook)
 
 void NotebookTab::showRenameDialog()
 {
-    auto dialog = new QDialog(this);
+    auto *dialog = new QDialog(this);
 
-    auto vbox = new QVBoxLayout;
+    auto *vbox = new QVBoxLayout;
 
-    auto lineEdit = new QLineEdit;
+    auto *lineEdit = new QLineEdit;
     lineEdit->setText(this->getCustomTitle());
     lineEdit->setPlaceholderText(this->getDefaultTitle());
     lineEdit->selectAll();
@@ -137,7 +137,7 @@ void NotebookTab::showRenameDialog()
     vbox->addWidget(lineEdit);
     vbox->addStretch(1);
 
-    auto buttonBox =
+    auto *buttonBox =
         new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
 
     vbox->addWidget(buttonBox);
@@ -423,7 +423,7 @@ void NotebookTab::moveAnimated(QPoint pos, bool animated)
 
 void NotebookTab::paintEvent(QPaintEvent *)
 {
-    auto app = getApp();
+    auto *app = getApp();
     QPainter painter(this);
     float scale = this->scale();
 
@@ -439,13 +439,21 @@ void NotebookTab::paintEvent(QPaintEvent *)
     Theme::TabColors colors;
 
     if (this->selected_)
+    {
         colors = this->theme->tabs.selected;
+    }
     else if (this->highlightState_ == HighlightState::Highlighted)
+    {
         colors = this->theme->tabs.highlighted;
+    }
     else if (this->highlightState_ == HighlightState::NewMessage)
+    {
         colors = this->theme->tabs.newMessage;
+    }
     else
+    {
         colors = this->theme->tabs.regular;
+    }
 
     bool windowFocused = this->window() == QApplication::activeWindow();
 

--- a/src/widgets/helper/ResizingTextEdit.cpp
+++ b/src/widgets/helper/ResizingTextEdit.cpp
@@ -124,7 +124,7 @@ bool ResizingTextEdit::eventFilter(QObject *obj, QEvent *event)
     {
         return false;
     }
-    auto ev = static_cast<QKeyEvent *>(event);
+    auto *ev = static_cast<QKeyEvent *>(event);
     ev->ignore();
     if ((ev->key() == Qt::Key_C || ev->key() == Qt::Key_Insert) &&
         ev->modifiers() == Qt::ControlModifier)

--- a/src/widgets/helper/SettingsDialogTab.cpp
+++ b/src/widgets/helper/SettingsDialogTab.cpp
@@ -42,7 +42,9 @@ void SettingsDialogTab::setSelected(bool _selected)
 SettingsPage *SettingsDialogTab::page()
 {
     if (this->page_)
+    {
         return this->page_;
+    }
 
     this->page_ = this->lazyPage_();
     this->page_->setTab(this);

--- a/src/widgets/listview/GenericItemDelegate.cpp
+++ b/src/widgets/listview/GenericItemDelegate.cpp
@@ -22,7 +22,9 @@ void SwitcherItemDelegate::paint(QPainter *painter,
     if (item)
     {
         if (option.state & QStyle::State_Selected)
+        {
             painter->fillRect(option.rect, option.palette.highlight());
+        }
 
         item->paint(painter, option.rect);
     }

--- a/src/widgets/listview/GenericListView.cpp
+++ b/src/widgets/listview/GenericListView.cpp
@@ -25,7 +25,7 @@ GenericListView::GenericListView()
 
 void GenericListView::setModel(QAbstractItemModel *model)
 {
-    auto casted = dynamic_cast<GenericListModel *>(model);
+    auto *casted = dynamic_cast<GenericListModel *>(model);
     assert(casted);
     this->setModel(casted);
 }

--- a/src/widgets/settingspages/AboutPage.cpp
+++ b/src/widgets/settingspages/AboutPage.cpp
@@ -203,7 +203,7 @@ AboutPage::AboutPage()
 
                 const auto addLabels = [&contributorBox2, &usernameLabel,
                                         &roleLabel] {
-                    auto labelBox = new QVBoxLayout();
+                    auto *labelBox = new QVBoxLayout();
                     contributorBox2->addLayout(labelBox);
 
                     labelBox->addWidget(usernameLabel);
@@ -236,7 +236,7 @@ void AboutPage::addLicense(QFormLayout *form, const QString &name,
                 parent);
             window->setWindowTitle("Chatterino - License for " + name);
             window->setAttribute(Qt::WA_DeleteOnClose);
-            auto layout = new QVBoxLayout();
+            auto *layout = new QVBoxLayout();
             auto *edit = new QTextEdit;
 
             QFile file(licenseLink);

--- a/src/widgets/settingspages/CommandPage.cpp
+++ b/src/widgets/settingspages/CommandPage.cpp
@@ -33,7 +33,7 @@ namespace {
 
 CommandPage::CommandPage()
 {
-    auto app = getApp();
+    auto *app = getApp();
 
     LayoutCreator<CommandPage> layoutCreator(this);
     auto layout = layoutCreator.setLayoutType<QVBoxLayout>();
@@ -54,7 +54,7 @@ CommandPage::CommandPage()
     // TODO: asyncronously check path
     if (QFile(c1settingsPath()).exists())
     {
-        auto button = new QPushButton("Import commands from Chatterino 1");
+        auto *button = new QPushButton("Import commands from Chatterino 1");
         view->addCustomButton(button);
 
         QObject::connect(button, &QPushButton::clicked, this, [] {

--- a/src/widgets/settingspages/FiltersPage.cpp
+++ b/src/widgets/settingspages/FiltersPage.cpp
@@ -54,7 +54,7 @@ FiltersPage::FiltersPage()
         }
     });
 
-    auto quickAddButton = new QPushButton("Quick Add");
+    auto *quickAddButton = new QPushButton("Quick Add");
     QObject::connect(quickAddButton, &QPushButton::pressed, [] {
         getSettings()->filterRecords.append(std::make_shared<FilterRecord>(
             "My filter", "message.content contains \"hello\""));
@@ -66,7 +66,7 @@ FiltersPage::FiltersPage()
                          this->tableCellClicked(clicked, view);
                      });
 
-    auto filterHelpLabel =
+    auto *filterHelpLabel =
         new QLabel(QString("<a href='%1'><span "
                            "style='color:#99f'>filter info</span></a>")
                        .arg(FILTERS_DOCUMENTATION));

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -89,12 +89,12 @@ namespace {
 
 GeneralPage::GeneralPage()
 {
-    auto y = new QVBoxLayout;
-    auto x = new QHBoxLayout;
-    auto view = new GeneralPageView;
+    auto *y = new QVBoxLayout;
+    auto *x = new QHBoxLayout;
+    auto *view = new GeneralPageView;
     this->view_ = view;
     x->addWidget(view);
-    auto z = new QFrame;
+    auto *z = new QFrame;
     z->setLayout(x);
     y->addWidget(z);
     this->setLayout(y);
@@ -107,9 +107,13 @@ GeneralPage::GeneralPage()
 bool GeneralPage::filterElements(const QString &query)
 {
     if (this->view_)
+    {
         return this->view_->filterElements(query) || query.isEmpty();
+    }
     else
+    {
         return false;
+    }
 }
 
 void GeneralPage::initLayout(GeneralPageView &layout)
@@ -154,9 +158,13 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         s.uiScale,
         [](auto val) {
             if (val == 1)
+            {
                 return QString("Default");
+            }
             else
+            {
                 return QString::number(val) + "x";
+            }
         },
         [](auto args) {
             return fuzzyToFloat(args.value, 1.f);
@@ -280,20 +288,32 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         s.pauseOnHoverDuration,
         [](auto val) {
             if (val < -0.5f)
+            {
                 return QString("Indefinite");
+            }
             else if (val < 0.001f)
+            {
                 return QString("Disabled");
+            }
             else
+            {
                 return QString::number(val) + "s";
+            }
         },
         [](auto args) {
             if (args.index == 0)
+            {
                 return 0.0f;
+            }
             else if (args.value == "Indefinite")
+            {
                 return -1.0f;
+            }
             else
+            {
                 return fuzzyToFloat(args.value,
                                     std::numeric_limits<float>::infinity());
+            }
         });
     addKeyboardModifierSetting(layout, "Pause while holding a key",
                                s.pauseChatModifier);
@@ -302,9 +322,13 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         s.mouseScrollMultiplier,
         [](auto val) {
             if (val == 1)
+            {
                 return QString("Default");
+            }
             else
+            {
                 return QString::number(val) + "x";
+            }
         },
         [](auto args) {
             return fuzzyToFloat(args.value, 1.f);
@@ -492,9 +516,13 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         s.emoteScale,
         [](auto val) {
             if (val == 1)
+            {
                 return QString("Default");
+            }
             else
+            {
                 return QString::number(val) + "x";
+            }
         },
         [](auto args) {
             return fuzzyToFloat(args.value, 1.f);
@@ -631,23 +659,39 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         {"Off", "Small", "Medium", "Large"}, s.thumbnailSize,
         [](auto val) {
             if (val == 0)
+            {
                 return QString("Off");
+            }
             else if (val == 100)
+            {
                 return QString("Small");
+            }
             else if (val == 200)
+            {
                 return QString("Medium");
+            }
             else if (val == 300)
+            {
                 return QString("Large");
+            }
             else
+            {
                 return QString::number(val);
+            }
         },
         [](auto args) {
             if (args.value == "Small")
+            {
                 return 100;
+            }
             else if (args.value == "Medium")
+            {
                 return 200;
+            }
             else if (args.value == "Large")
+            {
                 return 300;
+            }
 
             return fuzzyToInt(args.value, 0);
         });
@@ -656,23 +700,39 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         s.thumbnailSizeStream,
         [](auto val) {
             if (val == 0)
+            {
                 return QString("Off");
+            }
             else if (val == 1)
+            {
                 return QString("Small");
+            }
             else if (val == 2)
+            {
                 return QString("Medium");
+            }
             else if (val == 3)
+            {
                 return QString("Large");
+            }
             else
+            {
                 return QString::number(val);
+            }
         },
         [](auto args) {
             if (args.value == "Small")
+            {
                 return 1;
+            }
             else if (args.value == "Medium")
+            {
                 return 2;
+            }
             else if (args.value == "Large")
+            {
                 return 3;
+            }
 
             return fuzzyToInt(args.value, 0);
         });
@@ -742,7 +802,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         "Files that are used often (such as emotes) are saved to disk to "
         "reduce bandwidth usage and to speed up loading.");
 
-    auto cachePathLabel = layout.addDescription("placeholder :D");
+    auto *cachePathLabel = layout.addDescription("placeholder :D");
     getSettings()->cachePath.connect([cachePathLabel](const auto &,
                                                       auto) mutable {
         QString newPath = getPaths()->cacheDirectory();
@@ -756,7 +816,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
 
     // Choose and reset buttons
     {
-        auto box = new QHBoxLayout;
+        auto *box = new QHBoxLayout;
 
         box->addWidget(layout.makeButton("Choose cache path", [this]() {
             getSettings()->cachePath = QFileDialog::getExistingDirectory(this);
@@ -964,9 +1024,13 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         "Username font weight", {"50", "Default", "75", "100"}, s.boldScale,
         [](auto val) {
             if (val == 63)
+            {
                 return QString("Default");
+            }
             else
+            {
                 return QString::number(val);
+            }
         },
         [](auto args) {
             return fuzzyToFloat(args.value, 63.f);
@@ -1156,7 +1220,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     layout.addStretch();
 
     // invisible element for width
-    auto inv = new BaseWidget(this);
+    auto *inv = new BaseWidget(this);
     //    inv->setScaleIndependantWidth(600);
     layout.addWidget(inv);
 }
@@ -1192,9 +1256,13 @@ QString GeneralPage::getFont(const DropdownArgs &args) const
         auto font = dialog.getFont(&ok, this->window());
 
         if (ok)
+        {
             return font.family();
+        }
         else
+        {
             return args.combobox->itemText(0);
+        }
     }
     return args.value;
 }

--- a/src/widgets/settingspages/GeneralPageView.cpp
+++ b/src/widgets/settingspages/GeneralPageView.cpp
@@ -25,11 +25,11 @@ namespace chatterino {
 GeneralPageView::GeneralPageView(QWidget *parent)
     : QWidget(parent)
 {
-    auto scrollArea = this->contentScrollArea_ =
+    auto *scrollArea = this->contentScrollArea_ =
         makeScrollArea(this->contentLayout_ = new QVBoxLayout);
     scrollArea->setObjectName("generalSettingsScrollContent");
 
-    auto navigation =
+    auto *navigation =
         wrapLayout(this->navigationLayout_ = makeLayout<QVBoxLayout>({}));
     navigation->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Minimum);
     this->navigationLayout_->setAlignment(Qt::AlignTop);
@@ -63,14 +63,16 @@ TitleLabel *GeneralPageView::addTitle(const QString &title)
 {
     // space
     if (!this->groups_.empty())
+    {
         this->addWidget(this->groups_.back().space = new Space);
+    }
 
     // title
-    auto label = new TitleLabel(title + ":");
+    auto *label = new TitleLabel(title + ":");
     this->addWidget(label);
 
     // navigation item
-    auto navLabel = new NavigationLabel(title);
+    auto *navLabel = new NavigationLabel(title);
     navLabel->setCursor(Qt::PointingHandCursor);
     this->navigationLayout_->addWidget(navLabel);
 
@@ -82,14 +84,16 @@ TitleLabel *GeneralPageView::addTitle(const QString &title)
     this->groups_.push_back(Group{title, label, navLabel, nullptr, {}});
 
     if (this->groups_.size() == 1)
+    {
         this->updateNavigationHighlighting();
+    }
 
     return label;
 }
 
 SubtitleLabel *GeneralPageView::addSubtitle(const QString &title)
 {
-    auto label = new SubtitleLabel(title + ":");
+    auto *label = new SubtitleLabel(title + ":");
     this->addWidget(label);
 
     this->groups_.back().widgets.push_back({label, {title}});
@@ -101,7 +105,7 @@ QCheckBox *GeneralPageView::addCheckbox(const QString &text,
                                         BoolSetting &setting, bool inverse,
                                         QString toolTipText)
 {
-    auto check = new QCheckBox(text);
+    auto *check = new QCheckBox(text);
     this->addToolTip(*check, toolTipText);
 
     // update when setting changes
@@ -151,12 +155,12 @@ ComboBox *GeneralPageView::addDropdown(const QString &text,
                                        const QStringList &list,
                                        QString toolTipText)
 {
-    auto layout = new QHBoxLayout;
-    auto combo = new ComboBox;
+    auto *layout = new QHBoxLayout;
+    auto *combo = new ComboBox;
     combo->setFocusPolicy(Qt::StrongFocus);
     combo->addItems(list);
 
-    auto label = new QLabel(text + ":");
+    auto *label = new QLabel(text + ":");
     layout->addWidget(label);
     layout->addStretch(1);
     layout->addWidget(combo);
@@ -176,10 +180,12 @@ ComboBox *GeneralPageView::addDropdown(
     pajlada::Settings::Setting<QString> &setting, bool editable,
     QString toolTipText)
 {
-    auto combo = this->addDropdown(text, items, toolTipText);
+    auto *combo = this->addDropdown(text, items, toolTipText);
 
     if (editable)
+    {
         combo->setEditable(true);
+    }
 
     // update when setting changes
     setting.connect(
@@ -201,9 +207,9 @@ ColorButton *GeneralPageView::addColorButton(
     const QString &text, const QColor &color,
     pajlada::Settings::Setting<QString> &setting, QString toolTipText)
 {
-    auto colorButton = new ColorButton(color);
-    auto layout = new QHBoxLayout();
-    auto label = new QLabel(text + ":");
+    auto *colorButton = new ColorButton(color);
+    auto *layout = new QHBoxLayout();
+    auto *label = new QLabel(text + ":");
 
     layout->addWidget(label);
     layout->addStretch(1);
@@ -238,12 +244,12 @@ QSpinBox *GeneralPageView::addIntInput(const QString &text, IntSetting &setting,
                                        int min, int max, int step,
                                        QString toolTipText)
 {
-    auto layout = new QHBoxLayout;
+    auto *layout = new QHBoxLayout;
 
-    auto label = new QLabel(text + ":");
+    auto *label = new QLabel(text + ":");
     this->addToolTip(*label, toolTipText);
 
-    auto input = new QSpinBox;
+    auto *input = new QSpinBox;
     input->setMinimum(min);
     input->setMaximum(max);
 
@@ -280,7 +286,7 @@ void GeneralPageView::addNavigationSpacing()
 
 DescriptionLabel *GeneralPageView::addDescription(const QString &text)
 {
-    auto label = new DescriptionLabel(text);
+    auto *label = new DescriptionLabel(text);
 
     label->setTextInteractionFlags(Qt::TextBrowserInteraction |
                                    Qt::LinksAccessibleByKeyboard);
@@ -310,7 +316,7 @@ bool GeneralPageView::filterElements(const QString &query)
         bool descriptionMatches{};
         for (auto &&widget : group.widgets)
         {
-            if (auto x = dynamic_cast<DescriptionLabel *>(widget.element); x)
+            if (auto *x = dynamic_cast<DescriptionLabel *>(widget.element); x)
             {
                 if (x->text().contains(query, Qt::CaseInsensitive))
                 {
@@ -325,7 +331,9 @@ bool GeneralPageView::filterElements(const QString &query)
             descriptionMatches)
         {
             for (auto &&widget : group.widgets)
+            {
                 widget.element->show();
+            }
 
             group.title->show();
             group.navigationLink->show();
@@ -342,11 +350,13 @@ bool GeneralPageView::filterElements(const QString &query)
 
             for (auto &&widget : group.widgets)
             {
-                if (auto x = dynamic_cast<SubtitleLabel *>(widget.element))
+                if (auto *x = dynamic_cast<SubtitleLabel *>(widget.element))
                 {
                     currentSubtitleSearched = false;
                     if (currentSubtitle)
+                    {
                         currentSubtitle->setVisible(currentSubtitleVisible);
+                    }
 
                     currentSubtitleVisible = false;
                     currentSubtitle = widget.element;
@@ -375,10 +385,14 @@ bool GeneralPageView::filterElements(const QString &query)
             }
 
             if (currentSubtitle)
+            {
                 currentSubtitle->setVisible(currentSubtitleVisible);
+            }
 
             if (group.space)
+            {
                 group.space->setVisible(groupAny);
+            }
 
             group.title->setVisible(groupAny);
             group.navigationLink->setVisible(groupAny);

--- a/src/widgets/settingspages/GeneralPageView.hpp
+++ b/src/widgets/settingspages/GeneralPageView.hpp
@@ -123,7 +123,7 @@ public:
     template <typename OnClick>
     QPushButton *makeButton(const QString &text, OnClick onClick)
     {
-        auto button = new QPushButton(text);
+        auto *button = new QPushButton(text);
         this->groups_.back().widgets.push_back({button, {text}});
         QObject::connect(button, &QPushButton::clicked, onClick);
         return button;
@@ -133,7 +133,7 @@ public:
     QPushButton *addButton(const QString &text, OnClick onClick)
     {
         auto button = makeButton(text, onClick);
-        auto layout = new QHBoxLayout();
+        auto *layout = new QHBoxLayout();
         layout->addWidget(button);
         layout->addStretch(1);
         this->addLayout(layout);
@@ -155,19 +155,25 @@ public:
         {
             // QString
             if (!editable && !items2.contains(boost::get<QString>(selected)))
+            {
                 items2.insert(0, boost::get<QString>(selected));
+            }
         }
 
-        auto combo = this->addDropdown(text, items2, toolTipText);
+        auto *combo = this->addDropdown(text, items2, toolTipText);
         if (editable)
+        {
             combo->setEditable(true);
+        }
 
         if (selected.which() == 0)
         {
             // int
             auto value = boost::get<int>(selected);
             if (value >= 0 && value < items2.size())
+            {
                 combo->setCurrentIndex(value);
+            }
         }
         else if (selected.which() == 1)
         {
@@ -179,7 +185,9 @@ public:
             [getValue = std::move(getValue), combo](const T &value, auto) {
                 auto var = getValue(value);
                 if (var.which() == 0)
+                {
                     combo->setCurrentIndex(boost::get<int>(var));
+                }
                 else
                 {
                     combo->setCurrentText(boost::get<QString>(var));

--- a/src/widgets/settingspages/HighlightingPage.cpp
+++ b/src/widgets/settingspages/HighlightingPage.cpp
@@ -67,7 +67,7 @@ HighlightingPage::HighlightingPage()
                     "Message highlights are prioritized over badge highlights "
                     "and user highlights.");
 
-                auto view =
+                auto *view =
                     highlights
                         .emplace<EditableModelView>(
                             (new HighlightModel(nullptr))
@@ -170,12 +170,12 @@ HighlightingPage::HighlightingPage()
                     "user badges.\n"
                     "Badge highlights are prioritzed under user and message "
                     "highlights.");
-                auto view = badgeHighlights
-                                .emplace<EditableModelView>(
-                                    (new BadgeHighlightModel(nullptr))
-                                        ->initialized(
-                                            &getSettings()->highlightedBadges))
-                                .getElement();
+                auto *view = badgeHighlights
+                                 .emplace<EditableModelView>(
+                                     (new BadgeHighlightModel(nullptr))
+                                         ->initialized(
+                                             &getSettings()->highlightedBadges))
+                                 .getElement();
                 view->setTitles({"Name", "Show In\nMentions", "Flash\ntaskbar",
                                  "Play\nsound", "Custom\nsound", "Color"});
                 view->getTableView()->horizontalHeader()->setSectionResizeMode(

--- a/src/widgets/settingspages/IgnoresPage.cpp
+++ b/src/widgets/settingspages/IgnoresPage.cpp
@@ -83,7 +83,7 @@ void addUsersTab(IgnoresPage &page, LayoutCreator<QVBoxLayout> users,
     {
         anyways.emplace<QLabel>("Show messages from blocked users:");
 
-        auto combo = anyways.emplace<QComboBox>().getElement();
+        auto *combo = anyways.emplace<QComboBox>().getElement();
         combo->addItems(
             {"Never", "If you are Moderator", "If you are Broadcaster"});
 
@@ -97,7 +97,9 @@ void addUsersTab(IgnoresPage &page, LayoutCreator<QVBoxLayout> users,
                          QOverload<int>::of(&QComboBox::currentIndexChanged),
                          [&setting](int index) {
                              if (index != -1)
+                             {
                                  setting = index;
+                             }
                          });
 
         anyways->addStretch(1);

--- a/src/widgets/settingspages/ModerationPage.cpp
+++ b/src/widgets/settingspages/ModerationPage.cpp
@@ -43,7 +43,9 @@ QString formatSize(qint64 size)
     for (i = 0; i < units.size() - 1; i++)
     {
         if (outputSize < 1024)
+        {
             break;
+        }
         outputSize = outputSize / 1024;
     }
     return QString("%0 %1").arg(outputSize, 0, 'f', 2).arg(units[i]);
@@ -248,7 +250,7 @@ void ModerationPage::addModerationButtonSettings(
     const auto valueChanged = [=, this] {
         const auto index = QObject::sender()->objectName().toInt();
 
-        const auto line = this->durationInputs_[index];
+        auto *const line = this->durationInputs_[index];
         const auto duration = line->text().toInt();
         const auto unit = this->unitInputs_[index]->currentText();
 

--- a/src/widgets/splits/InputCompletionItem.cpp
+++ b/src/widgets/splits/InputCompletionItem.cpp
@@ -19,9 +19,13 @@ void InputCompletionItem::action()
     if (this->action_)
     {
         if (this->emote_)
+        {
             this->action_(this->emote_->name.string);
+        }
         else
+        {
             this->action_(this->text_);
+        }
     }
 }
 

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -199,11 +199,11 @@ namespace {
             parent);
         window->setWindowTitle("Chatterino - " + title);
         window->setAttribute(Qt::WA_DeleteOnClose);
-        auto layout = new QVBoxLayout();
+        auto *layout = new QVBoxLayout();
         layout->addWidget(new QLabel(description));
-        auto label = new QLabel(window);
+        auto *label = new QLabel(window);
         layout->addWidget(label);
-        auto movie = new QMovie(label);
+        auto *movie = new QMovie(label);
         movie->setFileName(source);
         label->setMovie(movie);
         movie->start();
@@ -805,7 +805,7 @@ void Split::refreshModerationMode()
 
 void Split::openChannelInBrowserPlayer(ChannelPtr channel)
 {
-    if (auto twitchChannel = dynamic_cast<TwitchChannel *>(channel.get()))
+    if (auto *twitchChannel = dynamic_cast<TwitchChannel *>(channel.get()))
     {
         QDesktopServices::openUrl(
             "https://player.twitch.tv/?parent=twitch.tv&channel=" +
@@ -918,7 +918,7 @@ void Split::showChangeChannelPopup(const char *dialogTitle, bool empty,
         return;
     }
 
-    auto dialog = new SelectChannelDialog(this);
+    auto *dialog = new SelectChannelDialog(this);
     if (!empty)
     {
         dialog->setSelectedChannel(this->getIndirectChannel());
@@ -1065,7 +1065,7 @@ void Split::explainSplitting()
 
 void Split::popup()
 {
-    auto app = getApp();
+    auto *app = getApp();
     Window &window = app->windows->createWindow(WindowType::Popup);
 
     Split *split = new Split(static_cast<SplitContainer *>(
@@ -1088,7 +1088,7 @@ void Split::openInBrowser()
 {
     auto channel = this->getChannel();
 
-    if (auto twitchChannel = dynamic_cast<TwitchChannel *>(channel.get()))
+    if (auto *twitchChannel = dynamic_cast<TwitchChannel *>(channel.get()))
     {
         QDesktopServices::openUrl("https://twitch.tv/" +
                                   twitchChannel->getName());
@@ -1111,7 +1111,7 @@ void Split::openModViewInBrowser()
 {
     auto channel = this->getChannel();
 
-    if (auto twitchChannel = dynamic_cast<TwitchChannel *>(channel.get()))
+    if (auto *twitchChannel = dynamic_cast<TwitchChannel *>(channel.get()))
     {
         QDesktopServices::openUrl("https://twitch.tv/moderator/" +
                                   twitchChannel->getName());
@@ -1131,9 +1131,9 @@ void Split::openWithCustomScheme()
         return;
     }
 
-    const auto channel = this->getChannel().get();
+    auto *const channel = this->getChannel().get();
 
-    if (const auto twitchChannel = dynamic_cast<TwitchChannel *>(channel))
+    if (auto *const twitchChannel = dynamic_cast<TwitchChannel *>(channel))
     {
         QDesktopServices::openUrl(QString("%1https://twitch.tv/%2")
                                       .arg(scheme)
@@ -1422,7 +1422,7 @@ void Split::openSubPage()
 {
     ChannelPtr channel = this->getChannel();
 
-    if (auto twitchChannel = dynamic_cast<TwitchChannel *>(channel.get()))
+    if (auto *twitchChannel = dynamic_cast<TwitchChannel *>(channel.get()))
     {
         QDesktopServices::openUrl(twitchChannel->subscriptionUrl());
     }
@@ -1466,8 +1466,8 @@ void Split::showSearch(bool singleChannel)
     auto &notebook = getApp()->windows->getMainWindow().getNotebook();
     for (int i = 0; i < notebook.getPageCount(); ++i)
     {
-        auto container = dynamic_cast<SplitContainer *>(notebook.getPageAt(i));
-        for (auto split : container->getSplits())
+        auto *container = dynamic_cast<SplitContainer *>(notebook.getPageAt(i));
+        for (auto *split : container->getSplits())
         {
             if (split->channel_.getType() != Channel::Type::TwitchAutomod)
             {
@@ -1484,7 +1484,7 @@ void Split::reloadChannelAndSubscriberEmotes()
     auto channel = this->getChannel();
     getApp()->accounts->twitch.getCurrent()->loadEmotes(channel);
 
-    if (auto twitchChannel = dynamic_cast<TwitchChannel *>(channel.get()))
+    if (auto *twitchChannel = dynamic_cast<TwitchChannel *>(channel.get()))
     {
         twitchChannel->refreshBTTVChannelEmotes(true);
         twitchChannel->refreshFFZChannelEmotes(true);
@@ -1551,8 +1551,8 @@ void Split::drag()
     startDraggingSplit();
 
     auto originalLocation = container->releaseSplit(this);
-    auto drag = new QDrag(this);
-    auto mimeData = new QMimeData;
+    auto *drag = new QDrag(this);
+    auto *mimeData = new QMimeData;
 
     mimeData->setData("chatterino/split", "xD");
     drag->setMimeData(mimeData);

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -50,13 +50,13 @@ SplitInput::SplitInput(QWidget *parent, Split *_chatWidget,
     this->installEventFilter(this);
     this->initLayout();
 
-    auto completer =
+    auto *completer =
         new QCompleter(&this->split_->getChannel()->completionModel);
     this->ui_.textEdit->setCompleter(completer);
 
     this->signalHolder_.managedConnect(this->split_->channelChanged, [this] {
         auto channel = this->split_->getChannel();
-        auto completer = new QCompleter(&channel->completionModel);
+        auto *completer = new QCompleter(&channel->completionModel);
         this->ui_.textEdit->setCompleter(completer);
     });
 
@@ -78,7 +78,7 @@ SplitInput::SplitInput(QWidget *parent, Split *_chatWidget,
 
 void SplitInput::initLayout()
 {
-    auto app = getApp();
+    auto *app = getApp();
     LayoutCreator<SplitInput> layoutCreator(this);
 
     auto layout =
@@ -202,7 +202,7 @@ void SplitInput::initLayout()
 
 void SplitInput::scaleChangedEvent(float scale)
 {
-    auto app = getApp();
+    auto *app = getApp();
     // update the icon size of the buttons
     this->updateEmoteButton();
     this->updateCancelReplyButton();
@@ -328,7 +328,9 @@ QString SplitInput::handleSendMessage(std::vector<QString> &arguments)
 {
     auto c = this->split_->getChannel();
     if (c == nullptr)
+    {
         return "";
+    }
 
     if (!c->isTwitchChannel() || this->replyThread_ == nullptr)
     {
@@ -347,7 +349,7 @@ QString SplitInput::handleSendMessage(std::vector<QString> &arguments)
     else
     {
         // Reply to message
-        auto tc = dynamic_cast<TwitchChannel *>(c.get());
+        auto *tc = dynamic_cast<TwitchChannel *>(c.get());
         if (!tc)
         {
             // this should not fail
@@ -635,7 +637,7 @@ bool SplitInput::eventFilter(QObject *obj, QEvent *event)
     if (event->type() == QEvent::ShortcutOverride ||
         event->type() == QEvent::Shortcut)
     {
-        if (auto popup = this->inputCompletionPopup_.data())
+        if (auto *popup = this->inputCompletionPopup_.data())
         {
             if (popup->isVisible())
             {
@@ -906,7 +908,7 @@ bool SplitInput::isHidden() const
 
 void SplitInput::editTextChanged()
 {
-    auto app = getApp();
+    auto *app = getApp();
 
     // set textLengthLabel value
     QString text = this->ui_.textEdit->toPlainText();


### PR DESCRIPTION
- Add script for running clang-tidy on all files
- run clang-tidy fix -*,readability-braces-around-statements,readability-qualified-auto

<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
