### PR TITLE
fix(windows): show split tooltip before move

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@
 - Bugfix: Fixed link info not updating without moving the cursor. (#5178)
 - Bugfix: Fixed an upload sometimes failing when copying an image from a browser if it contained extra properties. (#5156)
 - Bugfix: Fixed tooltips getting out of bounds when loading images. (#5186)
+- Bugfix: Fixed split header tooltips showing in the wrong position on Windows. (#5230)
 - Dev: Run miniaudio in a separate thread, and simplify it to not manage the device ourselves. There's a chance the simplification is a bad idea. (#4978)
 - Dev: Change clang-format from v14 to v16. (#4929)
 - Dev: Fixed UTF16 encoding of `modes` file for the installer. (#4791)

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -950,13 +950,27 @@ void SplitHeader::enterEvent(QEvent *event)
         this->tooltipWidget_->setOne({nullptr, this->tooltipText_});
         this->tooltipWidget_->setWordWrap(true);
         this->tooltipWidget_->adjustSize();
+
+        // On Windows, a lot of the resizing/activating happens when calling
+        // show() and calling it doesn't synchronously create a visible window,
+        // so moving the window won't cause the visible window to jump.
+        //
+        // On other platforms, this isn't the case, hence we call show() after
+        // moving.
+#ifdef Q_OS_WIN
+        this->tooltipWidget_->show();
+#endif
+
         auto pos =
             this->mapToGlobal(this->rect().bottomLeft()) +
             QPoint((this->width() - this->tooltipWidget_->width()) / 2, 1);
 
         this->tooltipWidget_->moveTo(pos,
                                      widgets::BoundsChecking::CursorPosition);
+
+#ifndef Q_OS_WIN
         this->tooltipWidget_->show();
+#endif
     }
 
     BaseWidget::enterEvent(event);


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

I believe https://github.com/Chatterino/chatterino2/issues/5189 is a Windows only bug. This PR fixes tooltips of splits appearing in the wrong position [after the first hover(?)] on Windows. The issue might also occur when a streamer goes offline and the thumbnail isn't shown, but I didn't test that.
While debugging, I noticed that even though we call `adjustSize` which, according to the documentation, adjusts the area its children occupy, the tooltip still has a larger size than expected. It's only adjusted when calling `show()` <sub>(if you want to reproduce this, try placing logpoints in `QLayoutPrivate::doResize`, `QWidget::setGeometry`, and `QWidgetPrivate::setGeometry_sys`)</sub>. 

For non-Windows platforms, nothing changes.
On Windows, the tooltip is now shown before it's moved. This is fine on Windows, as the new window doesn't become visible right after calling `show()` (only after processing some more events). Since a lot of the resizing/activating happens in `show()`, the window has the correct size afterward, and `moveTo`-ing it will place it at the desired position.
I don't know why we don't need to do this for the tooltips in `ChannelView`.

Fixes #5189. @8thony could you test the change? Make sure you place the window on some side of your screen.

I have a fix for the bug I mentioned in https://github.com/Chatterino/chatterino2/issues/5189#issuecomment-1953158885 (it's one line), but I suppose it's better to do that separately.