### PR TITLE
fix: ignore late pings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Bugfix: If a network request errors with 200 OK, Qt's error code is now reported instead of the HTTP status. (#5378)
 - Bugfix: Fixed restricted users usernames not being clickable. (#5405)
 - Bugfix: Fixed a crash that could occur when logging was enabled in IRC servers that were removed. (#5419)
+- Bugfix: Fixed message history occasionally not loading after a sleep. (#5457)
 - Dev: Update Windows build from Qt 6.5.0 to Qt 6.7.1. (#5420)
 - Dev: Update vcpkg build Qt from 6.5.0 to 6.7.0, boost from 1.83.0 to 1.85.0, openssl from 3.1.3 to 3.3.0. (#5422)
 - Dev: Use Qt's high DPI scaling. (#4868, #5400)

--- a/src/providers/irc/IrcConnection2.cpp
+++ b/src/providers/irc/IrcConnection2.cpp
@@ -60,6 +60,7 @@ IrcConnection::IrcConnection(QObject *parent)
     // Send ping every x seconds
     this->pingTimer_.setInterval(5000);
     this->pingTimer_.start();
+    this->lastPing_ = std::chrono::system_clock::now();
     QObject::connect(&this->pingTimer_, &QTimer::timeout, [this] {
         if (this->isConnected())
         {

--- a/src/providers/irc/IrcConnection2.hpp
+++ b/src/providers/irc/IrcConnection2.hpp
@@ -6,6 +6,8 @@
 #include <pajlada/signals/signal.hpp>
 #include <QTimer>
 
+#include <chrono>
+
 namespace chatterino {
 
 class IrcConnection : public Communi::IrcConnection
@@ -33,6 +35,7 @@ private:
     QTimer pingTimer_;
     QTimer reconnectTimer_;
     std::atomic<bool> recentlyReceivedMessage_{true};
+    std::chrono::time_point<std::chrono::system_clock> lastPing_;
 
     // Reconnect with a base delay of 1 second and max out at 1 second * (2^(5-1)) (i.e. 16 seconds)
     ExponentialBackoff<5> reconnectBackoff_{std::chrono::milliseconds{1000}};


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

When sleeping, both incoming messages and timer invocations are stalled and (kind of) replayed when waking up (i.e. `Communi::IrcConnection::messageReceived` will fire pending events _after_ waking up and `pingTimer_` will fire the pending ping). This leads to a heartbeat.

The logs before are from https://github.com/SevenTV/chatterino7/compare/chatterino7...355acd51ce30f1899ec85fd2231533c91ea3d9db and the logs after are from https://github.com/SevenTV/chatterino7/compare/chatterino7...nerix/rm-logging.

<details><summary>Logs before</summary>

```text
2024-06-14T20:28:15 chatterino.irc: Communi::IrcConnection::messageReceived "PRIVMSG"
2024-06-14T20:28:15 chatterino.irc: Communi::IrcConnection::messageReceived "PRIVMSG"
2024-06-14T20:28:15 chatterino.irc: Communi::IrcConnection::messageReceived "PRIVMSG"
2024-06-14T22:39:12 chatterino.irc: Communi::IrcConnection::messageReceived "PRIVMSG"
2024-06-14T22:39:12 chatterino.irc: Communi::IrcConnection::messageReceived "PRIVMSG"
2024-06-14T22:39:12 chatterino.irc: Communi::IrcConnection::messageReceived "PRIVMSG"
2024-06-14T22:39:12 chatterino.irc: Reconnecting
2024-06-14T22:39:12 chatterino.irc: pingTimer
2024-06-14T22:39:12 chatterino.recentmessages: "[...]" markConnected QDateTime(2024-06-14 20:39:12.670 UTC Qt::UTC)
```
</details> 

<details><summary>Logs after</summary>

```text
2024-06-15T20:25:54 chatterino.irc: Communi::IrcConnection::messageReceived "PRIVMSG" QDateTime(2024-06-15 20:25:54.633 Mitteleuropäische Sommerzeit Qt::LocalTime)
2024-06-15T20:25:54 chatterino.irc: Communi::IrcConnection::messageReceived "PRIVMSG" QDateTime(2024-06-15 20:25:54.938 Mitteleuropäische Sommerzeit Qt::LocalTime)
2024-06-15T20:25:55 chatterino.irc: pingTimer
2024-06-15T20:25:55 chatterino.irc: Communi::IrcConnection::messageReceived "PRIVMSG" QDateTime(2024-06-15 20:25:55.361 Mitteleuropäische Sommerzeit Qt::LocalTime)
2024-06-15T20:25:55 chatterino.irc: Communi::IrcConnection::messageReceived "PRIVMSG" QDateTime(2024-06-15 20:25:55.597 Mitteleuropäische Sommerzeit Qt::LocalTime)
2024-06-15T20:25:55 chatterino.irc: Communi::IrcConnection::messageReceived "PRIVMSG" QDateTime(2024-06-15 20:25:55.699 Mitteleuropäische Sommerzeit Qt::LocalTime)
2024-06-15T20:25:55 chatterino.irc: Communi::IrcConnection::messageReceived "PRIVMSG" QDateTime(2024-06-15 20:25:55.845 Mitteleuropäische Sommerzeit Qt::LocalTime)
2024-06-15T20:25:55 chatterino.irc: Communi::IrcConnection::messageReceived "PRIVMSG" QDateTime(2024-06-15 20:25:55.879 Mitteleuropäische Sommerzeit Qt::LocalTime)
2024-06-15T20:26:09 chatterino.irc: Reconnecting
2024-06-15T20:26:09 chatterino.irc: Communi::IrcConnection::messageReceived "PRIVMSG" QDateTime(2024-06-15 20:26:09.549 Mitteleuropäische Sommerzeit Qt::LocalTime)
2024-06-15T20:26:09 chatterino.irc: Communi::IrcConnection::messageReceived "PRIVMSG" QDateTime(2024-06-15 20:26:09.564 Mitteleuropäische Sommerzeit Qt::LocalTime)
2024-06-15T20:26:09 chatterino.irc: pingTimer
2024-06-15T20:26:09 chatterino.irc: no ping!
2024-06-15T20:26:09 chatterino.irc: pingTimer
2024-06-15T20:26:09 chatterino.irc: no ping!
2024-06-15T20:26:09 chatterino.irc: Communi::IrcConnection::messageReceived "PONG" QDateTime(2024-06-15 20:26:09.618 Mitteleuropäische Sommerzeit Qt::LocalTime)
2024-06-15T20:26:10 chatterino.irc: Communi::IrcConnection::messageReceived "PRIVMSG" QDateTime(2024-06-15 20:26:10.111 Mitteleuropäische Sommerzeit Qt::LocalTime)
2024-06-15T20:26:10 chatterino.irc: Communi::IrcConnection::messageReceived "PRIVMSG" QDateTime(2024-06-15 20:26:10.122 Mitteleuropäische Sommerzeit Qt::LocalTime)
2024-06-15T20:26:10 chatterino.irc: Communi::IrcConnection::messageReceived "PRIVMSG" QDateTime(2024-06-15 20:26:10.566 Mitteleuropäische Sommerzeit Qt::LocalTime)
2024-06-15T20:26:10 chatterino.irc: Communi::IrcConnection::messageReceived "PRIVMSG" QDateTime(2024-06-15 20:26:10.718 Mitteleuropäische Sommerzeit Qt::LocalTime)
2024-06-15T20:26:10 chatterino.irc: Communi::IrcConnection::messageReceived "PRIVMSG" QDateTime(2024-06-15 20:26:10.764 Mitteleuropäische Sommerzeit Qt::LocalTime)
2024-06-15T20:26:10 chatterino.irc: Communi::IrcConnection::messageReceived "PRIVMSG" QDateTime(2024-06-15 20:26:10.919 Mitteleuropäische Sommerzeit Qt::LocalTime)
2024-06-15T20:26:11 chatterino.irc: Communi::IrcConnection::messageReceived "PRIVMSG" QDateTime(2024-06-15 20:26:11.056 Mitteleuropäische Sommerzeit Qt::LocalTime)
2024-06-15T22:47:35 chatterino.irc: Communi::IrcConnection::messageReceived "PRIVMSG" QDateTime(2024-06-15 22:47:35.423 Mitteleuropäische Sommerzeit Qt::LocalTime)
2024-06-15T22:47:35 chatterino.irc: Communi::IrcConnection::messageReceived "PRIVMSG" QDateTime(2024-06-15 22:47:35.568 Mitteleuropäische Sommerzeit Qt::LocalTime)
2024-06-15T22:47:35 chatterino.irc: Communi::IrcConnection::messageReceived "PRIVMSG" QDateTime(2024-06-15 22:47:35.652 Mitteleuropäische Sommerzeit Qt::LocalTime)
2024-06-15T22:47:35 chatterino.irc: Communi::IrcConnection::messageReceived "PRIVMSG" QDateTime(2024-06-15 22:47:35.670 Mitteleuropäische Sommerzeit Qt::LocalTime)
2024-06-15T22:47:42 chatterino.irc: Connection error: QAbstractSocket::RemoteHostClosedError
2024-06-15T22:47:42 chatterino.irc: Read connection reconnect requested. Timeout: false
2024-06-15T22:47:42 chatterino.irc: Reconnecting in 1000 ms
2024-06-15T22:47:42 chatterino.notification: fetching fake channels
2024-06-15T22:47:42 chatterino.twitch.livecontroller: Make 1 requests
2024-06-15T22:47:43 chatterino.irc: pingTimer
2024-06-15T22:47:43 chatterino.irc: no ping!
```
</details> 

Fixes https://github.com/Chatterino/chatterino2/issues/5453.