### PR TITLE
refactor: move seventv/bttv event apis to application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 - Dev: The running Qt version is now shown in the about page if it differs from the compiled version. (#5501)
 - Dev: `FlagsEnum` is now `constexpr`. (#5510)
 - Dev: Documented and added tests to RTL handling. (#5473)
+- Dev: Refactored 7TV/BTTV definitions out of `TwitchIrcServer` into `Application`. (#5532)
 - Dev: Refactored a few `#define`s into `const(expr)` and cleaned includes. (#5527)
 - Dev: Prepared for Qt 6.8 by addressing some deprecations. (#5529)
 

--- a/mocks/include/mocks/BaseApplication.hpp
+++ b/mocks/include/mocks/BaseApplication.hpp
@@ -30,6 +30,11 @@ public:
         return &this->streamerMode;
     }
 
+    SeventvEventAPI *getSeventvEventAPI() override
+    {
+        return nullptr;
+    }
+
     Settings settings;
     DisabledStreamerMode streamerMode;
 };

--- a/mocks/include/mocks/BaseApplication.hpp
+++ b/mocks/include/mocks/BaseApplication.hpp
@@ -2,6 +2,7 @@
 
 #include "mocks/DisabledStreamerMode.hpp"
 #include "mocks/EmptyApplication.hpp"
+#include "providers/bttv/BttvLiveUpdates.hpp"
 #include "singletons/Settings.hpp"
 
 #include <QString>
@@ -28,6 +29,11 @@ public:
     IStreamerMode *getStreamerMode() override
     {
         return &this->streamerMode;
+    }
+
+    BttvLiveUpdates *getBttvLiveUpdates() override
+    {
+        return nullptr;
     }
 
     SeventvEventAPI *getSeventvEventAPI() override

--- a/mocks/include/mocks/EmptyApplication.hpp
+++ b/mocks/include/mocks/EmptyApplication.hpp
@@ -245,6 +245,13 @@ public:
         return nullptr;
     }
 
+    SeventvEventAPI *getSeventvEventAPI() override
+    {
+        assert(false && "EmptyApplication::getSeventvEventAPI was called "
+                        "without being initialized");
+        return nullptr;
+    }
+
     ILinkResolver *getLinkResolver() override
     {
         assert(false && "EmptyApplication::getLinkResolver was called without "

--- a/mocks/include/mocks/EmptyApplication.hpp
+++ b/mocks/include/mocks/EmptyApplication.hpp
@@ -231,6 +231,13 @@ public:
         return nullptr;
     }
 
+    BttvLiveUpdates *getBttvLiveUpdates() override
+    {
+        assert(false && "EmptyApplication::getBttvLiveUpdates was called "
+                        "without being initialized");
+        return nullptr;
+    }
+
     FfzEmotes *getFfzEmotes() override
     {
         assert(false && "EmptyApplication::getFfzEmotes was called without "

--- a/mocks/include/mocks/TwitchIrcServer.hpp
+++ b/mocks/include/mocks/TwitchIrcServer.hpp
@@ -8,7 +8,6 @@
 #include "providers/seventv/eventapi/Dispatch.hpp"
 #include "providers/seventv/eventapi/Message.hpp"
 #include "providers/seventv/SeventvEmotes.hpp"
-#include "providers/seventv/SeventvEventAPI.hpp"
 #include "providers/twitch/TwitchIrcServer.hpp"
 
 namespace chatterino::mock {
@@ -49,11 +48,6 @@ public:
     std::unique_ptr<BttvLiveUpdates> &getBTTVLiveUpdates() override
     {
         return this->bttvLiveUpdates;
-    }
-
-    std::unique_ptr<SeventvEventAPI> &getSeventvEventAPI() override
-    {
-        return this->seventvEventAPI;
     }
 
     const IndirectChannel &getWatchingChannel() const override
@@ -105,7 +99,6 @@ public:
     QString lastUserThatWhisperedMe{"forsen"};
 
     std::unique_ptr<BttvLiveUpdates> bttvLiveUpdates;
-    std::unique_ptr<SeventvEventAPI> seventvEventAPI;
 };
 
 }  // namespace chatterino::mock

--- a/mocks/include/mocks/TwitchIrcServer.hpp
+++ b/mocks/include/mocks/TwitchIrcServer.hpp
@@ -2,7 +2,6 @@
 
 #include "mocks/Channel.hpp"
 #include "providers/bttv/BttvEmotes.hpp"
-#include "providers/bttv/BttvLiveUpdates.hpp"
 #include "providers/ffz/FfzEmotes.hpp"
 #include "providers/seventv/eventapi/Client.hpp"
 #include "providers/seventv/eventapi/Dispatch.hpp"
@@ -43,11 +42,6 @@ public:
                             const QString &emoteSetID) override
     {
         //
-    }
-
-    std::unique_ptr<BttvLiveUpdates> &getBTTVLiveUpdates() override
-    {
-        return this->bttvLiveUpdates;
     }
 
     const IndirectChannel &getWatchingChannel() const override
@@ -97,8 +91,6 @@ public:
     ChannelPtr liveChannel;
     ChannelPtr automodChannel;
     QString lastUserThatWhisperedMe{"forsen"};
-
-    std::unique_ptr<BttvLiveUpdates> bttvLiveUpdates;
 };
 
 }  // namespace chatterino::mock

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -194,6 +194,7 @@ void Application::fakeDtor()
     this->accounts.reset();
     this->emotes.reset();
     this->themes.reset();
+    this->streamerMode.reset();
 }
 
 void Application::initialize(Settings &settings, const Paths &paths)

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -161,7 +161,10 @@ Application::Application(Settings &_settings, const Paths &paths,
     });
 }
 
