### PR TITLE
Fix rerun flag not being unset after stream finishes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 - Minor: Add a new Channel API for experimental plugins feature. (#5141, #5184, #5187)
 - Minor: Added the ability to change the top-most status of a window regardless of the _Always on top_ setting (right click the notebook). (#5135)
 - Minor: Introduce `c2.later()` function to Lua API. (#5154)
-- Minor: Live streams that are marked as reruns now mark a tab as yellow instead of red. (#5176)
+- Minor: Live streams that are marked as reruns now mark a tab as yellow instead of red. (#5176, #5237)
 - Minor: Updated to Emoji v15.1. Google emojis are now used as the fallback instead of Twitter emojis. (#5182)
 - Minor: Allow theming of tab live and rerun indicators. (#5188)
 - Minor: Added a fallback theme field to custom themes that will be used in case the custom theme does not contain a color Chatterino needs. If no fallback theme is specified, we'll pull the color from the included Dark or Light theme. (#5198)

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -384,6 +384,8 @@ void CommandController::initialize(Settings &, const Paths &paths)
 
 #ifndef NDEBUG
     this->registerCommand("/fakemsg", &commands::injectFakeMessage);
+    this->registerCommand("/debug-update-to-no-stream",
+                          &commands::injectStreamUpdateNoStream);
 #endif
 
     this->registerCommand("/copy", &commands::copyToClipboard);

--- a/src/controllers/commands/builtin/Misc.cpp
+++ b/src/controllers/commands/builtin/Misc.cpp
@@ -29,6 +29,8 @@
 #include <QString>
 #include <QUrl>
 
+#include <optional>
+
 namespace chatterino::commands {
 
 QString follow(const CommandContext &ctx)
@@ -566,6 +568,27 @@ QString injectFakeMessage(const CommandContext &ctx)
     auto ircText = ctx.words.mid(1).join(" ");
     getApp()->twitch->addFakeMessage(ircText);
 
+    return "";
+}
+
+QString injectStreamUpdateNoStream(const CommandContext &ctx)
+{
+    /**
+     * /debug-update-to-no-stream makes the current channel mimic going offline
+     */
+    if (ctx.channel == nullptr)
+    {
+        return "";
+    }
+    if (ctx.twitchChannel == nullptr)
+    {
+        ctx.channel->addMessage(
+            makeSystemMessage("The /debug-update-to-no-stream command only "
+                              "works in Twitch channels"));
+        return "";
+    }
+
+    ctx.twitchChannel->updateStreamStatus(std::nullopt);
     return "";
 }
 

--- a/src/controllers/commands/builtin/Misc.hpp
+++ b/src/controllers/commands/builtin/Misc.hpp
@@ -25,6 +25,7 @@ QString clearmessages(const CommandContext &ctx);
 QString openURL(const CommandContext &ctx);
 QString sendRawMessage(const CommandContext &ctx);
 QString injectFakeMessage(const CommandContext &ctx);
+QString injectStreamUpdateNoStream(const CommandContext &ctx);
 QString copyToClipboard(const CommandContext &ctx);
 QString unstableSetUserClientSideColor(const CommandContext &ctx);
 QString openUsercard(const CommandContext &ctx);

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -1178,6 +1178,11 @@ bool TwitchChannel::setLive(bool newLiveStatus)
         return false;
     }
     guard->live = newLiveStatus;
+    if (!newLiveStatus)
+    {
+        // A rerun is just a fancy livestream
+        guard->rerun = false;
+    }
 
     return true;
 }


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
Closes #5199. Try checking with `/debug-update-to-no-stream`.