### PR TITLE
fix: use login name when parsing highlights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@
 - Bugfix: Truncated IRC messages to be at most 512 bytes. (#5246)
 - Bugfix: Fixed a data race when disconnecting from Twitch PubSub. (#4771)
 - Bugfix: Fixed messages not immediately disappearing when clearing the chat. (#5282)
+- Bugfix: Fixed highlights triggering for ignored users in announcements. (#5295)
 - Dev: Run miniaudio in a separate thread, and simplify it to not manage the device ourselves. There's a chance the simplification is a bad idea. (#4978)
 - Dev: Change clang-format from v14 to v16. (#4929)
 - Dev: Fixed UTF16 encoding of `modes` file for the installer. (#4791)

--- a/src/messages/SharedMessageBuilder.cpp
+++ b/src/messages/SharedMessageBuilder.cpp
@@ -150,7 +150,7 @@ void SharedMessageBuilder::parseUsername()
 
 void SharedMessageBuilder::parseHighlights()
 {
-    if (getSettings()->isBlacklistedUser(this->ircMessage->nick()))
+    if (getSettings()->isBlacklistedUser(this->message().loginName))
     {
         // Do nothing. We ignore highlights from this user.
         return;
@@ -158,7 +158,7 @@ void SharedMessageBuilder::parseHighlights()
 
     auto badges = SharedMessageBuilder::parseBadgeTag(this->tags);
     auto [highlighted, highlightResult] = getIApp()->getHighlights()->check(
-        this->args, badges, this->ircMessage->nick(), this->originalMessage_,
+        this->args, badges, this->message().loginName, this->originalMessage_,
         this->message().flags);
 
     if (!highlighted)


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

Previously, `ircMessage->nick()` was used to get the login name. This doesn't return the login name for e.g. announcements (`USERNOTICE`). Since we already know the login name at that point, we can use `message().loginName`.

This might trigger more highlights where `loginName` is set, but the nick is unset/invalid, which was probably a bug before too.

Fixes #5294.