### PR TITLE
refactor: rename miniaudio thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 - Dev: Refactored 7TV/BTTV definitions out of `TwitchIrcServer` into `Application`. (#5532)
 - Dev: Refactored code that's responsible for deleting old update files. (#5535)
 - Dev: Cleanly exit on shutdown. (#5537)
+- Dev: Renamed miniaudio backend thread name. (#5538)
 - Dev: Refactored a few `#define`s into `const(expr)` and cleaned includes. (#5527)
 - Dev: Prepared for Qt 6.8 by addressing some deprecations. (#5529)
 

--- a/src/controllers/sound/MiniaudioBackend.cpp
+++ b/src/controllers/sound/MiniaudioBackend.cpp
@@ -6,6 +6,7 @@
 #include "singletons/Paths.hpp"
 #include "singletons/Settings.hpp"
 #include "singletons/WindowManager.hpp"
+#include "util/RenameThread.hpp"
 #include "widgets/Window.hpp"
 
 #include <boost/asio/executor_work_guard.hpp>
@@ -193,6 +194,7 @@ MiniaudioBackend::MiniaudioBackend()
     this->audioThread = std::make_unique<std::thread>([this] {
         this->ioContext.run();
     });
+    renameThread(*this->audioThread, "C2Miniaudio");
 }
 
 MiniaudioBackend::~MiniaudioBackend()

--- a/src/util/RenameThread.hpp
+++ b/src/util/RenameThread.hpp
@@ -10,7 +10,7 @@
 namespace chatterino {
 
 template <typename T>
-void renameThread(T &&thread, const QString &threadName)
+void renameThread(T &thread, const QString &threadName)
 {
 #ifdef Q_OS_LINUX
     pthread_setname_np(thread.native_handle(), threadName.toLocal8Bit());


### PR DESCRIPTION
- **use ref instead of doubleref for renameThread**
- **rename miniaudio thread name**
- **add changelog entry**

<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
