### PR TITLE
Use the same input padding between light & dark themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Minor: Added missing periods at various moderator messages and commands. (#5061)
 - Minor: Improved color selection and display. (#5057)
 - Minor: Improved Streamlink documentation in the settings dialog. (#5076)
+- Minor: Normalized the input padding between light & dark themes. (#5095)
 - Bugfix: Fixed an issue where certain emojis did not send to Twitch chat correctly. (#4840)
 - Bugfix: Fixed capitalized channel names in log inclusion list not being logged. (#4848)
 - Bugfix: Trimmed custom streamlink paths on all platforms making sure you don't accidentally add spaces at the beginning or end of its path. (#4834)

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -239,7 +239,7 @@ void SplitInput::themeChangedEvent()
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 12, 0))
     this->ui_.textEdit->setPalette(placeholderPalette);
 #endif
-    auto marginPx = (this->theme->isLightTheme() ? 4 : 2) * this->scale();
+    auto marginPx = static_cast<int>(2.F * this->scale());
     this->ui_.vbox->setContentsMargins(marginPx, marginPx, marginPx, marginPx);
 
     this->ui_.emoteButton->getLabel().setStyleSheet("color: #000");


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

For context, before this change there was a difference in the margin of a split input depending on if your theme was dark or light.
This PR makes the margin the same regardless of theme.


Dark mode:
![dark-mode](https://github.com/Chatterino/chatterino2/assets/962989/1820acda-494d-483f-9f2f-53310215b666)

Light mode before this PR:
![light-mode-before](https://github.com/Chatterino/chatterino2/assets/962989/c914ba89-cef2-4567-84e8-1c12318021f0)

Light mode with this PR:
![light-mode-after](https://github.com/Chatterino/chatterino2/assets/962989/0f9f3985-26db-40ab-b938-14c10a35134a)

Thoughts @treuks ?
