### PR TITLE
chore: remove dead message element code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,7 @@
 - Dev: Added the `launachable` entry to Linux AppData. (#5210)
 - Dev: Cleaned up and optimized resources. (#5222)
 - Dev: Refactor `StreamerMode`. (#5216)
+- Dev: Cleaned up unused code in `MessageElement` and `MessageLayoutElement`. (#5225)
 
 ## 2.4.6
 

--- a/src/messages/MessageElement.cpp
+++ b/src/messages/MessageElement.cpp
@@ -51,12 +51,6 @@ MessageElement *MessageElement::setLink(const Link &link)
     return this;
 }
 
-MessageElement *MessageElement::setText(const QString &text)
-{
-    this->text_ = text;
-    return this;
-}
-
 MessageElement *MessageElement::setTooltip(const QString &tooltip)
 {
     this->tooltip_ = tooltip;
@@ -94,29 +88,11 @@ void MessageElement::addFlags(MessageElementFlags flags)
     this->flags_.set(flags);
 }
 
-// Empty
-EmptyElement::EmptyElement()
-    : MessageElement(MessageElementFlag::None)
-{
-}
-
-void EmptyElement::addToContainer(MessageLayoutContainer &container,
-                                  MessageElementFlags flags)
-{
-}
-
-EmptyElement &EmptyElement::instance()
-{
-    static EmptyElement instance;
-    return instance;
-}
-
 // IMAGE
 ImageElement::ImageElement(ImagePtr image, MessageElementFlags flags)
     : MessageElement(flags)
-    , image_(image)
+    , image_(std::move(image))
 {
-    //    this->setTooltip(image->getTooltip());
 }
 
 void ImageElement::addToContainer(MessageLayoutContainer &container,
@@ -136,7 +112,7 @@ CircularImageElement::CircularImageElement(ImagePtr image, int padding,
                                            QColor background,
                                            MessageElementFlags flags)
     : MessageElement(flags)
-    , image_(image)
+    , image_(std::move(image))
     , padding_(padding)
     , background_(background)
 {
@@ -808,7 +784,7 @@ void LinebreakElement::addToContainer(MessageLayoutContainer &container,
 ScalingImageElement::ScalingImageElement(ImageSet images,
                                          MessageElementFlags flags)
     : MessageElement(flags)
-    , images_(images)
+    , images_(std::move(images))
 {
 }
 

--- a/src/messages/MessageElement.hpp
+++ b/src/messages/MessageElement.hpp
@@ -160,13 +160,6 @@ using MessageElementFlags = FlagsEnum<MessageElementFlag>;
 class MessageElement
 {
 public:
-    enum UpdateFlags : char {
-        Update_Text = 1,
-        Update_Emotes = 2,
-        Update_Images = 4,
-        Update_All = Update_Text | Update_Emotes | Update_Images
-    };
-
     virtual ~MessageElement();
 
     MessageElement(const MessageElement &) = delete;
@@ -176,7 +169,6 @@ public:
     MessageElement &operator=(MessageElement &&) = delete;
 
     MessageElement *setLink(const Link &link);
-    MessageElement *setText(const QString &text);
     MessageElement *setTooltip(const QString &tooltip);
 
     MessageElement *setTrailingSpace(bool value);
@@ -195,25 +187,9 @@ protected:
     bool trailingSpace = true;
 
 private:
-    QString text_;
     Link link_;
     QString tooltip_;
     MessageElementFlags flags_;
-};
-
-// used when layout element doesn't have a creator
-class EmptyElement : public MessageElement
-{
-public:
-    EmptyElement();
-
-    void addToContainer(MessageLayoutContainer &container,
-                        MessageElementFlags flags) override;
-
-    static EmptyElement &instance();
-
-private:
-    ImagePtr image_;
 };
 
 // contains a simple image

--- a/src/messages/layouts/MessageLayoutElement.hpp
+++ b/src/messages/layouts/MessageLayoutElement.hpp
@@ -162,8 +162,6 @@ public:
                       const QSize &size, QColor color_, FontStyle style_,
                       float scale_);
 
-    void listenToLinkChanges();
-
 protected:
     void addCopyTextToString(QString &str, uint32_t from = 0,
                              uint32_t to = UINT32_MAX) const override;
@@ -176,8 +174,6 @@ protected:
     QColor color_;
     FontStyle style_;
     float scale_;
-
-    pajlada::Signals::SignalHolder managedConnections_;
 };
 
 // TEXT ICON


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

- Removed `EmptyElement` <sub>(never used)</sub>
- Removed `text_` in `MessageElement` <sub>-24B in Qt 6 which is about 23% in the base class and 15% in TextElement (most common)</sub>
- Removed `TextLayoutElement::listenToLinkChanges` <sub>(never used)</sub>
- Added `std::move` to `{Circular,Scaling,}ImageElement` constructors taking `ImagePtr` <sub>(technically unrelated, but if you think of it like a cleanup, it's fine)</sub>