### PR TITLE
deps(conan): use `boost` in header-only mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,7 @@
 - Dev: Removed duplicate scale in settings dialog. (#5069)
 - Dev: Fix `NotebookTab` emitting updates for every message. (#5068)
 - Dev: Added benchmark for parsing and building recent messages. (#5071)
+- Dev: Boost is depended on as a header-only library when using conan. (#5107)
 
 ## 2.4.6
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -11,6 +11,7 @@ class Chatterino(ConanFile):
         "with_benchmark": False,
         "with_openssl3": False,
         "openssl*:shared": True,
+        "boost*:header_only": True,
     }
     options = {
         "with_benchmark": [True, False],
@@ -29,13 +30,15 @@ class Chatterino(ConanFile):
             self.requires("openssl/1.1.1t")
 
     def generate(self):
-        copy_bin = lambda dep, selector, subdir: copy(
-            self,
-            selector,
-            dep.cpp_info.bindirs[0],
-            path.join(self.build_folder, subdir),
-            keep_path=False,
-        )
+        def copy_bin(dep, selector, subdir):
+            src = path.realpath(dep.cpp_info.bindirs[0])
+            dst = path.realpath(path.join(self.build_folder, subdir))
+
+            if src == dst:
+                return
+
+            copy(self, selector, src, dst, keep_path=False)
+
         for dep in self.dependencies.values():
             # macOS
             copy_bin(dep, "*.dylib", "bin")


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

Seems like we can use boost in header-only mode. This saves some time when running `conan install`. However, the OpenSSL dependency still slows the build down. This can be solved by moving the WebSocket clients to boost-beast and using boost-wintls on Windows, which uses the native SChannel (first, all WebSocket clients would need some kind of common wrapper to make the transition easier).

<sub>Yes, `boost::json` works.</sub>
