### PR TITLE
Added `flags.action` filter variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Major: Improve high-DPI support on Windows. (#4868, #5391)
 - Minor: Add option to customise Moderation buttons with images. (#5369)
 - Minor: Colored usernames now update on the fly when changing the "Color @usernames" setting. (#5300)
-- Minor: Added `flags.action` filter variable. (#5397)
+- Minor: Added `flags.action` filter variable, allowing you to filter on `/me` messages. (#5397)
 - Bugfix: If a network request errors with 200 OK, Qt's error code is now reported instead of the HTTP status. (#5378)
 - Dev: Use Qt's high DPI scaling. (#4868)
 - Dev: Add doxygen build target. (#5377)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Major: Improve high-DPI support on Windows. (#4868, #5391)
 - Minor: Add option to customise Moderation buttons with images. (#5369)
 - Minor: Colored usernames now update on the fly when changing the "Color @usernames" setting. (#5300)
+- Minor Added `flags.action` filter variable. (#5397)
 - Bugfix: If a network request errors with 200 OK, Qt's error code is now reported instead of the HTTP status. (#5378)
 - Dev: Use Qt's high DPI scaling. (#4868)
 - Dev: Add doxygen build target. (#5377)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Major: Improve high-DPI support on Windows. (#4868, #5391)
 - Minor: Add option to customise Moderation buttons with images. (#5369)
 - Minor: Colored usernames now update on the fly when changing the "Color @usernames" setting. (#5300)
-- Minor Added `flags.action` filter variable. (#5397)
+- Minor: Added `flags.action` filter variable. (#5397)
 - Bugfix: If a network request errors with 200 OK, Qt's error code is now reported instead of the HTTP status. (#5378)
 - Dev: Use Qt's high DPI scaling. (#4868)
 - Dev: Add doxygen build target. (#5377)

--- a/src/controllers/filters/lang/Filter.cpp
+++ b/src/controllers/filters/lang/Filter.cpp
@@ -93,6 +93,7 @@ ContextMap buildContextMap(const MessagePtr &m, chatterino::Channel *channel)
         {"channel.name", m->channelName},
         {"channel.watching", watching},
 
+        {"flags.action", m->flags.has(MessageFlag::Action)},
         {"flags.highlighted", m->flags.has(MessageFlag::Highlighted)},
         {"flags.points_redeemed", m->flags.has(MessageFlag::RedeemedHighlight)},
         {"flags.sub_message", m->flags.has(MessageFlag::Subscription)},

--- a/src/controllers/filters/lang/Filter.hpp
+++ b/src/controllers/filters/lang/Filter.hpp
@@ -32,6 +32,7 @@ static const QMap<QString, Type> MESSAGE_TYPING_CONTEXT = {
     {"channel.name", Type::String},
     {"channel.watching", Type::Bool},
     {"channel.live", Type::Bool},
+    {"flags.action", Type::Bool},
     {"flags.highlighted", Type::Bool},
     {"flags.points_redeemed", Type::Bool},
     {"flags.sub_message", Type::Bool},

--- a/src/controllers/filters/lang/Tokenizer.hpp
+++ b/src/controllers/filters/lang/Tokenizer.hpp
@@ -18,6 +18,7 @@ static const QMap<QString, QString> validIdentifiersMap = {
     {"channel.name", "channel name"},
     {"channel.watching", "/watching channel?"},
     {"channel.live", "channel live?"},
+    {"flags.action", "action/me message?"},
     {"flags.highlighted", "highlighted?"},
     {"flags.points_redeemed", "redeemed points?"},
     {"flags.sub_message", "sub/resub message?"},


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
It's a filter for `/me` messages. Just the thing I was looking for to do at 03:00.