### PR TITLE
fix: correctly load twitch badges in highlights page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 - Bugfix: Fixed issue on Windows preventing the title bar from being dragged in the top left corner. (#4873)
 - Bugfix: Fixed an issue where reply context didn't render correctly if an emoji was touching text. (#4875, #4977, #5174)
 - Bugfix: Fixed the input completion popup from disappearing when clicking on it on Windows and macOS. (#4876)
+- Bugfix: Fixed Twitch badges not loading correctly in the badge highlighting setting page. (#5223)
 - Bugfix: Fixed double-click text selection moving its position with each new message. (#4898)
 - Bugfix: Fixed an issue where notifications on Windows would contain no or an old avatar. (#4899)
 - Bugfix: Fixed headers of tables in the settings switching to bold text when selected. (#4913)

--- a/src/providers/twitch/TwitchBadges.cpp
+++ b/src/providers/twitch/TwitchBadges.cpp
@@ -242,10 +242,11 @@ void TwitchBadges::getBadgeIcons(const QList<DisplayBadge> &badges,
 void TwitchBadges::loadEmoteImage(const QString &name, ImagePtr image,
                                   BadgeIconCallback &&callback)
 {
-    NetworkRequest(image->url().string)
+    auto url = image->url().string;
+    NetworkRequest(url)
         .concurrent()
         .cache()
-        .onSuccess([this, name, callback](auto result) {
+        .onSuccess([this, name, callback, url](auto result) {
             auto data = result.getData();
 
             // const cast since we are only reading from it
@@ -255,17 +256,18 @@ void TwitchBadges::loadEmoteImage(const QString &name, ImagePtr image,
 
             if (!reader.canRead() || reader.size().isEmpty())
             {
+                qCWarning(chatterinoTwitch)
+                    << "Can't read badge image at" << url << "for" << name
+                    << reader.errorString();
                 return;
             }
 
             QImage image = reader.read();
             if (image.isNull())
             {
-                return;
-            }
-
-            if (reader.imageCount() <= 0)
-            {
+                qCWarning(chatterinoTwitch)
+                    << "Failed reading badge image at" << url << "for" << name
+                    << reader.errorString();
                 return;
             }
 


### PR DESCRIPTION
Broken state:
![image](https://github.com/Chatterino/chatterino2/assets/962989/76f9992d-08e1-49f8-b60d-54a3679b1681)

Fixed state after this PR:
![image](https://github.com/Chatterino/chatterino2/assets/962989/6e8d04ac-8699-4556-989e-1280a3d329dd)


<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
