### PR TITLE
refactor: clean up toStdString usages in tests

### DIFF
--- a/tests/src/Emojis.cpp
+++ b/tests/src/Emojis.cpp
@@ -1,6 +1,7 @@
 #include "providers/emoji/Emojis.hpp"
 
 #include "common/Literals.hpp"
+#include "TestHelpers.hpp"
 
 #include <gtest/gtest.h>
 #include <QDebug>
@@ -53,7 +54,7 @@ TEST(Emojis, ShortcodeParsing)
         }
 
         EXPECT_EQ(output, test.expectedOutput)
-            << "Input " << test.input.toStdString() << " failed";
+            << "Input " << test.input << " failed";
     }
 }
 
@@ -165,8 +166,7 @@ TEST(Emojis, Parse)
         // can't use EXPECT_EQ because EmotePtr can't be printed
         if (output != test.expectedOutput)
         {
-            EXPECT_TRUE(false)
-                << "Input " << test.input.toStdString() << " failed";
+            EXPECT_TRUE(false) << "Input " << test.input << " failed";
         }
     }
 }

--- a/tests/src/LinkParser.cpp
+++ b/tests/src/LinkParser.cpp
@@ -1,5 +1,7 @@
 #include "common/LinkParser.hpp"
 
+#include "TestHelpers.hpp"
+
 #include <gtest/gtest.h>
 #include <QString>
 #include <QStringList>
@@ -15,13 +17,13 @@ struct Case {
     {
         auto input = this->protocol + this->host + this->rest;
         LinkParser p(input);
-        ASSERT_TRUE(p.result().has_value()) << input.toStdString();
+        ASSERT_TRUE(p.result().has_value()) << input;
 
         const auto &r = *p.result();
         ASSERT_EQ(r.source, input);
-        ASSERT_EQ(r.protocol, this->protocol) << this->protocol.toStdString();
-        ASSERT_EQ(r.host, this->host) << this->host.toStdString();
-        ASSERT_EQ(r.rest, this->rest) << this->rest.toStdString();
+        ASSERT_EQ(r.protocol, this->protocol) << this->protocol;
+        ASSERT_EQ(r.host, this->host) << this->host;
+        ASSERT_EQ(r.rest, this->rest) << this->rest;
     }
 };
 
@@ -126,7 +128,7 @@ TEST(LinkParser, doesntParseInvalidIpv4Links)
     for (const auto &input : inputs)
     {
         LinkParser p(input);
-        ASSERT_FALSE(p.result().has_value()) << input.toStdString();
+        ASSERT_FALSE(p.result().has_value()) << input;
     }
 }
 
@@ -170,6 +172,6 @@ TEST(LinkParser, doesntParseInvalidLinks)
     for (const auto &input : inputs)
     {
         LinkParser p(input);
-        ASSERT_FALSE(p.result().has_value()) << input.toStdString();
+        ASSERT_FALSE(p.result().has_value()) << input;
     }
 }

--- a/tests/src/TestHelpers.hpp
+++ b/tests/src/TestHelpers.hpp
@@ -1,6 +1,10 @@
 #pragma once
 
+#include <QString>
+#include <QStringView>
+
 #include <mutex>
+#include <ostream>
 
 template <typename T>
 class ReceivedMessage
@@ -42,3 +46,21 @@ public:
         return &this->t;
     }
 };
+
+inline std::ostream &operator<<(std::ostream &os, const QStringView &str)
+{
+    os << qUtf8Printable(str.toString());
+    return os;
+}
+
+inline std::ostream &operator<<(std::ostream &os, const QByteArray &bytes)
+{
+    os << qUtf8Printable(QString::fromUtf8(bytes));
+    return os;
+}
+
+inline std::ostream &operator<<(std::ostream &os, const QString &str)
+{
+    os << qUtf8Printable(str);
+    return os;
+}

--- a/tests/src/TestHelpers.hpp
+++ b/tests/src/TestHelpers.hpp
@@ -55,7 +55,7 @@ inline std::ostream &operator<<(std::ostream &os, const QStringView &str)
 
 inline std::ostream &operator<<(std::ostream &os, const QByteArray &bytes)
 {
-    os << qUtf8Printable(QString::fromUtf8(bytes));
+    os << bytes.toStdString();
     return os;
 }
 

