### PR TITLE
fix: prevent user info popups re-logging messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Bugfix: Fixed message history occasionally not loading after a sleep. (#5457)
 - Bugfix: Fixed a crash when tab completing while having an invalid plugin loaded. (#5401)
 - Bugfix: Fixed windows on Windows not saving correctly when snapping them to the edges. (#5478)
+- Bugfix: Fixed user info card popups adding duplicate line to log files. (#5487)
 - Dev: Update Windows build from Qt 6.5.0 to Qt 6.7.1. (#5420)
 - Dev: Update vcpkg build Qt from 6.5.0 to 6.7.0, boost from 1.83.0 to 1.85.0, openssl from 3.1.3 to 3.3.0. (#5422)
 - Dev: Unsingletonize `ISoundController`. (#5462)

--- a/src/common/Channel.cpp
+++ b/src/common/Channel.cpp
@@ -84,7 +84,11 @@ void Channel::addMessage(MessagePtr message,
 {
     MessagePtr deleted;
 
-    if (!overridingFlags || !overridingFlags->has(MessageFlag::DoNotLog))
+    auto isDoNotLogSet =
+        (overridingFlags && overridingFlags->has(MessageFlag::DoNotLog)) ||
+        message->flags.has(MessageFlag::DoNotLog);
+
+    if (!isDoNotLogSet)
     {
         QString channelPlatform("other");
         if (this->type_ == Type::Irc)

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1010,7 +1010,15 @@ void ChannelView::setChannel(const ChannelPtr &underlyingChannel)
         }
 
         this->messages_.pushBack(messageLayout);
-        this->channel_->addMessage(msg);
+
+        auto overrideFlags = std::optional<MessageFlags>(msg->flags);
+        if (this->context_ != Context::None)
+        {
+            overrideFlags->set(MessageFlag::DoNotLog);
+        }
+
+        this->channel_->addMessage(msg, overrideFlags);
+
         nMessagesAdded++;
         if (this->showScrollbarHighlights())
         {


### PR DESCRIPTION
This PR aims to fix #5470 where opening a user's info card would cause all of the user's messages to be re-logged for that channel. This only happens with user popups because all other "fake" channels (search, reply threads etc.) explicitly set the `MessageFlags::DoNotLog` flag when adding messages from a channel snapshot.

I've also cleaned up the logic around choosing what messages to log as it would prevent logging when passed overriding flags that DID NOT contain a `DoNotLog` flag. The altered logic now handles that, as well as checks the original message on the off chance someone's tagged that too. I've retested search and reply threads which all retain the original behaviour.

Original behaviour (7bfb5ac0a):

https://github.com/Chatterino/chatterino2/assets/4962764/d243e691-234b-4d62-a44c-902cdc435282

Post-change behaviour (aca9e9b0, the hash in this clip was stale on my clipboard):

https://github.com/Chatterino/chatterino2/assets/4962764/5b123026-c10a-4674-9d3f-79590c7de2a6