### PR TITLE
fix: truncate outgoing IRC messages to ensure we don't send more than 512 bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@
 - Bugfix: Fixed a crash that could occur when using certain features in a Reply popup after closing the split from which it was created. (#5036, #5051)
 - Bugfix: Fixed a bug on Wayland where tooltips would spawn as separate windows instead of behaving like tooltips. (#4998, #5040)
 - Bugfix: Fixes to section deletion in text input fields. (#5013)
+- Bugfix: Truncated IRC messages to be at most 512 bytes. (#5246)
 - Bugfix: Show user text input within watch streak notices. (#5029)
 - Bugfix: Fixed avatar in usercard and moderation button triggering when releasing the mouse outside their area. (#5052)
 - Bugfix: Fixed moderator-only topics being subscribed to for non-moderators. (#5056)

--- a/src/providers/irc/AbstractIrcServer.hpp
+++ b/src/providers/irc/AbstractIrcServer.hpp
@@ -37,7 +37,7 @@ public:
     void disconnect();
 
     void sendMessage(const QString &channelName, const QString &message);
-    void sendRawMessage(const QString &rawMessage);
+    virtual void sendRawMessage(const QString &rawMessage);
 
     // channels
     ChannelPtr getOrAddChannel(const QString &dirtyChannelName);

--- a/src/providers/irc/IrcServer.cpp
+++ b/src/providers/irc/IrcServer.cpp
@@ -371,6 +371,11 @@ void IrcServer::sendWhisper(const QString &target, const QString &message)
     }
 }
 
+void IrcServer::sendRawMessage(const QString &rawMessage)
+{
+    AbstractIrcServer::sendRawMessage(rawMessage.left(510));
+}
+
 bool IrcServer::hasEcho() const
 {
     return this->hasEcho_;

--- a/src/providers/irc/IrcServer.hpp
+++ b/src/providers/irc/IrcServer.hpp
@@ -25,6 +25,8 @@ public:
      */
     void sendWhisper(const QString &target, const QString &message);
 
+    void sendRawMessage(const QString &rawMessage) override;
+
     // AbstractIrcServer interface
 protected:
     void initializeConnectionSignals(IrcConnection *connection,


### PR DESCRIPTION
This is a best-effort fix, it's a bit up to the IRC server to handle the consequences of the message they produce being longer than what we send, imo.

Fixes #2890
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
