### PR TITLE
fix: remove ":" from the message the user is replying to if it's a /me message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@
 - Bugfix: Fixed split header tooltips appearing too tall. (#5232)
 - Bugfix: Fixed past messages not showing in the search popup after adding a channel. (#5248)
 - Bugfix: Detect when OBS is running on MacOS. (#5260)
+- Bugfix: Remove ":" from the message the user is replying to if it's a /me message. (#5263)
 - Dev: Run miniaudio in a separate thread, and simplify it to not manage the device ourselves. There's a chance the simplification is a bad idea. (#4978)
 - Dev: Change clang-format from v14 to v16. (#4929)
 - Dev: Fixed UTF16 encoding of `modes` file for the installer. (#4791)

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -893,8 +893,10 @@ void TwitchMessageBuilder::parseThread()
             ->setLink({Link::ViewThread, this->thread_->rootId()});
 
         this->emplace<TextElement>(
-                "@" + usernameText + ":", MessageElementFlag::RepliedMessage,
-                threadRoot->usernameColor, FontStyle::ChatMediumSmall)
+                "@" + usernameText +
+                    (threadRoot->flags.has(MessageFlag::Action) ? "" : ":"),
+                MessageElementFlag::RepliedMessage, threadRoot->usernameColor,
+                FontStyle::ChatMediumSmall)
             ->setLink({Link::UserInfo, threadRoot->displayName});
 
         MessageColor color = MessageColor::Text;


### PR DESCRIPTION
![Screenshot_20240324_140000](https://github.com/Chatterino/chatterino2/assets/54620595/5478f50f-02d6-46a5-90a2-db79daa17e69)

This removes a `:` from the reply if it's a reply to a `/me` message to keep it consistent with `/me` messages not having a `:`.