### PR TITLE
Add extra context to messages that are added to channels, allowing the logging controller to take more responsibility in what messages to log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Bugfix: Fixed message history occasionally not loading after a sleep. (#5457)
 - Bugfix: Fixed a crash when tab completing while having an invalid plugin loaded. (#5401)
 - Bugfix: Fixed windows on Windows not saving correctly when snapping them to the edges. (#5478)
+- Bugfix: Fixed user info card popups adding duplicate line to log files. (#5487)
 - Bugfix: Fixed `/clearmessages` not working with more than one window. (#5489)
 - Dev: Update Windows build from Qt 6.5.0 to Qt 6.7.1. (#5420)
 - Dev: Update vcpkg build Qt from 6.5.0 to 6.7.0, boost from 1.83.0 to 1.85.0, openssl from 3.1.3 to 3.3.0. (#5422)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 - Bugfix: Fixed message history occasionally not loading after a sleep. (#5457)
 - Bugfix: Fixed a crash when tab completing while having an invalid plugin loaded. (#5401)
 - Bugfix: Fixed windows on Windows not saving correctly when snapping them to the edges. (#5478)
-- Bugfix: Fixed user info card popups adding duplicate line to log files. (#5487)
+- Bugfix: Fixed user info card popups adding duplicate line to log files. (#5499)
 - Bugfix: Fixed `/clearmessages` not working with more than one window. (#5489)
 - Bugfix: Fixed splits staying paused after unfocusing Chatterino in certain configurations. (#5504)
 - Dev: Update Windows build from Qt 6.5.0 to Qt 6.7.1. (#5420)

--- a/mocks/include/mocks/Logging.hpp
+++ b/mocks/include/mocks/Logging.hpp
@@ -16,7 +16,9 @@ public:
 
     MOCK_METHOD(void, addMessage,
                 (const QString &channelName, MessagePtr message,
-                 const QString &platformName),
+                 const QString &platformName,
+                 std::optional<MessageFlags> overridingFlags,
+                 MessageContext context),
                 (override));
 };
 
@@ -27,7 +29,9 @@ public:
     ~EmptyLogging() override = default;
 
     void addMessage(const QString &channelName, MessagePtr message,
-                    const QString &platformName) override
+                    const QString &platformName,
+                    std::optional<MessageFlags> overridingFlags,
+                    MessageContext context) override
     {
         //
     }

--- a/mocks/include/mocks/Logging.hpp
+++ b/mocks/include/mocks/Logging.hpp
@@ -16,9 +16,7 @@ public:
 
     MOCK_METHOD(void, addMessage,
                 (const QString &channelName, MessagePtr message,
-                 const QString &platformName,
-                 std::optional<MessageFlags> overridingFlags,
-                 MessageContext context),
+                 const QString &platformName),
                 (override));
 };
 
@@ -29,9 +27,7 @@ public:
     ~EmptyLogging() override = default;
 
     void addMessage(const QString &channelName, MessagePtr message,
-                    const QString &platformName,
-                    std::optional<MessageFlags> overridingFlags,
-                    MessageContext context) override
+                    const QString &platformName) override
     {
         //
     }

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -664,7 +664,7 @@ void Application::initPubSub()
             postToThread([chan, action] {
                 MessageBuilder msg(action);
                 msg->flags.set(MessageFlag::PubSub);
-                chan->addMessage(msg.release());
+                chan->addMessage(msg.release(), MessageContext::Original);
             });
         });
 
@@ -703,7 +703,7 @@ void Application::initPubSub()
                 }
                 if (!replaced)
                 {
-                    chan->addMessage(msg);
+                    chan->addMessage(msg, MessageContext::Original);
                 }
             });
         });
@@ -720,7 +720,7 @@ void Application::initPubSub()
             auto msg = MessageBuilder(action).release();
 
             postToThread([chan, msg] {
-                chan->addMessage(msg);
+                chan->addMessage(msg, MessageContext::Original);
             });
         });
 
@@ -770,8 +770,10 @@ void Application::initPubSub()
                         TwitchMessageBuilder::makeLowTrustUserMessage(
                             action, twitchChannel->getName(),
                             twitchChannel.get());
-                    twitchChannel->addMessage(p.first);
-                    twitchChannel->addMessage(p.second);
+                    twitchChannel->addMessage(p.first,
+                                              MessageContext::Original);
+                    twitchChannel->addMessage(p.second,
+                                              MessageContext::Original);
                 });
             });
 
@@ -809,7 +811,7 @@ void Application::initPubSub()
                 postToThread([chan, action] {
                     auto msg =
                         TwitchMessageBuilder::makeLowTrustUpdateMessage(action);
-                    chan->addMessage(msg);
+                    chan->addMessage(msg, MessageContext::Original);
                 });
             });
 
@@ -891,28 +893,41 @@ void Application::initPubSub()
                             const auto p =
                                 TwitchMessageBuilder::makeAutomodMessage(
                                     action, chan->getName());
-                            chan->addMessage(p.first);
-                            chan->addMessage(p.second);
+                            chan->addMessage(p.first, MessageContext::Original);
+                            chan->addMessage(p.second,
+                                             MessageContext::Original);
 
                             getIApp()
                                 ->getTwitch()
                                 ->getAutomodChannel()
-                                ->addMessage(p.first);
+                                ->addMessage(
+                                    p.first,
+                                    MessageContext::
+                                        Original);  // is this original?
                             getIApp()
                                 ->getTwitch()
                                 ->getAutomodChannel()
-                                ->addMessage(p.second);
+                                ->addMessage(
+                                    p.second,
+                                    MessageContext::
+                                        Original);  // is this original?
 
                             if (getSettings()->showAutomodInMentions)
                             {
                                 getIApp()
                                     ->getTwitch()
                                     ->getMentionsChannel()
-                                    ->addMessage(p.first);
+                                    ->addMessage(
+                                        p.first,
+                                        MessageContext::
+                                            Original);  // is this original?
                                 getIApp()
                                     ->getTwitch()
                                     ->getMentionsChannel()
-                                    ->addMessage(p.second);
+                                    ->addMessage(
+                                        p.second,
+                                        MessageContext::
+                                            Original);  // is this original?
                             }
                         });
                     }
