### PR TITLE
Handle panning touch gestures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Minor: Support more Firefox variants for incognito link opening. (#5503)
 - Minor: Replying to a message will now display the message being replied to. (#4350, #5519)
 - Minor: Links can now have prefixes and suffixes such as parentheses. (#5486, #5515)
+- Minor: Added support for scrolling in splits with touchscreen panning gestures. (#5524)
 - Bugfix: Fixed tab move animation occasionally failing to start after closing a tab. (#5426)
 - Bugfix: If a network request errors with 200 OK, Qt's error code is now reported instead of the HTTP status. (#5378)
 - Bugfix: Fixed restricted users usernames not being clickable. (#5405)

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1819,6 +1819,8 @@ bool ChannelView::gestureEvent(const QGestureEvent *event)
                     {
                         this->disableScrolling();
                     }
+
+                    return true;
                 }
                 break;
 
@@ -1827,6 +1829,8 @@ bool ChannelView::gestureEvent(const QGestureEvent *event)
                     {
                         this->scrollBar_->offset(-gesture->delta().y() * 0.1);
                     }
+
+                    return true;
                 }
                 break;
 
@@ -1835,6 +1839,8 @@ bool ChannelView::gestureEvent(const QGestureEvent *event)
                 default: {
                     this->clearSelection();
                     this->isPanning_ = false;
+
+                    return true;
                 }
                 break;
             }

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1791,36 +1791,52 @@ void ChannelView::leaveEvent(QEvent * /*event*/)
 
 bool ChannelView::event(QEvent *event)
 {
-     if (event->type() == QEvent::Gesture)
-     {
-         return gestureEvent(dynamic_cast<QGestureEvent*>(event));
-     }
+    if (event->type() == QEvent::Gesture)
+    {
+        if (const auto *gestureEvent = dynamic_cast<QGestureEvent *>(event))
+        {
+            return this->gestureEvent(gestureEvent);
+        }
+    }
 
-    return BaseWidget::event(event);
+   return BaseWidget::event(event);
 }
 
 bool ChannelView::gestureEvent(const QGestureEvent *event)
 {
-     if (QGesture *pan = event->gesture(Qt::PanGesture))
-     {
-         auto const *gesture = dynamic_cast<QPanGesture *>(pan);
+    if (QGesture *pan = event->gesture(Qt::PanGesture))
+    {
+        if (const auto *gesture = dynamic_cast<QPanGesture *>(pan))
+        {
+            switch (gesture->state())
+            {
+                case Qt::GestureStarted:
+                    this->isPanning_ = true;
+                    // Remove any selections and hide tooltip while panning
+                    this->clearSelection();
+                    this->tooltipWidget_->hide();
+                    if (this->isScrolling_)
+                    {
+                        this->disableScrolling();
+                    }
+                break;
+                case Qt::GestureUpdated:
+                    if (this->scrollBar_->isVisible())
+                    {
+                        this->scrollBar_->offset(-gesture->delta().y() * 0.1);
+                    }
+                break;
+                case Qt::GestureFinished:
+                case Qt::GestureCanceled:
+                default:
+                    this->clearSelection();
+                    this->isPanning_ = false;
+                break;
+            }
+        }
+    }
 
-         switch (gesture->state())
-         {
-             case Qt::GestureStarted:
-             case Qt::GestureUpdated:
-                 this->isPanning_ = true;
-                 this->clearSelection();
-                 break;
-             default:
-                 this->isPanning_ = false;
-                 break;
-         }
-
-         this->scrollBar_->offset(-gesture->delta().y() * 0.5);
-     }
-
-     return false;
+    return false;
 }
 
 void ChannelView::mouseMoveEvent(QMouseEvent *event)

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1799,7 +1799,7 @@ bool ChannelView::event(QEvent *event)
         }
     }
 
-   return BaseWidget::event(event);
+    return BaseWidget::event(event);
 }
 
 bool ChannelView::gestureEvent(const QGestureEvent *event)
@@ -1810,7 +1810,7 @@ bool ChannelView::gestureEvent(const QGestureEvent *event)
         {
             switch (gesture->state())
             {
-                case Qt::GestureStarted:
+                case Qt::GestureStarted: {
                     this->isPanning_ = true;
                     // Remove any selections and hide tooltip while panning
                     this->clearSelection();
@@ -1819,18 +1819,23 @@ bool ChannelView::gestureEvent(const QGestureEvent *event)
                     {
                         this->disableScrolling();
                     }
+                }
                 break;
-                case Qt::GestureUpdated:
+
+                case Qt::GestureUpdated: {
                     if (this->scrollBar_->isVisible())
                     {
                         this->scrollBar_->offset(-gesture->delta().y() * 0.1);
                     }
+                }
                 break;
+
                 case Qt::GestureFinished:
                 case Qt::GestureCanceled:
-                default:
+                default: {
                     this->clearSelection();
                     this->isPanning_ = false;
+                }
                 break;
             }
         }

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1819,8 +1819,6 @@ bool ChannelView::gestureEvent(const QGestureEvent *event)
                     {
                         this->disableScrolling();
                     }
-
-                    return true;
                 }
                 break;
 
@@ -1829,8 +1827,6 @@ bool ChannelView::gestureEvent(const QGestureEvent *event)
                     {
                         this->scrollBar_->offset(-gesture->delta().y() * 0.1);
                     }
-
-                    return true;
                 }
                 break;
 
@@ -1839,11 +1835,11 @@ bool ChannelView::gestureEvent(const QGestureEvent *event)
                 default: {
                     this->clearSelection();
                     this->isPanning_ = false;
-
-                    return true;
                 }
                 break;
             }
+
+            return true;
         }
     }
 

--- a/src/widgets/helper/ChannelView.hpp
+++ b/src/widgets/helper/ChannelView.hpp
@@ -217,8 +217,8 @@ protected:
 #endif
     void leaveEvent(QEvent * /*event*/) override;
 
-    bool event(QEvent* event) override;
-    bool gestureEvent(const QGestureEvent* event);
+    bool event(QEvent *event) override;
+    bool gestureEvent(const QGestureEvent *event);
 
     void mouseMoveEvent(QMouseEvent *event) override;
     void mousePressEvent(QMouseEvent *event) override;

--- a/src/widgets/helper/ChannelView.hpp
+++ b/src/widgets/helper/ChannelView.hpp
@@ -10,6 +10,7 @@
 #include "widgets/TooltipWidget.hpp"
 
 #include <pajlada/signals/signal.hpp>
+#include <QGestureEvent>
 #include <QMenu>
 #include <QPaintEvent>
 #include <QPointer>
@@ -216,6 +217,9 @@ protected:
 #endif
     void leaveEvent(QEvent * /*event*/) override;
 
+    bool event(QEvent* event) override;
+    bool gestureEvent(const QGestureEvent* event);
+
     void mouseMoveEvent(QMouseEvent *event) override;
     void mousePressEvent(QMouseEvent *event) override;
     void mouseReleaseEvent(QMouseEvent *event) override;
@@ -374,6 +378,7 @@ private:
     QTimer clickTimer_;
 
     bool isScrolling_ = false;
+    bool isPanning_ = false;
     QPointF lastMiddlePressPosition_;
     QPointF currentMousePosition_;
     QTimer scrollTimer_;


### PR DESCRIPTION
This adds support for the panning gesture on `ChannelView`. This lets users who have touchscreens perform a two-finger pan of the chat (effectively a scroll).

Mouse move events aren't handled while panning is occurring so that erroneous text selection when going into and out panning is avoided.