### PR TITLE
revert: use max(minimum, min(bottom, value)) over clamp(..)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Dev: Use Qt's high DPI scaling. (#4868)
 - Dev: Add doxygen build target. (#5377)
 - Dev: Make printing of strings in tests easier. (#5379)
-- Dev: Refactor and document `Scrollbar`. (#5334)
+- Dev: Refactor and document `Scrollbar`. (#5334, #5393)
 
 ## 2.5.1
 

--- a/src/widgets/Scrollbar.cpp
+++ b/src/widgets/Scrollbar.cpp
@@ -153,7 +153,9 @@ void Scrollbar::setPageSize(qreal value)
 
 void Scrollbar::setDesiredValue(qreal value, bool animated)
 {
-    value = std::clamp(value, this->minimum_, this->getBottom());
+    // this can't use std::clamp, because minimum_ < getBottom() isn't always
+    // true, which is a precondition for std::clamp
+    value = std::max(this->minimum_, std::min(this->getBottom(), value));
     if (areClose(this->currentValue_, value))
     {
         // value has not changed


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

From https://github.com/Chatterino/chatterino2/pull/5334 - minimum might be larger than getBottom() (in that case no scrollbar is shown). `std::clamp` requires the minimum to be smaller than the maximum.