### PR TITLE
fix: warning in homebrew workflow

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -26,4 +26,5 @@ jobs:
           echo "Running bump-cask-pr for cask '$C2_CASK_NAME' and version '$C2_TAGGED_VERSION'"
           C2_TAGGED_VERSION_STRIPPED="${C2_TAGGED_VERSION:1}"
           echo "Stripped version: '$C2_TAGGED_VERSION_STRIPPED'"
+          brew developer on
           brew bump-cask-pr --version "$C2_TAGGED_VERSION_STRIPPED" "$C2_CASK_NAME"


### PR DESCRIPTION
```
Warning: bump-cask-pr is a developer command, so Homebrew's
developer mode has been automatically turned on.
To turn developer mode off, run:
  brew developer off
```