### PR TITLE
fix: global emotes not loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Dev: Add doxygen build target. (#5377)
 - Dev: Make printing of strings in tests easier. (#5379)
 - Dev: Refactor and document `Scrollbar`. (#5334, #5393)
-- Dev: Refactor `TwitchIrcServer`, making it abstracted. (#5421)
+- Dev: Refactor `TwitchIrcServer`, making it abstracted. (#5421, #5435)
 - Dev: Reduced the amount of scale events. (#5404, #5406)
 - Dev: Removed unused timegate settings. (#5361)
 - Dev: All Lua globals now show in the `c2` global in the LuaLS metadata. (#5385)

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -211,6 +211,8 @@ void Application::initialize(Settings &settings, const Paths &paths)
         singleton->initialize(settings, paths);
     }
 
+    this->twitch->initialize();
+
     // XXX: Loading Twitch badges after Helix has been initialized, which only happens after
     // the AccountController initialize has been called
     this->twitchBadges->loadTwitchBadges();

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -165,7 +165,7 @@ TwitchIrcServer::TwitchIrcServer()
     //                                                     false);
 }
 
-void TwitchIrcServer::initialize(Settings &settings, const Paths &paths)
+void TwitchIrcServer::initialize()
 {
     getIApp()->getAccounts()->twitch.currentUserChanged.connect([this]() {
         postToThread([this] {

--- a/src/providers/twitch/TwitchIrcServer.hpp
+++ b/src/providers/twitch/TwitchIrcServer.hpp
@@ -2,7 +2,6 @@
 
 #include "common/Atomic.hpp"
 #include "common/Channel.hpp"
-#include "common/Singleton.hpp"
 #include "providers/irc/AbstractIrcServer.hpp"
 
 #include <pajlada/signals/signalholder.hpp>
@@ -52,15 +51,13 @@ public:
     // Update this interface with TwitchIrcServer methods as needed
 };
 
-class TwitchIrcServer final : public AbstractIrcServer,
-                              public Singleton,
-                              public ITwitchIrcServer
+class TwitchIrcServer final : public AbstractIrcServer, public ITwitchIrcServer
 {
 public:
     TwitchIrcServer();
     ~TwitchIrcServer() override = default;
 
-    void initialize(Settings &settings, const Paths &paths) override;
+    void initialize();
 
     void forEachChannelAndSpecialChannels(
         std::function<void(ChannelPtr)> func) override;

--- a/src/providers/twitch/TwitchIrcServer.hpp
+++ b/src/providers/twitch/TwitchIrcServer.hpp
@@ -57,6 +57,11 @@ public:
     TwitchIrcServer();
     ~TwitchIrcServer() override = default;
 
+    TwitchIrcServer(const TwitchIrcServer &) = delete;
+    TwitchIrcServer(TwitchIrcServer &&) = delete;
+    TwitchIrcServer &operator=(const TwitchIrcServer &) = delete;
+    TwitchIrcServer &operator=(TwitchIrcServer &&) = delete;
+
     void initialize();
 
     void forEachChannelAndSpecialChannels(


### PR DESCRIPTION
- **fix: manually initialize twitchircserver after rest of singletons are initialized**
- **unrelated nit: remove copy/move ctors/operators of twitchircserver**

Fixes #5434

<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
