### PR TITLE
feat: notify mods when users are warned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Minor: Added `flags.action` filter variable, allowing you to filter on `/me` messages. (#5397)
 - Minor: The size of the emote popup is now saved. (#5415)
 - Minor: Added the ability to duplicate tabs. (#5277)
+- Minor: Moderators can now see when users are warned. (#5441)
 - Bugfix: Fixed tab move animation occasionally failing to start after closing a tab. (#5426)
 - Bugfix: If a network request errors with 200 OK, Qt's error code is now reported instead of the HTTP status. (#5378)
 - Bugfix: Fixed restricted users usernames not being clickable. (#5405)

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -650,6 +650,23 @@ void Application::initPubSub()
                 chan->addOrReplaceTimeout(msg.release());
             });
         });
+
+    std::ignore = this->twitchPubSub->moderation.userWarned.connect(
+        [&](const auto &action) {
+            auto chan = this->twitch->getChannelOrEmptyByID(action.roomID);
+
+            if (chan->isEmpty())
+            {
+                return;
+            }
+
+            postToThread([chan, action] {
+                MessageBuilder msg(action);
+                msg->flags.set(MessageFlag::PubSub);
+                chan->addMessage(msg.release());
+            });
+        });
+
     std::ignore = this->twitchPubSub->moderation.messageDeleted.connect(
         [&](const auto &action) {
             auto chan = this->twitch->getChannelOrEmptyByID(action.roomID);

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -660,6 +660,7 @@ void Application::initPubSub()
                 return;
             }
 
+            // TODO: Resolve the moderator's user ID into a full user here, so message can look better
             postToThread([chan, action] {
                 MessageBuilder msg(action);
                 msg->flags.set(MessageFlag::PubSub);

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -323,6 +323,30 @@ MessageBuilder::MessageBuilder(const UnbanAction &action)
     this->message().searchText = text;
 }
 
+MessageBuilder::MessageBuilder(const WarnAction &action)
+    : MessageBuilder()
+{
+    this->emplace<TimestampElement>();
+    this->message().flags.set(MessageFlag::System);
+
+    QString text;
+
+    this->emplaceSystemTextAndUpdate("A moderator", text)
+        ->setLink({Link::UserInfo, "id:" + action.source.id});
+    this->emplaceSystemTextAndUpdate("warned", text);
+    this->emplaceSystemTextAndUpdate(
+            action.target.login + (action.reason.isEmpty() ? "." : ":"), text)
+        ->setLink({Link::UserInfo, action.target.login});
+
+    if (!action.reason.isEmpty())
+    {
+        this->emplaceSystemTextAndUpdate(action.reason, text);
+    }
+
+    this->message().messageText = text;
+    this->message().searchText = text;
+}
+
 MessageBuilder::MessageBuilder(const AutomodUserAction &action)
     : MessageBuilder()
 {

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -331,6 +331,7 @@ MessageBuilder::MessageBuilder(const WarnAction &action)
 
     QString text;
 
+    // TODO: Use MentionElement here, once WarnAction includes username/displayname
     this->emplaceSystemTextAndUpdate("A moderator", text)
         ->setLink({Link::UserInfo, "id:" + action.source.id});
     this->emplaceSystemTextAndUpdate("warned", text);

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -336,12 +336,12 @@ MessageBuilder::MessageBuilder(const WarnAction &action)
         ->setLink({Link::UserInfo, "id:" + action.source.id});
     this->emplaceSystemTextAndUpdate("warned", text);
     this->emplaceSystemTextAndUpdate(
-            action.target.login + (action.reason.isEmpty() ? "." : ":"), text)
+            action.target.login + (action.reasons.isEmpty() ? "." : ":"), text)
         ->setLink({Link::UserInfo, action.target.login});
 
-    if (!action.reason.isEmpty())
+    if (!action.reasons.isEmpty())
     {
-        this->emplaceSystemTextAndUpdate(action.reason, text);
+        this->emplaceSystemTextAndUpdate(action.reasons.join(", "), text);
     }
 
     this->message().messageText = text;

--- a/src/messages/MessageBuilder.hpp
+++ b/src/messages/MessageBuilder.hpp
@@ -12,6 +12,7 @@
 namespace chatterino {
 struct BanAction;
 struct UnbanAction;
+struct WarnAction;
 struct AutomodAction;
 struct AutomodUserAction;
 struct AutomodInfoAction;
@@ -78,6 +79,7 @@ public:
                    const QTime &time = QTime::currentTime());
     MessageBuilder(const BanAction &action, uint32_t count = 1);
     MessageBuilder(const UnbanAction &action);
+    MessageBuilder(const WarnAction &action);
     MessageBuilder(const AutomodUserAction &action);
 
     MessageBuilder(LiveUpdatesAddEmoteMessageTag, const QString &platform,

--- a/src/providers/twitch/PubSubActions.hpp
+++ b/src/providers/twitch/PubSubActions.hpp
@@ -4,6 +4,7 @@
 #include <QDebug>
 #include <QJsonObject>
 #include <QString>
+#include <QStringList>
 
 #include <chrono>
 #include <cinttypes>
@@ -176,7 +177,7 @@ struct WarnAction : PubSubAction {
 
     ActionUser target;
 
-    QString reason;
+    QStringList reasons;
 };
 
 }  // namespace chatterino

--- a/src/providers/twitch/PubSubActions.hpp
+++ b/src/providers/twitch/PubSubActions.hpp
@@ -171,4 +171,12 @@ struct AutomodInfoAction : PubSubAction {
     } type;
 };
 
+struct WarnAction : PubSubAction {
+    using PubSubAction::PubSubAction;
+
+    ActionUser target;
+
+    QString reason;
+};
+
 }  // namespace chatterino

--- a/src/providers/twitch/PubSubManager.cpp
+++ b/src/providers/twitch/PubSubManager.cpp
@@ -299,14 +299,17 @@ PubSub::PubSub(const QString &host, std::chrono::seconds pingInterval)
 
         const auto reasons = data.value("args").toArray();
         bool firstArg = true;
-        for (const auto &reasonValue : reasons) {
-            if (firstArg) {
+        for (const auto &reasonValue : reasons)
+        {
+            if (firstArg)
+            {
                 // Skip first arg in the reasons array since it's not a reason
                 firstArg = false;
                 continue;
             }
             const auto &reason = reasonValue.toString();
-            if (!reason.isEmpty()) {
+            if (!reason.isEmpty())
+            {
                 action.reasons.append(reason);
             }
         }

--- a/src/providers/twitch/PubSubManager.cpp
+++ b/src/providers/twitch/PubSubManager.cpp
@@ -297,10 +297,18 @@ PubSub::PubSub(const QString &host, std::chrono::seconds pingInterval)
         action.target.id = data.value("target_user_id").toString();
         action.target.login = data.value("target_user_login").toString();
 
-        const auto args = data.value("args").toArray();
-        if (args.size() > 1)
-        {
-            action.reason = args[1].toString();
+        const auto reasons = data.value("args").toArray();
+        bool firstArg = true;
+        for (const auto &reasonValue : reasons) {
+            if (firstArg) {
+                // Skip first arg in the reasons array since it's not a reason
+                firstArg = false;
+                continue;
+            }
+            const auto &reason = reasonValue.toString();
+            if (!reason.isEmpty()) {
+                action.reasons.append(reason);
+            }
         }
 
         this->moderation.userWarned.invoke(action);

--- a/src/providers/twitch/PubSubManager.hpp
+++ b/src/providers/twitch/PubSubManager.hpp
@@ -34,6 +34,7 @@ struct PubSubAutoModQueueMessage;
 struct AutomodAction;
 struct AutomodUserAction;
 struct AutomodInfoAction;
+struct WarnAction;
 struct PubSubLowTrustUsersMessage;
 struct PubSubWhisperMessage;
 
@@ -97,6 +98,7 @@ public:
 
         Signal<BanAction> userBanned;
         Signal<UnbanAction> userUnbanned;
+        Signal<WarnAction> userWarned;
 
         Signal<PubSubLowTrustUsersMessage> suspiciousMessageReceived;
         Signal<PubSubLowTrustUsersMessage> suspiciousTreatmentUpdated;


### PR DESCRIPTION
Currently the pubsub topic only contains the moderator user id but not name, so we say `A moderator` did the action (which is still clickable to open their usercard based on id)

![image](https://github.com/Chatterino/chatterino2/assets/8106344/411662d6-d300-4294-9625-32d8b7e26be1)

Related to #5439
