### PR TITLE
chore: rename threads on Windows too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@
 - Dev: Refactored 7TV/BTTV definitions out of `TwitchIrcServer` into `Application`. (#5532)
 - Dev: Refactored code that's responsible for deleting old update files. (#5535)
 - Dev: Cleanly exit on shutdown. (#5537)
-- Dev: Renamed miniaudio backend thread name. (#5538)
+- Dev: Renamed threads created by Chatterino on Linux and Windows. (#5538, #5539)
 - Dev: Refactored a few `#define`s into `const(expr)` and cleaned includes. (#5527)
 - Dev: Prepared for Qt 6.8 by addressing some deprecations. (#5529)
 

--- a/src/BrowserExtension.cpp
+++ b/src/BrowserExtension.cpp
@@ -1,6 +1,7 @@
 #include "BrowserExtension.hpp"
 
 #include "singletons/NativeMessaging.hpp"
+#include "util/RenameThread.hpp"
 
 #include <iostream>
 #include <memory>
@@ -69,6 +70,7 @@ void runLoop()
             std::this_thread::sleep_for(10s);
         }
     });
+    renameThread(thread, "BrowserPingCheck");
 
     while (true)
     {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -511,6 +511,7 @@ set(SOURCE_FILES
         util/RapidjsonHelpers.hpp
         util/RatelimitBucket.cpp
         util/RatelimitBucket.hpp
+        util/RenameThread.cpp
         util/RenameThread.hpp
         util/SampleData.cpp
         util/SampleData.hpp

--- a/src/common/network/NetworkManager.cpp
+++ b/src/common/network/NetworkManager.cpp
@@ -13,6 +13,7 @@ void NetworkManager::init()
     assert(!NetworkManager::accessManager);
 
     NetworkManager::workerThread = new QThread;
+    NetworkManager::workerThread->setObjectName("NetworkWorker");
     NetworkManager::workerThread->start();
 
     NetworkManager::accessManager = new QNetworkAccessManager;

--- a/src/providers/twitch/PubSubManager.cpp
+++ b/src/providers/twitch/PubSubManager.cpp
@@ -10,6 +10,7 @@
 #include "util/DebugCount.hpp"
 #include "util/Helpers.hpp"
 #include "util/RapidjsonHelpers.hpp"
+#include "util/RenameThread.hpp"
 
 #include <QJsonArray>
 
@@ -17,6 +18,7 @@
 #include <exception>
 #include <future>
 #include <iostream>
+#include <memory>
 #include <thread>
 
 using websocketpp::lib::bind;
@@ -543,7 +545,10 @@ void PubSub::start()
 {
     this->work = std::make_shared<boost::asio::io_service::work>(
         this->websocketClient.get_io_service());
-    this->thread.reset(new std::thread(std::bind(&PubSub::runThread, this)));
+    this->thread = std::make_unique<std::thread>([this] {
+        runThread();
+    });
+    renameThread(*this->thread, "PubSub");
 }
 
 void PubSub::stop()

--- a/src/singletons/NativeMessaging.cpp
+++ b/src/singletons/NativeMessaging.cpp
@@ -134,6 +134,7 @@ namespace nm::client {
 NativeMessagingServer::NativeMessagingServer()
     : thread(*this)
 {
+    this->thread.setObjectName("NativeMessagingReceiver");
 }
 
 NativeMessagingServer::~NativeMessagingServer()

--- a/src/util/RenameThread.cpp
+++ b/src/util/RenameThread.cpp
@@ -2,14 +2,31 @@
 
 #include "common/QLogging.hpp"
 
+#include <QOperatingSystemVersion>
+
 #ifdef Q_OS_WIN
+
 #    include <Windows.h>
-#endif
 
 namespace chatterino::windows::detail {
 
 void renameThread(HANDLE hThread, const QString &threadName)
 {
+#    if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)  // Qt 6 requires Windows 10 1809
+    // Windows 10, version 1607
+    constexpr QOperatingSystemVersion minVersion{
+        QOperatingSystemVersion::Windows,
+        10,
+        0,
+        14393,
+    };
+    // minVersion is excluded, because it has some additional requirements
+    if (QOperatingSystemVersion::current() <= minVersion)
+    {
+        return;
+    }
+#    endif
+
     auto hr = SetThreadDescription(hThread, threadName.toStdWString().c_str());
     if (!SUCCEEDED(hr))
     {
@@ -20,3 +37,5 @@ void renameThread(HANDLE hThread, const QString &threadName)
 }
 
 }  // namespace chatterino::windows::detail
+
+#endif

--- a/src/util/RenameThread.cpp
+++ b/src/util/RenameThread.cpp
@@ -1,0 +1,14 @@
+#include "util/RenameThread.hpp"
+
+#ifdef Q_OS_WIN
+#    include <Windows.h>
+#endif
+
+namespace chatterino::windows::detail {
+
+void renameThread(HANDLE hThread, const QString &threadName)
+{
+    SetThreadDescription(hThread, threadName.toStdWString().c_str());
+}
+
+}  // namespace chatterino::windows::detail

--- a/src/util/RenameThread.cpp
+++ b/src/util/RenameThread.cpp
@@ -1,5 +1,7 @@
 #include "util/RenameThread.hpp"
 
+#include "common/QLogging.hpp"
+
 #ifdef Q_OS_WIN
 #    include <Windows.h>
 #endif
@@ -8,7 +10,13 @@ namespace chatterino::windows::detail {
 
 void renameThread(HANDLE hThread, const QString &threadName)
 {
-    SetThreadDescription(hThread, threadName.toStdWString().c_str());
+    auto hr = SetThreadDescription(hThread, threadName.toStdWString().c_str());
+    if (!SUCCEEDED(hr))
+    {
+        qCWarning(chatterinoCommon).nospace()
+            << "Failed to set thread description, hresult=0x"
+            << QString::number(hr, 16);
+    }
 }
 
 }  // namespace chatterino::windows::detail

--- a/src/util/RenameThread.hpp
+++ b/src/util/RenameThread.hpp
@@ -7,13 +7,25 @@
 #    include <pthread.h>
 #endif
 
+#ifdef Q_OS_WIN
+using HANDLE = void *;
+#endif
+
 namespace chatterino {
+
+#ifdef Q_OS_WIN
+namespace windows::detail {
+    void renameThread(HANDLE hThread, const QString &name);
+}  // namespace windows::detail
+#endif
 
 template <typename T>
 void renameThread(T &thread, const QString &threadName)
 {
 #ifdef Q_OS_LINUX
     pthread_setname_np(thread.native_handle(), threadName.toLocal8Bit());
+#elif defined(Q_OS_WIN)
+    windows::detail::renameThread(thread.native_handle(), threadName);
 #endif
 }
 

--- a/src/util/RenameThread.hpp
+++ b/src/util/RenameThread.hpp
@@ -7,15 +7,11 @@
 #    include <pthread.h>
 #endif
 
-#ifdef Q_OS_WIN
-using HANDLE = void *;
-#endif
-
 namespace chatterino {
 
 #ifdef Q_OS_WIN
 namespace windows::detail {
-    void renameThread(HANDLE hThread, const QString &name);
+    void renameThread(void *hThread, const QString &name);
 }  // namespace windows::detail
 #endif
 


### PR DESCRIPTION
Additionally, this adds a few names for threads not yet renamed. Names on Windows don't have tight restrictions on the length. On macOS, this would need to be done from inside the thread, as it doesn't have the first argument to `pthread_setname_np`.

![Code_2024-08-10_15-22-10](https://github.com/user-attachments/assets/1b079e01-a14f-4aab-91a2-cc0825acb3d8)
