### PR TITLE
Add `reward.cost` `reward.id`, `reward.title` filter variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - Minor: Image links now reflect the scale of their image instead of an internal label. (#5201)
 - Minor: IPC files are now stored in the Chatterino directory instead of system directories on Windows. (#5226)
 - Minor: 7TV emotes now have a 4x image rather than a 3x image. (#5209)
+- Minor: Add `reward.cost` `reward.id`, `reward.title` filter variables. (#5275)
 - Bugfix: Fixed an issue where certain emojis did not send to Twitch chat correctly. (#4840)
 - Bugfix: Fixed the `/shoutout` command not working with usernames starting with @'s (e.g. `/shoutout @forsen`). (#4800)
 - Bugfix: Fixed capitalized channel names in log inclusion list not being logged. (#4848)

--- a/src/controllers/filters/lang/Filter.cpp
+++ b/src/controllers/filters/lang/Filter.cpp
@@ -120,6 +120,18 @@ ContextMap buildContextMap(const MessagePtr &m, chatterino::Channel *channel)
             vars["channel.live"] = false;
         }
     }
+    if (m->reward != nullptr)
+    {
+        vars["reward.title"] = m->reward->title;
+        vars["reward.cost"] = m->reward->cost;
+        vars["reward.id"] = m->reward->id;
+    }
+    else
+    {
+        vars["reward.title"] = "";
+        vars["reward.cost"] = -1;
+        vars["reward.id"] = "";
+    }
     return vars;
 }
 

--- a/src/controllers/filters/lang/Filter.hpp
+++ b/src/controllers/filters/lang/Filter.hpp
@@ -48,6 +48,9 @@ static const QMap<QString, Type> MESSAGE_TYPING_CONTEXT = {
     {"flags.monitored", Type::Bool},
     {"message.content", Type::String},
     {"message.length", Type::Int},
+    {"reward.title", Type::String},
+    {"reward.cost", Type::Int},
+    {"reward.id", Type::String},
 };
 
 ContextMap buildContextMap(const MessagePtr &m, chatterino::Channel *channel);

--- a/src/controllers/filters/lang/Tokenizer.hpp
+++ b/src/controllers/filters/lang/Tokenizer.hpp
@@ -35,7 +35,11 @@ static const QMap<QString, QString> validIdentifiersMap = {
     {"flags.restricted", "restricted message?"},
     {"flags.monitored", "monitored message?"},
     {"message.content", "message text"},
-    {"message.length", "message length"}};
+    {"message.length", "message length"},
+    {"reward.title", "point reward title"},
+    {"reward.cost", "point reward cost"},
+    {"reward.id", "point reward id"},
+};
 
 // clang-format off
 static const QRegularExpression tokenRegex(

--- a/src/messages/Message.hpp
+++ b/src/messages/Message.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "common/FlagsEnum.hpp"
+#include "providers/twitch/ChannelPointReward.hpp"
 #include "util/QStringHash.hpp"
 
 #include <magic_enum/magic_enum.hpp>
@@ -107,6 +108,8 @@ struct Message {
     std::vector<std::unique_ptr<MessageElement>> elements;
 
     ScrollbarHighlight getScrollBarHighlight() const;
+
+    std::shared_ptr<ChannelPointReward> reward = nullptr;
 };
 
 }  // namespace chatterino

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -1625,6 +1625,8 @@ void TwitchMessageBuilder::appendChannelPointRewardMessage(
     builder->message().messageText = textList.join(" ");
     builder->message().searchText = textList.join(" ");
     builder->message().loginName = reward.user.login;
+
+    builder->message().reward = std::make_shared<ChannelPointReward>(reward);
 }
 
 void TwitchMessageBuilder::liveMessage(const QString &channelName,

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -268,6 +268,20 @@ void addHiddenContextMenuItems(QMenu *menu,
         jsonObject["searchText"] = message->searchText;
         jsonObject["messageText"] = message->messageText;
         jsonObject["flags"] = qmagicenum::enumFlagsName(message->flags.value());
+        if (message->reward)
+        {
+            QJsonObject reward;
+            reward["id"] = message->reward->id;
+            reward["title"] = message->reward->title;
+            reward["cost"] = message->reward->cost;
+            reward["isUserInputRequired"] =
+                message->reward->isUserInputRequired;
+            jsonObject["reward"] = reward;
+        }
+        else
+        {
+            jsonObject["reward"] = QJsonValue();
+        }
 
         jsonDocument.setObject(jsonObject);
 


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
This grows the Message struct by 16 bytes for the `shared_ptr`.

This adds the following filter variables:
- `reward.title`
- `reward.id`
- `reward.cost`

The use cases include having a separate split for high cost rewards that you don't want to miss, showing only some rewards in chat.

(felanbird): #4882 #4883 