### PR TITLE
dev: remove macos artifact from nightly release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -380,18 +380,9 @@ jobs:
           cp .CI/chatterino-nightly.flatpakref release-artifacts/
         shell: bash
 
-      # macOS
-      - uses: actions/download-artifact@v4
-        name: macOS x86_64 Qt5.15.2 dmg
-        with:
-          name: chatterino-macos-Qt-5.15.2.dmg
-          path: release-artifacts/
-
       - name: Rename artifacts
         run: |
           ls -l
-          # Rename the macos build to indicate that it's for macOS 10.15 users
-          mv chatterino-macos-Qt-5.15.2.dmg Chatterino-macOS-10.15.dmg
 
           # Mark all Windows Qt5 builds as old
           mv chatterino-windows-x86-64-Qt-5.15.2.zip chatterino-windows-old-x86-64-Qt-5.15.2.zip


### PR DESCRIPTION
My mac mini now builds the release artifacts for 10.15 using Qt 6.4.3 and for 11+ using Qt 6.7.0, so I'm removing the nightly artifact publishing for the mac CI build

<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