@@ -939,8 +954,8 @@ void Application::initPubSub()
             postToThread([chan, action] {
                 const auto p = TwitchMessageBuilder::makeAutomodMessage(
                     action, chan->getName());
-                chan->addMessage(p.first);
-                chan->addMessage(p.second);
+                chan->addMessage(p.first, MessageContext::Original);
+                chan->addMessage(p.second, MessageContext::Original);
             });
         });
 
@@ -961,7 +976,7 @@ void Application::initPubSub()
             auto msg = MessageBuilder(action).release();
 
             postToThread([chan, msg] {
-                chan->addMessage(msg);
+                chan->addMessage(msg, MessageContext::Original);
             });
             chan->deleteMessage(msg->id);
         });
@@ -978,7 +993,7 @@ void Application::initPubSub()
             postToThread([chan, action] {
                 const auto p =
                     TwitchMessageBuilder::makeAutomodInfoMessage(action);
-                chan->addMessage(p);
+                chan->addMessage(p, MessageContext::Original);
             });
         });
 

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -900,34 +900,25 @@ void Application::initPubSub()
                             getIApp()
                                 ->getTwitch()
                                 ->getAutomodChannel()
-                                ->addMessage(
-                                    p.first,
-                                    MessageContext::
-                                        Original);  // is this original?
+                                ->addMessage(p.first, MessageContext::Original);
                             getIApp()
                                 ->getTwitch()
                                 ->getAutomodChannel()
-                                ->addMessage(
-                                    p.second,
-                                    MessageContext::
-                                        Original);  // is this original?
+                                ->addMessage(p.second,
+                                             MessageContext::Original);
 
                             if (getSettings()->showAutomodInMentions)
                             {
                                 getIApp()
                                     ->getTwitch()
                                     ->getMentionsChannel()
-                                    ->addMessage(
-                                        p.first,
-                                        MessageContext::
-                                            Original);  // is this original?
+                                    ->addMessage(p.first,
+                                                 MessageContext::Original);
                                 getIApp()
                                     ->getTwitch()
                                     ->getMentionsChannel()
-                                    ->addMessage(
-                                        p.second,
-                                        MessageContext::
-                                            Original);  // is this original?
+                                    ->addMessage(p.second,
+                                                 MessageContext::Original);
                             }
                         });
                     }

--- a/src/common/Channel.cpp
+++ b/src/common/Channel.cpp
@@ -55,11 +55,6 @@ const QString &Channel::getName() const
     return this->name_;
 }
 
-QString Channel::getPlatform() const
-{
-    return this->platform_;
-}
-
 const QString &Channel::getDisplayName() const
 {
     return this->getName();
@@ -106,7 +101,7 @@ void Channel::addMessage(MessagePtr message, MessageContext context,
         {
             // Only log messages where the `DoNotLog` flag is not set
             getIApp()->getChatLogger()->addMessage(this->name_, message,
-                                                   this->getPlatform());
+                                                   this->platform_);
         }
     }
 

