### PR TITLE
dev: drop Qt 5.12 support and builds

### DIFF
--- a/.docker/Dockerfile-ubuntu-20.04-base
+++ b/.docker/Dockerfile-ubuntu-20.04-base
@@ -21,7 +21,12 @@ RUN apt-get update && apt-get -y install --no-install-recommends \
         libxcb-image0 \
         libxcb-keysyms1 \
         libxcb-render-util0 \
-        libxcb-xinerama0
+        libxcb-xinerama0 \
+        gcc-10
+
+RUN update-alternatives \
+        --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 \
+        --slave /usr/bin/g++ g++ /usr/bin/g++-10
 
 RUN apt-get -y install \
         git \
@@ -33,6 +38,6 @@ RUN apt-get -y install \
 
 RUN pip3 install -U pip && \
         pip3 install aqtinstall && \
-        aqt install-qt linux desktop 5.12.12 && \
-        mkdir -p /opt/qt512 && \
-        mv /5.12.12/gcc_64/* /opt/qt512
+        aqt install-qt linux desktop 5.15.2 && \
+        mkdir -p /opt/qt515 && \
+        mv /5.15.2/gcc_64/* /opt/qt515

--- a/.docker/Dockerfile-ubuntu-20.04-build
+++ b/.docker/Dockerfile-ubuntu-20.04-build
@@ -8,7 +8,7 @@ RUN mkdir /src/build
 RUN cd /src/build && \
         CXXFLAGS=-fno-sized-deallocation cmake \
         -DCMAKE_INSTALL_PREFIX=appdir/usr/ \
-        -DCMAKE_PREFIX_PATH=/opt/qt512/lib/cmake \
+        -DCMAKE_PREFIX_PATH=/opt/qt515/lib/cmake \
         -DBUILD_WITH_QTKEYCHAIN=OFF \
         ..
 

--- a/.docker/Dockerfile-ubuntu-20.04-package
+++ b/.docker/Dockerfile-ubuntu-20.04-package
@@ -1,7 +1,7 @@
 FROM chatterino-ubuntu-20.04-build
 
 # In CI, this is set from the aqtinstall action
-ENV Qt5_DIR=/opt/qt512
+ENV Qt5_DIR=/opt/qt515
 
 WORKDIR /src/build
 
@@ -13,9 +13,6 @@ RUN apt-get update && apt-get -y install --no-install-recommends \
         libfontconfig \
         libxrender1 \
         file
-
-# package deb
-RUN ./../.CI/CreateUbuntuDeb.sh
 
 # package appimage
 RUN ./../.CI/CreateAppImage.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,9 +30,9 @@ jobs:
     strategy:
       matrix:
         include:
-          # Ubuntu 20.04, Qt 5.12
+          # Ubuntu 20.04, Qt 5.15.2
           - os: ubuntu-20.04
-            qt-version: 5.12.12
+            qt-version: 5.15.2
             force-lto: false
             plugins: false
             skip-artifact: false
@@ -299,6 +299,20 @@ jobs:
               libxcb-render-util0 \
               libxcb-xinerama0
 
+      - name: Install GCC 10 (Ubuntu 20.04)
+        if: startsWith(matrix.os, 'ubuntu-20.04')
+        run: |
+          sudo apt-get -y install gcc-10
+          sudo update-alternatives \
+            --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 \
+            --slave /usr/bin/g++ g++ /usr/bin/g++-10
+
+      - name: Apply Qt patches (Ubuntu 20.04)
+        if: startsWith(matrix.os, 'ubuntu-20.04')
+        run: |
+          sudo patch /usr/include/boost/signals2/detail/auto_buffer.hpp .patches/boost-signals2-cpp20.patch
+        shell: bash
+
       - name: Apply Qt patches (Ubuntu)
         if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.qt-version, '5.')
         run: |
@@ -331,7 +345,7 @@ jobs:
         shell: bash
 
       - name: Package - .deb (Ubuntu)
-        if: startsWith(matrix.os, 'ubuntu') && !matrix.skip-artifact
+        if: startsWith(matrix.os, 'ubuntu-22.04') && !matrix.skip-artifact
         run: |
           cd build
           sh ./../.CI/CreateUbuntuDeb.sh
@@ -345,7 +359,7 @@ jobs:
           path: build/Chatterino-x86_64.AppImage
 
       - name: Upload artifact - .deb (Ubuntu)
-        if: startsWith(matrix.os, 'ubuntu') && !matrix.skip-artifact
+        if: startsWith(matrix.os, 'ubuntu-22.04') && !matrix.skip-artifact
         uses: actions/upload-artifact@v4
         with:
           name: Chatterino-${{ matrix.os }}-Qt-${{ matrix.qt-version }}.deb
@@ -429,15 +443,9 @@ jobs:
           path: release-artifacts/
 
       - uses: actions/download-artifact@v4
-        name: Linux Qt5.12.12 AppImage
+        name: Linux Qt5.15.2 AppImage
         with:
-          name: Chatterino-x86_64-5.12.12.AppImage
-          path: release-artifacts/
-
-      - uses: actions/download-artifact@v4
-        name: Ubuntu 20.04 Qt5.12.12 deb
-        with:
-          name: Chatterino-ubuntu-20.04-Qt-5.12.12.deb
+          name: Chatterino-x86_64-5.15.2.AppImage
           path: release-artifacts/
 
       - uses: actions/download-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,6 @@ jobs:
           - os: "ubuntu-22.04"
             qt-version: "5.15.2"
           - os: "ubuntu-22.04"
-            qt-version: "5.12.12"
-          - os: "ubuntu-22.04"
             qt-version: "6.2.4"
       fail-fast: false
     env:

--- a/.patches/boost-signals2-cpp20.patch
+++ b/.patches/boost-signals2-cpp20.patch
@@ -1,0 +1,26 @@
+From 15fcf213563718d2378b6b83a1614680a4fa8cec Mon Sep 17 00:00:00 2001
+From: Romain Geissler <romain.geissler@amadeus.com>
+Date: Mon, 9 Mar 2020 16:53:04 +0000
+Subject: [PATCH] Fix using signals2 with gcc 10 and --std=gnu++20: deprecated
+ std::allocator member access.
+
+---
+ include/boost/signals2/detail/auto_buffer.hpp | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/include/boost/signals2/detail/auto_buffer.hpp b/include/boost/signals2/detail/auto_buffer.hpp
+index 9ee9a5cf..d90563ca 100644
+--- a/include/boost/signals2/detail/auto_buffer.hpp
++++ b/include/boost/signals2/detail/auto_buffer.hpp
+@@ -142,7 +142,11 @@ namespace detail
+         typedef typename Allocator::size_type            size_type;
+         typedef typename Allocator::difference_type      difference_type;
+         typedef T*                                       pointer;
++#ifdef BOOST_NO_CXX11_ALLOCATOR
+         typedef typename Allocator::pointer              allocator_pointer;
++#else
++        typedef typename std::allocator_traits<Allocator>::pointer allocator_pointer;
++#endif
+         typedef const T*                                 const_pointer;
+         typedef T&                                       reference;
+         typedef const T&                                 const_reference;

--- a/BUILDING_ON_FREEBSD.md
+++ b/BUILDING_ON_FREEBSD.md
@@ -1,6 +1,6 @@
 # FreeBSD
 
-Note on Qt version compatibility: If you are installing Qt from a package manager, please ensure the version you are installing is at least **Qt 5.12 or newer**.
+Note on Qt version compatibility: If you are installing Qt from a package manager, please ensure the version you are installing is at least **Qt 5.15.2 or newer**.
 
 ## FreeBSD 12.1-RELEASE
 

--- a/BUILDING_ON_LINUX.md
+++ b/BUILDING_ON_LINUX.md
@@ -1,10 +1,10 @@
 # Linux
 
-Note on Qt version compatibility: If you are installing Qt from a package manager, please ensure the version you are installing is at least **Qt 5.12 or newer**.
+Note on Qt version compatibility: If you are installing Qt from a package manager, please ensure the version you are installing is at least **Qt 5.15.2 or newer**.
 
 ## Install dependencies
 
-### Ubuntu 20.04
+### Ubuntu 22.04
 
 _Most likely works the same for other Debian-like distros._
 

--- a/BUILDING_ON_WINDOWS.md
+++ b/BUILDING_ON_WINDOWS.md
@@ -24,7 +24,7 @@ Notes:
 
 Notes:
 
-- Installing the latest **stable** Qt version is advised for new installations, but if you want to use your existing installation please ensure you are running **Qt 5.12 or later**.
+- Installing the latest **stable** Qt version is advised for new installations, but if you want to use your existing installation please ensure you are running **Qt 5.15.2 or later**.
 
 #### Components
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,7 @@
 - Dev: Fix `NotebookTab` emitting updates for every message. (#5068)
 - Dev: Added benchmark for parsing and building recent messages. (#5071)
 - Dev: Boost is depended on as a header-only library when using conan. (#5107)
+- Dev: Qt 5.15.2 is now a minimum requirement. (#5113)
 
 ## 2.4.6
 


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

As explained in https://github.com/Chatterino/chatterino2/discussions/4292, requiring Qt 5.15.2 and a better C++ 20 support is a big step.

**What changed?**

- Qt 5.15.2 is now a minimum requirement to build Chatterino
- GCC 10 is now a minimum requirement to build Chatterino (see #5079; I could split this up)
- The `.deb` file for Ubuntu 20.04 is no longer available (use the AppImage or Flatpak)

**What didn't change?**

- AppImage builds remain (and use Qt 5.15 now, since it's bundled)
- Qt 5 is still supported (seems like we're stuck with this for some time 🙃)

Setting `QT_DISABLE_DEPRECATED_BEFORE` to 6.0.0 isn't possible due to Qt 5.15.2 not having the non-deprecated position accessors for [`QMouseEvent`](https://doc.qt.io/qt-6/qmouseevent.html) (moving the filters away from non-deprecated methods is possible).