### PR TITLE
fix: use the full url when resolving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+- Bugfix: Fixed links without a protocol not being clickable. (#5345)
+
 ## 2.5.0
 
 - Major: Twitch follower emotes can now be correctly tabbed in other channels when you are subscribed to the channel the emote is from. (#4922)

--- a/src/common/LinkParser.hpp
+++ b/src/common/LinkParser.hpp
@@ -12,9 +12,28 @@ struct ParsedLink {
 #else
     using StringView = QStringRef;
 #endif
+    /// The parsed protocol of the link. Can be empty.
+    ///
+    /// https://www.forsen.tv/commands
+    /// ^------^
     StringView protocol;
+
+    /// The parsed host of the link. Can not be empty.
+    ///
+    /// https://www.forsen.tv/commands
+    ///         ^-----------^
     StringView host;
+
+    /// The remainder of the link. Can be empty.
+    ///
+    /// https://www.forsen.tv/commands
+    ///                      ^-------^
     StringView rest;
+
+    /// The original unparsed link.
+    ///
+    /// https://www.forsen.tv/commands
+    /// ^----------------------------^
     QString source;
 };
 

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -617,16 +617,16 @@ void MessageBuilder::addLink(const ParsedLink &parsedLink)
 {
     QString lowercaseLinkString;
     QString origLink = parsedLink.source;
-    QString matchedLink;
+    QString fullUrl;
 
     if (parsedLink.protocol.isNull())
     {
-        matchedLink = QStringLiteral("http://") + parsedLink.source;
+        fullUrl = QStringLiteral("http://") + parsedLink.source;
     }
     else
     {
         lowercaseLinkString += parsedLink.protocol;
-        matchedLink = parsedLink.source;
+        fullUrl = parsedLink.source;
     }
 
     lowercaseLinkString += parsedLink.host.toString().toLower();
@@ -636,8 +636,7 @@ void MessageBuilder::addLink(const ParsedLink &parsedLink)
     auto *el = this->emplace<LinkElement>(
         LinkElement::Parsed{.lowercase = lowercaseLinkString,
                             .original = origLink},
-        MessageElementFlag::Text, textColor);
-    el->setLink({Link::Url, matchedLink});
+        fullUrl, MessageElementFlag::Text, textColor);
     getIApp()->getLinkResolver()->resolve(el->linkInfo());
 }
 

--- a/src/messages/MessageElement.cpp
+++ b/src/messages/MessageElement.cpp
@@ -679,10 +679,11 @@ void SingleLineTextElement::addToContainer(MessageLayoutContainer &container,
     }
 }
 
-LinkElement::LinkElement(const Parsed &parsed, MessageElementFlags flags,
-                         const MessageColor &color, FontStyle style)
+LinkElement::LinkElement(const Parsed &parsed, const QString &fullUrl,
+                         MessageElementFlags flags, const MessageColor &color,
+                         FontStyle style)
     : TextElement({}, flags, color, style)
-    , linkInfo_(parsed.original)
+    , linkInfo_(fullUrl)
     , lowercase_({parsed.lowercase})
     , original_({parsed.original})
 {

--- a/src/messages/MessageElement.hpp
+++ b/src/messages/MessageElement.hpp
@@ -272,7 +272,10 @@ public:
         QString original;
     };
 
-    LinkElement(const Parsed &parsed, MessageElementFlags flags,
+    /// @param parsed The link as it appeared in the message
+    /// @param fullUrl A full URL (notably with a protocol)
+    LinkElement(const Parsed &parsed, const QString &fullUrl,
+                MessageElementFlags flags,
                 const MessageColor &color = MessageColor::Text,
                 FontStyle style = FontStyle::ChatMedium);
     ~LinkElement() override = default;

--- a/tests/src/LinkParser.cpp
+++ b/tests/src/LinkParser.cpp
@@ -1,11 +1,8 @@
 #include "common/LinkParser.hpp"
 
 #include <gtest/gtest.h>
-#include <QList>
 #include <QString>
 #include <QStringList>
-
-#include <vector>
 
 using namespace chatterino;
 
@@ -174,82 +171,5 @@ TEST(LinkParser, doesntParseInvalidLinks)
     {
         LinkParser p(input);
         ASSERT_FALSE(p.result().has_value()) << input.toStdString();
-    }
-}
-
-TEST(LinkParser, full)
-{
-    struct TestCase {
-        QString input;
-        std::optional<ParsedLink> expectedResult;
-    };
-
-    std::vector<TestCase> tests{
-        {
-            .input = "https://forsen.tv",
-            .expectedResult =
-                ParsedLink{
-                    .protocol = QStringLiteral(u"https://"),
-                    .host = QStringLiteral(u"forsen.tv"),
-                    .rest = QStringLiteral(u""),
-                    .source = "https://forsen.tv",
-                },
-        },
-        {
-            .input = "forsen.tv",
-            .expectedResult =
-                ParsedLink{
-                    .protocol = QStringLiteral(u""),
-                    .host = QStringLiteral(u"forsen.tv"),
-                    .rest = QStringLiteral(u""),
-                    .source = "forsen.tv",
-                },
-        },
-        {
-            .input = "forsen.tv/",
-            .expectedResult =
-                ParsedLink{
-                    .protocol = QStringLiteral(u""),
-                    .host = QStringLiteral(u"forsen.tv"),
-                    .rest = QStringLiteral(u"/"),
-                    .source = "forsen.tv/",
-                },
-        },
-        {
-            .input = "forsen.tv/commands",
-            .expectedResult =
-                ParsedLink{
-                    .protocol = QStringLiteral(u""),
-                    .host = QStringLiteral(u"forsen.tv"),
-                    .rest = QStringLiteral(u"/commands"),
-                    .source = "forsen.tv/commands",
-                },
-        },
-    };
-
-    for (const auto &[input, expectedResult] : tests)
-    {
-        LinkParser p(input);
-        ASSERT_EQ(p.result().has_value(), expectedResult.has_value())
-            << input.toStdString();
-        if (p.result().has_value())
-        {
-            ASSERT_EQ(p.result()->protocol, expectedResult->protocol)
-                << input.toStdString() << ": "
-                << p.result()->protocol.toString().toStdString()
-                << " != " << expectedResult->protocol.toString().toStdString();
-            ASSERT_EQ(p.result()->host, expectedResult->host)
-                << input.toStdString() << ": "
-                << p.result()->host.toString().toStdString()
-                << " != " << expectedResult->host.toString().toStdString();
-            ASSERT_EQ(p.result()->rest, expectedResult->rest)
-                << input.toStdString() << ": "
-                << p.result()->rest.toString().toStdString()
-                << " != " << expectedResult->rest.toString().toStdString();
-            ASSERT_EQ(p.result()->source, expectedResult->source)
-                << input.toStdString() << ": "
-                << p.result()->source.toStdString()
-                << " != " << expectedResult->source.toStdString();
-        }
     }
 }

