### PR TITLE
fix: don't change the topmost value of child windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Bugfix: Fixed split tooltip getting stuck in some cases. (#5309)
 - Bugfix: Fixed the version string not showing up as expected in Finder on macOS. (#5311)
 - Bugfix: Fixed links having `http://` added to the beginning in certain cases. (#5323)
+- Bugfix: Fixed topmost windows from losing their status after opening dialogs on Windows. (#5330)
 
 ## 2.5.0-beta.1
 

--- a/src/widgets/BaseWindow.cpp
+++ b/src/widgets/BaseWindow.cpp
@@ -263,6 +263,13 @@ void BaseWindow::tryApplyTopMost()
     }
     this->waitingForTopMost_ = false;
 
+    if (this->parent())
+    {
+        // Don't change the topmost value of child windows. This would apply
+        // to the top-level window too.
+        return;
+    }
+
     ::SetWindowPos(*hwnd, this->isTopMost_ ? HWND_TOPMOST : HWND_NOTOPMOST, 0,
                    0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
 }


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

Changing the topmost value of a non-top-level window on Windows will cause the top-level window to have its value changed too. This would cause bugs when manually setting the topmost status on a window by right-clicking in the notebook and opening a dialog (e.g. the select-channel dialog), which would try to disable the topmost value (as the setting isn't set).

This should only affect Windows as we don't use Qt there, but might be good to test on other platforms as well.