--- a/src/common/Channel.cpp
+++ b/src/common/Channel.cpp
@@ -84,7 +84,11 @@ void Channel::addMessage(MessagePtr message,
 {
     MessagePtr deleted;
 
-    if (!overridingFlags || !overridingFlags->has(MessageFlag::DoNotLog))
+    auto isDoNotLogSet =
+        (overridingFlags && overridingFlags->has(MessageFlag::DoNotLog)) ||
+        message->flags.has(MessageFlag::DoNotLog);
+
+    if (!isDoNotLogSet)
     {
         QString channelPlatform("other");
         if (this->type_ == Type::Irc)

--- a/src/common/Channel.cpp
+++ b/src/common/Channel.cpp
@@ -112,8 +112,20 @@ void Channel::addMessage(MessagePtr message, MessageContext context,
 {
     MessagePtr deleted;
 
-    getIApp()->getChatLogger()->addMessage(
-        this->name_, message, this->getPlatform(), overridingFlags, context);
+    if (context == MessageContext::Original)
+    {
+        // Only log original messages
+        auto isDoNotLogSet =
+            (overridingFlags && overridingFlags->has(MessageFlag::DoNotLog)) ||
+            message->flags.has(MessageFlag::DoNotLog);
+
+        if (!isDoNotLogSet)
+        {
+            // Only log messages where the `DoNotLog` flag is not set
+            getIApp()->getChatLogger()->addMessage(this->name_, message,
+                                                   this->getPlatform());
+        }
+    }
 
     if (this->messages_.pushBack(message, deleted))
     {

--- a/src/common/Channel.cpp
+++ b/src/common/Channel.cpp
@@ -32,6 +32,12 @@ Channel::Channel(const QString &name, Type type)
     , messages_(getSettings()->scrollbackSplitLimit)
     , type_(type)
 {
+    if (this->isTwitchChannel())
+    {
+        this->platform_ = "twitch";
+    }
+
+    // Irc platform is set through IrcChannel2 ctor
 }
 
 Channel::~Channel()
@@ -51,30 +57,7 @@ const QString &Channel::getName() const
 
 QString Channel::getPlatform() const
 {
-    QString channelPlatform("other");
-    if (this->type_ == Type::Irc)
-    {
-        const auto *irc = dynamic_cast<const IrcChannel *>(this);
-        if (irc != nullptr)
-        {
-            auto *ircServer = irc->server();
-            if (ircServer != nullptr)
-            {
-                channelPlatform = QString("irc-%1").arg(
-                    irc->server()->userFriendlyIdentifier());
-            }
-            else
-            {
-                channelPlatform = "irc-unknown";
-            }
-        }
-    }
-    else if (this->isTwitchChannel())
-    {
-        channelPlatform = "twitch";
-    }
-
-    return channelPlatform;
+    return this->platform_;
 }
 
 const QString &Channel::getDisplayName() const

--- a/src/common/Channel.hpp
+++ b/src/common/Channel.hpp
@@ -28,6 +28,14 @@ enum class TimeoutStackStyle : int {
     Default = DontStackBeyondUserMessage,
 };
 
+/// Context of the message being added to a channel
+enum class MessageContext {
+    /// This message is the original
+    Original,
+    /// This message is a repost of a message that has already been added in a channel
+    Repost,
+};
+
 class Channel : public std::enable_shared_from_this<Channel>
 {
 public:
@@ -69,6 +77,7 @@ public:
 
     Type getType() const;
     const QString &getName() const;
+    QString getPlatform() const;
     virtual const QString &getDisplayName() const;
     virtual const QString &getLocalizedName() const;
     bool isTwitchChannel() const;
@@ -79,7 +88,7 @@ public:
     // overridingFlags can be filled in with flags that should be used instead
     // of the message's flags. This is useful in case a flag is specific to a
     // type of split
-    void addMessage(MessagePtr message,
+    void addMessage(MessagePtr message, MessageContext context,
                     std::optional<MessageFlags> overridingFlags = std::nullopt);
     void addMessagesAtStart(const std::vector<MessagePtr> &messages_);
 

--- a/src/common/Channel.hpp
+++ b/src/common/Channel.hpp
@@ -77,7 +77,6 @@ public:
 
     Type getType() const;
     const QString &getName() const;
-    QString getPlatform() const;
     virtual const QString &getDisplayName() const;
     virtual const QString &getLocalizedName() const;
     bool isTwitchChannel() const;

--- a/src/common/Channel.hpp
+++ b/src/common/Channel.hpp
@@ -129,6 +129,7 @@ public:
 protected:
     virtual void onConnected();
     virtual void messageRemovedFromStart(const MessagePtr &msg);
+    QString platform_;
 
 private:
     const QString name_;

--- a/src/common/Channel.hpp
+++ b/src/common/Channel.hpp
@@ -128,7 +128,7 @@ public:
 protected:
     virtual void onConnected();
     virtual void messageRemovedFromStart(const MessagePtr &msg);
-    QString platform_;
+    QString platform_{"other"};
 
 private:
     const QString name_;

--- a/src/common/ChannelChatters.cpp
+++ b/src/common/ChannelChatters.cpp
@@ -43,7 +43,8 @@ void ChannelChatters::addJoinedUser(const QString &user)
             TwitchMessageBuilder::listOfUsersSystemMessage(
                 "Users joined:", *joinedUsers, &this->channel_, &builder);
             builder->flags.set(MessageFlag::Collapsed);
-            this->channel_.addMessage(builder.release());
+            this->channel_.addMessage(builder.release(),
+                                      MessageContext::Original);
 
             joinedUsers->clear();
             this->joinedUsersMergeQueued_ = false;
@@ -68,7 +69,8 @@ void ChannelChatters::addPartedUser(const QString &user)
             TwitchMessageBuilder::listOfUsersSystemMessage(
                 "Users parted:", *partedUsers, &this->channel_, &builder);
             builder->flags.set(MessageFlag::Collapsed);
-            this->channel_.addMessage(builder.release());
+            this->channel_.addMessage(builder.release(),
+                                      MessageContext::Original);
 
             partedUsers->clear();
             this->partedUsersMergeQueued_ = false;

--- a/src/controllers/commands/builtin/chatterino/Debugging.cpp
+++ b/src/controllers/commands/builtin/chatterino/Debugging.cpp
@@ -90,7 +90,7 @@ QString listEnvironmentVariables(const CommandContext &ctx)
         builder.emplace<TimestampElement>(QTime::currentTime());
         builder.emplace<TextElement>(str, MessageElementFlag::Text,
                                      MessageColor::System);
-        channel->addMessage(builder.release());
+        channel->addMessage(builder.release(), MessageContext::Original);
     }
     return "";
 }

--- a/src/controllers/commands/builtin/twitch/Chatters.cpp
+++ b/src/controllers/commands/builtin/twitch/Chatters.cpp
@@ -129,7 +129,7 @@ QString testChatters(const CommandContext &ctx)
             TwitchMessageBuilder::listOfUsersSystemMessage(
                 prefix, entries, twitchChannel, &builder);
 
-            channel->addMessage(builder.release());
+            channel->addMessage(builder.release(), MessageContext::Original);
         },
         [channel{ctx.channel}](auto error, auto message) {
             auto errorMessage = formatChattersError(error, message);

--- a/src/controllers/commands/builtin/twitch/GetModerators.cpp
+++ b/src/controllers/commands/builtin/twitch/GetModerators.cpp
@@ -81,7 +81,7 @@ QString getModerators(const CommandContext &ctx)
             TwitchMessageBuilder::listOfUsersSystemMessage(
                 "The moderators of this channel are", result, twitchChannel,
                 &builder);
-            channel->addMessage(builder.release());
+            channel->addMessage(builder.release(), MessageContext::Original);
         },
         [channel{ctx.channel}](auto error, auto message) {
             auto errorMessage = formatModsError(error, message);

--- a/src/controllers/commands/builtin/twitch/GetVIPs.cpp
+++ b/src/controllers/commands/builtin/twitch/GetVIPs.cpp
@@ -110,7 +110,7 @@ QString getVIPs(const CommandContext &ctx)
             TwitchMessageBuilder::listOfUsersSystemMessage(
                 messagePrefix, vipList, twitchChannel, &builder);
 
-            channel->addMessage(builder.release());
+            channel->addMessage(builder.release(), MessageContext::Original);
         },
         [channel{ctx.channel}](auto error, auto message) {
             auto errorMessage = formatGetVIPsError(error, message);

--- a/src/controllers/commands/builtin/twitch/SendWhisper.cpp
+++ b/src/controllers/commands/builtin/twitch/SendWhisper.cpp
@@ -184,12 +184,10 @@ bool appendWhisperMessageWordsLocally(const QStringList &words)
         !(getSettings()->streamerModeSuppressInlineWhispers &&
           getIApp()->getStreamerMode()->isEnabled()))
     {
-        app->getTwitchAbstract()->forEachChannel([&messagexD](
-                                                     ChannelPtr _channel) {
-            // is an inline whisper an original message or a repost?
-            // if it is a repost, and we don't log reposts, we would not need to set the DoNotLog flag
-            _channel->addMessage(messagexD, MessageContext::Repost);
-        });
+        app->getTwitchAbstract()->forEachChannel(
+            [&messagexD](ChannelPtr _channel) {
+                _channel->addMessage(messagexD, MessageContext::Repost);
+            });
     }
 
     return true;

--- a/src/controllers/commands/builtin/twitch/SendWhisper.cpp
+++ b/src/controllers/commands/builtin/twitch/SendWhisper.cpp
@@ -178,21 +178,17 @@ bool appendWhisperMessageWordsLocally(const QStringList &words)
     auto messagexD = b.release();
 
     getIApp()->getTwitch()->getWhispersChannel()->addMessage(
-        messagexD, MessageContext::Original);  // is this original?
-
-    auto overrideFlags = std::optional<MessageFlags>(messagexD->flags);
-    overrideFlags->set(MessageFlag::DoNotLog);
+        messagexD, MessageContext::Original);
 
     if (getSettings()->inlineWhispers &&
         !(getSettings()->streamerModeSuppressInlineWhispers &&
           getIApp()->getStreamerMode()->isEnabled()))
     {
-        app->getTwitchAbstract()->forEachChannel([&messagexD, overrideFlags](
+        app->getTwitchAbstract()->forEachChannel([&messagexD](
                                                      ChannelPtr _channel) {
             // is an inline whisper an original message or a repost?
             // if it is a repost, and we don't log reposts, we would not need to set the DoNotLog flag
-            _channel->addMessage(messagexD, MessageContext::Repost,
-                                 overrideFlags);
+            _channel->addMessage(messagexD, MessageContext::Repost);
         });
     }
 

--- a/src/controllers/notifications/NotificationController.cpp
+++ b/src/controllers/notifications/NotificationController.cpp
@@ -202,7 +202,8 @@ void NotificationController::checkStream(bool live, QString channelName)
     }
     MessageBuilder builder;
     TwitchMessageBuilder::liveMessage(channelName, &builder);
-    getIApp()->getTwitch()->getLiveChannel()->addMessage(builder.release());
+    getIApp()->getTwitch()->getLiveChannel()->addMessage(
+        builder.release(), MessageContext::Original);
 
     // Indicate that we have pushed notifications for this stream
     fakeTwitchChannels.push_back(channelName);

--- a/src/controllers/plugins/PluginController.cpp
+++ b/src/controllers/plugins/PluginController.cpp
@@ -380,8 +380,8 @@ QString PluginController::tryExecPluginCommand(const QString &commandName,
             auto res = lua_pcall(L, 1, 0, 0);
             if (res != LUA_OK)
             {
-                ctx.channel->addMessage(makeSystemMessage(
-                    "Lua error: " + lua::humanErrorText(L, res)));
+                ctx.channel->addSystemMessage("Lua error: " +
+                                              lua::humanErrorText(L, res));
                 return "";
             }
             return "";

--- a/src/controllers/plugins/api/ChannelRef.cpp
+++ b/src/controllers/plugins/api/ChannelRef.cpp
@@ -200,7 +200,7 @@ int ChannelRef::add_system_message(lua_State *L)
     }
     ChannelPtr that = ChannelRef::getOrError(L);
     text = text.replace('\n', ' ');
-    that->addMessage(makeSystemMessage(text));
+    that->addSystemMessage(text);
     return 0;
 }
 

--- a/src/providers/irc/AbstractIrcServer.cpp
+++ b/src/providers/irc/AbstractIrcServer.cpp
@@ -156,7 +156,7 @@ void AbstractIrcServer::addGlobalSystemMessage(const QString &messageText)
             continue;
         }
 
-        chan->addMessage(message);
+        chan->addMessage(message, MessageContext::Original);
     }
 }
 
@@ -329,7 +329,7 @@ void AbstractIrcServer::onReadConnected(IrcConnection *connection)
         }
         else
         {
-            chan->addMessage(connectedMsg);
+            chan->addMessage(connectedMsg, MessageContext::Original);
         }
     }
 
