### PR TITLE
fix: resolve /live channel liveness using their channel ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - Bugfix: Fixed double-click text selection moving its position with each new message. (#4898)
 - Bugfix: Fixed an issue where notifications on Windows would contain no or an old avatar. (#4899)
 - Bugfix: Fixed headers of tables in the settings switching to bold text when selected. (#4913)
+- Bugfix: Fixed an issue in the `/live` split that caused some channels to not get grayed-out when they went offline. (#5172)
 - Bugfix: Fixed tooltips appearing too large and/or away from the cursor. (#4920)
 - Bugfix: Fixed a crash when clicking `More messages below` button in a usercard and closing it quickly. (#4933)
 - Bugfix: Fixed thread popup window missing messages for nested threads. (#4923)

--- a/src/controllers/notifications/NotificationController.cpp
+++ b/src/controllers/notifications/NotificationController.cpp
@@ -228,7 +228,7 @@ void NotificationController::removeFakeChannel(const QString channelName)
             const auto &s = snapshot[i];
 
             if (QString::compare(s->messageText, liveMessageSearchText,
-                                 Qt::CaseInsensitive))
+                                 Qt::CaseInsensitive) == 0)
             {
                 s->flags.set(MessageFlag::Disabled);
                 break;

--- a/src/controllers/notifications/NotificationController.cpp
+++ b/src/controllers/notifications/NotificationController.cpp
@@ -227,7 +227,7 @@ void NotificationController::removeFakeChannel(const QString channelName)
         {
             const auto &s = snapshot[i];
 
-            if (s->messageText == liveMessageSearchText)
+            if (QString::compare(s->messageText, liveMessageSearchText, Qt::CaseInsensitive))
             {
                 s->flags.set(MessageFlag::Disabled);
                 break;

--- a/src/controllers/notifications/NotificationController.cpp
+++ b/src/controllers/notifications/NotificationController.cpp
@@ -227,7 +227,8 @@ void NotificationController::removeFakeChannel(const QString channelName)
         {
             const auto &s = snapshot[i];
 
-            if (QString::compare(s->messageText, liveMessageSearchText, Qt::CaseInsensitive))
+            if (QString::compare(s->messageText, liveMessageSearchText,
+                                 Qt::CaseInsensitive))
             {
                 s->flags.set(MessageFlag::Disabled);
                 break;

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -164,12 +164,14 @@ TwitchChannel::TwitchChannel(const QString &name)
             MessageBuilder builder;
             TwitchMessageBuilder::liveSystemMessage(this->getDisplayName(),
                                                     &builder);
+            builder.message().id = this->roomId();
             this->addMessage(builder.release());
 
             // Message in /live channel
             MessageBuilder builder2;
             TwitchMessageBuilder::liveMessage(this->getDisplayName(),
                                               &builder2);
+            builder2.message().id = this->roomId();
             getApp()->twitch->liveChannel->addMessage(builder2.release());
 
             // Notify on all channels with a ping sound
@@ -197,14 +199,12 @@ TwitchChannel::TwitchChannel(const QString &name)
 
             // MSVC hates this code if the parens are not there
             int end = (std::max)(0, snapshotLength - 200);
-            auto liveMessageSearchText =
-                QString("%1 is live!").arg(this->getDisplayName());
 
             for (int i = snapshotLength - 1; i >= end; --i)
             {
                 const auto &s = snapshot[i];
 
-                if (s->messageText == liveMessageSearchText)
+                if (s->id == this->roomId())
                 {
                     s->flags.set(MessageFlag::Disabled);
                     break;


### PR DESCRIPTION
This fix for #5158 uses the `TwitchChannel` `roomId()` as the message id when sending live messages (`TwitchMessageBuilder::liveMessage` and `TwitchMessageBuilder::liveSystemMessage`). I wasn't able to replicate the same logic for live messages sent through `NotificationController` (I couldn't find a way to access the `TwitchChannel` from there), so I went with the other option of using a case insensitive string compare. I accept any ideas on how I could do this better, especially the `NotificationController` bit.

(felanbird): Fixes #5158 