### PR TITLE
fix: ignore channel name when copying message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 - Bugfix: Fixed a bug where buttons would remain in a hovered state after leaving them. (#5077)
 - Bugfix: Fixed popup windows not persisting between restarts. (#5081)
 - Bugfix: Fixed splits not retaining their focus after minimizing. (#5080)
+- Bugfix: Fixed _Copy message_ copying the channel name in global search. (#5106)
 - Dev: Run miniaudio in a separate thread, and simplify it to not manage the device ourselves. There's a chance the simplification is a bad idea. (#4978)
 - Dev: Change clang-format from v14 to v16. (#4929)
 - Dev: Fixed UTF16 encoding of `modes` file for the installer. (#4791)

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -318,9 +318,12 @@ void MessageLayoutContainer::addSelectionText(QString &str, uint32_t from,
 
         if (copymode == CopyMode::OnlyTextAndEmotes)
         {
-            if (element->getCreator().getFlags().hasAny(
-                    {MessageElementFlag::Timestamp,
-                     MessageElementFlag::Username, MessageElementFlag::Badges}))
+            if (element->getCreator().getFlags().hasAny({
+                    MessageElementFlag::Timestamp,
+                    MessageElementFlag::Username,
+                    MessageElementFlag::Badges,
+                    MessageElementFlag::ChannelName,
+                }))
             {
                 continue;
             }


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

The channel name can be ignored as stated in the issue.

Fixes #5101.