### PR TITLE
fix: badge highlights not immediately updating color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 - Bugfix: Fixed an occasional crash for channel point redemptions with text input. (#4949)
 - Bugfix: Fixed triple click on message also selecting moderation buttons. (#4961)
 - Bugfix: Fixed a freeze from a bad regex in _Ignores_. (#4965)
+- Bugfix: Fixed badge highlight changes not immediately being reflected. (#5110)
 - Bugfix: Fixed some emotes not appearing when using _Ignores_. (#4965)
 - Bugfix: Fixed lookahead/-behind not working in _Ignores_. (#4965)
 - Bugfix: Fixed Image Uploader accidentally deleting images with some hosts when link resolver was enabled. (#4971)

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -265,6 +265,10 @@ int Application::run(QApplication &qtApp)
         getSettings()->highlightedUsers.delayedItemsChanged.connect([this] {
             this->windows->forceLayoutChannelViews();
         });
+    std::ignore =
+        getSettings()->highlightedBadges.delayedItemsChanged.connect([this] {
+            this->windows->forceLayoutChannelViews();
+        });
 
     getSettings()->removeSpacesBetweenEmotes.connect([this] {
         this->windows->forceLayoutChannelViews();


### PR DESCRIPTION
When changing the color of a badge highlight, the highlights of the same badge did not immediately update. This PR fixes that.