### PR TITLE
Add launchable attribute to the Linux appdata file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,7 @@
 - Dev: Added the `developer_name` field to the Linux AppData specification. (#5138)
 - Dev: Twitch messages can be sent using Twitch's Helix API instead of IRC (disabled by default). (#5200)
 - Dev: Added estimation for image sizes to avoid layout shifts. (#5192)
+- Dev: Added the `launachable` entry to Linux AppData. (#5210)
 
 ## 2.4.6
 

--- a/resources/com.chatterino.chatterino.appdata.xml
+++ b/resources/com.chatterino.chatterino.appdata.xml
@@ -2,6 +2,7 @@
 <!-- 2019 Artem Polishchuk <ego.cordatus@gmail.com> -->
 <component type="desktop-application">
     <id>com.chatterino.chatterino.desktop</id>
+    <launchable type="desktop-id">com.chatterino.chatterino.desktop</launchable>
     <metadata_license>CC0-1.0</metadata_license>
     <project_license>MIT</project_license>
     <content_rating type="oars-1.0">


### PR DESCRIPTION
https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-launchable
This is needed so you can launch Chatterino after installing it in an app store.