-Application::~Application() = default;
+Application::~Application()
+{
+    Application::instance = nullptr;
+}
 
 void Application::fakeDtor()
 {

--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -50,6 +50,7 @@ class ImageUploader;
 class SeventvAPI;
 class CrashHandler;
 class BttvEmotes;
+class BttvLiveUpdates;
 class FfzEmotes;
 class SeventvEmotes;
 class SeventvEventAPI;
@@ -98,6 +99,7 @@ public:
 #endif
     virtual Updates &getUpdates() = 0;
     virtual BttvEmotes *getBttvEmotes() = 0;
+    virtual BttvLiveUpdates *getBttvLiveUpdates() = 0;
     virtual FfzEmotes *getFfzEmotes() = 0;
     virtual SeventvEmotes *getSeventvEmotes() = 0;
     virtual SeventvEventAPI *getSeventvEventAPI() = 0;
@@ -167,6 +169,7 @@ private:
     std::unique_ptr<TwitchBadges> twitchBadges;
     std::unique_ptr<ChatterinoBadges> chatterinoBadges;
     std::unique_ptr<BttvEmotes> bttvEmotes;
+    std::unique_ptr<BttvLiveUpdates> bttvLiveUpdates;
     std::unique_ptr<FfzEmotes> ffzEmotes;
     std::unique_ptr<SeventvEmotes> seventvEmotes;
     std::unique_ptr<SeventvEventAPI> seventvEventAPI;
@@ -221,6 +224,7 @@ public:
     }
 
     BttvEmotes *getBttvEmotes() override;
+    BttvLiveUpdates *getBttvLiveUpdates() override;
     FfzEmotes *getFfzEmotes() override;
     SeventvEmotes *getSeventvEmotes() override;
     SeventvEventAPI *getSeventvEventAPI() override;

--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -52,6 +52,7 @@ class CrashHandler;
 class BttvEmotes;
 class FfzEmotes;
 class SeventvEmotes;
+class SeventvEventAPI;
 class ILinkResolver;
 class IStreamerMode;
 class IAbstractIrcServer;
@@ -99,6 +100,7 @@ public:
     virtual BttvEmotes *getBttvEmotes() = 0;
     virtual FfzEmotes *getFfzEmotes() = 0;
     virtual SeventvEmotes *getSeventvEmotes() = 0;
+    virtual SeventvEventAPI *getSeventvEventAPI() = 0;
     virtual ILinkResolver *getLinkResolver() = 0;
     virtual IStreamerMode *getStreamerMode() = 0;
 };
@@ -167,6 +169,7 @@ private:
     std::unique_ptr<BttvEmotes> bttvEmotes;
     std::unique_ptr<FfzEmotes> ffzEmotes;
     std::unique_ptr<SeventvEmotes> seventvEmotes;
+    std::unique_ptr<SeventvEventAPI> seventvEventAPI;
     const std::unique_ptr<Logging> logging;
     std::unique_ptr<ILinkResolver> linkResolver;
     std::unique_ptr<IStreamerMode> streamerMode;
