### PR TITLE
ci: add workflow for WinGet

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,14 @@
+name: Publish to WinGet
+on:
+  release:
+    types: [released]
+jobs:
+  publish:
+    runs-on: windows-latest
+    if: ${{ startsWith(github.event.release.tag_name, 'v') }}
+    steps:
+      - uses: vedantmgoyal2009/winget-releaser@v2
+        with:
+          identifier: ChatterinoTeam.Chatterino
+          installers-regex: ^Chatterino.Installer.exe$
+          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

This PR adds a workflow to publish to WinGet once a release is made. It's similar to the homebrew action in that it needs a PAT for creating a PR. `WINGET_TOKEN` can probably use the same token as `HOMEBREW_GITHUB_API_TOKEN`. Current WinGet package: https://github.com/microsoft/winget-pkgs/tree/73fb073bca4622d59c445e0799e9a218ae7a3bca/manifests/c/ChatterinoTeam/Chatterino/2.4.6

The action uses https://github.com/russellbanks/Komac under the hood. Invoking it with `komac update -i ChatterinoTeam.Chatterino -v 2.5.0 --urls https://github.com/Chatterino/chatterino2/releases/download/v2.5.0/Chatterino.Installer.exe -o .` generates the following files:

**manifests/c/ChatterinoTeam/Chatterino/2.5.0/ChatterinoTeam.Chatterino.installer.yaml**

```yml
# Created with komac v2.2.1
# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json

PackageIdentifier: ChatterinoTeam.Chatterino
PackageVersion: 2.5.0
InstallerLocale: en-US
InstallerType: inno
InstallerSwitches:
  Silent: /VERYSILENT
  SilentWithProgress: /SILENT
UpgradeBehavior: install
ProductCode: '{F5FE6614-04D4-4D32-8600-0ABA0AC113A4}_is1'
ReleaseDate: 2024-04-21
Installers:
- Architecture: x64
  Scope: user
  InstallerUrl: https://github.com/Chatterino/chatterino2/releases/download/v2.5.0/Chatterino.Installer.exe
  InstallerSha256: 1C792BF7CDB3F6AD37059CBD65A0E4AC4AC181D56C30490D01E2075E66879872
  InstallerSwitches:
    Custom: /CURRENTUSER
- Architecture: x64
  Scope: machine
  InstallerUrl: https://github.com/Chatterino/chatterino2/releases/download/v2.5.0/Chatterino.Installer.exe
  InstallerSha256: 1C792BF7CDB3F6AD37059CBD65A0E4AC4AC181D56C30490D01E2075E66879872
  InstallerSwitches:
    Custom: /ALLUSERS
ManifestType: installer
ManifestVersion: 1.6.0
```

**manifests/c/ChatterinoTeam/Chatterino/2.5.0/ChatterinoTeam.Chatterino.locale.en-US.yaml**

