### PR TITLE
fix: searching redemptions that require user input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - Bugfix: Fixed too much text being copied when copying chat messages. (#4812, #4830, #4839)
 - Bugfix: Fixed an issue where the setting `Only search for emote autocompletion at the start of emote names` wouldn't disable if it was enabled when the client started. (#4855)
 - Bugfix: Fixed empty page being added when showing out of bounds dialog. (#4849)
+- Bugfix: Fixed an issue preventing searching a redemption by it's title when the redemption contained text input. (#5117)
 - Bugfix: Fixed issue on Windows preventing the title bar from being dragged in the top left corner. (#4873)
 - Bugfix: Fixed an issue where reply context didn't render correctly if an emoji was touching text. (#4875, #4977)
 - Bugfix: Fixed the input completion popup from disappearing when clicking on it on Windows and macOS. (#4876)

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -564,9 +564,10 @@ MessagePtr TwitchMessageBuilder::build()
         this->stylizeUsername(this->userName, this->message());
 
     this->message().messageText = this->originalMessage_;
-    this->message().searchText = stylizedUsername + " " +
-                                 this->message().localizedName + " " +
-                                 this->userName + ": " + this->originalMessage_;
+    this->message().searchText =
+        stylizedUsername + " " + this->message().localizedName + " " +
+        this->userName + ": " + this->originalMessage_ +
+        this->message().searchText;
 
     // highlights
     this->parseHighlights();

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -566,7 +566,7 @@ MessagePtr TwitchMessageBuilder::build()
     this->message().messageText = this->originalMessage_;
     this->message().searchText =
         stylizedUsername + " " + this->message().localizedName + " " +
-        this->userName + ": " + this->originalMessage_ +
+        this->userName + ": " + this->originalMessage_ + " " +
         this->message().searchText;
 
     // highlights


### PR DESCRIPTION
This fix stops discarding the previous `searchText` when building a message in `TwitchMessageBuilder::appendChannelPointRewardMessage`.

![image](https://github.com/Chatterino/chatterino2/assets/43550602/1b47f2bc-49ed-456c-9c34-782f3396eb04)

Let me know if any more tests are needed. From what I've seen, regular messages have an empty `searchText` by that point, so the search string doesn't become redundant.

Fixes: #4804