### PR TITLE
fix: Update Linux build instructions

### DIFF
--- a/BUILDING_ON_LINUX.md
+++ b/BUILDING_ON_LINUX.md
@@ -28,11 +28,6 @@ Enter the development environment with all the dependencies: `nix-shell -p opens
 
 ## Compile
 
-### Through Qt Creator
-
-1. Install C++ IDE Qt Creator by using `sudo apt install qtcreator`
-1. Open `CMakeLists.txt` with Qt Creator and select build
-
 ## Manually
 
 1. In the project directory, create a build directory and enter it
@@ -48,3 +43,8 @@ Enter the development environment with all the dependencies: `nix-shell -p opens
    ```sh
    make
    ```
+
+### Through Qt Creator
+
+1. Install C++ IDE Qt Creator by using `sudo apt install qtcreator` (Or whatever equivalent for your distro)
+1. Open `CMakeLists.txt` with Qt Creator and select build

--- a/BUILDING_ON_LINUX.md
+++ b/BUILDING_ON_LINUX.md
@@ -41,7 +41,7 @@ Enter the development environment with all the dependencies: `nix-shell -p opens
    ```
 1. Build the project
    ```sh
-   make
+   cmake --build .
    ```
 
 ### Through Qt Creator

--- a/BUILDING_ON_LINUX.md
+++ b/BUILDING_ON_LINUX.md
@@ -16,11 +16,15 @@ The built binary should be exportable from the final image & able to run on your
 
 ### Debian 12 (bookworm) or later
 
-Install all the dependencies using `sudo apt install qt6-base-dev qt6-5compat-dev qt6-svg-dev qt6-image-formats-plugins libboost1.81-dev libssl-dev cmake g++ git`
+```sh
+sudo apt install qt6-base-dev qt6-5compat-dev qt6-svg-dev qt6-image-formats-plugins libboost1.81-dev libssl-dev cmake g++ git
+```
 
 ### Arch Linux
 
