### PR TITLE
fix: get rid of duplicate scale events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Dev: Add doxygen build target. (#5377)
 - Dev: Make printing of strings in tests easier. (#5379)
 - Dev: Refactor and document `Scrollbar`. (#5334, #5393)
+- Dev: Reduced the amount of scale events. (#5404)
 
 ## 2.5.1
 

--- a/src/widgets/BaseWidget.cpp
+++ b/src/widgets/BaseWidget.cpp
@@ -54,7 +54,11 @@ float BaseWidget::scale() const
 
 void BaseWidget::setScale(float value)
 {
-    // update scale value
+    if (this->scale_ == value)
+    {
+        return;
+    }
+
     this->scale_ = value;
 
     this->scaleChangedEvent(this->scale());

--- a/src/widgets/BaseWindow.cpp
+++ b/src/widgets/BaseWindow.cpp
@@ -227,7 +227,6 @@ BaseWindow::BaseWindow(FlagsEnum<Flags> _flags, QWidget *parent)
         [this]() {
             postToThread([this] {
                 this->updateScale();
-                this->updateScale();
             });
         },
         this->connections_, false);

--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -593,6 +593,12 @@ void Notebook::showTabVisibilityInfoPopup()
 
 void Notebook::refresh()
 {
+    if (this->refreshPaused_)
+    {
+        this->refreshRequested_ = true;
+        return;
+    }
+
     this->performLayout();
     this->updateTabVisibility();
 }
@@ -652,12 +658,19 @@ void Notebook::resizeAddButton()
     this->addButton_->setFixedSize(h, h);
 }
 
-void Notebook::scaleChangedEvent(float)
+void Notebook::scaleChangedEvent(float /*scale*/)
 {
     this->resizeAddButton();
+    this->refreshPaused_ = true;
+    this->refreshRequested_ = false;
     for (auto &i : this->items_)
     {
         i.tab->updateSize();
+    }
+    this->refreshPaused_ = false;
+    if (this->refreshRequested_)
+    {
+        this->refresh();
     }
 }
 

--- a/src/widgets/Notebook.hpp
+++ b/src/widgets/Notebook.hpp
@@ -193,7 +193,12 @@ private:
     bool showAddButton_ = false;
     int lineOffset_ = 20;
     bool lockNotebookLayout_ = false;
+
+    bool refreshPaused_ = false;
+    bool refreshRequested_ = false;
+
     NotebookTabLocation tabLocation_ = NotebookTabLocation::Top;
+
     QAction *lockNotebookLayoutAction_;
     QAction *showTabsAction_;
     QAction *toggleTopMostAction_;

--- a/src/widgets/dialogs/SettingsDialog.cpp
+++ b/src/widgets/dialogs/SettingsDialog.cpp
@@ -397,12 +397,8 @@ void SettingsDialog::refresh()
     }
 }
 
-void SettingsDialog::scaleChangedEvent(float newDpi)
+void SettingsDialog::scaleChangedEvent(float /*newScale*/)
 {
-    assert(newDpi == 1.F &&
-           "Scaling is disabled for the settings dialog - its scale should "
-           "always be 1");
-
     for (SettingsDialogTab *tab : this->tabs_)
     {
         tab->setFixedHeight(30);

--- a/src/widgets/dialogs/SettingsDialog.cpp
+++ b/src/widgets/dialogs/SettingsDialog.cpp
@@ -397,8 +397,12 @@ void SettingsDialog::refresh()
     }
 }
 
-void SettingsDialog::scaleChangedEvent(float /*newScale*/)
+void SettingsDialog::scaleChangedEvent(float newScale)
 {
+    assert(newScale == 1.F &&
+           "Scaling is disabled for the settings dialog - its scale should "
+           "always be 1");
+
     for (SettingsDialogTab *tab : this->tabs_)
     {
         tab->setFixedHeight(30);

--- a/src/widgets/helper/NotebookTab.cpp
+++ b/src/widgets/helper/NotebookTab.cpp
@@ -8,7 +8,6 @@
 #include "singletons/Settings.hpp"
 #include "singletons/Theme.hpp"
 #include "singletons/WindowManager.hpp"
-#include "util/Clamp.hpp"
 #include "util/Helpers.hpp"
 #include "widgets/dialogs/SettingsDialog.hpp"
 #include "widgets/Notebook.hpp"
@@ -24,6 +23,8 @@
 #include <QLineEdit>
 #include <QMimeData>
 #include <QPainter>
+
+#include <algorithm>
 
 namespace chatterino {
 namespace {

--- a/src/widgets/helper/NotebookTab.cpp
+++ b/src/widgets/helper/NotebookTab.cpp
@@ -182,10 +182,15 @@ void NotebookTab::growWidth(int width)
     }
 }
 
-int NotebookTab::normalTabWidth()
+int NotebookTab::normalTabWidth() const
+{
+    return this->normalTabWidthForHeight(this->height());
+}
+
+int NotebookTab::normalTabWidthForHeight(int height) const
 {
     float scale = this->scale();
-    int width;
+    int width = 0;
 
     QFontMetrics metrics =
         getIApp()->getFonts()->getFontMetrics(FontStyle::UiTabs, scale);
@@ -199,13 +204,13 @@ int NotebookTab::normalTabWidth()
         width = (metrics.horizontalAdvance(this->getTitle()) + int(16 * scale));
     }
 
-    if (this->height() > 150 * scale)
+    if (static_cast<float>(height) > 150 * scale)
     {
-        width = this->height();
+        width = height;
     }
     else
     {
-        width = clamp(width, this->height(), int(150 * scale));
+        width = std::clamp(width, height, static_cast<int>(150 * scale));
     }
 
     return width;
@@ -214,8 +219,8 @@ int NotebookTab::normalTabWidth()
 void NotebookTab::updateSize()
 {
     float scale = this->scale();
-    int width = this->normalTabWidth();
-    auto height = int(NOTEBOOK_TAB_HEIGHT * scale);
+    auto height = static_cast<int>(NOTEBOOK_TAB_HEIGHT * scale);
+    int width = this->normalTabWidthForHeight(height);
 
     if (width < this->growWidth_)
     {
@@ -628,13 +633,13 @@ void NotebookTab::paintEvent(QPaintEvent *)
     }
 }
 
-bool NotebookTab::hasXButton()
+bool NotebookTab::hasXButton() const
 {
     return getSettings()->showTabCloseButton &&
            this->notebook_->getAllowUserTabManagement();
 }
 
-bool NotebookTab::shouldDrawXButton()
+bool NotebookTab::shouldDrawXButton() const
 {
     return this->hasXButton() && (this->mouseOver_ || this->selected_);
 }
@@ -820,18 +825,15 @@ void NotebookTab::update()
     Button::update();
 }
 
-QRect NotebookTab::getXRect()
+QRect NotebookTab::getXRect() const
 {
     QRect rect = this->rect();
     float s = this->scale();
     int size = static_cast<int>(16 * s);
 
-    int centerAdjustment =
-        this->tabLocation_ ==
-                (NotebookTabLocation::Top ||
-                 this->tabLocation_ == NotebookTabLocation::Bottom)
-            ? (size / 3)   // slightly off true center
-            : (size / 2);  // true center
+    int centerAdjustment = this->tabLocation_ == NotebookTabLocation::Top
+                               ? (size / 3)   // slightly off true center
+                               : (size / 2);  // true center
 
     QRect xRect(rect.right() - static_cast<int>(20 * s),
                 rect.center().y() - centerAdjustment, size, size);

--- a/src/widgets/helper/NotebookTab.hpp
+++ b/src/widgets/helper/NotebookTab.hpp
@@ -71,7 +71,7 @@ public:
     void hideTabXChanged();
 
     void growWidth(int width);
-    int normalTabWidth();
+    int normalTabWidth() const;
 
 protected:
     void themeChangedEvent() override;
@@ -100,10 +100,12 @@ protected:
 private:
     void showRenameDialog();
 
-    bool hasXButton();
-    bool shouldDrawXButton();
-    QRect getXRect();
+    bool hasXButton() const;
+    bool shouldDrawXButton() const;
+    QRect getXRect() const;
     void titleUpdated();
+
+    int normalTabWidthForHeight(int height) const;
 
     QPropertyAnimation positionChangedAnimation_;
     bool positionChangedAnimationRunning_ = false;

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -271,6 +271,8 @@ SplitHeader::SplitHeader(Split *split)
             }
         });
     }
+
+    this->scaleChangedEvent(this->scale());
 }
 
 void SplitHeader::initializeLayout()


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

Previously, two scale events were emitted to fix #1266. This PR fixes #1266 by introducing `NotebookTab::normalTabWidthForHeight` which computes the width for the height _after_ scaling (in `NotebookTab::updateSize`). This would previously require two invocations (first one to set the height and second one the width). Furthermore, it gets rid of refreshing the notebook too often (~> performing layout for every tab).

As a next step, this PR checks if the scale has changed at all in `BaseWidget::setScale`. This will probably introduce some bugs, but I think it's better to address these individually instead of spamming scale events (like I did for SplitHeader).