@@ -220,6 +223,7 @@ public:
     BttvEmotes *getBttvEmotes() override;
     FfzEmotes *getFfzEmotes() override;
     SeventvEmotes *getSeventvEmotes() override;
+    SeventvEventAPI *getSeventvEventAPI() override;
 
     ILinkResolver *getLinkResolver() override;
     IStreamerMode *getStreamerMode() override;

--- a/src/RunGui.cpp
+++ b/src/RunGui.cpp
@@ -297,4 +297,5 @@ void runGui(QApplication &a, const Paths &paths, Settings &settings,
 
     _exit(0);
 }
+
 }  // namespace chatterino

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -146,10 +146,9 @@ TwitchChannel::~TwitchChannel()
     getApp()->getTwitch()->dropSeventvChannel(this->seventvUserID_,
                                               this->seventvEmoteSetID_);
 
-    if (getApp()->getTwitch()->getBTTVLiveUpdates())
+    if (getApp()->getBttvLiveUpdates())
     {
-        getApp()->getTwitch()->getBTTVLiveUpdates()->partChannel(
-            this->roomId());
+        getApp()->getBttvLiveUpdates()->partChannel(this->roomId());
     }
 
     if (getApp()->getSeventvEventAPI())
@@ -854,7 +853,7 @@ const QString &TwitchChannel::seventvEmoteSetID() const
 
 void TwitchChannel::joinBttvChannel() const
 {
-    if (getApp()->getTwitch()->getBTTVLiveUpdates())
+    if (getApp()->getBttvLiveUpdates())
     {
         const auto currentAccount =
             getApp()->getAccounts()->twitch.getCurrent();
@@ -863,8 +862,7 @@ void TwitchChannel::joinBttvChannel() const
         {
             userName = currentAccount->getUserName();
         }
-        getApp()->getTwitch()->getBTTVLiveUpdates()->joinChannel(this->roomId(),
-                                                                 userName);
+        getApp()->getBttvLiveUpdates()->joinChannel(this->roomId(), userName);
     }
 }
 

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -152,9 +152,9 @@ TwitchChannel::~TwitchChannel()
             this->roomId());
     }
 
-    if (getApp()->getTwitch()->getSeventvEventAPI())
+    if (getApp()->getSeventvEventAPI())
     {
-        getApp()->getTwitch()->getSeventvEventAPI()->unsubscribeTwitchChannel(
+        getApp()->getSeventvEventAPI()->unsubscribeTwitchChannel(
             this->roomId());
     }
 }
