### PR TITLE
fix: usercard jumping when loading data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Dev: Add doxygen build target. (#5377)
 - Dev: Make printing of strings in tests easier. (#5379)
 - Dev: Refactor and document `Scrollbar`. (#5334, #5393)
-- Dev: Reduced the amount of scale events. (#5404)
+- Dev: Reduced the amount of scale events. (#5404, #5406)
 
 ## 2.5.1
 

--- a/src/widgets/Label.cpp
+++ b/src/widgets/Label.cpp
@@ -20,6 +20,7 @@ Label::Label(BaseWidget *parent, QString text, FontStyle style)
                                       [this] {
                                           this->updateSize();
                                       });
+    this->updateSize();
 }
 
 const QString &Label::getText() const


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

As anticipated in #5404, there are places expecting `scaleChangedEvent` to be called more often. One such place is `Label` which is used in `UserInfoPopup`. Before, it would jump when follower and subscription data was loaded. This PR fixes that bug. Thank you to @brian6932 for reporting this.