### PR TITLE
fix: don't attempt to scale windows opted out of scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Minor: Add option to customise Moderation buttons with images. (#5369)
 - Minor: Colored usernames now update on the fly when changing the "Color @usernames" setting. (#5300)
 - Bugfix: If a network request errors with 200 OK, Qt's error code is now reported instead of the HTTP status. (#5378)
-- Dev: Use Qt's high DPI scaling. (#4868)
+- Dev: Use Qt's high DPI scaling. (#4868, #5400)
 - Dev: Add doxygen build target. (#5377)
 - Dev: Make printing of strings in tests easier. (#5379)
 - Dev: Refactor and document `Scrollbar`. (#5334, #5393)

--- a/src/widgets/BaseWindow.cpp
+++ b/src/widgets/BaseWindow.cpp
@@ -943,9 +943,10 @@ void BaseWindow::applyScaleRecursive(QObject *root, float scale)
         if (base)
         {
             auto *window = dynamic_cast<BaseWindow *>(obj);
-            if (window && window->flags_.has(DisableCustomScaling))
+            if (window)
             {
-                continue;  // stop here
+                // stop here, the window will get the event as well (via uiScale)
+                continue;
             }
             base->setScale(scale);
         }

--- a/src/widgets/BaseWindow.cpp
+++ b/src/widgets/BaseWindow.cpp
@@ -931,9 +931,26 @@ void BaseWindow::updateScale()
 
     this->setScale(scale);
 
-    for (auto *child : this->findChildren<BaseWidget *>())
+    BaseWindow::applyScaleRecursive(this, scale);
+}
+
+// NOLINTNEXTLINE(misc-no-recursion)
+void BaseWindow::applyScaleRecursive(QObject *root, float scale)
+{
+    for (QObject *obj : root->children())
     {
-        child->setScale(scale);
+        auto *base = dynamic_cast<BaseWidget *>(obj);
+        if (base)
+        {
+            auto *window = dynamic_cast<BaseWindow *>(obj);
+            if (window && window->flags_.has(DisableCustomScaling))
+            {
+                continue;  // stop here
+            }
+            base->setScale(scale);
+        }
+
+        applyScaleRecursive(obj, scale);
     }
 }
 

--- a/src/widgets/BaseWindow.hpp
+++ b/src/widgets/BaseWindow.hpp
@@ -131,6 +131,8 @@ private:
     void drawCustomWindowFrame(QPainter &painter);
     void onFocusLost();
 
+    static void applyScaleRecursive(QObject *root, float scale);
+
     bool handleSHOWWINDOW(MSG *msg);
     bool handleSIZE(MSG *msg);
     bool handleMOVE(MSG *msg);

--- a/src/widgets/dialogs/SettingsDialog.cpp
+++ b/src/widgets/dialogs/SettingsDialog.cpp
@@ -196,7 +196,7 @@ void SettingsDialog::filterElements(const QString &text)
         auto *item = this->ui_.tabContainer->itemAt(i);
         if (auto *x = dynamic_cast<QSpacerItem *>(item); x)
         {
-            x->changeSize(10, shouldShowSpace ? int(16 * this->scale()) : 0);
+            x->changeSize(10, shouldShowSpace ? 16 : 0);
             shouldShowSpace = false;
         }
         else if (item->widget())


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

I wanted to get rid of the duplicate scaling we do, but I noticed that the settings dialog still receives scaling events even though it opted out of custom scaling. This is because of our widget-tree, where the settings window is a descendant of the main window, causing `setScale` to be called on it (~> and its children). That's not desired.

So instead of using Qt's `findChildren`, we're now using a custom recursive loop over all children. Its general structure is [similar to Qt's](https://github.com/qt/qtbase/blob/8d5e7d50d8dbf1ad79bd8ff9f6ef6028eba481c9/src/corelib/kernel/qobject.cpp#L2137-L2148), except that we don't keep a list. This might bite us if any objects are added/removed while iterating (in that case we can dump them into a vector first). If any `BaseWindow` is encountered that has custom scaling disabled, we won't go into it (that's the main fix).

I also found a misleading call to `scale` in the settings dialog I missed in #4868 (the scale is always 1).