### PR TITLE
refactor: move "delete old update files" logic to Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 - Dev: `FlagsEnum` is now `constexpr`. (#5510)
 - Dev: Documented and added tests to RTL handling. (#5473)
 - Dev: Refactored 7TV/BTTV definitions out of `TwitchIrcServer` into `Application`. (#5532)
+- Dev: Refactored code that's responsible for deleting old update files. (#5535)
 - Dev: Refactored a few `#define`s into `const(expr)` and cleaned includes. (#5527)
 - Dev: Prepared for Qt 6.8 by addressing some deprecations. (#5529)
 

--- a/src/RunGui.cpp
+++ b/src/RunGui.cpp
@@ -241,22 +241,7 @@ void runGui(QApplication &a, const Paths &paths, Settings &settings,
     }
 #endif
 
-    auto thread = std::thread([dir = paths.miscDirectory] {
-        {
-            auto path = combinePath(dir, "Update.exe");
-            if (QFile::exists(path))
-            {
-                QFile::remove(path);
-            }
-        }
-        {
-            auto path = combinePath(dir, "update.zip");
-            if (QFile::exists(path))
-            {
-                QFile::remove(path);
-            }
-        }
-    });
+    updates.deleteOldFiles();
 
     // Clear the cache 1 minute after start.
     QTimer::singleShot(60 * 1000, [cachePath = paths.cacheDirectory(),

--- a/src/singletons/Updates.cpp
+++ b/src/singletons/Updates.cpp
@@ -19,6 +19,8 @@
 #include <QStringBuilder>
 #include <semver/semver.hpp>
 
+#include <thread>
+
 namespace {
 
 using namespace chatterino;
@@ -73,6 +75,26 @@ bool Updates::isDowngradeOf(const QString &online, const QString &current)
     }
 
     return onlineVersion < currentVersion;
+}
+
+void Updates::deleteOldFiles()
+{
+    auto thread = std::thread([dir = paths.miscDirectory] {
+        {
+            auto path = combinePath(dir, "Update.exe");
+            if (QFile::exists(path))
+            {
+                QFile::remove(path);
+            }
+        }
+        {
+            auto path = combinePath(dir, "update.zip");
+            if (QFile::exists(path))
+            {
+                QFile::remove(path);
+            }
+        }
+    });
 }
 
 const QString &Updates::getCurrentVersion() const

--- a/src/singletons/Updates.cpp
+++ b/src/singletons/Updates.cpp
@@ -41,9 +41,9 @@ const QString CHATTERINO_OS = u"freebsd"_s;
 #else
 const QString CHATTERINO_OS = u"unknown"_s;
 #endif
-;
 
 }  // namespace
+
 namespace chatterino {
 
 Updates::Updates(const Paths &paths_)

--- a/src/singletons/Updates.cpp
+++ b/src/singletons/Updates.cpp
@@ -17,9 +17,8 @@
 #include <QProcess>
 #include <QRegularExpression>
 #include <QStringBuilder>
+#include <QtConcurrent>
 #include <semver/semver.hpp>
-
-#include <thread>
 
 namespace {
 
@@ -79,7 +78,7 @@ bool Updates::isDowngradeOf(const QString &online, const QString &current)
 
 void Updates::deleteOldFiles()
 {
-    auto thread = std::thread([dir = paths.miscDirectory] {
+    std::ignore = QtConcurrent::run([dir{this->paths.miscDirectory}] {
         {
             auto path = combinePath(dir, "Update.exe");
             if (QFile::exists(path))

--- a/src/singletons/Updates.hpp
+++ b/src/singletons/Updates.hpp
@@ -31,6 +31,11 @@ public:
 
     static bool isDowngradeOf(const QString &online, const QString &current);
 
+    /**
+     * @brief Delete old files that belong to the update process
+     */
+    void deleteOldFiles();
+
     void checkForUpdates();
     const QString &getCurrentVersion() const;
     const QString &getOnlineVersion() const;


### PR DESCRIPTION
This PR moves the "delete old update files" logic from RunGui to Updates, and uses `QtConcurrent::run` instead of an `std::thread`

I have purposefully not added a platform-check to this yet

<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
