### PR TITLE
feat: add system theme on Qt 6.5 and up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Minor: Normalized the input padding between light & dark themes. (#5095)
 - Minor: Add `--activate <channel>` (or `-a`) command line option to activate or add a Twitch channel. (#5111)
 - Minor: Chatters from recent-messages are now added to autocompletion. (#5116)
+- Minor: Add _System_ theme that updates according to the system's color scheme (requires Qt 6.5). (#5118)
 - Bugfix: Fixed an issue where certain emojis did not send to Twitch chat correctly. (#4840)
 - Bugfix: Fixed capitalized channel names in log inclusion list not being logged. (#4848)
 - Bugfix: Trimmed custom streamlink paths on all platforms making sure you don't accidentally add spaces at the beginning or end of its path. (#4834)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 - Minor: Normalized the input padding between light & dark themes. (#5095)
 - Minor: Add `--activate <channel>` (or `-a`) command line option to activate or add a Twitch channel. (#5111)
 - Minor: Chatters from recent-messages are now added to autocompletion. (#5116)
-- Minor: Add _System_ theme that updates according to the system's color scheme (requires Qt 6.5). (#5118)
+- Minor: Added a _System_ theme that updates according to the system's color scheme (requires Qt 6.5). (#5118)
 - Bugfix: Fixed an issue where certain emojis did not send to Twitch chat correctly. (#4840)
 - Bugfix: Fixed capitalized channel names in log inclusion list not being logged. (#4848)
 - Bugfix: Trimmed custom streamlink paths on all platforms making sure you don't accidentally add spaces at the beginning or end of its path. (#4834)

--- a/src/singletons/Theme.cpp
+++ b/src/singletons/Theme.cpp
@@ -212,15 +212,7 @@ const std::vector<ThemeDescriptor> Theme::builtInThemes{
         .key = "Black",
         .path = ":/themes/Black.json",
         .name = "Black",
-    }
-#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
-    ,
-    {
-        .key = "System",
-        .path = ":/themes/Dark.json",
-        .name = "System",
     },
-#endif
 };
 
 // Dark is our default & fallback theme
@@ -244,6 +236,14 @@ void Theme::initialize(Settings &settings, const Paths &paths)
             this->update();
         },
         false);
+    auto updateIfSystem = [this](const auto &) {
+        if (this->isSystemTheme())
+        {
+            this->update();
+        }
+    };
+    this->darkSystemThemeName.connect(updateIfSystem, false);
+    this->lightSystemThemeName.connect(updateIfSystem, false);
 
     this->loadAvailableThemes(paths);
 
@@ -270,10 +270,10 @@ void Theme::update()
             switch (qApp->styleHints()->colorScheme())
             {
                 case Qt::ColorScheme::Light:
-                    return u"Light"_s;
+                    return this->lightSystemThemeName;
                 case Qt::ColorScheme::Unknown:
                 case Qt::ColorScheme::Dark:
-                    return u"Dark"_s;
+                    return this->darkSystemThemeName;
             }
         }
 #endif

--- a/src/singletons/Theme.cpp
+++ b/src/singletons/Theme.cpp
@@ -225,7 +225,7 @@ bool Theme::isLightTheme() const
 
 bool Theme::isSystemTheme() const
 {
-    return this->themeName == u"System";
+    return this->themeName == u"System"_s;
 }
 
 void Theme::initialize(Settings &settings, const Paths &paths)

--- a/src/singletons/Theme.hpp
+++ b/src/singletons/Theme.hpp
@@ -46,6 +46,7 @@ public:
     void initialize(Settings &settings, const Paths &paths) final;
 
     bool isLightTheme() const;
+    bool isSystemTheme() const;
 
     struct TabColors {
         QColor text;
@@ -163,6 +164,8 @@ private:
     std::unique_ptr<QTimer> themeReloadTimer_;
     // This will only be populated when auto-reloading themes
     QJsonObject currentThemeJson_;
+
+    QObject lifetime_;
 
     /**
      * Figure out which themes are available in the Themes directory

--- a/src/singletons/Theme.hpp
+++ b/src/singletons/Theme.hpp
@@ -154,6 +154,9 @@ public:
     pajlada::Signals::NoArgSignal updated;
 
     QStringSetting themeName{"/appearance/theme/name", "Dark"};
+    QStringSetting lightSystemThemeName{"/appearance/theme/lightSystem",
+                                        "Light"};
+    QStringSetting darkSystemThemeName{"/appearance/theme/darkSystem", "Dark"};
 
 private:
     bool isLight_ = false;

--- a/src/widgets/settingspages/GeneralPageView.hpp
+++ b/src/widgets/settingspages/GeneralPageView.hpp
@@ -306,6 +306,15 @@ public:
         return combo;
     }
 
+    void enableIf(QComboBox *widget, auto &setting, auto cb)
+    {
+        auto updateVisibility = [cb = std::move(cb), &setting, widget]() {
+            auto enabled = cb(setting.getValue());
+            widget->setEnabled(enabled);
+        };
+        setting.connect(updateVisibility, this->managedConnections_);
+    }
+
     DescriptionLabel *addDescription(const QString &text);
 
     void addSeperator();


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

As explained in https://github.com/Chatterino/chatterino2/issues/2452#issuecomment-1452464154, Qt 6.5 added a signal for the system color scheme. The system theme I added is a dummy theme that resolves to the correct theme once `update` is called.

https://github.com/Chatterino/chatterino2/assets/19953266/4a13c346-3682-4077-91a7-a1fd40597fc5

Closes #2452.