### PR TITLE
fix(notebook): align actions and hotkeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unversioned
 
 - Bugfix: Fixed links without a protocol not being clickable. (#5345)
+- Bugfix: Fixed <kbd>Ctrl</kbd>+<kbd>U</kbd> and "Toggle visibility of tabs" not having the same effect. (#5353)
 
 ## 2.5.0
 

--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -52,8 +52,8 @@ Notebook::Notebook(QWidget *parent)
                      [this](bool value) {
                          this->setLockNotebookLayout(value);
                      });
-    this->showTabsAction_ = new QAction("Toggle visibility of tabs");
-    QObject::connect(this->showTabsAction_, &QAction::triggered, [this]() {
+    this->toggleTabsAction_ = new QAction("Toggle visibility of tabs");
+    QObject::connect(this->toggleTabsAction_, &QAction::triggered, [this]() {
         this->setShowTabs(!this->getShowTabs());
     });
     this->updateTabVisibilityMenuAction();
@@ -597,6 +597,11 @@ void Notebook::refresh()
     this->updateTabVisibility();
 }
 
+QAction *Notebook::toggleTabsAction()
+{
+    return this->toggleTabsAction_;
+}
+
 void Notebook::updateTabVisibility()
 {
     for (auto &item : this->items_)
@@ -631,7 +636,7 @@ void Notebook::updateTabVisibilityMenuAction()
                 HotkeyCategory::Window, "setTabVisibility", {{"on"}});
         }
     }
-    this->showTabsAction_->setShortcut(toggleSeq);
+    this->toggleTabsAction_->setShortcut(toggleSeq);
 }
 
 bool Notebook::getShowAddButton() const
@@ -1204,7 +1209,7 @@ void Notebook::setLockNotebookLayout(bool value)
 
 void Notebook::addNotebookActionsToMenu(QMenu *menu)
 {
-    menu->addAction(this->showTabsAction_);
+    menu->addAction(this->toggleTabsAction_);
 
     menu->addAction(this->lockNotebookLayoutAction_);
 
@@ -1395,6 +1400,11 @@ void SplitNotebook::toggleOfflineTabs()
                 ? NotebookTabVisibility::AllTabs
                 : NotebookTabVisibility::LiveOnly);
     }
+}
+
+QAction *SplitNotebook::toggleOfflineTabsAction()
+{
+    return this->toggleOfflineTabsAction_;
 }
 
 void SplitNotebook::addNotebookActionsToMenu(QMenu *menu)

--- a/src/widgets/Notebook.hpp
+++ b/src/widgets/Notebook.hpp
@@ -123,6 +123,8 @@ public:
     // Update layout and tab visibility
     void refresh();
 
+    QAction *toggleTabsAction();
+
 protected:
     void scaleChangedEvent(float scale_) override;
     void resizeEvent(QResizeEvent *) override;
@@ -195,7 +197,7 @@ private:
     bool lockNotebookLayout_ = false;
     NotebookTabLocation tabLocation_ = NotebookTabLocation::Top;
     QAction *lockNotebookLayoutAction_;
-    QAction *showTabsAction_;
+    QAction *toggleTabsAction_;
     QAction *toggleTopMostAction_;
 
     // This filter, if set, is used to figure out the visibility of
@@ -217,6 +219,8 @@ public:
 
     void addNotebookActionsToMenu(QMenu *menu) override;
     void toggleOfflineTabs();
+
+    QAction *toggleOfflineTabsAction();
 
 protected:
     void showEvent(QShowEvent *event) override;

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -647,11 +647,13 @@ void Window::addShortcuts()
              }
              else if (arg == "liveOnly")
              {
-                 this->notebook_->toggleOfflineTabsAction()->trigger();
+                 this->notebook_->setShowTabs(true);
+                 getSettings()->tabVisibility.setValue(
+                     NotebookTabVisibility::LiveOnly);
              }
              else if (arg == "toggleLiveOnly")
              {
-                 this->notebook_->toggleOfflineTabs();
+                 this->notebook_->toggleOfflineTabsAction()->trigger();
              }
              else
              {

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -636,26 +636,18 @@ void Window::addShortcuts()
              if (arg == "off")
              {
                  this->notebook_->setShowTabs(false);
-                 getSettings()->tabVisibility.setValue(
-                     NotebookTabVisibility::AllTabs);
              }
              else if (arg == "on")
              {
                  this->notebook_->setShowTabs(true);
-                 getSettings()->tabVisibility.setValue(
-                     NotebookTabVisibility::AllTabs);
              }
              else if (arg == "toggle")
              {
-                 this->notebook_->setShowTabs(!this->notebook_->getShowTabs());
-                 getSettings()->tabVisibility.setValue(
-                     NotebookTabVisibility::AllTabs);
+                 this->notebook_->toggleTabsAction()->trigger();
              }
              else if (arg == "liveOnly")
              {
-                 this->notebook_->setShowTabs(true);
-                 getSettings()->tabVisibility.setValue(
-                     NotebookTabVisibility::LiveOnly);
+                 this->notebook_->toggleOfflineTabsAction()->trigger();
              }
              else if (arg == "toggleLiveOnly")
              {


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

Aligns <kbd>Ctrl</kbd>+<kbd>U</kbd> and "Toggle visibility of tabs" to do the same. The hotkey will now trigger the same `QAction`. I've done the same for <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>L</kbd> and removed the visibility filter reset when the hotkey is activated with `on` or `off`.

Fixes #5341.