### PR TITLE
Add support for `input.text` in commands run with hotkeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Minor: Normalized the input padding between light & dark themes. (#5095)
 - Minor: Add `--activate <channel>` (or `-a`) command line option to activate or add a Twitch channel. (#5111)
 - Minor: Chatters from recent-messages are now added to autocompletion. (#5116)
+- Minor: Add support for input.text in commands run with hotkeys. (#5130)
 - Bugfix: Fixed an issue where certain emojis did not send to Twitch chat correctly. (#4840)
 - Bugfix: Fixed capitalized channel names in log inclusion list not being logged. (#4848)
 - Bugfix: Trimmed custom streamlink paths on all platforms making sure you don't accidentally add spaces at the beginning or end of its path. (#4834)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 - Minor: Normalized the input padding between light & dark themes. (#5095)
 - Minor: Add `--activate <channel>` (or `-a`) command line option to activate or add a Twitch channel. (#5111)
 - Minor: Chatters from recent-messages are now added to autocompletion. (#5116)
-- Minor: Add support for input.text in commands run with hotkeys. (#5130)
+- Minor: Added support for the `{input.text}` placeholder in the **Split** -> **Run a command** hotkey. (#5130)
 - Bugfix: Fixed an issue where certain emojis did not send to Twitch chat correctly. (#4840)
 - Bugfix: Fixed capitalized channel names in log inclusion list not being logged. (#4848)
 - Bugfix: Trimmed custom streamlink paths on all platforms making sure you don't accidentally add spaces at the beginning or end of its path. (#4834)

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -6,6 +6,7 @@
 #include "common/network/NetworkResult.hpp"
 #include "common/QLogging.hpp"
 #include "controllers/accounts/AccountController.hpp"
+#include "controllers/commands/Command.hpp"
 #include "controllers/commands/CommandController.hpp"
 #include "controllers/hotkeys/HotkeyController.hpp"
 #include "controllers/notifications/NotificationController.hpp"
@@ -684,15 +685,25 @@ void Split::addShortcuts()
          }},
         {"runCommand",
          [this](std::vector<QString> arguments) -> QString {
-             if (arguments.size() == 0)
+             if (arguments.empty())
              {
                  qCWarning(chatterinoHotkeys)
                      << "runCommand hotkey called without arguments!";
                  return "runCommand hotkey called without arguments!";
              }
-             QString command = getIApp()->getCommands()->execCommand(
-                 arguments.at(0).replace('\n', ' '), this->getChannel(), false);
-             this->getChannel()->sendMessage(command);
+             QString requestedText = arguments.at(0).replace('\n', ' ');
+
+             QString inputText = this->getInput().getInputText();
+             QString message = getIApp()->getCommands()->execCustomCommand(
+                 requestedText.split(' '), Command{"(hotkey)", requestedText},
+                 true, this->getChannel(), nullptr,
+                 {
+                     {"input.text", inputText},
+                 });
+
+             message = getIApp()->getCommands()->execCommand(
+                 message, this->getChannel(), false);
+             this->getChannel()->sendMessage(message);
              return "";
          }},
         {"setChannelNotification",


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
After this PR commands executed with `Split -> runCommand` ("Split->Run a command") will have the `input.text` placeholder available.
Note that this doesn't transfer to another command being run from this special command execution.

Working hotkey:
```
Category: Split; Action: runCommand
Arguments:
test: {input.text}
```

One that doesn't work by design:
```
Category: Split; Action: runCommand
Arguments:
/useinputtextplaceholder
```