### PR TITLE
perf: add signal to invalidate buffers without doing layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@
 - Dev: Fix `NotebookTab` emitting updates for every message. (#5068)
 - Dev: Added benchmark for parsing and building recent messages. (#5071)
 - Dev: Boost is depended on as a header-only library when using conan. (#5107)
+- Dev: Added signal to invalidate paint buffers of channel views without forcing a relayout. (#5123)
 
 ## 2.4.6
 

--- a/src/messages/layouts/MessageLayout.cpp
+++ b/src/messages/layouts/MessageLayout.cpp
@@ -74,7 +74,8 @@ int MessageLayout::getWidth() const
 
 // Layout
 // return true if redraw is required
-bool MessageLayout::layout(int width, float scale, MessageElementFlags flags)
+bool MessageLayout::layout(int width, float scale, MessageElementFlags flags,
+                           bool deleteBuffer)
 {
     //    BenchmarkGuard benchmark("MessageLayout::layout()");
 
@@ -108,6 +109,11 @@ bool MessageLayout::layout(int width, float scale, MessageElementFlags flags)
 
     if (!layoutRequired)
     {
+        if (deleteBuffer)
+        {
+            this->deleteBuffer();
+            return true;
+        }
         return false;
     }
 

--- a/src/messages/layouts/MessageLayout.cpp
+++ b/src/messages/layouts/MessageLayout.cpp
@@ -75,7 +75,7 @@ int MessageLayout::getWidth() const
 // Layout
 // return true if redraw is required
 bool MessageLayout::layout(int width, float scale, MessageElementFlags flags,
-                           bool deleteBuffer)
+                           bool shouldInvalidateBuffer)
 {
     //    BenchmarkGuard benchmark("MessageLayout::layout()");
 
@@ -109,9 +109,9 @@ bool MessageLayout::layout(int width, float scale, MessageElementFlags flags,
 
     if (!layoutRequired)
     {
-        if (deleteBuffer)
+        if (shouldInvalidateBuffer)
         {
-            this->deleteBuffer();
+            this->invalidateBuffer();
             return true;
         }
         return false;

--- a/src/messages/layouts/MessageLayout.hpp
+++ b/src/messages/layouts/MessageLayout.hpp
@@ -56,7 +56,8 @@ public:
 
     MessageLayoutFlags flags;
 
-    bool layout(int width, float scale_, MessageElementFlags flags);
+    bool layout(int width, float scale_, MessageElementFlags flags,
+                bool deleteBuffer);
 
     // Painting
     MessagePaintResult paint(const MessagePaintContext &ctx);

--- a/src/messages/layouts/MessageLayout.hpp
+++ b/src/messages/layouts/MessageLayout.hpp
@@ -57,7 +57,7 @@ public:
     MessageLayoutFlags flags;
 
     bool layout(int width, float scale_, MessageElementFlags flags,
-                bool deleteBuffer);
+                bool shouldInvalidateBuffer);
 
     // Painting
     MessagePaintResult paint(const MessagePaintContext &ctx);

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -211,9 +211,9 @@ void WindowManager::forceLayoutChannelViews()
     this->layoutChannelViews(nullptr);
 }
 
-void WindowManager::deleteChannelViewBuffers(Channel *channel)
+void WindowManager::invalidateChannelViewBuffers(Channel *channel)
 {
-    this->deleteBuffersRequested.invoke(channel);
+    this->invalidateBuffersRequested.invoke(channel);
 }
 
 void WindowManager::repaintVisibleChatWidgets(Channel *channel)
@@ -412,10 +412,10 @@ void WindowManager::initialize(Settings &settings, const Paths &paths)
         this->forceLayoutChannelViews();
     });
     settings.alternateMessages.connect([this](auto, auto) {
-        this->deleteChannelViewBuffers();
+        this->invalidateChannelViewBuffers();
     });
     settings.separateMessages.connect([this](auto, auto) {
-        this->deleteChannelViewBuffers();
+        this->invalidateChannelViewBuffers();
     });
     settings.collpseMessagesMinLines.connect([this](auto, auto) {
         this->forceLayoutChannelViews();

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -211,6 +211,11 @@ void WindowManager::forceLayoutChannelViews()
     this->layoutChannelViews(nullptr);
 }
 
+void WindowManager::deleteChannelViewBuffers(Channel *channel)
+{
+    this->deleteBuffersRequested.invoke(channel);
+}
+
 void WindowManager::repaintVisibleChatWidgets(Channel *channel)
 {
     this->layoutRequested.invoke(channel);
@@ -407,10 +412,10 @@ void WindowManager::initialize(Settings &settings, const Paths &paths)
         this->forceLayoutChannelViews();
     });
     settings.alternateMessages.connect([this](auto, auto) {
-        this->forceLayoutChannelViews();
+        this->deleteChannelViewBuffers();
     });
     settings.separateMessages.connect([this](auto, auto) {
-        this->forceLayoutChannelViews();
+        this->deleteChannelViewBuffers();
     });
     settings.collpseMessagesMinLines.connect([this](auto, auto) {
         this->forceLayoutChannelViews();

--- a/src/singletons/WindowManager.hpp
+++ b/src/singletons/WindowManager.hpp
@@ -66,6 +66,10 @@ public:
     // This is called, for example, when the emote scale or timestamp format has
     // changed
     void forceLayoutChannelViews();
+
+    // Tell a channel (or all channels if channel is nullptr) to delete all paint buffers
+    void deleteChannelViewBuffers(Channel *channel = nullptr);
+
     void repaintVisibleChatWidgets(Channel *channel = nullptr);
     void repaintGifEmotes();
 
@@ -124,6 +128,9 @@ public:
     // This signal fires whenever views rendering a channel, or all views if the
     // channel is a nullptr, need to redo their layout
     pajlada::Signals::Signal<Channel *> layoutRequested;
+    // This signal fires whenever views rendering a channel, or all views if the
+    // channel is a nullptr, need to delete their paint buffers
+    pajlada::Signals::Signal<Channel *> deleteBuffersRequested;
 
     pajlada::Signals::NoArgSignal wordFlagsChanged;
 

--- a/src/singletons/WindowManager.hpp
+++ b/src/singletons/WindowManager.hpp
@@ -67,8 +67,8 @@ public:
     // changed
     void forceLayoutChannelViews();
 
-    // Tell a channel (or all channels if channel is nullptr) to delete all paint buffers
-    void deleteChannelViewBuffers(Channel *channel = nullptr);
+    // Tell a channel (or all channels if channel is nullptr) to invalidate all paint buffers
+    void invalidateChannelViewBuffers(Channel *channel = nullptr);
 
     void repaintVisibleChatWidgets(Channel *channel = nullptr);
     void repaintGifEmotes();
@@ -129,8 +129,8 @@ public:
     // channel is a nullptr, need to redo their layout
     pajlada::Signals::Signal<Channel *> layoutRequested;
     // This signal fires whenever views rendering a channel, or all views if the
-    // channel is a nullptr, need to delete their paint buffers
-    pajlada::Signals::Signal<Channel *> deleteBuffersRequested;
+    // channel is a nullptr, need to invalidate their paint buffers
+    pajlada::Signals::Signal<Channel *> invalidateBuffersRequested;
 
     pajlada::Signals::NoArgSignal wordFlagsChanged;
 

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -426,7 +426,8 @@ void ChannelView::initializeSignals()
         });
 
     this->signalHolder_.managedConnect(
-        getIApp()->getWindows()->deleteBuffersRequested, [&](Channel *channel) {
+        getIApp()->getWindows()->invalidateBuffersRequested,
+        [this](Channel *channel) {
             if (this->isVisible() &&
                 (channel == nullptr || this->channel_.get() == channel))
             {

--- a/src/widgets/helper/ChannelView.hpp
+++ b/src/widgets/helper/ChannelView.hpp
@@ -148,7 +148,9 @@ public:
     bool hasSourceChannel() const;
 
     LimitedQueueSnapshot<MessageLayoutPtr> &getMessagesSnapshot();
+
     void queueLayout();
+    void invalidateBuffers();
 
     void clearMessages();
 
@@ -270,6 +272,7 @@ private:
     bool canReplyToMessages() const;
 
     bool layoutQueued_ = false;
+    bool bufferInvalidationQueued_ = false;
 
     bool lastMessageHasAlternateBackground_ = false;
     bool lastMessageHasAlternateBackgroundReverse_ = true;


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

I wanted to fix a [bug in the 7TV fork](https://github.com/SevenTV/chatterino7/issues/259#issuecomment-1906731105) related to paints and noticed that I needed a way to just invalidate the paint buffers but not do layout (if it's not needed).

This PR adds a signal similar to `layoutRequested` that tells channel-views to discard the paint buffers. This is done by setting a flag when doing (re-)layout.

I noticed two settings that benefit from this: _Alternate background color_ and _Separate with lines_. You can test this PR by toggling the settings.