### PR TITLE
fix: Remove "Show chatter list" entry from split header menu for non-mods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Bugfix: Fixed links having `http://` added to the beginning in certain cases. (#5323)
 - Bugfix: Fixed topmost windows from losing their status after opening dialogs on Windows. (#5330)
 - Bugfix: Fixed a gap appearing when using filters on `/watching`. (#5329)
+- Bugfix: Removed the remnant "Show chatter list" menu entry for non-moderators. (#5336)
 - Dev: Changed the order of the query parameters for Twitch player URLs. (#5326)
 
 ## 2.5.0-beta.1

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -525,9 +525,12 @@ std::unique_ptr<QMenu> SplitHeader::createMainMenu()
 
     if (twitchChannel)
     {
-        moreMenu->addAction(
-            "Show chatter list", this->split_, &Split::showChatterList,
-            h->getDisplaySequence(HotkeyCategory::Split, "openViewerList"));
+        if (twitchChannel->hasModRights())
+        {
+            moreMenu->addAction(
+                "Show chatter list", this->split_, &Split::showChatterList,
+                h->getDisplaySequence(HotkeyCategory::Split, "openViewerList"));
+        }
 
         moreMenu->addAction("Subscribe", this->split_, &Split::openSubPage);
 


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

Fixes #5335