-Install all the dependencies using `sudo pacman -S --needed qt6-base qt6-tools boost-libs openssl qt6-imageformats qt6-5compat qt6-svg boost rapidjson pkgconf openssl cmake`
+```sh
+sudo pacman -S --needed qt6-base qt6-tools boost-libs openssl qt6-imageformats qt6-5compat qt6-svg boost rapidjson pkgconf openssl cmake
+```
 
 Alternatively you can use the [chatterino2-git](https://aur.archlinux.org/packages/chatterino2-git/) package to build and install Chatterino for you.
 
@@ -28,11 +32,15 @@ Alternatively you can use the [chatterino2-git](https://aur.archlinux.org/packag
 
 _Most likely works the same for other Red Hat-like distros. Substitute `dnf` with `yum`._
 
-Install all the dependencies using `sudo dnf install qt6-qtbase-devel qt6-qtimageformats qt6-qtsvg-devel qt6-qt5compat-devel g++ git openssl-devel boost-devel cmake`
+```sh
+sudo dnf install qt6-qtbase-devel qt6-qtimageformats qt6-qtsvg-devel qt6-qt5compat-devel g++ git openssl-devel boost-devel cmake
+```
 
 ### NixOS 18.09+
 
-Enter the development environment with all the dependencies: `nix-shell -p openssl boost qt6.full pkg-config cmake`
+```sh
+nix-shell -p openssl boost qt6.full pkg-config cmake
+```
 
 ## Compile
 

--- a/BUILDING_ON_LINUX.md
+++ b/BUILDING_ON_LINUX.md
@@ -12,7 +12,7 @@ Install all the dependencies using `sudo apt install qttools5-dev qt5-image-form
 
 ### Arch Linux
 
-Install all the dependencies using `sudo pacman -S --needed qt5-base qt5-imageformats qt5-svg qt5-tools boost rapidjson pkgconf openssl cmake`
+Install all the dependencies using `sudo pacman -S --needed qt6-base qt6-tools boost-libs openssl qt6-imageformats qtkeychain-qt6 qt6-5compat qt6-svg boost rapidjson pkgconf openssl cmake`
 
 Alternatively you can use the [chatterino2-git](https://aur.archlinux.org/packages/chatterino2-git/) package to build and install Chatterino for you.
 

--- a/BUILDING_ON_LINUX.md
+++ b/BUILDING_ON_LINUX.md
@@ -1,30 +1,33 @@
 # Linux
 
-Note on Qt version compatibility: If you are installing Qt from a package manager, please ensure the version you are installing is at least **Qt 5.15 or newer**.
+For all dependencies below we use Qt6. Our minimum supported version is Qt5.15, but you are on your own.
 
 ## Install dependencies
 
-### Ubuntu 20.04
+### Ubuntu
 
-_Most likely works the same for other Debian-like distros._
+Building on Ubuntu requires Docker.
+Use https://github.com/Chatterino/docker/pkgs/container/chatterino2-build-ubuntu-20.04 as your base if youre on Ubuntu 20.04, or https://github.com/Chatterino/docker/pkgs/container/chatterino2-build-ubuntu-22.04 if you're on Ubuntu 22.04. The built binary should be exportable from the final image & able to run on your system assuming you perform a static build. See our build.yml github workflow file.
 
-Install all the dependencies using `sudo apt install qttools5-dev qt5-image-formats-plugins libqt5svg5-dev libboost-dev libssl-dev libboost-system-dev libboost-filesystem-dev cmake g++ libsecret-1-dev`
+### Debian 12 (bookworm) or later
+
+Install all the dependencies using `sudo apt install qt6-base-dev qt6-5compat-dev qt6-svg-dev qt6-image-formats-plugins libboost1.81-dev libssl-dev cmake g++ git`
 
 ### Arch Linux
 
-Install all the dependencies using `sudo pacman -S --needed qt6-base qt6-tools boost-libs openssl qt6-imageformats qtkeychain-qt6 qt6-5compat qt6-svg boost rapidjson pkgconf openssl cmake`
+Install all the dependencies using `sudo pacman -S --needed qt6-base qt6-tools boost-libs openssl qt6-imageformats qt6-5compat qt6-svg boost rapidjson pkgconf openssl cmake`
 
 Alternatively you can use the [chatterino2-git](https://aur.archlinux.org/packages/chatterino2-git/) package to build and install Chatterino for you.
 
-### Fedora 28 and above
+### Fedora 39 and above
 
 _Most likely works the same for other Red Hat-like distros. Substitute `dnf` with `yum`._
 
-Install all the dependencies using `sudo dnf install qt5-qtbase-devel qt5-qtimageformats qt5-qtsvg-devel qt5-linguist libsecret-devel openssl-devel boost-devel cmake`
+Install all the dependencies using `sudo dnf install qt6-qtbase-devel qt6-qtimageformats qt6-qtsvg-devel qt6-qt5compat-devel g++ git openssl-devel boost-devel cmake`
 
 ### NixOS 18.09+
 
-Enter the development environment with all the dependencies: `nix-shell -p openssl boost qt5.full pkg-config cmake`
+Enter the development environment with all the dependencies: `nix-shell -p openssl boost qt6.full pkg-config cmake`
 
 ## Compile
 
@@ -37,7 +40,7 @@ Enter the development environment with all the dependencies: `nix-shell -p opens
    ```
 1. Generate build files
    ```sh
-   cmake ..
+   cmake -DBUILD_WITH_QT6=ON -DBUILD_WITH_QTKEYCHAIN=OFF ..
    ```
 1. Build the project
    ```sh

--- a/BUILDING_ON_LINUX.md
+++ b/BUILDING_ON_LINUX.md
@@ -1,6 +1,6 @@
 # Linux
 
-Note on Qt version compatibility: If you are installing Qt from a package manager, please ensure the version you are installing is at least **Qt 5.12 or newer**.
+Note on Qt version compatibility: If you are installing Qt from a package manager, please ensure the version you are installing is at least **Qt 5.15 or newer**.
 
 ## Install dependencies
 

--- a/BUILDING_ON_LINUX.md
+++ b/BUILDING_ON_LINUX.md
@@ -7,7 +7,12 @@ For all dependencies below we use Qt6. Our minimum supported version is Qt5.15, 
 ### Ubuntu
 
 Building on Ubuntu requires Docker.
-Use https://github.com/Chatterino/docker/pkgs/container/chatterino2-build-ubuntu-20.04 as your base if youre on Ubuntu 20.04, or https://github.com/Chatterino/docker/pkgs/container/chatterino2-build-ubuntu-22.04 if you're on Ubuntu 22.04. The built binary should be exportable from the final image & able to run on your system assuming you perform a static build. See our build.yml github workflow file.
+
+Use https://github.com/Chatterino/docker/pkgs/container/chatterino2-build-ubuntu-20.04 as your base if you're on Ubuntu 20.04.
+
+Use https://github.com/Chatterino/docker/pkgs/container/chatterino2-build-ubuntu-22.04 if you're on Ubuntu 22.04.
+
+The built binary should be exportable from the final image & able to run on your system assuming you perform a static build. See our [build.yml github workflow file](.github/workflows/build.yml) for the cmake line used for Ubuntu builds.
 
 ### Debian 12 (bookworm) or later
 


### PR DESCRIPTION
- **fix: minimum qt version if 5.15**
- **fix: prioritize manual builds through terminal**
- **fix: use cmake --build . for building**
- **Update Arch Linux dependencies**
- **Update guide to use Qt6 (and fix Ubuntu instructions)**

<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
