### PR TITLE
fix: only attempt to rename threads on Qt6 versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@
 - Dev: Refactored 7TV/BTTV definitions out of `TwitchIrcServer` into `Application`. (#5532)
 - Dev: Refactored code that's responsible for deleting old update files. (#5535)
 - Dev: Cleanly exit on shutdown. (#5537)
-- Dev: Renamed threads created by Chatterino on Linux and Windows. (#5538, #5539)
+- Dev: Renamed threads created by Chatterino on Linux and Windows. (#5538, #5539, #5544)
 - Dev: Refactored a few `#define`s into `const(expr)` and cleaned includes. (#5527)
 - Dev: Prepared for Qt 6.8 by addressing some deprecations. (#5529)
 

--- a/src/util/RenameThread.cpp
+++ b/src/util/RenameThread.cpp
@@ -2,8 +2,6 @@
 
 #include "common/QLogging.hpp"
 
-#include <QOperatingSystemVersion>
-
 #ifdef Q_OS_WIN
 
 #    include <Windows.h>
@@ -12,20 +10,9 @@ namespace chatterino::windows::detail {
 
 void renameThread(HANDLE hThread, const QString &threadName)
 {
-#    if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)  // Qt 6 requires Windows 10 1809
-    // Windows 10, version 1607
-    constexpr QOperatingSystemVersion minVersion{
-        QOperatingSystemVersion::Windows,
-        10,
-        0,
-        14393,
-    };
-    // minVersion is excluded, because it has some additional requirements
-    if (QOperatingSystemVersion::current() <= minVersion)
-    {
-        return;
-    }
-#    endif
+#    if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    // SetThreadDescription requires Windows 10, version 1607
+    // Qt 6 requires Windows 10 1809
 
     auto hr = SetThreadDescription(hThread, threadName.toStdWString().c_str());
     if (!SUCCEEDED(hr))
@@ -34,6 +21,7 @@ void renameThread(HANDLE hThread, const QString &threadName)
             << "Failed to set thread description, hresult=0x"
             << QString::number(hr, 16);
     }
+#    endif
 }
 
 }  // namespace chatterino::windows::detail


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
