### PR TITLE
fix(tooltips): hide image label by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@
 - Bugfix: Fixed link info not updating without moving the cursor. (#5178)
 - Bugfix: Fixed an upload sometimes failing when copying an image from a browser if it contained extra properties. (#5156)
 - Bugfix: Fixed tooltips getting out of bounds when loading images. (#5186)
+- Bugfix: Fixed split header tooltips appearing too tall. (#5232)
 - Dev: Run miniaudio in a separate thread, and simplify it to not manage the device ourselves. There's a chance the simplification is a bad idea. (#4978)
 - Dev: Change clang-format from v14 to v16. (#4929)
 - Dev: Fixed UTF16 encoding of `modes` file for the installer. (#4791)

--- a/src/widgets/TooltipEntryWidget.cpp
+++ b/src/widgets/TooltipEntryWidget.cpp
@@ -24,6 +24,7 @@ TooltipEntryWidget::TooltipEntryWidget(ImagePtr image, const QString &text,
     this->displayImage_ = new QLabel();
     this->displayImage_->setAlignment(Qt::AlignHCenter);
     this->displayImage_->setStyleSheet("background: transparent");
+    this->displayImage_->hide();
     this->displayText_ = new QLabel(text);
     this->displayText_->setAlignment(Qt::AlignHCenter);
     this->displayText_->setStyleSheet("background: transparent");


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

This fixes the issue I mentioned in https://github.com/Chatterino/chatterino2/issues/5189#issuecomment-1953158885. When hovering over the split header the first time, the tooltip appears too large. That's because the image label occupies at least 6x16 px. This PR hides the image label by default. There's an explicit `show` in `refreshPixmap`.