### PR TITLE
fix(eventsub): compilation issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,6 +209,7 @@ else()
     add_subdirectory("${CMAKE_SOURCE_DIR}/lib/settings" EXCLUDE_FROM_ALL)
 endif()
 
+set(TWITCH_EVENTSUB_WS_LIBRARY_TYPE STATIC)
 add_subdirectory("${CMAKE_SOURCE_DIR}/lib/twitch-eventsub-ws" EXCLUDE_FROM_ALL)
 
 if (CHATTERINO_PLUGINS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -834,11 +834,6 @@ if (BUILD_APP)
 
     target_link_libraries(${EXECUTABLE_PROJECT} PUBLIC ${LIBRARY_PROJECT})
 
-    target_link_libraries(${EXECUTABLE_PROJECT}
-        PUBLIC
-        twitch-eventsub-ws
-        )
-
     set_target_directory_hierarchy(${EXECUTABLE_PROJECT})
 
     if (WIN32)

--- a/src/providers/twitch/EventSub.cpp
+++ b/src/providers/twitch/EventSub.cpp
@@ -266,11 +266,13 @@ void EventSub::start()
                                .toUtf8()
                                .toStdString();
 
-    auto [host, port, path] = getEventSubHost();
+    auto eventSubHost = getEventSubHost();
 
     this->mainThread = std::make_unique<std::thread>([=] {
         try
         {
+            auto [host, port, path] = eventSubHost;
+
             boost::asio::io_context ctx(1);
 
             boost::asio::ssl::context sslContext{


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

Compiling the library as an object library causes some object files to not be linked to the final executable if it depends on the library transitively. Compiling the library as a static library (like other libraries) solves this. I don't know why the default is an object library.