### PR TITLE
revert: uncomment NCCALCSIZE adjustment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@
 - Bugfix: Fixed splits not retaining their focus after minimizing. (#5080)
 - Bugfix: Fixed _Copy message_ copying the channel name in global search. (#5106)
 - Bugfix: Reply contexts now use the color of the replied-to message. (#5145)
-- Bugfix: Fixed top-level window getting stuck after opening settings. (#5161)
+- Bugfix: Fixed top-level window getting stuck after opening settings. (#5161, #5166)
 - Dev: Run miniaudio in a separate thread, and simplify it to not manage the device ourselves. There's a chance the simplification is a bad idea. (#4978)
 - Dev: Change clang-format from v14 to v16. (#4929)
 - Dev: Fixed UTF16 encoding of `modes` file for the installer. (#4791)

--- a/src/widgets/BaseWindow.cpp
+++ b/src/widgets/BaseWindow.cpp
@@ -913,8 +913,8 @@ bool BaseWindow::handleNCCALCSIZE(MSG *msg, long *result)
             auto *ncp = reinterpret_cast<NCCALCSIZE_PARAMS *>(msg->lParam);
             if (ncp)
             {
-                // ncp->lppos->flags |= SWP_NOREDRAW;
-                // ncp->rgrc[0].top -= 1;
+                ncp->lppos->flags |= SWP_NOREDRAW;
+                ncp->rgrc[0].top -= 1;
             }
         }
 


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

Just noticed, I made a mistake in #5161 where I accidentally commented out code in the NCCALCSIZE handler.

<sub>While the code isn't ideal (as it changes the window/client size), it should be changed in another PR.</sub>