### PR TITLE
fix: replace defines with constexpr/const and use more absolute paths for includes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 - Dev: The running Qt version is now shown in the about page if it differs from the compiled version. (#5501)
 - Dev: `FlagsEnum` is now `constexpr`. (#5510)
 - Dev: Documented and added tests to RTL handling. (#5473)
+- Dev: Refactored a few `#define`s into `const(expr)` and cleaned includes. (#5527)
 
 ## 2.5.1
 

--- a/docs/make-release.md
+++ b/docs/make-release.md
@@ -2,7 +2,7 @@
 
 ## In the release PR
 
-- [ ] Updated version code in `src/common/Version.cpp`
+- [ ] Updated version code in `src/common/Version.hpp`
 - [ ] Updated version code in `CMakeLists.txt`  
        This can only be "whole versions", so if you're releasing `2.4.0-beta` you'll need to condense it to `2.4.0`
 - [ ] Add a new release at the top of the `releases` key in `resources/com.chatterino.chatterino.appdata.xml`  

--- a/docs/make-release.md
+++ b/docs/make-release.md
@@ -2,7 +2,7 @@
 
 ## In the release PR
 
-- [ ] Updated version code in `src/common/Version.hpp`
+- [ ] Updated version code in `src/common/Version.cpp`
 - [ ] Updated version code in `CMakeLists.txt`  
        This can only be "whole versions", so if you're releasing `2.4.0-beta` you'll need to condense it to `2.4.0`
 - [ ] Add a new release at the top of the `releases` key in `resources/com.chatterino.chatterino.appdata.xml`  

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -204,8 +204,7 @@ void Application::initialize(Settings &settings, const Paths &paths)
     // Show changelog
     if (!this->args_.isFramelessEmbed &&
         getSettings()->currentVersion.getValue() != "" &&
-        getSettings()->currentVersion.getValue() !=
-            Version::instance().version())
+        getSettings()->currentVersion.getValue() != CHATTERINO_VERSION)
     {
         auto *box = new QMessageBox(QMessageBox::Information, "Chatterino 2",
                                     "Show changelog?",
@@ -220,7 +219,7 @@ void Application::initialize(Settings &settings, const Paths &paths)
 
     if (!this->args_.isFramelessEmbed)
     {
-        getSettings()->currentVersion.setValue(Version::instance().version());
+        getSettings()->currentVersion.setValue(CHATTERINO_VERSION);
 
         if (getSettings()->enableExperimentalIrc)
         {

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -204,7 +204,8 @@ void Application::initialize(Settings &settings, const Paths &paths)
     // Show changelog
     if (!this->args_.isFramelessEmbed &&
         getSettings()->currentVersion.getValue() != "" &&
-        getSettings()->currentVersion.getValue() != CHATTERINO_VERSION)
+        getSettings()->currentVersion.getValue() !=
+            Version::instance().version())
     {
         auto *box = new QMessageBox(QMessageBox::Information, "Chatterino 2",
                                     "Show changelog?",
@@ -219,7 +220,7 @@ void Application::initialize(Settings &settings, const Paths &paths)
 
     if (!this->args_.isFramelessEmbed)
     {
-        getSettings()->currentVersion.setValue(CHATTERINO_VERSION);
+        getSettings()->currentVersion.setValue(Version::instance().version());
 
         if (getSettings()->enableExperimentalIrc)
         {

--- a/src/common/ChannelChatters.cpp
+++ b/src/common/ChannelChatters.cpp
@@ -1,4 +1,4 @@
-#include "ChannelChatters.hpp"
+#include "common/ChannelChatters.hpp"
 
 #include "common/Channel.hpp"
 #include "messages/Message.hpp"

--- a/src/common/Common.hpp
+++ b/src/common/Common.hpp
@@ -5,17 +5,17 @@
 #include <QWidget>
 
 #include <memory>
-#include <optional>
-#include <string>
-
-#define LINK_CHATTERINO_WIKI "https://wiki.chatterino.com"
-#define LINK_CHATTERINO_DISCORD "https://discord.gg/7Y5AYhAK4z"
-#define LINK_CHATTERINO_SOURCE "https://github.com/Chatterino/chatterino2"
 
 namespace chatterino {
 
-const inline auto TWITCH_PLAYER_URL =
-    QStringLiteral("https://player.twitch.tv/?channel=%1&parent=twitch.tv");
+constexpr QStringView LINK_CHATTERINO_WIKI = u"https://wiki.chatterino.com";
+constexpr QStringView LINK_CHATTERINO_DISCORD =
+    u"https://discord.gg/7Y5AYhAK4z";
+constexpr QStringView LINK_CHATTERINO_SOURCE =
+    u"https://github.com/Chatterino/chatterino2";
+
+constexpr QStringView TWITCH_PLAYER_URL =
+    u"https://player.twitch.tv/?channel=%1&parent=twitch.tv";
 
 enum class HighlightState {
     None,
@@ -23,21 +23,14 @@ enum class HighlightState {
     NewMessage,
 };
 
-const Qt::KeyboardModifiers showSplitOverlayModifiers =
+constexpr Qt::KeyboardModifiers SHOW_SPLIT_OVERLAY_MODIFIERS =
     Qt::ControlModifier | Qt::AltModifier;
-const Qt::KeyboardModifiers showAddSplitRegions =
+constexpr Qt::KeyboardModifiers SHOW_ADD_SPLIT_REGIONS =
     Qt::ControlModifier | Qt::AltModifier;
-const Qt::KeyboardModifiers showResizeHandlesModifiers = Qt::ControlModifier;
+constexpr Qt::KeyboardModifiers SHOW_RESIZE_HANDLES_MODIFIERS =
+    Qt::ControlModifier;
 
-#ifndef ATTR_UNUSED
-#    ifdef Q_OS_WIN
-#        define ATTR_UNUSED
-#    else
-#        define ATTR_UNUSED __attribute__((unused))
-#    endif
-#endif
-
-static const char *ANONYMOUS_USERNAME_LABEL ATTR_UNUSED = " - anonymous - ";
+constexpr const char *ANONYMOUS_USERNAME_LABEL = " - anonymous - ";
 
 template <typename T>
 std::weak_ptr<T> weakOf(T *element)

--- a/src/common/Credentials.cpp
+++ b/src/common/Credentials.cpp
@@ -11,6 +11,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QSaveFile>
+#include <QStringBuilder>
 
 #include <variant>
 

--- a/src/common/Credentials.cpp
+++ b/src/common/Credentials.cpp
@@ -25,6 +25,7 @@
 #    else
 #        include "keychain.h"
 #    endif
+#endif
 
 namespace {
 
@@ -38,19 +39,19 @@ QString formatName(const QString &provider, const QString &name)
 
 bool useKeyring()
 {
-#    ifdef NO_QTKEYCHAIN
+#ifdef NO_QTKEYCHAIN
     return false;
-#    endif
+#endif
     if (Modes::instance().isPortable)
     {
         return false;
     }
 
-#    ifdef Q_OS_LINUX
+#ifdef Q_OS_LINUX
     return getSettings()->useKeyring;
-#    else
+#else
     return true;
-#    endif
+#endif
 }
 
 // Insecure storage:
@@ -116,7 +117,7 @@ std::queue<Job> &jobQueue()
 
 void runNextJob()
 {
-#    ifndef NO_QTKEYCHAIN
+#ifndef NO_QTKEYCHAIN
     auto &&queue = jobQueue();
 
     if (!queue.empty())
@@ -153,7 +154,7 @@ void runNextJob()
 
         queue.pop();
     }
-#    endif
+#endif
 }
 
 void queueJob(Job &&job)
@@ -188,7 +189,7 @@ void Credentials::get(const QString &provider, const QString &name_,
 
     if (useKeyring())
     {
-#    ifndef NO_QTKEYCHAIN
+#ifndef NO_QTKEYCHAIN
         // if NO_QTKEYCHAIN is set, then this code is never used either way
         auto *job = new QKeychain::ReadPasswordJob("chatterino");
         job->setAutoDelete(true);
@@ -200,7 +201,7 @@ void Credentials::get(const QString &provider, const QString &name_,
             },
             Qt::DirectConnection);
         job->start();
-#    endif
+#endif
     }
     else
     {

--- a/src/common/Credentials.cpp
+++ b/src/common/Credentials.cpp
@@ -4,7 +4,6 @@
 #include "common/Modes.hpp"
 #include "debug/AssertInGuiThread.hpp"
 #include "singletons/Paths.hpp"
-#include "singletons/Settings.hpp"
 #include "util/CombinePath.hpp"
 #include "util/Variant.hpp"
 
@@ -15,26 +14,18 @@
 #include <variant>
 
 #ifndef NO_QTKEYCHAIN
-#    ifdef CMAKE_BUILD
-#        if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-#            include "qt6keychain/keychain.h"
-#        else
-#            include "qt5keychain/keychain.h"
-#        endif
-#    else
-#        include "keychain.h"
-#    endif
+#    include "keychain.h"
 #endif
-
-#define FORMAT_NAME                                                  \
-    ([&] {                                                           \
-        assert(!provider.contains(":"));                             \
-        return QString("chatterino:%1:%2").arg(provider).arg(name_); \
-    })()
 
 namespace {
 
 using namespace chatterino;
+
+QString formatName(const QString &provider, const QString &name)
+{
+    assert(!provider.contains(":"));
+    return u"chatterino:" % provider % u':' % name;
+}
 
 bool useKeyring()
 {
@@ -184,7 +175,7 @@ void Credentials::get(const QString &provider, const QString &name_,
 {
     assertInGuiThread();
 
-    auto name = FORMAT_NAME;
+    auto name = formatName(provider, name_);
 
     if (useKeyring())
     {
@@ -219,7 +210,7 @@ void Credentials::set(const QString &provider, const QString &name_,
     /// On linux, we try to use a keychain but show a message to disable it when it fails.
     /// XXX: add said message
 
-    auto name = FORMAT_NAME;
+    auto name = formatName(provider, name_);
 
     if (useKeyring())
     {
@@ -242,7 +233,7 @@ void Credentials::erase(const QString &provider, const QString &name_)
 {
     assertInGuiThread();
 
-    auto name = FORMAT_NAME;
+    auto name = formatName(provider, name_);
 
     if (useKeyring())
     {

--- a/src/common/Credentials.cpp
+++ b/src/common/Credentials.cpp
@@ -4,6 +4,7 @@
 #include "common/Modes.hpp"
 #include "debug/AssertInGuiThread.hpp"
 #include "singletons/Paths.hpp"
+#include "singletons/Settings.hpp"
 #include "util/CombinePath.hpp"
 #include "util/Variant.hpp"
 

--- a/src/common/Credentials.cpp
+++ b/src/common/Credentials.cpp
@@ -16,8 +16,15 @@
 #include <variant>
 
 #ifndef NO_QTKEYCHAIN
-#    include "keychain.h"
-#endif
+#    ifdef CMAKE_BUILD
+#        if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#            include "qt6keychain/keychain.h"
+#        else
+#            include "qt5keychain/keychain.h"
+#        endif
+#    else
+#        include "keychain.h"
+#    endif
 
 namespace {
 
@@ -31,19 +38,19 @@ QString formatName(const QString &provider, const QString &name)
 
 bool useKeyring()
 {
-#ifdef NO_QTKEYCHAIN
+#    ifdef NO_QTKEYCHAIN
     return false;
-#endif
+#    endif
     if (Modes::instance().isPortable)
     {
         return false;
     }
 
-#ifdef Q_OS_LINUX
+#    ifdef Q_OS_LINUX
     return getSettings()->useKeyring;
-#else
+#    else
     return true;
-#endif
+#    endif
 }
 
 // Insecure storage:
@@ -109,7 +116,7 @@ std::queue<Job> &jobQueue()
 
 void runNextJob()
 {
-#ifndef NO_QTKEYCHAIN
+#    ifndef NO_QTKEYCHAIN
     auto &&queue = jobQueue();
 
     if (!queue.empty())
@@ -146,7 +153,7 @@ void runNextJob()
 
         queue.pop();
     }
-#endif
+#    endif
 }
 
 void queueJob(Job &&job)
@@ -181,7 +188,7 @@ void Credentials::get(const QString &provider, const QString &name_,
 
     if (useKeyring())
     {
-#ifndef NO_QTKEYCHAIN
+#    ifndef NO_QTKEYCHAIN
         // if NO_QTKEYCHAIN is set, then this code is never used either way
         auto *job = new QKeychain::ReadPasswordJob("chatterino");
         job->setAutoDelete(true);
@@ -193,7 +200,7 @@ void Credentials::get(const QString &provider, const QString &name_,
             },
             Qt::DirectConnection);
         job->start();
-#endif
+#    endif
     }
     else
     {

--- a/src/common/Modes.cpp
+++ b/src/common/Modes.cpp
@@ -1,4 +1,4 @@
-#include "Modes.hpp"
+#include "common/Modes.hpp"
 
 #include "util/CombinePath.hpp"
 

--- a/src/common/Version.cpp
+++ b/src/common/Version.cpp
@@ -10,6 +10,29 @@ namespace chatterino {
 
 using namespace literals;
 
+/**
+ * Valid version formats, in order of latest to oldest
+ *
+ * Stable:
+ *  - 2.4.0
+ *
+ * Release candidate:
+ *  - 2.4.0-rc.3
+ *  - 2.4.0-rc.2
+ *  - 2.4.0-rc
+ *
+ * Beta:
+ *  - 2.4.0-beta.3
+ *  - 2.4.0-beta.2
+ *  - 2.4.0-beta
+ *
+ * Alpha:
+ *  - 2.4.0-alpha.3
+ *  - 2.4.0-alpha.2
+ *  - 2.4.0-alpha
+ **/
+inline const QString CHATTERINO_VERSION = u"2.5.1"_s;
+
 Version::Version()
     : version_(CHATTERINO_VERSION)
     , commitHash_(QStringLiteral(CHATTERINO_GIT_HASH))

--- a/src/common/Version.cpp
+++ b/src/common/Version.cpp
@@ -31,10 +31,10 @@ using namespace literals;
  *  - 2.4.0-alpha.2
  *  - 2.4.0-alpha
  **/
-inline const QString CHATTERINO_VERSION = u"2.5.1"_s;
+constexpr QStringView CHATTERINO_VERSION = u"2.5.1";
 
 Version::Version()
-    : version_(CHATTERINO_VERSION)
+    : version_(CHATTERINO_VERSION.toString())
     , commitHash_(QStringLiteral(CHATTERINO_GIT_HASH))
     , isModified_(CHATTERINO_GIT_MODIFIED == 1)
     , dateOfBuild_(QStringLiteral(CHATTERINO_CMAKE_GEN_DATE))

--- a/src/common/Version.cpp
+++ b/src/common/Version.cpp
@@ -10,31 +10,8 @@ namespace chatterino {
 
 using namespace literals;
 
-/**
- * Valid version formats, in order of latest to oldest
- *
- * Stable:
- *  - 2.4.0
- *
- * Release candidate:
- *  - 2.4.0-rc.3
- *  - 2.4.0-rc.2
- *  - 2.4.0-rc
- *
- * Beta:
- *  - 2.4.0-beta.3
- *  - 2.4.0-beta.2
- *  - 2.4.0-beta
- *
- * Alpha:
- *  - 2.4.0-alpha.3
- *  - 2.4.0-alpha.2
- *  - 2.4.0-alpha
- **/
-constexpr QStringView CHATTERINO_VERSION = u"2.5.1";
-
 Version::Version()
-    : version_(CHATTERINO_VERSION.toString())
+    : version_(CHATTERINO_VERSION)
     , commitHash_(QStringLiteral(CHATTERINO_GIT_HASH))
     , isModified_(CHATTERINO_GIT_MODIFIED == 1)
     , dateOfBuild_(QStringLiteral(CHATTERINO_CMAKE_GEN_DATE))

--- a/src/common/Version.hpp
+++ b/src/common/Version.hpp
@@ -1,42 +1,6 @@
 #pragma once
 
 #include <QString>
-#include <QtGlobal>
-
-/**
- * Valid version formats, in order of latest to oldest
- *
- * Stable:
- *  - 2.4.0
- *
- * Release candidate:
- *  - 2.4.0-rc.3
- *  - 2.4.0-rc.2
- *  - 2.4.0-rc
- *
- * Beta:
- *  - 2.4.0-beta.3
- *  - 2.4.0-beta.2
- *  - 2.4.0-beta
- *
- * Alpha:
- *  - 2.4.0-alpha.3
- *  - 2.4.0-alpha.2
- *  - 2.4.0-alpha
- **/
-#define CHATTERINO_VERSION "2.5.1"
-
-#if defined(Q_OS_WIN)
-#    define CHATTERINO_OS "win"
-#elif defined(Q_OS_MACOS)
-#    define CHATTERINO_OS "macos"
-#elif defined(Q_OS_LINUX)
-#    define CHATTERINO_OS "linux"
-#elif defined(Q_OS_FREEBSD)
-#    define CHATTERINO_OS "freebsd"
-#else
-#    define CHATTERINO_OS "unknown"
-#endif
 
 namespace chatterino {
 

--- a/src/common/Version.hpp
+++ b/src/common/Version.hpp
@@ -4,6 +4,29 @@
 
 namespace chatterino {
 
+/**
+ * Valid version formats, in order of latest to oldest
+ *
+ * Stable:
+ *  - 2.4.0
+ *
+ * Release candidate:
+ *  - 2.4.0-rc.3
+ *  - 2.4.0-rc.2
+ *  - 2.4.0-rc
+ *
+ * Beta:
+ *  - 2.4.0-beta.3
+ *  - 2.4.0-beta.2
+ *  - 2.4.0-beta
+ *
+ * Alpha:
+ *  - 2.4.0-alpha.3
+ *  - 2.4.0-alpha.2
+ *  - 2.4.0-alpha
+ **/
+inline const QString CHATTERINO_VERSION = QStringLiteral("2.5.1");
+
 class Version
 {
 public:

--- a/src/controllers/accounts/Account.cpp
+++ b/src/controllers/accounts/Account.cpp
@@ -1,4 +1,4 @@
-#include "Account.hpp"
+#include "controllers/accounts/Account.hpp"
 
 #include <tuple>
 

--- a/src/controllers/accounts/AccountModel.cpp
+++ b/src/controllers/accounts/AccountModel.cpp
@@ -1,4 +1,4 @@
-#include "AccountModel.hpp"
+#include "controllers/accounts/AccountModel.hpp"
 
 #include "controllers/accounts/Account.hpp"
 #include "util/StandardItemHelper.hpp"

--- a/src/controllers/commands/Command.cpp
+++ b/src/controllers/commands/Command.cpp
@@ -1,4 +1,4 @@
-#include "Command.hpp"
+#include "controllers/commands/Command.hpp"
 
 namespace chatterino {
 

--- a/src/controllers/highlights/HighlightBadge.cpp
+++ b/src/controllers/highlights/HighlightBadge.cpp
@@ -1,4 +1,4 @@
-#include "highlights/HighlightBadge.hpp"
+#include "controllers/highlights/HighlightBadge.hpp"
 
 #include "messages/SharedMessageBuilder.hpp"
 #include "providers/twitch/TwitchBadge.hpp"

--- a/src/controllers/highlights/HighlightBadge.cpp
+++ b/src/controllers/highlights/HighlightBadge.cpp
@@ -1,4 +1,4 @@
-#include "HighlightBadge.hpp"
+#include "highlights/HighlightBadge.hpp"
 
 #include "messages/SharedMessageBuilder.hpp"
 #include "providers/twitch/TwitchBadge.hpp"

--- a/src/controllers/notifications/NotificationModel.cpp
+++ b/src/controllers/notifications/NotificationModel.cpp
@@ -1,4 +1,4 @@
-#include "NotificationModel.hpp"
+#include "controllers/notifications/NotificationModel.hpp"
 
 #include "Application.hpp"
 #include "singletons/Settings.hpp"

--- a/src/controllers/pings/MutedChannelModel.cpp
+++ b/src/controllers/pings/MutedChannelModel.cpp
@@ -1,4 +1,4 @@
-#include "MutedChannelModel.hpp"
+#include "controllers/pings/MutedChannelModel.hpp"
 
 #include "Application.hpp"
 #include "singletons/Settings.hpp"

--- a/src/debug/Benchmark.cpp
+++ b/src/debug/Benchmark.cpp
@@ -1,4 +1,4 @@
-#include "Benchmark.hpp"
+#include "debug/Benchmark.hpp"
 
 #include "common/QLogging.hpp"
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,7 +30,7 @@ int main(int argc, char **argv)
     QApplication a(argc, argv);
 
     QCoreApplication::setApplicationName("chatterino");
-    QCoreApplication::setApplicationVersion(CHATTERINO_VERSION);
+    QCoreApplication::setApplicationVersion(Version::instance().version());
     QCoreApplication::setOrganizationDomain("chatterino.com");
 
     std::unique_ptr<Paths> paths;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,7 +30,7 @@ int main(int argc, char **argv)
     QApplication a(argc, argv);
 
     QCoreApplication::setApplicationName("chatterino");
-    QCoreApplication::setApplicationVersion(Version::instance().version());
+    QCoreApplication::setApplicationVersion(CHATTERINO_VERSION);
     QCoreApplication::setOrganizationDomain("chatterino.com");
 
     std::unique_ptr<Paths> paths;

--- a/src/messages/Emote.cpp
+++ b/src/messages/Emote.cpp
@@ -1,4 +1,4 @@
-#include "Emote.hpp"
+#include "messages/Emote.hpp"
 
 #include <unordered_map>
 

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -1,4 +1,4 @@
-#include "MessageBuilder.hpp"
+#include "messages/MessageBuilder.hpp"
 
 #include "Application.hpp"
 #include "common/IrcColors.hpp"

--- a/src/messages/MessageColor.cpp
+++ b/src/messages/MessageColor.cpp
@@ -1,4 +1,4 @@
-#include "MessageColor.hpp"
+#include "messages/MessageColor.hpp"
 
 #include "singletons/Theme.hpp"
 

--- a/src/messages/layouts/MessageLayout.cpp
+++ b/src/messages/layouts/MessageLayout.cpp
@@ -19,12 +19,6 @@
 #include <QtGlobal>
 #include <QThread>
 
-#define MARGIN_LEFT (int)(8 * this->scale)
-#define MARGIN_RIGHT (int)(8 * this->scale)
-#define MARGIN_TOP (int)(4 * this->scale)
-#define MARGIN_BOTTOM (int)(4 * this->scale)
-#define COMPACT_EMOTES_OFFSET 6
-
 namespace chatterino {
 
 namespace {

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -18,13 +18,17 @@
 
 #include <optional>
 
-#define COMPACT_EMOTES_OFFSET 4
-#define MAX_UNCOLLAPSED_LINES \
-    (getSettings()->collpseMessagesMinLines.getValue())
-
 namespace {
 
-constexpr const QMargins MARGIN{8, 4, 8, 4};
+using namespace chatterino;
+
+constexpr QMargins MARGIN{8, 4, 8, 4};
+constexpr int COMPACT_EMOTES_OFFSET = 4;
+
+int maxUncollapsedLines()
+{
+    return getSettings()->collpseMessagesMinLines.getValue();
+}
 
 }  // namespace
 
@@ -208,7 +212,7 @@ void MessageLayoutContainer::breakLine()
     this->lineStart_ = this->elements_.size();
     //    this->currentX = (int)(this->scale * 8);
 
-    if (this->canCollapse() && this->line_ + 1 >= MAX_UNCOLLAPSED_LINES)
+    if (this->canCollapse() && this->line_ + 1 >= maxUncollapsedLines())
     {
         this->canAddMessages_ = false;
         return;
@@ -568,8 +572,9 @@ int MessageLayoutContainer::remainingWidth() const
 {
     return (this->width_ - int(MARGIN.left() * this->scale_) -
             int(MARGIN.right() * this->scale_) -
-            (this->line_ + 1 == MAX_UNCOLLAPSED_LINES ? this->dotdotdotWidth_
-                                                      : 0)) -
+            (static_cast<int>(this->line_ + 1) == maxUncollapsedLines()
+                 ? this->dotdotdotWidth_
+                 : 0)) -
            this->currentX_;
 }
 

--- a/src/messages/search/RegexPredicate.cpp
+++ b/src/messages/search/RegexPredicate.cpp
@@ -1,4 +1,4 @@
-#include "RegexPredicate.hpp"
+#include "messages/search/RegexPredicate.hpp"
 
 #include "messages/Message.hpp"
 

--- a/src/messages/search/RegexPredicate.hpp
+++ b/src/messages/search/RegexPredicate.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "messages/search/MessagePredicate.hpp"
-#include "QRegularExpression"
 
+#include <QRegularExpression>
 #include <QString>
 
 namespace chatterino {

--- a/src/providers/IvrApi.cpp
+++ b/src/providers/IvrApi.cpp
@@ -1,4 +1,4 @@
-#include "IvrApi.hpp"
+#include "providers/IvrApi.hpp"
 
 #include "common/network/NetworkResult.hpp"
 #include "common/QLogging.hpp"

--- a/src/providers/IvrApi.hpp
+++ b/src/providers/IvrApi.hpp
@@ -64,9 +64,7 @@ struct IvrEmote {
         : code(root.value("code").toString())
         , id(root.value("id").toString())
         , setId(root.value("setID").toString())
-        , url(QString(TWITCH_EMOTE_TEMPLATE)
-                  .replace("{id}", this->id)
-                  .replace("{scale}", "3.0"))
+        , url(TWITCH_EMOTE_TEMPLATE.arg(this->id, u"3.0"))
         , emoteType(root.value("type").toString())
         , imageType(root.value("assetType").toString())
     {

--- a/src/providers/irc/AbstractIrcServer.cpp
+++ b/src/providers/irc/AbstractIrcServer.cpp
@@ -1,4 +1,4 @@
-#include "AbstractIrcServer.hpp"
+#include "providers/irc/AbstractIrcServer.hpp"
 
 #include "common/Channel.hpp"
 #include "common/QLogging.hpp"

--- a/src/providers/irc/Irc2.cpp
+++ b/src/providers/irc/Irc2.cpp
@@ -1,4 +1,4 @@
-#include "Irc2.hpp"
+#include "providers/irc/Irc2.hpp"
 
 #include "Application.hpp"
 #include "common/Credentials.hpp"

--- a/src/providers/irc/IrcAccount.cpp
+++ b/src/providers/irc/IrcAccount.cpp
@@ -1,4 +1,4 @@
-#include "IrcAccount.hpp"
+#include "providers/irc/IrcAccount.hpp"
 
 // namespace chatterino {
 //

--- a/src/providers/irc/IrcChannel2.cpp
+++ b/src/providers/irc/IrcChannel2.cpp
@@ -1,4 +1,4 @@
-#include "IrcChannel2.hpp"
+#include "providers/irc/IrcChannel2.hpp"
 
 #include "common/Channel.hpp"
 #include "debug/AssertInGuiThread.hpp"

--- a/src/providers/irc/IrcCommands.cpp
+++ b/src/providers/irc/IrcCommands.cpp
@@ -1,4 +1,4 @@
-#include "IrcCommands.hpp"
+#include "providers/irc/IrcCommands.hpp"
 
 #include "messages/MessageBuilder.hpp"
 #include "providers/irc/IrcChannel2.hpp"

--- a/src/providers/irc/IrcConnection2.cpp
+++ b/src/providers/irc/IrcConnection2.cpp
@@ -11,7 +11,7 @@ namespace chatterino {
 
 namespace {
 
-    const auto payload = "chatterino/" + Version::instance().version();
+    const auto payload = "chatterino/" + CHATTERINO_VERSION;
 
 }  // namespace
 

--- a/src/providers/irc/IrcConnection2.cpp
+++ b/src/providers/irc/IrcConnection2.cpp
@@ -1,4 +1,4 @@
-#include "IrcConnection2.hpp"
+#include "providers/irc/IrcConnection2.hpp"
 
 #include "common/QLogging.hpp"
 #include "common/Version.hpp"
@@ -11,7 +11,7 @@ namespace chatterino {
 
 namespace {
 
-    const auto payload = QString("chatterino/" CHATTERINO_VERSION);
+    const auto payload = "chatterino/" + Version::instance().version();
 
 }  // namespace
 

--- a/src/providers/irc/IrcServer.cpp
+++ b/src/providers/irc/IrcServer.cpp
@@ -1,4 +1,4 @@
-#include "IrcServer.hpp"
+#include "providers/irc/IrcServer.hpp"
 
 #include "Application.hpp"
 #include "common/QLogging.hpp"

--- a/src/providers/twitch/ChannelPointReward.cpp
+++ b/src/providers/twitch/ChannelPointReward.cpp
@@ -1,7 +1,15 @@
-#include "ChannelPointReward.hpp"
+#include "providers/twitch/ChannelPointReward.hpp"
 
-#include "common/QLogging.hpp"
 #include "messages/Image.hpp"
+
+namespace {
+
+QString twitchChannelPointRewardUrl(const QString &file)
+{
+    return u"https://static-cdn.jtvnw.net/custom-reward-images/default-" % file;
+}
+
+}  // namespace
 
 namespace chatterino {
 
@@ -94,11 +102,10 @@ ChannelPointReward::ChannelPointReward(const QJsonObject &redemption)
     else
     {
         static const ImageSet defaultImage{
-            Image::fromUrl({TWITCH_CHANNEL_POINT_REWARD_URL("1.png")}, 1,
-                           baseSize),
-            Image::fromUrl({TWITCH_CHANNEL_POINT_REWARD_URL("2.png")}, 0.5,
+            Image::fromUrl({twitchChannelPointRewardUrl("1.png")}, 1, baseSize),
+            Image::fromUrl({twitchChannelPointRewardUrl("2.png")}, 0.5,
                            baseSize * 2),
-            Image::fromUrl({TWITCH_CHANNEL_POINT_REWARD_URL("4.png")}, 0.25,
+            Image::fromUrl({twitchChannelPointRewardUrl("4.png")}, 0.25,
                            baseSize * 4)};
         this->image = defaultImage;
     }

--- a/src/providers/twitch/ChannelPointReward.cpp
+++ b/src/providers/twitch/ChannelPointReward.cpp
@@ -2,6 +2,8 @@
 
 #include "messages/Image.hpp"
 
+#include <QStringBuilder>
+
 namespace {
 
 QString twitchChannelPointRewardUrl(const QString &file)

--- a/src/providers/twitch/ChannelPointReward.hpp
+++ b/src/providers/twitch/ChannelPointReward.hpp
@@ -1,15 +1,11 @@
 #pragma once
 
-#include "common/Aliases.hpp"
 #include "messages/ImageSet.hpp"
 
 #include <QJsonObject>
 
-#define TWITCH_CHANNEL_POINT_REWARD_URL(x)                                  \
-    QString("https://static-cdn.jtvnw.net/custom-reward-images/default-%1") \
-        .arg(x)
-
 namespace chatterino {
+
 struct ChannelPointReward {
     ChannelPointReward(const QJsonObject &redemption);
     ChannelPointReward() = delete;

--- a/src/providers/twitch/TwitchEmotes.cpp
+++ b/src/providers/twitch/TwitchEmotes.cpp
@@ -11,9 +11,7 @@ using namespace chatterino;
 
 Url getEmoteLink(const EmoteId &id, const QString &emoteScale)
 {
-    return {QString(TWITCH_EMOTE_TEMPLATE)
-                .replace("{id}", id.string)
-                .replace("{scale}", emoteScale)};
+    return {TWITCH_EMOTE_TEMPLATE.arg(id.string, emoteScale)};
 }
 
 QSize getEmoteExpectedBaseSize(const EmoteId &id)

--- a/src/providers/twitch/TwitchEmotes.hpp
+++ b/src/providers/twitch/TwitchEmotes.hpp
@@ -10,12 +10,15 @@
 #include <memory>
 #include <unordered_map>
 
+namespace chatterino {
+
 // NB: "default" can be replaced with "static" to always get a non-animated
 // variant
-#define TWITCH_EMOTE_TEMPLATE \
-    "https://static-cdn.jtvnw.net/emoticons/v2/{id}/default/dark/{scale}"
+/// %1 <-> {id}
+/// %2 <-> {scale} (1.0, 2.0, 3.0)
+constexpr QStringView TWITCH_EMOTE_TEMPLATE =
+    u"https://static-cdn.jtvnw.net/emoticons/v2/%1/default/dark/%2";
 
-namespace chatterino {
 struct Emote;
 using EmotePtr = std::shared_ptr<const Emote>;
 

--- a/src/providers/twitch/api/Helix.hpp
+++ b/src/providers/twitch/api/Helix.hpp
@@ -276,9 +276,7 @@ struct HelixChannelEmote {
         , name(jsonObject.value("name").toString())
         , type(jsonObject.value("emote_type").toString())
         , setId(jsonObject.value("emote_set_id").toString())
-        , url(QString(TWITCH_EMOTE_TEMPLATE)
-                  .replace("{id}", this->emoteId)
-                  .replace("{scale}", "3.0"))
+        , url(TWITCH_EMOTE_TEMPLATE.arg(this->emoteId, u"3.0"))
     {
     }
 };

--- a/src/singletons/ImageUploader.cpp
+++ b/src/singletons/ImageUploader.cpp
@@ -24,10 +24,10 @@
 
 #include <utility>
 
-#define UPLOAD_DELAY 2000
-// Delay between uploads in milliseconds
-
 namespace {
+
+// Delay between uploads in milliseconds
+constexpr int UPLOAD_DELAY = 2000;
 
 std::optional<QByteArray> convertToPng(const QImage &image)
 {

--- a/src/singletons/Theme.cpp
+++ b/src/singletons/Theme.cpp
@@ -1,4 +1,3 @@
-
 #include "singletons/Theme.hpp"
 
 #include "Application.hpp"

--- a/src/singletons/Toasts.cpp
+++ b/src/singletons/Toasts.cpp
@@ -1,4 +1,4 @@
-#include "Toasts.hpp"
+#include "singletons/Toasts.hpp"
 
 #include "Application.hpp"
 #include "common/Common.hpp"
@@ -83,19 +83,17 @@ bool Toasts::isEnabled()
 
 QString Toasts::findStringFromReaction(const ToastReaction &reaction)
 {
-    // The constants are macros right now, but we want to avoid ASCII casts,
-    // so we're concatenating them with a QString literal - effectively making them part of it.
     switch (reaction)
     {
         case ToastReaction::OpenInBrowser:
-            return OPEN_IN_BROWSER u""_s;
+            return OPEN_IN_BROWSER;
         case ToastReaction::OpenInPlayer:
-            return OPEN_PLAYER_IN_BROWSER u""_s;
+            return OPEN_PLAYER_IN_BROWSER;
         case ToastReaction::OpenInStreamlink:
-            return OPEN_IN_STREAMLINK u""_s;
+            return OPEN_IN_STREAMLINK;
         case ToastReaction::DontOpen:
         default:
-            return DONT_OPEN u""_s;
+            return DONT_OPEN;
     }
 }
 

--- a/src/singletons/Updates.cpp
+++ b/src/singletons/Updates.cpp
@@ -48,7 +48,7 @@ namespace chatterino {
 
 Updates::Updates(const Paths &paths_)
     : paths(paths_)
-    , currentVersion_(Version::instance().version())
+    , currentVersion_(CHATTERINO_VERSION)
     , updateGuideLink_("https://chatterino.com")
 {
     qCDebug(chatterinoUpdate) << "init UpdateManager";

--- a/src/singletons/Updates.cpp
+++ b/src/singletons/Updates.cpp
@@ -16,6 +16,7 @@
 #include <QMessageBox>
 #include <QProcess>
 #include <QRegularExpression>
+#include <QStringBuilder>
 #include <semver/semver.hpp>
 
 namespace {

--- a/src/singletons/Updates.cpp
+++ b/src/singletons/Updates.cpp
@@ -29,19 +29,18 @@ QString currentBranch()
     return getSettings()->betaUpdates ? "beta" : "stable";
 }
 
-const QString CHATTERINO_OS = u""_s
 #if defined(Q_OS_WIN)
-                              "win"
+const QString CHATTERINO_OS = u"win"_s;
 #elif defined(Q_OS_MACOS)
-                              "macos"
+const QString CHATTERINO_OS = u"macos"_s;
 #elif defined(Q_OS_LINUX)
-                              "linux"
+const QString CHATTERINO_OS = u"linux"_s;
 #elif defined(Q_OS_FREEBSD)
-                              "freebsd"
+const QString CHATTERINO_OS = u"freebsd"_s;
 #else
-                              "unknown"
+const QString CHATTERINO_OS = u"unknown"_s;
 #endif
-    ;
+;
 
 }  // namespace
 namespace chatterino {

--- a/src/singletons/Updates.cpp
+++ b/src/singletons/Updates.cpp
@@ -1,12 +1,13 @@
-#include "Updates.hpp"
+#include "singletons/Updates.hpp"
 
+#include "common/Literals.hpp"
 #include "common/Modes.hpp"
 #include "common/network/NetworkRequest.hpp"
 #include "common/network/NetworkResult.hpp"
 #include "common/QLogging.hpp"
 #include "common/Version.hpp"
-#include "Settings.hpp"
 #include "singletons/Paths.hpp"
+#include "singletons/Settings.hpp"
 #include "util/CombinePath.hpp"
 #include "util/PostToThread.hpp"
 
@@ -17,18 +18,36 @@
 #include <QRegularExpression>
 #include <semver/semver.hpp>
 
-namespace chatterino {
 namespace {
-    QString currentBranch()
-    {
-        return getSettings()->betaUpdates ? "beta" : "stable";
-    }
+
+using namespace chatterino;
+using namespace literals;
+
+QString currentBranch()
+{
+    return getSettings()->betaUpdates ? "beta" : "stable";
+}
+
+const QString CHATTERINO_OS = u""_s
+#if defined(Q_OS_WIN)
+                              "win"
+#elif defined(Q_OS_MACOS)
+                              "macos"
+#elif defined(Q_OS_LINUX)
+                              "linux"
+#elif defined(Q_OS_FREEBSD)
+                              "freebsd"
+#else
+                              "unknown"
+#endif
+    ;
 
 }  // namespace
+namespace chatterino {
 
 Updates::Updates(const Paths &paths_)
     : paths(paths_)
-    , currentVersion_(CHATTERINO_VERSION)
+    , currentVersion_(Version::instance().version())
     , updateGuideLink_("https://chatterino.com")
 {
     qCDebug(chatterinoUpdate) << "init UpdateManager";
@@ -262,9 +281,8 @@ void Updates::checkForUpdates()
         return;
     }
 
-    QString url =
-        "https://notitia.chatterino.com/version/chatterino/" CHATTERINO_OS "/" +
-        currentBranch();
+    QString url = "https://notitia.chatterino.com/version/chatterino/" %
+                  CHATTERINO_OS % "/" % currentBranch();
 
     NetworkRequest(url)
         .timeout(60000)

--- a/src/util/DisplayBadge.cpp
+++ b/src/util/DisplayBadge.cpp
@@ -1,4 +1,4 @@
-#include "DisplayBadge.hpp"
+#include "util/DisplayBadge.hpp"
 
 namespace chatterino {
 DisplayBadge::DisplayBadge(QString displayName, QString badgeName)

--- a/src/util/FunctionEventFilter.cpp
+++ b/src/util/FunctionEventFilter.cpp
@@ -1,4 +1,4 @@
-#include "FunctionEventFilter.hpp"
+#include "util/FunctionEventFilter.hpp"
 
 namespace chatterino {
 

--- a/src/util/FuzzyConvert.cpp
+++ b/src/util/FuzzyConvert.cpp
@@ -1,4 +1,4 @@
-#include "FuzzyConvert.hpp"
+#include "util/FuzzyConvert.hpp"
 
 #include <QRegularExpression>
 

--- a/src/util/Helpers.cpp
+++ b/src/util/Helpers.cpp
@@ -1,4 +1,4 @@
-#include "Helpers.hpp"
+#include "util/Helpers.hpp"
 
 #include "providers/twitch/TwitchCommon.hpp"
 

--- a/src/util/RatelimitBucket.cpp
+++ b/src/util/RatelimitBucket.cpp
@@ -1,4 +1,4 @@
-#include "RatelimitBucket.hpp"
+#include "util/RatelimitBucket.hpp"
 
 #include <QTimer>
 

--- a/src/util/SampleData.cpp
+++ b/src/util/SampleData.cpp
@@ -1,4 +1,4 @@
-#include "SampleData.hpp"
+#include "util/SampleData.hpp"
 
 namespace chatterino {
 

--- a/src/widgets/AccountSwitchWidget.cpp
+++ b/src/widgets/AccountSwitchWidget.cpp
@@ -1,4 +1,4 @@
-#include "AccountSwitchWidget.hpp"
+#include "widgets/AccountSwitchWidget.hpp"
 
 #include "Application.hpp"
 #include "common/Common.hpp"

--- a/src/widgets/TooltipWidget.cpp
+++ b/src/widgets/TooltipWidget.cpp
@@ -7,10 +7,10 @@
 
 #include <QPainter>
 
-// number of columns in grid mode
-#define GRID_NUM_COLS 3
-
 namespace {
+
+// number of columns in grid mode
+constexpr int GRID_NUM_COLS = 3;
 
 #ifdef Q_OS_WIN
 template <typename T>

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -737,19 +737,19 @@ void Window::addMenuBar()
     // Help->Chatterino Wiki item
     QAction *helpWiki = helpMenu->addAction(QString("Chatterino Wiki"));
     connect(helpWiki, &QAction::triggered, this, []() {
-        QDesktopServices::openUrl(QUrl(LINK_CHATTERINO_WIKI));
+        QDesktopServices::openUrl(QUrl(LINK_CHATTERINO_WIKI.toString()));
     });
 
     // Help->Chatterino Github
     QAction *helpGithub = helpMenu->addAction(QString("Chatterino GitHub"));
     connect(helpGithub, &QAction::triggered, this, []() {
-        QDesktopServices::openUrl(QUrl(LINK_CHATTERINO_SOURCE));
+        QDesktopServices::openUrl(QUrl(LINK_CHATTERINO_SOURCE.toString()));
     });
 
     // Help->Chatterino Discord
     QAction *helpDiscord = helpMenu->addAction(QString("Chatterino Discord"));
     connect(helpDiscord, &QAction::triggered, this, []() {
-        QDesktopServices::openUrl(QUrl(LINK_CHATTERINO_DISCORD));
+        QDesktopServices::openUrl(QUrl(LINK_CHATTERINO_DISCORD.toString()));
     });
 }
 

--- a/src/widgets/dialogs/BadgePickerDialog.cpp
+++ b/src/widgets/dialogs/BadgePickerDialog.cpp
@@ -1,4 +1,4 @@
-#include "BadgePickerDialog.hpp"
+#include "widgets/dialogs/BadgePickerDialog.hpp"
 
 #include "Application.hpp"
 #include "providers/twitch/TwitchBadges.hpp"

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -1,4 +1,4 @@
-#include "EmotePopup.hpp"
+#include "widgets/dialogs/EmotePopup.hpp"
 
 #include "Application.hpp"
 #include "common/QLogging.hpp"

--- a/src/widgets/dialogs/IrcConnectionEditor.cpp
+++ b/src/widgets/dialogs/IrcConnectionEditor.cpp
@@ -1,4 +1,4 @@
-#include "IrcConnectionEditor.hpp"
+#include "widgets/dialogs/IrcConnectionEditor.hpp"
 
 #include "ui_IrcConnectionEditor.h"
 

--- a/src/widgets/dialogs/QualityPopup.cpp
+++ b/src/widgets/dialogs/QualityPopup.cpp
@@ -1,4 +1,4 @@
-#include "QualityPopup.hpp"
+#include "widgets/dialogs/QualityPopup.hpp"
 
 #include "Application.hpp"
 #include "common/QLogging.hpp"

--- a/src/widgets/dialogs/SelectChannelDialog.cpp
+++ b/src/widgets/dialogs/SelectChannelDialog.cpp
@@ -1,4 +1,4 @@
-#include "SelectChannelDialog.hpp"
+#include "widgets/dialogs/SelectChannelDialog.hpp"
 
 #include "Application.hpp"
 #include "common/QLogging.hpp"
@@ -25,10 +25,10 @@
 #include <QTableView>
 #include <QVBoxLayout>
 
-#define TAB_TWITCH 0
-#define TAB_IRC 1
-
 namespace chatterino {
+
+constexpr int TAB_TWITCH = 0;
+constexpr int TAB_IRC = 1;
 
 SelectChannelDialog::SelectChannelDialog(QWidget *parent)
     : BaseWindow(

--- a/src/widgets/dialogs/SelectChannelFiltersDialog.cpp
+++ b/src/widgets/dialogs/SelectChannelFiltersDialog.cpp
@@ -1,4 +1,4 @@
-#include "SelectChannelFiltersDialog.hpp"
+#include "widgets/dialogs/SelectChannelFiltersDialog.hpp"
 
 #include "controllers/filters/FilterRecord.hpp"
 #include "singletons/Settings.hpp"

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -38,6 +38,7 @@
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QPointer>
+#include <QStringBuilder>
 
 namespace {
 

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -39,99 +39,101 @@
 #include <QNetworkReply>
 #include <QPointer>
 
-const QString TEXT_FOLLOWERS("Followers: %1");
-const QString TEXT_CREATED("Created: %1");
-const QString TEXT_TITLE("%1's Usercard - #%2");
-#define TEXT_USER_ID "ID: "
-#define TEXT_UNAVAILABLE "(not available)"
-
-namespace chatterino {
 namespace {
-    Label *addCopyableLabel(LayoutCreator<QHBoxLayout> box, const char *tooltip,
-                            Button **copyButton = nullptr)
+
+constexpr QStringView TEXT_FOLLOWERS = u"Followers: %1";
+constexpr QStringView TEXT_CREATED = u"Created: %1";
+constexpr QStringView TEXT_TITLE = u"%1's Usercard - #%2";
+constexpr QStringView TEXT_USER_ID = u"ID: ";
+constexpr QStringView TEXT_UNAVAILABLE = u"(not available)";
+
+using namespace chatterino;
+
+Label *addCopyableLabel(LayoutCreator<QHBoxLayout> box, const char *tooltip,
+                        Button **copyButton = nullptr)
+{
+    auto label = box.emplace<Label>();
+    auto button = box.emplace<Button>();
+    if (copyButton != nullptr)
     {
-        auto label = box.emplace<Label>();
-        auto button = box.emplace<Button>();
-        if (copyButton != nullptr)
-        {
-            button.assign(copyButton);
-        }
-        button->setPixmap(getApp()->getThemes()->buttons.copy);
-        button->setScaleIndependantSize(18, 18);
-        button->setDim(Button::Dim::Lots);
-        button->setToolTip(tooltip);
-        QObject::connect(
-            button.getElement(), &Button::leftClicked,
-            [label = label.getElement()] {
-                auto copyText = label->property("copy-text").toString();
+        button.assign(copyButton);
+    }
+    button->setPixmap(getApp()->getThemes()->buttons.copy);
+    button->setScaleIndependantSize(18, 18);
+    button->setDim(Button::Dim::Lots);
+    button->setToolTip(tooltip);
+    QObject::connect(
+        button.getElement(), &Button::leftClicked,
+        [label = label.getElement()] {
+            auto copyText = label->property("copy-text").toString();
 
-                crossPlatformCopy(copyText.isEmpty() ? label->getText()
-                                                     : copyText);
-            });
+            crossPlatformCopy(copyText.isEmpty() ? label->getText() : copyText);
+        });
 
-        return label.getElement();
-    };
+    return label.getElement();
+};
 
-    bool checkMessageUserName(const QString &userName, MessagePtr message)
+bool checkMessageUserName(const QString &userName, MessagePtr message)
+{
+    if (message->flags.has(MessageFlag::Whisper))
     {
-        if (message->flags.has(MessageFlag::Whisper))
-        {
-            return false;
-        }
-
-        bool isSubscription = message->flags.has(MessageFlag::Subscription) &&
-                              message->loginName.isEmpty() &&
-                              message->messageText.split(" ").at(0).compare(
-                                  userName, Qt::CaseInsensitive) == 0;
-
-        bool isModAction =
-            message->timeoutUser.compare(userName, Qt::CaseInsensitive) == 0;
-        bool isSelectedUser =
-            message->loginName.compare(userName, Qt::CaseInsensitive) == 0;
-
-        return (isSubscription || isModAction || isSelectedUser);
+        return false;
     }
 
-    ChannelPtr filterMessages(const QString &userName, ChannelPtr channel)
+    bool isSubscription = message->flags.has(MessageFlag::Subscription) &&
+                          message->loginName.isEmpty() &&
+                          message->messageText.split(" ").at(0).compare(
+                              userName, Qt::CaseInsensitive) == 0;
+
+    bool isModAction =
+        message->timeoutUser.compare(userName, Qt::CaseInsensitive) == 0;
+    bool isSelectedUser =
+        message->loginName.compare(userName, Qt::CaseInsensitive) == 0;
+
+    return (isSubscription || isModAction || isSelectedUser);
+}
+
+ChannelPtr filterMessages(const QString &userName, ChannelPtr channel)
+{
+    LimitedQueueSnapshot<MessagePtr> snapshot = channel->getMessageSnapshot();
+
+    ChannelPtr channelPtr;
+    if (channel->isTwitchChannel())
     {
-        LimitedQueueSnapshot<MessagePtr> snapshot =
-            channel->getMessageSnapshot();
-
-        ChannelPtr channelPtr;
-        if (channel->isTwitchChannel())
-        {
-            channelPtr = std::make_shared<TwitchChannel>(channel->getName());
-        }
-        else
-        {
-            channelPtr = std::make_shared<Channel>(channel->getName(),
-                                                   Channel::Type::None);
-        }
-
-        for (size_t i = 0; i < snapshot.size(); i++)
-        {
-            MessagePtr message = snapshot[i];
-
-            if (checkMessageUserName(userName, message))
-            {
-                channelPtr->addMessage(message, MessageContext::Repost);
-            }
-        }
-
-        return channelPtr;
-    };
-
-    const auto borderColor = QColor(255, 255, 255, 80);
-
-    int calculateTimeoutDuration(TimeoutButton timeout)
-    {
-        static const QMap<QString, int> durations{
-            {"s", 1}, {"m", 60}, {"h", 3600}, {"d", 86400}, {"w", 604800},
-        };
-        return timeout.second * durations[timeout.first];
+        channelPtr = std::make_shared<TwitchChannel>(channel->getName());
     }
+    else
+    {
+        channelPtr =
+            std::make_shared<Channel>(channel->getName(), Channel::Type::None);
+    }
+
+    for (size_t i = 0; i < snapshot.size(); i++)
+    {
+        MessagePtr message = snapshot[i];
+
+        if (checkMessageUserName(userName, message))
+        {
+            channelPtr->addMessage(message, MessageContext::Repost);
+        }
+    }
+
+    return channelPtr;
+};
+
+const auto borderColor = QColor(255, 255, 255, 80);
+
+int calculateTimeoutDuration(TimeoutButton timeout)
+{
+    static const QMap<QString, int> durations{
+        {"s", 1}, {"m", 60}, {"h", 3600}, {"d", 86400}, {"w", 604800},
+    };
+    return timeout.second * durations[timeout.first];
+}
 
 }  // namespace
+
+namespace chatterino {
 
 UserInfoPopup::UserInfoPopup(bool closeAutomatically, Split *split)
     : DraggablePopup(closeAutomatically, split)
@@ -813,10 +815,9 @@ void UserInfoPopup::updateUserData()
 
         this->ui_.nameLabel->setText(this->userName_);
 
-        this->ui_.userIDLabel->setText(QString("ID ") +
-                                       QString(TEXT_UNAVAILABLE));
+        this->ui_.userIDLabel->setText(u"ID " % TEXT_UNAVAILABLE);
         this->ui_.userIDLabel->setProperty("copy-text",
-                                           QString(TEXT_UNAVAILABLE));
+                                           TEXT_UNAVAILABLE.toString());
     };
     const auto onUserFetched = [this, hack,
                                 currentUser](const HelixUser &user) {
@@ -855,7 +856,7 @@ void UserInfoPopup::updateUserData()
             user.displayName, this->underlyingChannel_->getName()));
         this->ui_.createdDateLabel->setText(
             TEXT_CREATED.arg(user.createdAt.section("T", 0, 0)));
-        this->ui_.userIDLabel->setText(TEXT_USER_ID + user.id);
+        this->ui_.userIDLabel->setText(TEXT_USER_ID % user.id);
         this->ui_.userIDLabel->setProperty("copy-text", user.id);
 
         if (getApp()->getStreamerMode()->isEnabled() &&

--- a/src/widgets/dialogs/WelcomeDialog.cpp
+++ b/src/widgets/dialogs/WelcomeDialog.cpp
@@ -1,4 +1,4 @@
-#include "WelcomeDialog.hpp"
+#include "widgets/dialogs/WelcomeDialog.hpp"
 
 namespace chatterino {
 

--- a/src/widgets/helper/Button.cpp
+++ b/src/widgets/helper/Button.cpp
@@ -1,4 +1,4 @@
-#include "Button.hpp"
+#include "widgets/helper/Button.hpp"
 
 #include "singletons/Theme.hpp"
 #include "util/FunctionEventFilter.hpp"

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -68,11 +68,9 @@
 #include <functional>
 #include <memory>
 
-#define SELECTION_RESUME_SCROLLING_MSG_THRESHOLD 3
-#define CHAT_HOVER_PAUSE_DURATION 1000
-#define TOOLTIP_EMOTE_ENTRIES_LIMIT 7
-
 namespace {
+
+constexpr size_t TOOLTIP_EMOTE_ENTRIES_LIMIT = 7;
 
 using namespace chatterino;
 

--- a/src/widgets/helper/ComboBoxItemDelegate.cpp
+++ b/src/widgets/helper/ComboBoxItemDelegate.cpp
@@ -1,4 +1,4 @@
-#include "ComboBoxItemDelegate.hpp"
+#include "widgets/helper/ComboBoxItemDelegate.hpp"
 
 #include <QComboBox>
 

--- a/src/widgets/helper/CommonTexts.hpp
+++ b/src/widgets/helper/CommonTexts.hpp
@@ -1,8 +1,13 @@
 #pragma once
 
-#define OPEN_IN_BROWSER "Open stream in browser"
-#define OPEN_PLAYER_IN_BROWSER "Open player in browser"
-#define OPEN_MOD_VIEW_IN_BROWSER "Open mod view in browser"
-#define OPEN_IN_STREAMLINK "Open in streamlink"
-#define DONT_OPEN "Don't open"
-#define OPEN_WHISPERS_IN_BROWSER "Open whispers in browser"
+#include <QString>
+
+inline const QString OPEN_IN_BROWSER = QStringLiteral("Open stream in browser");
+inline const QString OPEN_PLAYER_IN_BROWSER =
+    QStringLiteral("Open player in browser");
+inline const QString OPEN_MOD_VIEW_IN_BROWSER =
+    QStringLiteral("Open mod view in browser");
+inline const QString OPEN_IN_STREAMLINK = QStringLiteral("Open in streamlink");
+inline const QString DONT_OPEN = QStringLiteral("Don't open");
+inline const QString OPEN_WHISPERS_IN_BROWSER =
+    QStringLiteral("Open whispers in browser");

--- a/src/widgets/helper/CommonTexts.hpp
+++ b/src/widgets/helper/CommonTexts.hpp
@@ -2,6 +2,8 @@
 
 #include <QString>
 
+namespace chatterino {
+
 inline const QString OPEN_IN_BROWSER = QStringLiteral("Open stream in browser");
 inline const QString OPEN_PLAYER_IN_BROWSER =
     QStringLiteral("Open player in browser");
@@ -11,3 +13,5 @@ inline const QString OPEN_IN_STREAMLINK = QStringLiteral("Open in streamlink");
 inline const QString DONT_OPEN = QStringLiteral("Don't open");
 inline const QString OPEN_WHISPERS_IN_BROWSER =
     QStringLiteral("Open whispers in browser");
+
+}  // namespace chatterino

--- a/src/widgets/helper/EditableModelView.cpp
+++ b/src/widgets/helper/EditableModelView.cpp
@@ -1,4 +1,4 @@
-#include "EditableModelView.hpp"
+#include "widgets/helper/EditableModelView.hpp"
 
 #include "widgets/helper/RegExpItemDelegate.hpp"
 #include "widgets/helper/TableStyles.hpp"

--- a/src/widgets/helper/NotebookButton.cpp
+++ b/src/widgets/helper/NotebookButton.cpp
@@ -14,8 +14,6 @@
 #include <QPainterPath>
 #include <QRadialGradient>
 
-#define nuuls nullptr
-
 namespace chatterino {
 
 NotebookButton::NotebookButton(Notebook *parent)

--- a/src/widgets/helper/NotebookTab.hpp
+++ b/src/widgets/helper/NotebookTab.hpp
@@ -11,7 +11,7 @@
 
 namespace chatterino {
 
-#define NOTEBOOK_TAB_HEIGHT 28
+constexpr int NOTEBOOK_TAB_HEIGHT = 28;
 
 class SplitContainer;
 

--- a/src/widgets/helper/SearchPopup.cpp
+++ b/src/widgets/helper/SearchPopup.cpp
@@ -1,4 +1,4 @@
-#include "SearchPopup.hpp"
+#include "widgets/helper/SearchPopup.hpp"
 
 #include "Application.hpp"
 #include "common/Channel.hpp"

--- a/src/widgets/helper/TitlebarButton.cpp
+++ b/src/widgets/helper/TitlebarButton.cpp
@@ -1,4 +1,4 @@
-#include "TitlebarButton.hpp"
+#include "widgets/helper/TitlebarButton.hpp"
 
 #include "singletons/Theme.hpp"
 

--- a/src/widgets/listview/GenericListItem.cpp
+++ b/src/widgets/listview/GenericListItem.cpp
@@ -1,4 +1,4 @@
-#include "GenericListItem.hpp"
+#include "widgets/listview/GenericListItem.hpp"
 
 namespace chatterino {
 

--- a/src/widgets/listview/GenericListModel.cpp
+++ b/src/widgets/listview/GenericListModel.cpp
@@ -1,4 +1,4 @@
-#include "GenericListModel.hpp"
+#include "widgets/listview/GenericListModel.hpp"
 
 namespace chatterino {
 

--- a/src/widgets/settingspages/AboutPage.cpp
+++ b/src/widgets/settingspages/AboutPage.cpp
@@ -1,13 +1,11 @@
-#include "AboutPage.hpp"
+#include "widgets/settingspages/AboutPage.hpp"
 
 #include "common/Common.hpp"
-#include "common/Modes.hpp"
 #include "common/QLogging.hpp"
 #include "common/Version.hpp"
 #include "util/LayoutCreator.hpp"
 #include "util/RemoveScrollAreaBackground.hpp"
 #include "widgets/BasePopup.hpp"
-#include "widgets/helper/SignalLabel.hpp"
 #include "widgets/layout/FlowLayout.hpp"
 
 #include <QFile>
@@ -18,12 +16,12 @@
 #include <QTextStream>
 #include <QVBoxLayout>
 
-#define PIXMAP_WIDTH 500
-
-#define LINK_DONATE "https://streamelements.com/fourtf/tip"
-#define LINK_CHATTERINO_FEATURES "https://chatterino.com/#features"
-
 namespace chatterino {
+
+constexpr int PIXMAP_WIDTH = 500;
+
+constexpr QStringView LINK_CHATTERINO_FEATURES =
+    u"https://chatterino.com/#features";
 
 AboutPage::AboutPage()
 {
@@ -66,9 +64,9 @@ AboutPage::AboutPage()
             auto l = aboutChatterino.emplace<QVBoxLayout>();
 
             // clang-format off
-            l.emplace<QLabel>("Chatterino Wiki can be found <a href=\"" LINK_CHATTERINO_WIKI "\">here</a>")->setOpenExternalLinks(true);
-            l.emplace<QLabel>("All about Chatterino's <a href=\"" LINK_CHATTERINO_FEATURES "\">features</a>")->setOpenExternalLinks(true);
-            l.emplace<QLabel>("Join the official Chatterino <a href=\"" LINK_CHATTERINO_DISCORD "\">Discord</a>")->setOpenExternalLinks(true);
+            l.emplace<QLabel>("Chatterino Wiki can be found <a href=\"" % LINK_CHATTERINO_WIKI % "\">here</a>")->setOpenExternalLinks(true);
+            l.emplace<QLabel>("All about Chatterino's <a href=\"" % LINK_CHATTERINO_FEATURES % "\">features</a>")->setOpenExternalLinks(true);
+            l.emplace<QLabel>("Join the official Chatterino <a href=\"" % LINK_CHATTERINO_DISCORD % "\">Discord</a>")->setOpenExternalLinks(true);
             // clang-format on
         }
 

--- a/src/widgets/settingspages/AboutPage.cpp
+++ b/src/widgets/settingspages/AboutPage.cpp
@@ -12,6 +12,7 @@
 #include <QFormLayout>
 #include <QGroupBox>
 #include <QLabel>
+#include <QStringBuilder>
 #include <QTextEdit>
 #include <QTextStream>
 #include <QVBoxLayout>

--- a/src/widgets/settingspages/AccountsPage.cpp
+++ b/src/widgets/settingspages/AccountsPage.cpp
@@ -1,4 +1,4 @@
-#include "AccountsPage.hpp"
+#include "widgets/settingspages/AccountsPage.hpp"
 
 #include "Application.hpp"
 #include "controllers/accounts/AccountController.hpp"

--- a/src/widgets/settingspages/CommandPage.cpp
+++ b/src/widgets/settingspages/CommandPage.cpp
@@ -108,7 +108,7 @@ CommandPage::CommandPage()
         view->addCustomButton(button);
 
         QObject::connect(button, &QPushButton::clicked, this, [] {
-            QFile c1settings = c1settingsPath();
+            QFile c1settings(c1settingsPath());
             c1settings.open(QIODevice::ReadOnly);
             for (auto line :
                  QString(c1settings.readAll())

--- a/src/widgets/settingspages/CommandPage.cpp
+++ b/src/widgets/settingspages/CommandPage.cpp
@@ -19,7 +19,6 @@
 #include <QTableView>
 #include <QTextEdit>
 
-
 namespace {
 
 using namespace chatterino;

--- a/src/widgets/settingspages/CommandPage.cpp
+++ b/src/widgets/settingspages/CommandPage.cpp
@@ -1,6 +1,7 @@
-#include "CommandPage.hpp"
+#include "widgets/settingspages/CommandPage.hpp"
 
 #include "Application.hpp"
+#include "common/Literals.hpp"
 #include "controllers/commands/Command.hpp"
 #include "controllers/commands/CommandController.hpp"
 #include "controllers/commands/CommandModel.hpp"
@@ -18,13 +19,15 @@
 #include <QTableView>
 #include <QTextEdit>
 
-// clang-format off
-#define TEXT "{1} => first word &nbsp;&nbsp;&nbsp; {1+} => first word and after &nbsp;&nbsp;&nbsp; {{ => { &nbsp;&nbsp;&nbsp; <a href='https://chatterino.com/help/commands'>more info</a>"
-// clang-format on
 
 namespace {
 
 using namespace chatterino;
+using namespace literals;
+
+// clang-format off
+inline const QString HELP_TEXT = u"{1} => first word &nbsp;&nbsp;&nbsp; {1+} => first word and after &nbsp;&nbsp;&nbsp; {{ => { &nbsp;&nbsp;&nbsp; <a href='https://chatterino.com/help/commands'>more info</a>"_s;
+// clang-format on
 
 QString c1settingsPath()
 {
@@ -125,7 +128,7 @@ CommandPage::CommandPage()
         this->createCheckBox("Also match the trigger at the end of the message",
                              getSettings()->allowCommandsAtEnd));
 
-    QLabel *text = layout.emplace<QLabel>(TEXT).getElement();
+    QLabel *text = layout.emplace<QLabel>(HELP_TEXT).getElement();
     text->setWordWrap(true);
     text->setStyleSheet("color: #bbb");
     text->setOpenExternalLinks(true);

--- a/src/widgets/settingspages/ExternalToolsPage.cpp
+++ b/src/widgets/settingspages/ExternalToolsPage.cpp
@@ -10,10 +10,10 @@
 #include <QGroupBox>
 #include <QLabel>
 
-#define STREAMLINK_QUALITY \
-    "Choose", "Source", "High", "Medium", "Low", "Audio only"
-
 namespace chatterino {
+
+inline const QStringList STREAMLINK_QUALITY = {
+    "Choose", "Source", "High", "Medium", "Low", "Audio only"};
 
 ExternalToolsPage::ExternalToolsPage()
 {
@@ -75,7 +75,7 @@ ExternalToolsPage::ExternalToolsPage()
         groupLayout->addRow("Custom streamlink path:", customPath);
         groupLayout->addRow(
             "Preferred quality:",
-            this->createComboBox({STREAMLINK_QUALITY},
+            this->createComboBox(STREAMLINK_QUALITY,
                                  getSettings()->preferredQuality));
         groupLayout->addRow(
             "Additional options:",

--- a/src/widgets/settingspages/FiltersPage.cpp
+++ b/src/widgets/settingspages/FiltersPage.cpp
@@ -1,4 +1,4 @@
-#include "FiltersPage.hpp"
+#include "widgets/settingspages/FiltersPage.hpp"
 
 #include "Application.hpp"
 #include "controllers/filters/FilterModel.hpp"
@@ -8,14 +8,14 @@
 #include "util/LayoutCreator.hpp"
 #include "widgets/dialogs/ChannelFilterEditorDialog.hpp"
 #include "widgets/helper/EditableModelView.hpp"
-#include "widgets/Window.hpp"
 
 #include <QHeaderView>
 #include <QTableView>
 
-#define FILTERS_DOCUMENTATION "https://wiki.chatterino.com/Filters"
-
 namespace chatterino {
+
+constexpr QStringView FILTERS_DOCUMENTATION =
+    u"https://wiki.chatterino.com/Filters";
 
 FiltersPage::FiltersPage()
 {
@@ -67,8 +67,8 @@ FiltersPage::FiltersPage()
                      });
 
     auto *filterHelpLabel =
-        new QLabel(QString("<a href='%1'><span "
-                           "style='color:#99f'>filter info</span></a>")
+        new QLabel(QStringView(u"<a href='%1'><span "
+                               "style='color:#99f'>filter info</span></a>")
                        .arg(FILTERS_DOCUMENTATION));
     filterHelpLabel->setOpenExternalLinks(true);
     view->addCustomButton(filterHelpLabel);

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1,6 +1,7 @@
 #include "widgets/settingspages/GeneralPage.hpp"
 
 #include "Application.hpp"
+#include "common/Literals.hpp"
 #include "common/QLogging.hpp"
 #include "common/Version.hpp"
 #include "controllers/hotkeys/HotkeyCategory.hpp"
@@ -19,7 +20,6 @@
 #include "util/IncognitoBrowser.hpp"
 #include "widgets/BaseWindow.hpp"
 #include "widgets/settingspages/GeneralPageView.hpp"
-#include "widgets/splits/SplitInput.hpp"
 
 #include <magic_enum/magic_enum.hpp>
 #include <QDesktopServices>
@@ -28,63 +28,62 @@
 #include <QLabel>
 #include <QScrollArea>
 
-#define CHROME_EXTENSION_LINK                                           \
-    "https://chrome.google.com/webstore/detail/chatterino-native-host/" \
-    "glknmaideaikkmemifbfkhnomoknepka"
-#define FIREFOX_EXTENSION_LINK \
-    "https://addons.mozilla.org/en-US/firefox/addon/chatterino-native-host/"
+namespace {
 
-// define to highlight sections in editor
-#define addTitle addTitle
-#define addSubtitle addSubtitle
+using namespace chatterino;
+using namespace literals;
+
+const QString CHROME_EXTENSION_LINK =
+    u"https://chrome.google.com/webstore/detail/chatterino-native-host/glknmaideaikkmemifbfkhnomoknepka"_s;
+const QString FIREFOX_EXTENSION_LINK =
+    u"https://addons.mozilla.org/en-US/firefox/addon/chatterino-native-host/"_s;
 
 #ifdef Q_OS_WIN
-#    define META_KEY "Windows"
+const QString META_KEY = u"Windows"_s;
 #else
-#    define META_KEY "Meta"
+const QString META_KEY = u"Meta"_s;
 #endif
 
-namespace chatterino {
-namespace {
-    void addKeyboardModifierSetting(GeneralPageView &layout,
-                                    const QString &title,
-                                    EnumSetting<Qt::KeyboardModifier> &setting)
-    {
-        layout.addDropdown<std::underlying_type<Qt::KeyboardModifier>::type>(
-            title, {"None", "Shift", "Control", "Alt", META_KEY}, setting,
-            [](int index) {
-                switch (index)
-                {
-                    case Qt::ShiftModifier:
-                        return 1;
-                    case Qt::ControlModifier:
-                        return 2;
-                    case Qt::AltModifier:
-                        return 3;
-                    case Qt::MetaModifier:
-                        return 4;
-                    default:
-                        return 0;
-                }
-            },
-            [](DropdownArgs args) {
-                switch (args.index)
-                {
-                    case 1:
-                        return Qt::ShiftModifier;
-                    case 2:
-                        return Qt::ControlModifier;
-                    case 3:
-                        return Qt::AltModifier;
-                    case 4:
-                        return Qt::MetaModifier;
-                    default:
-                        return Qt::NoModifier;
-                }
-            },
-            false);
-    }
+void addKeyboardModifierSetting(GeneralPageView &layout, const QString &title,
+                                EnumSetting<Qt::KeyboardModifier> &setting)
+{
+    layout.addDropdown<std::underlying_type<Qt::KeyboardModifier>::type>(
+        title, {"None", "Shift", "Control", "Alt", META_KEY}, setting,
+        [](int index) {
+            switch (index)
+            {
+                case Qt::ShiftModifier:
+                    return 1;
+                case Qt::ControlModifier:
+                    return 2;
+                case Qt::AltModifier:
+                    return 3;
+                case Qt::MetaModifier:
+                    return 4;
+                default:
+                    return 0;
+            }
+        },
+        [](DropdownArgs args) {
+            switch (args.index)
+            {
+                case 1:
+                    return Qt::ShiftModifier;
+                case 2:
+                    return Qt::ControlModifier;
+                case 3:
+                    return Qt::AltModifier;
+                case 4:
+                    return Qt::MetaModifier;
+                default:
+                    return Qt::NoModifier;
+            }
+        },
+        false);
+}
 }  // namespace
+
+namespace chatterino {
 
 GeneralPage::GeneralPage()
 {

--- a/src/widgets/settingspages/HighlightingPage.cpp
+++ b/src/widgets/settingspages/HighlightingPage.cpp
@@ -1,4 +1,4 @@
-#include "HighlightingPage.hpp"
+#include "widgets/settingspages/HighlightingPage.hpp"
 
 #include "Application.hpp"
 #include "controllers/highlights/BadgeHighlightModel.hpp"
@@ -10,7 +10,6 @@
 #include "controllers/highlights/UserHighlightModel.hpp"
 #include "providers/colors/ColorProvider.hpp"
 #include "singletons/Settings.hpp"
-#include "singletons/Theme.hpp"
 #include "util/Helpers.hpp"
 #include "util/LayoutCreator.hpp"
 #include "widgets/dialogs/BadgePickerDialog.hpp"
@@ -24,8 +23,6 @@
 #include <QStandardItemModel>
 #include <QTableView>
 #include <QTabWidget>
-
-#define ALWAYS_PLAY "Play highlight sound even when Chatterino is focused"
 
 namespace chatterino {
 
@@ -312,8 +309,9 @@ HighlightingPage::HighlightingPage()
                 this->managedConnections_);
         }
 
-        layout.append(createCheckBox(ALWAYS_PLAY,
-                                     getSettings()->highlightAlwaysPlaySound));
+        layout.append(createCheckBox(
+            "Play highlight sound even when Chatterino is focused",
+            getSettings()->highlightAlwaysPlaySound));
         layout.append(createCheckBox(
             "Flash taskbar only stops highlighting when Chatterino is focused",
             getSettings()->longAlerts));

--- a/src/widgets/settingspages/IgnoresPage.cpp
+++ b/src/widgets/settingspages/IgnoresPage.cpp
@@ -1,6 +1,7 @@
 #include "widgets/settingspages/IgnoresPage.hpp"
 
 #include "Application.hpp"
+#include "common/Literals.hpp"
 #include "controllers/accounts/AccountController.hpp"
 #include "controllers/ignores/IgnoreModel.hpp"
 #include "controllers/ignores/IgnorePhrase.hpp"
@@ -19,11 +20,13 @@
 #include <QTableView>
 #include <QVBoxLayout>
 
-// clang-format off
-#define INFO "/block <user> in chat blocks a user.\n/unblock <user> in chat unblocks a user.\nYou can also click on a user to open the usercard."
-// clang-format on
-
 namespace chatterino {
+
+using namespace literals;
+
+// clang-format off
+inline const QString INFO = u"/block <user> in chat blocks a user.\n/unblock <user> in chat unblocks a user.\nYou can also click on a user to open the usercard."_s;
+// clang-format on
 
 static void addPhrasesTab(LayoutCreator<QVBoxLayout> box);
 static void addUsersTab(IgnoresPage &page, LayoutCreator<QVBoxLayout> box,

--- a/src/widgets/settingspages/IgnoresPage.cpp
+++ b/src/widgets/settingspages/IgnoresPage.cpp
@@ -24,10 +24,6 @@ namespace chatterino {
 
 using namespace literals;
 
-// clang-format off
-inline const QString INFO = u"/block <user> in chat blocks a user.\n/unblock <user> in chat unblocks a user.\nYou can also click on a user to open the usercard."_s;
-// clang-format on
-
 static void addPhrasesTab(LayoutCreator<QVBoxLayout> box);
 static void addUsersTab(IgnoresPage &page, LayoutCreator<QVBoxLayout> box,
                         QStringListModel &model);
@@ -77,7 +73,8 @@ void addPhrasesTab(LayoutCreator<QVBoxLayout> layout)
 void addUsersTab(IgnoresPage &page, LayoutCreator<QVBoxLayout> users,
                  QStringListModel &userModel)
 {
-    auto label = users.emplace<QLabel>(INFO);
+    auto label = users.emplace<QLabel>(
+        u"/block <user> in chat blocks a user.\n/unblock <user> in chat unblocks a user.\nYou can also click on a user to open the usercard."_s);
     label->setWordWrap(true);
     users.append(page.createCheckBox("Enable Twitch blocked users",
                                      getSettings()->enableTwitchBlockedUsers));

--- a/src/widgets/settingspages/ModerationPage.cpp
+++ b/src/widgets/settingspages/ModerationPage.cpp
@@ -1,4 +1,4 @@
-#include "ModerationPage.hpp"
+#include "widgets/settingspages/ModerationPage.hpp"
 
 #include "Application.hpp"
 #include "controllers/logging/ChannelLoggingModel.hpp"

--- a/src/widgets/settingspages/NicknamesPage.cpp
+++ b/src/widgets/settingspages/NicknamesPage.cpp
@@ -1,4 +1,4 @@
-#include "NicknamesPage.hpp"
+#include "widgets/settingspages/NicknamesPage.hpp"
 
 #include "controllers/nicknames/Nickname.hpp"
 #include "controllers/nicknames/NicknamesModel.hpp"

--- a/src/widgets/settingspages/NotificationPage.cpp
+++ b/src/widgets/settingspages/NotificationPage.cpp
@@ -1,4 +1,4 @@
-#include "NotificationPage.hpp"
+#include "widgets/settingspages/NotificationPage.hpp"
 
 #include "Application.hpp"
 #include "controllers/notifications/NotificationController.hpp"

--- a/src/widgets/settingspages/SettingsPage.cpp
+++ b/src/widgets/settingspages/SettingsPage.cpp
@@ -1,4 +1,4 @@
-#include "SettingsPage.hpp"
+#include "widgets/settingspages/SettingsPage.hpp"
 
 #include "Application.hpp"
 #include "singletons/WindowManager.hpp"

--- a/src/widgets/splits/ClosedSplits.cpp
+++ b/src/widgets/splits/ClosedSplits.cpp
@@ -1,4 +1,4 @@
-#include "widgets/split/ClosedSplits.hpp"
+#include "widgets/splits/ClosedSplits.hpp"
 
 namespace chatterino {
 

--- a/src/widgets/splits/ClosedSplits.cpp
+++ b/src/widgets/splits/ClosedSplits.cpp
@@ -1,4 +1,4 @@
-#include "ClosedSplits.hpp"
+#include "widgets/split/ClosedSplits.hpp"
 
 namespace chatterino {
 

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -343,29 +343,30 @@ Split::Split(QWidget *parent)
             this->refreshModerationMode();
         });
 
-    this->signalHolder_.managedConnect(
-        modifierStatusChanged, [this](Qt::KeyboardModifiers status) {
-            if ((status ==
-                 showSplitOverlayModifiers /*|| status == showAddSplitRegions*/) &&
-                this->isMouseOver_)
-            {
-                this->overlay_->show();
-            }
-            else
-            {
-                this->overlay_->hide();
-            }
+    this->signalHolder_.managedConnect(modifierStatusChanged, [this](
+                                                                  Qt::KeyboardModifiers
+                                                                      status) {
+        if ((status ==
+             SHOW_SPLIT_OVERLAY_MODIFIERS /*|| status == showAddSplitRegions*/) &&
+            this->isMouseOver_)
+        {
+            this->overlay_->show();
+        }
+        else
+        {
+            this->overlay_->hide();
+        }
 
-            if (getSettings()->pauseChatModifier.getEnum() != Qt::NoModifier &&
-                status == getSettings()->pauseChatModifier.getEnum())
-            {
-                this->view_->pause(PauseReason::KeyboardModifier);
-            }
-            else
-            {
-                this->view_->unpause(PauseReason::KeyboardModifier);
-            }
-        });
+        if (getSettings()->pauseChatModifier.getEnum() != Qt::NoModifier &&
+            status == getSettings()->pauseChatModifier.getEnum())
+        {
+            this->view_->pause(PauseReason::KeyboardModifier);
+        }
+        else
+        {
+            this->view_->unpause(PauseReason::KeyboardModifier);
+        }
+    });
 
     this->signalHolder_.managedConnect(this->input_->ui_.textEdit->focused,
                                        [this] {
@@ -1019,7 +1020,7 @@ void Split::enterEvent(QEvent * /*event*/)
     this->handleModifiers(QGuiApplication::queryKeyboardModifiers());
 
     if (modifierStatus ==
-        showSplitOverlayModifiers /*|| modifierStatus == showAddSplitRegions*/)
+        SHOW_SPLIT_OVERLAY_MODIFIERS /*|| modifierStatus == showAddSplitRegions*/)
     {
         this->overlay_->show();
     }

--- a/src/widgets/splits/SplitContainer.cpp
+++ b/src/widgets/splits/SplitContainer.cpp
@@ -41,7 +41,7 @@ SplitContainer::SplitContainer(Notebook *parent)
         Split::modifierStatusChanged, [this](auto modifiers) {
             this->layout();
 
-            if (modifiers == showResizeHandlesModifiers)
+            if (modifiers == SHOW_RESIZE_HANDLES_MODIFIERS)
             {
                 for (auto &handle : this->resizeHandles_)
                 {
@@ -57,7 +57,7 @@ SplitContainer::SplitContainer(Notebook *parent)
                 }
             }
 
-            if (modifiers == showSplitOverlayModifiers)
+            if (modifiers == SHOW_SPLIT_OVERLAY_MODIFIERS)
             {
                 this->setCursor(Qt::PointingHandCursor);
             }
@@ -496,7 +496,7 @@ void SplitContainer::layout()
     std::vector<ResizeRect> resizeRects;
 
     const bool addSpacing =
-        Split::modifierStatus == showAddSplitRegions || this->isDragging_;
+        Split::modifierStatus == SHOW_ADD_SPLIT_REGIONS || this->isDragging_;
     this->baseNode_.layout(addSpacing, this->scale(), dropRects, resizeRects);
 
     this->dropRects_ = dropRects;
@@ -559,7 +559,7 @@ void SplitContainer::layout()
             handle->setVertical(resizeRect.vertical);
             handle->node = resizeRect.node;
 
-            if (Split::modifierStatus == showResizeHandlesModifiers)
+            if (Split::modifierStatus == SHOW_RESIZE_HANDLES_MODIFIERS)
             {
                 handle->show();
                 handle->raise();
@@ -720,7 +720,7 @@ void SplitContainer::dragEnterEvent(QDragEnterEvent *event)
 
 void SplitContainer::mouseMoveEvent(QMouseEvent *event)
 {
-    if (Split::modifierStatus == showSplitOverlayModifiers)
+    if (Split::modifierStatus == SHOW_SPLIT_OVERLAY_MODIFIERS)
     {
         this->setCursor(Qt::PointingHandCursor);
     }

--- a/src/widgets/splits/SplitOverlay.cpp
+++ b/src/widgets/splits/SplitOverlay.cpp
@@ -1,4 +1,4 @@
-#include "widgets/split/SplitOverlay.hpp"
+#include "widgets/splits/SplitOverlay.hpp"
 
 #include "Application.hpp"
 #include "singletons/Resources.hpp"

--- a/src/widgets/splits/SplitOverlay.cpp
+++ b/src/widgets/splits/SplitOverlay.cpp
@@ -1,4 +1,4 @@
-#include "SplitOverlay.hpp"
+#include "widgets/split/SplitOverlay.hpp"
 
 #include "Application.hpp"
 #include "singletons/Resources.hpp"

--- a/tests/src/Updates.cpp
+++ b/tests/src/Updates.cpp
@@ -37,7 +37,8 @@ TEST(Updates, MustNotBeDowngrade)
 
 TEST(Updates, ValidateCurrentVersion)
 {
-    EXPECT_NO_THROW(auto v = semver::from_string(
+    EXPECT_NO_THROW([[maybe_unused]] auto v = semver::from_string(
                         Version::instance().version().toStdString()))
         << "Current version must be valid semver";
+    EXPECT_EQ(Version::instance().version(), CHATTERINO_VERSION);
 }

--- a/tests/src/Updates.cpp
+++ b/tests/src/Updates.cpp
@@ -37,6 +37,7 @@ TEST(Updates, MustNotBeDowngrade)
 
 TEST(Updates, ValidateCurrentVersion)
 {
-    EXPECT_NO_THROW(auto v = semver::from_string(CHATTERINO_VERSION))
+    EXPECT_NO_THROW(auto v = semver::from_string(
+                        Version::instance().version().toStdString()))
         << "Current version must be valid semver";
 }


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

- Replaces constant `#define`s with `constexpr` where possible. In case a `QString` is desired, they're replaced with a static `QString`.
	- For concatenations, QStringBuilder is required. This is included with QString in Qt 6 but requires an include in Qt 5
- Uses paths relative to `src/` for all includes. Check with `rg -P '^#include "(?!Application|BrowserExtension|RunGui|ForwardDecl)[^"/]+"' -g 'src/**/*.{cpp,hpp}'`.