### PR TITLE
fix: Missing includes when building with `USE_PRECOMPILED_HEADERS=OFF`

### DIFF
--- a/src/util/AttachToConsole.cpp
+++ b/src/util/AttachToConsole.cpp
@@ -3,6 +3,7 @@
 #ifdef USEWINSDK
 #    include <Windows.h>
 
+#    include <cstdio>
 #    include <tuple>
 #endif
 

--- a/src/widgets/helper/TitlebarButtons.hpp
+++ b/src/widgets/helper/TitlebarButtons.hpp
@@ -3,6 +3,7 @@
 class QPoint;
 class QWidget;
 
+#include <QObject>
 #include <QtGlobal>
 
 namespace chatterino {


### PR DESCRIPTION
Fixes the following build errors with `-DUSE_PRECOMPILED_HEADERS=OFF` on Windows.

<details>
	<summary>TitlebarButtons.hpp</summary>

```
src\widgets/helper/TitlebarButtons.hpp(13): error C2504: 'QObject': base class undefined
src\widgets\helper\TitlebarButtons.cpp(16): error C2614: 'chatterino::TitleBarButtons': illegal member initialization: 'QObject' is not a base or member
```
</details>

<details>
	<summary>AttachToConsole.cpp</summary>

```
src\util\AttachToConsole.cpp(16): error C2065: 'stdout': undeclared identifier
src\util\AttachToConsole.cpp(16): error C3861: 'freopen_s': identifier not found
src\util\AttachToConsole.cpp(16): error C2678: binary '=': no operator found which takes a left-hand operand of type 'const std::_Ignore' (or there is no acceptable conversion)
C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.39.33519\include\tuple(129): note: could be 'std::_Ignore &std::_Ignore::operator =(std::_Ignore &&)'
src\util\AttachToConsole.cpp(16): note: 'std::_Ignore &std::_Ignore::operator =(std::_Ignore &&)': cannot convert 'this' pointer from 'const std::_Ignore' to 'std::_Ignore &'
src\util\AttachToConsole.cpp(16): note: Conversion loses qualifiers
C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.39.33519\include\tuple(129): note: or       'std::_Ignore &std::_Ignore::operator =(const std::_Ignore &)'
src\util\AttachToConsole.cpp(16): note: 'std::_Ignore &std::_Ignore::operator =(const std::_Ignore &)': cannot convert 'this' pointer from 'const std::_Ignore' to 'std::_Ignore &'
src\util\AttachToConsole.cpp(16): note: Conversion loses qualifiers
C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.39.33519\include\tuple(125): note: or       'const std::_Ignore &std::_Ignore::operator =(const _Ty &) noexcept const'
src\util\AttachToConsole.cpp(16): note: Failed to specialize function template 'const std::_Ignore &std::_Ignore::operator =(const _Ty &) noexcept const'
src\util\AttachToConsole.cpp(16): note: With the following template arguments:
src\util\AttachToConsole.cpp(16): note: '_Ty=unknown-type'
src\util\AttachToConsole.cpp(16): note: while trying to match the argument list '(const std::_Ignore, unknown-type)'
src\util\AttachToConsole.cpp(17): error C2065: 'stderr': undeclared identifier
src\util\AttachToConsole.cpp(17): error C3861: 'freopen_s': identifier not found
src\util\AttachToConsole.cpp(17): error C2678: binary '=': no operator found which takes a left-hand operand of type 'const std::_Ignore' (or there is no acceptable conversion)
C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.39.33519\include\tuple(129): note: could be 'std::_Ignore &std::_Ignore::operator =(std::_Ignore &&)'
src\util\AttachToConsole.cpp(17): note: 'std::_Ignore &std::_Ignore::operator =(std::_Ignore &&)': cannot convert 'this' pointer from 'const std::_Ignore' to 'std::_Ignore &'
src\util\AttachToConsole.cpp(17): note: Conversion loses qualifiers
C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.39.33519\include\tuple(129): note: or       'std::_Ignore &std::_Ignore::operator =(const std::_Ignore &)'
src\util\AttachToConsole.cpp(17): note: 'std::_Ignore &std::_Ignore::operator =(const std::_Ignore &)': cannot convert 'this' pointer from 'const std::_Ignore' to 'std::_Ignore &'
src\util\AttachToConsole.cpp(17): note: Conversion loses qualifiers
C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.39.33519\include\tuple(125): note: or       'const std::_Ignore &std::_Ignore::operator =(const _Ty &) noexcept const'
src\util\AttachToConsole.cpp(17): note: Failed to specialize function template 'const std::_Ignore &std::_Ignore::operator =(const _Ty &) noexcept const'
src\util\AttachToConsole.cpp(17): note: With the following template arguments:
src\util\AttachToConsole.cpp(17): note: '_Ty=unknown-type'
src\util\AttachToConsole.cpp(17): note: while trying to match the argument list '(const std::_Ignore, unknown-type)'
```
</details>