### PR TITLE
clang-tidy: Make protected & private suffix underscore optional

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -45,11 +45,9 @@ CheckOptions:
   - key: readability-identifier-naming.MemberCase
     value: camelBack
   - key: readability-identifier-naming.PrivateMemberIgnoredRegexp
-    value: .*
-  - key: readability-identifier-naming.PrivateMemberSuffix
-    value: _
-  - key: readability-identifier-naming.ProtectedMemberSuffix
-    value: _
+    value: ^.*_$
+  - key: readability-identifier-naming.ProtectedMemberIgnoredRegexp
+    value: ^.*_$
   - key: readability-identifier-naming.UnionCase
     value: CamelCase
   - key: readability-identifier-naming.GlobalConstantCase


### PR DESCRIPTION
The rationale behind this is: The underscore is not there as a hint that the member is private, the underscore is there to allow for a function to have the "real" name, so it can be used as a getter or something similar in the public API.
We had an ignore on all private members either way, meaning this didn't fire.
Being a bit more flexible here allows us to make private-accessing code that doesn't have a public API to look cleaner.
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