@@ -357,7 +357,7 @@ void AbstractIrcServer::onDisconnected()
             continue;
         }
 
-        chan->addMessage(disconnectedMsg);
+        chan->addMessage(disconnectedMsg, MessageContext::Original);
 
         if (auto *channel = dynamic_cast<TwitchChannel *>(chan.get()))
         {

--- a/src/providers/irc/IrcChannel2.cpp
+++ b/src/providers/irc/IrcChannel2.cpp
@@ -70,7 +70,7 @@ void IrcChannel::sendMessage(const QString &message)
             builder.message().messageText = message;
             builder.message().searchText = username + ": " + message;
 
-            this->addMessage(builder.release());
+            this->addMessage(builder.release(), MessageContext::Original);
         }
         else
         {
@@ -79,7 +79,7 @@ void IrcChannel::sendMessage(const QString &message)
     }
 }
 
-IrcServer *IrcChannel::server()
+IrcServer *IrcChannel::server() const
 {
     assertInGuiThread();
 

--- a/src/providers/irc/IrcChannel2.cpp
+++ b/src/providers/irc/IrcChannel2.cpp
@@ -17,6 +17,16 @@ IrcChannel::IrcChannel(const QString &name, IrcServer *server)
     , ChannelChatters(*static_cast<Channel *>(this))
     , server_(server)
 {
+    auto *ircServer = this->server();
+    if (ircServer != nullptr)
+    {
+        this->platform_ =
+            QString("irc-%1").arg(ircServer->userFriendlyIdentifier());
+    }
+    else
+    {
+        this->platform_ = "irc-unknown";
+    }
 }
 
 void IrcChannel::sendMessage(const QString &message)

--- a/src/providers/irc/IrcChannel2.hpp
+++ b/src/providers/irc/IrcChannel2.hpp
@@ -16,7 +16,7 @@ public:
     void sendMessage(const QString &message) override;
 
     // server may be nullptr
-    IrcServer *server();
+    IrcServer *server() const;
 
     // Channel methods
     bool canReconnect() const override;

--- a/src/providers/irc/IrcServer.cpp
+++ b/src/providers/irc/IrcServer.cpp
@@ -111,7 +111,8 @@ void IrcServer::initializeConnectionSignals(IrcConnection *connection,
                          {
                              if (auto shared = weak.lock())
                              {
-                                 shared->addMessage(msg);
+                                 shared->addMessage(msg,
+                                                    MessageContext::Original);
                              }
                          }
                      });
