### PR TITLE
fix: minimize button remaining hovered on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@
 - Bugfix: Fixed rare crash with Image Uploader when closing a split right after starting an upload. (#4971)
 - Bugfix: Fixed an issue on macOS where the image uploader would keep prompting the user even after they clicked "Yes, don't ask again". (#5011)
 - Bugfix: Hide the Usercard button in the User Info Popup when in special channels. (#4972)
-- Bugfix: Fixed support for Windows 11 Snap layouts. (#4994)
+- Bugfix: Fixed support for Windows 11 Snap layouts. (#4994, #5175)
 - Bugfix: Fixed some windows appearing between screens. (#4797)
 - Bugfix: Fixed a crash that could occur when using certain features in a Usercard after closing the split from which it was created. (#5034, #5051)
 - Bugfix: Fixed a crash that could occur when using certain features in a Reply popup after closing the split from which it was created. (#5036, #5051)

--- a/src/widgets/BaseWindow.cpp
+++ b/src/widgets/BaseWindow.cpp
@@ -962,6 +962,13 @@ bool BaseWindow::handleSIZE(MSG *msg)
                           QPoint(rect.right - 1, rect.bottom - 1));
             }
             this->useNextBounds_.stop();
+
+            if (msg->wParam == SIZE_MINIMIZED && this->ui_.titlebarButtons)
+            {
+                // Windows doesn't send a WM_NCMOUSELEAVE event when clicking
+                // the minimize button, so we have to emulate it.
+                this->ui_.titlebarButtons->leave();
+            }
         }
     }
     return false;


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

When clicking the minimize button and restoring the window, the minimize button will remain in a hovered state until the mouse enters the window. This is because we don't receive a `WM_NCMOUSELEAVE` event after the button was clicked. We emulate the event by checking for `SIZE_MINIMIZED` in the `WM_SIZE` handler.