```yml
# Created with komac v2.2.1
# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json

PackageIdentifier: ChatterinoTeam.Chatterino
PackageVersion: 2.5.0
PackageLocale: en-US
Publisher: Chatterino Team
PublisherUrl: https://chatterino.com/
PublisherSupportUrl: https://github.com/Chatterino/chatterino2/issues
Author: fourtf, pajlada, and contributors
PackageName: Chatterino
License: MIT
LicenseUrl: https://github.com/Chatterino/chatterino2/blob/HEAD/LICENSE
ShortDescription: Chat client for https://twitch.tv
Moniker: chatterino
Tags:
- twitch
ReleaseNotes: |-
  What's Changed
  - Major: Twitch follower emotes can now be correctly tabbed in other channels when you are subscribed to the channel the emote is from. (#4922)
  - Major: Added /automod split to track automod caught messages across all open channels the user moderates. (#4986, #5026)
  - Major: Moderators can now see restricted chat messages and suspicious treatment updates. (#5056, #5060)
  - Minor: Migrated to the new Get Channel Followers Helix endpoint, fixing follower count not showing up in usercards. (#4809)
  - Minor: Moderation commands such as /ban, /timeout, /unban, and /untimeout can now be used via User IDs by using the id:123 syntax (e.g. /timeout id:22484632 1m stop winning). (#4945, #4956, #4957)
  - Minor: The /usercard command now accepts user ids. (/usercard id:22484632) (#4934)
  - Minor: Added menu actions to reply directly to a message or the original thread root. (#4923)
  - Minor: The /reply command now replies to the latest message from the user. Due to this change, the message you intended to reply to is now shown in the reply context, instead of the first message in a thread. (#4919)
  - Minor: The chatter list button is now hidden if you don't have moderator privileges. (#5245, #5336)
  - Minor: Live streams that are marked as reruns now mark a tab as yellow instead of red. (#5176, #5237)
  - Minor: Allowed theming of tab live and rerun indicators. (#5188)
  - Minor: The Restart on crash setting works again on Windows. (#5012)
  - Minor: Added an option to use new experimental smarter emote completion. (#4987)
  - Minor: Added support for FrankerFaceZ channel badges. These can be configured at https://www.frankerfacez.com/channel/mine - currently only supports bot badges for your chat bots. (#5119)
  - Minor: Added support to send /announce[color] commands. Colored announcements only appear with the chosen color in Twitch chat. (#5250)
  - Minor: The whisper highlight color can now be configured through the settings. (#5053)
  - Minor: Added an option to always include the broadcaster in user completions. This is enabled by default. (#5193, #5244)
  - Minor: Added a warning message if you have multiple commands with the same trigger. (#4322)
  - Minor: Chatters from message history are now added to autocompletion. (#5116)
  - Minor: Added support for the {input.text} placeholder in the Split -> Run a command hotkey. (#5130)
  - Minor: Added --activate <channel> (or -a) command line option to focus or add a certain Twitch channel on startup. (#5111)
  - Minor: Added the --incognito/--no-incognito options to the /openurl command, allowing you to override the "Open links in incognito/private mode" setting. (#5149, #5197)
  - Minor: Added the ability to change the top-most status of a window regardless of the Always on top setting (right click the notebook). (#5135)
  - Minor: Added the ability to show AutoMod caught messages in mentions. (#5215)
  - Minor: Added the ability to configure the color of highlighted AutoMod caught messages. (#5215)
  - Minor: Updated to Emoji v15.1. Google emojis are now used as the fallback instead of Twitter emojis. (#5182)
  - Minor: Added icons for newer versions of macOS. (#5148)
  - Minor: Added more menu items in macOS menu bar. (#5266)
  - Minor: Improved color selection and display. (#5057)
  - Minor: Added a System theme setting that updates according to the system's color scheme (requires Qt 6.5). (#5118)
  - Minor: Normalized the input padding between light & dark themes. (#5095)
  - Minor: The account switcher is now styled to match your theme. (#4817)
  - Minor: Added a fallback theme field to custom themes that will be used in case the custom theme does not contain a color Chatterino needs. If no fallback theme is specified, we'll pull the color from the included Dark or Light theme. (#5198)
  - Minor: Added a new completion API for experimental plugins feature. (#5000, #5047)
  - Minor: Added a new Channel API for experimental plugins feature. (#5141, #5184, #5187)
  - Minor: Introduce c2.later() function to Lua API. (#5154)
  - Minor: Added --safe-mode command line option that can be used for troubleshooting when Chatterino is misbehaving or is misconfigured. It disables hiding the settings button & prevents plugins from loading. (#4985)
  - Minor: Added wrappers for Lua io library for experimental plugins feature. (#5231)
  - Minor: Added permissions to experimental plugins feature. (#5231)
  - Minor: Added missing periods at various moderator messages and commands. (#5061)
  - Minor: Improved Streamlink documentation in the settings dialog. (#5076)
  - Minor: The installer now checks for the VC Runtime version and shows more info when it's outdated. (#4847)
  - Minor: All sound capabilities can now be disabled by setting your "Sound backend" setting to "Null" and restarting Chatterino. (#4978)
  - Minor: Added an invisible resize handle to the bottom of frameless user info popups and reply thread popups. (#4795)
  - Minor: Updated the flatpakref link included with nightly builds to point to up-to-date flathub-beta builds. (#5008)
  - Minor: Image links now reflect the scale of their image instead of an internal label. (#5201)
  - Minor: IPC files are now stored in the Chatterino directory instead of system directories on Windows. (#5226)
  - Minor: 7TV emotes now have a 4x image rather than a 3x image. (#5209)
  - Minor: Add reward.cost reward.id, reward.title filter variables. (#5275)
  - Minor: Change Lua CompletionRequested handler to use an event table. (#5280)
  - Minor: Changed the layout of the about page. (#5287)
  - Minor: Add duration to multi-month anon sub gift messages. (#5293)
  - Minor: Added context menu action to toggle visibility of offline tabs. (#5318)
  - Minor: Report sub duration for more multi-month gift cases. (#5319)
  - Minor: Improved error reporting for the automatic streamer mode detection on Linux and macOS. (#5321)
  - Bugfix: Fixed a crash that could occur on Wayland when using the image uploader. (#5314)
  - Bugfix: Fixed split tooltip getting stuck in some cases. (#5309)
  - Bugfix: Fixed the version string not showing up as expected in Finder on macOS. (#5311)
  - Bugfix: Fixed links having http:// added to the beginning in certain cases. (#5323)
  - Bugfix: Fixed topmost windows from losing their status after opening dialogs on Windows. (#5330)
  - Bugfix: Fixed a gap appearing when using filters on /watching. (#5329)
  - Bugfix: Fixed an issue where certain emojis did not send to Twitch chat correctly. (#4840)
  - Bugfix: Fixed the /shoutout command not working with usernames starting with @'s (e.g. /shoutout @forsen). (#4800)
  - Bugfix: Fixed capitalized channel names in log inclusion list not being logged. (#4848)
  - Bugfix: Trimmed custom streamlink paths on all platforms making sure you don't accidentally add spaces at the beginning or end of its path. (#4834)
  - Bugfix: Fixed a performance issue when displaying replies to certain messages. (#4807)
  - Bugfix: Fixed an issue where certain parts of the split input wouldn't focus the split when clicked. (#4958)
  - Bugfix: Fixed an issue in the /live split that caused some channels to not get grayed-out when they went offline. (#5172)\
  - Bugfix: User text input within watch streak notices now correctly shows up. (#5029)
  - Bugfix: Fixed selection of tabs after closing a tab when using "Live Tabs Only". (#4770)
  - Bugfix: Fixed input in the reply thread popup losing focus when dragging said window. (#4815)
  - Bugfix: Fixed the Quick Switcher (CTRL+K) sometimes showing up on the wrong window. (#4819)
  - Bugfix: Fixed the font switcher not remembering what font you had previously selected. (#5224)
  - Bugfix: Fixed too much text being copied when copying chat messages. (#4812, #4830, #4839)
  - Bugfix: Fixed issue on Windows preventing the title bar from being dragged in the top left corner. (#4873)
  - Bugfix: Fixed an issue where Streamer Mode did not detect that OBS was running on MacOS. (#5260)
  - Bugfix: Remove ":" from the message the user is replying to if it's a /me message. (#5263)
  - Bugfix: Fixed the "Cancel" button in the settings dialog only working after opening the settings dialog twice. (#5229)
  - Bugfix: Fixed an issue where the setting Only search for emote autocompletion at the start of emote names wouldn't disable if it was enabled when the client started. (#4855)
  - Bugfix: Fixed an empty page being added when showing the out of bounds dialog. (#4849)
  - Bugfix: Fixed an issue preventing searching a redemption by it's title when the redemption contained user text input. (#5117)
  - Bugfix: Fixed an issue where reply context didn't render correctly if an emoji was touching text. (#4875, #4977, #5174)
  - Bugfix: Fixed the input completion popup sometimes disappearing when clicking on it on Windows and macOS. (#4876)
  - Bugfix: Fixed Twitch badges not loading correctly in the badge highlighting setting page. (#5223)
  - Bugfix: Fixed double-click text selection moving its position with each new message. (#4898)
  - Bugfix: Fixed an issue where notifications on Windows would contain no or an old avatar. (#4899)
  - Bugfix: Fixed headers of tables in the settings switching to bold text when selected. (#4913)
  - Bugfix: Fixed tooltips appearing too large and/or away from the cursor. (#4920)
  - Bugfix: Fixed thread popup window missing messages for nested threads. (#4923)
  - Bugfix: Fixed an occasional crash for channel point redemptions with text input. (#4949)
  - Bugfix: Fixed triple-click on message also selecting moderation buttons. (#4961)
  - Bugfix: Fixed badge highlight changes not immediately being reflected. (#5110)
  - Bugfix: Fixed emotes being reloaded when pressing "Cancel" in the settings dialog, causing a slowdown. (#5240)
  - Bugfix: Fixed double-click selection not correctly selecting words that were split onto multiple lines. (#5243)
  - Bugfix: Fixed some emotes not appearing when using Ignores. (#4965, #5126)
  - Bugfix: Fixed a freeze from a bad regex in Ignores. (#4965, #5126)
  - Bugfix: Fixed lookahead/-behind not working in Ignores. (#4965, #5126)
ReleaseNotesUrl: https://github.com/Chatterino/chatterino2/releases/tag/v2.5.0
ManifestType: defaultLocale
ManifestVersion: 1.6.0
```

**manifests/c/ChatterinoTeam/Chatterino/2.5.0/ChatterinoTeam.Chatterino.yaml**

```yml
# Created with komac v2.2.1
# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json

PackageIdentifier: ChatterinoTeam.Chatterino
PackageVersion: 2.5.0
DefaultLocale: en-US
ManifestType: version
ManifestVersion: 1.6.0
```

Closes #5022 