### PR TITLE
fix: the font switcher now remembers your previous font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - Bugfix: Fixed selection of tabs after closing a tab when using "Live Tabs Only". (#4770)
 - Bugfix: Fixed input in reply thread popup losing focus when dragging. (#4815)
 - Bugfix: Fixed the Quick Switcher (CTRL+K) from sometimes showing up on the wrong window. (#4819)
+- Bugfix: Fixed the font switcher not remembering what font you had previously selected. (#5224)
 - Bugfix: Fixed too much text being copied when copying chat messages. (#4812, #4830, #4839)
 - Bugfix: Fixed an issue where the setting `Only search for emote autocompletion at the start of emote names` wouldn't disable if it was enabled when the client started. (#4855)
 - Bugfix: Fixed empty page being added when showing out of bounds dialog. (#4849)

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -173,7 +173,8 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         },
         [this](auto args) {
             return this->getFont(args);
-        });
+        },
+        true, "", true);
     layout.addDropdown<int>(
         "Font size", {"9pt", "10pt", "12pt", "14pt", "16pt", "20pt"},
         getIApp()->getFonts()->chatFontSize,
@@ -1293,22 +1294,19 @@ QString GeneralPage::getFont(const DropdownArgs &args) const
 {
     if (args.combobox->currentIndex() == args.combobox->count() - 1)
     {
-        args.combobox->setCurrentIndex(0);
         args.combobox->setEditText("Choosing...");
-        QFontDialog dialog(
-            getIApp()->getFonts()->getFont(FontStyle::ChatMedium, 1.));
 
         auto ok = bool();
-        auto font = dialog.getFont(&ok, this->window());
+        auto previousFont =
+            getIApp()->getFonts()->getFont(FontStyle::ChatMedium, 1.);
+        auto font = QFontDialog::getFont(&ok, previousFont, this->window());
 
         if (ok)
         {
             return font.family();
         }
-        else
-        {
-            return args.combobox->itemText(0);
-        }
+
+        return previousFont.family();
     }
     return args.value;
 }

--- a/src/widgets/settingspages/GeneralPageView.hpp
+++ b/src/widgets/settingspages/GeneralPageView.hpp
@@ -197,29 +197,26 @@ public:
             },
             this->managedConnections_);
 
+        auto updateSetting = [combo, &setting, setValue = std::move(setValue)](
+                                 const int newIndex) {
+            setting = setValue(DropdownArgs{
+                .value = combo->itemText(newIndex),
+                .index = combo->currentIndex(),
+                .combobox = combo,
+            });
+            getIApp()->getWindows()->forceLayoutChannelViews();
+        };
+
         if (listenToActivated)
         {
-            QObject::connect(
-                combo, &QComboBox::activated,
-                [combo, &setting,
-                 setValue = std::move(setValue)](const int index) {
-                    setting = setValue(DropdownArgs{
-                        combo->itemText(index), combo->currentIndex(), combo});
-                    getIApp()->getWindows()->forceLayoutChannelViews();
-                });
+            QObject::connect(combo, &QComboBox::activated, updateSetting);
         }
         else
         {
             QObject::connect(
                 combo,
                 QOverload<const int>::of(&QComboBox::currentIndexChanged),
-                [combo, &setting,
-                 setValue = std::move(setValue)](const int newIndex) {
-                    setting =
-                        setValue(DropdownArgs{combo->itemText(newIndex),
-                                              combo->currentIndex(), combo});
-                    getIApp()->getWindows()->forceLayoutChannelViews();
-                });
+                updateSetting);
         }
 
         return combo;


### PR DESCRIPTION
Fixes #2112

I would appreciate someone other than me testing this out to make sure I've covered everything

You should be able to:
 - select one of the predefined fonts and the chat fonts should update
 - select "choose" which opens a font dialog & select a custom font
 - select "choose" which opens a font dialog & select cancel (which should revert back to your previously chosen font)

<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
