### PR TITLE
fix: restore input layout (almost)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - Minor: Improve appearance of reply button. (#5491)
 - Minor: Introduce HTTP API for plugins. (#5383, #5492, #5494)
 - Minor: Support more Firefox variants for incognito link opening. (#5503)
-- Minor: Replying to a message will now display the message being replied to. (#4350)
+- Minor: Replying to a message will now display the message being replied to. (#4350, #5519)
 - Minor: Links can now have prefixes and suffixes such as parentheses. (#5486)
 - Bugfix: Fixed tab move animation occasionally failing to start after closing a tab. (#5426)
 - Bugfix: If a network request errors with 200 OK, Qt's error code is now reported instead of the HTTP status. (#5378)

--- a/src/widgets/splits/SplitInput.hpp
+++ b/src/widgets/splits/SplitInput.hpp
@@ -124,6 +124,10 @@ protected:
 
     int marginForTheme() const;
 
+    void applyOuterMargin();
+
+    int replyMessageWidth() const;
+
     Split *const split_;
     ChannelView *const channelView_;
     QPointer<EmotePopup> emotePopup_;


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

Almost restores the layout of the input before #4350.
"Almost" because it's slightly taller now.

Left: after, right: before

![Code_2024-07-20_23-29-09](https://github.com/user-attachments/assets/d652ee24-c5ce-46cf-9684-f127b9123e40)
![Code_2024-07-20_23-28-51](https://github.com/user-attachments/assets/566ca5c2-aeec-4375-9ad9-b98b3cc6698f)
![Code_2024-07-20_23-28-10](https://github.com/user-attachments/assets/c326e58d-1736-4514-825a-e2e19cc54a2d)
![Code_2024-07-20_23-27-47](https://github.com/user-attachments/assets/fb808152-1107-4c35-b0f3-eee440a71e33)


