### PR TITLE
fix: improve error messaging when pgrep fails streamer mode detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unversioned
 
 - Minor: Report sub duration for more multi-month gift cases. (#5319)
+- Minor: Improved error reporting for the automatic streamer mode detection on Linux and macOS. (#5321)
 - Bugfix: Fixed split tooltip getting stuck in some cases. (#5309)
 - Bugfix: Fixed the version string not showing up as expected in Finder on macOS. (#5311)
 

--- a/src/singletons/StreamerMode.cpp
+++ b/src/singletons/StreamerMode.cpp
@@ -102,6 +102,7 @@ bool isBroadcasterSoftwareActive()
                 });
             }
         }
+        break;
     }
 
     return false;

--- a/src/singletons/StreamerMode.cpp
+++ b/src/singletons/StreamerMode.cpp
@@ -51,6 +51,9 @@ const QStringList &broadcastingBinaries()
 bool isBroadcasterSoftwareActive()
 {
 #if defined(Q_OS_LINUX) || defined(Q_OS_MACOS)
+    static bool shouldShowTimeoutWarning = true;
+    static bool shouldShowWarning = true;
+
     QProcess p;
     p.start("pgrep", {"-xi", broadcastingBinaries().join("|")},
             QIODevice::NotOpen);
@@ -62,20 +65,45 @@ bool isBroadcasterSoftwareActive()
 
     // Fallback to false and showing a warning
 
-    static bool shouldShowWarning = true;
-    if (shouldShowWarning)
+    switch (p.error())
     {
-        shouldShowWarning = false;
+        case QProcess::Timedout: {
+            qCWarning(chatterinoStreamerMode) << "pgrep execution timed out!";
+            if (shouldShowTimeoutWarning)
+            {
+                shouldShowTimeoutWarning = false;
 
-        postToThread([] {
-            getApp()->twitch->addGlobalSystemMessage(
-                "Streamer Mode is set to Automatic, but pgrep is missing. "
-                "Install it to fix the issue or set Streamer Mode to "
-                "Enabled or Disabled in the Settings.");
-        });
+                postToThread([] {
+                    getApp()->twitch->addGlobalSystemMessage(
+                        "Streamer Mode is set to Automatic, but pgrep timed "
+                        "out. This can happen if your system lagged at the "
+                        "wrong moment. If Streamer Mode continues to not work, "
+                        "you can manually set it to Enabled or Disabled in the "
+                        "Settings.");
+                });
+            }
+        }
+        break;
+
+        default: {
+            qCWarning(chatterinoStreamerMode)
+                << "pgrep execution failed:" << p.error();
+
+            if (shouldShowWarning)
+            {
+                shouldShowWarning = false;
+
+                postToThread([] {
+                    getApp()->twitch->addGlobalSystemMessage(
+                        "Streamer Mode is set to Automatic, but pgrep is "
+                        "missing. "
+                        "Install it to fix the issue or set Streamer Mode to "
+                        "Enabled or Disabled in the Settings.");
+                });
+            }
+        }
     }
 
-    qCWarning(chatterinoStreamerMode) << "pgrep execution timed out!";
     return false;
 #elif defined(Q_OS_WIN)
     if (!IsWindowsVistaOrGreater())


### PR DESCRIPTION
We now correctly detect a timeout & show a special error message for it.
I've gone for the approach of possibly posting two streamer-mode messages, instead of sharing a boolean for them.

I've tested this locally on my system in 2 ways
1) Remove pgrep - the original messaging still works
2) Replace pgrep with a script that runs sleep 5 - the new timeout message shows
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
