### PR TITLE
fix(helix-chat): show better error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,7 +186,7 @@
 - Dev: Added signal to invalidate paint buffers of channel views without forcing a relayout. (#5123)
 - Dev: Specialize `Atomic<std::shared_ptr<T>>` if underlying standard library supports it. (#5133)
 - Dev: Added the `developer_name` field to the Linux AppData specification. (#5138)
-- Dev: Twitch messages can be sent using Twitch's Helix API instead of IRC (disabled by default). (#5200)
+- Dev: Twitch messages can be sent using Twitch's Helix API instead of IRC (disabled by default). (#5200, #5276)
 - Dev: Added estimation for image sizes to avoid layout shifts. (#5192)
 - Dev: Added the `launachable` entry to Linux AppData. (#5210)
 - Dev: Cleaned up and optimized resources. (#5222)

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -39,9 +39,17 @@ const QString SEVENTV_EVENTAPI_URL = "wss://events.7tv.io/v3";
 void sendHelixMessage(const std::shared_ptr<TwitchChannel> &channel,
                       const QString &message, const QString &replyParentId = {})
 {
+    auto broadcasterID = channel->roomId();
+    if (broadcasterID.isEmpty())
+    {
+        channel->addMessage(makeSystemMessage(
+            "Sending messages in this channel isn't possible."));
+        return;
+    }
+
     getHelix()->sendChatMessage(
         {
-            .broadcasterID = channel->roomId(),
+            .broadcasterID = broadcasterID,
             .senderID =
                 getIApp()->getAccounts()->twitch.getCurrent()->getUserId(),
             .message = message,

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -76,11 +76,16 @@ void sendHelixMessage(const std::shared_ptr<TwitchChannel> &channel,
             }();
             chan->addMessage(errorMessage);
         },
-        [weak = std::weak_ptr(channel)](auto error, const auto &message) {
+        [weak = std::weak_ptr(channel)](auto error, auto message) {
             auto chan = weak.lock();
             if (!chan)
             {
                 return;
+            }
+
+            if (message.isEmpty())
+            {
+                message = "(empty message)";
             }
 
             using Error = decltype(error);


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

- Shows a better message in case the roomID is empty. Previously _Unknown error: Missing required parameter "broadcaster_id"_  would be shown.
- Shows _(empty message)_ if the response from Twitch is empty (I don't know how to trigger that, but I got it at least once in the past).