### PR TITLE
fix: compare settings before updating them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
 - Bugfix: Fixed triple click on message also selecting moderation buttons. (#4961)
 - Bugfix: Fixed a freeze from a bad regex in _Ignores_. (#4965, #5126)
 - Bugfix: Fixed badge highlight changes not immediately being reflected. (#5110)
+- Bugfix: Fixed emotes being reloaded when pressing "Cancel" in the settings dialog, causing a slowdown. (#5240)
 - Bugfix: Fixed some emotes not appearing when using _Ignores_. (#4965, #5126)
 - Bugfix: Fixed lookahead/-behind not working in _Ignores_. (#4965, #5126)
 - Bugfix: Fixed Image Uploader accidentally deleting images with some hosts when link resolver was enabled. (#4971)

--- a/src/common/ChatterinoSetting.hpp
+++ b/src/common/ChatterinoSetting.hpp
@@ -13,13 +13,16 @@ class ChatterinoSetting : public pajlada::Settings::Setting<Type>
 {
 public:
     ChatterinoSetting(const std::string &path)
-        : pajlada::Settings::Setting<Type>(path)
+        : pajlada::Settings::Setting<Type>(
+              path, pajlada::Settings::SettingOption::CompareBeforeSet)
     {
         _registerSetting(this->getData());
     }
 
     ChatterinoSetting(const std::string &path, const Type &defaultValue)
-        : pajlada::Settings::Setting<Type>(path, defaultValue)
+        : pajlada::Settings::Setting<Type>(
+              path, defaultValue,
+              pajlada::Settings::SettingOption::CompareBeforeSet)
     {
         _registerSetting(this->getData());
     }

--- a/src/controllers/logging/ChannelLog.cpp
+++ b/src/controllers/logging/ChannelLog.cpp
@@ -7,6 +7,11 @@ ChannelLog::ChannelLog(QString channelName)
 {
 }
 
+bool ChannelLog::operator==(const ChannelLog &other) const
+{
+    return this->channelName_ == other.channelName_;
+}
+
 QString ChannelLog::channelName() const
 {
     return this->channelName_.toLower();

--- a/src/singletons/Settings.cpp
+++ b/src/singletons/Settings.cpp
@@ -9,6 +9,7 @@
 #include "controllers/moderationactions/ModerationAction.hpp"
 #include "controllers/nicknames/Nickname.hpp"
 #include "debug/Benchmark.hpp"
+#include "pajlada/settings/signalargs.hpp"
 #include "util/Clamp.hpp"
 #include "util/PersistSignalVector.hpp"
 #include "util/WindowsHelper.hpp"
@@ -257,7 +258,10 @@ void Settings::restoreSnapshot()
             continue;
         }
 
-        setting->marshalJSON(snapshot[path]);
+        pajlada::Settings::SignalArgs args;
+        args.compareBeforeSet = true;
+
+        setting->marshalJSON(snapshot[path], std::move(args));
     }
 }
 


### PR DESCRIPTION
Most of the changes are done in https://github.com/pajlada/settings/pull/74

This speeds up the "Cancel" option for the settings dialog by a lot

I'm going to merge this in without super much testing to make sure it gets a broad spread of testing.
There's a chance signals don't fire even though they should, so update your settings after this PR has been merged in please. :-)

Fixes #4785

<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
