### PR TITLE
chore: unsingletonize UserDataController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Dev: Images are now loaded in worker threads. (#5431)
 - Dev: Qt Creator now auto-configures Conan when loading the project and skips vcpkg. (#5305)
 - Dev: The MSVC CRT is now bundled with Chatterino as it depends on having a recent version installed. (#5447)
+- Dev: Refactor/unsingletonize `UserDataController`. (#5459)
 
 ## 2.5.1
 

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -135,7 +135,7 @@ Application::Application(Settings &_settings, const Paths &paths,
     , twitch(new TwitchIrcServer)
     , ffzBadges(&this->emplace<FfzBadges>())
     , seventvBadges(&this->emplace<SeventvBadges>())
-    , userData(&this->emplace(new UserDataController(paths)))
+    , userData(new UserDataController(paths))
     , sound(&this->emplace<ISoundController>(makeSoundController(_settings)))
     , twitchLiveController(&this->emplace<TwitchLiveController>())
     , twitchPubSub(new PubSub(TWITCH_PUBSUB_URL))
@@ -173,6 +173,7 @@ void Application::fakeDtor()
     this->seventvEmotes.reset();
     // this->twitch.reset();
     this->fonts.reset();
+    this->userData.reset();
 }
 
 void Application::initialize(Settings &settings, const Paths &paths)
@@ -427,7 +428,7 @@ IUserDataController *Application::getUserData()
 {
     assertInGuiThread();
 
-    return this->userData;
+    return this->userData.get();
 }
 
 ISoundController *Application::getSound()

--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -160,7 +160,7 @@ private:
     std::unique_ptr<TwitchIrcServer> twitch;
     FfzBadges *const ffzBadges{};
     SeventvBadges *const seventvBadges{};
-    UserDataController *const userData{};
+    std::unique_ptr<UserDataController> userData;
     ISoundController *const sound{};
     TwitchLiveController *const twitchLiveController{};
     std::unique_ptr<PubSub> twitchPubSub;

--- a/src/controllers/userdata/UserDataController.cpp
+++ b/src/controllers/userdata/UserDataController.cpp
@@ -37,11 +37,6 @@ UserDataController::UserDataController(const Paths &paths)
     this->users = this->setting.getValue();
 }
 
-void UserDataController::save()
-{
-    this->sm->save();
-}
-
 std::optional<UserData> UserDataController::getUser(const QString &userID) const
 {
     std::shared_lock lock(this->usersMutex);

--- a/src/controllers/userdata/UserDataController.hpp
+++ b/src/controllers/userdata/UserDataController.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "common/Singleton.hpp"
 #include "controllers/userdata/UserData.hpp"
 #include "util/QStringHash.hpp"
 #include "util/RapidjsonHelpers.hpp"
@@ -30,7 +29,7 @@ public:
                               const QString &colorString) = 0;
 };
 
-class UserDataController : public IUserDataController, public Singleton
+class UserDataController : public IUserDataController
 {
 public:
     explicit UserDataController(const Paths &paths);
@@ -42,9 +41,6 @@ public:
     // Update or insert extra data for the user's color override
     void setUserColor(const QString &userID,
                       const QString &colorString) override;
-
-protected:
-    void save() override;
 
 private:
     void update(std::unordered_map<QString, UserData> &&newUsers);


### PR DESCRIPTION
The `user-data.json` file will save immediately on change, and on exit
(on dtor) if necessary. So we don't need to manually call save

<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
