### PR TITLE
fix: /openurl can now open urls with spaces, assuming the url allows it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 - Minor: Chatters from recent-messages are now added to autocompletion. (#5116)
 - Minor: Added a _System_ theme that updates according to the system's color scheme (requires Qt 6.5). (#5118)
 - Minor: Added icons for newer versions of macOS. (#5148)
-- Minor: Added the `--incognito/--no-incognito` options to the `/openurl` command, allowing you to override the "Open links in incognito/private mode" setting. (#5149)
+- Minor: Added the `--incognito/--no-incognito` options to the `/openurl` command, allowing you to override the "Open links in incognito/private mode" setting. (#5149, #5197)
 - Minor: Added support for the `{input.text}` placeholder in the **Split** -> **Run a command** hotkey. (#5130)
 - Minor: Add a new Channel API for experimental plugins feature. (#5141, #5184, #5187)
 - Minor: Added the ability to change the top-most status of a window regardless of the _Always on top_ setting (right click the notebook). (#5135)

--- a/src/controllers/commands/builtin/Misc.cpp
+++ b/src/controllers/commands/builtin/Misc.cpp
@@ -443,6 +443,8 @@ QString openURL(const CommandContext &ctx)
     }
 
     QCommandLineParser parser;
+    parser.setOptionsAfterPositionalArgumentsMode(
+        QCommandLineParser::ParseAsPositionalArguments);
     parser.addPositionalArgument("URL", "The URL to open");
     QCommandLineOption privateModeOption(
         {
@@ -469,7 +471,7 @@ QString openURL(const CommandContext &ctx)
             "Usage: /openurl <URL> [--incognito/--no-incognito]"));
         return "";
     }
-    auto urlString = parser.positionalArguments().at(0);
+    auto urlString = parser.positionalArguments().join(' ');
 
     QUrl url = QUrl::fromUserInput(urlString);
     if (!url.isValid())


### PR DESCRIPTION
This allows for commands like `/openurl https://www.deepl.com/en/translator#auto/en/{1+}` that previously worked

Fixes #5196

<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
