### PR TITLE
chore: specialize `Atomic<std::shared_ptr<T>>`

### DIFF
--- a/src/common/Atomic.hpp
+++ b/src/common/Atomic.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <atomic>
+#include <memory>
 #include <mutex>
 
 namespace chatterino {
@@ -9,9 +11,10 @@ class Atomic
 {
 public:
     Atomic() = default;
+    ~Atomic() = default;
 
     Atomic(T &&val)
-        : value_(val)
+        : value_(std::move(val))
     {
     }
 
@@ -46,5 +49,68 @@ private:
     mutable std::mutex mutex_;
     T value_;
 };
+
+#if defined(__cpp_lib_atomic_shared_ptr) && defined(__cpp_concepts)
+
+template <typename T>
+class Atomic<std::shared_ptr<T>>
+{
+    // Atomic<std::shared_ptr<T>> must be instantated with a const T
+};
+
+template <typename T>
+    requires std::is_const_v<T>
+class Atomic<std::shared_ptr<T>>
+{
+public:
+    Atomic() = default;
+    ~Atomic() = default;
+
+    Atomic(T &&val)
+        : value_(std::make_shared<T>(std::move(val)))
+    {
+    }
+
+    Atomic(std::shared_ptr<T> &&val)
+        : value_(std::move(val))
+    {
+    }
+
+    Atomic(const Atomic &) = delete;
+    Atomic &operator=(const Atomic &) = delete;
+
+    Atomic(Atomic &&) = delete;
+    Atomic &operator=(Atomic &&) = delete;
+
+    std::shared_ptr<T> get() const
+    {
+        return this->value_.load();
+    }
+
+    void set(const T &val)
+    {
+        this->value_.store(std::make_shared<T>(val));
+    }
+
+    void set(T &&val)
+    {
+        this->value_.store(std::make_shared<T>(std::move(val)));
+    }
+
+    void set(const std::shared_ptr<T> &val)
+    {
+        this->value_.store(val);
+    }
+
+    void set(std::shared_ptr<T> &&val)
+    {
+        this->value_.store(std::move(val));
+    }
+
+private:
+    std::atomic<std::shared_ptr<T>> value_;
+};
+
+#endif
 
 }  // namespace chatterino


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

Since https://github.com/Chatterino/chatterino2/issues/5128 refactors message parsing, it would be nice to do that off the main thread. To do this safely, we can utilize the `Atomic` class to provide shared state for workers (similar to the `MessageLayoutContext`).

C++ 20 added `std::atomic<std::shared_ptr<T>>`. Not every standard library implementation has added this yet, so it's behind an `#ifdef`. To ensure sane use, `Atomic<std::shared_ptr<T>>` requires `T` to be `const` (otherwise the atomic is kinda useless). Since only the MSVC STL and GCC libstdc++ implement this and ship in compiler versions that have concepts, it's fine to require these too.

Neither implementation is lock-free, but both are better than using a `std::mutex` (e.g. the implementation in the STL spins on a single bit compared to a mutex which uses a shared read-write lock).