### PR TITLE
fix: set maximum of scrollbar after filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Bugfix: Fixed split tooltip getting stuck in some cases. (#5309)
 - Bugfix: Fixed the version string not showing up as expected in Finder on macOS. (#5311)
 - Bugfix: Fixed links having `http://` added to the beginning in certain cases. (#5323)
+- Bugfix: Fixed a gap appearing when using filters on `/watching`. (#5329)
 
 ## 2.5.0-beta.1
 

--- a/src/messages/LimitedQueue.hpp
+++ b/src/messages/LimitedQueue.hpp
@@ -25,14 +25,6 @@ public:
 private:
     /// Property Accessors
     /**
-     * @brief Return the limit of the internal buffer
-     */
-    [[nodiscard]] size_t limit() const
-    {
-        return this->limit_;
-    }
-
-    /**
      * @brief Return the amount of space left in the buffer
      *
      * This does not lock
@@ -43,6 +35,14 @@ private:
     }
 
 public:
+    /**
+     * @brief Return the limit of the queue
+     */
+    [[nodiscard]] size_t limit() const
+    {
+        return this->limit_;
+    }
+
     /**
      * @brief Return true if the buffer is empty
      */

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -982,8 +982,7 @@ void ChannelView::setChannel(const ChannelPtr &underlyingChannel)
     // and the ui.
     auto snapshot = underlyingChannel->getMessageSnapshot();
 
-    this->scrollBar_->setMaximum(qreal(snapshot.size()));
-
+    size_t nMessagesAdded = 0;
     for (const auto &msg : snapshot)
     {
         if (!this->shouldIncludeMessage(msg))
@@ -1007,11 +1006,15 @@ void ChannelView::setChannel(const ChannelPtr &underlyingChannel)
 
         this->messages_.pushBack(messageLayout);
         this->channel_->addMessage(msg);
+        nMessagesAdded++;
         if (this->showScrollbarHighlights())
         {
             this->scrollBar_->addHighlight(msg->getScrollBarHighlight());
         }
     }
+
+    this->scrollBar_->setMaximum(
+        static_cast<qreal>(std::min(nMessagesAdded, this->messages_.limit())));
 
     //
     // Standard channel connections


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

When adding messages to a ChannelView from an already existing channel and filtering those, the final number of messages will be lower (or equal) than the number of messages actually added. The same can appear if the message snapshot is larger than what `ChannelView::messages_` can hold. If we set the maximum before filtering, it might be higher than the actual amount and most importantly, it might be higher than the capacity of `messages_`, which will cause it to never decrease (and create the observed gap).

I thought it was introduced in #5248, but this doesn't seem to be the case.

Fixes #5327.