### PR TITLE
Fix: tabs move animation for duplicated tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Minor: Colored usernames now update on the fly when changing the "Color @usernames" setting. (#5300)
 - Minor: Added `flags.action` filter variable, allowing you to filter on `/me` messages. (#5397)
 - Minor: Added the ability to duplicate tabs. (#5277)
+- Bugfix: Fixed tab move animation occasionally failing to start after closing a tab. (#5426)
 - Bugfix: If a network request errors with 200 OK, Qt's error code is now reported instead of the HTTP status. (#5378)
 - Bugfix: Fixed a crash that could occur when logging was enabled in IRC servers that were removed. (#5419)
 - Dev: Update Windows build from Qt 6.5.0 to Qt 6.7.1. (#5420)

--- a/src/widgets/helper/NotebookTab.cpp
+++ b/src/widgets/helper/NotebookTab.cpp
@@ -15,6 +15,7 @@
 #include "widgets/splits/SplitContainer.hpp"
 
 #include <boost/bind/bind.hpp>
+#include <QAbstractAnimation>
 #include <QApplication>
 #include <QDebug>
 #include <QDialogButtonBox>
@@ -422,7 +423,9 @@ void NotebookTab::moveAnimated(QPoint pos, bool animated)
         return;
     }
 
-    if (this->positionChangedAnimation_.endValue() == pos)
+    if (this->positionChangedAnimation_.state() ==
+            QAbstractAnimation::Running &&
+        this->positionChangedAnimation_.endValue() == pos)
     {
         return;
     }

--- a/src/widgets/helper/NotebookTab.cpp
+++ b/src/widgets/helper/NotebookTab.cpp
@@ -412,6 +412,11 @@ void NotebookTab::moveAnimated(QPoint pos, bool animated)
 {
     this->positionAnimationDesiredPoint_ = pos;
 
+    if (this->pos() == pos)
+    {
+        return;
+    }
+
     QWidget *w = this->window();
 
     if ((w != nullptr && !w->isVisible()) || !animated ||

--- a/src/widgets/helper/NotebookTab.cpp
+++ b/src/widgets/helper/NotebookTab.cpp
@@ -419,12 +419,9 @@ void NotebookTab::moveAnimated(QPoint pos, bool animated)
 
     QWidget *w = this->window();
 
-    if ((w != nullptr && !w->isVisible()) || !animated ||
-        !this->positionChangedAnimationRunning_)
+    if ((w != nullptr && !w->isVisible()) || !animated)
     {
         this->move(pos);
-
-        this->positionChangedAnimationRunning_ = true;
         return;
     }
 

--- a/src/widgets/helper/NotebookTab.cpp
+++ b/src/widgets/helper/NotebookTab.cpp
@@ -408,24 +408,24 @@ void NotebookTab::hideTabXChanged()
     this->update();
 }
 
-void NotebookTab::moveAnimated(QPoint pos, bool animated)
+void NotebookTab::moveAnimated(QPoint targetPos, bool animated)
 {
-    this->positionAnimationDesiredPoint_ = pos;
+    this->positionAnimationDesiredPoint_ = targetPos;
 
-    if (this->pos() == pos)
+    if (this->pos() == targetPos)
     {
         return;
     }
 
     if (!animated || !this->notebook_->isVisible())
     {
-        this->move(pos);
+        this->move(targetPos);
         return;
     }
 
     if (this->positionChangedAnimation_.state() ==
             QAbstractAnimation::Running &&
-        this->positionChangedAnimation_.endValue() == pos)
+        this->positionChangedAnimation_.endValue() == targetPos)
     {
         return;
     }
@@ -433,7 +433,7 @@ void NotebookTab::moveAnimated(QPoint pos, bool animated)
     this->positionChangedAnimation_.stop();
     this->positionChangedAnimation_.setDuration(75);
     this->positionChangedAnimation_.setStartValue(this->pos());
-    this->positionChangedAnimation_.setEndValue(pos);
+    this->positionChangedAnimation_.setEndValue(targetPos);
     this->positionChangedAnimation_.start();
 }
 

--- a/src/widgets/helper/NotebookTab.cpp
+++ b/src/widgets/helper/NotebookTab.cpp
@@ -417,9 +417,7 @@ void NotebookTab::moveAnimated(QPoint pos, bool animated)
         return;
     }
 
-    QWidget *w = this->window();
-
-    if ((w != nullptr && !w->isVisible()) || !animated)
+    if (!animated || !this->notebook_->isVisible())
     {
         this->move(pos);
         return;

--- a/src/widgets/helper/NotebookTab.hpp
+++ b/src/widgets/helper/NotebookTab.hpp
@@ -65,7 +65,7 @@ public:
     void setHighlightsEnabled(const bool &newVal);
     bool hasHighlightsEnabled() const;
 
-    void moveAnimated(QPoint pos, bool animated = true);
+    void moveAnimated(QPoint targetPos, bool animated = true);
 
     QRect getDesiredRect() const;
     void hideTabXChanged();

--- a/src/widgets/helper/NotebookTab.hpp
+++ b/src/widgets/helper/NotebookTab.hpp
@@ -108,7 +108,6 @@ private:
     int normalTabWidthForHeight(int height) const;
 
     QPropertyAnimation positionChangedAnimation_;
-    bool positionChangedAnimationRunning_ = false;
     QPoint positionAnimationDesiredPoint_;
 
     Notebook *notebook_;


### PR DESCRIPTION
**Repro steps**
1. duplicate a tab which is not last
2. close duplicated tab (might require 2 attempts)
3. removed tab will leave blank gap, following tab wont start animation to blank space

**Issue**
`positionChangedAnimation_` (QAbstractAnimation) for tabs is kept between animations, 
if `endValue()` of previously run animation match current targetPos - animation won't fire even though it should because current starting position might be different. This results in a gap which will stay until next notebook layout happen (where all tabs are moved again without animation).
There are also a lot of unnecessary Notebook layouts (like creating new tab results in 5x layouts of whole notebook) so that's something to fix too.

**Fix**
1. `endValue` for animation is now only checked for running animations (adf0458b8bcaa0d749f650e431822e1c91c316c5)
2. returning early when move is not needed also fixes the problem alone (72f48b9e80288be941aff503dea5eaf9fe033472)

added some minor refactors too