@@ -1012,9 +1012,9 @@ void TwitchChannel::updateSeventvData(const QString &newUserID,
     this->seventvUserID_ = newUserID;
     this->seventvEmoteSetID_ = newEmoteSetID;
     runInGuiThread([this, oldUserID, oldEmoteSetID]() {
-        if (getApp()->getTwitch()->getSeventvEventAPI())
+        if (getApp()->getSeventvEventAPI())
         {
-            getApp()->getTwitch()->getSeventvEventAPI()->subscribeUser(
+            getApp()->getSeventvEventAPI()->subscribeUser(
                 this->seventvUserID_, this->seventvEmoteSetID_);
 
             if (oldUserID || oldEmoteSetID)
@@ -1811,10 +1811,9 @@ void TwitchChannel::updateSevenTVActivity()
 
 void TwitchChannel::listenSevenTVCosmetics() const
 {
-    if (getApp()->getTwitch()->getSeventvEventAPI())
+    if (getApp()->getSeventvEventAPI())
     {
-        getApp()->getTwitch()->getSeventvEventAPI()->subscribeTwitchChannel(
-            this->roomId());
+        getApp()->getSeventvEventAPI()->subscribeTwitchChannel(this->roomId());
     }
 }
 

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -33,8 +33,6 @@ namespace {
 
 using namespace chatterino;
 
-const QString BTTV_LIVE_UPDATES_URL = "wss://sockets.betterttv.net/ws";
-
 void sendHelixMessage(const std::shared_ptr<TwitchChannel> &channel,
                       const QString &message, const QString &replyParentId = {})
 {
@@ -143,13 +141,6 @@ TwitchIrcServer::TwitchIrcServer()
     , watchingChannel(Channel::getEmpty(), Channel::Type::TwitchWatching)
 {
     this->initializeIrc();
-
-    if (getSettings()->enableBTTVLiveUpdates &&
-        getSettings()->enableBTTVChannelEmotes)
-    {
-        this->bttvLiveUpdates =
-            std::make_unique<BttvLiveUpdates>(BTTV_LIVE_UPDATES_URL);
-    }
 
     // getSettings()->twitchSeperateWriteConnection.connect([this](auto, auto) {
     // this->connect(); },
@@ -628,11 +619,6 @@ void TwitchIrcServer::onReplySendRequested(
                              channel->getName() + " :" + message);
     }
     sent = true;
-}
-
-std::unique_ptr<BttvLiveUpdates> &TwitchIrcServer::getBTTVLiveUpdates()
-{
-    return this->bttvLiveUpdates;
 }
 
 const IndirectChannel &TwitchIrcServer::getWatchingChannel() const

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -34,7 +34,6 @@ namespace {
 using namespace chatterino;
 
 const QString BTTV_LIVE_UPDATES_URL = "wss://sockets.betterttv.net/ws";
-const QString SEVENTV_EVENTAPI_URL = "wss://events.7tv.io/v3";
 
 void sendHelixMessage(const std::shared_ptr<TwitchChannel> &channel,
                       const QString &message, const QString &replyParentId = {})
@@ -150,13 +149,6 @@ TwitchIrcServer::TwitchIrcServer()
     {
         this->bttvLiveUpdates =
             std::make_unique<BttvLiveUpdates>(BTTV_LIVE_UPDATES_URL);
-    }
-
-    if (getSettings()->enableSevenTVEventAPI &&
-        getSettings()->enableSevenTVChannelEmotes)
-    {
-        this->seventvEventAPI =
-            std::make_unique<SeventvEventAPI>(SEVENTV_EVENTAPI_URL);
     }
 
     // getSettings()->twitchSeperateWriteConnection.connect([this](auto, auto) {
@@ -643,11 +635,6 @@ std::unique_ptr<BttvLiveUpdates> &TwitchIrcServer::getBTTVLiveUpdates()
     return this->bttvLiveUpdates;
 }
 
-std::unique_ptr<SeventvEventAPI> &TwitchIrcServer::getSeventvEventAPI()
-{
-    return this->seventvEventAPI;
-}
-
 const IndirectChannel &TwitchIrcServer::getWatchingChannel() const
 {
     return this->watchingChannel;
@@ -759,7 +746,7 @@ void TwitchIrcServer::forEachSeventvUser(
 void TwitchIrcServer::dropSeventvChannel(const QString &userID,
                                          const QString &emoteSetID)
 {
-    if (!this->seventvEventAPI)
+    if (!getApp()->getSeventvEventAPI())
     {
         return;
     }
@@ -798,11 +785,11 @@ void TwitchIrcServer::dropSeventvChannel(const QString &userID,
 
     if (!foundUser)
     {
-        this->seventvEventAPI->unsubscribeUser(userID);
+        getApp()->getSeventvEventAPI()->unsubscribeUser(userID);
     }
     if (!foundSet)
     {
-        this->seventvEventAPI->unsubscribeEmoteSet(emoteSetID);
+        getApp()->getSeventvEventAPI()->unsubscribeEmoteSet(emoteSetID);
     }
 }
 

--- a/src/providers/twitch/TwitchIrcServer.hpp
+++ b/src/providers/twitch/TwitchIrcServer.hpp
@@ -16,7 +16,6 @@ class Settings;
 class Paths;
 class TwitchChannel;
 class BttvLiveUpdates;
-class SeventvEventAPI;
 class BttvEmotes;
 class FfzEmotes;
 class SeventvEmotes;
@@ -36,7 +35,6 @@ public:
                                     const QString &emoteSetID) = 0;
 
     virtual std::unique_ptr<BttvLiveUpdates> &getBTTVLiveUpdates() = 0;
-    virtual std::unique_ptr<SeventvEventAPI> &getSeventvEventAPI() = 0;
 
     virtual const IndirectChannel &getWatchingChannel() const = 0;
     virtual void setWatchingChannel(ChannelPtr newWatchingChannel) = 0;
@@ -103,11 +101,9 @@ private:
     IndirectChannel watchingChannel;
 
     std::unique_ptr<BttvLiveUpdates> bttvLiveUpdates;
-    std::unique_ptr<SeventvEventAPI> seventvEventAPI;
 
 public:
     std::unique_ptr<BttvLiveUpdates> &getBTTVLiveUpdates() override;
-    std::unique_ptr<SeventvEventAPI> &getSeventvEventAPI() override;
 
     const IndirectChannel &getWatchingChannel() const override;
     void setWatchingChannel(ChannelPtr newWatchingChannel) override;

--- a/src/providers/twitch/TwitchIrcServer.hpp
+++ b/src/providers/twitch/TwitchIrcServer.hpp
@@ -15,7 +15,6 @@ namespace chatterino {
 class Settings;
 class Paths;
 class TwitchChannel;
-class BttvLiveUpdates;
 class BttvEmotes;
 class FfzEmotes;
 class SeventvEmotes;
@@ -33,8 +32,6 @@ public:
 
     virtual void dropSeventvChannel(const QString &userID,
                                     const QString &emoteSetID) = 0;
-
-    virtual std::unique_ptr<BttvLiveUpdates> &getBTTVLiveUpdates() = 0;
 
     virtual const IndirectChannel &getWatchingChannel() const = 0;
     virtual void setWatchingChannel(ChannelPtr newWatchingChannel) = 0;
@@ -100,11 +97,7 @@ private:
     const ChannelPtr automodChannel;
     IndirectChannel watchingChannel;
 
-    std::unique_ptr<BttvLiveUpdates> bttvLiveUpdates;
-
 public:
-    std::unique_ptr<BttvLiveUpdates> &getBTTVLiveUpdates() override;
-
     const IndirectChannel &getWatchingChannel() const override;
     void setWatchingChannel(ChannelPtr newWatchingChannel) override;
     ChannelPtr getWhispersChannel() const override;

--- a/src/singletons/StreamerMode.cpp
+++ b/src/singletons/StreamerMode.cpp
@@ -152,6 +152,11 @@ class StreamerModePrivate
 {
 public:
     StreamerModePrivate(StreamerMode *parent_);
+    ~StreamerModePrivate();
+    StreamerModePrivate(const StreamerModePrivate &) = delete;
+    StreamerModePrivate(StreamerModePrivate &&) = delete;
+    StreamerModePrivate &operator=(const StreamerModePrivate &) = delete;
+    StreamerModePrivate &operator=(StreamerModePrivate &&) = delete;
 
     [[nodiscard]] bool isEnabled() const;
 
@@ -217,6 +222,12 @@ StreamerModePrivate::StreamerModePrivate(StreamerMode *parent)
         this->settingChanged(getSettings()->enableStreamerMode.getEnum());
     });
     this->thread_.start();
+}
+
+StreamerModePrivate::~StreamerModePrivate()
+{
+    this->thread_.quit();
+    this->thread_.wait(50);
 }
 
 bool StreamerModePrivate::isEnabled() const

--- a/tests/src/Commands.cpp
+++ b/tests/src/Commands.cpp
@@ -3,7 +3,7 @@
 #include "controllers/commands/CommandContext.hpp"
 #include "controllers/commands/CommandController.hpp"
 #include "controllers/commands/common/ChannelAction.hpp"
-#include "mocks/EmptyApplication.hpp"
+#include "mocks/BaseApplication.hpp"
 #include "mocks/Helix.hpp"
 #include "mocks/Logging.hpp"
 #include "mocks/TwitchIrcServer.hpp"
@@ -22,12 +22,11 @@ using ::testing::StrictMock;
 
 namespace {
 
-class MockApplication : mock::EmptyApplication
+class MockApplication : public mock::BaseApplication
 {
 public:
     MockApplication()
-        : settings(this->settingsDir.filePath("settings.json"))
-        , commands(this->paths_)
+        : commands(this->paths_)
     {
     }
 
@@ -56,7 +55,6 @@ public:
         return &this->chatLogger;
     }
 
-    Settings settings;
     AccountController accounts;
     CommandController commands;
     mock::MockTwitchIrcServer twitch;


### PR DESCRIPTION
- **Gracefully quit streamer mode**
- **Set Application::instance to nullptr in dtor, allow us to better catch usages of getApp() after Application is destroyed**
- **move SeventvEventAPI from TwitchIrcServer to Application**
- **move BttvLiveUpdates to Application**

<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
