### PR TITLE
chore: refactor TwitchIrcServer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Dev: Add doxygen build target. (#5377)
 - Dev: Make printing of strings in tests easier. (#5379)
 - Dev: Refactor and document `Scrollbar`. (#5334, #5393)
+- Dev: Refactor `TwitchIrcServer`, making it abstracted. (#5421)
 - Dev: Reduced the amount of scale events. (#5404, #5406)
 - Dev: Removed unused timegate settings. (#5361)
 - Dev: All Lua globals now show in the `c2` global in the LuaLS metadata. (#5385)

--- a/mocks/include/mocks/EmptyApplication.hpp
+++ b/mocks/include/mocks/EmptyApplication.hpp
@@ -118,6 +118,13 @@ public:
         return nullptr;
     }
 
+    IAbstractIrcServer *getTwitchAbstract() override
+    {
+        assert(false && "EmptyApplication::getTwitchAbstract was called "
+                        "without being initialized");
+        return nullptr;
+    }
+
     PubSub *getTwitchPubSub() override
     {
         assert(false && "getTwitchPubSub was called without being initialized");

--- a/mocks/include/mocks/TwitchIrcServer.hpp
+++ b/mocks/include/mocks/TwitchIrcServer.hpp
@@ -26,6 +26,11 @@ public:
         return this->watchingChannel;
     }
 
+    void setWatchingChannel(ChannelPtr newWatchingChannel) override
+    {
+        this->watchingChannel.reset(newWatchingChannel);
+    }
+
     QString getLastUserThatWhisperedMe() const override
     {
         return this->lastUserThatWhisperedMe;

--- a/mocks/include/mocks/TwitchIrcServer.hpp
+++ b/mocks/include/mocks/TwitchIrcServer.hpp
@@ -16,6 +16,7 @@ public:
               std::shared_ptr<Channel>(new MockChannel("testaccount_420")))
         , watchingChannel(this->watchingChannelInner,
                           Channel::Type::TwitchWatching)
+        , whispersChannel(std::shared_ptr<Channel>(new MockChannel("whispers")))
         , mentionsChannel(std::shared_ptr<Channel>(new MockChannel("forsen3")))
         , liveChannel(std::shared_ptr<Channel>(new MockChannel("forsen")))
         , automodChannel(std::shared_ptr<Channel>(new MockChannel("forsen2")))
@@ -37,6 +38,11 @@ public:
         return this->lastUserThatWhisperedMe;
     }
 
+    ChannelPtr getWhispersChannel() const override
+    {
+        return this->whispersChannel;
+    }
+
     ChannelPtr getMentionsChannel() const override
     {
         return this->mentionsChannel;
@@ -54,6 +60,7 @@ public:
 
     ChannelPtr watchingChannelInner;
     IndirectChannel watchingChannel;
+    ChannelPtr whispersChannel;
     ChannelPtr mentionsChannel;
     ChannelPtr liveChannel;
     ChannelPtr automodChannel;

--- a/mocks/include/mocks/TwitchIrcServer.hpp
+++ b/mocks/include/mocks/TwitchIrcServer.hpp
@@ -16,6 +16,7 @@ public:
               std::shared_ptr<Channel>(new MockChannel("testaccount_420")))
         , watchingChannel(this->watchingChannelInner,
                           Channel::Type::TwitchWatching)
+        , liveChannel(std::shared_ptr<Channel>(new MockChannel("forsen")))
     {
     }
 
@@ -29,8 +30,14 @@ public:
         return this->lastUserThatWhisperedMe;
     }
 
+    ChannelPtr getLiveChannel() const override
+    {
+        return this->liveChannel;
+    }
+
     ChannelPtr watchingChannelInner;
     IndirectChannel watchingChannel;
+    ChannelPtr liveChannel;
     QString lastUserThatWhisperedMe{"forsen"};
 };
 

--- a/mocks/include/mocks/TwitchIrcServer.hpp
+++ b/mocks/include/mocks/TwitchIrcServer.hpp
@@ -17,6 +17,7 @@ public:
         , watchingChannel(this->watchingChannelInner,
                           Channel::Type::TwitchWatching)
         , liveChannel(std::shared_ptr<Channel>(new MockChannel("forsen")))
+        , automodChannel(std::shared_ptr<Channel>(new MockChannel("forsen2")))
     {
     }
 
@@ -35,9 +36,15 @@ public:
         return this->liveChannel;
     }
 
+    ChannelPtr getAutomodChannel() const override
+    {
+        return this->automodChannel;
+    }
+
     ChannelPtr watchingChannelInner;
     IndirectChannel watchingChannel;
     ChannelPtr liveChannel;
+    ChannelPtr automodChannel;
     QString lastUserThatWhisperedMe{"forsen"};
 };
 

--- a/mocks/include/mocks/TwitchIrcServer.hpp
+++ b/mocks/include/mocks/TwitchIrcServer.hpp
@@ -16,6 +16,7 @@ public:
               std::shared_ptr<Channel>(new MockChannel("testaccount_420")))
         , watchingChannel(this->watchingChannelInner,
                           Channel::Type::TwitchWatching)
+        , mentionsChannel(std::shared_ptr<Channel>(new MockChannel("forsen3")))
         , liveChannel(std::shared_ptr<Channel>(new MockChannel("forsen")))
         , automodChannel(std::shared_ptr<Channel>(new MockChannel("forsen2")))
     {
@@ -36,6 +37,11 @@ public:
         return this->lastUserThatWhisperedMe;
     }
 
+    ChannelPtr getMentionsChannel() const override
+    {
+        return this->mentionsChannel;
+    }
+
     ChannelPtr getLiveChannel() const override
     {
         return this->liveChannel;
@@ -48,6 +54,7 @@ public:
 
     ChannelPtr watchingChannelInner;
     IndirectChannel watchingChannel;
+    ChannelPtr mentionsChannel;
     ChannelPtr liveChannel;
     ChannelPtr automodChannel;
     QString lastUserThatWhisperedMe{"forsen"};

--- a/mocks/include/mocks/TwitchIrcServer.hpp
+++ b/mocks/include/mocks/TwitchIrcServer.hpp
@@ -4,7 +4,11 @@
 #include "providers/bttv/BttvEmotes.hpp"
 #include "providers/bttv/BttvLiveUpdates.hpp"
 #include "providers/ffz/FfzEmotes.hpp"
+#include "providers/seventv/eventapi/Client.hpp"
+#include "providers/seventv/eventapi/Dispatch.hpp"
+#include "providers/seventv/eventapi/Message.hpp"
 #include "providers/seventv/SeventvEmotes.hpp"
+#include "providers/seventv/SeventvEventAPI.hpp"
 #include "providers/twitch/TwitchIrcServer.hpp"
 
 namespace chatterino::mock {
@@ -39,6 +43,11 @@ public:
     std::unique_ptr<BttvLiveUpdates> &getBTTVLiveUpdates() override
     {
         return this->bttvLiveUpdates;
+    }
+
+    std::unique_ptr<SeventvEventAPI> &getSeventvEventAPI() override
+    {
+        return this->seventvEventAPI;
     }
 
     const IndirectChannel &getWatchingChannel() const override
@@ -90,6 +99,7 @@ public:
     QString lastUserThatWhisperedMe{"forsen"};
 
     std::unique_ptr<BttvLiveUpdates> bttvLiveUpdates;
+    std::unique_ptr<SeventvEventAPI> seventvEventAPI;
 };
 
 }  // namespace chatterino::mock

--- a/mocks/include/mocks/TwitchIrcServer.hpp
+++ b/mocks/include/mocks/TwitchIrcServer.hpp
@@ -2,6 +2,7 @@
 
 #include "mocks/Channel.hpp"
 #include "providers/bttv/BttvEmotes.hpp"
+#include "providers/bttv/BttvLiveUpdates.hpp"
 #include "providers/ffz/FfzEmotes.hpp"
 #include "providers/seventv/SeventvEmotes.hpp"
 #include "providers/twitch/TwitchIrcServer.hpp"
@@ -33,6 +34,11 @@ public:
         const QString &channelID) override
     {
         return {};
+    }
+
+    std::unique_ptr<BttvLiveUpdates> &getBTTVLiveUpdates() override
+    {
+        return this->bttvLiveUpdates;
     }
 
     const IndirectChannel &getWatchingChannel() const override
@@ -82,6 +88,8 @@ public:
     ChannelPtr liveChannel;
     ChannelPtr automodChannel;
     QString lastUserThatWhisperedMe{"forsen"};
+
+    std::unique_ptr<BttvLiveUpdates> bttvLiveUpdates;
 };
 
 }  // namespace chatterino::mock

--- a/mocks/include/mocks/TwitchIrcServer.hpp
+++ b/mocks/include/mocks/TwitchIrcServer.hpp
@@ -29,6 +29,12 @@ public:
         //
     }
 
+    std::shared_ptr<Channel> getChannelOrEmptyByID(
+        const QString &channelID) override
+    {
+        return {};
+    }
+
     const IndirectChannel &getWatchingChannel() const override
     {
         return this->watchingChannel;

--- a/mocks/include/mocks/TwitchIrcServer.hpp
+++ b/mocks/include/mocks/TwitchIrcServer.hpp
@@ -23,6 +23,12 @@ public:
     {
     }
 
+    void forEachChannelAndSpecialChannels(
+        std::function<void(ChannelPtr)> func) override
+    {
+        //
+    }
+
     const IndirectChannel &getWatchingChannel() const override
     {
         return this->watchingChannel;

--- a/mocks/include/mocks/TwitchIrcServer.hpp
+++ b/mocks/include/mocks/TwitchIrcServer.hpp
@@ -44,6 +44,11 @@ public:
         return this->lastUserThatWhisperedMe;
     }
 
+    void setLastUserThatWhisperedMe(const QString &user) override
+    {
+        this->lastUserThatWhisperedMe = user;
+    }
+
     ChannelPtr getWhispersChannel() const override
     {
         return this->whispersChannel;

--- a/mocks/include/mocks/TwitchIrcServer.hpp
+++ b/mocks/include/mocks/TwitchIrcServer.hpp
@@ -40,6 +40,12 @@ public:
         return {};
     }
 
+    void dropSeventvChannel(const QString &userID,
+                            const QString &emoteSetID) override
+    {
+        //
+    }
+
     std::unique_ptr<BttvLiveUpdates> &getBTTVLiveUpdates() override
     {
         return this->bttvLiveUpdates;

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -877,10 +877,14 @@ void Application::initPubSub()
 
                             if (getSettings()->showAutomodInMentions)
                             {
-                                getApp()->twitch->mentionsChannel->addMessage(
-                                    p.first);
-                                getApp()->twitch->mentionsChannel->addMessage(
-                                    p.second);
+                                getIApp()
+                                    ->getTwitch()
+                                    ->getMentionsChannel()
+                                    ->addMessage(p.first);
+                                getIApp()
+                                    ->getTwitch()
+                                    ->getMentionsChannel()
+                                    ->addMessage(p.second);
                             }
                         });
                     }

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -131,7 +131,7 @@ Application::Application(Settings &_settings, const Paths &paths,
     , commands(&this->emplace<CommandController>())
     , notifications(&this->emplace<NotificationController>())
     , highlights(&this->emplace<HighlightController>())
-    , twitch(&this->emplace<TwitchIrcServer>())
+    , twitch(new TwitchIrcServer)
     , ffzBadges(&this->emplace<FfzBadges>())
     , seventvBadges(&this->emplace<SeventvBadges>())
     , userData(&this->emplace(new UserDataController(paths)))
@@ -170,6 +170,7 @@ void Application::fakeDtor()
     this->bttvEmotes.reset();
     this->ffzEmotes.reset();
     this->seventvEmotes.reset();
+    // this->twitch.reset();
     this->fonts.reset();
 }
 
