### PR TITLE
fix: avoid crash when uploading pasted image on wayland

### DIFF
--- a/src/singletons/ImageUploader.cpp
+++ b/src/singletons/ImageUploader.cpp
@@ -248,9 +248,17 @@ void ImageUploader::handleSuccessfulUpload(const NetworkResult &result,
     this->logToFile(originalFilePath, link, deletionLink, channel);
 }
 
-void ImageUploader::upload(const QMimeData *source, ChannelPtr channel,
-                           QPointer<ResizingTextEdit> outputTextEdit)
+void ImageUploader::uploadClipboard(ChannelPtr channel,
+                                    QPointer<ResizingTextEdit> outputTextEdit)
 {
+    const QMimeData *source = QApplication::clipboard()->mimeData();
+    if (!source)
+    {
+        channel->addMessage(makeSystemMessage(
+            QString("Clipboard does not have a valid image.")));
+        return;
+    }
+
     if (!this->uploadMutex_.tryLock())
     {
         channel->addMessage(makeSystemMessage(

--- a/src/singletons/ImageUploader.cpp
+++ b/src/singletons/ImageUploader.cpp
@@ -13,6 +13,7 @@
 #include "widgets/helper/ResizingTextEdit.hpp"
 
 #include <QBuffer>
+#include <QClipboard>
 #include <QHttpMultiPart>
 #include <QJsonArray>
 #include <QJsonDocument>

--- a/src/singletons/ImageUploader.hpp
+++ b/src/singletons/ImageUploader.hpp
@@ -26,8 +26,8 @@ class ImageUploader final : public Singleton
 {
 public:
     void save() override;
-    void upload(const QMimeData *source, ChannelPtr channel,
-                QPointer<ResizingTextEdit> outputTextEdit);
+    void uploadClipboard(ChannelPtr channel,
+                         QPointer<ResizingTextEdit> outputTextEdit);
 
 private:
     void sendImageUploadRequest(RawImageData imageData, ChannelPtr channel,

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -428,8 +428,8 @@ Split::Split(QWidget *parent)
                 }
             }
             QPointer<ResizingTextEdit> edit = this->input_->ui_.textEdit;
-            getIApp()->getImageUploader()->upload(source, this->getChannel(),
-                                                  edit);
+            getIApp()->getImageUploader()->uploadClipboard(this->getChannel(),
+                                                           edit);
         });
 
     getSettings()->imageUploaderEnabled.connect(


### PR DESCRIPTION
Closes #2879 

More of a workaround to the underlying issue, so feel free to close in favor of a PR that tackles more of the root cause
