### PR TITLE
fix(channel-view): use `underlyingChannel_` over `channel_`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@
 - Bugfix: Fixed the "Cancel" button in the settings dialog only working after opening the settings dialog twice. (#5229)
 - Bugfix: Fixed split header tooltips showing in the wrong position on Windows. (#5230)
 - Bugfix: Fixed split header tooltips appearing too tall. (#5232)
+- Bugfix: Fixed past messages not showing in the search popup after adding a channel. (#5248)
 - Dev: Run miniaudio in a separate thread, and simplify it to not manage the device ourselves. There's a chance the simplification is a bad idea. (#4978)
 - Dev: Change clang-format from v14 to v16. (#4929)
 - Dev: Fixed UTF16 encoding of `modes` file for the installer. (#4791)

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -453,7 +453,8 @@ void ChannelView::initializeSignals()
     this->signalHolder_.managedConnect(
         getIApp()->getWindows()->layoutRequested, [&](Channel *channel) {
             if (this->isVisible() &&
-                (channel == nullptr || this->channel_.get() == channel))
+                (channel == nullptr ||
+                 this->underlyingChannel_.get() == channel))
             {
                 this->queueLayout();
             }
@@ -463,7 +464,8 @@ void ChannelView::initializeSignals()
         getIApp()->getWindows()->invalidateBuffersRequested,
         [this](Channel *channel) {
             if (this->isVisible() &&
-                (channel == nullptr || this->channel_.get() == channel))
+                (channel == nullptr ||
+                 this->underlyingChannel_.get() == channel))
             {
                 this->invalidateBuffers();
             }
@@ -889,7 +891,7 @@ ChannelPtr ChannelView::channel()
 
 bool ChannelView::showScrollbarHighlights() const
 {
-    return this->channel_->getType() != Channel::Type::TwitchMentions;
+    return this->underlyingChannel_->getType() != Channel::Type::TwitchMentions;
 }
 
 void ChannelView::setChannel(const ChannelPtr &underlyingChannel)
@@ -1128,7 +1130,7 @@ void ChannelView::messageAppended(MessagePtr &message,
     {
         messageRef->flags.set(MessageLayoutFlag::AlternateBackground);
     }
-    if (this->channel_->shouldIgnoreHighlights())
+    if (this->underlyingChannel_->shouldIgnoreHighlights())
     {
         messageRef->flags.set(MessageLayoutFlag::IgnoreHighlights);
     }
@@ -1288,7 +1290,7 @@ void ChannelView::messagesUpdated()
         this->lastMessageHasAlternateBackground_ =
             !this->lastMessageHasAlternateBackground_;
 
-        if (this->channel_->shouldIgnoreHighlights())
+        if (this->underlyingChannel_->shouldIgnoreHighlights())
         {
             messageLayout->flags.set(MessageLayoutFlag::IgnoreHighlights);
         }
@@ -2181,7 +2183,7 @@ void ChannelView::mouseReleaseEvent(QMouseEvent *event)
             if (hoverLayoutElement->getFlags().has(
                     MessageElementFlag::Username))
             {
-                openTwitchUsercard(this->channel_->getName(),
+                openTwitchUsercard(this->underlyingChannel_->getName(),
                                    hoverLayoutElement->getLink().value);
                 return;
             }
@@ -2999,10 +3001,6 @@ void ChannelView::setInputReply(const MessagePtr &message)
         // Message did not already have a thread attached, try to find or create one
         auto *tc =
             dynamic_cast<TwitchChannel *>(this->underlyingChannel_.get());
-        if (!tc)
-        {
-            tc = dynamic_cast<TwitchChannel *>(this->channel_.get());
-        }
 
         if (tc)
         {
@@ -3059,18 +3057,18 @@ bool ChannelView::canReplyToMessages() const
         return false;
     }
 
-    if (this->channel_ == nullptr)
+    if (this->underlyingChannel_ == nullptr)
     {
         return false;
     }
 
-    if (!this->channel_->isTwitchChannel())
+    if (!this->underlyingChannel_->isTwitchChannel())
     {
         return false;
     }
 
-    if (this->channel_->getType() == Channel::Type::TwitchWhispers ||
-        this->channel_->getType() == Channel::Type::TwitchLive)
+    if (this->underlyingChannel_->getType() == Channel::Type::TwitchWhispers ||
+        this->underlyingChannel_->getType() == Channel::Type::TwitchLive)
     {
         return false;
     }

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1130,7 +1130,7 @@ void ChannelView::messageAppended(MessagePtr &message,
     {
         messageRef->flags.set(MessageLayoutFlag::AlternateBackground);
     }
-    if (this->underlyingChannel_->shouldIgnoreHighlights())
+    if (this->channel_->shouldIgnoreHighlights())
     {
         messageRef->flags.set(MessageLayoutFlag::IgnoreHighlights);
     }

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -891,7 +891,7 @@ ChannelPtr ChannelView::channel()
 
 bool ChannelView::showScrollbarHighlights() const
 {
-    return this->underlyingChannel_->getType() != Channel::Type::TwitchMentions;
+    return this->channel_->getType() != Channel::Type::TwitchMentions;
 }
 
 void ChannelView::setChannel(const ChannelPtr &underlyingChannel)
@@ -1290,7 +1290,7 @@ void ChannelView::messagesUpdated()
         this->lastMessageHasAlternateBackground_ =
             !this->lastMessageHasAlternateBackground_;
 
-        if (this->underlyingChannel_->shouldIgnoreHighlights())
+        if (this->channel_->shouldIgnoreHighlights())
         {
             messageLayout->flags.set(MessageLayoutFlag::IgnoreHighlights);
         }
@@ -2183,7 +2183,7 @@ void ChannelView::mouseReleaseEvent(QMouseEvent *event)
             if (hoverLayoutElement->getFlags().has(
                     MessageElementFlag::Username))
             {
-                openTwitchUsercard(this->underlyingChannel_->getName(),
+                openTwitchUsercard(this->channel_->getName(),
                                    hoverLayoutElement->getLink().value);
                 return;
             }
@@ -3057,18 +3057,18 @@ bool ChannelView::canReplyToMessages() const
         return false;
     }
 
-    if (this->underlyingChannel_ == nullptr)
+    if (this->channel_ == nullptr)
     {
         return false;
     }
 
-    if (!this->underlyingChannel_->isTwitchChannel())
+    if (!this->channel_->isTwitchChannel())
     {
         return false;
     }
 
-    if (this->underlyingChannel_->getType() == Channel::Type::TwitchWhispers ||
-        this->underlyingChannel_->getType() == Channel::Type::TwitchLive)
+    if (this->channel_->getType() == Channel::Type::TwitchWhispers ||
+        this->channel_->getType() == Channel::Type::TwitchLive)
     {
         return false;
     }

--- a/src/widgets/helper/ChannelView.hpp
+++ b/src/widgets/helper/ChannelView.hpp
@@ -139,15 +139,32 @@ public:
 
     MessageElementFlags getFlags() const;
 
+    /// @brief The virtual channel used to display messages
+    ///
+    /// This channel contains all messages in this view and respects the
+    /// filter settings. It will always be of type Channel, not TwitchChannel
+    /// nor IrcChannel.
+    /// It's **not** equal to the channel passed in #setChannel().
     ChannelPtr channel();
+
+    /// Set the channel this view is displaying
     void setChannel(const ChannelPtr &underlyingChannel);
 
     void setFilters(const QList<QUuid> &ids);
     QList<QUuid> getFilterIds() const;
     FilterSetPtr getFilterSet() const;
 
+    /// @brief The channel this is derived from
+    ///
+    /// In case of "nested" channel views such as in user popups,
+    /// this channel is set to the original channel the messages came from,
+    /// which is used to open user popups from this view.
+    /// It's not always set.
+    /// @see #hasSourceChannel()
     ChannelPtr sourceChannel() const;
+    /// Setter for #sourceChannel()
     void setSourceChannel(ChannelPtr sourceChannel);
+    /// Checks if this view has a #sourceChannel
     bool hasSourceChannel() const;
 
     LimitedQueueSnapshot<MessageLayoutPtr> &getMessagesSnapshot();
@@ -300,8 +317,31 @@ private:
     ThreadGuard snapshotGuard_;
     LimitedQueueSnapshot<MessageLayoutPtr> snapshot_;
 
+    /// @brief The backing (internal) channel
+    ///
+    /// This is a "virtual" channel where all filtered messages from
+    /// @a underlyingChannel_ are added to. It contains messages visible on
+    /// screen and will always be a @a Channel, or, it will never be a
+    /// TwitchChannel or IrcChannel, however, it will have the same type and
+    /// name as @a underlyingChannel_. It's not know to any registry/server.
     ChannelPtr channel_ = nullptr;
+
+    /// @brief The channel receiving messages
+    ///
+    /// This channel is the one passed in #setChannel(). It's known to the
+    /// respective registry (e.g. TwitchIrcServer). For Twitch channels for
+    /// example, this will be an instance of TwitchChannel. This channel might
+    /// contain more messages than visible if filters are active.
     ChannelPtr underlyingChannel_ = nullptr;
+
+    /// @brief The channel @a underlyingChannel_ is derived from
+    ///
+    /// In case of "nested" channel views such as in user popups,
+    /// this channel is set to the original channel the messages came from,
+    /// which is used to open user popups from this view.
+    ///
+    /// @see #sourceChannel()
+    /// @see #hasSourceChannel()
     ChannelPtr sourceChannel_ = nullptr;
     Split *split_;
 


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

When setting a channel in a `ChannelView` that has messages, these are copied into the internal message buffer, but aren't added to the backing channel used for search. With this PR, the messages are both added to the backing buffer and to the channel. This also fixes a bug where filters weren't taken into account (non-issue here, as there aren't any set by default).

Seems like this broke in #1748.

Fixes #3861.

---

To help future patches, I commented all channels a view holds onto. It's a bit confusing to have three channels and one always needs to check what they are. In the past, we've made mistakes of using the wrong channel. For example, I missed this in #5123 and even #1748 missed this [when handling `layoutRequested`](https://github.com/Chatterino/chatterino2/blame/e7508332ff1399a89424bfdc0997f979fd0c9acc/src/widgets/helper/ChannelView.cpp#L456).