### PR TITLE
show running qt version if it differs from compiled version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - Dev: Refactor/unsingletonize `UserDataController`. (#5459)
 - Dev: Cleanup `BrowserExtension`. (#5465)
 - Dev: Deprecate Qt 5.12. (#5396)
+- Dev: The running Qt version is now shown in the about page if it differs from the compiled version. (#5501)
 
 ## 2.5.1
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -947,6 +947,10 @@ set_target_properties(${LIBRARY_PROJECT}
 # this is its own project.
 set(VERSION_SOURCE_FILES common/Version.cpp common/Version.hpp)
 add_library(${VERSION_PROJECT} STATIC ${VERSION_SOURCE_FILES})
+target_compile_definitions(${VERSION_PROJECT} PRIVATE
+    $<$<BOOL:${WIN32}>:USEWINSDK>
+    $<$<BOOL:${BUILD_WITH_CRASHPAD}>:CHATTERINO_WITH_CRASHPAD>
+)
 
 # source group for IDEs
 source_group(TREE ${CMAKE_SOURCE_DIR} FILES ${VERSION_SOURCE_FILES})

--- a/src/common/Version.cpp
+++ b/src/common/Version.cpp
@@ -1,10 +1,14 @@
 #include "common/Version.hpp"
 
+#include "common/Literals.hpp"
 #include "common/Modes.hpp"
 
 #include <QFileInfo>
+#include <QStringBuilder>
 
 namespace chatterino {
+
+using namespace literals;
 
 Version::Version()
     : version_(CHATTERINO_VERSION)
@@ -79,11 +83,17 @@ QStringList Version::buildTags() const
 {
     QStringList tags;
 
-    tags.append("Qt " QT_VERSION_STR);
+    const auto *runtimeVersion = qVersion();
+    if (runtimeVersion != QLatin1String{QT_VERSION_STR})
+    {
+        tags.append(u"Qt "_s QT_VERSION_STR u" (running on " % runtimeVersion %
+                    u")");
+    }
+    else
+    {
+        tags.append(u"Qt "_s QT_VERSION_STR);
+    }
 
-#ifdef USEWINSDK
-    tags.append("Windows SDK");
-#endif
 #ifdef _MSC_FULL_VER
     tags.append("MSVC " + QString::number(_MSC_FULL_VER, 10));
 #endif


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

The running version can be different from the compiled version, and this should be shown. I know it's in the build string but it makes sense to have the different versions next to each other.

Also properly shows Crashpad enabled builds.