### PR TITLE
refactor: Remove most raw accesses into Application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@
 - Dev: Renamed `tools` directory to `scripts`. (#5035)
 - Dev: Refactor `ChannelView`, removing a bunch of clang-tidy warnings. (#4926)
 - Dev: Refactor `IrcMessageHandler`, removing a bunch of clang-tidy warnings & changing its public API. (#4927)
+- Dev: Removed almost all raw accesses into Application. (#5104)
 - Dev: `Details` file properties tab is now populated on Windows. (#4912)
 - Dev: Removed `Outcome` from network requests. (#4959)
 - Dev: Added Tests for Windows and MacOS in CI. (#4970, #5032)

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -311,6 +311,13 @@ IEmotes *Application::getEmotes()
     return this->emotes;
 }
 
+HotkeyController *Application::getHotkeys()
+{
+    assertInGuiThread();
+
+    return this->hotkeys;
+}
+
 WindowManager *Application::getWindows()
 {
     assertInGuiThread();

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -447,6 +447,15 @@ SeventvAPI *Application::getSeventvAPI()
     return this->seventvAPI;
 }
 
+#ifdef CHATTERINO_HAVE_PLUGINS
+PluginController *Application::getPlugins()
+{
+    assertInGuiThread();
+
+    return this->plugins;
+}
+#endif
+
 ITwitchIrcServer *Application::getTwitch()
 {
     assertInGuiThread();

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -361,6 +361,13 @@ CrashHandler *Application::getCrashHandler()
     return this->crashHandler;
 }
 
+CommandController *Application::getCommands()
+{
+    assertInGuiThread();
+
+    return this->commands;
+}
+
 FfzBadges *Application::getFfzBadges()
 {
     assertInGuiThread();

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -412,6 +412,13 @@ ImageUploader *Application::getImageUploader()
     return this->imageUploader;
 }
 
+SeventvAPI *Application::getSeventvAPI()
+{
+    assertInGuiThread();
+
+    return this->seventvAPI;
+}
+
 ITwitchIrcServer *Application::getTwitch()
 {
     assertInGuiThread();

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -311,6 +311,14 @@ IEmotes *Application::getEmotes()
     return this->emotes;
 }
 
+WindowManager *Application::getWindows()
+{
+    assertInGuiThread();
+    assert(this->windows);
+
+    return this->windows;
+}
+
 IUserDataController *Application::getUserData()
 {
     assertInGuiThread();

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -354,6 +354,13 @@ Toasts *Application::getToasts()
     return this->toasts;
 }
 
+CrashHandler *Application::getCrashHandler()
+{
+    assertInGuiThread();
+
+    return this->crashHandler;
+}
+
 FfzBadges *Application::getFfzBadges()
 {
     assertInGuiThread();

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -347,6 +347,13 @@ WindowManager *Application::getWindows()
     return this->windows;
 }
 
+Toasts *Application::getToasts()
+{
+    assertInGuiThread();
+
+    return this->toasts;
+}
+
 FfzBadges *Application::getFfzBadges()
 {
     assertInGuiThread();

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -368,6 +368,13 @@ CommandController *Application::getCommands()
     return this->commands;
 }
 
+NotificationController *Application::getNotifications()
+{
+    assertInGuiThread();
+
+    return this->notifications;
+}
+
 FfzBadges *Application::getFfzBadges()
 {
     assertInGuiThread();

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -304,6 +304,13 @@ int Application::run(QApplication &qtApp)
     return qtApp.exec();
 }
 
+Theme *Application::getThemes()
+{
+    assertInGuiThread();
+
+    return this->themes;
+}
+
 Fonts *Application::getFonts()
 {
     assertInGuiThread();

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -311,6 +311,13 @@ IEmotes *Application::getEmotes()
     return this->emotes;
 }
 
+AccountController *Application::getAccounts()
+{
+    assertInGuiThread();
+
+    return this->accounts;
+}
+
 HotkeyController *Application::getHotkeys()
 {
     assertInGuiThread();

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -375,6 +375,13 @@ NotificationController *Application::getNotifications()
     return this->notifications;
 }
 
+HighlightController *Application::getHighlights()
+{
+    assertInGuiThread();
+
+    return this->highlights;
+}
+
 FfzBadges *Application::getFfzBadges()
 {
     assertInGuiThread();

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -319,6 +319,13 @@ WindowManager *Application::getWindows()
     return this->windows;
 }
 
+SeventvBadges *Application::getSeventvBadges()
+{
+    // SeventvBadges handles its own locks, so we don't need to assert that this is called in the GUI thread
+
+    return this->seventvBadges;
+}
+
 IUserDataController *Application::getUserData()
 {
     assertInGuiThread();

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -405,6 +405,13 @@ IChatterinoBadges *Application::getChatterinoBadges()
     return this->chatterinoBadges.get();
 }
 
+ImageUploader *Application::getImageUploader()
+{
+    assertInGuiThread();
+
+    return this->imageUploader;
+}
+
 ITwitchIrcServer *Application::getTwitch()
 {
     assertInGuiThread();

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -304,6 +304,13 @@ int Application::run(QApplication &qtApp)
     return qtApp.exec();
 }
 
+Fonts *Application::getFonts()
+{
+    assertInGuiThread();
+
+    return this->fonts;
+}
+
 IEmotes *Application::getEmotes()
 {
     assertInGuiThread();

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -319,6 +319,13 @@ WindowManager *Application::getWindows()
     return this->windows;
 }
 
+FfzBadges *Application::getFfzBadges()
+{
+    assertInGuiThread();
+
+    return this->ffzBadges;
+}
+
 SeventvBadges *Application::getSeventvBadges()
 {
     // SeventvBadges handles its own locks, so we don't need to assert that this is called in the GUI thread

--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -138,9 +138,9 @@ private:
     SeventvAPI *const seventvAPI{};
     CrashHandler *const crashHandler{};
     CommandController *const commands{};
+    NotificationController *const notifications{};
 
 public:
-    NotificationController *const notifications{};
     HighlightController *const highlights{};
     TwitchIrcServer *const twitch{};
 
@@ -177,12 +177,7 @@ public:
     Toasts *getToasts() override;
     CrashHandler *getCrashHandler() override;
     CommandController *getCommands() override;
-    NotificationController *getNotifications() override
-    {
-        assertInGuiThread();
-
-        return this->notifications;
-    }
+    NotificationController *getNotifications() override;
     HighlightController *getHighlights() override
     {
         assertInGuiThread();

--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -144,9 +144,9 @@ public:
     FfzBadges *const ffzBadges{};
     SeventvBadges *const seventvBadges{};
     UserDataController *const userData{};
-    ISoundController *const sound{};
 
 private:
+    ISoundController *const sound{};
     TwitchLiveController *const twitchLiveController{};
     std::unique_ptr<PubSub> twitchPubSub;
     std::unique_ptr<TwitchBadges> twitchBadges;

--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -123,7 +123,11 @@ public:
     friend void test();
 
     Theme *const themes{};
+
+private:
     Fonts *const fonts{};
+
+public:
     Emotes *const emotes{};
 
 private:
@@ -172,12 +176,7 @@ public:
 
         return this->themes;
     }
-    Fonts *getFonts() override
-    {
-        assertInGuiThread();
-
-        return this->fonts;
-    }
+    Fonts *getFonts() override;
     IEmotes *getEmotes() override;
     AccountController *getAccounts() override;
     HotkeyController *getHotkeys() override;

--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -134,9 +134,9 @@ private:
     HotkeyController *const hotkeys{};
     WindowManager *const windows{};
     Toasts *const toasts{};
+    ImageUploader *const imageUploader{};
 
 public:
-    ImageUploader *const imageUploader{};
     SeventvAPI *const seventvAPI{};
     CrashHandler *const crashHandler{};
 
@@ -210,12 +210,7 @@ public:
     ITwitchLiveController *getTwitchLiveController() override;
     TwitchBadges *getTwitchBadges() override;
     IChatterinoBadges *getChatterinoBadges() override;
-    ImageUploader *getImageUploader() override
-    {
-        assertInGuiThread();
-
-        return this->imageUploader;
-    }
+    ImageUploader *getImageUploader() override;
     SeventvAPI *getSeventvAPI() override
     {
         assertInGuiThread();

--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -142,9 +142,9 @@ public:
     HighlightController *const highlights{};
     TwitchIrcServer *const twitch{};
     FfzBadges *const ffzBadges{};
-    SeventvBadges *const seventvBadges{};
 
 private:
+    SeventvBadges *const seventvBadges{};
     UserDataController *const userData{};
     ISoundController *const sound{};
     TwitchLiveController *const twitchLiveController{};
@@ -231,12 +231,7 @@ public:
 
         return this->ffzBadges;
     }
-    SeventvBadges *getSeventvBadges() override
-    {
-        assertInGuiThread();
-
-        return this->seventvBadges;
-    }
+    SeventvBadges *getSeventvBadges() override;
     IUserDataController *getUserData() override;
     ISoundController *getSound() override;
     ITwitchLiveController *getTwitchLiveController() override;

--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -141,9 +141,9 @@ public:
     NotificationController *const notifications{};
     HighlightController *const highlights{};
     TwitchIrcServer *const twitch{};
-    FfzBadges *const ffzBadges{};
 
 private:
+    FfzBadges *const ffzBadges{};
     SeventvBadges *const seventvBadges{};
     UserDataController *const userData{};
     ISoundController *const sound{};
@@ -225,12 +225,7 @@ public:
     ITwitchIrcServer *getTwitch() override;
     PubSub *getTwitchPubSub() override;
     Logging *getChatLogger() override;
-    FfzBadges *getFfzBadges() override
-    {
-        assertInGuiThread();
-
-        return this->ffzBadges;
-    }
+    FfzBadges *getFfzBadges() override;
     SeventvBadges *getSeventvBadges() override;
     IUserDataController *getUserData() override;
     ISoundController *getSound() override;

--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -136,10 +136,9 @@ private:
     Toasts *const toasts{};
     ImageUploader *const imageUploader{};
     SeventvAPI *const seventvAPI{};
-
-public:
     CrashHandler *const crashHandler{};
 
+public:
     CommandController *const commands{};
     NotificationController *const notifications{};
     HighlightController *const highlights{};
@@ -176,12 +175,7 @@ public:
     HotkeyController *getHotkeys() override;
     WindowManager *getWindows() override;
     Toasts *getToasts() override;
-    CrashHandler *getCrashHandler() override
-    {
-        assertInGuiThread();
-
-        return this->crashHandler;
-    }
+    CrashHandler *getCrashHandler() override;
     CommandController *getCommands() override
     {
         assertInGuiThread();

--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -137,9 +137,9 @@ private:
     ImageUploader *const imageUploader{};
     SeventvAPI *const seventvAPI{};
     CrashHandler *const crashHandler{};
+    CommandController *const commands{};
 
 public:
-    CommandController *const commands{};
     NotificationController *const notifications{};
     HighlightController *const highlights{};
     TwitchIrcServer *const twitch{};
@@ -176,12 +176,7 @@ public:
     WindowManager *getWindows() override;
     Toasts *getToasts() override;
     CrashHandler *getCrashHandler() override;
-    CommandController *getCommands() override
-    {
-        assertInGuiThread();
-
-        return this->commands;
-    }
+    CommandController *getCommands() override;
     NotificationController *getNotifications() override
     {
         assertInGuiThread();

--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -143,9 +143,9 @@ public:
     TwitchIrcServer *const twitch{};
     FfzBadges *const ffzBadges{};
     SeventvBadges *const seventvBadges{};
-    UserDataController *const userData{};
 
 private:
+    UserDataController *const userData{};
     ISoundController *const sound{};
     TwitchLiveController *const twitchLiveController{};
     std::unique_ptr<PubSub> twitchPubSub;

--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -127,7 +127,11 @@ public:
     Emotes *const emotes{};
     AccountController *const accounts{};
     HotkeyController *const hotkeys{};
+
+private:
     WindowManager *const windows{};
+
+public:
     Toasts *const toasts{};
     ImageUploader *const imageUploader{};
     SeventvAPI *const seventvAPI{};
@@ -187,12 +191,7 @@ public:
 
         return this->hotkeys;
     }
-    WindowManager *getWindows() override
-    {
-        assertInGuiThread();
-
-        return this->windows;
-    }
+    WindowManager *getWindows() override;
     Toasts *getToasts() override
     {
         assertInGuiThread();

--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -126,9 +126,9 @@ public:
     Fonts *const fonts{};
     Emotes *const emotes{};
     AccountController *const accounts{};
-    HotkeyController *const hotkeys{};
 
 private:
+    HotkeyController *const hotkeys{};
     WindowManager *const windows{};
 
 public:
@@ -185,12 +185,7 @@ public:
 
         return this->accounts;
     }
-    HotkeyController *getHotkeys() override
-    {
-        assertInGuiThread();
-
-        return this->hotkeys;
-    }
+    HotkeyController *getHotkeys() override;
     WindowManager *getWindows() override;
     Toasts *getToasts() override
     {

--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -122,9 +122,8 @@ public:
 
     friend void test();
 
-    Theme *const themes{};
-
 private:
+    Theme *const themes{};
     Fonts *const fonts{};
 
 public:
@@ -170,12 +169,7 @@ public:
     {
         return this->args_;
     }
-    Theme *getThemes() override
-    {
-        assertInGuiThread();
-
-        return this->themes;
-    }
+    Theme *getThemes() override;
     Fonts *getFonts() override;
     IEmotes *getEmotes() override;
     AccountController *getAccounts() override;

--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -85,6 +85,9 @@ public:
     virtual TwitchBadges *getTwitchBadges() = 0;
     virtual ImageUploader *getImageUploader() = 0;
     virtual SeventvAPI *getSeventvAPI() = 0;
+#ifdef CHATTERINO_HAVE_PLUGINS
+    virtual PluginController *getPlugins() = 0;
+#endif
     virtual Updates &getUpdates() = 0;
 };
 
@@ -154,12 +157,11 @@ private:
     std::unique_ptr<TwitchBadges> twitchBadges;
     std::unique_ptr<ChatterinoBadges> chatterinoBadges;
     const std::unique_ptr<Logging> logging;
-
-public:
 #ifdef CHATTERINO_HAVE_PLUGINS
     PluginController *const plugins{};
 #endif
 
+public:
     const Paths &getPaths() override
     {
         return this->paths_;
@@ -191,6 +193,9 @@ public:
     IChatterinoBadges *getChatterinoBadges() override;
     ImageUploader *getImageUploader() override;
     SeventvAPI *getSeventvAPI() override;
+#ifdef CHATTERINO_HAVE_PLUGINS
+    PluginController *getPlugins() override;
+#endif
     Updates &getUpdates() override
     {
         assertInGuiThread();

--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -125,9 +125,9 @@ public:
     Theme *const themes{};
     Fonts *const fonts{};
     Emotes *const emotes{};
-    AccountController *const accounts{};
 
 private:
+    AccountController *const accounts{};
     HotkeyController *const hotkeys{};
     WindowManager *const windows{};
 
@@ -179,12 +179,7 @@ public:
         return this->fonts;
     }
     IEmotes *getEmotes() override;
-    AccountController *getAccounts() override
-    {
-        assertInGuiThread();
-
-        return this->accounts;
-    }
+    AccountController *getAccounts() override;
     HotkeyController *getHotkeys() override;
     WindowManager *getWindows() override;
     Toasts *getToasts() override

--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -139,9 +139,9 @@ private:
     CrashHandler *const crashHandler{};
     CommandController *const commands{};
     NotificationController *const notifications{};
+    HighlightController *const highlights{};
 
 public:
-    HighlightController *const highlights{};
     TwitchIrcServer *const twitch{};
 
 private:
@@ -178,12 +178,7 @@ public:
     CrashHandler *getCrashHandler() override;
     CommandController *getCommands() override;
     NotificationController *getNotifications() override;
-    HighlightController *getHighlights() override
-    {
-        assertInGuiThread();
-
-        return this->highlights;
-    }
+    HighlightController *getHighlights() override;
     ITwitchIrcServer *getTwitch() override;
     PubSub *getTwitchPubSub() override;
     Logging *getChatLogger() override;

--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -135,9 +135,9 @@ private:
     WindowManager *const windows{};
     Toasts *const toasts{};
     ImageUploader *const imageUploader{};
+    SeventvAPI *const seventvAPI{};
 
 public:
-    SeventvAPI *const seventvAPI{};
     CrashHandler *const crashHandler{};
 
     CommandController *const commands{};
@@ -211,12 +211,7 @@ public:
     TwitchBadges *getTwitchBadges() override;
     IChatterinoBadges *getChatterinoBadges() override;
     ImageUploader *getImageUploader() override;
-    SeventvAPI *getSeventvAPI() override
-    {
-        assertInGuiThread();
-
-        return this->seventvAPI;
-    }
+    SeventvAPI *getSeventvAPI() override;
     Updates &getUpdates() override
     {
         assertInGuiThread();

--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -133,9 +133,9 @@ private:
     AccountController *const accounts{};
     HotkeyController *const hotkeys{};
     WindowManager *const windows{};
+    Toasts *const toasts{};
 
 public:
-    Toasts *const toasts{};
     ImageUploader *const imageUploader{};
     SeventvAPI *const seventvAPI{};
     CrashHandler *const crashHandler{};
@@ -175,12 +175,7 @@ public:
     AccountController *getAccounts() override;
     HotkeyController *getHotkeys() override;
     WindowManager *getWindows() override;
-    Toasts *getToasts() override
-    {
-        assertInGuiThread();
-
-        return this->toasts;
-    }
+    Toasts *getToasts() override;
     CrashHandler *getCrashHandler() override
     {
         assertInGuiThread();

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -562,7 +562,7 @@ bool CommandController::registerPluginCommand(const QString &commandName)
     }
 
     this->commands_[commandName] = [commandName](const CommandContext &ctx) {
-        return getApp()->plugins->tryExecPluginCommand(commandName, ctx);
+        return getIApp()->getPlugins()->tryExecPluginCommand(commandName, ctx);
     };
     this->pluginCommands_.append(commandName);
     return true;

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -120,7 +120,8 @@ const std::unordered_map<QString, VariableReplacer> COMMAND_VARS{
         [](const auto &altText, const auto &channel, const auto *message) {
             (void)(channel);  //unused
             (void)(message);  //unused
-            auto uid = getApp()->accounts->twitch.getCurrent()->getUserId();
+            auto uid =
+                getIApp()->getAccounts()->twitch.getCurrent()->getUserId();
             return uid.isEmpty() ? altText : uid;
         },
     },
@@ -129,7 +130,8 @@ const std::unordered_map<QString, VariableReplacer> COMMAND_VARS{
         [](const auto &altText, const auto &channel, const auto *message) {
             (void)(channel);  //unused
             (void)(message);  //unused
-            auto name = getApp()->accounts->twitch.getCurrent()->getUserName();
+            auto name =
+                getIApp()->getAccounts()->twitch.getCurrent()->getUserName();
             return name.isEmpty() ? altText : name;
         },
     },

--- a/src/controllers/commands/builtin/Misc.cpp
+++ b/src/controllers/commands/builtin/Misc.cpp
@@ -219,7 +219,7 @@ QString marker(const CommandContext &ctx)
     }
 
     // Avoid Helix calls without Client ID and/or OAuth Token
-    if (getApp()->accounts->twitch.getCurrent()->isAnon())
+    if (getIApp()->getAccounts()->twitch.getCurrent()->isAnon())
     {
         ctx.channel->addMessage(makeSystemMessage(
             "You need to be logged in to create stream markers!"));

--- a/src/controllers/commands/builtin/Misc.cpp
+++ b/src/controllers/commands/builtin/Misc.cpp
@@ -365,8 +365,12 @@ QString popup(const CommandContext &ctx)
     // Popup the current split
     if (target.isEmpty())
     {
-        auto *currentPage = dynamic_cast<SplitContainer *>(
-            getApp()->windows->getMainWindow().getNotebook().getSelectedPage());
+        auto *currentPage =
+            dynamic_cast<SplitContainer *>(getIApp()
+                                               ->getWindows()
+                                               ->getMainWindow()
+                                               .getNotebook()
+                                               .getSelectedPage());
         if (currentPage != nullptr)
         {
             auto *currentSplit = currentPage->getSelectedSplit();
@@ -385,7 +389,7 @@ QString popup(const CommandContext &ctx)
     // Open channel passed as argument in a popup
     auto *app = getApp();
     auto targetChannel = app->twitch->getOrAddChannel(target);
-    app->windows->openInPopup(targetChannel);
+    app->getWindows()->openInPopup(targetChannel);
 
     return "";
 }
@@ -394,8 +398,11 @@ QString clearmessages(const CommandContext &ctx)
 {
     (void)ctx;
 
-    auto *currentPage = dynamic_cast<SplitContainer *>(
-        getApp()->windows->getMainWindow().getNotebook().getSelectedPage());
+    auto *currentPage = dynamic_cast<SplitContainer *>(getIApp()
+                                                           ->getWindows()
+                                                           ->getMainWindow()
+                                                           .getNotebook()
+                                                           .getSelectedPage());
 
     if (auto *split = currentPage->getSelectedSplit())
     {
@@ -580,8 +587,11 @@ QString openUsercard(const CommandContext &ctx)
 
     // try to link to current split if possible
     Split *currentSplit = nullptr;
-    auto *currentPage = dynamic_cast<SplitContainer *>(
-        getApp()->windows->getMainWindow().getNotebook().getSelectedPage());
+    auto *currentPage = dynamic_cast<SplitContainer *>(getIApp()
+                                                           ->getWindows()
+                                                           ->getMainWindow()
+                                                           .getNotebook()
+                                                           .getSelectedPage());
     if (currentPage != nullptr)
     {
         currentSplit = currentPage->getSelectedSplit();
@@ -592,7 +602,8 @@ QString openUsercard(const CommandContext &ctx)
     if (differentChannel || currentSplit == nullptr)
     {
         // not possible to use current split, try searching for one
-        const auto &notebook = getApp()->windows->getMainWindow().getNotebook();
+        const auto &notebook =
+            getIApp()->getWindows()->getMainWindow().getNotebook();
         auto count = notebook.getPageCount();
         for (int i = 0; i < count; i++)
         {

--- a/src/controllers/commands/builtin/twitch/AddModerator.cpp
+++ b/src/controllers/commands/builtin/twitch/AddModerator.cpp
@@ -34,7 +34,7 @@ QString addModerator(const CommandContext &ctx)
         return "";
     }
 
-    auto currentUser = getApp()->accounts->twitch.getCurrent();
+    auto currentUser = getIApp()->getAccounts()->twitch.getCurrent();
     if (currentUser->isAnon())
     {
         ctx.channel->addMessage(

--- a/src/controllers/commands/builtin/twitch/AddVIP.cpp
+++ b/src/controllers/commands/builtin/twitch/AddVIP.cpp
@@ -34,7 +34,7 @@ QString addVIP(const CommandContext &ctx)
         return "";
     }
 
-    auto currentUser = getApp()->accounts->twitch.getCurrent();
+    auto currentUser = getIApp()->getAccounts()->twitch.getCurrent();
     if (currentUser->isAnon())
     {
         ctx.channel->addMessage(

--- a/src/controllers/commands/builtin/twitch/Announce.cpp
+++ b/src/controllers/commands/builtin/twitch/Announce.cpp
@@ -33,7 +33,7 @@ QString sendAnnouncement(const CommandContext &ctx)
         return "";
     }
 
-    auto user = getApp()->accounts->twitch.getCurrent();
+    auto user = getIApp()->getAccounts()->twitch.getCurrent();
     if (user->isAnon())
     {
         ctx.channel->addMessage(makeSystemMessage(

--- a/src/controllers/commands/builtin/twitch/Ban.cpp
+++ b/src/controllers/commands/builtin/twitch/Ban.cpp
@@ -147,7 +147,7 @@ QString sendBan(const CommandContext &ctx)
         return "";
     }
 
-    auto currentUser = getApp()->accounts->twitch.getCurrent();
+    auto currentUser = getIApp()->getAccounts()->twitch.getCurrent();
     if (currentUser->isAnon())
     {
         channel->addMessage(
@@ -210,7 +210,7 @@ QString sendBanById(const CommandContext &ctx)
         return "";
     }
 
-    auto currentUser = getApp()->accounts->twitch.getCurrent();
+    auto currentUser = getIApp()->getAccounts()->twitch.getCurrent();
     if (currentUser->isAnon())
     {
         channel->addMessage(
@@ -258,7 +258,7 @@ QString sendTimeout(const CommandContext &ctx)
         return "";
     }
 
-    auto currentUser = getApp()->accounts->twitch.getCurrent();
+    auto currentUser = getIApp()->getAccounts()->twitch.getCurrent();
     if (currentUser->isAnon())
     {
         channel->addMessage(

--- a/src/controllers/commands/builtin/twitch/Block.cpp
+++ b/src/controllers/commands/builtin/twitch/Block.cpp
@@ -37,7 +37,7 @@ QString blockUser(const CommandContext &ctx)
         return "";
     }
 
-    auto currentUser = getApp()->accounts->twitch.getCurrent();
+    auto currentUser = getIApp()->getAccounts()->twitch.getCurrent();
 
     if (currentUser->isAnon())
     {
@@ -53,7 +53,7 @@ QString blockUser(const CommandContext &ctx)
         target,
         [currentUser, channel{ctx.channel},
          target](const HelixUser &targetUser) {
-            getApp()->accounts->twitch.getCurrent()->blockUser(
+            getIApp()->getAccounts()->twitch.getCurrent()->blockUser(
                 targetUser.id, nullptr,
                 [channel, target, targetUser] {
                     channel->addMessage(makeSystemMessage(
@@ -111,7 +111,7 @@ QString unblockUser(const CommandContext &ctx)
         return "";
     }
 
-    auto currentUser = getApp()->accounts->twitch.getCurrent();
+    auto currentUser = getIApp()->getAccounts()->twitch.getCurrent();
 
     if (currentUser->isAnon())
     {
@@ -126,7 +126,7 @@ QString unblockUser(const CommandContext &ctx)
     getHelix()->getUserByName(
         target,
         [currentUser, channel{ctx.channel}, target](const auto &targetUser) {
-            getApp()->accounts->twitch.getCurrent()->unblockUser(
+            getIApp()->getAccounts()->twitch.getCurrent()->unblockUser(
                 targetUser.id, nullptr,
                 [channel, target, targetUser] {
                     channel->addMessage(makeSystemMessage(

--- a/src/controllers/commands/builtin/twitch/ChatSettings.cpp
+++ b/src/controllers/commands/builtin/twitch/ChatSettings.cpp
@@ -101,7 +101,7 @@ namespace chatterino::commands {
 
 QString emoteOnly(const CommandContext &ctx)
 {
-    auto currentUser = getApp()->accounts->twitch.getCurrent();
+    auto currentUser = getIApp()->getAccounts()->twitch.getCurrent();
     if (currentUser->isAnon())
     {
         ctx.channel->addMessage(makeSystemMessage(P_NOT_LOGGED_IN));
@@ -131,7 +131,7 @@ QString emoteOnly(const CommandContext &ctx)
 
 QString emoteOnlyOff(const CommandContext &ctx)
 {
-    auto currentUser = getApp()->accounts->twitch.getCurrent();
+    auto currentUser = getIApp()->getAccounts()->twitch.getCurrent();
     if (currentUser->isAnon())
     {
         ctx.channel->addMessage(makeSystemMessage(P_NOT_LOGGED_IN));
@@ -160,7 +160,7 @@ QString emoteOnlyOff(const CommandContext &ctx)
 
 QString subscribers(const CommandContext &ctx)
 {
-    auto currentUser = getApp()->accounts->twitch.getCurrent();
+    auto currentUser = getIApp()->getAccounts()->twitch.getCurrent();
     if (currentUser->isAnon())
     {
         ctx.channel->addMessage(makeSystemMessage(P_NOT_LOGGED_IN));
@@ -190,7 +190,7 @@ QString subscribers(const CommandContext &ctx)
 
 QString subscribersOff(const CommandContext &ctx)
 {
-    auto currentUser = getApp()->accounts->twitch.getCurrent();
+    auto currentUser = getIApp()->getAccounts()->twitch.getCurrent();
     if (currentUser->isAnon())
     {
         ctx.channel->addMessage(makeSystemMessage(P_NOT_LOGGED_IN));
@@ -220,7 +220,7 @@ QString subscribersOff(const CommandContext &ctx)
 
 QString slow(const CommandContext &ctx)
 {
-    auto currentUser = getApp()->accounts->twitch.getCurrent();
+    auto currentUser = getIApp()->getAccounts()->twitch.getCurrent();
     if (currentUser->isAnon())
     {
         ctx.channel->addMessage(makeSystemMessage(P_NOT_LOGGED_IN));
@@ -267,7 +267,7 @@ QString slow(const CommandContext &ctx)
 
 QString slowOff(const CommandContext &ctx)
 {
-    auto currentUser = getApp()->accounts->twitch.getCurrent();
+    auto currentUser = getIApp()->getAccounts()->twitch.getCurrent();
     if (currentUser->isAnon())
     {
         ctx.channel->addMessage(makeSystemMessage(P_NOT_LOGGED_IN));
@@ -297,7 +297,7 @@ QString slowOff(const CommandContext &ctx)
 
 QString followers(const CommandContext &ctx)
 {
-    auto currentUser = getApp()->accounts->twitch.getCurrent();
+    auto currentUser = getIApp()->getAccounts()->twitch.getCurrent();
     if (currentUser->isAnon())
     {
         ctx.channel->addMessage(makeSystemMessage(P_NOT_LOGGED_IN));
@@ -345,7 +345,7 @@ QString followers(const CommandContext &ctx)
 
 QString followersOff(const CommandContext &ctx)
 {
-    auto currentUser = getApp()->accounts->twitch.getCurrent();
+    auto currentUser = getIApp()->getAccounts()->twitch.getCurrent();
     if (currentUser->isAnon())
     {
         ctx.channel->addMessage(makeSystemMessage(P_NOT_LOGGED_IN));
@@ -375,7 +375,7 @@ QString followersOff(const CommandContext &ctx)
 
 QString uniqueChat(const CommandContext &ctx)
 {
-    auto currentUser = getApp()->accounts->twitch.getCurrent();
+    auto currentUser = getIApp()->getAccounts()->twitch.getCurrent();
     if (currentUser->isAnon())
     {
         ctx.channel->addMessage(makeSystemMessage(P_NOT_LOGGED_IN));
@@ -405,7 +405,7 @@ QString uniqueChat(const CommandContext &ctx)
 
 QString uniqueChatOff(const CommandContext &ctx)
 {
-    auto currentUser = getApp()->accounts->twitch.getCurrent();
+    auto currentUser = getIApp()->getAccounts()->twitch.getCurrent();
     if (currentUser->isAnon())
     {
         ctx.channel->addMessage(makeSystemMessage(P_NOT_LOGGED_IN));

--- a/src/controllers/commands/builtin/twitch/Chatters.cpp
+++ b/src/controllers/commands/builtin/twitch/Chatters.cpp
@@ -77,7 +77,7 @@ QString chatters(const CommandContext &ctx)
     // Refresh chatter list via helix api for mods
     getHelix()->getChatters(
         ctx.twitchChannel->roomId(),
-        getApp()->accounts->twitch.getCurrent()->getUserId(), 1,
+        getIApp()->getAccounts()->twitch.getCurrent()->getUserId(), 1,
         [channel{ctx.channel}](auto result) {
             channel->addMessage(
                 makeSystemMessage(QString("Chatter count: %1.")
@@ -107,7 +107,7 @@ QString testChatters(const CommandContext &ctx)
 
     getHelix()->getChatters(
         ctx.twitchChannel->roomId(),
-        getApp()->accounts->twitch.getCurrent()->getUserId(), 5000,
+        getIApp()->getAccounts()->twitch.getCurrent()->getUserId(), 5000,
         [channel{ctx.channel}, twitchChannel{ctx.twitchChannel}](auto result) {
             QStringList entries;
             for (const auto &username : result.chatters)

--- a/src/controllers/commands/builtin/twitch/DeleteMessages.cpp
+++ b/src/controllers/commands/builtin/twitch/DeleteMessages.cpp
@@ -21,7 +21,7 @@ QString deleteMessages(TwitchChannel *twitchChannel, const QString &messageID)
 {
     const auto *commandName = messageID.isEmpty() ? "/clear" : "/delete";
 
-    auto user = getApp()->accounts->twitch.getCurrent();
+    auto user = getIApp()->getAccounts()->twitch.getCurrent();
 
     // Avoid Helix calls without Client ID and/or OAuth Token
     if (user->isAnon())

--- a/src/controllers/commands/builtin/twitch/GetVIPs.cpp
+++ b/src/controllers/commands/builtin/twitch/GetVIPs.cpp
@@ -82,7 +82,7 @@ QString getVIPs(const CommandContext &ctx)
         return "";
     }
 
-    auto currentUser = getApp()->accounts->twitch.getCurrent();
+    auto currentUser = getIApp()->getAccounts()->twitch.getCurrent();
     if (currentUser->isAnon())
     {
         ctx.channel->addMessage(makeSystemMessage(

--- a/src/controllers/commands/builtin/twitch/Raid.cpp
+++ b/src/controllers/commands/builtin/twitch/Raid.cpp
@@ -137,7 +137,7 @@ QString startRaid(const CommandContext &ctx)
         return "";
     }
 
-    auto currentUser = getApp()->accounts->twitch.getCurrent();
+    auto currentUser = getIApp()->getAccounts()->twitch.getCurrent();
     if (currentUser->isAnon())
     {
         ctx.channel->addMessage(
@@ -195,7 +195,7 @@ QString cancelRaid(const CommandContext &ctx)
         return "";
     }
 
-    auto currentUser = getApp()->accounts->twitch.getCurrent();
+    auto currentUser = getIApp()->getAccounts()->twitch.getCurrent();
     if (currentUser->isAnon())
     {
         ctx.channel->addMessage(

--- a/src/controllers/commands/builtin/twitch/RemoveModerator.cpp
+++ b/src/controllers/commands/builtin/twitch/RemoveModerator.cpp
@@ -34,7 +34,7 @@ QString removeModerator(const CommandContext &ctx)
         return "";
     }
 
-    auto currentUser = getApp()->accounts->twitch.getCurrent();
+    auto currentUser = getIApp()->getAccounts()->twitch.getCurrent();
     if (currentUser->isAnon())
     {
         ctx.channel->addMessage(

--- a/src/controllers/commands/builtin/twitch/RemoveVIP.cpp
+++ b/src/controllers/commands/builtin/twitch/RemoveVIP.cpp
@@ -34,7 +34,7 @@ QString removeVIP(const CommandContext &ctx)
         return "";
     }
 
-    auto currentUser = getApp()->accounts->twitch.getCurrent();
+    auto currentUser = getIApp()->getAccounts()->twitch.getCurrent();
     if (currentUser->isAnon())
     {
         ctx.channel->addMessage(

--- a/src/controllers/commands/builtin/twitch/SendWhisper.cpp
+++ b/src/controllers/commands/builtin/twitch/SendWhisper.cpp
@@ -99,7 +99,7 @@ bool appendWhisperMessageWordsLocally(const QStringList &words)
         MessageElementFlag::Text, MessageColor::Text,
         FontStyle::ChatMediumBold);
     b.emplace<TextElement>("->", MessageElementFlag::Text,
-                           getApp()->themes->messages.textColors.system);
+                           getIApp()->getThemes()->messages.textColors.system);
     b.emplace<TextElement>(words[1] + ":", MessageElementFlag::Text,
                            MessageColor::Text, FontStyle::ChatMediumBold);
 

--- a/src/controllers/commands/builtin/twitch/SendWhisper.cpp
+++ b/src/controllers/commands/builtin/twitch/SendWhisper.cpp
@@ -94,15 +94,16 @@ bool appendWhisperMessageWordsLocally(const QStringList &words)
     MessageBuilder b;
 
     b.emplace<TimestampElement>();
-    b.emplace<TextElement>(app->accounts->twitch.getCurrent()->getUserName(),
-                           MessageElementFlag::Text, MessageColor::Text,
-                           FontStyle::ChatMediumBold);
+    b.emplace<TextElement>(
+        app->getAccounts()->twitch.getCurrent()->getUserName(),
+        MessageElementFlag::Text, MessageColor::Text,
+        FontStyle::ChatMediumBold);
     b.emplace<TextElement>("->", MessageElementFlag::Text,
                            getApp()->themes->messages.textColors.system);
     b.emplace<TextElement>(words[1] + ":", MessageElementFlag::Text,
                            MessageColor::Text, FontStyle::ChatMediumBold);
 
-    const auto &acc = app->accounts->twitch.getCurrent();
+    const auto &acc = app->getAccounts()->twitch.getCurrent();
     const auto &accemotes = *acc->accessEmotes();
     const auto &bttvemotes = app->twitch->getBttvEmotes();
     const auto &ffzemotes = app->twitch->getFfzEmotes();
@@ -208,7 +209,7 @@ QString sendWhisper(const CommandContext &ctx)
         return "";
     }
 
-    auto currentUser = getApp()->accounts->twitch.getCurrent();
+    auto currentUser = getIApp()->getAccounts()->twitch.getCurrent();
     if (currentUser->isAnon())
     {
         ctx.channel->addMessage(

--- a/src/controllers/commands/builtin/twitch/ShieldMode.cpp
+++ b/src/controllers/commands/builtin/twitch/ShieldMode.cpp
@@ -23,7 +23,7 @@ QString toggleShieldMode(const CommandContext &ctx, bool isActivating)
         return {};
     }
 
-    auto user = getApp()->accounts->twitch.getCurrent();
+    auto user = getIApp()->getAccounts()->twitch.getCurrent();
 
     // Avoid Helix calls without Client ID and/or OAuth Token
     if (user->isAnon())

--- a/src/controllers/commands/builtin/twitch/Shoutout.cpp
+++ b/src/controllers/commands/builtin/twitch/Shoutout.cpp
@@ -24,7 +24,7 @@ QString sendShoutout(const CommandContext &ctx)
         return "";
     }
 
-    auto currentUser = getApp()->accounts->twitch.getCurrent();
+    auto currentUser = getIApp()->getAccounts()->twitch.getCurrent();
     if (currentUser->isAnon())
     {
         channel->addMessage(

--- a/src/controllers/commands/builtin/twitch/StartCommercial.cpp
+++ b/src/controllers/commands/builtin/twitch/StartCommercial.cpp
@@ -100,7 +100,7 @@ QString startCommercial(const CommandContext &ctx)
         return "";
     }
 
-    auto user = getApp()->accounts->twitch.getCurrent();
+    auto user = getIApp()->getAccounts()->twitch.getCurrent();
 
     // Avoid Helix calls without Client ID and/or OAuth Token
     if (user->isAnon())

--- a/src/controllers/commands/builtin/twitch/Unban.cpp
+++ b/src/controllers/commands/builtin/twitch/Unban.cpp
@@ -106,7 +106,7 @@ QString unbanUser(const CommandContext &ctx)
         return "";
     }
 
-    auto currentUser = getApp()->accounts->twitch.getCurrent();
+    auto currentUser = getIApp()->getAccounts()->twitch.getCurrent();
     if (currentUser->isAnon())
     {
         ctx.channel->addMessage(

--- a/src/controllers/commands/builtin/twitch/UpdateColor.cpp
+++ b/src/controllers/commands/builtin/twitch/UpdateColor.cpp
@@ -25,7 +25,7 @@ QString updateUserColor(const CommandContext &ctx)
             "The /color command only works in Twitch channels."));
         return "";
     }
-    auto user = getApp()->accounts->twitch.getCurrent();
+    auto user = getIApp()->getAccounts()->twitch.getCurrent();
 
     // Avoid Helix calls without Client ID and/or OAuth Token
     if (user->isAnon())

--- a/src/controllers/completion/TabCompletionModel.cpp
+++ b/src/controllers/completion/TabCompletionModel.cpp
@@ -38,8 +38,9 @@ void TabCompletionModel::updateResults(const QString &query,
 #ifdef CHATTERINO_HAVE_PLUGINS
         // Try plugins first
         bool done{};
-        std::tie(done, results) = getApp()->plugins->updateCustomCompletions(
-            query, fullTextContent, cursorPosition, isFirstWord);
+        std::tie(done, results) =
+            getIApp()->getPlugins()->updateCustomCompletions(
+                query, fullTextContent, cursorPosition, isFirstWord);
         if (done)
         {
             this->setStringList(results);

--- a/src/controllers/completion/sources/CommandSource.cpp
+++ b/src/controllers/completion/sources/CommandSource.cpp
@@ -71,7 +71,7 @@ void CommandSource::initializeItems()
     std::vector<CommandItem> commands;
 
 #ifdef CHATTERINO_HAVE_PLUGINS
-    for (const auto &command : getApp()->commands->pluginCommands())
+    for (const auto &command : getIApp()->getCommands()->pluginCommands())
     {
         addCommand(command, commands);
     }

--- a/src/controllers/highlights/HighlightModel.cpp
+++ b/src/controllers/highlights/HighlightModel.cpp
@@ -509,7 +509,7 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
         break;
     }
 
-    getApp()->windows->forceLayoutChannelViews();
+    getIApp()->getWindows()->forceLayoutChannelViews();
 }
 
 }  // namespace chatterino

--- a/src/controllers/highlights/UserHighlightModel.cpp
+++ b/src/controllers/highlights/UserHighlightModel.cpp
@@ -113,7 +113,7 @@ void UserHighlightModel::customRowSetData(
         break;
     }
 
-    getApp()->windows->forceLayoutChannelViews();
+    getIApp()->getWindows()->forceLayoutChannelViews();
 }
 
 // row into vector item

--- a/src/controllers/hotkeys/Hotkey.cpp
+++ b/src/controllers/hotkeys/Hotkey.cpp
@@ -58,7 +58,7 @@ std::vector<QString> Hotkey::arguments() const
 
 QString Hotkey::getCategory() const
 {
-    return getApp()->hotkeys->categoryDisplayName(this->category_);
+    return getIApp()->getHotkeys()->categoryDisplayName(this->category_);
 }
 
 Qt::ShortcutContext Hotkey::getContext() const

--- a/src/controllers/ignores/IgnorePhrase.cpp
+++ b/src/controllers/ignores/IgnorePhrase.cpp
@@ -95,7 +95,7 @@ bool IgnorePhrase::containsEmote() const
 {
     if (!this->emotesChecked_)
     {
-        const auto &accvec = getApp()->accounts->twitch.accounts;
+        const auto &accvec = getIApp()->getAccounts()->twitch.accounts;
         for (const auto &acc : accvec)
         {
             const auto &accemotes = *acc->accessEmotes();

--- a/src/controllers/notifications/NotificationController.cpp
+++ b/src/controllers/notifications/NotificationController.cpp
@@ -190,7 +190,7 @@ void NotificationController::checkStream(bool live, QString channelName)
         !(isInStreamerMode() &&
           getSettings()->streamerModeSuppressLiveNotifications))
     {
-        getApp()->notifications->playSound();
+        getIApp()->getNotifications()->playSound();
     }
     if (getSettings()->notificationFlashTaskbar &&
         !(isInStreamerMode() &&

--- a/src/controllers/notifications/NotificationController.cpp
+++ b/src/controllers/notifications/NotificationController.cpp
@@ -183,8 +183,8 @@ void NotificationController::checkStream(bool live, QString channelName)
 
     if (Toasts::isEnabled())
     {
-        getApp()->toasts->sendChannelNotification(channelName, QString(),
-                                                  Platform::Twitch);
+        getIApp()->getToasts()->sendChannelNotification(channelName, QString(),
+                                                        Platform::Twitch);
     }
     if (getSettings()->notificationPlaySound &&
         !(isInStreamerMode() &&

--- a/src/controllers/notifications/NotificationController.cpp
+++ b/src/controllers/notifications/NotificationController.cpp
@@ -196,7 +196,7 @@ void NotificationController::checkStream(bool live, QString channelName)
         !(isInStreamerMode() &&
           getSettings()->streamerModeSuppressLiveNotifications))
     {
-        getApp()->windows->sendAlert();
+        getIApp()->getWindows()->sendAlert();
     }
     MessageBuilder builder;
     TwitchMessageBuilder::liveMessage(channelName, &builder);

--- a/src/controllers/plugins/LuaAPI.cpp
+++ b/src/controllers/plugins/LuaAPI.cpp
@@ -63,7 +63,7 @@ namespace chatterino::lua::api {
 
 int c2_register_command(lua_State *L)
 {
-    auto *pl = getApp()->plugins->getPluginByStatePtr(L);
+    auto *pl = getIApp()->getPlugins()->getPluginByStatePtr(L);
     if (pl == nullptr)
     {
         luaL_error(L, "internal error: no plugin");
@@ -97,7 +97,7 @@ int c2_register_command(lua_State *L)
 
 int c2_register_callback(lua_State *L)
 {
-    auto *pl = getApp()->plugins->getPluginByStatePtr(L);
+    auto *pl = getIApp()->getPlugins()->getPluginByStatePtr(L);
     if (pl == nullptr)
     {
         luaL_error(L, "internal error: no plugin");
@@ -155,7 +155,7 @@ int c2_send_msg(lua_State *L)
     const auto chn = getApp()->twitch->getChannelOrEmpty(channel);
     if (chn->isEmpty())
     {
-        auto *pl = getApp()->plugins->getPluginByStatePtr(L);
+        auto *pl = getIApp()->getPlugins()->getPluginByStatePtr(L);
 
         qCWarning(chatterinoLua)
             << "Plugin" << pl->id
@@ -204,7 +204,7 @@ int c2_system_msg(lua_State *L)
     const auto chn = getApp()->twitch->getChannelOrEmpty(channel);
     if (chn->isEmpty())
     {
-        auto *pl = getApp()->plugins->getPluginByStatePtr(L);
+        auto *pl = getIApp()->getPlugins()->getPluginByStatePtr(L);
         qCWarning(chatterinoLua)
             << "Plugin" << pl->id
             << "tried to show a system message (using system_msg) in channel"
@@ -219,7 +219,7 @@ int c2_system_msg(lua_State *L)
 
 int c2_log(lua_State *L)
 {
-    auto *pl = getApp()->plugins->getPluginByStatePtr(L);
+    auto *pl = getIApp()->getPlugins()->getPluginByStatePtr(L);
     if (pl == nullptr)
     {
         luaL_error(L, "c2_log: internal error: no plugin?");
@@ -286,7 +286,7 @@ int g_load(lua_State *L)
 
 int loadfile(lua_State *L, const QString &str)
 {
-    auto *pl = getApp()->plugins->getPluginByStatePtr(L);
+    auto *pl = getIApp()->getPlugins()->getPluginByStatePtr(L);
     if (pl == nullptr)
     {
         return luaL_error(L, "loadfile: internal error: no plugin?");
@@ -328,7 +328,7 @@ int searcherAbsolute(lua_State *L)
     name = name.replace('.', QDir::separator());
 
     QString filename;
-    auto *pl = getApp()->plugins->getPluginByStatePtr(L);
+    auto *pl = getIApp()->getPlugins()->getPluginByStatePtr(L);
     if (pl == nullptr)
     {
         return luaL_error(L, "searcherAbsolute: internal error: no plugin?");
@@ -369,7 +369,7 @@ int searcherRelative(lua_State *L)
 
 int g_print(lua_State *L)
 {
-    auto *pl = getApp()->plugins->getPluginByStatePtr(L);
+    auto *pl = getIApp()->getPlugins()->getPluginByStatePtr(L);
     if (pl == nullptr)
     {
         luaL_error(L, "c2_print: internal error: no plugin?");

--- a/src/controllers/plugins/LuaAPI.cpp
+++ b/src/controllers/plugins/LuaAPI.cpp
@@ -166,7 +166,8 @@ int c2_send_msg(lua_State *L)
     }
     QString message = text;
     message = message.replace('\n', ' ');
-    QString outText = getApp()->commands->execCommand(message, chn, false);
+    QString outText =
+        getIApp()->getCommands()->execCommand(message, chn, false);
     chn->sendMessage(outText);
     lua::push(L, true);
     return 1;

--- a/src/controllers/plugins/Plugin.cpp
+++ b/src/controllers/plugins/Plugin.cpp
@@ -146,7 +146,7 @@ bool Plugin::registerCommand(const QString &name, const QString &functionName)
         return false;
     }
 
-    auto ok = getApp()->commands->registerPluginCommand(name);
+    auto ok = getIApp()->getCommands()->registerPluginCommand(name);
     if (!ok)
     {
         return false;

--- a/src/controllers/plugins/PluginController.cpp
+++ b/src/controllers/plugins/PluginController.cpp
@@ -281,7 +281,7 @@ bool PluginController::reload(const QString &id)
     }
     for (const auto &[cmd, _] : it->second->ownedCommands)
     {
-        getApp()->commands->unregisterPluginCommand(cmd);
+        getIApp()->getCommands()->unregisterPluginCommand(cmd);
     }
     it->second->ownedCommands.clear();
     QDir loadDir = it->second->loadDirectory_;

--- a/src/messages/Image.cpp
+++ b/src/messages/Image.cpp
@@ -252,7 +252,7 @@ namespace detail {
             }
         }
 
-        getApp()->windows->forceLayoutChannelViews();
+        getIApp()->getWindows()->forceLayoutChannelViews();
 
         loadedEventQueued = false;
     }

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -204,7 +204,7 @@ MessageBuilder::MessageBuilder(TimeoutMessageTag, const QString &username,
 MessageBuilder::MessageBuilder(const BanAction &action, uint32_t count)
     : MessageBuilder()
 {
-    auto current = getApp()->accounts->twitch.getCurrent();
+    auto current = getIApp()->getAccounts()->twitch.getCurrent();
 
     this->emplace<TimestampElement>();
     this->message().flags.set(MessageFlag::System);

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -682,7 +682,8 @@ void MessageBuilder::addIrcMessageText(const QString &text)
 
     auto words = text.split(' ');
     MessageColor defaultColorType = MessageColor::Text;
-    const auto &defaultColor = defaultColorType.getColor(*getApp()->themes);
+    const auto &defaultColor =
+        defaultColorType.getColor(*getIApp()->getThemes());
     QColor textColor = defaultColor;
     int fg = -1;
     int bg = -1;
@@ -726,7 +727,7 @@ void MessageBuilder::addIrcMessageText(const QString &text)
                 if (fg >= 0 && fg <= 98)
                 {
                     textColor = IRC_COLORS[fg];
-                    getApp()->themes->normalizeColor(textColor);
+                    getIApp()->getThemes()->normalizeColor(textColor);
                 }
                 else
                 {
@@ -766,7 +767,7 @@ void MessageBuilder::addIrcMessageText(const QString &text)
         if (fg >= 0 && fg <= 98)
         {
             textColor = IRC_COLORS[fg];
-            getApp()->themes->normalizeColor(textColor);
+            getIApp()->getThemes()->normalizeColor(textColor);
         }
         else
         {

--- a/src/messages/MessageElement.cpp
+++ b/src/messages/MessageElement.cpp
@@ -528,8 +528,8 @@ void TextElement::addToContainer(MessageLayoutContainer &container,
         {
             auto getTextLayoutElement = [&](QString text, int width,
                                             bool hasTrailingSpace) {
-                auto color = this->color_.getColor(*app->themes);
-                app->themes->normalizeColor(color);
+                auto color = this->color_.getColor(*app->getThemes());
+                app->getThemes()->normalizeColor(color);
 
                 auto *e = (new TextLayoutElement(
                                *this, text, QSize(width, metrics.height()),
@@ -646,8 +646,8 @@ void SingleLineTextElement::addToContainer(MessageLayoutContainer &container,
 
         auto getTextLayoutElement = [&](QString text, int width,
                                         bool hasTrailingSpace) {
-            auto color = this->color_.getColor(*app->themes);
-            app->themes->normalizeColor(color);
+            auto color = this->color_.getColor(*app->getThemes());
+            app->getThemes()->normalizeColor(color);
 
             auto *e = (new TextLayoutElement(
                            *this, text, QSize(width, metrics.height()), color,

--- a/src/messages/MessageElement.cpp
+++ b/src/messages/MessageElement.cpp
@@ -522,7 +522,7 @@ void TextElement::addToContainer(MessageLayoutContainer &container,
     if (flags.hasAny(this->getFlags()))
     {
         QFontMetrics metrics =
-            app->fonts->getFontMetrics(this->style_, container.getScale());
+            app->getFonts()->getFontMetrics(this->style_, container.getScale());
 
         for (Word &word : this->words_)
         {
@@ -642,7 +642,7 @@ void SingleLineTextElement::addToContainer(MessageLayoutContainer &container,
     if (flags.hasAny(this->getFlags()))
     {
         QFontMetrics metrics =
-            app->fonts->getFontMetrics(this->style_, container.getScale());
+            app->getFonts()->getFontMetrics(this->style_, container.getScale());
 
         auto getTextLayoutElement = [&](QString text, int width,
                                         bool hasTrailingSpace) {

--- a/src/messages/SharedMessageBuilder.cpp
+++ b/src/messages/SharedMessageBuilder.cpp
@@ -236,7 +236,7 @@ void SharedMessageBuilder::triggerHighlights(
 
     if (windowAlert)
     {
-        getApp()->windows->sendAlert();
+        getIApp()->getWindows()->sendAlert();
     }
 }
 

--- a/src/messages/layouts/MessageLayout.cpp
+++ b/src/messages/layouts/MessageLayout.cpp
@@ -78,8 +78,6 @@ bool MessageLayout::layout(int width, float scale, MessageElementFlags flags)
 {
     //    BenchmarkGuard benchmark("MessageLayout::layout()");
 
-    auto *app = getApp();
-
     bool layoutRequired = false;
 
     // check if width changed
@@ -88,11 +86,12 @@ bool MessageLayout::layout(int width, float scale, MessageElementFlags flags)
     this->currentLayoutWidth_ = width;
 
     // check if layout state changed
-    if (this->layoutState_ != app->windows->getGeneration())
+    const auto layoutGeneration = getIApp()->getWindows()->getGeneration();
+    if (this->layoutState_ != layoutGeneration)
     {
         layoutRequired = true;
         this->flags.set(MessageLayoutFlag::RequiresBufferUpdate);
-        this->layoutState_ = app->windows->getGeneration();
+        this->layoutState_ = layoutGeneration;
     }
 
     // check if work mask changed

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -47,7 +47,7 @@ void MessageLayoutContainer::beginLayout(int width, float scale,
     this->scale_ = scale;
     this->flags_ = flags;
     auto mediumFontMetrics =
-        getApp()->fonts->getFontMetrics(FontStyle::ChatMedium, scale);
+        getIApp()->getFonts()->getFontMetrics(FontStyle::ChatMedium, scale);
     this->textLineHeight_ = mediumFontMetrics.height();
     this->spaceWidth_ = mediumFontMetrics.horizontalAdvance(' ');
     this->dotdotdotWidth_ = mediumFontMetrics.horizontalAdvance("...");

--- a/src/messages/layouts/MessageLayoutElement.cpp
+++ b/src/messages/layouts/MessageLayoutElement.cpp
@@ -442,7 +442,7 @@ void TextLayoutElement::paint(QPainter &painter,
 
     painter.setPen(this->color_);
 
-    painter.setFont(app->fonts->getFont(this->style_, this->scale_));
+    painter.setFont(app->getFonts()->getFont(this->style_, this->scale_));
 
     painter.drawText(
         QRectF(this->getRect().x(), this->getRect().y(), 10000, 10000), text,
@@ -463,7 +463,7 @@ int TextLayoutElement::getMouseOverIndex(const QPoint &abs) const
 
     auto *app = getApp();
 
-    auto metrics = app->fonts->getFontMetrics(this->style_, this->scale_);
+    auto metrics = app->getFonts()->getFontMetrics(this->style_, this->scale_);
     auto x = this->getRect().left();
 
     for (auto i = 0; i < this->getText().size(); i++)
@@ -498,7 +498,7 @@ int TextLayoutElement::getXFromIndex(size_t index)
     auto *app = getApp();
 
     QFontMetrics metrics =
-        app->fonts->getFontMetrics(this->style_, this->scale_);
+        app->getFonts()->getFontMetrics(this->style_, this->scale_);
 
     if (index <= 0)
     {
@@ -546,7 +546,7 @@ void TextIconLayoutElement::paint(QPainter &painter,
 {
     auto *app = getApp();
 
-    QFont font = app->fonts->getFont(FontStyle::Tiny, this->scale);
+    QFont font = app->getFonts()->getFont(FontStyle::Tiny, this->scale);
 
     painter.setPen(messageColors.system);
     painter.setFont(font);

--- a/src/providers/seventv/SeventvEventAPI.cpp
+++ b/src/providers/seventv/SeventvEventAPI.cpp
@@ -347,9 +347,7 @@ void SeventvEventAPI::onUserUpdate(const Dispatch &dispatch)
 
 void SeventvEventAPI::onCosmeticCreate(const CosmeticCreateDispatch &cosmetic)
 {
-    // We're using `Application::instance` instead of getApp(), because we're not in the GUI thread.
-    // `seventvBadges` does its own locking.
-    auto *badges = Application::instance->seventvBadges;
+    auto *badges = getIApp()->getSeventvBadges();
     switch (cosmetic.kind)
     {
         case CosmeticKind::Badge: {
@@ -364,9 +362,7 @@ void SeventvEventAPI::onCosmeticCreate(const CosmeticCreateDispatch &cosmetic)
 void SeventvEventAPI::onEntitlementCreate(
     const EntitlementCreateDeleteDispatch &entitlement)
 {
-    // We're using `Application::instance` instead of getApp(), because we're not in the GUI thread.
-    // `seventvBadges` does its own locking.
-    auto *badges = Application::instance->seventvBadges;
+    auto *badges = getIApp()->getSeventvBadges();
     switch (entitlement.kind)
     {
         case CosmeticKind::Badge: {
@@ -382,9 +378,7 @@ void SeventvEventAPI::onEntitlementCreate(
 void SeventvEventAPI::onEntitlementDelete(
     const EntitlementCreateDeleteDispatch &entitlement)
 {
-    // We're using `Application::instance` instead of getApp(), because we're not in the GUI thread.
-    // `seventvBadges` does its own locking.
-    auto *badges = Application::instance->seventvBadges;
+    auto *badges = getIApp()->getSeventvBadges();
     switch (entitlement.kind)
     {
         case CosmeticKind::Badge: {

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -774,10 +774,10 @@ void IrcMessageHandler::handleClearChatMessage(Communi::IrcMessage *message)
     chan->addOrReplaceTimeout(std::move(clearChat.message));
 
     // refresh all
-    getApp()->windows->repaintVisibleChatWidgets(chan.get());
+    getIApp()->getWindows()->repaintVisibleChatWidgets(chan.get());
     if (getSettings()->hideModerated)
     {
-        getApp()->windows->forceLayoutChannelViews();
+        getIApp()->getWindows()->forceLayoutChannelViews();
     }
 }
 

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -386,7 +386,7 @@ std::vector<MessagePtr> parseNoticeMessage(Communi::IrcNoticeMessage *message)
     {
         const auto linkColor = MessageColor(MessageColor::Link);
         const auto accountsLink = Link(Link::OpenAccountsPage, QString());
-        const auto curUser = getApp()->accounts->twitch.getCurrent();
+        const auto curUser = getIApp()->getAccounts()->twitch.getCurrent();
         const auto expirationText = QString("Login expired for user \"%1\"!")
                                         .arg(curUser->getUserName());
         const auto loginPromptText = QString("Try adding your account again.");
@@ -828,7 +828,7 @@ void IrcMessageHandler::handleClearMessageMessage(Communi::IrcMessage *message)
 
 void IrcMessageHandler::handleUserStateMessage(Communi::IrcMessage *message)
 {
-    auto currentUser = getApp()->accounts->twitch.getCurrent();
+    auto currentUser = getIApp()->getAccounts()->twitch.getCurrent();
 
     // set received emote-sets, used in TwitchAccount::loadUserstateEmotes
     bool emoteSetsChanged = currentUser->setUserstateEmoteSets(
@@ -880,7 +880,7 @@ void IrcMessageHandler::handleUserStateMessage(Communi::IrcMessage *message)
 void IrcMessageHandler::handleGlobalUserStateMessage(
     Communi::IrcMessage *message)
 {
-    auto currentUser = getApp()->accounts->twitch.getCurrent();
+    auto currentUser = getIApp()->getAccounts()->twitch.getCurrent();
 
     // set received emote-sets, this time used to initially load emotes
     // NOTE: this should always return true unless we reconnect
@@ -1134,7 +1134,7 @@ void IrcMessageHandler::handleJoinMessage(Communi::IrcMessage *message)
     }
 
     if (message->nick() ==
-        getApp()->accounts->twitch.getCurrent()->getUserName())
+        getIApp()->getAccounts()->twitch.getCurrent()->getUserName())
     {
         twitchChannel->addMessage(makeSystemMessage("joined channel"));
         twitchChannel->joined.invoke();
@@ -1157,7 +1157,7 @@ void IrcMessageHandler::handlePartMessage(Communi::IrcMessage *message)
     }
 
     const auto selfAccountName =
-        getApp()->accounts->twitch.getCurrent()->getUserName();
+        getIApp()->getAccounts()->twitch.getCurrent()->getUserName();
     if (message->nick() != selfAccountName &&
         getSettings()->showParts.getValue())
     {
@@ -1207,8 +1207,9 @@ void IrcMessageHandler::setSimilarityFlags(const MessagePtr &message,
 {
     if (getSettings()->similarityEnabled)
     {
-        bool isMyself = message->loginName ==
-                        getApp()->accounts->twitch.getCurrent()->getUserName();
+        bool isMyself =
+            message->loginName ==
+            getIApp()->getAccounts()->twitch.getCurrent()->getUserName();
         bool hideMyself = getSettings()->hideSimilarMyself;
 
         if (isMyself && !hideMyself)

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -156,7 +156,7 @@ TwitchChannel::TwitchChannel(const QString &name)
                 }
                 if (getSettings()->notificationFlashTaskbar)
                 {
-                    getApp()->windows->sendAlert();
+                    getIApp()->getWindows()->sendAlert();
                 }
             }
             // Channel live message

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -141,8 +141,8 @@ TwitchChannel::TwitchChannel(const QString &name)
         {
             qCDebug(chatterinoTwitch)
                 << "[TwitchChannel" << this->getName() << "] Online";
-            if (getApp()->notifications->isChannelNotified(this->getName(),
-                                                           Platform::Twitch))
+            if (getIApp()->getNotifications()->isChannelNotified(
+                    this->getName(), Platform::Twitch))
             {
                 if (Toasts::isEnabled())
                 {
@@ -152,7 +152,7 @@ TwitchChannel::TwitchChannel(const QString &name)
                 }
                 if (getSettings()->notificationPlaySound)
                 {
-                    getApp()->notifications->playSound();
+                    getIApp()->getNotifications()->playSound();
                 }
                 if (getSettings()->notificationFlashTaskbar)
                 {
@@ -176,7 +176,7 @@ TwitchChannel::TwitchChannel(const QString &name)
                 !(isInStreamerMode() &&
                   getSettings()->streamerModeSuppressLiveNotifications))
             {
-                getApp()->notifications->playSound();
+                getIApp()->getNotifications()->playSound();
             }
         }
         else

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -146,7 +146,7 @@ TwitchChannel::TwitchChannel(const QString &name)
             {
                 if (Toasts::isEnabled())
                 {
-                    getApp()->toasts->sendChannelNotification(
+                    getIApp()->getToasts()->sendChannelNotification(
                         this->getName(), this->accessStreamStatus()->title,
                         Platform::Twitch);
                 }

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -94,7 +94,7 @@ TwitchChannel::TwitchChannel(const QString &name)
     }
 
     this->bSignals_.emplace_back(
-        getApp()->accounts->twitch.currentUserChanged.connect([this] {
+        getIApp()->getAccounts()->twitch.currentUserChanged.connect([this] {
             this->setMod(false);
             this->refreshPubSub();
         }));
@@ -538,7 +538,7 @@ void TwitchChannel::showLoginMessage()
 {
     const auto linkColor = MessageColor(MessageColor::Link);
     const auto accountsLink = Link(Link::OpenAccountsPage, QString());
-    const auto currentUser = getApp()->accounts->twitch.getCurrent();
+    const auto currentUser = getIApp()->getAccounts()->twitch.getCurrent();
     const auto expirationText =
         QStringLiteral("You need to log in to send messages. You can link your "
                        "Twitch account");
@@ -622,7 +622,7 @@ QString TwitchChannel::prepareMessage(const QString &message) const
 void TwitchChannel::sendMessage(const QString &message)
 {
     auto *app = getApp();
-    if (!app->accounts->twitch.isLoggedIn())
+    if (!app->getAccounts()->twitch.isLoggedIn())
     {
         if (!message.isEmpty())
         {
@@ -656,7 +656,7 @@ void TwitchChannel::sendMessage(const QString &message)
 void TwitchChannel::sendReply(const QString &message, const QString &replyId)
 {
     auto *app = getApp();
-    if (!app->accounts->twitch.isLoggedIn())
+    if (!app->getAccounts()->twitch.isLoggedIn())
     {
         if (!message.isEmpty())
         {
@@ -864,7 +864,8 @@ void TwitchChannel::joinBttvChannel() const
 {
     if (getApp()->twitch->bttvLiveUpdates)
     {
-        const auto currentAccount = getApp()->accounts->twitch.getCurrent();
+        const auto currentAccount =
+            getIApp()->getAccounts()->twitch.getCurrent();
         QString userName;
         if (currentAccount && !currentAccount->isAnon())
         {
@@ -1307,7 +1308,7 @@ void TwitchChannel::refreshPubSub()
         return;
     }
 
-    auto currentAccount = getApp()->accounts->twitch.getCurrent();
+    auto currentAccount = getIApp()->getAccounts()->twitch.getCurrent();
 
     getIApp()->getTwitchPubSub()->setAccount(currentAccount);
 
@@ -1342,7 +1343,8 @@ void TwitchChannel::refreshChatters()
 
     // Get chatter list via helix api
     getHelix()->getChatters(
-        this->roomId(), getApp()->accounts->twitch.getCurrent()->getUserId(),
+        this->roomId(),
+        getIApp()->getAccounts()->twitch.getCurrent()->getUserId(),
         MAX_CHATTERS_TO_FETCH,
         [this, weak = weakOf<Channel>(this)](auto result) {
             if (auto shared = weak.lock())
@@ -1731,7 +1733,7 @@ void TwitchChannel::updateSevenTVActivity()
         QStringLiteral("https://7tv.io/v3/users/%1/presences");
 
     const auto currentSeventvUserID =
-        getApp()->accounts->twitch.getCurrent()->getSeventvUserID();
+        getIApp()->getAccounts()->twitch.getCurrent()->getSeventvUserID();
     if (currentSeventvUserID.isEmpty())
     {
         return;

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -66,7 +66,7 @@ TwitchIrcServer::TwitchIrcServer()
 
 void TwitchIrcServer::initialize(Settings &settings, const Paths &paths)
 {
-    getApp()->accounts->twitch.currentUserChanged.connect([this]() {
+    getIApp()->getAccounts()->twitch.currentUserChanged.connect([this]() {
         postToThread([this] {
             this->connect();
         });
@@ -81,7 +81,7 @@ void TwitchIrcServer::initializeConnection(IrcConnection *connection,
                                            ConnectionType type)
 {
     std::shared_ptr<TwitchAccount> account =
-        getApp()->accounts->twitch.getCurrent();
+        getIApp()->getAccounts()->twitch.getCurrent();
 
     qCDebug(chatterinoTwitch) << "logging in as" << account->getUserName();
 

--- a/src/singletons/Fonts.cpp
+++ b/src/singletons/Fonts.cpp
@@ -111,7 +111,7 @@ void Fonts::initialize(Settings &, const Paths &)
             assertInGuiThread();
 
             // REMOVED
-            getApp()->windows->incGeneration();
+            getIApp()->getWindows()->incGeneration();
 
             for (auto &map : this->fontsByType_)
             {

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -346,9 +346,10 @@ void WindowManager::initialize(Settings &settings, const Paths &paths)
     // We can safely ignore this signal connection since both Themes and WindowManager
     // share the Application state lifetime
     // NOTE: APPLICATION_LIFETIME
-    std::ignore = getApp()->themes->repaintVisibleChatWidgets_.connect([this] {
-        this->repaintVisibleChatWidgets();
-    });
+    std::ignore =
+        getIApp()->getThemes()->repaintVisibleChatWidgets_.connect([this] {
+            this->repaintVisibleChatWidgets();
+        });
 
     assert(!this->initialized_);
 

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -121,7 +121,7 @@ WindowManager::WindowManager(const Paths &paths)
     this->saveTimer->setSingleShot(true);
 
     QObject::connect(this->saveTimer, &QTimer::timeout, [] {
-        getApp()->windows->save();
+        getIApp()->getWindows()->save();
     });
 }
 

--- a/src/singletons/helper/GifTimer.cpp
+++ b/src/singletons/helper/GifTimer.cpp
@@ -31,7 +31,7 @@ void GIFTimer::initialize()
 
         this->position_ += GIF_FRAME_LENGTH;
         this->signal.invoke();
-        getApp()->windows->repaintGifEmotes();
+        getIApp()->getWindows()->repaintGifEmotes();
     });
 }
 

--- a/src/util/StreamLink.cpp
+++ b/src/util/StreamLink.cpp
@@ -184,8 +184,11 @@ void openStreamlinkForChannel(const QString &channel)
 {
     static const QString INFO_TEMPLATE("Opening %1 in Streamlink ...");
 
-    auto *currentPage = dynamic_cast<SplitContainer *>(
-        getApp()->windows->getMainWindow().getNotebook().getSelectedPage());
+    auto *currentPage = dynamic_cast<SplitContainer *>(getIApp()
+                                                           ->getWindows()
+                                                           ->getMainWindow()
+                                                           .getNotebook()
+                                                           .getSelectedPage());
     if (currentPage != nullptr)
     {
         auto *currentSplit = currentPage->getSelectedSplit();

--- a/src/widgets/AccountSwitchWidget.cpp
+++ b/src/widgets/AccountSwitchWidget.cpp
@@ -15,20 +15,21 @@ AccountSwitchWidget::AccountSwitchWidget(QWidget *parent)
 
     this->addItem(ANONYMOUS_USERNAME_LABEL);
 
-    for (const auto &userName : app->accounts->twitch.getUsernames())
+    for (const auto &userName : app->getAccounts()->twitch.getUsernames())
     {
         this->addItem(userName);
     }
 
     this->managedConnections_.managedConnect(
-        app->accounts->twitch.userListUpdated, [=, this]() {
+        app->getAccounts()->twitch.userListUpdated, [=, this]() {
             this->blockSignals(true);
 
             this->clear();
 
             this->addItem(ANONYMOUS_USERNAME_LABEL);
 
-            for (const auto &userName : app->accounts->twitch.getUsernames())
+            for (const auto &userName :
+                 app->getAccounts()->twitch.getUsernames())
             {
                 this->addItem(userName);
             }
@@ -47,11 +48,11 @@ AccountSwitchWidget::AccountSwitchWidget(QWidget *parent)
             if (newUsername.compare(ANONYMOUS_USERNAME_LABEL,
                                     Qt::CaseInsensitive) == 0)
             {
-                app->accounts->twitch.currentUsername = "";
+                app->getAccounts()->twitch.currentUsername = "";
             }
             else
             {
-                app->accounts->twitch.currentUsername = newUsername;
+                app->getAccounts()->twitch.currentUsername = newUsername;
             }
         }
     });
@@ -71,7 +72,7 @@ void AccountSwitchWidget::refreshSelection()
     {
         auto *app = getApp();
 
-        auto currentUser = app->accounts->twitch.getCurrent();
+        auto currentUser = app->getAccounts()->twitch.getCurrent();
 
         if (currentUser->isAnon())
         {

--- a/src/widgets/BaseWindow.cpp
+++ b/src/widgets/BaseWindow.cpp
@@ -508,7 +508,7 @@ void BaseWindow::resizeEvent(QResizeEvent *)
     // Queue up save because: Window resized
     if (!flags_.has(DisableLayoutSave))
     {
-        getApp()->windows->queueSave();
+        getIApp()->getWindows()->queueSave();
     }
 
 #ifdef USEWINSDK
@@ -540,7 +540,7 @@ void BaseWindow::moveEvent(QMoveEvent *event)
 #ifdef CHATTERINO
     if (!flags_.has(DisableLayoutSave))
     {
-        getApp()->windows->queueSave();
+        getIApp()->getWindows()->queueSave();
     }
 #endif
 

--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -532,16 +532,16 @@ void Notebook::setShowTabs(bool value)
 
 void Notebook::showTabVisibilityInfoPopup()
 {
-    auto unhideSeq = getApp()->hotkeys->getDisplaySequence(
+    auto unhideSeq = getIApp()->getHotkeys()->getDisplaySequence(
         HotkeyCategory::Window, "setTabVisibility", {std::vector<QString>()});
     if (unhideSeq.isEmpty())
     {
-        unhideSeq = getApp()->hotkeys->getDisplaySequence(
+        unhideSeq = getIApp()->getHotkeys()->getDisplaySequence(
             HotkeyCategory::Window, "setTabVisibility", {{"toggle"}});
     }
     if (unhideSeq.isEmpty())
     {
-        unhideSeq = getApp()->hotkeys->getDisplaySequence(
+        unhideSeq = getIApp()->getHotkeys()->getDisplaySequence(
             HotkeyCategory::Window, "setTabVisibility", {{"on"}});
     }
     QString hotkeyInfo = "(currently unbound)";

--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -70,7 +70,7 @@ Notebook::Notebook(QWidget *parent)
 NotebookTab *Notebook::addPage(QWidget *page, QString title, bool select)
 {
     // Queue up save because: Tab added
-    getApp()->windows->queueSave();
+    getIApp()->getWindows()->queueSave();
 
     auto *tab = new NotebookTab(this);
     tab->page = page;
@@ -100,7 +100,7 @@ NotebookTab *Notebook::addPage(QWidget *page, QString title, bool select)
 void Notebook::removePage(QWidget *page)
 {
     // Queue up save because: Tab removed
-    getApp()->windows->queueSave();
+    getIApp()->getWindows()->queueSave();
 
     int removingIndex = this->indexOf(page);
     assert(removingIndex != -1);
@@ -491,7 +491,7 @@ void Notebook::rearrangePage(QWidget *page, int index)
     }
 
     // Queue up save because: Tab rearranged
-    getApp()->windows->queueSave();
+    getIApp()->getWindows()->queueSave();
 
     this->items_.move(this->indexOf(page), index);
 
@@ -1293,7 +1293,7 @@ SplitNotebook::SplitNotebook(Window *parent)
         this->signalHolder_, true);
 
     this->signalHolder_.managedConnect(
-        getApp()->windows->selectSplit, [this](Split *split) {
+        getIApp()->getWindows()->selectSplit, [this](Split *split) {
             for (auto &&item : this->items())
             {
                 if (auto *sc = dynamic_cast<SplitContainer *>(item.page))
@@ -1310,13 +1310,14 @@ SplitNotebook::SplitNotebook(Window *parent)
             }
         });
 
-    this->signalHolder_.managedConnect(getApp()->windows->selectSplitContainer,
-                                       [this](SplitContainer *sc) {
-                                           this->select(sc);
-                                       });
+    this->signalHolder_.managedConnect(
+        getIApp()->getWindows()->selectSplitContainer,
+        [this](SplitContainer *sc) {
+            this->select(sc);
+        });
 
     this->signalHolder_.managedConnect(
-        getApp()->windows->scrollToMessageSignal,
+        getIApp()->getWindows()->scrollToMessageSignal,
         [this](const MessagePtr &message) {
             for (auto &&item : this->items())
             {
@@ -1382,7 +1383,7 @@ void SplitNotebook::addCustomButtons()
     settingsBtn->setIcon(NotebookButton::Settings);
 
     QObject::connect(settingsBtn, &NotebookButton::leftClicked, [this] {
-        getApp()->windows->showSettingsDialog(this);
+        getIApp()->getWindows()->showSettingsDialog(this);
     });
 
     // account
@@ -1396,7 +1397,7 @@ void SplitNotebook::addCustomButtons()
 
     userBtn->setIcon(NotebookButton::User);
     QObject::connect(userBtn, &NotebookButton::leftClicked, [this, userBtn] {
-        getApp()->windows->showAccountSelectPopup(
+        getIApp()->getWindows()->showAccountSelectPopup(
             this->mapToGlobal(userBtn->rect().bottomRight()));
     });
 
@@ -1409,7 +1410,7 @@ void SplitNotebook::addCustomButtons()
     this->streamerModeIcon_ = this->addCustomButton();
     QObject::connect(this->streamerModeIcon_, &NotebookButton::leftClicked,
                      [this] {
-                         getApp()->windows->showSettingsDialog(
+                         getIApp()->getWindows()->showSettingsDialog(
                              this, SettingsDialogPreference::StreamerMode);
                      });
     this->signalHolder_.managedConnect(getApp()->streamerModeChanged, [this]() {

--- a/src/widgets/TooltipWidget.cpp
+++ b/src/widgets/TooltipWidget.cpp
@@ -52,7 +52,7 @@ TooltipWidget::TooltipWidget(BaseWidget *parent)
     });
     this->updateFont();
 
-    auto *windows = getApp()->windows;
+    auto *windows = getIApp()->getWindows();
     this->connections_.managedConnect(windows->gifRepaintRequested, [this] {
         if (!this->isVisible())
         {

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -61,7 +61,7 @@ Window::Window(WindowType type, QWidget *parent)
 #endif
 
     this->bSignals_.emplace_back(
-        getApp()->accounts->twitch.currentUserChanged.connect([this] {
+        getIApp()->getAccounts()->twitch.currentUserChanged.connect([this] {
             this->onAccountSelected();
         }));
     this->onAccountSelected();
@@ -725,7 +725,7 @@ void Window::addMenuBar()
 
 void Window::onAccountSelected()
 {
-    auto user = getApp()->accounts->twitch.getCurrent();
+    auto user = getIApp()->getAccounts()->twitch.getCurrent();
 
     // update title (also append username on Linux and MacOS)
     QString windowTitle = Version::instance().fullVersion();

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -75,7 +75,7 @@ Window::Window(WindowType type, QWidget *parent)
         this->resize(int(300 * this->scale()), int(500 * this->scale()));
     }
 
-    this->signalHolder_.managedConnect(getApp()->hotkeys->onItemsUpdated,
+    this->signalHolder_.managedConnect(getIApp()->getHotkeys()->onItemsUpdated,
                                        [this]() {
                                            this->clearShortcuts();
                                            this->addShortcuts();
@@ -690,7 +690,7 @@ void Window::addShortcuts()
 
     this->addDebugStuff(actions);
 
-    this->shortcuts_ = getApp()->hotkeys->shortcutsForCategory(
+    this->shortcuts_ = getIApp()->getHotkeys()->shortcutsForCategory(
         HotkeyCategory::Window, actions, this);
 }
 

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -105,7 +105,7 @@ bool Window::event(QEvent *event)
     switch (event->type())
     {
         case QEvent::WindowActivate: {
-            getApp()->windows->selectedWindow_ = this;
+            getIApp()->getWindows()->selectedWindow_ = this;
             break;
         }
 
@@ -136,15 +136,14 @@ void Window::closeEvent(QCloseEvent *)
 {
     if (this->type_ == WindowType::Main)
     {
-        auto *app = getApp();
-        app->windows->save();
-        app->windows->closeAll();
+        getIApp()->getWindows()->save();
+        getIApp()->getWindows()->closeAll();
     }
 
     // Ensure selectedWindow_ is never an invalid pointer.
     // WindowManager will return the main window if no window is pointed to by
     // `selectedWindow_`.
-    getApp()->windows->selectedWindow_ = nullptr;
+    getIApp()->getWindows()->selectedWindow_ = nullptr;
 
     this->closed.invoke();
 
@@ -181,7 +180,7 @@ void Window::addCustomTitlebarButtons()
 
     // settings
     this->addTitleBarButton(TitleBarButtonStyle::Settings, [this] {
-        getApp()->windows->showSettingsDialog(this);
+        getIApp()->getWindows()->showSettingsDialog(this);
     });
 
     // updates
@@ -191,15 +190,16 @@ void Window::addCustomTitlebarButtons()
 
     // account
     this->userLabel_ = this->addTitleBarLabel([this] {
-        getApp()->windows->showAccountSelectPopup(this->userLabel_->mapToGlobal(
-            this->userLabel_->rect().bottomLeft()));
+        getIApp()->getWindows()->showAccountSelectPopup(
+            this->userLabel_->mapToGlobal(
+                this->userLabel_->rect().bottomLeft()));
     });
     this->userLabel_->setMinimumWidth(20 * scale());
 
     // streamer mode
     this->streamerModeTitlebarIcon_ =
         this->addTitleBarButton(TitleBarButtonStyle::StreamerMode, [this] {
-            getApp()->windows->showSettingsDialog(
+            getIApp()->getWindows()->showSettingsDialog(
                 this, SettingsDialogPreference::StreamerMode);
         });
     this->signalHolder_.managedConnect(getApp()->streamerModeChanged, [this]() {
@@ -489,7 +489,7 @@ void Window::addShortcuts()
         {"toggleLocalR9K",
          [](std::vector<QString>) -> QString {
              getSettings()->hideSimilar.setValue(!getSettings()->hideSimilar);
-             getApp()->windows->forceLayoutChannelViews();
+             getIApp()->getWindows()->forceLayoutChannelViews();
              return "";
          }},
         {"openQuickSwitcher",

--- a/src/widgets/dialogs/EditHotkeyDialog.cpp
+++ b/src/widgets/dialogs/EditHotkeyDialog.cpp
@@ -26,7 +26,8 @@ EditHotkeyDialog::EditHotkeyDialog(const std::shared_ptr<Hotkey> hotkey,
     this->ui_->easyArgsPicker->setVisible(false);
     this->ui_->easyArgsLabel->setVisible(false);
     // dynamically add category names to the category picker
-    for (const auto &[_, hotkeyCategory] : getApp()->hotkeys->categories())
+    for (const auto &[_, hotkeyCategory] :
+         getIApp()->getHotkeys()->categories())
     {
         this->ui_->categoryPicker->addItem(hotkeyCategory.displayName,
                                            hotkeyCategory.name);
@@ -153,7 +154,7 @@ void EditHotkeyDialog::afterEdit()
     auto arguments =
         parseHotkeyArguments(this->ui_->argumentsEdit->toPlainText());
 
-    auto category = getApp()->hotkeys->hotkeyCategoryFromName(
+    auto category = getIApp()->getHotkeys()->hotkeyCategoryFromName(
         this->ui_->categoryPicker->currentData().toString());
     if (!category)
     {
@@ -165,7 +166,7 @@ void EditHotkeyDialog::afterEdit()
 
     // check if another hotkey with this name exists, accounts for editing a hotkey
     bool isEditing = bool(this->data_);
-    if (getApp()->hotkeys->getHotkeyByName(nameText))
+    if (getIApp()->getHotkeys()->getHotkeyByName(nameText))
     {
         // A hotkey with this name already exists
         if (isEditing && this->data()->name() == nameText)
@@ -242,7 +243,8 @@ void EditHotkeyDialog::afterEdit()
     {
         if (keyComboWasEdited || nameWasEdited)
         {
-            if (getApp()->hotkeys->isDuplicate(hotkey, this->data()->name()))
+            if (getIApp()->getHotkeys()->isDuplicate(hotkey,
+                                                     this->data()->name()))
             {
                 this->showEditError(
                     "Keybinding needs to be unique in the category.");
@@ -252,7 +254,7 @@ void EditHotkeyDialog::afterEdit()
     }
     else
     {
-        if (getApp()->hotkeys->isDuplicate(hotkey, QString()))
+        if (getIApp()->getHotkeys()->isDuplicate(hotkey, QString()))
         {
             this->showEditError(
                 "Keybinding needs to be unique in the category.");
@@ -266,7 +268,7 @@ void EditHotkeyDialog::afterEdit()
 
 void EditHotkeyDialog::updatePossibleActions()
 {
-    const auto &hotkeys = getApp()->hotkeys;
+    const auto &hotkeys = getIApp()->getHotkeys();
     auto category = hotkeys->hotkeyCategoryFromName(
         this->ui_->categoryPicker->currentData().toString());
     if (!category)
@@ -318,7 +320,7 @@ void EditHotkeyDialog::updateArgumentsInput()
         this->ui_->argumentsEdit->setEnabled(true);
         return;
     }
-    const auto &hotkeys = getApp()->hotkeys;
+    const auto &hotkeys = getIApp()->getHotkeys();
     auto category = hotkeys->hotkeyCategoryFromName(
         this->ui_->categoryPicker->currentData().toString());
     if (!category)

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -394,9 +394,12 @@ void EmotePopup::loadChannel(ChannelPtr channel)
     auto channelChannel = std::make_shared<Channel>("", Channel::Type::None);
 
     // twitch
-    addTwitchEmoteSets(
-        getApp()->accounts->twitch.getCurrent()->accessEmotes()->emoteSets,
-        *globalChannel, *subChannel, this->channel_->getName());
+    addTwitchEmoteSets(getIApp()
+                           ->getAccounts()
+                           ->twitch.getCurrent()
+                           ->accessEmotes()
+                           ->emoteSets,
+                       *globalChannel, *subChannel, this->channel_->getName());
 
     // global
     if (Settings::instance().enableBTTVGlobalEmotes)
@@ -467,8 +470,11 @@ bool EmotePopup::eventFilter(QObject *object, QEvent *event)
 void EmotePopup::filterTwitchEmotes(std::shared_ptr<Channel> searchChannel,
                                     const QString &searchText)
 {
-    auto twitchEmoteSets =
-        getApp()->accounts->twitch.getCurrent()->accessEmotes()->emoteSets;
+    auto twitchEmoteSets = getIApp()
+                               ->getAccounts()
+                               ->twitch.getCurrent()
+                               ->accessEmotes()
+                               ->emoteSets;
     std::vector<std::shared_ptr<TwitchAccount::EmoteSet>> twitchGlobalEmotes{};
 
     for (const auto &set : twitchEmoteSets)

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -206,7 +206,7 @@ EmotePopup::EmotePopup(QWidget *parent)
     , notebook_(new Notebook(this))
 {
     // this->setStayInScreenRect(true);
-    this->moveTo(getApp()->windows->emotePopupPos(),
+    this->moveTo(getIApp()->getWindows()->emotePopupPos(),
                  widgets::BoundsChecking::DesiredPosition);
 
     auto *layout = new QVBoxLayout();
@@ -589,7 +589,7 @@ void EmotePopup::filterEmotes(const QString &searchText)
 
 void EmotePopup::closeEvent(QCloseEvent *event)
 {
-    getApp()->windows->setEmotePopupPos(this->pos());
+    getIApp()->getWindows()->setEmotePopupPos(this->pos());
     BaseWindow::closeEvent(event);
 }
 

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -273,7 +273,7 @@ EmotePopup::EmotePopup(QWidget *parent)
     loadEmojis(*this->viewEmojis_,
                getApp()->getEmotes()->getEmojis()->getEmojis());
     this->addShortcuts();
-    this->signalHolder_.managedConnect(getApp()->hotkeys->onItemsUpdated,
+    this->signalHolder_.managedConnect(getIApp()->getHotkeys()->onItemsUpdated,
                                        [this]() {
                                            this->clearShortcuts();
                                            this->addShortcuts();
@@ -371,7 +371,7 @@ void EmotePopup::addShortcuts()
          }},
     };
 
-    this->shortcuts_ = getApp()->hotkeys->shortcutsForCategory(
+    this->shortcuts_ = getIApp()->getHotkeys()->shortcutsForCategory(
         HotkeyCategory::PopupWindow, actions, this);
 }
 

--- a/src/widgets/dialogs/LoginDialog.cpp
+++ b/src/widgets/dialogs/LoginDialog.cpp
@@ -66,8 +66,8 @@ namespace {
         pajlada::Settings::Setting<QString>::set(basePath + "/oauthToken",
                                                  oauthToken);
 
-        getApp()->accounts->twitch.reloadUsers();
-        getApp()->accounts->twitch.currentUsername = username;
+        getIApp()->getAccounts()->twitch.reloadUsers();
+        getIApp()->getAccounts()->twitch.currentUsername = username;
         return true;
     }
 

--- a/src/widgets/dialogs/QualityPopup.cpp
+++ b/src/widgets/dialogs/QualityPopup.cpp
@@ -14,7 +14,7 @@ QualityPopup::QualityPopup(const QString &channelURL, QStringList options)
               BaseWindow::DisableLayoutSave,
               BaseWindow::BoundsCheckOnShow,
           },
-          static_cast<QWidget *>(&(getApp()->windows->getMainWindow())))
+          static_cast<QWidget *>(&(getIApp()->getWindows()->getMainWindow())))
     , channelURL_(channelURL)
 {
     this->ui_.selector = new QComboBox(this);

--- a/src/widgets/dialogs/ReplyThreadPopup.cpp
+++ b/src/widgets/dialogs/ReplyThreadPopup.cpp
@@ -98,7 +98,7 @@ ReplyThreadPopup::ReplyThreadPopup(bool closeAutomatically, Split *split)
         new SplitInput(this, this->split_, this->ui_.threadView, false);
 
     this->bSignals_.emplace_back(
-        getApp()->accounts->twitch.currentUserChanged.connect([this] {
+        getIApp()->getAccounts()->twitch.currentUserChanged.connect([this] {
             this->updateInputUI();
         }));
 
@@ -284,7 +284,7 @@ void ReplyThreadPopup::updateInputUI()
 
     this->ui_.replyInput->setVisible(channel->isWritable());
 
-    auto user = getApp()->accounts->twitch.getCurrent();
+    auto user = getIApp()->getAccounts()->twitch.getCurrent();
     QString placeholderText;
 
     if (user->isAnon())
@@ -293,9 +293,11 @@ void ReplyThreadPopup::updateInputUI()
     }
     else
     {
-        placeholderText =
-            QStringLiteral("Reply as %1...")
-                .arg(getApp()->accounts->twitch.getCurrent()->getUserName());
+        placeholderText = QStringLiteral("Reply as %1...")
+                              .arg(getIApp()
+                                       ->getAccounts()
+                                       ->twitch.getCurrent()
+                                       ->getUserName());
     }
 
     this->ui_.replyInput->setPlaceholderText(placeholderText);

--- a/src/widgets/dialogs/ReplyThreadPopup.cpp
+++ b/src/widgets/dialogs/ReplyThreadPopup.cpp
@@ -77,7 +77,7 @@ ReplyThreadPopup::ReplyThreadPopup(bool closeAutomatically, Split *split)
         {"search", nullptr},
     };
 
-    this->shortcuts_ = getApp()->hotkeys->shortcutsForCategory(
+    this->shortcuts_ = getIApp()->getHotkeys()->shortcutsForCategory(
         HotkeyCategory::PopupWindow, actions, this);
 
     // initialize UI

--- a/src/widgets/dialogs/SelectChannelDialog.cpp
+++ b/src/widgets/dialogs/SelectChannelDialog.cpp
@@ -615,7 +615,7 @@ void SelectChannelDialog::addShortcuts()
         actions.emplace("openTab", nullptr);
     }
 
-    this->shortcuts_ = getApp()->hotkeys->shortcutsForCategory(
+    this->shortcuts_ = getIApp()->getHotkeys()->shortcutsForCategory(
         HotkeyCategory::PopupWindow, actions, this);
 }
 

--- a/src/widgets/dialogs/SettingsDialog.cpp
+++ b/src/widgets/dialogs/SettingsDialog.cpp
@@ -54,7 +54,7 @@ SettingsDialog::SettingsDialog(QWidget *parent)
     this->overrideBackgroundColor_ = QColor("#111111");
 
     this->addShortcuts();
-    this->signalHolder_.managedConnect(getApp()->hotkeys->onItemsUpdated,
+    this->signalHolder_.managedConnect(getIApp()->getHotkeys()->onItemsUpdated,
                                        [this]() {
                                            this->clearShortcuts();
                                            this->addShortcuts();
@@ -78,13 +78,13 @@ void SettingsDialog::addShortcuts()
         {"openTab", nullptr},
     };
 
-    this->shortcuts_ = getApp()->hotkeys->shortcutsForCategory(
+    this->shortcuts_ = getIApp()->getHotkeys()->shortcutsForCategory(
         HotkeyCategory::PopupWindow, actions, this);
 }
 void SettingsDialog::setSearchPlaceholderText()
 {
     QString searchHotkey;
-    auto searchSeq = getApp()->hotkeys->getDisplaySequence(
+    auto searchSeq = getIApp()->getHotkeys()->getDisplaySequence(
         HotkeyCategory::PopupWindow, "search");
     if (!searchSeq.isEmpty())
     {

--- a/src/widgets/dialogs/SettingsDialog.cpp
+++ b/src/widgets/dialogs/SettingsDialog.cpp
@@ -432,7 +432,7 @@ void SettingsDialog::onOkClicked()
 {
     if (!getApp()->getArgs().dontSaveSettings)
     {
-        getApp()->commands->save();
+        getIApp()->getCommands()->save();
         pajlada::Settings::SettingManager::gSave();
     }
     this->close();

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -299,7 +299,7 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically, Split *split)
                             "Open channel in a new popup window", this,
                             [loginName] {
                                 auto *app = getApp();
-                                auto &window = app->windows->createWindow(
+                                auto &window = app->getWindows()->createWindow(
                                     WindowType::Popup, true);
                                 auto *split = window.getNotebook()
                                                   .getOrAddSelectedPage()
@@ -314,7 +314,8 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically, Split *split)
                                     getApp()->twitch->getOrAddChannel(
                                         loginName);
                                 auto &nb = getApp()
-                                               ->windows->getMainWindow()
+                                               ->getWindows()
+                                               ->getMainWindow()
                                                .getNotebook();
                                 SplitContainer *container = nb.addPage(true);
                                 Split *split = new Split(container);

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -56,7 +56,7 @@ namespace {
         {
             button.assign(copyButton);
         }
-        button->setPixmap(getApp()->themes->buttons.copy);
+        button->setPixmap(getIApp()->getThemes()->buttons.copy);
         button->setScaleIndependantSize(18, 18);
         button->setDim(Button::Dim::Lots);
         button->setToolTip(tooltip);

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -451,9 +451,11 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically, Split *split)
             if (twitchChannel)
             {
                 bool isMyself =
-                    QString::compare(
-                        getApp()->accounts->twitch.getCurrent()->getUserName(),
-                        this->userName_, Qt::CaseInsensitive) == 0;
+                    QString::compare(getIApp()
+                                         ->getAccounts()
+                                         ->twitch.getCurrent()
+                                         ->getUserName(),
+                                     this->userName_, Qt::CaseInsensitive) == 0;
 
                 visibilityModButtons =
                     twitchChannel->isBroadcaster() && !isMyself;
@@ -595,7 +597,7 @@ void UserInfoPopup::installEvents()
     QObject::connect(
         this->ui_.block, &QCheckBox::stateChanged,
         [this](int newState) mutable {
-            auto currentUser = getApp()->accounts->twitch.getCurrent();
+            auto currentUser = getIApp()->getAccounts()->twitch.getCurrent();
 
             const auto reenableBlockCheckbox = [this] {
                 this->ui_.block->setEnabled(true);
@@ -612,7 +614,7 @@ void UserInfoPopup::installEvents()
                 case Qt::CheckState::Unchecked: {
                     this->ui_.block->setEnabled(false);
 
-                    getApp()->accounts->twitch.getCurrent()->unblockUser(
+                    getIApp()->getAccounts()->twitch.getCurrent()->unblockUser(
                         this->userId_, this,
                         [this, reenableBlockCheckbox, currentUser] {
                             this->channel_->addMessage(makeSystemMessage(
@@ -639,7 +641,7 @@ void UserInfoPopup::installEvents()
                 case Qt::CheckState::Checked: {
                     this->ui_.block->setEnabled(false);
 
-                    getApp()->accounts->twitch.getCurrent()->blockUser(
+                    getIApp()->getAccounts()->twitch.getCurrent()->blockUser(
                         this->userId_, this,
                         [this, reenableBlockCheckbox, currentUser] {
                             this->channel_->addMessage(makeSystemMessage(
@@ -796,7 +798,7 @@ void UserInfoPopup::updateLatestMessages()
 void UserInfoPopup::updateUserData()
 {
     std::weak_ptr<bool> hack = this->lifetimeHack_;
-    auto currentUser = getApp()->accounts->twitch.getCurrent();
+    auto currentUser = getIApp()->getAccounts()->twitch.getCurrent();
 
     const auto onUserFetchFailed = [this, hack] {
         if (!hack.lock())

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -226,7 +226,7 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically, Split *split)
                            .arg(calculateTimeoutDuration(button));
              }
 
-             msg = getApp()->commands->execCommand(
+             msg = getIApp()->getCommands()->execCommand(
                  msg, this->underlyingChannel_, false);
 
              this->underlyingChannel_->sendMessage(msg);
@@ -415,25 +415,25 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically, Split *split)
 
         QObject::connect(mod.getElement(), &Button::leftClicked, [this] {
             QString value = "/mod " + this->userName_;
-            value = getApp()->commands->execCommand(
+            value = getIApp()->getCommands()->execCommand(
                 value, this->underlyingChannel_, false);
             this->underlyingChannel_->sendMessage(value);
         });
         QObject::connect(unmod.getElement(), &Button::leftClicked, [this] {
             QString value = "/unmod " + this->userName_;
-            value = getApp()->commands->execCommand(
+            value = getIApp()->getCommands()->execCommand(
                 value, this->underlyingChannel_, false);
             this->underlyingChannel_->sendMessage(value);
         });
         QObject::connect(vip.getElement(), &Button::leftClicked, [this] {
             QString value = "/vip " + this->userName_;
-            value = getApp()->commands->execCommand(
+            value = getIApp()->getCommands()->execCommand(
                 value, this->underlyingChannel_, false);
             this->underlyingChannel_->sendMessage(value);
         });
         QObject::connect(unvip.getElement(), &Button::leftClicked, [this] {
             QString value = "/unvip " + this->userName_;
-            value = getApp()->commands->execCommand(
+            value = getIApp()->getCommands()->execCommand(
                 value, this->underlyingChannel_, false);
             this->underlyingChannel_->sendMessage(value);
         });
@@ -500,7 +500,7 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically, Split *split)
                     if (this->underlyingChannel_)
                     {
                         QString value = "/ban " + this->userName_;
-                        value = getApp()->commands->execCommand(
+                        value = getIApp()->getCommands()->execCommand(
                             value, this->underlyingChannel_, false);
 
                         this->underlyingChannel_->sendMessage(value);
@@ -511,7 +511,7 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically, Split *split)
                     if (this->underlyingChannel_)
                     {
                         QString value = "/unban " + this->userName_;
-                        value = getApp()->commands->execCommand(
+                        value = getIApp()->getCommands()->execCommand(
                             value, this->underlyingChannel_, false);
 
                         this->underlyingChannel_->sendMessage(value);
@@ -524,7 +524,7 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically, Split *split)
                         QString value = "/timeout " + this->userName_ + " " +
                                         QString::number(arg);
 
-                        value = getApp()->commands->execCommand(
+                        value = getIApp()->getCommands()->execCommand(
                             value, this->underlyingChannel_, false);
 
                         this->underlyingChannel_->sendMessage(value);

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -245,7 +245,7 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically, Split *split)
         {"search", nullptr},
     };
 
-    this->shortcuts_ = getApp()->hotkeys->shortcutsForCategory(
+    this->shortcuts_ = getIApp()->getHotkeys()->shortcutsForCategory(
         HotkeyCategory::PopupWindow, actions, this);
 
     auto layers = LayoutCreator<QWidget>(this->getLayoutContainer())

--- a/src/widgets/dialogs/switcher/NewPopupItem.cpp
+++ b/src/widgets/dialogs/switcher/NewPopupItem.cpp
@@ -33,7 +33,8 @@ void NewPopupItem::paint(QPainter *painter, const QRect &rect) const
 
     painter->setPen(getApp()->themes->splits.header.text);
     painter->setBrush(Qt::SolidPattern);
-    painter->setFont(getApp()->fonts->getFont(FontStyle::UiMediumBold, 1.0));
+    painter->setFont(
+        getIApp()->getFonts()->getFont(FontStyle::UiMediumBold, 1.0));
 
     QRect iconRect(rect.topLeft(), ICON_SIZE);
     this->icon_.paint(painter, iconRect, Qt::AlignLeft | Qt::AlignVCenter);

--- a/src/widgets/dialogs/switcher/NewPopupItem.cpp
+++ b/src/widgets/dialogs/switcher/NewPopupItem.cpp
@@ -21,9 +21,8 @@ NewPopupItem::NewPopupItem(const QString &channelName)
 
 void NewPopupItem::action()
 {
-    auto *app = getApp();
-    auto channel = app->twitch->getOrAddChannel(this->channelName_);
-    app->windows->openInPopup(channel);
+    auto channel = getApp()->twitch->getOrAddChannel(this->channelName_);
+    getIApp()->getWindows()->openInPopup(channel);
 }
 
 void NewPopupItem::paint(QPainter *painter, const QRect &rect) const

--- a/src/widgets/dialogs/switcher/NewPopupItem.cpp
+++ b/src/widgets/dialogs/switcher/NewPopupItem.cpp
@@ -31,7 +31,7 @@ void NewPopupItem::paint(QPainter *painter, const QRect &rect) const
 
     painter->setRenderHint(QPainter::Antialiasing, true);
 
-    painter->setPen(getApp()->themes->splits.header.text);
+    painter->setPen(getIApp()->getThemes()->splits.header.text);
     painter->setBrush(Qt::SolidPattern);
     painter->setFont(
         getIApp()->getFonts()->getFont(FontStyle::UiMediumBold, 1.0));

--- a/src/widgets/dialogs/switcher/NewTabItem.cpp
+++ b/src/widgets/dialogs/switcher/NewTabItem.cpp
@@ -37,7 +37,7 @@ void NewTabItem::paint(QPainter *painter, const QRect &rect) const
     painter->setRenderHint(QPainter::Antialiasing, true);
 
     // TODO(leon): Right pen/brush/font settings?
-    painter->setPen(getApp()->themes->splits.header.text);
+    painter->setPen(getIApp()->getThemes()->splits.header.text);
     painter->setBrush(Qt::SolidPattern);
     painter->setFont(
         getIApp()->getFonts()->getFont(FontStyle::UiMediumBold, 1.0));

--- a/src/widgets/dialogs/switcher/NewTabItem.cpp
+++ b/src/widgets/dialogs/switcher/NewTabItem.cpp
@@ -39,7 +39,8 @@ void NewTabItem::paint(QPainter *painter, const QRect &rect) const
     // TODO(leon): Right pen/brush/font settings?
     painter->setPen(getApp()->themes->splits.header.text);
     painter->setBrush(Qt::SolidPattern);
-    painter->setFont(getApp()->fonts->getFont(FontStyle::UiMediumBold, 1.0));
+    painter->setFont(
+        getIApp()->getFonts()->getFont(FontStyle::UiMediumBold, 1.0));
 
     QRect iconRect(rect.topLeft(), ICON_SIZE);
     this->icon_.paint(painter, iconRect, Qt::AlignLeft | Qt::AlignVCenter);

--- a/src/widgets/dialogs/switcher/SwitchSplitItem.cpp
+++ b/src/widgets/dialogs/switcher/SwitchSplitItem.cpp
@@ -38,7 +38,8 @@ void SwitchSplitItem::paint(QPainter *painter, const QRect &rect) const
     // TODO(leon): Right pen/brush/font settings?
     painter->setPen(getApp()->themes->splits.header.text);
     painter->setBrush(Qt::SolidPattern);
-    painter->setFont(getApp()->fonts->getFont(FontStyle::UiMediumBold, 1.0));
+    painter->setFont(
+        getIApp()->getFonts()->getFont(FontStyle::UiMediumBold, 1.0));
 
     QRect iconRect(rect.topLeft(), ICON_SIZE);
     this->icon_.paint(painter, iconRect, Qt::AlignLeft | Qt::AlignVCenter);
@@ -58,7 +59,8 @@ void SwitchSplitItem::paint(QPainter *painter, const QRect &rect) const
             QRect(leftTextRect.topRight(),
                   QSize(0.7 * availableTextWidth, iconRect.height()));
 
-        painter->setFont(getApp()->fonts->getFont(FontStyle::UiMedium, 1.0));
+        painter->setFont(
+            getIApp()->getFonts()->getFont(FontStyle::UiMedium, 1.0));
         painter->drawText(rightTextRect, Qt::AlignRight | Qt::AlignVCenter,
                           this->container_->getTab()->getTitle());
     }

--- a/src/widgets/dialogs/switcher/SwitchSplitItem.cpp
+++ b/src/widgets/dialogs/switcher/SwitchSplitItem.cpp
@@ -36,7 +36,7 @@ void SwitchSplitItem::paint(QPainter *painter, const QRect &rect) const
     painter->setRenderHint(QPainter::Antialiasing, true);
 
     // TODO(leon): Right pen/brush/font settings?
-    painter->setPen(getApp()->themes->splits.header.text);
+    painter->setPen(getIApp()->getThemes()->splits.header.text);
     painter->setBrush(Qt::SolidPattern);
     painter->setFont(
         getIApp()->getFonts()->getFont(FontStyle::UiMediumBold, 1.0));

--- a/src/widgets/dialogs/switcher/SwitchSplitItem.cpp
+++ b/src/widgets/dialogs/switcher/SwitchSplitItem.cpp
@@ -21,11 +21,11 @@ void SwitchSplitItem::action()
 {
     if (this->split_)
     {
-        getApp()->windows->select(this->split_);
+        getIApp()->getWindows()->select(this->split_);
     }
     else if (this->container_)
     {
-        getApp()->windows->select(this->container_);
+        getIApp()->getWindows()->select(this->container_);
     }
 }
 

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -2539,7 +2539,7 @@ void ChannelView::addCommandExecutionContextMenuItems(
     /* Get commands to be displayed in context menu; 
      * only those that had the showInMsgContextMenu check box marked in the Commands page */
     std::vector<Command> cmds;
-    for (const auto &cmd : getApp()->commands->items)
+    for (const auto &cmd : getIApp()->getCommands()->items)
     {
         if (cmd.showInMsgContextMenu)
         {
@@ -2586,13 +2586,14 @@ void ChannelView::addCommandExecutionContextMenuItems(
             }
 
             // Execute command through right-clicking a message -> Execute command
-            QString value = getApp()->commands->execCustomCommand(
+            QString value = getIApp()->getCommands()->execCustomCommand(
                 inputText.split(' '), cmd, true, channel, layout->getMessage(),
                 {
                     {"input.text", userText},
                 });
 
-            value = getApp()->commands->execCommand(value, channel, false);
+            value =
+                getIApp()->getCommands()->execCommand(value, channel, false);
 
             channel->sendMessage(value);
         });
@@ -2757,11 +2758,12 @@ void ChannelView::handleLinkClick(QMouseEvent *event, const Link &link,
             }
 
             // Execute command clicking a moderator button
-            value = getApp()->commands->execCustomCommand(
+            value = getIApp()->getCommands()->execCustomCommand(
                 QStringList(), Command{"(modaction)", value}, true, channel,
                 layout->getMessage());
 
-            value = getApp()->commands->execCommand(value, channel, false);
+            value =
+                getIApp()->getCommands()->execCommand(value, channel, false);
 
             channel->sendMessage(value);
         }

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -425,9 +425,10 @@ void ChannelView::initializeSignals()
             }
         });
 
-    this->signalHolder_.managedConnect(getApp()->fonts->fontChanged, [this] {
-        this->queueLayout();
-    });
+    this->signalHolder_.managedConnect(getIApp()->getFonts()->fontChanged,
+                                       [this] {
+                                           this->queueLayout();
+                                       });
 }
 
 bool ChannelView::pausable() const

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -396,11 +396,11 @@ void ChannelView::initializeScrollbar()
 
 void ChannelView::initializeSignals()
 {
-    this->signalHolder_.managedConnect(getApp()->windows->wordFlagsChanged,
-                                       [this] {
-                                           this->queueLayout();
-                                           this->update();
-                                       });
+    this->signalHolder_.managedConnect(
+        getIApp()->getWindows()->wordFlagsChanged, [this] {
+            this->queueLayout();
+            this->update();
+        });
 
     getSettings()->showLastMessageIndicator.connect(
         [this](auto, auto) {
@@ -409,7 +409,7 @@ void ChannelView::initializeSignals()
         this->signalHolder_);
 
     this->signalHolder_.managedConnect(
-        getApp()->windows->gifRepaintRequested, [&] {
+        getIApp()->getWindows()->gifRepaintRequested, [&] {
             if (!this->animationArea_.isEmpty())
             {
                 this->queueUpdate(this->animationArea_);
@@ -417,7 +417,7 @@ void ChannelView::initializeSignals()
         });
 
     this->signalHolder_.managedConnect(
-        getApp()->windows->layoutRequested, [&](Channel *channel) {
+        getIApp()->getWindows()->layoutRequested, [&](Channel *channel) {
             if (this->isVisible() &&
                 (channel == nullptr || this->channel_.get() == channel))
             {
@@ -1290,7 +1290,7 @@ MessageElementFlags ChannelView::getFlags() const
         return *this->overrideFlags_;
     }
 
-    MessageElementFlags flags = app->windows->getWordFlags();
+    MessageElementFlags flags = app->getWindows()->getWordFlags();
 
     auto *split = dynamic_cast<Split *>(this->parentWidget());
 
@@ -1376,7 +1376,7 @@ bool ChannelView::scrollToMessage(const MessagePtr &message)
     this->scrollToMessageLayout(messagesSnapshot[messageIdx].get(), messageIdx);
     if (this->split_)
     {
-        getApp()->windows->select(this->split_);
+        getIApp()->getWindows()->select(this->split_);
     }
     return true;
 }
@@ -1408,7 +1408,7 @@ bool ChannelView::scrollToMessageId(const QString &messageId)
     this->scrollToMessageLayout(messagesSnapshot[messageIdx].get(), messageIdx);
     if (this->split_)
     {
-        getApp()->windows->select(this->split_);
+        getIApp()->getWindows()->select(this->split_);
     }
     return true;
 }
@@ -2444,7 +2444,7 @@ void ChannelView::addMessageContextMenuItems(QMenu *menu,
             }
             else if (isMentions || isAutomod)
             {
-                getApp()->windows->scrollToMessage(messagePtr);
+                getIApp()->getWindows()->scrollToMessage(messagePtr);
             }
             else if (isReplyOrUserCard)
             {
@@ -2454,7 +2454,7 @@ void ChannelView::addMessageContextMenuItems(QMenu *menu,
                 if (type == Channel::Type::TwitchMentions ||
                     type == Channel::Type::TwitchAutomod)
                 {
-                    getApp()->windows->scrollToMessage(messagePtr);
+                    getIApp()->getWindows()->scrollToMessage(messagePtr);
                 }
                 else
                 {
@@ -2784,7 +2784,7 @@ void ChannelView::handleLinkClick(QMouseEvent *event, const Link &link,
             // Get all currently open pages
             QList<SplitContainer *> openPages;
 
-            auto &nb = getApp()->windows->getMainWindow().getNotebook();
+            auto &nb = getIApp()->getWindows()->getMainWindow().getNotebook();
             for (int i = 0; i < nb.getPageCount(); ++i)
             {
                 openPages.push_back(

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1023,8 +1023,11 @@ bool ChannelView::shouldIncludeMessage(const MessagePtr &m) const
     if (this->channelFilters_)
     {
         if (getSettings()->excludeUserMessagesFromFilter &&
-            getApp()->accounts->twitch.getCurrent()->getUserName().compare(
-                m->loginName, Qt::CaseInsensitive) == 0)
+            getIApp()
+                    ->getAccounts()
+                    ->twitch.getCurrent()
+                    ->getUserName()
+                    .compare(m->loginName, Qt::CaseInsensitive) == 0)
         {
             return true;
         }
@@ -2764,13 +2767,13 @@ void ChannelView::handleLinkClick(QMouseEvent *event, const Link &link,
         break;
 
         case Link::AutoModAllow: {
-            getApp()->accounts->twitch.getCurrent()->autoModAllow(
+            getIApp()->getAccounts()->twitch.getCurrent()->autoModAllow(
                 link.value, this->channel());
         }
         break;
 
         case Link::AutoModDeny: {
-            getApp()->accounts->twitch.getCurrent()->autoModDeny(
+            getIApp()->getAccounts()->twitch.getCurrent()->autoModDeny(
                 link.value, this->channel());
         }
         break;

--- a/src/widgets/helper/NotebookTab.cpp
+++ b/src/widgets/helper/NotebookTab.cpp
@@ -613,7 +613,7 @@ void NotebookTab::paintEvent(QPaintEvent *)
                 borderRect = QRect(0, 0, this->width(), 1);
                 break;
         }
-        painter.fillRect(borderRect, app->themes->window.background);
+        painter.fillRect(borderRect, app->getThemes()->window.background);
     }
 }
 

--- a/src/widgets/helper/NotebookTab.cpp
+++ b/src/widgets/helper/NotebookTab.cpp
@@ -289,7 +289,7 @@ const QString &NotebookTab::getTitle() const
 void NotebookTab::titleUpdated()
 {
     // Queue up save because: Tab title changed
-    getApp()->windows->queueSave();
+    getIApp()->getWindows()->queueSave();
     this->notebook_->refresh();
     this->updateSize();
     this->update();

--- a/src/widgets/helper/NotebookTab.cpp
+++ b/src/widgets/helper/NotebookTab.cpp
@@ -429,9 +429,9 @@ void NotebookTab::paintEvent(QPaintEvent *)
 
     auto div = std::max<float>(0.01f, this->logicalDpiX() * deviceDpi(this));
     painter.setFont(
-        getApp()->fonts->getFont(FontStyle::UiTabs, scale * 96.f / div));
+        getIApp()->getFonts()->getFont(FontStyle::UiTabs, scale * 96.f / div));
     QFontMetrics metrics =
-        app->fonts->getFontMetrics(FontStyle::UiTabs, scale * 96.f / div);
+        app->getFonts()->getFontMetrics(FontStyle::UiTabs, scale * 96.f / div);
 
     int height = int(scale * NOTEBOOK_TAB_HEIGHT);
 

--- a/src/widgets/helper/SearchPopup.cpp
+++ b/src/widgets/helper/SearchPopup.cpp
@@ -103,7 +103,7 @@ void SearchPopup::addShortcuts()
         {"scrollPage", nullptr},
     };
 
-    this->shortcuts_ = getApp()->hotkeys->shortcutsForCategory(
+    this->shortcuts_ = getIApp()->getHotkeys()->shortcutsForCategory(
         HotkeyCategory::PopupWindow, actions, this);
 }
 

--- a/src/widgets/helper/SearchPopup.cpp
+++ b/src/widgets/helper/SearchPopup.cpp
@@ -138,7 +138,7 @@ void SearchPopup::goToMessage(const MessagePtr &message)
         if (type == Channel::Type::TwitchMentions ||
             type == Channel::Type::TwitchAutomod)
         {
-            getApp()->windows->scrollToMessage(message);
+            getIApp()->getWindows()->scrollToMessage(message);
             return;
         }
 

--- a/src/widgets/settingspages/AccountsPage.cpp
+++ b/src/widgets/settingspages/AccountsPage.cpp
@@ -26,8 +26,8 @@ AccountsPage::AccountsPage()
 
     EditableModelView *view =
         layout
-            .emplace<EditableModelView>(app->accounts->createModel(nullptr),
-                                        false)
+            .emplace<EditableModelView>(
+                app->getAccounts()->createModel(nullptr), false)
             .getElement();
 
     view->getTableView()->horizontalHeader()->setVisible(false);
@@ -63,7 +63,7 @@ AccountsPage::AccountsPage()
     //            return;
     //        }
 
-    //        getApp()->accounts->Twitch.removeUser(selectedUser);
+    //        getIApp()->getAccounts()->Twitch.removeUser(selectedUser);
     //    });
 }
 

--- a/src/widgets/settingspages/CommandPage.cpp
+++ b/src/widgets/settingspages/CommandPage.cpp
@@ -38,16 +38,17 @@ CommandPage::CommandPage()
     LayoutCreator<CommandPage> layoutCreator(this);
     auto layout = layoutCreator.setLayoutType<QVBoxLayout>();
 
-    EditableModelView *view =
-        layout.emplace<EditableModelView>(app->commands->createModel(nullptr))
-            .getElement();
+    EditableModelView *view = layout
+                                  .emplace<EditableModelView>(
+                                      app->getCommands()->createModel(nullptr))
+                                  .getElement();
 
     view->setTitles({"Trigger", "Command", "Show In\nMessage Menu"});
     view->getTableView()->horizontalHeader()->setSectionResizeMode(
         1, QHeaderView::Stretch);
     // We can safely ignore this signal connection since we own the view
     std::ignore = view->addButtonPressed.connect([] {
-        getApp()->commands->items.append(
+        getIApp()->getCommands()->items.append(
             Command{"/command", "I made a new command HeyGuys"});
     });
 
@@ -66,7 +67,7 @@ CommandPage::CommandPage()
             {
                 if (int index = line.indexOf(' '); index != -1)
                 {
-                    getApp()->commands->items.insert(
+                    getIApp()->getCommands()->items.insert(
                         Command(line.mid(0, index), line.mid(index + 1)));
                 }
             }

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -878,7 +878,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
                        s.shownSimilarTriggerHighlights);
     s.hideSimilar.connect(
         []() {
-            getApp()->windows->forceLayoutChannelViews();
+            getIApp()->getWindows()->forceLayoutChannelViews();
         },
         false);
     layout.addDropdown<float>(

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -241,7 +241,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     layout.addCheckbox("Show message reply button", s.showReplyButton, false,
                        "Show a reply button next to every chat message");
 
-    auto removeTabSeq = getApp()->hotkeys->getDisplaySequence(
+    auto removeTabSeq = getIApp()->getHotkeys()->getDisplaySequence(
         HotkeyCategory::Window, "removeTab");
     QString removeTabShortcut = "an assigned hotkey (Window -> remove tab)";
     if (!removeTabSeq.isEmpty())
@@ -262,7 +262,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
 #endif
     if (!BaseWindow::supportsCustomWindowFrame())
     {
-        auto settingsSeq = getApp()->hotkeys->getDisplaySequence(
+        auto settingsSeq = getIApp()->getHotkeys()->getDisplaySequence(
             HotkeyCategory::Window, "openSettings");
         QString shortcut = " (no key bound to open them otherwise)";
         // TODO: maybe prevent the user from locking themselves out of the settings?
@@ -858,7 +858,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
                        "Show the stream title");
 
     layout.addSubtitle("R9K");
-    auto toggleLocalr9kSeq = getApp()->hotkeys->getDisplaySequence(
+    auto toggleLocalr9kSeq = getIApp()->getHotkeys()->getDisplaySequence(
         HotkeyCategory::Window, "toggleLocalR9K");
     QString toggleLocalr9kShortcut =
         "an assigned hotkey (Window -> Toggle local R9K)";

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -123,8 +123,8 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     layout.addTitle("Interface");
 
     layout.addDropdown<QString>(
-        "Theme", getApp()->themes->availableThemes(),
-        getApp()->themes->themeName,
+        "Theme", getIApp()->getThemes()->availableThemes(),
+        getIApp()->getThemes()->themeName,
         [](const auto *combo, const auto &themeKey) {
             return combo->findData(themeKey, Qt::UserRole);
         },

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -135,7 +135,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
 
     layout.addDropdown<QString>(
         "Font", {"Segoe UI", "Arial", "Choose..."},
-        getApp()->fonts->chatFontFamily,
+        getIApp()->getFonts()->chatFontFamily,
         [](auto val) {
             return val;
         },
@@ -144,7 +144,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         });
     layout.addDropdown<int>(
         "Font size", {"9pt", "10pt", "12pt", "14pt", "16pt", "20pt"},
-        getApp()->fonts->chatFontSize,
+        getIApp()->getFonts()->chatFontSize,
         [](auto val) {
             return QString::number(val) + "pt";
         },
@@ -1251,7 +1251,8 @@ QString GeneralPage::getFont(const DropdownArgs &args) const
     {
         args.combobox->setCurrentIndex(0);
         args.combobox->setEditText("Choosing...");
-        QFontDialog dialog(getApp()->fonts->getFont(FontStyle::ChatMedium, 1.));
+        QFontDialog dialog(
+            getIApp()->getFonts()->getFont(FontStyle::ChatMedium, 1.));
 
         auto ok = bool();
         auto font = dialog.getFont(&ok, this->window());

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -940,10 +940,10 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     layout.addCustomCheckbox(
         "Restart on crash (requires restart)",
         [] {
-            return getApp()->crashHandler->shouldRecover();
+            return getIApp()->getCrashHandler()->shouldRecover();
         },
         [](bool on) {
-            return getApp()->crashHandler->saveShouldRecover(on);
+            return getIApp()->getCrashHandler()->saveShouldRecover(on);
         },
         "When possible, restart Chatterino if the program crashes");
 

--- a/src/widgets/settingspages/GeneralPageView.cpp
+++ b/src/widgets/settingspages/GeneralPageView.cpp
@@ -197,7 +197,7 @@ ComboBox *GeneralPageView::addDropdown(
     QObject::connect(combo, &QComboBox::currentTextChanged,
                      [&setting](const QString &newValue) {
                          setting = newValue;
-                         getApp()->windows->forceLayoutChannelViews();
+                         getIApp()->getWindows()->forceLayoutChannelViews();
                      });
 
     return combo;

--- a/src/widgets/settingspages/GeneralPageView.hpp
+++ b/src/widgets/settingspages/GeneralPageView.hpp
@@ -203,7 +203,7 @@ public:
              setValue = std::move(setValue)](const int newIndex) {
                 setting = setValue(DropdownArgs{combo->itemText(newIndex),
                                                 combo->currentIndex(), combo});
-                getApp()->windows->forceLayoutChannelViews();
+                getIApp()->getWindows()->forceLayoutChannelViews();
             });
 
         return combo;
@@ -255,7 +255,7 @@ public:
              setValue = std::move(setValue)](const int newIndex) {
                 setting = setValue(DropdownArgs{combo->itemText(newIndex),
                                                 combo->currentIndex(), combo});
-                getApp()->windows->forceLayoutChannelViews();
+                getIApp()->getWindows()->forceLayoutChannelViews();
             });
 
         return combo;
@@ -300,7 +300,7 @@ public:
                 // Instead, it's up to the getters to make sure that the setting is legic - see the enum_cast above
                 // You could also use the settings `getEnum` function
                 setting = newText;
-                getApp()->windows->forceLayoutChannelViews();
+                getIApp()->getWindows()->forceLayoutChannelViews();
             });
 
         return combo;

--- a/src/widgets/settingspages/IgnoresPage.cpp
+++ b/src/widgets/settingspages/IgnoresPage.cpp
@@ -120,7 +120,7 @@ void IgnoresPage::onShow()
 {
     auto *app = getApp();
 
-    auto user = app->accounts->twitch.getCurrent();
+    auto user = app->getAccounts()->twitch.getCurrent();
 
     if (user->isAnon())
     {

--- a/src/widgets/settingspages/KeyboardSettingsPage.cpp
+++ b/src/widgets/settingspages/KeyboardSettingsPage.cpp
@@ -22,7 +22,7 @@ using namespace chatterino;
 void tableCellClicked(const QModelIndex &clicked, EditableModelView *view,
                       HotkeyModel *model)
 {
-    auto hotkey = getApp()->hotkeys->getHotkeyByName(
+    auto hotkey = getIApp()->getHotkeys()->getHotkeyByName(
         clicked.siblingAtColumn(0).data(Qt::EditRole).toString());
     if (!hotkey)
     {
@@ -34,8 +34,8 @@ void tableCellClicked(const QModelIndex &clicked, EditableModelView *view,
     if (wasAccepted)
     {
         auto newHotkey = dialog.data();
-        getApp()->hotkeys->replaceHotkey(hotkey->name(), newHotkey);
-        getApp()->hotkeys->save();
+        getIApp()->getHotkeys()->replaceHotkey(hotkey->name(), newHotkey);
+        getIApp()->getHotkeys()->save();
     }
 }
 
@@ -48,7 +48,7 @@ KeyboardSettingsPage::KeyboardSettingsPage()
     LayoutCreator<KeyboardSettingsPage> layoutCreator(this);
     auto layout = layoutCreator.emplace<QVBoxLayout>();
 
-    auto *model = getApp()->hotkeys->createModel(nullptr);
+    auto *model = getIApp()->getHotkeys()->createModel(nullptr);
     EditableModelView *view =
         layout.emplace<EditableModelView>(model).getElement();
 
@@ -68,8 +68,8 @@ KeyboardSettingsPage::KeyboardSettingsPage()
         if (wasAccepted)
         {
             auto newHotkey = dialog.data();
-            getApp()->hotkeys->hotkeys_.append(newHotkey);
-            getApp()->hotkeys->save();
+            getIApp()->getHotkeys()->hotkeys_.append(newHotkey);
+            getIApp()->getHotkeys()->save();
         }
     });
 
@@ -87,7 +87,7 @@ KeyboardSettingsPage::KeyboardSettingsPage()
 
         if (reply == QMessageBox::Yes)
         {
-            getApp()->hotkeys->resetToDefaults();
+            getIApp()->getHotkeys()->resetToDefaults();
         }
     });
     view->addCustomButton(resetEverything);

--- a/src/widgets/settingspages/NotificationPage.cpp
+++ b/src/widgets/settingspages/NotificationPage.cpp
@@ -93,7 +93,7 @@ NotificationPage::NotificationPage()
                 EditableModelView *view =
                     twitchChannels
                         .emplace<EditableModelView>(
-                            getApp()->notifications->createModel(
+                            getIApp()->getNotifications()->createModel(
                                 nullptr, Platform::Twitch))
                         .getElement();
                 view->setTitles({"Twitch channels"});
@@ -112,7 +112,8 @@ NotificationPage::NotificationPage()
                 // We can safely ignore this signal connection since we own the view
                 std::ignore = view->addButtonPressed.connect([] {
                     getApp()
-                        ->notifications->channelMap[Platform::Twitch]
+                        ->getNotifications()
+                        ->channelMap[Platform::Twitch]
                         .append("channel");
                 });
             }

--- a/src/widgets/settingspages/PluginsPage.cpp
+++ b/src/widgets/settingspages/PluginsPage.cpp
@@ -80,7 +80,7 @@ void PluginsPage::rebuildContent()
     this->scrollAreaWidget_.append(this->dataFrame_);
     auto layout = frame.setLayoutType<QVBoxLayout>();
     layout->setParent(this->dataFrame_);
-    for (const auto &[id, plugin] : getApp()->plugins->plugins())
+    for (const auto &[id, plugin] : getIApp()->getPlugins()->plugins())
     {
         auto groupHeaderText =
             QString("%1 (%2, from %3)")
@@ -185,7 +185,7 @@ void PluginsPage::rebuildContent()
                         val.push_back(name);
                     }
                     getSettings()->enabledPlugins.setValue(val);
-                    getApp()->plugins->reload(name);
+                    getIApp()->getPlugins()->reload(name);
                     this->rebuildContent();
                 });
             pluginEntry->addRow(toggleButton);
@@ -194,7 +194,7 @@ void PluginsPage::rebuildContent()
         auto *reloadButton = new QPushButton("Reload", this->dataFrame_);
         QObject::connect(reloadButton, &QPushButton::pressed,
                          [name = id, this]() {
-                             getApp()->plugins->reload(name);
+                             getIApp()->getPlugins()->reload(name);
                              this->rebuildContent();
                          });
         pluginEntry->addRow(reloadButton);

--- a/src/widgets/settingspages/SettingsPage.cpp
+++ b/src/widgets/settingspages/SettingsPage.cpp
@@ -108,7 +108,7 @@ QCheckBox *SettingsPage::createCheckBox(
     QObject::connect(checkbox, &QCheckBox::toggled, this,
                      [&setting](bool state) {
                          setting = state;
-                         getApp()->windows->forceLayoutChannelViews();
+                         getIApp()->getWindows()->forceLayoutChannelViews();
                      });
 
     return checkbox;

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -427,7 +427,8 @@ Split::Split(QWidget *parent)
                 }
             }
             QPointer<ResizingTextEdit> edit = this->input_->ui_.textEdit;
-            getApp()->imageUploader->upload(source, this->getChannel(), edit);
+            getIApp()->getImageUploader()->upload(source, this->getChannel(),
+                                                  edit);
         });
 
     getSettings()->imageUploaderEnabled.connect(

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -241,7 +241,7 @@ Split::Split(QWidget *parent)
 
     // update placeholder text on Twitch account change and channel change
     this->bSignals_.emplace_back(
-        getApp()->accounts->twitch.currentUserChanged.connect([this] {
+        getIApp()->getAccounts()->twitch.currentUserChanged.connect([this] {
             this->updateInputPlaceholder();
         }));
     this->signalHolder_.managedConnect(channelChanged, [this] {
@@ -770,7 +770,7 @@ void Split::updateInputPlaceholder()
         return;
     }
 
-    auto user = getApp()->accounts->twitch.getCurrent();
+    auto user = getIApp()->getAccounts()->twitch.getCurrent();
     QString placeholderText;
 
     if (user->isAnon())
@@ -779,9 +779,11 @@ void Split::updateInputPlaceholder()
     }
     else
     {
-        placeholderText =
-            QString("Send message as %1...")
-                .arg(getApp()->accounts->twitch.getCurrent()->getUserName());
+        placeholderText = QString("Send message as %1...")
+                              .arg(getIApp()
+                                       ->getAccounts()
+                                       ->twitch.getCurrent()
+                                       ->getUserName());
     }
 
     this->input_->ui_.textEdit->setPlaceholderText(placeholderText);
@@ -1104,7 +1106,8 @@ void Split::openInBrowser()
 
 void Split::openWhispersInBrowser()
 {
-    auto userName = getApp()->accounts->twitch.getCurrent()->getUserName();
+    auto userName =
+        getIApp()->getAccounts()->twitch.getCurrent()->getUserName();
     QDesktopServices::openUrl("https://twitch.tv/popout/moderator/" + userName +
                               "/whispers");
 }
@@ -1241,7 +1244,7 @@ void Split::showChatterList()
     auto loadChatters = [=](auto modList, auto vipList, bool isBroadcaster) {
         getHelix()->getChatters(
             twitchChannel->roomId(),
-            getApp()->accounts->twitch.getCurrent()->getUserId(), 50000,
+            getIApp()->getAccounts()->twitch.getCurrent()->getUserId(), 50000,
             [=](auto chatters) {
                 auto broadcaster = channel->getName().toLower();
                 QStringList chatterList;
@@ -1489,7 +1492,7 @@ void Split::showSearch(bool singleChannel)
 void Split::reloadChannelAndSubscriberEmotes()
 {
     auto channel = this->getChannel();
-    getApp()->accounts->twitch.getCurrent()->loadEmotes(channel);
+    getIApp()->getAccounts()->twitch.getCurrent()->loadEmotes(channel);
 
     if (auto *twitchChannel = dynamic_cast<TwitchChannel *>(channel.get()))
     {

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -690,7 +690,7 @@ void Split::addShortcuts()
                      << "runCommand hotkey called without arguments!";
                  return "runCommand hotkey called without arguments!";
              }
-             QString command = getApp()->commands->execCommand(
+             QString command = getIApp()->getCommands()->execCommand(
                  arguments.at(0).replace('\n', ' '), this->getChannel(), false);
              this->getChannel()->sendMessage(command);
              return "";

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -436,7 +436,7 @@ Split::Split(QWidget *parent)
         },
         this->signalHolder_);
     this->addShortcuts();
-    this->signalHolder_.managedConnect(getApp()->hotkeys->onItemsUpdated,
+    this->signalHolder_.managedConnect(getIApp()->getHotkeys()->onItemsUpdated,
                                        [this]() {
                                            this->clearShortcuts();
                                            this->addShortcuts();
@@ -741,7 +741,7 @@ void Split::addShortcuts()
          }},
     };
 
-    this->shortcuts_ = getApp()->hotkeys->shortcutsForCategory(
+    this->shortcuts_ = getIApp()->getHotkeys()->shortcutsForCategory(
         HotkeyCategory::Split, actions, this);
 }
 
@@ -1406,8 +1406,8 @@ void Split::showChatterList()
          }},
     };
 
-    getApp()->hotkeys->shortcutsForCategory(HotkeyCategory::PopupWindow,
-                                            actions, chatterDock);
+    getIApp()->getHotkeys()->shortcutsForCategory(HotkeyCategory::PopupWindow,
+                                                  actions, chatterDock);
 
     dockVbox->addWidget(searchBar);
     dockVbox->addWidget(loadingLabel);

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -789,7 +789,7 @@ void Split::updateInputPlaceholder()
 
 void Split::joinChannelInNewTab(ChannelPtr channel)
 {
-    auto &nb = getApp()->windows->getMainWindow().getNotebook();
+    auto &nb = getIApp()->getWindows()->getMainWindow().getNotebook();
     SplitContainer *container = nb.addPage(true);
 
     Split *split = new Split(container);
@@ -889,7 +889,7 @@ void Split::setChannel(IndirectChannel newChannel)
     this->actionRequested.invoke(Action::RefreshTab);
 
     // Queue up save because: Split channel changed
-    getApp()->windows->queueSave();
+    getIApp()->getWindows()->queueSave();
 }
 
 void Split::setModerationMode(bool value)
@@ -983,7 +983,7 @@ void Split::keyReleaseEvent(QKeyEvent *event)
 void Split::resizeEvent(QResizeEvent *event)
 {
     // Queue up save because: Split resized
-    getApp()->windows->queueSave();
+    getIApp()->getWindows()->queueSave();
 
     BaseWidget::resizeEvent(event);
 
@@ -1073,7 +1073,7 @@ void Split::explainSplitting()
 void Split::popup()
 {
     auto *app = getApp();
-    Window &window = app->windows->createWindow(WindowType::Popup);
+    Window &window = app->getWindows()->createWindow(WindowType::Popup);
 
     Split *split = new Split(static_cast<SplitContainer *>(
         window.getNotebook().getOrAddSelectedPage()));
@@ -1470,7 +1470,7 @@ void Split::showSearch(bool singleChannel)
     }
 
     // Pass every ChannelView for every Split across the app to the search popup
-    auto &notebook = getApp()->windows->getMainWindow().getNotebook();
+    auto &notebook = getIApp()->getWindows()->getMainWindow().getNotebook();
     for (int i = 0; i < notebook.getPageCount(); ++i)
     {
         auto *container = dynamic_cast<SplitContainer *>(notebook.getPageAt(i));

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -1194,7 +1194,8 @@ void Split::showChatterList()
     auto formatListItemText = [](QString text) {
         auto *item = new QListWidgetItem();
         item->setText(text);
-        item->setFont(getApp()->fonts->getFont(FontStyle::ChatMedium, 1.0));
+        item->setFont(
+            getIApp()->getFonts()->getFont(FontStyle::ChatMedium, 1.0));
         return item;
     };
 

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -725,17 +725,17 @@ void Split::addShortcuts()
 
              if (mode == 0)
              {
-                 getApp()->notifications->removeChannelNotification(
+                 getIApp()->getNotifications()->removeChannelNotification(
                      this->getChannel()->getName(), Platform::Twitch);
              }
              else if (mode == 1)
              {
-                 getApp()->notifications->addChannelNotification(
+                 getIApp()->getNotifications()->addChannelNotification(
                      this->getChannel()->getName(), Platform::Twitch);
              }
              else
              {
-                 getApp()->notifications->updateChannelNotification(
+                 getIApp()->getNotifications()->updateChannelNotification(
                      this->getChannel()->getName(), Platform::Twitch);
              }
              return "";

--- a/src/widgets/splits/SplitContainer.cpp
+++ b/src/widgets/splits/SplitContainer.cpp
@@ -634,7 +634,7 @@ void SplitContainer::paintEvent(QPaintEvent * /*event*/)
     }
     else
     {
-        if (getApp()->themes->isLightTheme())
+        if (getIApp()->getThemes()->isLightTheme())
         {
             painter.fillRect(rect(), QColor("#999"));
         }
@@ -646,8 +646,8 @@ void SplitContainer::paintEvent(QPaintEvent * /*event*/)
 
     for (DropRect &dropRect : this->dropRects_)
     {
-        QColor border = getApp()->themes->splits.dropTargetRectBorder;
-        QColor background = getApp()->themes->splits.dropTargetRect;
+        QColor border = getIApp()->getThemes()->splits.dropTargetRectBorder;
+        QColor background = getIApp()->getThemes()->splits.dropTargetRect;
 
         if (!dropRect.rect.contains(this->mouseOverPoint_))
         {
@@ -1436,15 +1436,15 @@ void SplitContainer::DropOverlay::paintEvent(QPaintEvent * /*event*/)
     {
         if (!foundMover && rect.rect.contains(this->mouseOverPoint_))
         {
-            painter.setBrush(getApp()->themes->splits.dropPreview);
-            painter.setPen(getApp()->themes->splits.dropPreviewBorder);
+            painter.setBrush(getIApp()->getThemes()->splits.dropPreview);
+            painter.setPen(getIApp()->getThemes()->splits.dropPreviewBorder);
             foundMover = true;
         }
         else
         {
             painter.setBrush(QColor(0, 0, 0, 0));
             painter.setPen(QColor(0, 0, 0, 0));
-            // painter.setPen(getApp()->themes->splits.dropPreviewBorder);
+            // painter.setPen(getIApp()->getThemes()->splits.dropPreviewBorder);
         }
 
         painter.drawRect(rect.rect);
@@ -1526,10 +1526,10 @@ SplitContainer::ResizeHandle::ResizeHandle(SplitContainer *_parent)
 void SplitContainer::ResizeHandle::paintEvent(QPaintEvent * /*event*/)
 {
     QPainter painter(this);
-    painter.setPen(QPen(getApp()->themes->splits.resizeHandle, 2));
+    painter.setPen(QPen(getIApp()->getThemes()->splits.resizeHandle, 2));
 
     painter.fillRect(this->rect(),
-                     getApp()->themes->splits.resizeHandleBackground);
+                     getIApp()->getThemes()->splits.resizeHandleBackground);
 
     if (this->vertical_)
     {

--- a/src/widgets/splits/SplitContainer.cpp
+++ b/src/widgets/splits/SplitContainer.cpp
@@ -614,8 +614,8 @@ void SplitContainer::paintEvent(QPaintEvent * /*event*/)
 
         painter.setPen(this->theme->splits.header.text);
 
-        const auto font =
-            getApp()->fonts->getFont(FontStyle::ChatMedium, this->scale());
+        const auto font = getIApp()->getFonts()->getFont(FontStyle::ChatMedium,
+                                                         this->scale());
         painter.setFont(font);
 
         QString text = "Click to add a split";

--- a/src/widgets/splits/SplitContainer.cpp
+++ b/src/widgets/splits/SplitContainer.cpp
@@ -131,7 +131,7 @@ Split *SplitContainer::appendNewSplit(bool openChannelNameDialog)
 void SplitContainer::insertSplit(Split *split, InsertOptions &&options)
 {
     // Queue up save because: Split added
-    getApp()->windows->queueSave();
+    getIApp()->getWindows()->queueSave();
 
     assertInGuiThread();
 
@@ -345,7 +345,7 @@ SplitContainer::Position SplitContainer::releaseSplit(Split *split)
 SplitContainer::Position SplitContainer::deleteSplit(Split *split)
 {
     // Queue up save because: Split removed
-    getApp()->windows->queueSave();
+    getIApp()->getWindows()->queueSave();
 
     assertInGuiThread();
     assert(split != nullptr);
@@ -774,7 +774,7 @@ void SplitContainer::applyFromDescriptor(const NodeDescriptor &rootNode)
 
 void SplitContainer::popup()
 {
-    Window &window = getApp()->windows->createWindow(WindowType::Popup);
+    Window &window = getIApp()->getWindows()->createWindow(WindowType::Popup);
     auto *popupContainer = window.getNotebook().getOrAddSelectedPage();
 
     QJsonObject encodedTab;

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -363,7 +363,7 @@ void SplitHeader::initializeLayout()
 std::unique_ptr<QMenu> SplitHeader::createMainMenu()
 {
     // top level menu
-    const auto &h = getApp()->hotkeys;
+    const auto &h = getIApp()->getHotkeys();
     auto menu = std::make_unique<QMenu>();
     menu->addAction(
         "Change channel", this->split_, &Split::changeChannel,

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -295,7 +295,7 @@ void SplitHeader::initializeLayout()
                         case Qt::LeftButton:
                             if (getSettings()->moderationActions.empty())
                             {
-                                getApp()->windows->showSettingsDialog(
+                                getIApp()->getWindows()->showSettingsDialog(
                                     this, SettingsDialogPreference::
                                               ModerationActions);
                                 this->split_->setModerationMode(true);
@@ -313,7 +313,7 @@ void SplitHeader::initializeLayout()
 
                         case Qt::RightButton:
                         case Qt::MiddleButton:
-                            getApp()->windows->showSettingsDialog(
+                            getIApp()->getWindows()->showSettingsDialog(
                                 this,
                                 SettingsDialogPreference::ModerationActions);
                             break;

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -246,7 +246,7 @@ SplitHeader::SplitHeader(Split *split)
     });
 
     this->bSignals_.emplace_back(
-        getApp()->accounts->twitch.currentUserChanged.connect([this] {
+        getIApp()->getAccounts()->twitch.currentUserChanged.connect([this] {
             this->updateModerationModeIcon();
         }));
 
@@ -1034,7 +1034,7 @@ void SplitHeader::reloadSubscriberEmotes()
     this->lastReloadedSubEmotes_ = now;
 
     auto channel = this->split_->getChannel();
-    getApp()->accounts->twitch.getCurrent()->loadEmotes(channel);
+    getIApp()->getAccounts()->twitch.getCurrent()->loadEmotes(channel);
 }
 
 void SplitHeader::reconnect()

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -533,11 +533,11 @@ std::unique_ptr<QMenu> SplitHeader::createMainMenu()
         action->setShortcut(notifySeq);
 
         QObject::connect(moreMenu, &QMenu::aboutToShow, this, [action, this]() {
-            action->setChecked(getApp()->notifications->isChannelNotified(
+            action->setChecked(getIApp()->getNotifications()->isChannelNotified(
                 this->split_->getChannel()->getName(), Platform::Twitch));
         });
         QObject::connect(action, &QAction::triggered, this, [this]() {
-            getApp()->notifications->updateChannelNotification(
+            getIApp()->getNotifications()->updateChannelNotification(
                 this->split_->getChannel()->getName(), Platform::Twitch);
         });
 

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -69,7 +69,7 @@ SplitInput::SplitInput(QWidget *parent, Split *_chatWidget,
         this->hideCompletionPopup();
     });
     this->scaleChangedEvent(this->scale());
-    this->signalHolder_.managedConnect(getApp()->hotkeys->onItemsUpdated,
+    this->signalHolder_.managedConnect(getIApp()->getHotkeys()->onItemsUpdated,
                                        [this]() {
                                            this->clearShortcuts();
                                            this->addShortcuts();
@@ -640,7 +640,7 @@ void SplitInput::addShortcuts()
          }},
     };
 
-    this->shortcuts_ = getApp()->hotkeys->shortcutsForCategory(
+    this->shortcuts_ = getIApp()->getHotkeys()->shortcutsForCategory(
         HotkeyCategory::SplitInput, actions, this->parentWidget());
 }
 

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -96,7 +96,7 @@ void SplitInput::initLayout()
     auto replyLabel = replyHbox.emplace<QLabel>().assign(&this->ui_.replyLabel);
     replyLabel->setAlignment(Qt::AlignLeft);
     replyLabel->setFont(
-        app->fonts->getFont(FontStyle::ChatMedium, this->scale()));
+        app->getFonts()->getFont(FontStyle::ChatMedium, this->scale()));
 
     replyHbox->addStretch(1);
 
@@ -157,18 +157,18 @@ void SplitInput::initLayout()
 
     // set edit font
     this->ui_.textEdit->setFont(
-        app->fonts->getFont(FontStyle::ChatMedium, this->scale()));
+        app->getFonts()->getFont(FontStyle::ChatMedium, this->scale()));
     QObject::connect(this->ui_.textEdit, &QTextEdit::cursorPositionChanged,
                      this, &SplitInput::onCursorPositionChanged);
     QObject::connect(this->ui_.textEdit, &QTextEdit::textChanged, this,
                      &SplitInput::onTextChanged);
 
     this->managedConnections_.managedConnect(
-        app->fonts->fontChanged, [=, this]() {
+        app->getFonts()->fontChanged, [=, this]() {
             this->ui_.textEdit->setFont(
-                app->fonts->getFont(FontStyle::ChatMedium, this->scale()));
-            this->ui_.replyLabel->setFont(
-                app->fonts->getFont(FontStyle::ChatMediumBold, this->scale()));
+                app->getFonts()->getFont(FontStyle::ChatMedium, this->scale()));
+            this->ui_.replyLabel->setFont(app->getFonts()->getFont(
+                FontStyle::ChatMediumBold, this->scale()));
         });
 
     // open emote popup
@@ -213,11 +213,11 @@ void SplitInput::scaleChangedEvent(float scale)
         this->setMaximumHeight(this->scaledMaxHeight());
     }
     this->ui_.textEdit->setFont(
-        app->fonts->getFont(FontStyle::ChatMedium, scale));
+        app->getFonts()->getFont(FontStyle::ChatMedium, scale));
     this->ui_.textEditLength->setFont(
-        app->fonts->getFont(FontStyle::ChatMedium, scale));
+        app->getFonts()->getFont(FontStyle::ChatMedium, scale));
     this->ui_.replyLabel->setFont(
-        app->fonts->getFont(FontStyle::ChatMediumBold, scale));
+        app->getFonts()->getFont(FontStyle::ChatMediumBold, scale));
 }
 
 void SplitInput::themeChangedEvent()

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -332,7 +332,7 @@ QString SplitInput::handleSendMessage(const std::vector<QString> &arguments)
 
         message = message.replace('\n', ' ');
         QString sendMessage =
-            getApp()->commands->execCommand(message, c, false);
+            getIApp()->getCommands()->execCommand(message, c, false);
 
         c->sendMessage(sendMessage);
 
@@ -363,7 +363,8 @@ QString SplitInput::handleSendMessage(const std::vector<QString> &arguments)
     }
 
     message = message.replace('\n', ' ');
-    QString sendMessage = getApp()->commands->execCommand(message, c, false);
+    QString sendMessage =
+        getIApp()->getCommands()->execCommand(message, c, false);
 
     // Reply within TwitchChannel
     tc->sendReply(sendMessage, this->replyThread_->id);
@@ -947,8 +948,8 @@ void SplitInput::editTextChanged()
         this->textChanged.invoke(text);
 
         text = text.trimmed();
-        text =
-            app->commands->execCommand(text, this->split_->getChannel(), true);
+        text = app->getCommands()->execCommand(text, this->split_->getChannel(),
+                                               true);
     }
 
     if (text.length() > 0 &&

--- a/src/widgets/splits/SplitOverlay.cpp
+++ b/src/widgets/splits/SplitOverlay.cpp
@@ -268,8 +268,8 @@ void SplitOverlay::paintEvent(QPaintEvent *event)
     {
         rect.setRight(rect.right() - 1);
         rect.setBottom(rect.bottom() - 1);
-        painter.setPen(getApp()->themes->splits.dropPreviewBorder);
-        painter.setBrush(getApp()->themes->splits.dropPreview);
+        painter.setPen(getIApp()->getThemes()->splits.dropPreviewBorder);
+        painter.setBrush(getIApp()->getThemes()->splits.dropPreview);
         painter.drawRect(rect);
     }
 }


### PR DESCRIPTION
Almost everything now uses their getXXX() function, meaning we always check/assert if required by the getter

The one real change this PR does is remove the assert from the `getSeventvBadges()` function

This PR will be force-pushed after #5103 has been merged in
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