--- a/tests/src/LinkParser.cpp
+++ b/tests/src/LinkParser.cpp
@@ -1,8 +1,11 @@
 #include "common/LinkParser.hpp"
 
 #include <gtest/gtest.h>
+#include <QList>
 #include <QString>
 #include <QStringList>
+
+#include <vector>
 
 using namespace chatterino;
 
@@ -171,5 +174,82 @@ TEST(LinkParser, doesntParseInvalidLinks)
     {
         LinkParser p(input);
         ASSERT_FALSE(p.result().has_value()) << input.toStdString();
+    }
+}
+
+TEST(LinkParser, full)
+{
+    struct TestCase {
+        QString input;
+        std::optional<ParsedLink> expectedResult;
+    };
+
+    std::vector<TestCase> tests{
+        {
+            .input = "https://forsen.tv",
+            .expectedResult =
+                ParsedLink{
+                    .protocol = QStringLiteral(u"https://"),
+                    .host = QStringLiteral(u"forsen.tv"),
+                    .rest = QStringLiteral(u""),
+                    .source = "https://forsen.tv",
+                },
+        },
+        {
+            .input = "forsen.tv",
+            .expectedResult =
+                ParsedLink{
+                    .protocol = QStringLiteral(u""),
+                    .host = QStringLiteral(u"forsen.tv"),
+                    .rest = QStringLiteral(u""),
+                    .source = "forsen.tv",
+                },
+        },
+        {
+            .input = "forsen.tv/",
+            .expectedResult =
+                ParsedLink{
+                    .protocol = QStringLiteral(u""),
+                    .host = QStringLiteral(u"forsen.tv"),
+                    .rest = QStringLiteral(u"/"),
+                    .source = "forsen.tv/",
+                },
+        },
+        {
+            .input = "forsen.tv/commands",
+            .expectedResult =
+                ParsedLink{
+                    .protocol = QStringLiteral(u""),
+                    .host = QStringLiteral(u"forsen.tv"),
+                    .rest = QStringLiteral(u"/commands"),
+                    .source = "forsen.tv/commands",
+                },
+        },
+    };
+
+    for (const auto &[input, expectedResult] : tests)
+    {
+        LinkParser p(input);
+        ASSERT_EQ(p.result().has_value(), expectedResult.has_value())
+            << input.toStdString();
+        if (p.result().has_value())
+        {
+            ASSERT_EQ(p.result()->protocol, expectedResult->protocol)
+                << input.toStdString() << ": "
+                << p.result()->protocol.toString().toStdString()
+                << " != " << expectedResult->protocol.toString().toStdString();
+            ASSERT_EQ(p.result()->host, expectedResult->host)
+                << input.toStdString() << ": "
+                << p.result()->host.toString().toStdString()
+                << " != " << expectedResult->host.toString().toStdString();
+            ASSERT_EQ(p.result()->rest, expectedResult->rest)
+                << input.toStdString() << ": "
+                << p.result()->rest.toString().toStdString()
+                << " != " << expectedResult->rest.toString().toStdString();
+            ASSERT_EQ(p.result()->source, expectedResult->source)
+                << input.toStdString() << ": "
+                << p.result()->source.toStdString()
+                << " != " << expectedResult->source.toStdString();
+        }
     }
 }


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

The link passed to the link resolver is the one that ends up in the return value of `getLink()` (if it wasn't resolved in the meantime).

Calling `setLink` on a `LinkElement` doesn't actually do anything, because it provides its own `getLink`.

Fixes #5343.

<sub>voting for a patch release this week</sub>