### PR TITLE
refactor: Fix a bunch of minor things

### DIFF
--- a/src/messages/Emote.hpp
+++ b/src/messages/Emote.hpp
@@ -16,7 +16,7 @@ struct Emote {
     ImageSet images;
     Tooltip tooltip;
     Url homePage;
-    bool zeroWidth;
+    bool zeroWidth{};
     EmoteId id;
     EmoteAuthor author;
     /**

--- a/src/messages/SharedMessageBuilder.hpp
+++ b/src/messages/SharedMessageBuilder.hpp
@@ -54,6 +54,7 @@ protected:
 
     virtual Outcome tryAppendEmote(const EmoteName &name)
     {
+        (void)name;
         return Failure;
     }
 

--- a/src/providers/irc/AbstractIrcServer.hpp
+++ b/src/providers/irc/AbstractIrcServer.hpp
@@ -57,7 +57,11 @@ protected:
     // initializeConnectionSignals is called on a connection once in its lifetime.
     // it can be used to connect signals to your class
     virtual void initializeConnectionSignals(IrcConnection *connection,
-                                             ConnectionType type){};
+                                             ConnectionType type)
+    {
+        (void)connection;
+        (void)type;
+    }
 
     // initializeConnection is called every time before we try to connect to the IRC server
     virtual void initializeConnection(IrcConnection *connection,

--- a/src/providers/irc/AbstractIrcServer.hpp
+++ b/src/providers/irc/AbstractIrcServer.hpp
@@ -23,6 +23,10 @@ public:
     enum ConnectionType { Read = 1, Write = 2, Both = 3 };
 
     ~AbstractIrcServer() override = default;
+    AbstractIrcServer(const AbstractIrcServer &) = delete;
+    AbstractIrcServer(AbstractIrcServer &&) = delete;
+    AbstractIrcServer &operator=(const AbstractIrcServer &) = delete;
+    AbstractIrcServer &operator=(AbstractIrcServer &&) = delete;
 
     // initializeIrc must be called from the derived class
     // this allows us to initialize the abstract IRC server based on the derived class's parameters

--- a/src/providers/twitch/PubSubClient.cpp
+++ b/src/providers/twitch/PubSubClient.cpp
@@ -76,7 +76,7 @@ void PubSubClient::close(const std::string &reason,
 
 bool PubSubClient::listen(const PubSubListenMessage &msg)
 {
-    int numRequestedListens = msg.topics.size();
+    auto numRequestedListens = msg.topics.size();
 
     if (this->numListens_ + numRequestedListens > PubSubClient::MAX_LISTENS)
     {
@@ -84,7 +84,8 @@ bool PubSubClient::listen(const PubSubListenMessage &msg)
         return false;
     }
     this->numListens_ += numRequestedListens;
-    DebugCount::increase("PubSub topic pending listens", numRequestedListens);
+    DebugCount::increase("PubSub topic pending listens",
+                         static_cast<int64_t>(numRequestedListens));
 
     for (const auto &topic : msg.topics)
     {
@@ -134,7 +135,7 @@ PubSubClient::UnlistenPrefixResponse PubSubClient::unlistenPrefix(
 
     this->numListens_ -= numRequestedUnlistens;
     DebugCount::increase("PubSub topic pending unlistens",
-                         numRequestedUnlistens);
+                         static_cast<int64_t>(numRequestedUnlistens));
 
     PubSubUnlistenMessage message(topics);
 

--- a/src/providers/twitch/PubSubClient.cpp
+++ b/src/providers/twitch/PubSubClient.cpp
@@ -200,6 +200,7 @@ void PubSubClient::ping()
 
     runAfter(this->heartbeatTimer_, this->clientOptions_.pingInterval_,
              [self](auto timer) {
+                 (void)timer;
                  if (!self->started_)
                  {
                      return;

--- a/src/providers/twitch/PubSubClient.cpp
+++ b/src/providers/twitch/PubSubClient.cpp
@@ -88,7 +88,14 @@ bool PubSubClient::listen(PubSubListenMessage msg)
 
     for (const auto &topic : msg.topics)
     {
-        this->listeners_.emplace_back(Listener{topic, false, false, false});
+        this->listeners_.emplace_back(Listener{
+            TopicData{
+                topic,
+                false,
+                false,
+            },
+            false,
+        });
     }
 
     qCDebug(chatterinoPubSub)

--- a/src/providers/twitch/PubSubClient.cpp
+++ b/src/providers/twitch/PubSubClient.cpp
@@ -74,7 +74,7 @@ void PubSubClient::close(const std::string &reason,
         });
 }
 
-bool PubSubClient::listen(PubSubListenMessage msg)
+bool PubSubClient::listen(const PubSubListenMessage &msg)
 {
     int numRequestedListens = msg.topics.size();
 

--- a/src/providers/twitch/PubSubClient.hpp
+++ b/src/providers/twitch/PubSubClient.hpp
@@ -45,7 +45,7 @@ public:
                websocketpp::close::status::value code =
                    websocketpp::close::status::normal);
 
-    bool listen(PubSubListenMessage msg);
+    bool listen(const PubSubListenMessage &msg);
     UnlistenPrefixResponse unlistenPrefix(const QString &prefix);
 
     void handleListenResponse(const PubSubMessage &message);

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -779,12 +779,12 @@ void TwitchChannel::setRoomId(const QString &id)
 SharedAccessGuard<const TwitchChannel::RoomModes>
     TwitchChannel::accessRoomModes() const
 {
-    return this->roomModes_.accessConst();
+    return this->roomModes.accessConst();
 }
 
-void TwitchChannel::setRoomModes(const RoomModes &_roomModes)
+void TwitchChannel::setRoomModes(const RoomModes &newRoomModes)
 {
-    this->roomModes_ = _roomModes;
+    this->roomModes = newRoomModes;
 
     this->roomModesChanged.invoke();
 }

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -1134,7 +1134,7 @@ const QString &TwitchChannel::popoutPlayerUrl()
     return this->popoutPlayerUrl_;
 }
 
-int TwitchChannel::chatterCount()
+int TwitchChannel::chatterCount() const
 {
     return this->chatterCount_;
 }

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -321,13 +321,15 @@ void TwitchChannel::refreshFFZChannelEmotes(bool manualRefresh)
         [this, weak = weakOf<Channel>(this)](auto &&modBadge) {
             if (auto shared = weak.lock())
             {
-                this->ffzCustomModBadge_.set(std::move(modBadge));
+                this->ffzCustomModBadge_.set(
+                    std::forward<decltype(modBadge)>(modBadge));
             }
         },
         [this, weak = weakOf<Channel>(this)](auto &&vipBadge) {
             if (auto shared = weak.lock())
             {
-                this->ffzCustomVipBadge_.set(std::move(vipBadge));
+                this->ffzCustomVipBadge_.set(
+                    std::forward<decltype(vipBadge)>(vipBadge));
             }
         },
         manualRefresh);

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -1352,7 +1352,10 @@ void TwitchChannel::refreshChatters()
             }
         },
         // Refresh chatters should only be used when failing silently is an option
-        [](auto error, auto message) {});
+        [](auto error, auto message) {
+            (void)error;
+            (void)message;
+        });
 }
 
 void TwitchChannel::addReplyThread(const std::shared_ptr<MessageThread> &thread)

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -1430,14 +1430,15 @@ void TwitchChannel::refreshBadges()
                 for (const auto &version : badgeSet.versions)
                 {
                     auto emote = Emote{
-                        EmoteName{},
-                        ImageSet{
-                            Image::fromUrl(version.imageURL1x, 1),
-                            Image::fromUrl(version.imageURL2x, .5),
-                            Image::fromUrl(version.imageURL4x, .25),
-                        },
-                        Tooltip{version.title},
-                        version.clickURL,
+                        .name = EmoteName{},
+                        .images =
+                            ImageSet{
+                                Image::fromUrl(version.imageURL1x, 1),
+                                Image::fromUrl(version.imageURL2x, .5),
+                                Image::fromUrl(version.imageURL4x, .25),
+                            },
+                        .tooltip = Tooltip{version.title},
+                        .homePage = version.clickURL,
                     };
                     (*badgeSets)[setID][version.id] =
                         std::make_shared<Emote>(emote);

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -1202,7 +1202,7 @@ void TwitchChannel::loadRecentMessages()
             tc->loadingRecentMessages_.clear();
 
             std::vector<MessagePtr> msgs;
-            for (MessagePtr msg : messages)
+            for (const auto &msg : messages)
             {
                 const auto highlighted =
                     msg->flags.has(MessageFlag::Highlighted);

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -1508,22 +1508,28 @@ void TwitchChannel::refreshCheerEmotes()
                     // Combine the prefix (e.g. BibleThump) with the tier (1, 100 etc.)
                     auto emoteTooltip =
                         set.prefix + tier.id + "<br>Twitch Cheer Emote";
-                    cheerEmote.animatedEmote = std::make_shared<Emote>(
-                        Emote{EmoteName{"cheer emote"},
-                              ImageSet{
-                                  tier.darkAnimated.imageURL1x,
-                                  tier.darkAnimated.imageURL2x,
-                                  tier.darkAnimated.imageURL4x,
-                              },
-                              Tooltip{emoteTooltip}, Url{}});
-                    cheerEmote.staticEmote = std::make_shared<Emote>(
-                        Emote{EmoteName{"cheer emote"},
-                              ImageSet{
-                                  tier.darkStatic.imageURL1x,
-                                  tier.darkStatic.imageURL2x,
-                                  tier.darkStatic.imageURL4x,
-                              },
-                              Tooltip{emoteTooltip}, Url{}});
+                    cheerEmote.animatedEmote = std::make_shared<Emote>(Emote{
+                        .name = EmoteName{"cheer emote"},
+                        .images =
+                            ImageSet{
+                                tier.darkAnimated.imageURL1x,
+                                tier.darkAnimated.imageURL2x,
+                                tier.darkAnimated.imageURL4x,
+                            },
+                        .tooltip = Tooltip{emoteTooltip},
+                        .homePage = Url{},
+                    });
+                    cheerEmote.staticEmote = std::make_shared<Emote>(Emote{
+                        .name = EmoteName{"cheer emote"},
+                        .images =
+                            ImageSet{
+                                tier.darkStatic.imageURL1x,
+                                tier.darkStatic.imageURL2x,
+                                tier.darkStatic.imageURL4x,
+                            },
+                        .tooltip = Tooltip{emoteTooltip},
+                        .homePage = Url{},
+                    });
 
                     cheerEmoteSet.cheerEmotes.emplace_back(
                         std::move(cheerEmote));

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -1760,7 +1760,7 @@ void TwitchChannel::updateSevenTVActivity()
         });
 }
 
-void TwitchChannel::listenSevenTVCosmetics()
+void TwitchChannel::listenSevenTVCosmetics() const
 {
     if (getApp()->twitch->seventvEventAPI)
     {

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -83,7 +83,6 @@ TwitchChannel::TwitchChannel(const QString &name)
     , bttvEmotes_(std::make_shared<EmoteMap>())
     , ffzEmotes_(std::make_shared<EmoteMap>())
     , seventvEmotes_(std::make_shared<EmoteMap>())
-    , mod_(false)
 {
     qCDebug(chatterinoTwitch) << "[TwitchChannel" << name << "] Opened";
 

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -110,6 +110,11 @@ public:
     explicit TwitchChannel(const QString &channelName);
     ~TwitchChannel() override;
 
+    TwitchChannel(const TwitchChannel &) = delete;
+    TwitchChannel(TwitchChannel &&) = delete;
+    TwitchChannel &operator=(const TwitchChannel &) = delete;
+    TwitchChannel &operator=(TwitchChannel &&) = delete;
+
     void initialize();
 
     // Channel methods

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -135,7 +135,7 @@ public:
     const QString &subscriptionUrl();
     const QString &channelUrl();
     const QString &popoutPlayerUrl();
-    int chatterCount();
+    int chatterCount() const;
     bool isLive() const override;
     QString roomId() const;
     SharedAccessGuard<const RoomModes> accessRoomModes() const;

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -305,7 +305,7 @@ private:
      * This is done at most once every 60s.
      */
     void updateSevenTVActivity();
-    void listenSevenTVCosmetics();
+    void listenSevenTVCosmetics() const;
 
     /**
      * @brief Sets the live status of this Twitch channel

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -317,7 +317,7 @@ private:
     void setVIP(bool value);
     void setStaff(bool value);
     void setRoomId(const QString &id);
-    void setRoomModes(const RoomModes &roomModes_);
+    void setRoomModes(const RoomModes &newRoomModes);
     void setDisplayName(const QString &name);
     void setLocalizedName(const QString &name);
 
@@ -376,7 +376,7 @@ private:
     const QString popoutPlayerUrl_;
     int chatterCount_{};
     UniqueAccess<StreamStatus> streamStatus_;
-    UniqueAccess<RoomModes> roomModes_;
+    UniqueAccess<RoomModes> roomModes;
     bool disconnected_{};
     std::optional<std::chrono::time_point<std::chrono::system_clock>>
         lastConnectedAt_{};

--- a/src/widgets/settingspages/GeneralPageView.hpp
+++ b/src/widgets/settingspages/GeneralPageView.hpp
@@ -78,6 +78,7 @@ class ComboBox : public QComboBox
 
     void wheelEvent(QWheelEvent *event) override
     {
+        (void)event;
     }
 };
 
@@ -311,8 +312,9 @@ public:
     bool filterElements(const QString &query);
 
 protected:
-    void resizeEvent(QResizeEvent *ev) override
+    void resizeEvent(QResizeEvent *event) override
     {
+        (void)event;
     }
 
 private:

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -959,17 +959,23 @@ void Split::paintEvent(QPaintEvent *)
 
 void Split::mouseMoveEvent(QMouseEvent *event)
 {
+    (void)event;
+
     this->handleModifiers(QGuiApplication::queryKeyboardModifiers());
 }
 
 void Split::keyPressEvent(QKeyEvent *event)
 {
+    (void)event;
+
     this->view_->unsetCursor();
     this->handleModifiers(QGuiApplication::queryKeyboardModifiers());
 }
 
 void Split::keyReleaseEvent(QKeyEvent *event)
 {
+    (void)event;
+
     this->view_->unsetCursor();
     this->handleModifiers(QGuiApplication::queryKeyboardModifiers());
 }
@@ -1005,6 +1011,8 @@ void Split::enterEvent(QEvent * /*event*/)
 
 void Split::leaveEvent(QEvent *event)
 {
+    (void)event;
+
     this->isMouseOver_ = false;
 
     this->overlay_->hide();

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -398,7 +398,7 @@ void SplitInput::addShortcuts()
 {
     HotkeyController::HotkeyMap actions{
         {"cursorToStart",
-         [this](std::vector<QString> arguments) -> QString {
+         [this](const std::vector<QString> &arguments) -> QString {
              if (arguments.size() != 1)
              {
                  qCWarning(chatterinoHotkeys)
@@ -409,7 +409,7 @@ void SplitInput::addShortcuts()
              }
              QTextCursor cursor = this->ui_.textEdit->textCursor();
              auto place = QTextCursor::Start;
-             auto stringTakeSelection = arguments.at(0);
+             const auto &stringTakeSelection = arguments.at(0);
              bool select{};
              if (stringTakeSelection == "withSelection")
              {
@@ -433,7 +433,7 @@ void SplitInput::addShortcuts()
              return "";
          }},
         {"cursorToEnd",
-         [this](std::vector<QString> arguments) -> QString {
+         [this](const std::vector<QString> &arguments) -> QString {
              if (arguments.size() != 1)
              {
                  qCWarning(chatterinoHotkeys)
@@ -444,7 +444,7 @@ void SplitInput::addShortcuts()
              }
              QTextCursor cursor = this->ui_.textEdit->textCursor();
              auto place = QTextCursor::End;
-             auto stringTakeSelection = arguments.at(0);
+             const auto &stringTakeSelection = arguments.at(0);
              bool select{};
              if (stringTakeSelection == "withSelection")
              {
@@ -468,12 +468,14 @@ void SplitInput::addShortcuts()
              return "";
          }},
         {"openEmotesPopup",
-         [this](std::vector<QString>) -> QString {
+         [this](const std::vector<QString> &arguments) -> QString {
+             (void)arguments;
+
              this->openEmotePopup();
              return "";
          }},
         {"sendMessage",
-         [this](std::vector<QString> arguments) -> QString {
+         [this](const std::vector<QString> &arguments) -> QString {
              return this->handleSendMessage(arguments);
          }},
         {"previousMessage",
@@ -502,7 +504,9 @@ void SplitInput::addShortcuts()
              return "";
          }},
         {"nextMessage",
-         [this](std::vector<QString>) -> QString {
+         [this](const std::vector<QString> &arguments) -> QString {
+             (void)arguments;
+
              // If user did not write anything before then just do nothing.
              if (this->prevMsg_.isEmpty())
              {
@@ -551,17 +555,21 @@ void SplitInput::addShortcuts()
              return "";
          }},
         {"undo",
-         [this](std::vector<QString>) -> QString {
+         [this](const std::vector<QString> &arguments) -> QString {
+             (void)arguments;
+
              this->ui_.textEdit->undo();
              return "";
          }},
         {"redo",
-         [this](std::vector<QString>) -> QString {
+         [this](const std::vector<QString> &arguments) -> QString {
+             (void)arguments;
+
              this->ui_.textEdit->redo();
              return "";
          }},
         {"copy",
-         [this](std::vector<QString> arguments) -> QString {
+         [this](const std::vector<QString> &arguments) -> QString {
              // XXX: this action is unused at the moment, a qt standard shortcut is used instead
              if (arguments.size() == 0)
              {
@@ -573,8 +581,9 @@ void SplitInput::addShortcuts()
                         "copied. Automatic will pick whichever has a "
                         "selection";
              }
+
              bool copyFromSplit = false;
-             auto mode = arguments.at(0);
+             const auto &mode = arguments.at(0);
              if (mode == "split")
              {
                  copyFromSplit = true;
@@ -600,22 +609,30 @@ void SplitInput::addShortcuts()
              return "";
          }},
         {"paste",
-         [this](std::vector<QString>) -> QString {
+         [this](const std::vector<QString> &arguments) -> QString {
+             (void)arguments;
+
              this->ui_.textEdit->paste();
              return "";
          }},
         {"clear",
-         [this](std::vector<QString>) -> QString {
+         [this](const std::vector<QString> &arguments) -> QString {
+             (void)arguments;
+
              this->clearInput();
              return "";
          }},
         {"selectAll",
-         [this](std::vector<QString>) -> QString {
+         [this](const std::vector<QString> &arguments) -> QString {
+             (void)arguments;
+
              this->ui_.textEdit->selectAll();
              return "";
          }},
         {"selectWord",
-         [this](std::vector<QString>) -> QString {
+         [this](const std::vector<QString> &arguments) -> QString {
+             (void)arguments;
+
              auto cursor = this->ui_.textEdit->textCursor();
              cursor.select(QTextCursor::WordUnderCursor);
              this->ui_.textEdit->setTextCursor(cursor);

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -410,7 +410,7 @@ void SplitInput::addShortcuts()
              QTextCursor cursor = this->ui_.textEdit->textCursor();
              auto place = QTextCursor::Start;
              auto stringTakeSelection = arguments.at(0);
-             bool select;
+             bool select{};
              if (stringTakeSelection == "withSelection")
              {
                  select = true;
@@ -445,7 +445,7 @@ void SplitInput::addShortcuts()
              QTextCursor cursor = this->ui_.textEdit->textCursor();
              auto place = QTextCursor::End;
              auto stringTakeSelection = arguments.at(0);
-             bool select;
+             bool select{};
              if (stringTakeSelection == "withSelection")
              {
                  select = true;
@@ -1008,7 +1008,7 @@ void SplitInput::paintEvent(QPaintEvent * /*event*/)
 {
     QPainter painter(this);
 
-    int s;
+    int s{};
     QColor borderColor;
 
     if (this->theme->isLightTheme())

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -275,7 +275,7 @@ void SplitInput::updateCancelReplyButton()
     auto text =
         QStringLiteral("<img src=':/buttons/%1.svg' width='%2' height='%2' />")
             .arg(this->theme->isLightTheme() ? "cancelDark" : "cancel")
-            .arg(QString::number(int(12 * scale)));
+            .arg(int(12 * scale));
 
     this->ui_.cancelReplyButton->getLabel().setText(text);
     this->ui_.cancelReplyButton->setFixedHeight(int(12 * scale));

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -257,15 +257,12 @@ void SplitInput::themeChangedEvent()
 
 void SplitInput::updateEmoteButton()
 {
-    float scale = this->scale();
+    auto scale = this->scale();
 
-    QString text = "<img src=':/buttons/emote.svg' width='xD' height='xD' />";
-    text.replace("xD", QString::number(int(12 * scale)));
-
-    if (this->theme->isLightTheme())
-    {
-        text.replace("emote", "emoteDark");
-    }
+    auto text =
+        QStringLiteral("<img src=':/buttons/%1.svg' width='%2' height='%2' />")
+            .arg(this->theme->isLightTheme() ? "emoteDark" : "emote")
+            .arg(int(12 * scale));
 
     this->ui_.emoteButton->getLabel().setText(text);
     this->ui_.emoteButton->setFixedHeight(int(18 * scale));

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -317,7 +317,7 @@ void SplitInput::openEmotePopup()
     this->emotePopup_->activateWindow();
 }
 
-QString SplitInput::handleSendMessage(std::vector<QString> &arguments)
+QString SplitInput::handleSendMessage(const std::vector<QString> &arguments)
 {
     auto c = this->split_->getChannel();
     if (c == nullptr)

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -571,7 +571,7 @@ void SplitInput::addShortcuts()
         {"copy",
          [this](const std::vector<QString> &arguments) -> QString {
              // XXX: this action is unused at the moment, a qt standard shortcut is used instead
-             if (arguments.size() == 0)
+             if (arguments.empty())
              {
                  return "copy action takes only one argument: the source "
                         "of the copy \"split\", \"input\" or "

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -477,23 +477,28 @@ void SplitInput::addShortcuts()
              return this->handleSendMessage(arguments);
          }},
         {"previousMessage",
-         [this](std::vector<QString>) -> QString {
-             if (this->prevMsg_.size() && this->prevIndex_)
+         [this](const std::vector<QString> &arguments) -> QString {
+             (void)arguments;
+
+             if (this->prevMsg_.isEmpty() || this->prevIndex_ == 0)
              {
-                 if (this->prevIndex_ == (this->prevMsg_.size()))
-                 {
-                     this->currMsg_ = ui_.textEdit->toPlainText();
-                 }
-
-                 this->prevIndex_--;
-                 this->ui_.textEdit->setPlainText(
-                     this->prevMsg_.at(this->prevIndex_));
-                 this->ui_.textEdit->resetCompletion();
-
-                 QTextCursor cursor = this->ui_.textEdit->textCursor();
-                 cursor.movePosition(QTextCursor::End);
-                 this->ui_.textEdit->setTextCursor(cursor);
+                 return "";
              }
+
+             if (this->prevIndex_ == (this->prevMsg_.size()))
+             {
+                 this->currMsg_ = ui_.textEdit->toPlainText();
+             }
+
+             this->prevIndex_--;
+             this->ui_.textEdit->setPlainText(
+                 this->prevMsg_.at(this->prevIndex_));
+             this->ui_.textEdit->resetCompletion();
+
+             QTextCursor cursor = this->ui_.textEdit->textCursor();
+             cursor.movePosition(QTextCursor::End);
+             this->ui_.textEdit->setTextCursor(cursor);
+
              return "";
          }},
         {"nextMessage",

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -213,11 +213,11 @@ void SplitInput::scaleChangedEvent(float scale)
         this->setMaximumHeight(this->scaledMaxHeight());
     }
     this->ui_.textEdit->setFont(
-        app->fonts->getFont(FontStyle::ChatMedium, this->scale()));
+        app->fonts->getFont(FontStyle::ChatMedium, scale));
     this->ui_.textEditLength->setFont(
-        app->fonts->getFont(FontStyle::ChatMedium, this->scale()));
+        app->fonts->getFont(FontStyle::ChatMedium, scale));
     this->ui_.replyLabel->setFont(
-        app->fonts->getFont(FontStyle::ChatMediumBold, this->scale()));
+        app->fonts->getFont(FontStyle::ChatMediumBold, scale));
 }
 
 void SplitInput::themeChangedEvent()

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -1064,8 +1064,10 @@ void SplitInput::paintEvent(QPaintEvent * /*event*/)
     }
 }
 
-void SplitInput::resizeEvent(QResizeEvent *)
+void SplitInput::resizeEvent(QResizeEvent *event)
 {
+    (void)event;
+
     if (this->height() == this->maximumHeight())
     {
         this->ui_.textEdit->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -339,40 +339,37 @@ QString SplitInput::handleSendMessage(std::vector<QString> &arguments)
         this->postMessageSend(message, arguments);
         return "";
     }
-    else
+
+    // Reply to message
+    auto *tc = dynamic_cast<TwitchChannel *>(c.get());
+    if (!tc)
     {
-        // Reply to message
-        auto *tc = dynamic_cast<TwitchChannel *>(c.get());
-        if (!tc)
-        {
-            // this should not fail
-            return "";
-        }
-
-        QString message = this->ui_.textEdit->toPlainText();
-
-        if (this->enableInlineReplying_)
-        {
-            // Remove @username prefix that is inserted when doing inline replies
-            message.remove(0, this->replyThread_->displayName.length() +
-                                  1);  // remove "@username"
-
-            if (!message.isEmpty() && message.at(0) == ' ')
-            {
-                message.remove(0, 1);  // remove possible space
-            }
-        }
-
-        message = message.replace('\n', ' ');
-        QString sendMessage =
-            getApp()->commands->execCommand(message, c, false);
-
-        // Reply within TwitchChannel
-        tc->sendReply(sendMessage, this->replyThread_->id);
-
-        this->postMessageSend(message, arguments);
+        // this should not fail
         return "";
     }
+
+    QString message = this->ui_.textEdit->toPlainText();
+
+    if (this->enableInlineReplying_)
+    {
+        // Remove @username prefix that is inserted when doing inline replies
+        message.remove(0, this->replyThread_->displayName.length() +
+                              1);  // remove "@username"
+
+        if (!message.isEmpty() && message.at(0) == ' ')
+        {
+            message.remove(0, 1);  // remove possible space
+        }
+    }
+
+    message = message.replace('\n', ' ');
+    QString sendMessage = getApp()->commands->execCommand(message, c, false);
+
+    // Reply within TwitchChannel
+    tc->sendReply(sendMessage, this->replyThread_->id);
+
+    this->postMessageSend(message, arguments);
+    return "";
 }
 
 void SplitInput::postMessageSend(const QString &message,

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -272,15 +272,10 @@ void SplitInput::updateCancelReplyButton()
 {
     float scale = this->scale();
 
-    QString text =
-        QStringLiteral(
-            "<img src=':/buttons/cancel.svg' width='%1' height='%1' />")
+    auto text =
+        QStringLiteral("<img src=':/buttons/%1.svg' width='%2' height='%2' />")
+            .arg(this->theme->isLightTheme() ? "cancelDark" : "cancel")
             .arg(QString::number(int(12 * scale)));
-
-    if (this->theme->isLightTheme())
-    {
-        text.replace("cancel", "cancelDark");
-    }
 
     this->ui_.cancelReplyButton->getLabel().setText(text);
     this->ui_.cancelReplyButton->setFixedHeight(int(12 * scale));

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -222,7 +222,8 @@ void SplitInput::scaleChangedEvent(float scale)
 
 void SplitInput::themeChangedEvent()
 {
-    QPalette palette, placeholderPalette;
+    QPalette palette;
+    QPalette placeholderPalette;
 
     palette.setColor(QPalette::WindowText, this->theme->splits.input.text);
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 12, 0))

--- a/src/widgets/splits/SplitInput.hpp
+++ b/src/widgets/splits/SplitInput.hpp
@@ -87,7 +87,6 @@ protected:
     /// Clears the input box, clears reply thread if inline replies are enabled
     void clearInput();
 
-protected:
     void addShortcuts() override;
     void initLayout();
     bool eventFilter(QObject *obj, QEvent *event) override;

--- a/src/widgets/splits/SplitInput.hpp
+++ b/src/widgets/splits/SplitInput.hpp
@@ -80,7 +80,7 @@ protected:
 
     virtual void giveFocus(Qt::FocusReason reason);
 
-    QString handleSendMessage(std::vector<QString> &arguments);
+    QString handleSendMessage(const std::vector<QString> &arguments);
     void postMessageSend(const QString &message,
                          const std::vector<QString> &arguments);
 


### PR DESCRIPTION
- Correctly brace it up in Listener construction
- PubSubClient: Pass the listen msg as a const ref
- PubSubClient: auto numListen/numUnlisten size, and cast to int64 for debugcount
- PubSubClient: unused timer
- Split: unused event param
- SharedMessageBuilder: unused param name
- AbstractIrcServer: unused params
- AbstractIrcServer: delete copy & move ctor/assignment operators
- TwitchChannel: delete move/copy ctor/assigners
- Emote: default-initialize zeroWidth to false
- TwitchChannel: make listenSevenTVCosmetics const
- TwitchChannel: named initializer for cheermote loading
- TwitchChannel: remove duplicate mod_ initializer
- TwitchChannel: Forward instead of move ffz custom mod badge/vip badge
- TwitchChannel: Rename roomModes member
- TwitchChannel: named initializer for twitch badges
- TwitchChannel: make chatterCount method const
- TwitchChannel: const auto&
- TwitchChannel: unused params
- GeneralPageView: unused param
- SplitInput: use scale param instead of this->scale()
- SplitInput: Split up variable declarations
- SplitInput: Clean up updateEmoteButton logic
- SplitInput: Clean up cancel reply button logic
- SplitInput: Don't use else after return
- SplitInput: default-initialize
- SplitInput: refactor previousMessage logic
- SplitInput: constify handleSendMessage parameter
- SplitInput: Remove double visibility modifier
- SplitInput: const& hotkey arguments
- SplitInput: use `empty()` instead of `size()` to check arguments
- SplitInput: unused param

<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
