### PR TITLE
fix: use `deleteLater` for network objects and order them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,7 +201,7 @@
 - Dev: Refactor `StreamerMode`. (#5216, #5236)
 - Dev: Cleaned up unused code in `MessageElement` and `MessageLayoutElement`. (#5225)
 - Dev: Adapted `magic_enum` to Qt's Utf-16 strings. (#5258)
-- Dev: `NetworkManager`'s statics are now created in its `init` method. (#5254)
+- Dev: `NetworkManager`'s statics are now created in its `init` method. (#5254, #5297)
 - Dev: `clang-tidy` CI now uses Qt 6. (#5273)
 - Dev: Enabled `InsertNewlineAtEOF` in `clang-format`. (#5278)
 

--- a/src/common/network/NetworkManager.cpp
+++ b/src/common/network/NetworkManager.cpp
@@ -24,15 +24,19 @@ void NetworkManager::deinit()
     assert(NetworkManager::workerThread);
     assert(NetworkManager::accessManager);
 
+    // delete the access manager first:
+    // - put the event on the worker thread
+    // - wait for it to process
+    NetworkManager::accessManager->deleteLater();
+    NetworkManager::accessManager = nullptr;
+
     if (NetworkManager::workerThread)
     {
         NetworkManager::workerThread->quit();
         NetworkManager::workerThread->wait();
     }
 
-    delete NetworkManager::accessManager;
-    NetworkManager::accessManager = nullptr;
-    delete NetworkManager::workerThread;
+    NetworkManager::workerThread->deleteLater();
     NetworkManager::workerThread = nullptr;
 }
 


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

I made a silly mistake in #5254 by not using `deleteLater` and turning off the worker thread before it could process the deletion event of the network access manager. This _could_ result in a failed assertion when closing Chatterino (when network requests were in flight, I think).