### PR TITLE
feat: add /announce[color] commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - Minor: 7TV emotes now have a 4x image rather than a 3x image. (#5209)
 - Minor: Add wrappers for Lua `io` library for experimental plugins feature. (#5231)
 - Minor: Add permissions to experimental plugins feature. (#5231)
+- Minor: Add support to send /announce[color] commands. (#5250)
 - Bugfix: Fixed an issue where certain emojis did not send to Twitch chat correctly. (#4840)
 - Bugfix: Fixed capitalized channel names in log inclusion list not being logged. (#4848)
 - Bugfix: Trimmed custom streamlink paths on all platforms making sure you don't accidentally add spaces at the beginning or end of its path. (#4834)

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -401,6 +401,10 @@ void CommandController::initialize(Settings &, const Paths &paths)
     this->registerCommand("/unmod", &commands::removeModerator);
 
     this->registerCommand("/announce", &commands::sendAnnouncement);
+    this->registerCommand("/announceblue", &commands::sendAnnouncementBlue);
+    this->registerCommand("/announcegreen", &commands::sendAnnouncementGreen);
+    this->registerCommand("/announceorange", &commands::sendAnnouncementOrange);
+    this->registerCommand("/announcepurple", &commands::sendAnnouncementPurple);
 
     this->registerCommand("/vip", &commands::addVIP);
 

--- a/src/controllers/commands/builtin/twitch/Announce.cpp
+++ b/src/controllers/commands/builtin/twitch/Announce.cpp
@@ -9,7 +9,8 @@
 #include "providers/twitch/TwitchAccount.hpp"
 #include "providers/twitch/TwitchChannel.hpp"
 
-namespace chatterino::commands {
+namespace {
+using namespace chatterino;
 
 QString sendAnnouncementColor(const CommandContext &ctx,
                               const HelixAnnouncementColor color)
@@ -91,6 +92,9 @@ QString sendAnnouncementColor(const CommandContext &ctx,
         });
     return "";
 }
+} // namespace
+
+namespace chatterino::commands {
 
 QString sendAnnouncement(const CommandContext &ctx)
 {

--- a/src/controllers/commands/builtin/twitch/Announce.cpp
+++ b/src/controllers/commands/builtin/twitch/Announce.cpp
@@ -26,11 +26,23 @@ QString sendAnnouncementColor(const CommandContext &ctx,
         return "";
     }
 
+    QString colorStr = "";
+    if (color != HelixAnnouncementColor::Primary)
+    {
+        colorStr =
+            QString::fromStdString(
+                std::string{
+                    magic_enum::enum_name<HelixAnnouncementColor>(color)})
+                .toLower();
+    }
+
     if (ctx.words.size() < 2)
     {
         ctx.channel->addMessage(makeSystemMessage(
-            "Usage: /announce <message> - Call attention to your "
-            "message with a highlight."));
+            QString("Usage: /announce%1 <message> - Call attention to your "
+                    "message with a %1%2highlight.")
+                .arg(colorStr)
+                .arg(color == HelixAnnouncementColor::Primary ? "" : " ")));
         return "";
     }
 
@@ -38,7 +50,8 @@ QString sendAnnouncementColor(const CommandContext &ctx,
     if (user->isAnon())
     {
         ctx.channel->addMessage(makeSystemMessage(
-            "You must be logged in to use the /announce command."));
+            QString("You must be logged in to use the /announce%1 command.")
+                .arg(colorStr)));
         return "";
     }
 

--- a/src/controllers/commands/builtin/twitch/Announce.cpp
+++ b/src/controllers/commands/builtin/twitch/Announce.cpp
@@ -39,11 +39,20 @@ QString sendAnnouncementColor(const CommandContext &ctx,
 
     if (ctx.words.size() < 2)
     {
-        ctx.channel->addMessage(makeSystemMessage(
-            QString("Usage: /announce%1 <message> - Call attention to your "
-                    "message with a %1%2highlight.")
-                .arg(colorStr)
-                .arg(color == HelixAnnouncementColor::Primary ? "" : " ")));
+        QString usageMsg;
+        if (color == HelixAnnouncementColor::Primary)
+        {
+            usageMsg = "Usage: /announce <message> - Call attention to your "
+                       "message with a highlight.";
+        }
+        else
+        {
+            usageMsg =
+                QString("Usage: /announce%1 <message> - Call attention to your "
+                        "message with a %1 highlight.")
+                    .arg(colorStr);
+        }
+        ctx.channel->addMessage(makeSystemMessage(usageMsg));
         return "";
     }
 
@@ -92,7 +101,8 @@ QString sendAnnouncementColor(const CommandContext &ctx,
         });
     return "";
 }
-} // namespace
+
+}  // namespace
 
 namespace chatterino::commands {
 

--- a/src/controllers/commands/builtin/twitch/Announce.cpp
+++ b/src/controllers/commands/builtin/twitch/Announce.cpp
@@ -11,7 +11,8 @@
 
 namespace chatterino::commands {
 
-QString sendAnnouncement(const CommandContext &ctx)
+QString sendAnnouncementColor(const CommandContext &ctx,
+                              const HelixAnnouncementColor color)
 {
     if (ctx.channel == nullptr)
     {
@@ -43,7 +44,7 @@ QString sendAnnouncement(const CommandContext &ctx)
 
     getHelix()->sendChatAnnouncement(
         ctx.twitchChannel->roomId(), user->getUserId(),
-        ctx.words.mid(1).join(" "), HelixAnnouncementColor::Primary,
+        ctx.words.mid(1).join(" "), color,
         []() {
             // do nothing.
         },
@@ -76,6 +77,31 @@ QString sendAnnouncement(const CommandContext &ctx)
             channel->addMessage(makeSystemMessage(errorMessage));
         });
     return "";
+}
+
+QString sendAnnouncement(const CommandContext &ctx)
+{
+    return sendAnnouncementColor(ctx, HelixAnnouncementColor::Primary);
+}
+
+QString sendAnnouncementBlue(const CommandContext &ctx)
+{
+    return sendAnnouncementColor(ctx, HelixAnnouncementColor::Blue);
+}
+
+QString sendAnnouncementGreen(const CommandContext &ctx)
+{
+    return sendAnnouncementColor(ctx, HelixAnnouncementColor::Green);
+}
+
+QString sendAnnouncementOrange(const CommandContext &ctx)
+{
+    return sendAnnouncementColor(ctx, HelixAnnouncementColor::Orange);
+}
+
+QString sendAnnouncementPurple(const CommandContext &ctx)
+{
+    return sendAnnouncementColor(ctx, HelixAnnouncementColor::Purple);
 }
 
 }  // namespace chatterino::commands

--- a/src/controllers/commands/builtin/twitch/Announce.hpp
+++ b/src/controllers/commands/builtin/twitch/Announce.hpp
@@ -13,4 +13,16 @@ namespace chatterino::commands {
 /// /announce
 QString sendAnnouncement(const CommandContext &ctx);
 
+/// /announceblue
+QString sendAnnouncementBlue(const CommandContext &ctx);
+
+/// /announcegreen
+QString sendAnnouncementGreen(const CommandContext &ctx);
+
+/// /announceorange
+QString sendAnnouncementOrange(const CommandContext &ctx);
+
+/// /announcepurple
+QString sendAnnouncementPurple(const CommandContext &ctx);
+
 }  // namespace chatterino::commands


### PR DESCRIPTION
This adds support to send the `/announce[color]` commands.  
Resolves sending part for https://github.com/Chatterino/chatterino2/issues/5218.  
Note that Chatterino currently does not support receiving colored highlights, so the color is currently only visible in the browser chat.

Screenshot:
![announce](https://github.com/Chatterino/chatterino2/assets/78976058/70ec39ec-d05d-40f9-86ee-98ae84ed1338)

