### PR TITLE
feat: Allow /openurl to force use private/non-private mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Minor: Chatters from recent-messages are now added to autocompletion. (#5116)
 - Minor: Added a _System_ theme that updates according to the system's color scheme (requires Qt 6.5). (#5118)
 - Minor: Added icons for newer versions of macOS. (#5148)
+- Minor: Added the `--incognito/--no-incognito` options to the `/openurl` command, allowing you to override the "Open links in incognito/private mode" setting. (#5149)
 - Minor: Added support for the `{input.text}` placeholder in the **Split** -> **Run a command** hotkey. (#5130)
 - Bugfix: Fixed an issue where certain emojis did not send to Twitch chat correctly. (#4840)
 - Bugfix: Fixed capitalized channel names in log inclusion list not being logged. (#4848)

--- a/src/controllers/commands/builtin/Misc.cpp
+++ b/src/controllers/commands/builtin/Misc.cpp
@@ -24,6 +24,7 @@
 #include "widgets/splits/SplitContainer.hpp"
 #include "widgets/Window.hpp"
 
+#include <QCommandLineParser>
 #include <QDesktopServices>
 #include <QString>
 #include <QUrl>
@@ -414,26 +415,95 @@ QString clearmessages(const CommandContext &ctx)
 
 QString openURL(const CommandContext &ctx)
 {
+    /**
+     * The /openurl command
+     * Takes a positional argument as the URL to open
+     *
+     * Accepts the option --private or --no-private (or --incognito or --no-incognito).
+     * These options will force the URL to be opened in private or non-private mode, regardless of the
+     * default incognito mode setting.
+     *
+     * Examples:
+     *  - /openurl https://twitch.tv/forsen
+     *    with the setting "Open links in incognito/private mode" enabled
+     *    Opens https://twitch.tv/forsen in private mode
+     *  - /openurl https://twitch.tv/forsen
+     *    with the setting "Open links in incognito/private mode" disabled
+     *    Opens https://twitch.tv/forsen in normal mode
+     *  - /openurl https://twitch.tv/forsen --private
+     *    with the setting "Open links in incognito/private mode" disabled
+     *    Opens https://twitch.tv/forsen in private mode
+     *  - /openurl https://twitch.tv/forsen --no-private
+     *    with the setting "Open links in incognito/private mode" enabled
+     *    Opens https://twitch.tv/forsen in normal mode
+     */
     if (ctx.channel == nullptr)
     {
         return "";
     }
 
-    if (ctx.words.size() < 2)
+    QCommandLineParser parser;
+    parser.addPositionalArgument("URL", "The URL to open");
+    QCommandLineOption privateModeOption(
+        {
+            "private",
+            "incognito",
+        },
+        "Force private mode. Cannot be used together with --no-private");
+    QCommandLineOption noPrivateModeOption(
+        {
+            "no-private",
+            "no-incognito",
+        },
+        "Force non-private mode. Cannot be used together with --private");
+    parser.addOptions({
+        privateModeOption,
+        noPrivateModeOption,
+    });
+    parser.parse(ctx.words);
+
+    const auto &positionalArguments = parser.positionalArguments();
+    if (positionalArguments.isEmpty())
     {
-        ctx.channel->addMessage(makeSystemMessage("Usage: /openurl <URL>"));
+        ctx.channel->addMessage(makeSystemMessage(
+            "Usage: /openurl <URL> [--incognito/--no-incognito]"));
         return "";
     }
+    auto urlString = parser.positionalArguments().at(0);
 
-    QUrl url = QUrl::fromUserInput(ctx.words.mid(1).join(" "));
+    QUrl url = QUrl::fromUserInput(urlString);
     if (!url.isValid())
     {
         ctx.channel->addMessage(makeSystemMessage("Invalid URL specified."));
         return "";
     }
 
+    auto preferPrivateMode = getSettings()->openLinksIncognito.getValue();
+    auto forcePrivateMode = parser.isSet(privateModeOption);
+    auto forceNonPrivateMode = parser.isSet(noPrivateModeOption);
+
+    if (forcePrivateMode && forceNonPrivateMode)
+    {
+        ctx.channel->addMessage(makeSystemMessage(
+            "Error: /openurl may only be called with --incognito or "
+            "--no-incognito, not both at the same time."));
+        return "";
+    }
+
+    bool usePrivateMode = false;
+
+    if (forceNonPrivateMode)
+    {
+        usePrivateMode = false;
+    }
+    else if (supportsIncognitoLinks() &&
+             (forcePrivateMode || preferPrivateMode))
+    {
+        usePrivateMode = true;
+    }
+
     bool res = false;
-    if (supportsIncognitoLinks() && getSettings()->openLinksIncognito)
+    if (usePrivateMode)
     {
         res = openLinkIncognito(url.toString(QUrl::FullyEncoded));
     }


### PR DESCRIPTION
Examples:
 - /openurl https://twitch.tv/forsen
   with the setting "Open links in incognito/private mode" enabled
   Opens https://twitch.tv/forsen in private mode
 - /openurl https://twitch.tv/forsen
   with the setting "Open links in incognito/private mode" disabled
   Opens https://twitch.tv/forsen in normal mode
 - /openurl https://twitch.tv/forsen --private
   with the setting "Open links in incognito/private mode" disabled
   Opens https://twitch.tv/forsen in private mode
 - /openurl https://twitch.tv/forsen --no-private
   with the setting "Open links in incognito/private mode" enabled
   Opens https://twitch.tv/forsen in normal mode

<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
