### PR TITLE
Change order of query parameters of Twitch Player URLs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Minor: Added context menu action to toggle visibility of offline tabs. (#5318)
 - Minor: Report sub duration for more multi-month gift cases. (#5319)
 - Minor: Improved error reporting for the automatic streamer mode detection on Linux and macOS. (#5321)
+- Minor: Remove unnecessary redirect of player.twitch.tv URLs (#5327)
 - Bugfix: Fixed a crash that could occur on Wayland when using the image uploader. (#5314)
 - Bugfix: Fixed split tooltip getting stuck in some cases. (#5309)
 - Bugfix: Fixed the version string not showing up as expected in Finder on macOS. (#5311)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@
 - Minor: Added context menu action to toggle visibility of offline tabs. (#5318)
 - Minor: Report sub duration for more multi-month gift cases. (#5319)
 - Minor: Improved error reporting for the automatic streamer mode detection on Linux and macOS. (#5321)
-- Minor: Remove unnecessary redirect of player.twitch.tv URLs (#5327)
 - Bugfix: Fixed a crash that could occur on Wayland when using the image uploader. (#5314)
 - Bugfix: Fixed split tooltip getting stuck in some cases. (#5309)
 - Bugfix: Fixed the version string not showing up as expected in Finder on macOS. (#5311)
 - Bugfix: Fixed links having `http://` added to the beginning in certain cases. (#5323)
 - Bugfix: Fixed topmost windows from losing their status after opening dialogs on Windows. (#5330)
 - Bugfix: Fixed a gap appearing when using filters on `/watching`. (#5329)
+- Dev: Changed the order of the query parameters for Twitch player URLs. (#5326)
 
 ## 2.5.0-beta.1
 

--- a/src/common/Common.hpp
+++ b/src/common/Common.hpp
@@ -12,7 +12,8 @@
 #define LINK_CHATTERINO_DISCORD "https://discord.gg/7Y5AYhAK4z"
 #define LINK_CHATTERINO_SOURCE "https://github.com/Chatterino/chatterino2"
 
-const QString FSTRING_TWITCH_PLAYER_URL = "https://player.twitch.tv/?channel=%1&parent=twitch.tv";
+const QString FSTRING_TWITCH_PLAYER_URL =
+    "https://player.twitch.tv/?channel=%1&parent=twitch.tv";
 
 namespace chatterino {
 

--- a/src/common/Common.hpp
+++ b/src/common/Common.hpp
@@ -12,6 +12,8 @@
 #define LINK_CHATTERINO_DISCORD "https://discord.gg/7Y5AYhAK4z"
 #define LINK_CHATTERINO_SOURCE "https://github.com/Chatterino/chatterino2"
 
+const QString FSTRING_TWITCH_PLAYER_URL = "https://player.twitch.tv/?channel=%1&parent=twitch.tv";
+
 namespace chatterino {
 
 enum class HighlightState {

--- a/src/common/Common.hpp
+++ b/src/common/Common.hpp
@@ -12,10 +12,10 @@
 #define LINK_CHATTERINO_DISCORD "https://discord.gg/7Y5AYhAK4z"
 #define LINK_CHATTERINO_SOURCE "https://github.com/Chatterino/chatterino2"
 
+namespace chatterino {
+
 const QString FSTRING_TWITCH_PLAYER_URL =
     "https://player.twitch.tv/?channel=%1&parent=twitch.tv";
-
-namespace chatterino {
 
 enum class HighlightState {
     None,

--- a/src/common/Common.hpp
+++ b/src/common/Common.hpp
@@ -14,7 +14,7 @@
 
 namespace chatterino {
 
-const QString FSTRING_TWITCH_PLAYER_URL =
+const QString TWITCH_PLAYER_URL =
     "https://player.twitch.tv/?channel=%1&parent=twitch.tv";
 
 enum class HighlightState {

--- a/src/common/Common.hpp
+++ b/src/common/Common.hpp
@@ -14,8 +14,8 @@
 
 namespace chatterino {
 
-const QString TWITCH_PLAYER_URL =
-    "https://player.twitch.tv/?channel=%1&parent=twitch.tv";
+const inline auto TWITCH_PLAYER_URL =
+    QStringLiteral("https://player.twitch.tv/?channel=%1&parent=twitch.tv");
 
 enum class HighlightState {
     None,

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -84,7 +84,7 @@ TwitchChannel::TwitchChannel(const QString &name)
     , nameOptions{name, name, name}
     , subscriptionUrl_("https://www.twitch.tv/subs/" + name)
     , channelUrl_("https://twitch.tv/" + name)
-    , popoutPlayerUrl_(FSTRING_TWITCH_PLAYER_URL.arg(name))
+    , popoutPlayerUrl_(TWITCH_PLAYER_URL.arg(name))
     , bttvEmotes_(std::make_shared<EmoteMap>())
     , ffzEmotes_(std::make_shared<EmoteMap>())
     , seventvEmotes_(std::make_shared<EmoteMap>())

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -84,8 +84,7 @@ TwitchChannel::TwitchChannel(const QString &name)
     , nameOptions{name, name, name}
     , subscriptionUrl_("https://www.twitch.tv/subs/" + name)
     , channelUrl_("https://twitch.tv/" + name)
-    , popoutPlayerUrl_("https://player.twitch.tv/?parent=twitch.tv&channel=" +
-                       name)
+    , popoutPlayerUrl_(FSTRING_TWITCH_PLAYER_URL.arg(name))
     , bttvEmotes_(std::make_shared<EmoteMap>())
     , ffzEmotes_(std::make_shared<EmoteMap>())
     , seventvEmotes_(std::make_shared<EmoteMap>())

--- a/src/singletons/Toasts.cpp
+++ b/src/singletons/Toasts.cpp
@@ -179,7 +179,7 @@ public:
                 if (platform_ == Platform::Twitch)
                 {
                     QDesktopServices::openUrl(
-                        QUrl(FSTRING_TWITCH_PLAYER_URL.arg(channelName_)));
+                        QUrl(TWITCH_PLAYER_URL.arg(channelName_)));
                 }
                 break;
             case ToastReaction::OpenInStreamlink: {

--- a/src/singletons/Toasts.cpp
+++ b/src/singletons/Toasts.cpp
@@ -179,7 +179,7 @@ public:
                 if (platform_ == Platform::Twitch)
                 {
                     QDesktopServices::openUrl(QUrl(
-                        FSTRING_TWITCH_PLAYER_URL.arg(channelName_));
+                        FSTRING_TWITCH_PLAYER_URL.arg(channelName_)));
                 }
                 break;
             case ToastReaction::OpenInStreamlink: {

--- a/src/singletons/Toasts.cpp
+++ b/src/singletons/Toasts.cpp
@@ -1,6 +1,7 @@
 #include "Toasts.hpp"
 
 #include "Application.hpp"
+#include "common/Common.hpp"
 #include "common/Literals.hpp"
 #include "common/QLogging.hpp"
 #include "common/Version.hpp"
@@ -178,8 +179,7 @@ public:
                 if (platform_ == Platform::Twitch)
                 {
                     QDesktopServices::openUrl(QUrl(
-                        u"https://player.twitch.tv/?parent=twitch.tv&channel=" %
-                        channelName_));
+                        FSTRING_TWITCH_PLAYER_URL.arg(channelName_));
                 }
                 break;
             case ToastReaction::OpenInStreamlink: {

--- a/src/singletons/Toasts.cpp
+++ b/src/singletons/Toasts.cpp
@@ -178,8 +178,8 @@ public:
             case ToastReaction::OpenInPlayer:
                 if (platform_ == Platform::Twitch)
                 {
-                    QDesktopServices::openUrl(QUrl(
-                        FSTRING_TWITCH_PLAYER_URL.arg(channelName_)));
+                    QDesktopServices::openUrl(
+                        QUrl(FSTRING_TWITCH_PLAYER_URL.arg(channelName_)));
                 }
                 break;
             case ToastReaction::OpenInStreamlink: {

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -835,8 +835,8 @@ void Split::openChannelInBrowserPlayer(ChannelPtr channel)
 {
     if (auto *twitchChannel = dynamic_cast<TwitchChannel *>(channel.get()))
     {
-        QDesktopServices::openUrl(QUrl(
-            FSTRING_TWITCH_PLAYER_URL.arg(twitchChannel->getName())));
+        QDesktopServices::openUrl(
+            QUrl(FSTRING_TWITCH_PLAYER_URL.arg(twitchChannel->getName())));
     }
 }
 

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -835,9 +835,8 @@ void Split::openChannelInBrowserPlayer(ChannelPtr channel)
 {
     if (auto *twitchChannel = dynamic_cast<TwitchChannel *>(channel.get()))
     {
-        QDesktopServices::openUrl(
-            "https://player.twitch.tv/?parent=twitch.tv&channel=" +
-            twitchChannel->getName());
+        QDesktopServices::openUrl(QUrl(
+            FSTRING_TWITCH_PLAYER_URL.arg(twitchChannel->getName())));
     }
 }
 

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -836,7 +836,7 @@ void Split::openChannelInBrowserPlayer(ChannelPtr channel)
     if (auto *twitchChannel = dynamic_cast<TwitchChannel *>(channel.get()))
     {
         QDesktopServices::openUrl(
-            QUrl(FSTRING_TWITCH_PLAYER_URL.arg(twitchChannel->getName())));
+            QUrl(TWITCH_PLAYER_URL.arg(twitchChannel->getName())));
     }
 }
 


### PR DESCRIPTION
- This feature removes the unnecessary redirect of `player.twitch.tv` by moving the `channel` and `parent` key around.
- This also makes sure that the URL used in multiple place can be changed in one place.
- Attempts at fixing #5317 
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
