### PR TITLE
fix: check state when completing commmands

### DIFF
--- a/src/controllers/plugins/PluginController.cpp
+++ b/src/controllers/plugins/PluginController.cpp
@@ -420,7 +420,7 @@ std::pair<bool, QStringList> PluginController::updateCustomCompletions(
 
     for (const auto &[name, pl] : this->plugins())
     {
-        if (!pl->error().isNull())
+        if (!pl->error().isNull() || pl->state_ == nullptr)
         {
             continue;
         }


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

A plugin with invalid metadata (e.g. a plugin for testing #5383 loaded in a regular version) will cause a segfault when completing commands, because its state is `nullptr`. This adds a check for the state. There should probably a method like `isLoaded` or `isEnabled` or `isEnabledAndLoaded` that does these checks in the future, because currently, even disabled plugins will be checked for completions (they don't have any completion callback, so it's fine [for now]).