@@ -483,7 +484,7 @@ ITwitchIrcServer *Application::getTwitch()
 {
     assertInGuiThread();
 
-    return this->twitch;
+    return this->twitch.get();
 }
 
 PubSub *Application::getTwitchPubSub()

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -866,10 +866,14 @@ void Application::initPubSub()
                             chan->addMessage(p.first);
                             chan->addMessage(p.second);
 
-                            getApp()->twitch->automodChannel->addMessage(
-                                p.first);
-                            getApp()->twitch->automodChannel->addMessage(
-                                p.second);
+                            getIApp()
+                                ->getTwitch()
+                                ->getAutomodChannel()
+                                ->addMessage(p.first);
+                            getIApp()
+                                ->getTwitch()
+                                ->getAutomodChannel()
+                                ->addMessage(p.second);
 
                             if (getSettings()->showAutomodInMentions)
                             {

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -1050,7 +1050,9 @@ void Application::initBttvLiveUpdates()
 
 void Application::initSeventvEventAPI()
 {
-    if (!this->twitch->seventvEventAPI)
+    auto &seventvEventAPI = this->twitch->getSeventvEventAPI();
+
+    if (!seventvEventAPI)
     {
         qCDebug(chatterinoSeventvEventAPI)
             << "Skipping initialization as the EventAPI is disabled";
@@ -1059,8 +1061,8 @@ void Application::initSeventvEventAPI()
 
     // We can safely ignore these signal connections since the twitch object will always
     // be destroyed before the Application
-    std::ignore = this->twitch->seventvEventAPI->signals_.emoteAdded.connect(
-        [&](const auto &data) {
+    std::ignore =
+        seventvEventAPI->signals_.emoteAdded.connect([&](const auto &data) {
             postToThread([this, data] {
                 this->twitch->forEachSeventvEmoteSet(
                     data.emoteSetID, [data](TwitchChannel &chan) {
@@ -1068,8 +1070,8 @@ void Application::initSeventvEventAPI()
                     });
             });
         });
-    std::ignore = this->twitch->seventvEventAPI->signals_.emoteUpdated.connect(
-        [&](const auto &data) {
+    std::ignore =
+        seventvEventAPI->signals_.emoteUpdated.connect([&](const auto &data) {
             postToThread([this, data] {
                 this->twitch->forEachSeventvEmoteSet(
                     data.emoteSetID, [data](TwitchChannel &chan) {
@@ -1077,8 +1079,8 @@ void Application::initSeventvEventAPI()
                     });
             });
         });
-    std::ignore = this->twitch->seventvEventAPI->signals_.emoteRemoved.connect(
-        [&](const auto &data) {
+    std::ignore =
+        seventvEventAPI->signals_.emoteRemoved.connect([&](const auto &data) {
             postToThread([this, data] {
                 this->twitch->forEachSeventvEmoteSet(
                     data.emoteSetID, [data](TwitchChannel &chan) {
@@ -1086,15 +1088,15 @@ void Application::initSeventvEventAPI()
                     });
             });
         });
-    std::ignore = this->twitch->seventvEventAPI->signals_.userUpdated.connect(
-        [&](const auto &data) {
+    std::ignore =
+        seventvEventAPI->signals_.userUpdated.connect([&](const auto &data) {
             this->twitch->forEachSeventvUser(data.userID,
                                              [data](TwitchChannel &chan) {
                                                  chan.updateSeventvUser(data);
                                              });
         });
 
-    this->twitch->seventvEventAPI->start();
+    seventvEventAPI->start();
 }
 
 Application *getApp()

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -1001,7 +1001,9 @@ void Application::initPubSub()
 
 void Application::initBttvLiveUpdates()
 {
-    if (!this->twitch->bttvLiveUpdates)
+    auto &bttvLiveUpdates = this->twitch->getBTTVLiveUpdates();
+
+    if (!bttvLiveUpdates)
     {
         qCDebug(chatterinoBttv)
             << "Skipping initialization of Live Updates as it's disabled";
@@ -1010,8 +1012,8 @@ void Application::initBttvLiveUpdates()
 
     // We can safely ignore these signal connections since the twitch object will always
     // be destroyed before the Application
-    std::ignore = this->twitch->bttvLiveUpdates->signals_.emoteAdded.connect(
-        [&](const auto &data) {
+    std::ignore =
+        bttvLiveUpdates->signals_.emoteAdded.connect([&](const auto &data) {
             auto chan = this->twitch->getChannelOrEmptyByID(data.channelID);
 
             postToThread([chan, data] {
@@ -1021,8 +1023,8 @@ void Application::initBttvLiveUpdates()
                 }
             });
         });
-    std::ignore = this->twitch->bttvLiveUpdates->signals_.emoteUpdated.connect(
-        [&](const auto &data) {
+    std::ignore =
+        bttvLiveUpdates->signals_.emoteUpdated.connect([&](const auto &data) {
             auto chan = this->twitch->getChannelOrEmptyByID(data.channelID);
 
             postToThread([chan, data] {
@@ -1032,8 +1034,8 @@ void Application::initBttvLiveUpdates()
                 }
             });
         });
-    std::ignore = this->twitch->bttvLiveUpdates->signals_.emoteRemoved.connect(
-        [&](const auto &data) {
+    std::ignore =
+        bttvLiveUpdates->signals_.emoteRemoved.connect([&](const auto &data) {
             auto chan = this->twitch->getChannelOrEmptyByID(data.channelID);
 
             postToThread([chan, data] {
@@ -1043,7 +1045,7 @@ void Application::initBttvLiveUpdates()
                 }
             });
         });
-    this->twitch->bttvLiveUpdates->start();
+    bttvLiveUpdates->start();
 }
 
 void Application::initSeventvEventAPI()

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -13,6 +13,7 @@
 #include "controllers/sound/ISoundController.hpp"
 #include "providers/bttv/BttvEmotes.hpp"
 #include "providers/ffz/FfzEmotes.hpp"
+#include "providers/irc/AbstractIrcServer.hpp"
 #include "providers/links/LinkResolver.hpp"
 #include "providers/seventv/SeventvAPI.hpp"
 #include "providers/seventv/SeventvEmotes.hpp"
@@ -481,6 +482,13 @@ PluginController *Application::getPlugins()
 #endif
 
 ITwitchIrcServer *Application::getTwitch()
+{
+    assertInGuiThread();
+
+    return this->twitch.get();
+}
+
+IAbstractIrcServer *Application::getTwitchAbstract()
 {
     assertInGuiThread();
 

--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -149,11 +149,7 @@ private:
     CommandController *const commands{};
     NotificationController *const notifications{};
     HighlightController *const highlights{};
-
-public:
     std::unique_ptr<TwitchIrcServer> twitch;
-
-private:
     FfzBadges *const ffzBadges{};
     SeventvBadges *const seventvBadges{};
     UserDataController *const userData{};

--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -149,7 +149,7 @@ private:
     HighlightController *const highlights{};
 
 public:
-    TwitchIrcServer *const twitch{};
+    std::unique_ptr<TwitchIrcServer> twitch;
 
 private:
     FfzBadges *const ffzBadges{};

--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -54,6 +54,7 @@ class FfzEmotes;
 class SeventvEmotes;
 class ILinkResolver;
 class IStreamerMode;
+class IAbstractIrcServer;
 
 class IApplication
 {
@@ -77,6 +78,7 @@ public:
     virtual HighlightController *getHighlights() = 0;
     virtual NotificationController *getNotifications() = 0;
     virtual ITwitchIrcServer *getTwitch() = 0;
+    virtual IAbstractIrcServer *getTwitchAbstract() = 0;
     virtual PubSub *getTwitchPubSub() = 0;
     virtual Logging *getChatLogger() = 0;
     virtual IChatterinoBadges *getChatterinoBadges() = 0;
@@ -191,6 +193,7 @@ public:
     NotificationController *getNotifications() override;
     HighlightController *getHighlights() override;
     ITwitchIrcServer *getTwitch() override;
+    IAbstractIrcServer *getTwitchAbstract() override;
     PubSub *getTwitchPubSub() override;
     Logging *getChatLogger() override;
     FfzBadges *getFfzBadges() override;

--- a/src/controllers/commands/builtin/Misc.cpp
+++ b/src/controllers/commands/builtin/Misc.cpp
@@ -390,9 +390,9 @@ QString popup(const CommandContext &ctx)
     }
 
     // Open channel passed as argument in a popup
-    auto *app = getApp();
-    auto targetChannel = app->twitch->getOrAddChannel(target);
-    app->getWindows()->openInPopup(targetChannel);
+    auto targetChannel =
+        getIApp()->getTwitchAbstract()->getOrAddChannel(target);
+    getIApp()->getWindows()->openInPopup(targetChannel);
 
     return "";
 }

--- a/src/controllers/commands/builtin/Misc.cpp
+++ b/src/controllers/commands/builtin/Misc.cpp
@@ -566,7 +566,7 @@ QString injectFakeMessage(const CommandContext &ctx)
     }
 
     auto ircText = ctx.words.mid(1).join(" ");
-    getApp()->twitch->addFakeMessage(ircText);
+    getIApp()->getTwitchAbstract()->addFakeMessage(ircText);
 
     return "";
 }

--- a/src/controllers/commands/builtin/Misc.cpp
+++ b/src/controllers/commands/builtin/Misc.cpp
@@ -533,7 +533,8 @@ QString sendRawMessage(const CommandContext &ctx)
 
     if (ctx.channel->isTwitchChannel())
     {
-        getApp()->twitch->sendRawMessage(ctx.words.mid(1).join(" "));
+        getIApp()->getTwitchAbstract()->sendRawMessage(
+            ctx.words.mid(1).join(" "));
     }
     else
     {

--- a/src/controllers/commands/builtin/Misc.cpp
+++ b/src/controllers/commands/builtin/Misc.cpp
@@ -667,7 +667,7 @@ QString openUsercard(const CommandContext &ctx)
         stripChannelName(channelName);
 
         ChannelPtr channelTemp =
-            getApp()->twitch->getChannelOrEmpty(channelName);
+            getIApp()->getTwitchAbstract()->getChannelOrEmpty(channelName);
 
         if (channelTemp->isEmpty())
         {

--- a/src/controllers/commands/builtin/twitch/SendWhisper.cpp
+++ b/src/controllers/commands/builtin/twitch/SendWhisper.cpp
@@ -177,7 +177,7 @@ bool appendWhisperMessageWordsLocally(const QStringList &words)
     b->flags.set(MessageFlag::Whisper);
     auto messagexD = b.release();
 
-    app->twitch->whispersChannel->addMessage(messagexD);
+    getIApp()->getTwitch()->getWhispersChannel()->addMessage(messagexD);
 
     auto overrideFlags = std::optional<MessageFlags>(messagexD->flags);
     overrideFlags->set(MessageFlag::DoNotLog);

--- a/src/controllers/commands/builtin/twitch/SendWhisper.cpp
+++ b/src/controllers/commands/builtin/twitch/SendWhisper.cpp
@@ -92,7 +92,7 @@ QString formatWhisperError(HelixWhisperError error, const QString &message)
 
 bool appendWhisperMessageWordsLocally(const QStringList &words)
 {
-    auto *app = getApp();
+    auto *app = getIApp();
 
     MessageBuilder b;
 
@@ -186,7 +186,7 @@ bool appendWhisperMessageWordsLocally(const QStringList &words)
         !(getSettings()->streamerModeSuppressInlineWhispers &&
           getIApp()->getStreamerMode()->isEnabled()))
     {
-        app->twitch->forEachChannel(
+        app->getTwitchAbstract()->forEachChannel(
             [&messagexD, overrideFlags](ChannelPtr _channel) {
                 _channel->addMessage(messagexD, overrideFlags);
             });

--- a/src/controllers/notifications/NotificationController.cpp
+++ b/src/controllers/notifications/NotificationController.cpp
@@ -202,7 +202,7 @@ void NotificationController::checkStream(bool live, QString channelName)
     }
     MessageBuilder builder;
     TwitchMessageBuilder::liveMessage(channelName, &builder);
-    getApp()->twitch->liveChannel->addMessage(builder.release());
+    getIApp()->getTwitch()->getLiveChannel()->addMessage(builder.release());
 
     // Indicate that we have pushed notifications for this stream
     fakeTwitchChannels.push_back(channelName);
@@ -217,7 +217,7 @@ void NotificationController::removeFakeChannel(const QString channelName)
         fakeTwitchChannels.erase(it);
         // "delete" old 'CHANNEL is live' message
         LimitedQueueSnapshot<MessagePtr> snapshot =
-            getApp()->twitch->liveChannel->getMessageSnapshot();
+            getIApp()->getTwitch()->getLiveChannel()->getMessageSnapshot();
         int snapshotLength = snapshot.size();
 
         // MSVC hates this code if the parens are not there

--- a/src/controllers/notifications/NotificationController.cpp
+++ b/src/controllers/notifications/NotificationController.cpp
@@ -124,7 +124,7 @@ void NotificationController::fetchFakeChannels()
     for (std::vector<int>::size_type i = 0;
          i < channelMap[Platform::Twitch].raw().size(); i++)
     {
-        auto chan = getApp()->twitch->getChannelOrEmpty(
+        auto chan = getIApp()->getTwitchAbstract()->getChannelOrEmpty(
             channelMap[Platform::Twitch].raw()[i]);
         if (chan->isEmpty())
         {

--- a/src/controllers/plugins/api/ChannelRef.cpp
+++ b/src/controllers/plugins/api/ChannelRef.cpp
@@ -300,7 +300,7 @@ int ChannelRef::get_by_name(lua_State *L)
         lua_pushnil(L);
         return 1;
     }
-    auto chn = getApp()->twitch->getChannelOrEmpty(name);
+    auto chn = getIApp()->getTwitchAbstract()->getChannelOrEmpty(name);
     lua::push(L, chn);
     return 1;
 }

--- a/src/controllers/plugins/api/ChannelRef.cpp
+++ b/src/controllers/plugins/api/ChannelRef.cpp
@@ -324,7 +324,7 @@ int ChannelRef::get_by_twitch_id(lua_State *L)
         lua_pushnil(L);
         return 1;
     }
-    auto chn = getApp()->twitch->getChannelOrEmptyByID(id);
+    auto chn = getIApp()->getTwitch()->getChannelOrEmptyByID(id);
 
     lua::push(L, chn);
     return 1;

--- a/src/providers/irc/AbstractIrcServer.hpp
+++ b/src/providers/irc/AbstractIrcServer.hpp
@@ -20,6 +20,8 @@ class RatelimitBucket;
 class IAbstractIrcServer
 {
 public:
+    virtual void connect() = 0;
+
     virtual void sendRawMessage(const QString &rawMessage) = 0;
 
     virtual ChannelPtr getOrAddChannel(const QString &dirtyChannelName) = 0;
@@ -48,7 +50,7 @@ public:
     void initializeIrc();
 
     // connection
-    void connect();
+    void connect() final;
     void disconnect();
 
     void sendMessage(const QString &channelName, const QString &message);

--- a/src/providers/irc/AbstractIrcServer.hpp
+++ b/src/providers/irc/AbstractIrcServer.hpp
@@ -22,6 +22,8 @@ class IAbstractIrcServer
 public:
     virtual ChannelPtr getOrAddChannel(const QString &dirtyChannelName) = 0;
     virtual ChannelPtr getChannelOrEmpty(const QString &dirtyChannelName) = 0;
+
+    virtual void addFakeMessage(const QString &data) = 0;
 };
 
 class AbstractIrcServer : public IAbstractIrcServer, public QObject
@@ -55,7 +57,7 @@ public:
     pajlada::Signals::NoArgSignal connected;
     pajlada::Signals::NoArgSignal disconnected;
 
-    void addFakeMessage(const QString &data);
+    void addFakeMessage(const QString &data) final;
 
     void addGlobalSystemMessage(const QString &messageText);
 

--- a/src/providers/irc/AbstractIrcServer.hpp
+++ b/src/providers/irc/AbstractIrcServer.hpp
@@ -28,6 +28,8 @@ public:
     virtual void addFakeMessage(const QString &data) = 0;
 
     virtual void addGlobalSystemMessage(const QString &messageText) = 0;
+
+    virtual void forEachChannel(std::function<void(ChannelPtr)> func) = 0;
 };
 
 class AbstractIrcServer : public IAbstractIrcServer, public QObject
@@ -66,7 +68,7 @@ public:
     void addGlobalSystemMessage(const QString &messageText) final;
 
     // iteration
-    void forEachChannel(std::function<void(ChannelPtr)> func);
+    void forEachChannel(std::function<void(ChannelPtr)> func) final;
 
 protected:
     AbstractIrcServer();

--- a/src/providers/irc/AbstractIrcServer.hpp
+++ b/src/providers/irc/AbstractIrcServer.hpp
@@ -19,6 +19,8 @@ class RatelimitBucket;
 
 class IAbstractIrcServer
 {
+public:
+    virtual ChannelPtr getOrAddChannel(const QString &dirtyChannelName) = 0;
 };
 
 class AbstractIrcServer : public IAbstractIrcServer, public QObject
@@ -44,7 +46,7 @@ public:
     virtual void sendRawMessage(const QString &rawMessage);
 
     // channels
-    ChannelPtr getOrAddChannel(const QString &dirtyChannelName);
+    ChannelPtr getOrAddChannel(const QString &dirtyChannelName) final;
     ChannelPtr getChannelOrEmpty(const QString &dirtyChannelName);
     std::vector<std::weak_ptr<Channel>> getChannels();
 

--- a/src/providers/irc/AbstractIrcServer.hpp
+++ b/src/providers/irc/AbstractIrcServer.hpp
@@ -21,6 +21,7 @@ class IAbstractIrcServer
 {
 public:
     virtual ChannelPtr getOrAddChannel(const QString &dirtyChannelName) = 0;
+    virtual ChannelPtr getChannelOrEmpty(const QString &dirtyChannelName) = 0;
 };
 
 class AbstractIrcServer : public IAbstractIrcServer, public QObject
@@ -47,7 +48,7 @@ public:
 
     // channels
     ChannelPtr getOrAddChannel(const QString &dirtyChannelName) final;
-    ChannelPtr getChannelOrEmpty(const QString &dirtyChannelName);
+    ChannelPtr getChannelOrEmpty(const QString &dirtyChannelName) final;
     std::vector<std::weak_ptr<Channel>> getChannels();
 
     // signals

--- a/src/providers/irc/AbstractIrcServer.hpp
+++ b/src/providers/irc/AbstractIrcServer.hpp
@@ -24,6 +24,8 @@ public:
     virtual ChannelPtr getChannelOrEmpty(const QString &dirtyChannelName) = 0;
 
     virtual void addFakeMessage(const QString &data) = 0;
+
+    virtual void addGlobalSystemMessage(const QString &messageText) = 0;
 };
 
 class AbstractIrcServer : public IAbstractIrcServer, public QObject
@@ -59,7 +61,7 @@ public:
 
     void addFakeMessage(const QString &data) final;
 
-    void addGlobalSystemMessage(const QString &messageText);
+    void addGlobalSystemMessage(const QString &messageText) final;
 
     // iteration
     void forEachChannel(std::function<void(ChannelPtr)> func);

--- a/src/providers/irc/AbstractIrcServer.hpp
+++ b/src/providers/irc/AbstractIrcServer.hpp
@@ -17,7 +17,11 @@ class Channel;
 using ChannelPtr = std::shared_ptr<Channel>;
 class RatelimitBucket;
 
-class AbstractIrcServer : public QObject
+class IAbstractIrcServer
+{
+};
+
+class AbstractIrcServer : public IAbstractIrcServer, public QObject
 {
 public:
     enum ConnectionType { Read = 1, Write = 2, Both = 3 };

--- a/src/providers/irc/AbstractIrcServer.hpp
+++ b/src/providers/irc/AbstractIrcServer.hpp
@@ -20,6 +20,8 @@ class RatelimitBucket;
 class IAbstractIrcServer
 {
 public:
+    virtual void sendRawMessage(const QString &rawMessage) = 0;
+
     virtual ChannelPtr getOrAddChannel(const QString &dirtyChannelName) = 0;
     virtual ChannelPtr getChannelOrEmpty(const QString &dirtyChannelName) = 0;
 
@@ -48,7 +50,7 @@ public:
     void disconnect();
 
     void sendMessage(const QString &channelName, const QString &message);
-    virtual void sendRawMessage(const QString &rawMessage);
+    void sendRawMessage(const QString &rawMessage) override;
 
     // channels
     ChannelPtr getOrAddChannel(const QString &dirtyChannelName) final;

--- a/src/providers/irc/IrcServer.cpp
+++ b/src/providers/irc/IrcServer.cpp
@@ -244,7 +244,7 @@ void IrcServer::privateMessageReceived(Communi::IrcPrivateMessage *message)
 
             if (highlighted && showInMentions)
             {
-                getApp()->twitch->mentionsChannel->addMessage(msg);
+                getIApp()->getTwitch()->getMentionsChannel()->addMessage(msg);
             }
         }
         else

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -943,7 +943,7 @@ void IrcMessageHandler::handleWhisperMessage(Communi::IrcMessage *ircMessage)
 
     args.isReceivedWhisper = true;
 
-    auto *c = getApp()->twitch->whispersChannel.get();
+    auto *c = getIApp()->getTwitch()->getWhispersChannel().get();
 
     TwitchMessageBuilder builder(
         c, ircMessage, args,

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -963,7 +963,7 @@ void IrcMessageHandler::handleWhisperMessage(Communi::IrcMessage *ircMessage)
 
     if (message->flags.has(MessageFlag::ShowInMentions))
     {
-        getApp()->twitch->mentionsChannel->addMessage(message);
+        getIApp()->getTwitch()->getMentionsChannel()->addMessage(message);
     }
 
     c->addMessage(message);
@@ -1446,7 +1446,7 @@ void IrcMessageHandler::addMessage(Communi::IrcMessage *message,
 
         if (highlighted && showInMentions)
         {
-            server.mentionsChannel->addMessage(msg);
+            server.getMentionsChannel()->addMessage(msg);
         }
 
         chan->addMessage(msg);

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -959,7 +959,7 @@ void IrcMessageHandler::handleWhisperMessage(Communi::IrcMessage *ircMessage)
     MessagePtr message = builder.build();
     builder.triggerHighlights();
 
-    getApp()->twitch->lastUserThatWhisperedMe.set(builder.userName);
+    getIApp()->getTwitch()->setLastUserThatWhisperedMe(builder.userName);
 
     if (message->flags.has(MessageFlag::ShowInMentions))
     {

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -1111,7 +1111,7 @@ void IrcMessageHandler::handleNoticeMessage(Communi::IrcNoticeMessage *message)
         {
             // Notice wasn't targeted at a single channel, send to all twitch
             // channels
-            getApp()->twitch->forEachChannelAndSpecialChannels(
+            getIApp()->getTwitch()->forEachChannelAndSpecialChannels(
                 [msg](const auto &c) {
                     c->addMessage(msg);
                 });

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -976,7 +976,7 @@ void IrcMessageHandler::handleWhisperMessage(Communi::IrcMessage *ircMessage)
         !(getSettings()->streamerModeSuppressInlineWhispers &&
           getIApp()->getStreamerMode()->isEnabled()))
     {
-        getApp()->twitch->forEachChannel(
+        getIApp()->getTwitchAbstract()->forEachChannel(
             [&message, overrideFlags](ChannelPtr channel) {
                 channel->addMessage(message, overrideFlags);
             });

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -733,7 +733,7 @@ void IrcMessageHandler::handleRoomStateMessage(Communi::IrcMessage *message)
     {
         return;
     }
-    auto chan = getApp()->twitch->getChannelOrEmpty(chanName);
+    auto chan = getIApp()->getTwitchAbstract()->getChannelOrEmpty(chanName);
 
     auto *twitchChannel = dynamic_cast<TwitchChannel *>(chan.get());
     if (!twitchChannel)
@@ -795,7 +795,7 @@ void IrcMessageHandler::handleClearChatMessage(Communi::IrcMessage *message)
     }
 
     // get channel
-    auto chan = getApp()->twitch->getChannelOrEmpty(chanName);
+    auto chan = getIApp()->getTwitchAbstract()->getChannelOrEmpty(chanName);
 
     if (chan->isEmpty())
     {
@@ -839,7 +839,7 @@ void IrcMessageHandler::handleClearMessageMessage(Communi::IrcMessage *message)
     }
 
     // get channel
-    auto chan = getApp()->twitch->getChannelOrEmpty(chanName);
+    auto chan = getIApp()->getTwitchAbstract()->getChannelOrEmpty(chanName);
 
     if (chan->isEmpty())
     {
@@ -888,7 +888,7 @@ void IrcMessageHandler::handleUserStateMessage(Communi::IrcMessage *message)
         return;
     }
 
-    auto c = getApp()->twitch->getChannelOrEmpty(channelName);
+    auto c = getIApp()->getTwitchAbstract()->getChannelOrEmpty(channelName);
     if (c->isEmpty())
     {
         return;
@@ -1119,7 +1119,8 @@ void IrcMessageHandler::handleNoticeMessage(Communi::IrcNoticeMessage *message)
             return;
         }
 
-        auto channel = getApp()->twitch->getChannelOrEmpty(channelName);
+        auto channel =
+            getIApp()->getTwitchAbstract()->getChannelOrEmpty(channelName);
 
         if (channel->isEmpty())
         {
@@ -1202,8 +1203,8 @@ void IrcMessageHandler::handleNoticeMessage(Communi::IrcNoticeMessage *message)
 
 void IrcMessageHandler::handleJoinMessage(Communi::IrcMessage *message)
 {
-    auto channel =
-        getApp()->twitch->getChannelOrEmpty(message->parameter(0).remove(0, 1));
+    auto channel = getIApp()->getTwitchAbstract()->getChannelOrEmpty(
+        message->parameter(0).remove(0, 1));
 
     auto *twitchChannel = dynamic_cast<TwitchChannel *>(channel.get());
     if (!twitchChannel)
@@ -1225,8 +1226,8 @@ void IrcMessageHandler::handleJoinMessage(Communi::IrcMessage *message)
 
 void IrcMessageHandler::handlePartMessage(Communi::IrcMessage *message)
 {
-    auto channel =
-        getApp()->twitch->getChannelOrEmpty(message->parameter(0).remove(0, 1));
+    auto channel = getIApp()->getTwitchAbstract()->getChannelOrEmpty(
+        message->parameter(0).remove(0, 1));
 
     auto *twitchChannel = dynamic_cast<TwitchChannel *>(channel.get());
     if (!twitchChannel)

--- a/src/providers/twitch/IrcMessageHandler.hpp
+++ b/src/providers/twitch/IrcMessageHandler.hpp
@@ -9,7 +9,8 @@
 
 namespace chatterino {
 
-class TwitchIrcServer;
+class IAbstractIrcServer;
+class ITwitchIrcServer;
 class Channel;
 using ChannelPtr = std::shared_ptr<Channel>;
 struct Message;
@@ -38,7 +39,8 @@ public:
         std::vector<MessagePtr> &otherLoaded);
 
     void handlePrivMessage(Communi::IrcPrivateMessage *message,
-                           TwitchIrcServer &server);
+                           ITwitchIrcServer &twitchServer,
+                           IAbstractIrcServer &abstractIrcServer);
 
     void handleRoomStateMessage(Communi::IrcMessage *message);
     void handleClearChatMessage(Communi::IrcMessage *message);
@@ -48,7 +50,8 @@ public:
     void handleWhisperMessage(Communi::IrcMessage *ircMessage);
 
     void handleUserNoticeMessage(Communi::IrcMessage *message,
-                                 TwitchIrcServer &server);
+                                 ITwitchIrcServer &twitchServer,
+                                 IAbstractIrcServer &abstractIrcServer);
 
     void handleNoticeMessage(Communi::IrcNoticeMessage *message);
 
@@ -56,7 +59,7 @@ public:
     void handlePartMessage(Communi::IrcMessage *message);
 
     void addMessage(Communi::IrcMessage *message, const ChannelPtr &chan,
-                    const QString &originalContent, TwitchIrcServer &server,
+                    const QString &originalContent, ITwitchIrcServer &server,
                     bool isSub, bool isAction);
 
 private:

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -1252,7 +1252,8 @@ void TwitchChannel::loadRecentMessages()
                 tc->addRecentChatter(msg->displayName);
             }
 
-            getApp()->twitch->mentionsChannel->fillInMissingMessages(msgs);
+            getIApp()->getTwitch()->getMentionsChannel()->fillInMissingMessages(
+                msgs);
         },
         [weak]() {
             auto shared = weak.lock();

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -176,7 +176,8 @@ TwitchChannel::TwitchChannel(const QString &name)
             TwitchMessageBuilder::liveMessage(this->getDisplayName(),
                                               &builder2);
             builder2.message().id = this->roomId();
-            getApp()->twitch->liveChannel->addMessage(builder2.release());
+            getIApp()->getTwitch()->getLiveChannel()->addMessage(
+                builder2.release());
 
             // Notify on all channels with a ping sound
             if (getSettings()->notificationOnAnyChannel &&
@@ -198,7 +199,7 @@ TwitchChannel::TwitchChannel(const QString &name)
 
             // "delete" old 'CHANNEL is live' message
             LimitedQueueSnapshot<MessagePtr> snapshot =
-                getApp()->twitch->liveChannel->getMessageSnapshot();
+                getIApp()->getTwitch()->getLiveChannel()->getMessageSnapshot();
             int snapshotLength = snapshot.size();
 
             // MSVC hates this code if the parens are not there

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -425,7 +425,7 @@ void TwitchChannel::addChannelPointReward(const ChannelPointReward &reward)
             << "] Channel point reward added:" << reward.id << ","
             << reward.title << "," << reward.isUserInputRequired;
 
-        auto *server = getApp()->twitch;
+        auto &server = getApp()->twitch;
         auto it = std::remove_if(
             this->waitingRedemptions_.begin(), this->waitingRedemptions_.end(),
             [&](const QueuedRedemption &msg) {

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -247,9 +247,9 @@ TwitchChannel::~TwitchChannel()
             this->roomId());
     }
 
-    if (getApp()->twitch->seventvEventAPI)
+    if (getIApp()->getTwitch()->getSeventvEventAPI())
     {
-        getApp()->twitch->seventvEventAPI->unsubscribeTwitchChannel(
+        getIApp()->getTwitch()->getSeventvEventAPI()->unsubscribeTwitchChannel(
             this->roomId());
     }
 }
@@ -1050,9 +1050,9 @@ void TwitchChannel::updateSeventvData(const QString &newUserID,
     this->seventvUserID_ = newUserID;
     this->seventvEmoteSetID_ = newEmoteSetID;
     runInGuiThread([this, oldUserID, oldEmoteSetID]() {
-        if (getApp()->twitch->seventvEventAPI)
+        if (getIApp()->getTwitch()->getSeventvEventAPI())
         {
-            getApp()->twitch->seventvEventAPI->subscribeUser(
+            getIApp()->getTwitch()->getSeventvEventAPI()->subscribeUser(
                 this->seventvUserID_, this->seventvEmoteSetID_);
 
             if (oldUserID || oldEmoteSetID)
@@ -1844,9 +1844,9 @@ void TwitchChannel::updateSevenTVActivity()
 
 void TwitchChannel::listenSevenTVCosmetics() const
 {
-    if (getApp()->twitch->seventvEventAPI)
+    if (getIApp()->getTwitch()->getSeventvEventAPI())
     {
-        getApp()->twitch->seventvEventAPI->subscribeTwitchChannel(
+        getIApp()->getTwitch()->getSeventvEventAPI()->subscribeTwitchChannel(
             this->roomId());
     }
 }

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -778,7 +778,7 @@ bool TwitchChannel::canReconnect() const
 
 void TwitchChannel::reconnect()
 {
-    getApp()->twitch->connect();
+    getIApp()->getTwitchAbstract()->connect();
 }
 
 QString TwitchChannel::roomId() const

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -238,8 +238,8 @@ TwitchChannel::~TwitchChannel()
         return;
     }
 
-    getApp()->twitch->dropSeventvChannel(this->seventvUserID_,
-                                         this->seventvEmoteSetID_);
+    getIApp()->getTwitch()->dropSeventvChannel(this->seventvUserID_,
+                                               this->seventvEmoteSetID_);
 
     if (getIApp()->getTwitch()->getBTTVLiveUpdates())
     {
@@ -1057,7 +1057,7 @@ void TwitchChannel::updateSeventvData(const QString &newUserID,
 
             if (oldUserID || oldEmoteSetID)
             {
-                getApp()->twitch->dropSeventvChannel(
+                getIApp()->getTwitch()->dropSeventvChannel(
                     oldUserID.value_or(QString()),
                     oldEmoteSetID.value_or(QString()));
             }

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -427,7 +427,7 @@ void TwitchChannel::addChannelPointReward(const ChannelPointReward &reward)
             << "] Channel point reward added:" << reward.id << ","
             << reward.title << "," << reward.isUserInputRequired;
 
-        auto &server = getApp()->twitch;
+        auto *server = getIApp()->getTwitch();
         auto it = std::remove_if(
             this->waitingRedemptions_.begin(), this->waitingRedemptions_.end(),
             [&](const QueuedRedemption &msg) {

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -241,9 +241,10 @@ TwitchChannel::~TwitchChannel()
     getApp()->twitch->dropSeventvChannel(this->seventvUserID_,
                                          this->seventvEmoteSetID_);
 
-    if (getApp()->twitch->bttvLiveUpdates)
+    if (getIApp()->getTwitch()->getBTTVLiveUpdates())
     {
-        getApp()->twitch->bttvLiveUpdates->partChannel(this->roomId());
+        getIApp()->getTwitch()->getBTTVLiveUpdates()->partChannel(
+            this->roomId());
     }
 
     if (getApp()->twitch->seventvEventAPI)
@@ -892,7 +893,7 @@ const QString &TwitchChannel::seventvEmoteSetID() const
 
 void TwitchChannel::joinBttvChannel() const
 {
-    if (getApp()->twitch->bttvLiveUpdates)
+    if (getIApp()->getTwitch()->getBTTVLiveUpdates())
     {
         const auto currentAccount =
             getIApp()->getAccounts()->twitch.getCurrent();
@@ -901,8 +902,8 @@ void TwitchChannel::joinBttvChannel() const
         {
             userName = currentAccount->getUserName();
         }
-        getApp()->twitch->bttvLiveUpdates->joinChannel(this->roomId(),
-                                                       userName);
+        getIApp()->getTwitch()->getBTTVLiveUpdates()->joinChannel(
+            this->roomId(), userName);
     }
 }
 

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -655,6 +655,11 @@ void TwitchIrcServer::setWatchingChannel(ChannelPtr newWatchingChannel)
     this->watchingChannel.reset(newWatchingChannel);
 }
 
+ChannelPtr TwitchIrcServer::getWhispersChannel() const
+{
+    return this->whispersChannel;
+}
+
 ChannelPtr TwitchIrcServer::getMentionsChannel() const
 {
     return this->mentionsChannel;

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -655,6 +655,11 @@ ChannelPtr TwitchIrcServer::getLiveChannel() const
     return this->liveChannel;
 }
 
+ChannelPtr TwitchIrcServer::getAutomodChannel() const
+{
+    return this->automodChannel;
+}
+
 QString TwitchIrcServer::getLastUserThatWhisperedMe() const
 {
     return this->lastUserThatWhisperedMe.get();

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -650,6 +650,11 @@ const IndirectChannel &TwitchIrcServer::getWatchingChannel() const
     return this->watchingChannel;
 }
 
+ChannelPtr TwitchIrcServer::getLiveChannel() const
+{
+    return this->liveChannel;
+}
+
 QString TwitchIrcServer::getLastUserThatWhisperedMe() const
 {
     return this->lastUserThatWhisperedMe.get();

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -650,6 +650,11 @@ const IndirectChannel &TwitchIrcServer::getWatchingChannel() const
     return this->watchingChannel;
 }
 
+void TwitchIrcServer::setWatchingChannel(ChannelPtr newWatchingChannel)
+{
+    this->watchingChannel.reset(newWatchingChannel);
+}
+
 ChannelPtr TwitchIrcServer::getLiveChannel() const
 {
     return this->liveChannel;

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -655,6 +655,11 @@ void TwitchIrcServer::setWatchingChannel(ChannelPtr newWatchingChannel)
     this->watchingChannel.reset(newWatchingChannel);
 }
 
+ChannelPtr TwitchIrcServer::getMentionsChannel() const
+{
+    return this->mentionsChannel;
+}
+
 ChannelPtr TwitchIrcServer::getLiveChannel() const
 {
     return this->liveChannel;

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -263,7 +263,7 @@ std::shared_ptr<Channel> TwitchIrcServer::createChannel(
 void TwitchIrcServer::privateMessageReceived(
     Communi::IrcPrivateMessage *message)
 {
-    IrcMessageHandler::instance().handlePrivMessage(message, *this);
+    IrcMessageHandler::instance().handlePrivMessage(message, *this, *this);
 }
 
 void TwitchIrcServer::readConnectionMessageReceived(
@@ -310,7 +310,7 @@ void TwitchIrcServer::readConnectionMessageReceived(
     }
     else if (command == "USERNOTICE")
     {
-        handler.handleUserNoticeMessage(message, *this);
+        handler.handleUserNoticeMessage(message, *this, *this);
     }
     else if (command == "NOTICE")
     {

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -680,6 +680,11 @@ QString TwitchIrcServer::getLastUserThatWhisperedMe() const
     return this->lastUserThatWhisperedMe.get();
 }
 
+void TwitchIrcServer::setLastUserThatWhisperedMe(const QString &user)
+{
+    this->lastUserThatWhisperedMe.set(user);
+}
+
 void TwitchIrcServer::reloadBTTVGlobalEmotes()
 {
     getIApp()->getBttvEmotes()->loadEmotes();

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -650,6 +650,11 @@ std::unique_ptr<BttvLiveUpdates> &TwitchIrcServer::getBTTVLiveUpdates()
     return this->bttvLiveUpdates;
 }
 
+std::unique_ptr<SeventvEventAPI> &TwitchIrcServer::getSeventvEventAPI()
+{
+    return this->seventvEventAPI;
+}
+
 const IndirectChannel &TwitchIrcServer::getWatchingChannel() const
 {
     return this->watchingChannel;

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -645,6 +645,11 @@ void TwitchIrcServer::onReplySendRequested(
     sent = true;
 }
 
+std::unique_ptr<BttvLiveUpdates> &TwitchIrcServer::getBTTVLiveUpdates()
+{
+    return this->bttvLiveUpdates;
+}
+
 const IndirectChannel &TwitchIrcServer::getWatchingChannel() const
 {
     return this->watchingChannel;

--- a/src/providers/twitch/TwitchIrcServer.hpp
+++ b/src/providers/twitch/TwitchIrcServer.hpp
@@ -29,6 +29,7 @@ public:
 
     virtual const IndirectChannel &getWatchingChannel() const = 0;
     virtual ChannelPtr getLiveChannel() const = 0;
+    virtual ChannelPtr getAutomodChannel() const = 0;
 
     virtual QString getLastUserThatWhisperedMe() const = 0;
 
@@ -78,9 +79,9 @@ public:
 
 private:
     const ChannelPtr liveChannel;
+    const ChannelPtr automodChannel;
 
 public:
-    const ChannelPtr automodChannel;
     IndirectChannel watchingChannel;
 
     std::unique_ptr<BttvLiveUpdates> bttvLiveUpdates;
@@ -88,6 +89,7 @@ public:
 
     const IndirectChannel &getWatchingChannel() const override;
     ChannelPtr getLiveChannel() const override;
+    ChannelPtr getAutomodChannel() const override;
 
     QString getLastUserThatWhisperedMe() const override;
 

--- a/src/providers/twitch/TwitchIrcServer.hpp
+++ b/src/providers/twitch/TwitchIrcServer.hpp
@@ -28,6 +28,7 @@ public:
     virtual ~ITwitchIrcServer() = default;
 
     virtual const IndirectChannel &getWatchingChannel() const = 0;
+    virtual void setWatchingChannel(ChannelPtr newWatchingChannel) = 0;
     virtual ChannelPtr getLiveChannel() const = 0;
     virtual ChannelPtr getAutomodChannel() const = 0;
 
@@ -80,14 +81,14 @@ public:
 private:
     const ChannelPtr liveChannel;
     const ChannelPtr automodChannel;
-
-public:
     IndirectChannel watchingChannel;
 
+public:
     std::unique_ptr<BttvLiveUpdates> bttvLiveUpdates;
     std::unique_ptr<SeventvEventAPI> seventvEventAPI;
 
     const IndirectChannel &getWatchingChannel() const override;
+    void setWatchingChannel(ChannelPtr newWatchingChannel) override;
     ChannelPtr getLiveChannel() const override;
     ChannelPtr getAutomodChannel() const override;
 

--- a/src/providers/twitch/TwitchIrcServer.hpp
+++ b/src/providers/twitch/TwitchIrcServer.hpp
@@ -29,6 +29,7 @@ public:
 
     virtual const IndirectChannel &getWatchingChannel() const = 0;
     virtual void setWatchingChannel(ChannelPtr newWatchingChannel) = 0;
+    virtual ChannelPtr getWhispersChannel() const = 0;
     virtual ChannelPtr getMentionsChannel() const = 0;
     virtual ChannelPtr getLiveChannel() const = 0;
     virtual ChannelPtr getAutomodChannel() const = 0;
@@ -76,9 +77,8 @@ public:
 
     Atomic<QString> lastUserThatWhisperedMe;
 
-    const ChannelPtr whispersChannel;
-
 private:
+    const ChannelPtr whispersChannel;
     const ChannelPtr mentionsChannel;
     const ChannelPtr liveChannel;
     const ChannelPtr automodChannel;
@@ -90,6 +90,7 @@ public:
 
     const IndirectChannel &getWatchingChannel() const override;
     void setWatchingChannel(ChannelPtr newWatchingChannel) override;
+    ChannelPtr getWhispersChannel() const override;
     ChannelPtr getMentionsChannel() const override;
     ChannelPtr getLiveChannel() const override;
     ChannelPtr getAutomodChannel() const override;

--- a/src/providers/twitch/TwitchIrcServer.hpp
+++ b/src/providers/twitch/TwitchIrcServer.hpp
@@ -29,6 +29,7 @@ public:
 
     virtual const IndirectChannel &getWatchingChannel() const = 0;
     virtual void setWatchingChannel(ChannelPtr newWatchingChannel) = 0;
+    virtual ChannelPtr getMentionsChannel() const = 0;
     virtual ChannelPtr getLiveChannel() const = 0;
     virtual ChannelPtr getAutomodChannel() const = 0;
 
@@ -76,9 +77,9 @@ public:
     Atomic<QString> lastUserThatWhisperedMe;
 
     const ChannelPtr whispersChannel;
-    const ChannelPtr mentionsChannel;
 
 private:
+    const ChannelPtr mentionsChannel;
     const ChannelPtr liveChannel;
     const ChannelPtr automodChannel;
     IndirectChannel watchingChannel;
@@ -89,6 +90,7 @@ public:
 
     const IndirectChannel &getWatchingChannel() const override;
     void setWatchingChannel(ChannelPtr newWatchingChannel) override;
+    ChannelPtr getMentionsChannel() const override;
     ChannelPtr getLiveChannel() const override;
     ChannelPtr getAutomodChannel() const override;
 

--- a/src/providers/twitch/TwitchIrcServer.hpp
+++ b/src/providers/twitch/TwitchIrcServer.hpp
@@ -28,6 +28,7 @@ public:
     virtual ~ITwitchIrcServer() = default;
 
     virtual const IndirectChannel &getWatchingChannel() const = 0;
+    virtual ChannelPtr getLiveChannel() const = 0;
 
     virtual QString getLastUserThatWhisperedMe() const = 0;
 
@@ -74,7 +75,11 @@ public:
 
     const ChannelPtr whispersChannel;
     const ChannelPtr mentionsChannel;
+
+private:
     const ChannelPtr liveChannel;
+
+public:
     const ChannelPtr automodChannel;
     IndirectChannel watchingChannel;
 
@@ -82,6 +87,7 @@ public:
     std::unique_ptr<SeventvEventAPI> seventvEventAPI;
 
     const IndirectChannel &getWatchingChannel() const override;
+    ChannelPtr getLiveChannel() const override;
 
     QString getLastUserThatWhisperedMe() const override;
 

--- a/src/providers/twitch/TwitchIrcServer.hpp
+++ b/src/providers/twitch/TwitchIrcServer.hpp
@@ -30,6 +30,9 @@ public:
     virtual void forEachChannelAndSpecialChannels(
         std::function<void(ChannelPtr)> func) = 0;
 
+    virtual std::shared_ptr<Channel> getChannelOrEmptyByID(
+        const QString &channelID) = 0;
+
     virtual const IndirectChannel &getWatchingChannel() const = 0;
     virtual void setWatchingChannel(ChannelPtr newWatchingChannel) = 0;
     virtual ChannelPtr getWhispersChannel() const = 0;
@@ -56,7 +59,8 @@ public:
     void forEachChannelAndSpecialChannels(
         std::function<void(ChannelPtr)> func) override;
 
-    std::shared_ptr<Channel> getChannelOrEmptyByID(const QString &channelID);
+    std::shared_ptr<Channel> getChannelOrEmptyByID(
+        const QString &channelID) override;
 
     void reloadBTTVGlobalEmotes();
     void reloadAllBTTVChannelEmotes();

--- a/src/providers/twitch/TwitchIrcServer.hpp
+++ b/src/providers/twitch/TwitchIrcServer.hpp
@@ -38,6 +38,7 @@ public:
     virtual ChannelPtr getAutomodChannel() const = 0;
 
     virtual QString getLastUserThatWhisperedMe() const = 0;
+    virtual void setLastUserThatWhisperedMe(const QString &user) = 0;
 
     // Update this interface with TwitchIrcServer methods as needed
 };
@@ -79,9 +80,9 @@ public:
      */
     void dropSeventvChannel(const QString &userID, const QString &emoteSetID);
 
+private:
     Atomic<QString> lastUserThatWhisperedMe;
 
-private:
     const ChannelPtr whispersChannel;
     const ChannelPtr mentionsChannel;
     const ChannelPtr liveChannel;
@@ -100,6 +101,7 @@ public:
     ChannelPtr getAutomodChannel() const override;
 
     QString getLastUserThatWhisperedMe() const override;
+    void setLastUserThatWhisperedMe(const QString &user) override;
 
 protected:
     void initializeConnection(IrcConnection *connection,

--- a/src/providers/twitch/TwitchIrcServer.hpp
+++ b/src/providers/twitch/TwitchIrcServer.hpp
@@ -33,6 +33,9 @@ public:
     virtual std::shared_ptr<Channel> getChannelOrEmptyByID(
         const QString &channelID) = 0;
 
+    virtual void dropSeventvChannel(const QString &userID,
+                                    const QString &emoteSetID) = 0;
+
     virtual std::unique_ptr<BttvLiveUpdates> &getBTTVLiveUpdates() = 0;
     virtual std::unique_ptr<SeventvEventAPI> &getSeventvEventAPI() = 0;
 
@@ -85,7 +88,8 @@ public:
      * It's currently not possible to share emote sets among users,
      * but it's a commonly requested feature.
      */
-    void dropSeventvChannel(const QString &userID, const QString &emoteSetID);
+    void dropSeventvChannel(const QString &userID,
+                            const QString &emoteSetID) override;
 
 private:
     Atomic<QString> lastUserThatWhisperedMe;

--- a/src/providers/twitch/TwitchIrcServer.hpp
+++ b/src/providers/twitch/TwitchIrcServer.hpp
@@ -27,6 +27,9 @@ class ITwitchIrcServer
 public:
     virtual ~ITwitchIrcServer() = default;
 
+    virtual void forEachChannelAndSpecialChannels(
+        std::function<void(ChannelPtr)> func) = 0;
+
     virtual const IndirectChannel &getWatchingChannel() const = 0;
     virtual void setWatchingChannel(ChannelPtr newWatchingChannel) = 0;
     virtual ChannelPtr getWhispersChannel() const = 0;
@@ -49,7 +52,8 @@ public:
 
     void initialize(Settings &settings, const Paths &paths) override;
 
-    void forEachChannelAndSpecialChannels(std::function<void(ChannelPtr)> func);
+    void forEachChannelAndSpecialChannels(
+        std::function<void(ChannelPtr)> func) override;
 
     std::shared_ptr<Channel> getChannelOrEmptyByID(const QString &channelID);
 

--- a/src/providers/twitch/TwitchIrcServer.hpp
+++ b/src/providers/twitch/TwitchIrcServer.hpp
@@ -33,6 +33,8 @@ public:
     virtual std::shared_ptr<Channel> getChannelOrEmptyByID(
         const QString &channelID) = 0;
 
+    virtual std::unique_ptr<BttvLiveUpdates> &getBTTVLiveUpdates() = 0;
+
     virtual const IndirectChannel &getWatchingChannel() const = 0;
     virtual void setWatchingChannel(ChannelPtr newWatchingChannel) = 0;
     virtual ChannelPtr getWhispersChannel() const = 0;
@@ -93,9 +95,12 @@ private:
     const ChannelPtr automodChannel;
     IndirectChannel watchingChannel;
 
-public:
     std::unique_ptr<BttvLiveUpdates> bttvLiveUpdates;
+
+public:
     std::unique_ptr<SeventvEventAPI> seventvEventAPI;
+
+    std::unique_ptr<BttvLiveUpdates> &getBTTVLiveUpdates() override;
 
     const IndirectChannel &getWatchingChannel() const override;
     void setWatchingChannel(ChannelPtr newWatchingChannel) override;

--- a/src/providers/twitch/TwitchIrcServer.hpp
+++ b/src/providers/twitch/TwitchIrcServer.hpp
@@ -34,6 +34,7 @@ public:
         const QString &channelID) = 0;
 
     virtual std::unique_ptr<BttvLiveUpdates> &getBTTVLiveUpdates() = 0;
+    virtual std::unique_ptr<SeventvEventAPI> &getSeventvEventAPI() = 0;
 
     virtual const IndirectChannel &getWatchingChannel() const = 0;
     virtual void setWatchingChannel(ChannelPtr newWatchingChannel) = 0;
@@ -96,11 +97,11 @@ private:
     IndirectChannel watchingChannel;
 
     std::unique_ptr<BttvLiveUpdates> bttvLiveUpdates;
-
-public:
     std::unique_ptr<SeventvEventAPI> seventvEventAPI;
 
+public:
     std::unique_ptr<BttvLiveUpdates> &getBTTVLiveUpdates() override;
+    std::unique_ptr<SeventvEventAPI> &getSeventvEventAPI() override;
 
     const IndirectChannel &getWatchingChannel() const override;
     void setWatchingChannel(ChannelPtr newWatchingChannel) override;

--- a/src/singletons/NativeMessaging.cpp
+++ b/src/singletons/NativeMessaging.cpp
@@ -241,9 +241,9 @@ void NativeMessagingServer::ReceiverThread::handleSelect(
         if (!name.isEmpty())
         {
             auto channel = app->twitch->getOrAddChannel(name);
-            if (app->twitch->watchingChannel.get() != channel)
+            if (getIApp()->getTwitch()->getWatchingChannel().get() != channel)
             {
-                app->twitch->watchingChannel.reset(channel);
+                getIApp()->getTwitch()->setWatchingChannel(channel);
             }
         }
 

--- a/src/singletons/NativeMessaging.cpp
+++ b/src/singletons/NativeMessaging.cpp
@@ -236,11 +236,10 @@ void NativeMessagingServer::ReceiverThread::handleSelect(
     }
 
     postToThread([=] {
-        auto *app = getApp();
-
         if (!name.isEmpty())
         {
-            auto channel = app->twitch->getOrAddChannel(name);
+            auto channel =
+                getIApp()->getTwitchAbstract()->getOrAddChannel(name);
             if (getIApp()->getTwitch()->getWatchingChannel().get() != channel)
             {
                 getIApp()->getTwitch()->setWatchingChannel(channel);
@@ -253,7 +252,8 @@ void NativeMessagingServer::ReceiverThread::handleSelect(
             auto *window = AttachedWindow::getForeground(args);
             if (!name.isEmpty())
             {
-                window->setChannel(app->twitch->getOrAddChannel(name));
+                window->setChannel(
+                    getIApp()->getTwitchAbstract()->getOrAddChannel(name));
             }
 #endif
         }
@@ -294,8 +294,6 @@ void NativeMessagingServer::syncChannels(const QJsonArray &twitchChannels)
 {
     assertInGuiThread();
 
-    auto *app = getApp();
-
     std::vector<ChannelPtr> updated;
     updated.reserve(twitchChannels.size());
     for (const auto &value : twitchChannels)
@@ -306,7 +304,8 @@ void NativeMessagingServer::syncChannels(const QJsonArray &twitchChannels)
             continue;
         }
         // the deduping is done on the extension side
-        updated.emplace_back(app->twitch->getOrAddChannel(name));
+        updated.emplace_back(
+            getIApp()->getTwitchAbstract()->getOrAddChannel(name));
     }
 
     // This will destroy channels that aren't used anymore.

--- a/src/singletons/StreamerMode.cpp
+++ b/src/singletons/StreamerMode.cpp
@@ -74,7 +74,7 @@ bool isBroadcasterSoftwareActive()
                 shouldShowTimeoutWarning = false;
 
                 postToThread([] {
-                    getApp()->twitch->addGlobalSystemMessage(
+                    getIApp()->getTwitchAbstract()->addGlobalSystemMessage(
                         "Streamer Mode is set to Automatic, but pgrep timed "
                         "out. This can happen if your system lagged at the "
                         "wrong moment. If Streamer Mode continues to not work, "
@@ -94,7 +94,7 @@ bool isBroadcasterSoftwareActive()
                 shouldShowWarning = false;
 
                 postToThread([] {
-                    getApp()->twitch->addGlobalSystemMessage(
+                    getIApp()->getTwitchAbstract()->addGlobalSystemMessage(
                         "Streamer Mode is set to Automatic, but pgrep is "
                         "missing. "
                         "Install it to fix the issue or set Streamer Mode to "

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -704,7 +704,7 @@ IndirectChannel WindowManager::decodeChannel(const SplitDescriptor &descriptor)
     }
     else if (descriptor.type_ == "live")
     {
-        return app->twitch->liveChannel;
+        return getIApp()->getTwitch()->getLiveChannel();
     }
     else if (descriptor.type_ == "automod")
     {

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -708,7 +708,7 @@ IndirectChannel WindowManager::decodeChannel(const SplitDescriptor &descriptor)
     }
     else if (descriptor.type_ == "automod")
     {
-        return app->twitch->automodChannel;
+        return getIApp()->getTwitch()->getAutomodChannel();
     }
     else if (descriptor.type_ == "irc")
     {

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -692,7 +692,7 @@ IndirectChannel WindowManager::decodeChannel(const SplitDescriptor &descriptor)
     }
     else if (descriptor.type_ == "mentions")
     {
-        return app->twitch->mentionsChannel;
+        return getIApp()->getTwitch()->getMentionsChannel();
     }
     else if (descriptor.type_ == "watching")
     {

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -700,7 +700,7 @@ IndirectChannel WindowManager::decodeChannel(const SplitDescriptor &descriptor)
     }
     else if (descriptor.type_ == "whispers")
     {
-        return app->twitch->whispersChannel;
+        return getIApp()->getTwitch()->getWhispersChannel();
     }
     else if (descriptor.type_ == "live")
     {

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -696,7 +696,7 @@ IndirectChannel WindowManager::decodeChannel(const SplitDescriptor &descriptor)
     }
     else if (descriptor.type_ == "watching")
     {
-        return app->twitch->watchingChannel;
+        return getIApp()->getTwitch()->getWatchingChannel();
     }
     else if (descriptor.type_ == "whispers")
     {

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -688,7 +688,8 @@ IndirectChannel WindowManager::decodeChannel(const SplitDescriptor &descriptor)
 
     if (descriptor.type_ == "twitch")
     {
-        return app->twitch->getOrAddChannel(descriptor.channelName_);
+        return getIApp()->getTwitchAbstract()->getOrAddChannel(
+            descriptor.channelName_);
     }
     else if (descriptor.type_ == "mentions")
     {

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -718,7 +718,8 @@ IndirectChannel WindowManager::decodeChannel(const SplitDescriptor &descriptor)
     }
     else if (descriptor.type_ == "misc")
     {
-        return app->twitch->getChannelOrEmpty(descriptor.channelName_);
+        return getIApp()->getTwitchAbstract()->getChannelOrEmpty(
+            descriptor.channelName_);
     }
 
     return Channel::getEmpty();

--- a/src/widgets/FramelessEmbedWindow.cpp
+++ b/src/widgets/FramelessEmbedWindow.cpp
@@ -54,7 +54,8 @@ bool FramelessEmbedWindow::nativeEvent(const QByteArray &eventType,
                 auto channelName = root.value("channel-name").toString();
 
                 this->split_->setChannel(
-                    getApp()->twitch->getOrAddChannel(channelName));
+                    getIApp()->getTwitchAbstract()->getOrAddChannel(
+                        channelName));
             }
         }
     }

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -480,8 +480,8 @@ void Window::addShortcuts()
                  splitContainer = this->notebook_->getOrAddSelectedPage();
              }
              Split *split = new Split(splitContainer);
-             split->setChannel(
-                 getApp()->twitch->getOrAddChannel(si.channelName));
+             split->setChannel(getIApp()->getTwitchAbstract()->getOrAddChannel(
+                 si.channelName));
              split->setFilters(si.filters);
              splitContainer->insertSplit(split);
              splitContainer->setSelected(split);

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -254,7 +254,7 @@ void Window::addDebugStuff(HotkeyController::HotkeyMap &actions)
         const auto &messages = getSampleMiscMessages();
         static int index = 0;
         const auto &msg = messages[index++ % messages.size()];
-        getApp()->twitch->addFakeMessage(msg);
+        getIApp()->getTwitchAbstract()->addFakeMessage(msg);
         return "";
     });
 
@@ -262,7 +262,7 @@ void Window::addDebugStuff(HotkeyController::HotkeyMap &actions)
         const auto &messages = getSampleCheerMessages();
         static int index = 0;
         const auto &msg = messages[index++ % messages.size()];
-        getApp()->twitch->addFakeMessage(msg);
+        getIApp()->getTwitchAbstract()->addFakeMessage(msg);
         return "";
     });
 
@@ -270,7 +270,7 @@ void Window::addDebugStuff(HotkeyController::HotkeyMap &actions)
         const auto &messages = getSampleLinkMessages();
         static int index = 0;
         const auto &msg = messages[index++ % messages.size()];
-        getApp()->twitch->addFakeMessage(msg);
+        getIApp()->getTwitchAbstract()->addFakeMessage(msg);
         return "";
     });
 
@@ -286,7 +286,8 @@ void Window::addDebugStuff(HotkeyController::HotkeyMap &actions)
                 oMessage->toInner<PubSubMessageMessage>()
                     ->toInner<PubSubCommunityPointsChannelV1Message>();
 
-            app->twitch->addFakeMessage(getSampleChannelRewardIRCMessage());
+            getIApp()->getTwitchAbstract()->addFakeMessage(
+                getSampleChannelRewardIRCMessage());
             getIApp()->getTwitchPubSub()->pointReward.redeemed.invoke(
                 oInnerMessage->data.value("redemption").toObject());
             alt = !alt;
@@ -309,7 +310,7 @@ void Window::addDebugStuff(HotkeyController::HotkeyMap &actions)
         const auto &messages = getSampleEmoteTestMessages();
         static int index = 0;
         const auto &msg = messages[index++ % messages.size()];
-        getApp()->twitch->addFakeMessage(msg);
+        getIApp()->getTwitchAbstract()->addFakeMessage(msg);
         return "";
     });
 
@@ -317,7 +318,7 @@ void Window::addDebugStuff(HotkeyController::HotkeyMap &actions)
         const auto &messages = getSampleSubMessages();
         static int index = 0;
         const auto &msg = messages[index++ % messages.size()];
-        getApp()->twitch->addFakeMessage(msg);
+        getIApp()->getTwitchAbstract()->addFakeMessage(msg);
         return "";
     });
 #endif

--- a/src/widgets/dialogs/SelectChannelDialog.cpp
+++ b/src/widgets/dialogs/SelectChannelDialog.cpp
@@ -391,7 +391,7 @@ IndirectChannel SelectChannelDialog::getSelectedChannel() const
             }
             else if (this->ui_.twitch.mentions->isChecked())
             {
-                return app->twitch->mentionsChannel;
+                return getIApp()->getTwitch()->getMentionsChannel();
             }
             else if (this->ui_.twitch.whispers->isChecked())
             {

--- a/src/widgets/dialogs/SelectChannelDialog.cpp
+++ b/src/widgets/dialogs/SelectChannelDialog.cpp
@@ -387,7 +387,7 @@ IndirectChannel SelectChannelDialog::getSelectedChannel() const
             }
             else if (this->ui_.twitch.watching->isChecked())
             {
-                return app->twitch->watchingChannel;
+                return getIApp()->getTwitch()->getWatchingChannel();
             }
             else if (this->ui_.twitch.mentions->isChecked())
             {

--- a/src/widgets/dialogs/SelectChannelDialog.cpp
+++ b/src/widgets/dialogs/SelectChannelDialog.cpp
@@ -403,7 +403,7 @@ IndirectChannel SelectChannelDialog::getSelectedChannel() const
             }
             else if (this->ui_.twitch.automod->isChecked())
             {
-                return app->twitch->automodChannel;
+                return getIApp()->getTwitch()->getAutomodChannel();
             }
         }
         break;

--- a/src/widgets/dialogs/SelectChannelDialog.cpp
+++ b/src/widgets/dialogs/SelectChannelDialog.cpp
@@ -399,7 +399,7 @@ IndirectChannel SelectChannelDialog::getSelectedChannel() const
             }
             else if (this->ui_.twitch.live->isChecked())
             {
-                return app->twitch->liveChannel;
+                return getIApp()->getTwitch()->getLiveChannel();
             }
             else if (this->ui_.twitch.automod->isChecked())
             {

--- a/src/widgets/dialogs/SelectChannelDialog.cpp
+++ b/src/widgets/dialogs/SelectChannelDialog.cpp
@@ -395,7 +395,7 @@ IndirectChannel SelectChannelDialog::getSelectedChannel() const
             }
             else if (this->ui_.twitch.whispers->isChecked())
             {
-                return app->twitch->whispersChannel;
+                return getIApp()->getTwitch()->getWhispersChannel();
             }
             else if (this->ui_.twitch.live->isChecked())
             {

--- a/src/widgets/dialogs/SelectChannelDialog.cpp
+++ b/src/widgets/dialogs/SelectChannelDialog.cpp
@@ -375,14 +375,12 @@ IndirectChannel SelectChannelDialog::getSelectedChannel() const
         return this->selectedChannel_;
     }
 
-    auto *app = getApp();
-
     switch (this->ui_.notebook->getSelectedIndex())
     {
         case TAB_TWITCH: {
             if (this->ui_.twitch.channel->isChecked())
             {
-                return app->twitch->getOrAddChannel(
+                return getIApp()->getTwitchAbstract()->getOrAddChannel(
                     this->ui_.twitch.channelName->text().trimmed());
             }
             else if (this->ui_.twitch.watching->isChecked())

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -298,21 +298,23 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically, Split *split)
                         menu->addAction(
                             "Open channel in a new popup window", this,
                             [loginName] {
-                                auto *app = getApp();
+                                auto *app = getIApp();
                                 auto &window = app->getWindows()->createWindow(
                                     WindowType::Popup, true);
                                 auto *split = window.getNotebook()
                                                   .getOrAddSelectedPage()
                                                   ->appendNewSplit(false);
-                                split->setChannel(app->twitch->getOrAddChannel(
-                                    loginName.toLower()));
+                                split->setChannel(
+                                    app->getTwitchAbstract()->getOrAddChannel(
+                                        loginName.toLower()));
                             });
 
                         menu->addAction(
                             "Open channel in a new tab", this, [loginName] {
                                 ChannelPtr channel =
-                                    getApp()->twitch->getOrAddChannel(
-                                        loginName);
+                                    getIApp()
+                                        ->getTwitchAbstract()
+                                        ->getOrAddChannel(loginName);
                                 auto &nb = getApp()
                                                ->getWindows()
                                                ->getMainWindow()

--- a/src/widgets/dialogs/switcher/NewPopupItem.cpp
+++ b/src/widgets/dialogs/switcher/NewPopupItem.cpp
@@ -21,7 +21,8 @@ NewPopupItem::NewPopupItem(const QString &channelName)
 
 void NewPopupItem::action()
 {
-    auto channel = getApp()->twitch->getOrAddChannel(this->channelName_);
+    auto channel =
+        getIApp()->getTwitchAbstract()->getOrAddChannel(this->channelName_);
     getIApp()->getWindows()->openInPopup(channel);
 }
 

--- a/src/widgets/dialogs/switcher/NewTabItem.cpp
+++ b/src/widgets/dialogs/switcher/NewTabItem.cpp
@@ -26,7 +26,8 @@ void NewTabItem::action()
     SplitContainer *container = nb.addPage(true);
 
     Split *split = new Split(container);
-    split->setChannel(getApp()->twitch->getOrAddChannel(this->channelName_));
+    split->setChannel(
+        getIApp()->getTwitchAbstract()->getOrAddChannel(this->channelName_));
     container->insertSplit(split);
 }
 

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1386,7 +1386,8 @@ MessageElementFlags ChannelView::getFlags() const
         if (this->underlyingChannel_ == app->twitch->mentionsChannel ||
             this->underlyingChannel_ ==
                 getIApp()->getTwitch()->getLiveChannel() ||
-            this->underlyingChannel_ == app->twitch->automodChannel)
+            this->underlyingChannel_ ==
+                getIApp()->getTwitch()->getAutomodChannel())
         {
             flags.set(MessageElementFlag::ChannelName);
             flags.unset(MessageElementFlag::ChannelPointReward);
@@ -1394,7 +1395,7 @@ MessageElementFlags ChannelView::getFlags() const
     }
 
     if (this->sourceChannel_ == app->twitch->mentionsChannel ||
-        this->sourceChannel_ == app->twitch->automodChannel)
+        this->sourceChannel_ == getIApp()->getTwitch()->getAutomodChannel())
     {
         flags.set(MessageElementFlag::ChannelName);
     }

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1383,7 +1383,8 @@ MessageElementFlags ChannelView::getFlags() const
         {
             flags.set(MessageElementFlag::ModeratorTools);
         }
-        if (this->underlyingChannel_ == app->twitch->mentionsChannel ||
+        if (this->underlyingChannel_ ==
+                getIApp()->getTwitch()->getMentionsChannel() ||
             this->underlyingChannel_ ==
                 getIApp()->getTwitch()->getLiveChannel() ||
             this->underlyingChannel_ ==
@@ -1394,7 +1395,7 @@ MessageElementFlags ChannelView::getFlags() const
         }
     }
 
-    if (this->sourceChannel_ == app->twitch->mentionsChannel ||
+    if (this->sourceChannel_ == getIApp()->getTwitch()->getMentionsChannel() ||
         this->sourceChannel_ == getIApp()->getTwitch()->getAutomodChannel())
     {
         flags.set(MessageElementFlag::ChannelName);
@@ -1548,8 +1549,8 @@ void ChannelView::drawMessages(QPainter &painter, const QRect &area)
 
         .canvasWidth = this->width(),
         .isWindowFocused = this->window() == QApplication::activeWindow(),
-        .isMentions =
-            this->underlyingChannel_ == getApp()->twitch->mentionsChannel,
+        .isMentions = this->underlyingChannel_ ==
+                      getIApp()->getTwitch()->getMentionsChannel(),
 
         .y = int(-(messagesSnapshot[start]->getHeight() *
                    (fmod(this->scrollBar_->getRelativeCurrentValue(), 1)))),

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1384,7 +1384,8 @@ MessageElementFlags ChannelView::getFlags() const
             flags.set(MessageElementFlag::ModeratorTools);
         }
         if (this->underlyingChannel_ == app->twitch->mentionsChannel ||
-            this->underlyingChannel_ == app->twitch->liveChannel ||
+            this->underlyingChannel_ ==
+                getIApp()->getTwitch()->getLiveChannel() ||
             this->underlyingChannel_ == app->twitch->automodChannel)
         {
             flags.set(MessageElementFlag::ChannelName);

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -2710,8 +2710,8 @@ void ChannelView::showUserInfoPopup(const QString &userName,
     auto *userPopup =
         new UserInfoPopup(getSettings()->autoCloseUserPopup, this->split_);
 
-    auto contextChannel =
-        getApp()->twitch->getChannelOrEmpty(alternativePopoutChannel);
+    auto contextChannel = getIApp()->getTwitchAbstract()->getChannelOrEmpty(
+        alternativePopoutChannel);
     auto openingChannel = this->hasSourceChannel() ? this->sourceChannel_
                                                    : this->underlyingChannel_;
     userPopup->setData(userName, contextChannel, openingChannel);

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -570,7 +570,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     // as an official description from 7TV devs is best
     s.showUnlistedSevenTVEmotes.connect(
         []() {
-            getApp()->twitch->forEachChannelAndSpecialChannels(
+            getIApp()->getTwitch()->forEachChannelAndSpecialChannels(
                 [](const auto &c) {
                     if (c->isTwitchChannel())
                     {

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -272,7 +272,7 @@ Split::Split(QWidget *parent)
     std::ignore = this->view_->openChannelIn.connect(
         [this](QString twitchChannel, FromTwitchLinkOpenChannelIn openIn) {
             ChannelPtr channel =
-                getApp()->twitch->getOrAddChannel(twitchChannel);
+                getIApp()->getTwitchAbstract()->getOrAddChannel(twitchChannel);
             switch (openIn)
             {
                 case FromTwitchLinkOpenChannelIn::Split:


### PR DESCRIPTION
This PR aims to remove all direct uses of `getApp()->twitch`, ensuring we can add tests for anything adjacent to `TwitchIrcServer`

The class and its inheritance is ugly, so this refactor PR is also pretty ugly. To achieve the goal of this PR without making too many changes, I've added `getTwitchAbstract()` alongside `getTwitch()` which returns the `IAbstractIrcServer` of the `TwitchIrcServer`.