### PR TITLE
Add developer_name appdata field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@
 - Minor: Chatters from recent-messages are now added to autocompletion. (#5116)
 - Minor: Added a _System_ theme that updates according to the system's color scheme (requires Qt 6.5). (#5118)
 - Minor: Added support for the `{input.text}` placeholder in the **Split** -> **Run a command** hotkey. (#5130)
-- Minor: Added the `developer_name` field to the Linux AppData specification. (#5138)
 - Bugfix: Fixed an issue where certain emojis did not send to Twitch chat correctly. (#4840)
 - Bugfix: Fixed capitalized channel names in log inclusion list not being logged. (#4848)
 - Bugfix: Trimmed custom streamlink paths on all platforms making sure you don't accidentally add spaces at the beginning or end of its path. (#4834)
@@ -137,6 +136,7 @@
 - Dev: Boost is depended on as a header-only library when using conan. (#5107)
 - Dev: Added signal to invalidate paint buffers of channel views without forcing a relayout. (#5123)
 - Dev: Specialize `Atomic<std::shared_ptr<T>>` if underlying standard library supports it. (#5133)
+- Dev: Added the `developer_name` field to the Linux AppData specification. (#5138)
 
 ## 2.4.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Minor: Chatters from recent-messages are now added to autocompletion. (#5116)
 - Minor: Added a _System_ theme that updates according to the system's color scheme (requires Qt 6.5). (#5118)
 - Minor: Added support for the `{input.text}` placeholder in the **Split** -> **Run a command** hotkey. (#5130)
+- Minor: Added the `developer_name` field to the Linux AppData specification. (#5138)
 - Bugfix: Fixed an issue where certain emojis did not send to Twitch chat correctly. (#4840)
 - Bugfix: Fixed capitalized channel names in log inclusion list not being logged. (#4848)
 - Bugfix: Trimmed custom streamlink paths on all platforms making sure you don't accidentally add spaces at the beginning or end of its path. (#4834)

--- a/resources/com.chatterino.chatterino.appdata.xml
+++ b/resources/com.chatterino.chatterino.appdata.xml
@@ -8,6 +8,7 @@
         <content_attribute id="social-chat">intense</content_attribute>
     </content_rating>
     <name>Chatterino</name>
+    <developer_name>Chatterino Developers</developer_name>
     <summary>
         Chat client for twitch.tv
     </summary>


### PR DESCRIPTION
According to recent Flathub changes, the `developer_name` of the appdata file now has to be filled. 