@@ -218,7 +219,7 @@ void IrcServer::privateMessageReceived(Communi::IrcPrivateMessage *message)
         {
             if (auto shared = weak.lock())
             {
-                shared->addMessage(msg);
+                shared->addMessage(msg, MessageContext::Original);
             }
         }
         return;
@@ -236,7 +237,7 @@ void IrcServer::privateMessageReceived(Communi::IrcPrivateMessage *message)
         {
             auto msg = builder.build();
 
-            channel->addMessage(msg);
+            channel->addMessage(msg, MessageContext::Original);
             builder.triggerHighlights();
             const auto highlighted = msg->flags.has(MessageFlag::Highlighted);
             const auto showInMentions =
@@ -244,7 +245,8 @@ void IrcServer::privateMessageReceived(Communi::IrcPrivateMessage *message)
 
             if (highlighted && showInMentions)
             {
-                getIApp()->getTwitch()->getMentionsChannel()->addMessage(msg);
+                getIApp()->getTwitch()->getMentionsChannel()->addMessage(
+                    msg, MessageContext::Original);
             }
         }
         else
@@ -332,7 +334,7 @@ void IrcServer::readConnectionMessageReceived(Communi::IrcMessage *message)
                 {
                     if (auto shared = weak.lock())
                     {
-                        shared->addMessage(msg);
+                        shared->addMessage(msg, MessageContext::Original);
                     }
                 }
             };
@@ -366,7 +368,7 @@ void IrcServer::sendWhisper(const QString &target, const QString &message)
     {
         if (auto shared = weak.lock())
         {
-            shared->addMessage(msg);
+            shared->addMessage(msg, MessageContext::Original);
         }
     }
 }

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -983,7 +983,6 @@ void IrcMessageHandler::handleWhisperMessage(Communi::IrcMessage *ircMessage)
     {
         getIApp()->getTwitchAbstract()->forEachChannel(
             [&message, overrideFlags](ChannelPtr channel) {
-                // is inline whisper a repost? probably!
                 channel->addMessage(message, MessageContext::Repost,
                                     overrideFlags);
             });

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -1120,7 +1120,6 @@ void IrcMessageHandler::handleNoticeMessage(Communi::IrcNoticeMessage *message)
             // channels
             getIApp()->getTwitch()->forEachChannelAndSpecialChannels(
                 [msg](const auto &c) {
-                    // assume it's original?
                     c->addMessage(msg, MessageContext::Original);
                 });
 

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -161,7 +161,7 @@ TwitchChannel::TwitchChannel(const QString &name)
             TwitchMessageBuilder::liveSystemMessage(this->getDisplayName(),
                                                     &builder);
             builder.message().id = this->roomId();
-            this->addMessage(builder.release());
+            this->addMessage(builder.release(), MessageContext::Original);
 
             // Message in /live channel
             MessageBuilder builder2;
@@ -169,7 +169,7 @@ TwitchChannel::TwitchChannel(const QString &name)
                                               &builder2);
             builder2.message().id = this->roomId();
             getIApp()->getTwitch()->getLiveChannel()->addMessage(
-                builder2.release());
+                builder2.release(), MessageContext::Original);
 
             // Notify on all channels with a ping sound
             if (getSettings()->notificationOnAnyChannel &&
@@ -187,7 +187,7 @@ TwitchChannel::TwitchChannel(const QString &name)
             MessageBuilder builder;
             TwitchMessageBuilder::offlineSystemMessage(this->getDisplayName(),
                                                        &builder);
-            this->addMessage(builder.release());
+            this->addMessage(builder.release(), MessageContext::Original);
 
             // "delete" old 'CHANNEL is live' message
             LimitedQueueSnapshot<MessagePtr> snapshot =
@@ -395,7 +395,7 @@ void TwitchChannel::addChannelPointReward(const ChannelPointReward &reward)
         MessageBuilder builder;
         TwitchMessageBuilder::appendChannelPointRewardMessage(
             reward, &builder, this->isMod(), this->isBroadcaster());
-        this->addMessage(builder.release());
+        this->addMessage(builder.release(), MessageContext::Original);
         return;
     }
 
@@ -566,7 +566,7 @@ void TwitchChannel::showLoginMessage()
                               linkColor)
         ->setLink(accountsLink);
 
-    this->addMessage(builder.release());
+    this->addMessage(builder.release(), MessageContext::Original);
 }
 
 void TwitchChannel::roomIdChanged()
