### PR TITLE
ci: pin to macos-13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,7 +112,7 @@ jobs:
       matrix:
         include:
           # macOS
-          - os: macos-latest
+          - os: macos-13
             qt-version: 5.15.2
             force-lto: false
             plugins: false


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

`macos-latest` now points to `macos-14` which uses ARM, but there are no ARM binaries for Qt 5.