### PR TITLE
chore: improve link parser and its tests a bit

### DIFF
--- a/tests/src/LinkParser.cpp
+++ b/tests/src/LinkParser.cpp
@@ -72,6 +72,8 @@ TEST(LinkParser, parseDomainLinks)
         {"", "chatterino.com", ":80"},
         {"", "wiki.chatterino.com", ":80"},
         {"", "wiki.chatterino.com", ":80/foo/bar"},
+        {"", "wiki.chatterino.com", ":80?foo"},
+        {"", "wiki.chatterino.com", ":80#foo"},
         {"", "wiki.chatterino.com", "/:80?foo/bar"},
         {"", "wiki.chatterino.com", "/127.0.0.1"},
         {"", "a.b.c.chatterino.com"},
@@ -156,6 +158,7 @@ TEST(LinkParser, parseIpv4Links)
 TEST(LinkParser, doesntParseInvalidIpv4Links)
 {
     const QStringList inputs = {
+        "196.162.a.1",
         // U+0660 - in category "number digits"
         QStringLiteral("٠.٠.٠.٠"),
         "https://127.0.0.",
@@ -186,6 +189,10 @@ TEST(LinkParser, doesntParseInvalidIpv4Links)
         "196.162.8.1(",
         "196.162.8.1(!",
         "127.1.1;.com",
+        "127.0.-.1",
+        "127...",
+        "1.1.1.",
+        "1.1.1.:80",
     };
 
     for (const auto &input : inputs)
@@ -223,6 +230,10 @@ TEST(LinkParser, doesntParseInvalidLinks)
         "https://pn./",
         "pn./",
         "pn.",
+        "pn.:80",
+        "pn./foo",
+        "pn.#foo",
+        "pn.?foo",
         "http/chatterino.com",
         "http/wiki.chatterino.com",
         "http:cat.com",


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

- Adds a few more tests
- Switches to `QCompareCaseInsensitive` and `std::set` (no more allocations when searching for domains)

That's the most coverage we can get out of it (codecov doesn't really show which cases were covered in case of partial coverage). 

None of the following checks will trigger, because there will always be three dots and never duplicated dots (guaranteed from the caller, `parse`):
https://github.com/Chatterino/chatterino2/blob/a0b70b8c5e1ee60f2d746ca5234dffd1e2b8a4c2/src/common/LinkParser.cpp#L64

I could remove them, but that makes it a bit more fragile.

Similar things go for https://github.com/Chatterino/chatterino2/blob/a0b70b8c5e1ee60f2d746ca5234dffd1e2b8a4c2/src/common/LinkParser.cpp#L89

With the only difference that we're not guaranteed that `host` doesn't end in `.` (there's a test for it).