@@ -925,7 +925,7 @@ void TwitchChannel::updateBttvEmote(
     auto builder = MessageBuilder(liveUpdatesUpdateEmoteMessage, "BTTV",
                                   QString() /* actor */, newEmote->name.string,
                                   oldEmote->name.string);
-    this->addMessage(builder.release());
+    this->addMessage(builder.release(), MessageContext::Original);
 }
 
 void TwitchChannel::removeBttvEmote(
@@ -964,7 +964,7 @@ void TwitchChannel::updateSeventvEmote(
     auto builder =
         MessageBuilder(liveUpdatesUpdateEmoteMessage, "7TV", dispatch.actorName,
                        dispatch.emoteName, dispatch.oldEmoteName);
-    this->addMessage(builder.release());
+    this->addMessage(builder.release(), MessageContext::Original);
 }
 
 void TwitchChannel::removeSeventvEmote(
@@ -1002,7 +1002,8 @@ void TwitchChannel::updateSeventvUser(
                     auto builder =
                         MessageBuilder(liveUpdatesUpdateEmoteSetMessage, "7TV",
                                        dispatch.actorName, name);
-                    this->addMessage(builder.release());
+                    this->addMessage(builder.release(),
+                                     MessageContext::Original);
                 }
             });
         },
@@ -1085,7 +1086,7 @@ void TwitchChannel::addOrReplaceLiveUpdatesAddRemove(bool isEmoteAdd,
     this->lastLiveUpdateEmotePlatform_ = platform;
     this->lastLiveUpdateMessage_ = msg;
     this->lastLiveUpdateEmoteActor_ = actor;
-    this->addMessage(msg);
+    this->addMessage(msg, MessageContext::Original);
 }
 
 bool TwitchChannel::tryReplaceLastLiveUpdateAddOrRemove(
@@ -1650,7 +1651,7 @@ void TwitchChannel::createClip()
                                       MessageColor::Link)
                 ->setLink(Link(Link::Url, clip.editUrl));
 
-            this->addMessage(builder.release());
+            this->addMessage(builder.release(), MessageContext::Original);
         },
         // failureCallback
         [this](auto error) {
@@ -1699,7 +1700,7 @@ void TwitchChannel::createClip()
             builder.message().messageText = text;
             builder.message().searchText = text;
 
-            this->addMessage(builder.release());
+            this->addMessage(builder.release(), MessageContext::Original);
         },
         // finallyCallback - this will always execute, so clip creation won't ever be stuck
         [this] {

--- a/src/singletons/ImageUploader.cpp
+++ b/src/singletons/ImageUploader.cpp
@@ -239,7 +239,7 @@ void ImageUploader::handleSuccessfulUpload(const NetworkResult &result,
     auto timeToUpload = this->uploadQueue_.size() * (UPLOAD_DELAY / 1000 + 1);
     MessageBuilder builder(imageUploaderResultMessage, link, deletionLink,
                            this->uploadQueue_.size(), timeToUpload);
-    channel->addMessage(builder.release());
+    channel->addMessage(builder.release(), MessageContext::Original);
     if (this->uploadQueue_.empty())
     {
         this->uploadMutex_.unlock();

--- a/src/singletons/Logging.cpp
+++ b/src/singletons/Logging.cpp
@@ -33,9 +33,7 @@ Logging::Logging(Settings &settings)
 }
 
 void Logging::addMessage(const QString &channelName, MessagePtr message,
-                         const QString &platformName,
-                         std::optional<MessageFlags> overridingFlags,
-                         MessageContext context)
+                         const QString &platformName)
 {
     this->threadGuard.guard();
 
@@ -50,20 +48,6 @@ void Logging::addMessage(const QString &channelName, MessagePtr message,
         {
             return;
         }
-    }
-
-    if (context == MessageContext::Repost)
-    {
-        return;
-    }
-
-    auto isDoNotLogSet =
-        (overridingFlags && overridingFlags->has(MessageFlag::DoNotLog)) ||
-        message->flags.has(MessageFlag::DoNotLog);
-
-    if (isDoNotLogSet)
-    {
-        return;
     }
 
     auto platIt = this->loggingChannels_.find(platformName);

--- a/src/singletons/Logging.hpp
+++ b/src/singletons/Logging.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
+#include "common/Channel.hpp"
 #include "util/QStringHash.hpp"
 #include "util/ThreadGuard.hpp"
+#include "widgets/helper/ChannelView.hpp"
 
 #include <QString>
 
@@ -22,7 +24,9 @@ public:
     virtual ~ILogging() = default;
 
     virtual void addMessage(const QString &channelName, MessagePtr message,
-                            const QString &platformName) = 0;
+                            const QString &platformName,
+                            std::optional<MessageFlags> overridingFlags,
+                            MessageContext context) = 0;
 };
 
 class Logging : public ILogging
@@ -31,7 +35,9 @@ public:
     Logging(Settings &settings);
 
     void addMessage(const QString &channelName, MessagePtr message,
-                    const QString &platformName) override;
+                    const QString &platformName,
+                    std::optional<MessageFlags> overridingFlags,
+                    MessageContext context) override;
 
 private:
     using PlatformName = QString;

--- a/src/singletons/Logging.hpp
+++ b/src/singletons/Logging.hpp
@@ -1,9 +1,7 @@
 #pragma once
 
-#include "common/Channel.hpp"
 #include "util/QStringHash.hpp"
 #include "util/ThreadGuard.hpp"
-#include "widgets/helper/ChannelView.hpp"
 
 #include <QString>
 

--- a/src/singletons/Logging.hpp
+++ b/src/singletons/Logging.hpp
@@ -24,9 +24,7 @@ public:
     virtual ~ILogging() = default;
 
     virtual void addMessage(const QString &channelName, MessagePtr message,
-                            const QString &platformName,
-                            std::optional<MessageFlags> overridingFlags,
-                            MessageContext context) = 0;
+                            const QString &platformName) = 0;
 };
 
 class Logging : public ILogging
@@ -35,9 +33,7 @@ public:
     Logging(Settings &settings);
 
     void addMessage(const QString &channelName, MessagePtr message,
-                    const QString &platformName,
-                    std::optional<MessageFlags> overridingFlags,
-                    MessageContext context) override;
+                    const QString &platformName) override;
 
 private:
     using PlatformName = QString;

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -145,7 +145,7 @@ void addTwitchEmoteSets(
     auto currentChannelPair = mapOfSets[currentChannelName];
     for (const auto &message : currentChannelPair.second)
     {
-        subChannel.addMessage(message);
+        subChannel.addMessage(message, MessageContext::Original);
     }
     mapOfSets.remove(currentChannelName);
 
@@ -154,7 +154,7 @@ void addTwitchEmoteSets(
         auto &channel = pair.first ? globalChannel : subChannel;
         for (const auto &message : pair.second)
         {
-            channel.addMessage(message);
+            channel.addMessage(message, MessageContext::Original);
         }
     }
 }
