### PR TITLE
fix: hide tooltip on window leave event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+- Bugfix: Fixed split tooltip getting stuck in some cases. (#5309)
+
 ## 2.5.0-beta.1
 
 - Major: Twitch follower emotes can now be correctly tabbed in other channels when you are subscribed to the channel the emote is from. (#4922)

--- a/src/widgets/BaseWindow.cpp
+++ b/src/widgets/BaseWindow.cpp
@@ -527,6 +527,7 @@ void BaseWindow::changeEvent(QEvent *)
 
 void BaseWindow::leaveEvent(QEvent *)
 {
+    this->leaving.invoke();
 }
 
 void BaseWindow::moveTo(QPoint point, widgets::BoundsChecking mode)

--- a/src/widgets/BaseWindow.hpp
+++ b/src/widgets/BaseWindow.hpp
@@ -85,6 +85,7 @@ public:
     void setTopMost(bool topMost);
 
     pajlada::Signals::NoArgSignal closing;
+    pajlada::Signals::NoArgSignal leaving;
 
     static bool supportsCustomWindowFrame();
 

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -257,6 +257,20 @@ SplitHeader::SplitHeader(Split *split)
     getSettings()->headerStreamTitle.connect(_, this->managedConnections_);
     getSettings()->headerGame.connect(_, this->managedConnections_);
     getSettings()->headerUptime.connect(_, this->managedConnections_);
+
+    auto *window = dynamic_cast<BaseWindow *>(this->window());
+    if (window)
+    {
+        // Hack: In some cases Qt doesn't send the leaveEvent the "actual" last mouse receiver.
+        // This can happen when quickly moving the mouse out of the window and right clicking.
+        // To prevent the tooltip from getting stuck, we use the window's leaveEvent.
+        this->managedConnections_.managedConnect(window->leaving, [this] {
+            if (this->tooltipWidget_->isVisible())
+            {
+                this->tooltipWidget_->hide();
+            }
+        });
+    }
 }
 
 void SplitHeader::initializeLayout()


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

Disclaimer: This solution is really hacky.

I think https://github.com/Chatterino/chatterino2/issues/5308 is a bug in Qt. I'm not entirely sure what the root cause is (possibly some bad order of queued events). The bug happens when quickly moving the mouse and right-clicking on the split header. When the QMenu is shown, focus is transferred, eventually causing a leave-event to be sent to the focused window. In our case, it's a QWidgetWindow. Usually, the widget to receive the leave-event (and propagate it upwards) is [set to `qt_last_mouse_receiver`](https://github.com/qt/qtbase/blob/ce23c9083f4d06054eb59781c3309b1fcc807a1f/src/widgets/kernel/qwidgetwindow.cpp#L411-L412) - e.g. the QLabel showing the channel info. However, when things go wrong, [`qt_last_mouse_receiver` is set to the newly created QMenu](https://github.com/qt/qtbase/blob/ce23c9083f4d06054eb59781c3309b1fcc807a1f/src/widgets/kernel/qwidgetwindow.cpp#L546) before the leave-event is delivered. But wait, doesn't `sendMouseEvent` get the last mouse receiver, so it could deliver the leave-event? Yea, but it only does so [if the mouse is over the QMenu](https://github.com/qt/qtbase/blob/ce23c9083f4d06054eb59781c3309b1fcc807a1f/src/widgets/kernel/qapplication.cpp#L2320), which it isn't.

So, what do we do? If the receiver isn't set to `qt_last_mouse_receiver`, it's set to the window-widget, `m_widget`, which is our `BaseWindow`. To prevent the tooltip getting stuck, we use the window's leave-event to hide it. This isn't ideal, but it works.

If you test a lot, you might notice similar effects in other parts. For example, buttons sometimes get stuck in a hovered state when moving the mouse quickly and clicking. I suspect the same (or a really similar) cause. This is a pain to debug - it would be nice if there was an easier way to reproduce.

Fixes #5308.