### PR TITLE
feat: use 4x images on 7TV instead of 3x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Minor: Allow theming of tab live and rerun indicators. (#5188)
 - Minor: Added a fallback theme field to custom themes that will be used in case the custom theme does not contain a color Chatterino needs. If no fallback theme is specified, we'll pull the color from the included Dark or Light theme. (#5198)
 - Minor: Image links now reflect the scale of their image instead of an internal label. (#5201)
+- Minor: 7TV emotes now have a 4x image rather than a 3x image. (#5209)
 - Bugfix: Fixed an issue where certain emojis did not send to Twitch chat correctly. (#4840)
 - Bugfix: Fixed capitalized channel names in log inclusion list not being logged. (#4848)
 - Bugfix: Trimmed custom streamlink paths on all platforms making sure you don't accidentally add spaces at the beginning or end of its path. (#4834)

--- a/src/providers/seventv/SeventvEmotes.cpp
+++ b/src/providers/seventv/SeventvEmotes.cpp
@@ -432,7 +432,7 @@ ImageSet SeventvEmotes::createImageSet(const QJsonObject &emoteData)
     auto baseUrl = host["url"].toString();
     auto files = host["files"].toArray();
 
-    std::array<ImagePtr, 3> sizes;
+    std::array<ImagePtr, 4> sizes;
     double baseWidth = 0.0;
     size_t nextSize = 0;
 
@@ -486,7 +486,18 @@ ImageSet SeventvEmotes::createImageSet(const QJsonObject &emoteData)
         }
     }
 
-    return ImageSet{sizes[0], sizes[1], sizes[2]};
+    // Typically, 7TV provides four versions (1x, 2x, 3x, and 4x). The 3x
+    // version has a scale factor of 1/3, which is a size other providers don't
+    // provide - they only provide the 4x version (0.25). To be in line with
+    // other providers, we prefer the 4x version but fall back to the 3x one if
+    // it doesn't exist.
+    auto largest = std::move(sizes[3]);
+    if (!largest || largest->isEmpty())
+    {
+        largest = std::move(sizes[2]);
+    }
+
+    return ImageSet{sizes[0], sizes[1], largest};
 }
 
 }  // namespace chatterino


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

As mentioned in #5201, this PR changes the largest image on 7TV to be the 4x version (when available) instead of the 3x version.