--- a/tests/src/TwitchMessageBuilder.cpp
+++ b/tests/src/TwitchMessageBuilder.cpp
@@ -15,6 +15,7 @@
 #include "providers/seventv/SeventvBadges.hpp"
 #include "providers/twitch/TwitchBadge.hpp"
 #include "singletons/Emotes.hpp"
+#include "TestHelpers.hpp"
 
 #include <gtest/gtest.h>
 #include <IrcConnection>
@@ -147,7 +148,7 @@ TEST(TwitchMessageBuilder, CommaSeparatedListTagParsing)
         auto output = TwitchMessageBuilder::slashKeyValue(test.input);
 
         EXPECT_EQ(output, test.expectedOutput)
-            << "Input " << test.input.toStdString() << " failed";
+            << "Input " << test.input << " failed";
     }
 }
 
@@ -230,12 +231,12 @@ TEST(TwitchMessageBuilder, BadgeInfoParsing)
         auto outputBadgeInfo =
             TwitchMessageBuilder::parseBadgeInfoTag(privmsg->tags());
         EXPECT_EQ(outputBadgeInfo, test.expectedBadgeInfo)
-            << "Input for badgeInfo " << test.input.toStdString() << " failed";
+            << "Input for badgeInfo " << test.input << " failed";
 
         auto outputBadges =
             SharedMessageBuilder::parseBadgeTag(privmsg->tags());
         EXPECT_EQ(outputBadges, test.expectedBadges)
-            << "Input for badges " << test.input.toStdString() << " failed";
+            << "Input for badges " << test.input << " failed";
 
         delete privmsg;
     }
@@ -413,8 +414,7 @@ TEST_F(TestTwitchMessageBuilder, ParseTwitchEmotes)
             privmsg->tags(), originalMessage, 0);
 
         EXPECT_EQ(actualTwitchEmotes, test.expectedTwitchEmotes)
-            << "Input for twitch emotes " << test.input.toStdString()
-            << " failed";
+            << "Input for twitch emotes " << test.input << " failed";
 
         delete privmsg;
     }
@@ -617,11 +617,11 @@ TEST_F(TestTwitchMessageBuilder, IgnoresReplace)
                                                    emotes);
 
         EXPECT_EQ(message, test.expectedMessage)
-            << "Message not equal for input '" << test.input.toStdString()
-            << "' - expected: '" << test.expectedMessage.toStdString()
-            << "' got: '" << message.toStdString() << "'";
+            << "Message not equal for input '" << test.input
+            << "' - expected: '" << test.expectedMessage << "' got: '"
+            << message << "'";
         EXPECT_EQ(emotes, test.expectedTwitchEmotes)
-            << "Twitch emotes not equal for input '" << test.input.toStdString()
-            << "' and output '" << message.toStdString() << "'";
+            << "Twitch emotes not equal for input '" << test.input
+            << "' and output '" << message << "'";
     }
 }

--- a/tests/src/XDGHelper.cpp
+++ b/tests/src/XDGHelper.cpp
@@ -1,5 +1,7 @@
 #include "util/XDGHelper.hpp"
 
+#include "TestHelpers.hpp"
+
 #include <gtest/gtest.h>
 #include <QDebug>
 
@@ -57,9 +59,8 @@ TEST(XDGHelper, ParseDesktopExecProgram)
         auto output = parseDesktopExecProgram(test.input);
 
         EXPECT_EQ(output, test.expectedOutput)
-            << "Input '" << test.input.toStdString() << "' failed. Expected '"
-            << test.expectedOutput.toStdString() << "' but got '"
-            << output.toStdString() << "'";
+            << "Input '" << test.input << "' failed. Expected '"
+            << test.expectedOutput << "' but got '" << output << "'";
     }
 }
 


### PR DESCRIPTION
- **tests: Add QString/QStringView << operators for std::ostream**
- **tests: clean up toStdString usages**

<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
