### PR TITLE
Fixed links having `http://` added to the beginning in certain cases.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Bugfix: Fixed a crash that could occur on Wayland when using the image uploader. (#5314)
 - Bugfix: Fixed split tooltip getting stuck in some cases. (#5309)
 - Bugfix: Fixed the version string not showing up as expected in Finder on macOS. (#5311)
+- Bugfix: Fixed links having `http://` added to the beginning in certain cases. (#5323)
 
 ## 2.5.0-beta.1
 

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -635,7 +635,7 @@ void MessageBuilder::addLink(const ParsedLink &parsedLink)
     auto textColor = MessageColor(MessageColor::Link);
     auto *el = this->emplace<LinkElement>(
         LinkElement::Parsed{.lowercase = lowercaseLinkString,
-                            .original = matchedLink},
+                            .original = origLink},
         MessageElementFlag::Text, textColor);
     el->setLink({Link::Url, matchedLink});
     getIApp()->getLinkResolver()->resolve(el->linkInfo());


### PR DESCRIPTION
Display the original link text (not the one with the protocol)

<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
Fixes #5322. @pajlada please hold release 2.5.0 until the issue is fixed. This is a really simple fix. I don't think I've made mistakes in this?