@@ -162,14 +162,16 @@ void addTwitchEmoteSets(
 void addEmotes(Channel &channel, const EmoteMap &map, const QString &title,
                const MessageElementFlag &emoteFlag)
 {
-    channel.addMessage(makeTitleMessage(title));
-    channel.addMessage(makeEmoteMessage(map, emoteFlag));
+    channel.addMessage(makeTitleMessage(title), MessageContext::Original);
+    channel.addMessage(makeEmoteMessage(map, emoteFlag),
+                       MessageContext::Original);
 }
 
 void loadEmojis(ChannelView &view, const std::vector<EmojiPtr> &emojiMap)
 {
     ChannelPtr emojiChannel(new Channel("", Channel::Type::None));
-    emojiChannel->addMessage(makeEmojiMessage(emojiMap));
+    emojiChannel->addMessage(makeEmojiMessage(emojiMap),
+                             MessageContext::Original);
 
     view.setChannel(emojiChannel);
 }
@@ -177,8 +179,8 @@ void loadEmojis(ChannelView &view, const std::vector<EmojiPtr> &emojiMap)
 void loadEmojis(Channel &channel, const std::vector<EmojiPtr> &emojiMap,
                 const QString &title)
 {
-    channel.addMessage(makeTitleMessage(title));
-    channel.addMessage(makeEmojiMessage(emojiMap));
+    channel.addMessage(makeTitleMessage(title), MessageContext::Original);
+    channel.addMessage(makeEmojiMessage(emojiMap), MessageContext::Original);
 }
 
 // Create an emote
@@ -454,7 +456,7 @@ void EmotePopup::loadChannel(ChannelPtr channel)
         builder.emplace<TextElement>("no subscription emotes available",
                                      MessageElementFlag::Text,
                                      MessageColor::System);
-        subChannel->addMessage(builder.release());
+        subChannel->addMessage(builder.release(), MessageContext::Original);
     }
 }
 

--- a/src/widgets/dialogs/ReplyThreadPopup.cpp
+++ b/src/widgets/dialogs/ReplyThreadPopup.cpp
@@ -244,7 +244,6 @@ void ReplyThreadPopup::addMessagesFromThread()
         std::optional<MessageFlags>(this->thread_->root()->flags);
     rootOverrideFlags->set(MessageFlag::DoNotLog);
 
-    // TODO: Verify
     this->virtualChannel_->addMessage(
         this->thread_->root(), MessageContext::Repost, rootOverrideFlags);
     for (const auto &msgRef : this->thread_->replies())
@@ -254,7 +253,6 @@ void ReplyThreadPopup::addMessagesFromThread()
             auto overrideFlags = std::optional<MessageFlags>(msg->flags);
             overrideFlags->set(MessageFlag::DoNotLog);
 
-            // TODO: Verify
             this->virtualChannel_->addMessage(msg, MessageContext::Repost,
                                               overrideFlags);
         }
@@ -271,7 +269,6 @@ void ReplyThreadPopup::addMessagesFromThread()
                         overrideFlags->set(MessageFlag::DoNotLog);
 
                         // same reply thread, add message
-                        // TODO: Verify
                         this->virtualChannel_->addMessage(
                             message, MessageContext::Repost, overrideFlags);
                     }

--- a/src/widgets/dialogs/ReplyThreadPopup.cpp
+++ b/src/widgets/dialogs/ReplyThreadPopup.cpp
@@ -244,7 +244,9 @@ void ReplyThreadPopup::addMessagesFromThread()
         std::optional<MessageFlags>(this->thread_->root()->flags);
     rootOverrideFlags->set(MessageFlag::DoNotLog);
 
-    this->virtualChannel_->addMessage(this->thread_->root(), rootOverrideFlags);
+    // TODO: Verify
+    this->virtualChannel_->addMessage(
+        this->thread_->root(), MessageContext::Repost, rootOverrideFlags);
     for (const auto &msgRef : this->thread_->replies())
     {
         if (auto msg = msgRef.lock())
@@ -252,24 +254,28 @@ void ReplyThreadPopup::addMessagesFromThread()
             auto overrideFlags = std::optional<MessageFlags>(msg->flags);
             overrideFlags->set(MessageFlag::DoNotLog);
 
-            this->virtualChannel_->addMessage(msg, overrideFlags);
+            // TODO: Verify
+            this->virtualChannel_->addMessage(msg, MessageContext::Repost,
+                                              overrideFlags);
         }
     }
 
     this->messageConnection_ =
         std::make_unique<pajlada::Signals::ScopedConnection>(
-            sourceChannel->messageAppended.connect([this](MessagePtr &message,
-                                                          auto) {
-                if (message->replyThread == this->thread_)
-                {
-                    auto overrideFlags =
-                        std::optional<MessageFlags>(message->flags);
-                    overrideFlags->set(MessageFlag::DoNotLog);
+            sourceChannel->messageAppended.connect(
+                [this](MessagePtr &message, auto) {
+                    if (message->replyThread == this->thread_)
+                    {
+                        auto overrideFlags =
+                            std::optional<MessageFlags>(message->flags);
+                        overrideFlags->set(MessageFlag::DoNotLog);
 
-                    // same reply thread, add message
-                    this->virtualChannel_->addMessage(message, overrideFlags);
-                }
-            }));
+                        // same reply thread, add message
+                        // TODO: Verify
+                        this->virtualChannel_->addMessage(
+                            message, MessageContext::Repost, overrideFlags);
+                    }
+                }));
 }
 
 void ReplyThreadPopup::updateInputUI()

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -112,12 +112,9 @@ namespace {
         {
             MessagePtr message = snapshot[i];
 
-            auto overrideFlags = std::optional<MessageFlags>(message->flags);
-            overrideFlags->set(MessageFlag::DoNotLog);
-
             if (checkMessageUserName(userName, message))
             {
-                channelPtr->addMessage(message, overrideFlags);
+                channelPtr->addMessage(message, MessageContext::Repost);
             }
         }
 
@@ -787,7 +784,7 @@ void UserInfoPopup::updateLatestMessages()
                     {
                         // display message in ChannelView
                         this->ui_.latestMessages->channel()->addMessage(
-                            message);
+                            message, MessageContext::Repost);
                     }
                     else
                     {

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1010,7 +1010,15 @@ void ChannelView::setChannel(const ChannelPtr &underlyingChannel)
         }
 
         this->messages_.pushBack(messageLayout);
