### PR TITLE
feat: Send messages using Helix API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Minor: Updated to Emoji v15.1. Google emojis are now used as the fallback instead of Twitter emojis. (#5182)
 - Minor: Allow theming of tab live and rerun indicators. (#5188)
 - Minor: Added a fallback theme field to custom themes that will be used in case the custom theme does not contain a color Chatterino needs. If no fallback theme is specified, we'll pull the color from the included Dark or Light theme. (#5198)
+- Minor: Twitch messages are now sent using Twitch's Helix API instead of IRC by default. (#5200)
 - Bugfix: Fixed an issue where certain emojis did not send to Twitch chat correctly. (#4840)
 - Bugfix: Fixed capitalized channel names in log inclusion list not being logged. (#4848)
 - Bugfix: Trimmed custom streamlink paths on all platforms making sure you don't accidentally add spaces at the beginning or end of its path. (#4834)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,6 @@
 - Minor: Updated to Emoji v15.1. Google emojis are now used as the fallback instead of Twitter emojis. (#5182)
 - Minor: Allow theming of tab live and rerun indicators. (#5188)
 - Minor: Added a fallback theme field to custom themes that will be used in case the custom theme does not contain a color Chatterino needs. If no fallback theme is specified, we'll pull the color from the included Dark or Light theme. (#5198)
-- Minor: Twitch messages are now sent using Twitch's Helix API instead of IRC by default. (#5200)
 - Bugfix: Fixed an issue where certain emojis did not send to Twitch chat correctly. (#4840)
 - Bugfix: Fixed capitalized channel names in log inclusion list not being logged. (#4848)
 - Bugfix: Trimmed custom streamlink paths on all platforms making sure you don't accidentally add spaces at the beginning or end of its path. (#4834)
@@ -162,6 +161,7 @@
 - Dev: Added signal to invalidate paint buffers of channel views without forcing a relayout. (#5123)
 - Dev: Specialize `Atomic<std::shared_ptr<T>>` if underlying standard library supports it. (#5133)
 - Dev: Added the `developer_name` field to the Linux AppData specification. (#5138)
+- Dev: Twitch messages can be sent using Twitch's Helix API instead of IRC (disabled by default). (#5200)
 
 ## 2.4.6
 

--- a/mocks/include/mocks/Helix.hpp
+++ b/mocks/include/mocks/Helix.hpp
@@ -392,6 +392,14 @@ public:
          (FailureCallback<HelixSendShoutoutError, QString> failureCallback)),
         (override));
 
+    // send message
+    MOCK_METHOD(
+        void, sendChatMessage,
+        (HelixSendMessageArgs args,
+         ResultCallback<HelixSentMessage> successCallback,
+         (FailureCallback<HelixSendMessageError, QString> failureCallback)),
+        (override));
+
     MOCK_METHOD(void, update, (QString clientId, QString oauthToken),
                 (override));
 

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -103,6 +103,22 @@ void sendHelixMessage(const std::shared_ptr<TwitchChannel> &channel,
         });
 }
 
+/// Returns true if chat messages should be sent over Helix
+bool shouldSendHelixChat()
+{
+    switch (getSettings()->chatSendProtocol)
+    {
+        case ChatSendProtocol::Helix:
+            return true;
+        case ChatSendProtocol::Default:
+        case ChatSendProtocol::IRC:
+            return false;
+        default:
+            assert(false && "Invalid chat protocol value");
+            return false;
+    }
+}
+
 }  // namespace
 
 namespace chatterino {
@@ -580,7 +596,7 @@ void TwitchIrcServer::onMessageSendRequested(
         return;
     }
 
-    if (getSettings()->enableHelixChatSend)
+    if (shouldSendHelixChat())
     {
         sendHelixMessage(channel, message);
     }
@@ -604,7 +620,7 @@ void TwitchIrcServer::onReplySendRequested(
         return;
     }
 
-    if (getSettings()->enableHelixChatSend)
+    if (shouldSendHelixChat())
     {
         sendHelixMessage(channel, message, replyId);
     }

--- a/src/providers/twitch/TwitchIrcServer.hpp
+++ b/src/providers/twitch/TwitchIrcServer.hpp
@@ -101,12 +101,13 @@ protected:
     bool hasSeparateWriteConnection() const override;
 
 private:
-    void onMessageSendRequested(TwitchChannel *channel, const QString &message,
-                                bool &sent);
-    void onReplySendRequested(TwitchChannel *channel, const QString &message,
-                              const QString &replyId, bool &sent);
+    void onMessageSendRequested(const std::shared_ptr<TwitchChannel> &channel,
+                                const QString &message, bool &sent);
+    void onReplySendRequested(const std::shared_ptr<TwitchChannel> &channel,
+                              const QString &message, const QString &replyId,
+                              bool &sent);
 
-    bool prepareToSend(TwitchChannel *channel);
+    bool prepareToSend(const std::shared_ptr<TwitchChannel> &channel);
 
     std::mutex lastMessageMutex_;
     std::queue<std::chrono::steady_clock::time_point> lastMessagePleb_;

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -2840,7 +2840,7 @@ void Helix::sendShoutout(
         .execute();
 }
 
-// https://dev.twitch.tv/docs/api/reference/#send-a-shoutout
+// https://dev.twitch.tv/docs/api/reference/#send-chat-message
 void Helix::sendChatMessage(
     HelixSendMessageArgs args, ResultCallback<HelixSentMessage> successCallback,
     FailureCallback<HelixSendMessageError, QString> failureCallback)

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -2840,6 +2840,94 @@ void Helix::sendShoutout(
         .execute();
 }
 
+// https://dev.twitch.tv/docs/api/reference/#send-a-shoutout
+void Helix::sendChatMessage(
+    HelixSendMessageArgs args, ResultCallback<HelixSentMessage> successCallback,
+    FailureCallback<HelixSendMessageError, QString> failureCallback)
+{
+    using Error = HelixSendMessageError;
+
+    QJsonObject json{{
+        {"broadcaster_id", args.broadcasterID},
+        {"sender_id", args.senderID},
+        {"message", args.message},
+    }};
+    if (!args.replyParentMessageID.isEmpty())
+    {
+        json["reply_parent_message_id"] = args.replyParentMessageID;
+    }
+
+    this->makePost("chat/messages", {})
+        .json(json)
+        .onSuccess([successCallback](const NetworkResult &result) {
+            if (result.status() != 200)
+            {
+                qCWarning(chatterinoTwitch)
+                    << "Success result for sending chat message was "
+                    << result.formatError() << "but we expected it to be 200";
+            }
+            auto json = result.parseJson();
+
+            successCallback(HelixSentMessage(
+                json.value("data").toArray().at(0).toObject()));
+        })
+        .onError([failureCallback](const NetworkResult &result) -> void {
+            if (!result.status())
+            {
+                failureCallback(Error::Unknown, result.formatError());
+                return;
+            }
+
+            const auto obj = result.parseJson();
+            auto message =
+                obj["message"].toString(u"Twitch internal server error"_s);
+
+            switch (*result.status())
+            {
+                case 400: {
+                    failureCallback(Error::Unknown, message);
+                }
+                break;
+
+                case 401: {
+                    if (message.startsWith("User access token requires the",
+                                           Qt::CaseInsensitive))
+                    {
+                        failureCallback(Error::UserMissingScope, message);
+                    }
+                    else
+                    {
+                        failureCallback(Error::Forwarded, message);
+                    }
+                }
+                break;
+
+                case 403: {
+                    failureCallback(Error::Forbidden, message);
+                }
+                break;
+
+                case 422: {
+                    failureCallback(Error::MessageTooLarge, message);
+                }
+                break;
+
+                case 500: {
+                    failureCallback(Error::Unknown, message);
+                }
+                break;
+
+                default: {
+                    qCWarning(chatterinoTwitch)
+                        << "Helix send chat message, unhandled error data:"
+                        << result.formatError() << result.getData() << obj;
+                    failureCallback(Error::Unknown, message);
+                }
+            }
+        })
+        .execute();
+}
+
 NetworkRequest Helix::makeRequest(const QString &url, const QUrlQuery &urlQuery,
                                   NetworkRequestType type)
 {

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -524,6 +524,8 @@ public:
         HelixTimegateOverride::Timegate,
     };
 
+    BoolSetting enableHelixChatSend = {"/misc/helixChatSend", true};
+
     BoolSetting openLinksIncognito = {"/misc/openLinksIncognito", 0};
 
     EnumSetting<ThumbnailPreviewMode> emotesTooltipPreview = {

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -62,6 +62,12 @@ enum UsernameRightClickBehavior : int {
     Ignore = 2,
 };
 
+enum class ChatSendProtocol : int {
+    Default = 0,
+    IRC = 1,
+    Helix = 2,
+};
+
 /// Settings which are availlable for reading and writing on the gui thread.
 // These settings are still accessed concurrently in the code but it is bad practice.
 class Settings
@@ -524,7 +530,8 @@ public:
         HelixTimegateOverride::Timegate,
     };
 
-    BoolSetting enableHelixChatSend = {"/misc/helixChatSend", true};
+    EnumStringSetting<ChatSendProtocol> chatSendProtocol = {
+        "/misc/chatSendProtocol", ChatSendProtocol::Default};
 
     BoolSetting openLinksIncognito = {"/misc/openLinksIncognito", 0};
 

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1243,6 +1243,11 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     helixTimegateModerators->setMinimumWidth(
         helixTimegateModerators->minimumSizeHint().width());
 
+    layout.addCheckbox("Send messages use Twitch's Helix API",
+                       s.enableHelixChatSend, false,
+                       "When enabled, sends messages using the Helix API. When "
+                       "disabled, messages are sent over IRC.");
+
     layout.addCheckbox(
         "Show send message button", s.showSendButton, false,
         "Show a Send button next to each split input that can be "

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1243,10 +1243,12 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     helixTimegateModerators->setMinimumWidth(
         helixTimegateModerators->minimumSizeHint().width());
 
-    layout.addCheckbox("Send messages use Twitch's Helix API",
-                       s.enableHelixChatSend, false,
-                       "When enabled, sends messages using the Helix API. When "
-                       "disabled, messages are sent over IRC.");
+    layout.addDropdownEnumClass<ChatSendProtocol>(
+        "Chat send protocol", magic_enum::enum_names<ChatSendProtocol>(),
+        s.chatSendProtocol,
+        "'Helix' will use Twitch's Helix API to send message. 'IRC' will use "
+        "IRC to send messages.",
+        {});
 
     layout.addCheckbox(
         "Show send message button", s.showSendButton, false,


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

This changes the default way messages are sent to use the Helix API instead of IRC. There's still an option to use IRC.

I decided to use a struct as the parameters to the Helix call to make help callers get the order right (using `{.property = value}`), since it would be four `QString` values in a row.

This augments #4962.
Fixes #5127.