### PR TITLE
chore: silence some deprecation warnings in Qt 6.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 - Dev: `FlagsEnum` is now `constexpr`. (#5510)
 - Dev: Documented and added tests to RTL handling. (#5473)
 - Dev: Refactored a few `#define`s into `const(expr)` and cleaned includes. (#5527)
+- Dev: Prepared for Qt 6.8 by addressing some deprecations. (#5529)
 
 ## 2.5.1
 

--- a/src/controllers/filters/lang/Types.hpp
+++ b/src/controllers/filters/lang/Types.hpp
@@ -72,22 +72,35 @@ QString possibleTypeToString(const PossibleType &possible);
 
 bool isList(const PossibleType &possibleType);
 
-inline bool variantIs(const QVariant &a, QMetaType::Type type)
+inline bool variantIs(const QVariant &a, int type)
 {
-    return static_cast<QMetaType::Type>(a.type()) == type;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    return a.typeId() == type;
+#else
+    return a.type() == type;
+#endif
 }
 
-inline bool variantIsNot(const QVariant &a, QMetaType::Type type)
+inline bool variantIsNot(const QVariant &a, int type)
 {
-    return static_cast<QMetaType::Type>(a.type()) != type;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    return a.typeId() != type;
+#else
+    return a.type() != type;
+#endif
 }
 
 inline bool convertVariantTypes(QVariant &a, QVariant &b, int type)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    QMetaType ty(type);
+    return a.convert(ty) && b.convert(ty);
+#else
     return a.convert(type) && b.convert(type);
+#endif
 }
 
-inline bool variantTypesMatch(QVariant &a, QVariant &b, QMetaType::Type type)
+inline bool variantTypesMatch(QVariant &a, QVariant &b, int type)
 {
     return variantIs(a, type) && variantIs(b, type);
 }

--- a/src/controllers/filters/lang/expressions/BinaryOperation.cpp
+++ b/src/controllers/filters/lang/expressions/BinaryOperation.cpp
@@ -56,9 +56,8 @@ QVariant BinaryOperation::execute(const ContextMap &context) const
     switch (this->op_)
     {
         case PLUS:
-            if (static_cast<QMetaType::Type>(left.type()) ==
-                    QMetaType::QString &&
-                right.canConvert(QMetaType::QString))
+            if (variantIs(left, QMetaType::QString) &&
+                right.canConvert<QString>())
             {
                 return left.toString().append(right.toString());
             }
@@ -143,14 +142,14 @@ QVariant BinaryOperation::execute(const ContextMap &context) const
             return false;
         case CONTAINS:
             if (variantIs(left, QMetaType::QStringList) &&
-                right.canConvert(QMetaType::QString))
+                right.canConvert<QString>())
             {
                 return left.toStringList().contains(right.toString(),
                                                     Qt::CaseInsensitive);
             }
 
             if (variantIs(left, QMetaType::QVariantMap) &&
-                right.canConvert(QMetaType::QString))
+                right.canConvert<QString>())
             {
                 return left.toMap().contains(right.toString());
             }
@@ -160,8 +159,7 @@ QVariant BinaryOperation::execute(const ContextMap &context) const
                 return left.toList().contains(right);
             }
 
-            if (left.canConvert(QMetaType::QString) &&
-                right.canConvert(QMetaType::QString))
+            if (left.canConvert<QString>() && right.canConvert<QString>())
             {
                 return left.toString().contains(right.toString(),
                                                 Qt::CaseInsensitive);
@@ -170,7 +168,7 @@ QVariant BinaryOperation::execute(const ContextMap &context) const
             return false;
         case STARTS_WITH:
             if (variantIs(left, QMetaType::QStringList) &&
-                right.canConvert(QMetaType::QString))
+                right.canConvert<QString>())
             {
                 auto list = left.toStringList();
                 return !list.isEmpty() &&
@@ -183,8 +181,7 @@ QVariant BinaryOperation::execute(const ContextMap &context) const
                 return left.toList().startsWith(right);
             }
 
-            if (left.canConvert(QMetaType::QString) &&
-                right.canConvert(QMetaType::QString))
+            if (left.canConvert<QString>() && right.canConvert<QString>())
             {
                 return left.toString().startsWith(right.toString(),
                                                   Qt::CaseInsensitive);
@@ -194,7 +191,7 @@ QVariant BinaryOperation::execute(const ContextMap &context) const
 
         case ENDS_WITH:
             if (variantIs(left, QMetaType::QStringList) &&
-                right.canConvert(QMetaType::QString))
+                right.canConvert<QString>())
             {
                 auto list = left.toStringList();
                 return !list.isEmpty() &&
@@ -207,8 +204,7 @@ QVariant BinaryOperation::execute(const ContextMap &context) const
                 return left.toList().endsWith(right);
             }
 
-            if (left.canConvert(QMetaType::QString) &&
-                right.canConvert(QMetaType::QString))
+            if (left.canConvert<QString>() && right.canConvert<QString>())
             {
                 return left.toString().endsWith(right.toString(),
                                                 Qt::CaseInsensitive);
@@ -216,14 +212,18 @@ QVariant BinaryOperation::execute(const ContextMap &context) const
 
             return false;
         case MATCH: {
-            if (!left.canConvert(QMetaType::QString))
+            if (!left.canConvert<QString>())
             {
                 return false;
             }
 
             auto matching = left.toString();
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            switch (static_cast<QMetaType::Type>(right.typeId()))
+#else
             switch (static_cast<QMetaType::Type>(right.type()))
+#endif
             {
                 case QMetaType::QRegularExpression: {
                     return right.toRegularExpression()

--- a/src/providers/emoji/Emojis.cpp
+++ b/src/providers/emoji/Emojis.cpp
@@ -28,7 +28,7 @@ void parseEmoji(const std::shared_ptr<EmojiData> &emojiData,
                 const rapidjson::Value &unparsedEmoji,
                 const QString &shortCode = {})
 {
-    std::vector<uint32_t> unicodeBytes{};
+    std::vector<char32_t> unicodeBytes{};
 
     struct {
         bool apple;
@@ -82,7 +82,7 @@ void parseEmoji(const std::shared_ptr<EmojiData> &emojiData,
     for (const QString &unicodeCharacter : unicodeCharacters)
     {
         bool ok{false};
-        unicodeBytes.push_back(QString(unicodeCharacter).toUInt(&ok, 16));
+        unicodeBytes.push_back(unicodeCharacter.toUInt(&ok, 16));
         if (!ok)
         {
             qCWarning(chatterinoEmoji)
@@ -92,14 +92,15 @@ void parseEmoji(const std::shared_ptr<EmojiData> &emojiData,
     }
 
     // We can safely do a narrowing static cast since unicodeBytes will never be a large number
-    emojiData->value = QString::fromUcs4(unicodeBytes.data(),
-                                         static_cast<int>(unicodeBytes.size()));
+    emojiData->value =
+        QString::fromUcs4(unicodeBytes.data(),
+                          static_cast<QString::size_type>(unicodeBytes.size()));
 
     if (!emojiData->nonQualifiedCode.isEmpty())
     {
         QStringList nonQualifiedCharacters =
             emojiData->nonQualifiedCode.toLower().split('-');
-        std::vector<uint32_t> nonQualifiedBytes{};
+        std::vector<char32_t> nonQualifiedBytes{};
         for (const QString &unicodeCharacter : nonQualifiedCharacters)
         {
             bool ok{false};
@@ -115,9 +116,9 @@ void parseEmoji(const std::shared_ptr<EmojiData> &emojiData,
         }
 
         // We can safely do a narrowing static cast since unicodeBytes will never be a large number
-        emojiData->nonQualified =
-            QString::fromUcs4(nonQualifiedBytes.data(),
-                              static_cast<int>(nonQualifiedBytes.size()));
+        emojiData->nonQualified = QString::fromUcs4(
+            nonQualifiedBytes.data(),
+            static_cast<QString::size_type>(nonQualifiedBytes.size()));
     }
 }
 

--- a/src/providers/twitch/TwitchAccount.cpp
+++ b/src/providers/twitch/TwitchAccount.cpp
@@ -232,7 +232,7 @@ void TwitchAccount::loadUserstateEmotes(std::weak_ptr<Channel> weakChannel)
     }
 
     // filter out emote sets from userstate message, which are not in fetched emote set list
-    for (const auto &emoteSetKey : qAsConst(this->userstateEmoteSets_))
+    for (const auto &emoteSetKey : this->userstateEmoteSets_)
     {
         if (!existingEmoteSetKeys.contains(emoteSetKey))
         {

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -1185,7 +1185,11 @@ void TwitchMessageBuilder::processIgnorePhrases(
             QRegularExpression emoteregex(
                 "\\b" + emote.name.string + "\\b",
                 QRegularExpression::UseUnicodePropertiesOption);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+            auto match = emoteregex.matchView(midExtendedRef);
+#else
             auto match = emoteregex.match(midExtendedRef);
+#endif
             if (match.hasMatch())
             {
                 emote.start = static_cast<int>(from + match.capturedStart());

--- a/src/providers/twitch/api/Helix.hpp
+++ b/src/providers/twitch/api/Helix.hpp
@@ -11,6 +11,7 @@
 #include <QJsonObject>
 #include <QString>
 #include <QStringList>
+#include <QTimeZone>
 #include <QUrl>
 #include <QUrlQuery>
 
@@ -722,7 +723,7 @@ struct HelixShieldModeStatus {
         , lastActivatedAt(QDateTime::fromString(
               json["last_activated_at"].toString(), Qt::ISODate))
     {
-        this->lastActivatedAt.setTimeSpec(Qt::UTC);
+        this->lastActivatedAt.setTimeZone(QTimeZone::utc());
     }
 };
 

--- a/src/util/IrcHelpers.hpp
+++ b/src/util/IrcHelpers.hpp
@@ -2,6 +2,7 @@
 
 #include <IrcMessage>
 #include <QString>
+#include <QTimeZone>
 
 namespace chatterino {
 
@@ -88,7 +89,7 @@ inline QDateTime calculateMessageTime(const Communi::IrcMessage *message)
         QString timedate = message->tags().value("time").toString();
 
         auto date = QDateTime::fromString(timedate, Qt::ISODate);
-        date.setTimeSpec(Qt::TimeSpec::UTC);
+        date.setTimeZone(QTimeZone::utc());
         return date.toLocalTime();
     }
 

--- a/src/widgets/helper/color/ColorItemDelegate.cpp
+++ b/src/widgets/helper/color/ColorItemDelegate.cpp
@@ -15,7 +15,11 @@ void ColorItemDelegate::paint(QPainter *painter,
 {
     auto data = index.data(Qt::DecorationRole);
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    if (data.typeId() != QMetaType::QColor)
+#else
     if (data.type() != QVariant::Color)
+#endif
     {
         return QStyledItemDelegate::paint(painter, option, index);
     }


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

The underlying deprecations aren't new, but they haven't shown up as a warning in 6.7 and below. 

Notably, the variant conversion/checking in `controllers/filters/lang/Types.hpp` was quite vocal (seems to be included in most files; transitively). `QVariant::type` is deprecated (`typeId` is preferred) in Qt 6, but there's no alternative in Qt 5. Furthermore, `QMetaType::Type` contains predefined type-ids, while a type-id is of type `int` (in both Qt 5 and 6). This isn't really relevant for us, since we don't use user-types.

Some other changes:

- `QVariant::canConvert<T>` is preferred over `QVariant::canConvert(type-id)`
- `QString::fromUcs4` prefers the `char32_t` overload (available in Qt 5)
- Prefer `std::as_const` over `qAsConst` (but we don't need either)
- `QRegularExpression` got a `matchView` in 6.5 which is preferred over `match` for string views to avoid allocating a string
- `QDateTime::setTimeSpec` is deprecated (use `setTimeZone` - that's what `setTimeSpec` does under the hood too)

There are two other deprecations that are now reported which don't have a Qt 5 equivalent:

- `QMouseEvent::{screenPos, globalPos}` are deprecated, and `globalPosition` should be used (not in Qt 5)
- `QWidget::addAction`: use `addAction(text, shortcut, object, slot)` instead (not in Qt 5 and these methods are on `QMenu` in Qt 5)

Otherwise, Qt 6.8 seems to work good enough on Windows. The only compilation error was that `QFile(path)` is now explicit (fixed in https://github.com/Chatterino/chatterino2/pull/5527/files#diff-07c979414bf7268bd34c32515e8500e25726e4ed1d43eb970f45bacff76b5bf3R111).