### PR TITLE
chore(deps): update ccache-action back to upstream repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,7 +197,7 @@ jobs:
 
       - name: Setup sccache (Windows)
         # sccache v0.5.3
-        uses: nerixyz/ccache-action@9a7e8d00116ede600ee7717350c6594b8af6aaa5
+        uses: hendrikmuhs/ccache-action@v1.2.12
         if: startsWith(matrix.os, 'windows')
         with:
           variant: sccache

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Setup sccache
         # sccache v0.5.3
-        uses: nerixyz/ccache-action@9a7e8d00116ede600ee7717350c6594b8af6aaa5
+        uses: hendrikmuhs/ccache-action@v1.2.12
         with:
           variant: sccache
           # only save on the default (master) branch


### PR DESCRIPTION
Upstream repo has been updated and satisfies our use case.

As discussed in chat, Github now suggests using hashes for these, but unlike some of our other dependencies which use branches and can silently update on us, this repo only uses tags so it's probably fine to use versioning for this.

✔️ on #5152