### PR TITLE
fix(streamer-mode): check setting on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,7 +170,7 @@
 - Dev: Added estimation for image sizes to avoid layout shifts. (#5192)
 - Dev: Added the `launachable` entry to Linux AppData. (#5210)
 - Dev: Cleaned up and optimized resources. (#5222)
-- Dev: Refactor `StreamerMode`. (#5216)
+- Dev: Refactor `StreamerMode`. (#5216, #5236)
 - Dev: Cleaned up unused code in `MessageElement` and `MessageLayoutElement`. (#5225)
 
 ## 2.4.6

--- a/src/singletons/StreamerMode.cpp
+++ b/src/singletons/StreamerMode.cpp
@@ -163,7 +163,6 @@ bool StreamerMode::isEnabled() const
 StreamerModePrivate::StreamerModePrivate(StreamerMode *parent)
     : parent_(parent)
 {
-    this->thread_.start();
     this->timer_.moveToThread(&this->thread_);
     QObject::connect(&this->timer_, &QTimer::timeout, [this] {
         auto timeouts =
@@ -184,6 +183,11 @@ StreamerModePrivate::StreamerModePrivate(StreamerMode *parent)
             });
         },
         this->settingConnections_);
+
+    QObject::connect(&this->thread_, &QThread::started, [this] {
+        this->settingChanged(getSettings()->enableStreamerMode.getEnum());
+    });
+    this->thread_.start();
 }
 
 bool StreamerModePrivate::isEnabled() const


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

Fixes a bug I introduced in #5216, where the timer wouldn't start when Chatterino was started (as the thread didn't have an event dispatcher yet).

I don't know how I missed this while testing. I probably just toggled the setting.