### PR TITLE
feat: Add "Copy message as JSON" option when shift-right-clicking a message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@
 - Dev: `Details` file properties tab is now populated on Windows. (#4912)
 - Dev: Removed `Outcome` from network requests. (#4959)
 - Dev: Added Tests for Windows and MacOS in CI. (#4970, #5032)
+- Dev: Added "Copy message as JSON" option when shift-right-clicking a message. (#5150)
 - Dev: Move `clang-tidy` checker to its own CI job. (#4996)
 - Dev: Refactored the Image Uploader feature. (#4971)
 - Dev: Refactored the SplitOverlay code. (#5082)

--- a/src/messages/Message.hpp
+++ b/src/messages/Message.hpp
@@ -3,6 +3,7 @@
 #include "common/FlagsEnum.hpp"
 #include "util/QStringHash.hpp"
 
+#include <magic_enum/magic_enum.hpp>
 #include <QColor>
 #include <QTime>
 
@@ -107,3 +108,8 @@ struct Message {
 };
 
 }  // namespace chatterino
+
+template <>
+struct magic_enum::customize::enum_range<chatterino::MessageFlag> {
+    static constexpr bool is_flags = true;
+};

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -241,7 +241,6 @@ void addHiddenContextMenuItems(QMenu *menu,
 
     if (!layout->getMessage()->id.isEmpty())
     {
-        qDebug() << "XXX: ADD COPY MESSAGE HANDLER";
         menu->addAction("Copy message &ID",
                         [messageID = layout->getMessage()->id] {
                             crossPlatformCopy(messageID);

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -45,6 +45,7 @@
 #include "widgets/TooltipWidget.hpp"
 #include "widgets/Window.hpp"
 
+#include <magic_enum/magic_enum_flags.hpp>
 #include <QClipboard>
 #include <QColor>
 #include <QDate>
@@ -52,6 +53,7 @@
 #include <QDesktopServices>
 #include <QEasingCurve>
 #include <QGraphicsBlurEffect>
+#include <QJsonDocument>
 #include <QMessageBox>
 #include <QPainter>
 #include <QScreen>
@@ -239,10 +241,35 @@ void addHiddenContextMenuItems(QMenu *menu,
 
     if (!layout->getMessage()->id.isEmpty())
     {
+        qDebug() << "XXX: ADD COPY MESSAGE HANDLER";
         menu->addAction("Copy message &ID",
                         [messageID = layout->getMessage()->id] {
                             crossPlatformCopy(messageID);
                         });
+    }
+
+    const auto *message = layout->getMessage();
+
+    if (message != nullptr)
+    {
+        QJsonDocument jsonDocument;
+
+        QJsonObject jsonObject;
+
+        jsonObject["id"] = message->id;
+        jsonObject["searchText"] = message->searchText;
+        jsonObject["messageText"] = message->messageText;
+        jsonObject["flags"] = QString::fromStdString(
+            magic_enum::enum_flags_name(message->flags.value()));
+
+        jsonDocument.setObject(jsonObject);
+
+        auto jsonString =
+            jsonDocument.toJson(QJsonDocument::JsonFormat::Indented);
+
+        menu->addAction("Copy message &JSON", [jsonString] {
+            crossPlatformCopy(jsonString);
+        });
     }
 }
 


### PR DESCRIPTION
Example output:
```json
{
    "flags": "Highlighted|Collapsed|Subscription",
    "id": "e099de58-daa1-41c5-bb9b-7ecafe8cb204",
    "messageText": "forsen",
    "searchText": "testaccount_420(테스트계정420) 테스트계정420 testaccount_420: forsen"
}
```

<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
