### PR TITLE
fix: use neutral or username color for reply messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@
 - Bugfix: Fixed popup windows not persisting between restarts. (#5081)
 - Bugfix: Fixed splits not retaining their focus after minimizing. (#5080)
 - Bugfix: Fixed _Copy message_ copying the channel name in global search. (#5106)
+- Bugfix: Reply contexts now use the color of the replied-to message. (#5145)
 - Dev: Run miniaudio in a separate thread, and simplify it to not manage the device ourselves. There's a chance the simplification is a bad idea. (#4978)
 - Dev: Change clang-format from v14 to v16. (#4929)
 - Dev: Fixed UTF16 encoding of `modes` file for the installer. (#4791)

--- a/src/messages/Message.hpp
+++ b/src/messages/Message.hpp
@@ -57,6 +57,8 @@ enum class MessageFlag : int64_t {
     RestrictedMessage = (1LL << 33),
     /// The message is sent by a user marked as monitor with Twitch's "Low Trust"/"Suspicious User" feature
     MonitoredMessage = (1LL << 34),
+    /// The message is an ACTION message (/me)
+    Action = (1LL << 35),
 };
 using MessageFlags = FlagsEnum<MessageFlag>;
 

--- a/src/messages/SharedMessageBuilder.cpp
+++ b/src/messages/SharedMessageBuilder.cpp
@@ -77,6 +77,7 @@ void SharedMessageBuilder::parse()
     if (this->action_)
     {
         this->textColor_ = this->usernameColor_;
+        this->message().flags.set(MessageFlag::Action);
     }
 
     this->parseUsername();

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -896,11 +896,16 @@ void TwitchMessageBuilder::parseThread()
                 threadRoot->usernameColor, FontStyle::ChatMediumSmall)
             ->setLink({Link::UserInfo, threadRoot->displayName});
 
+        MessageColor color = MessageColor::Text;
+        if (threadRoot->flags.has(MessageFlag::Action))
+        {
+            color = threadRoot->usernameColor;
+        }
         this->emplace<SingleLineTextElement>(
                 threadRoot->messageText,
                 MessageElementFlags({MessageElementFlag::RepliedMessage,
                                      MessageElementFlag::Text}),
-                this->textColor_, FontStyle::ChatMediumSmall)
+                color, FontStyle::ChatMediumSmall)
             ->setLink({Link::ViewThread, this->thread_->rootId()});
     }
     else if (this->tags.find("reply-parent-msg-id") != this->tags.end())


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

![chatterino_2024-02-02_15-06-56](https://github.com/Chatterino/chatterino2/assets/19953266/8d5b30fc-18fd-4ef7-86bb-aa758e02eaf5)

Polluting `MessageFlag` seems better than adding a `QColor textColor` to `Message`.

Fixes #5143.

<sub>Changes in #4962 will be required.</sub>