### PR TITLE
fix: don't use DPI aware functions on Qt 5 (Windows 7/8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unversioned
 
 - Major: Release plugins alpha. (#5288)
-- Major: Improve high-DPI support on Windows. (#4868)
+- Major: Improve high-DPI support on Windows. (#4868, #5391)
 - Minor: Add option to customise Moderation buttons with images. (#5369)
 - Minor: Colored usernames now update on the fly when changing the "Color @usernames" setting. (#5300)
 - Bugfix: If a network request errors with 200 OK, Qt's error code is now reported instead of the HTTP status. (#5378)

--- a/src/widgets/BaseWindow.cpp
+++ b/src/widgets/BaseWindow.cpp
@@ -121,12 +121,19 @@ RECT windowBordersFor(HWND hwnd, bool isMaximized)
     auto addBorders = isMaximized || isWindows11OrGreater();
     if (addBorders)
     {
+        // GetDpiForWindow and GetSystemMetricsForDpi are only supported on
+        // Windows 10 and later. Qt 6 requires Windows 10.
+#    if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
         auto dpi = GetDpiForWindow(hwnd);
+#    endif
+
         auto systemMetric = [&](auto index) {
+#    if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
             if (dpi != 0)
             {
                 return GetSystemMetricsForDpi(index, dpi);
             }
+#    endif
             return GetSystemMetrics(index);
         };
 


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

https://github.com/Chatterino/chatterino2/pull/4868 added DPI aware functions that only work on Windows 10. When compiling with Qt 5 on Windows, it is now assumed the application will run on older systems. Maybe there should be a warning when running with Qt 5 on Windows 10 to use Qt 6.

Fixes #5390.

---

To make this work on Qt 5 and Windows 10, I'd need to load `user32.dll` and find the export (if it's there). I don't think that's worth the effort.