-        this->channel_->addMessage(msg);
+
+        auto overrideFlags = std::optional<MessageFlags>(msg->flags);
+        if (this->context_ != Context::None)
+        {
+            overrideFlags->set(MessageFlag::DoNotLog);
+        }
+
+        this->channel_->addMessage(msg, overrideFlags);
+
         nMessagesAdded++;
         if (this->showScrollbarHighlights())
         {

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1002,14 +1002,7 @@ void ChannelView::setChannel(const ChannelPtr &underlyingChannel)
 
         this->messages_.pushBack(messageLayout);
 
-        auto overrideFlags = std::optional<MessageFlags>(msg->flags);
-        if (this->context_ != Context::None)
-        {
-            overrideFlags->set(MessageFlag::DoNotLog);
-        }
-
-        // TODO: Verify
-        this->channel_->addMessage(msg, MessageContext::Repost, overrideFlags);
+        this->channel_->addMessage(msg, MessageContext::Repost);
 
         nMessagesAdded++;
         if (this->showScrollbarHighlights())

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -925,12 +925,13 @@ void ChannelView::setChannel(const ChannelPtr &underlyingChannel)
             {
                 if (this->channel_->lastDate_ != QDate::currentDate())
                 {
+                    // Day change message
                     this->channel_->lastDate_ = QDate::currentDate();
                     auto msg = makeSystemMessage(
                         QLocale().toString(QDate::currentDate(),
                                            QLocale::LongFormat),
                         QTime(0, 0));
-                    // TODO: Verify
+                    msg->flags.set(MessageFlag::DoNotLog);
                     this->channel_->addMessage(msg, MessageContext::Original);
                 }
                 // When the message was received in the underlyingChannel,

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -930,7 +930,8 @@ void ChannelView::setChannel(const ChannelPtr &underlyingChannel)
                         QLocale().toString(QDate::currentDate(),
                                            QLocale::LongFormat),
                         QTime(0, 0));
-                    this->channel_->addMessage(msg);
+                    // TODO: Verify
+                    this->channel_->addMessage(msg, MessageContext::Original);
                 }
                 // When the message was received in the underlyingChannel,
                 // logging will be handled. Prevent duplications.
@@ -944,7 +945,9 @@ void ChannelView::setChannel(const ChannelPtr &underlyingChannel)
                     overridingFlags->set(MessageFlag::DoNotLog);
                 }
 
-                this->channel_->addMessage(message, overridingFlags);
+                // TODO: Verify
+                this->channel_->addMessage(message, MessageContext::Repost,
+                                           overridingFlags);
             }
         });
 
@@ -1017,7 +1020,8 @@ void ChannelView::setChannel(const ChannelPtr &underlyingChannel)
             overrideFlags->set(MessageFlag::DoNotLog);
         }
 
-        this->channel_->addMessage(msg, overrideFlags);
+        // TODO: Verify
+        this->channel_->addMessage(msg, MessageContext::Repost, overrideFlags);
 
         nMessagesAdded++;
         if (this->showScrollbarHighlights())

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -934,19 +934,6 @@ void ChannelView::setChannel(const ChannelPtr &underlyingChannel)
                     msg->flags.set(MessageFlag::DoNotLog);
                     this->channel_->addMessage(msg, MessageContext::Original);
                 }
-                // When the message was received in the underlyingChannel,
-                // logging will be handled. Prevent duplications.
-                if (overridingFlags)
-                {
-                    overridingFlags->set(MessageFlag::DoNotLog);
-                }
-                else
-                {
-                    overridingFlags = MessageFlags(message->flags);
-                    overridingFlags->set(MessageFlag::DoNotLog);
-                }
-
-                // TODO: Verify
                 this->channel_->addMessage(message, MessageContext::Repost,
                                            overridingFlags);
             }

--- a/src/widgets/helper/SearchPopup.cpp
+++ b/src/widgets/helper/SearchPopup.cpp
@@ -55,7 +55,6 @@ ChannelPtr SearchPopup::filter(const QString &text, const QString &channelName,
             auto overrideFlags = std::optional<MessageFlags>(message->flags);
             overrideFlags->set(MessageFlag::DoNotLog);
 
-            // TODO: Verify
             channel->addMessage(message, MessageContext::Repost, overrideFlags);
         }
     }

--- a/src/widgets/helper/SearchPopup.cpp
+++ b/src/widgets/helper/SearchPopup.cpp
@@ -55,7 +55,8 @@ ChannelPtr SearchPopup::filter(const QString &text, const QString &channelName,
             auto overrideFlags = std::optional<MessageFlags>(message->flags);
             overrideFlags->set(MessageFlag::DoNotLog);
 
-            channel->addMessage(message, overrideFlags);
+            // TODO: Verify
+            channel->addMessage(message, MessageContext::Repost, overrideFlags);
         }
     }
 


### PR DESCRIPTION
I have removed the `DoNotLog` flags from `UserInfoPopup` on purpose since all messages added from it are "reposts", i.e. messages that wouldn't be logged anyway

~~Currently it's the logger that checks whether or not to log reposts - this should just be moved to Channel's addMessage function instead~~

Fixes #5470