### PR TITLE
Fix CI for install-qt-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,6 +156,15 @@ jobs:
           cache-key-prefix: ${{ runner.os }}-QtCache-${{ matrix.qt-version }}-v2
           version: ${{ matrix.qt-version }}
 
+      - name: Install Qt6
+        if: startsWith(matrix.qt-version, '6.')
+        uses: jurplel/install-qt-action@v4.0.0
+        with:
+          cache: true
+          cache-key-prefix: ${{ runner.os }}-QtCache-${{ matrix.qt-version }}-v2
+          modules: qt5compat qtimageformats
+          version: ${{ matrix.qt-version }}
+
       - name: Install Qt 6.5.3 imageformats
         if: startsWith(matrix.qt-version, '6.')
         uses: jurplel/install-qt-action@v4.0.0
@@ -175,15 +184,6 @@ jobs:
           cd (Get-ChildItem)[0].Name
           cd plugins/imageformats
           echo "PLUGIN_PATH=$(pwd)" | Out-File -Path "$Env:GITHUB_OUTPUT" -Encoding ASCII
-
-      - name: Install Qt6
-        if: startsWith(matrix.qt-version, '6.')
-        uses: jurplel/install-qt-action@v4.0.0
-        with:
-          cache: true
-          cache-key-prefix: ${{ runner.os }}-QtCache-${{ matrix.qt-version }}-v2
-          modules: qt5compat qtimageformats
-          version: ${{ matrix.qt-version }}
 
       # WINDOWS
       - name: Enable Developer Command Prompt (Windows)


### PR DESCRIPTION
I've seen windows-latest, Qt 6.5.0 fail in the Dependabot PR and this change seems to solve it, so I thought I'd do a PR into the PR.

I don't know if there has been a reason for the order of the steps how they were before, tho.

My Test PR: https://github.com/Wissididom/chatterino2/pull/27