### PR TITLE
ci: show recent changes in nightly release

### DIFF
--- a/.CI/format-recent-changes.py
+++ b/.CI/format-recent-changes.py
@@ -1,0 +1,61 @@
+from datetime import datetime, timezone
+import os
+import subprocess
+import re
+
+LINE_REGEX = re.compile(
+    r"""(?x)
+^(?P<commit>[A-Fa-f0-9]+)\s+
+\(
+    <(?P<email>[^>]+)>\s+
+    (?P<date>[^\s]+\s[^\s]+\s[^\s]+)\s+
+    (?P<line>\d+)
+\)\s
+(?P<content>.*)$
+"""
+)
+VERSION_REGEX = re.compile(r"^#+\s*v?\d")
+
+# contains lines in the form of
+# {commit-sha} (<{email}>\s+{date}\s+{line-no}) {line}
+p = subprocess.run(
+    ["git", "blame", "-e", "--date=iso", "../CHANGELOG.md"],
+    cwd=os.path.dirname(os.path.realpath(__file__)),
+    text=True,
+    check=True,
+    capture_output=True,
+)
+
+unreleased_lines: list[tuple[datetime, str]] = []
+for line in p.stdout.splitlines():
+    if not line:
+        continue
+    m = LINE_REGEX.match(line)
+    assert m, f"Failed to match '{line}'"
+    content = m.group("content")
+
+    if not content:
+        continue
+    if content.startswith("#"):
+        if VERSION_REGEX.match(content):
+            break
+        continue  # ignore lines with '#'
+
+    d = datetime.fromisoformat(m.group("date"))
+    d = d.astimezone(tz=timezone.utc)
+    content = content.replace("- ", f"- [{d.strftime('%Y-%m-%d')}] ", 1)
+    unreleased_lines.append((d, content))
+
+unreleased_lines.sort(key=lambda it: it[0], reverse=True)
+
+if len(unreleased_lines) == 0:
+    print("No changes since last release.")
+
+for _, line in unreleased_lines[:5]:
+    print(line)
+
+if len(unreleased_lines) > 5:
+    print("<details><summary>More Changes</summary>\n")
+    for _, line in unreleased_lines[5:]:
+        print(line)
+    print("</details>")

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -389,6 +389,17 @@ jobs:
         working-directory: release-artifacts
         shell: bash
 
+      - name: Format changes
+        id: format-changes
+        run: |
+          delimiter=$(openssl rand -hex 32)
+          {
+            echo "changelog<<$delimiter"
+            python3 ./.CI/format-recent-changes.py
+            echo $delimiter
+          } >> "$GITHUB_OUTPUT"
+        shell: bash
+
       - name: Create release
         uses: ncipollo/release-action@v1.14.0
         with:
@@ -396,7 +407,7 @@ jobs:
           allowUpdates: true
           artifactErrorsFailBuild: true
           artifacts: "release-artifacts/*"
-          body: ${{ github.event.head_commit.message }}
+          body: ${{ steps.format-changes.outputs.changelog }}
           prerelease: true
           name: Nightly Release
           tag: nightly-build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 - Dev: Refactored a few `#define`s into `const(expr)` and cleaned includes. (#5527)
 - Dev: Added `FlagsEnum::isEmpty`. (#5550)
 - Dev: Prepared for Qt 6.8 by addressing some deprecations. (#5529)
+- Dev: Recent changes are now shown in the nightly release description. (#5553)
 
 ## 2.5.1
 


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
With this PR, the nightly release will show the changelog ordered by date. The first five lines will be shown in a list and all other lines in a \<details> to save space. All lines include the date at which the change was done to help users figure out what changed between dates without opening the commit history. See [docs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#example-of-a-multiline-string) for multiline strings and outputs.

<details><summary>Preview</summary>

_GitHub shows the title of PRs here. It doesn't do that in the release description._

- [2024-08-18] Minor: Removed experimental IRC support. (#5547)
- [2024-08-18] Dev: Refactored `MessageFlag` into its own file. (#5549)
- [2024-08-18] Dev: Added `FlagsEnum::isEmpty`. (#5550)
- [2024-08-17] Bugfix: Fixed tooltips and input completion popups not working after moving a split. (#5541)
- [2024-08-12] Dev: Renamed threads created by Chatterino on Linux and Windows. (#5538, #5539, #5544)
<details><summary>More Changes</summary>

- [2024-08-10] Dev: Cleanly exit on shutdown. (#5537)
- [2024-08-08] Dev: Refactored code that's responsible for deleting old update files. (#5535)
- [2024-08-08] Dev: Refactored 7TV/BTTV definitions out of `TwitchIrcServer` into `Application`. (#5532)
- [2024-08-04] Dev: Prepared for Qt 6.8 by addressing some deprecations. (#5529)
- [2024-08-03] Dev: Refactored a few `#define`s into `const(expr)` and cleaned includes. (#5527)
- [2024-07-28] Bugfix: Fixed janky selection for messages with RTL segments (selection is still wrong, but consistently wrong). (#5525)
- [2024-07-28] Minor: Added support for scrolling in splits with touchscreen panning gestures. (#5524)
- [2024-07-27] Dev: Documented and added tests to RTL handling. (#5473)
- [2024-07-21] Minor: Links can now have prefixes and suffixes such as parentheses. (#5486, #5515)
- [2024-07-20] Minor: Replying to a message will now display the message being replied to. (#4350, #5519)
- [2024-07-20] Minor: Added option to suppress live notifictions on startup. (#5388)
- [2024-07-20] Bugfix: Links with invalid characters in the domain are no longer detected. (#5509)
- [2024-07-16] Dev: `FlagsEnum` is now `constexpr`. (#5510)
- [2024-07-14] Minor: Added option to log streams by their ID, allowing for easier "per-stream" log analyzing. (#5507)
- [2024-07-13] Bugfix: Fixed user info card popups adding duplicate line to log files. (#5499)
- [2024-07-13] Bugfix: Fixed splits staying paused after unfocusing Chatterino in certain configurations. (#5504)
- [2024-07-11] Minor: Support more Firefox variants for incognito link opening. (#5503)
- [2024-07-09] Dev: The running Qt version is now shown in the about page if it differs from the compiled version. (#5501)
- [2024-07-07] Dev: Add `Channel::addSystemMessage` helper function, allowing us to avoid the common `channel->addMessage(makeSystemMessage(...));` pattern. (#5500)
- [2024-07-07] Bugfix: Fixed `/clearmessages` not working with more than one window. (#5489)
- [2024-07-07] Minor: Improve appearance of reply button. (#5491)
- [2024-07-06] Minor: Introduce HTTP API for plugins. (#5383, #5492, #5494)
- [2024-06-23] Dev: Deprecate Qt 5.12. (#5396)
- [2024-06-23] Bugfix: Fixed windows on Windows not saving correctly when snapping them to the edges. (#5478)
- [2024-06-22] Dev: Cleanup `BrowserExtension`. (#5465)
- [2024-06-22] Minor: Add channel points indication for new bits power-up redemptions. (#5471)
- [2024-06-22] Minor: Added `/warn <username> <reason>` command for mods. This prevents the user from chatting until they acknowledge the warning. (#5474)
- [2024-06-19] Bugfix: Fixed a crash when tab completing while having an invalid plugin loaded. (#5401)
- [2024-06-16] Dev: Unsingletonize `ISoundController`. (#5462)
- [2024-06-16] Dev: Unsingletonize `Resources2`. (#5460)
- [2024-06-16] Dev: Refactor/unsingletonize `UserDataController`. (#5459)
- [2024-06-16] Minor: Added drop indicator line while dragging in tables. (#5256)
- [2024-06-16] Minor: Added the ability for `/ban`, `/timeout`, `/unban`, and `/untimeout` to specify multiple channels to duplicate the action to. Example: `/timeout --channel id:11148817 --channel testaccount_420 forsen 7m game complaining`. (#5402)
- [2024-06-16] Bugfix: Fixed message history occasionally not loading after a sleep. (#5457)
- [2024-06-15] Dev: Qt Creator now auto-configures Conan when loading the project and skips vcpkg. (#5305)
- [2024-06-15] Dev: The MSVC CRT is now bundled with Chatterino as it depends on having a recent version installed. (#5447)
- [2024-06-15] Minor: Added support for Brave & google-chrome-stable browsers. (#5452)
- [2024-06-09] Minor: Improved error messages for channel update commands. (#5429)
- [2024-06-06] Minor: Moderators can now see when users are warned. (#5441)
- [2024-06-03] Dev: Refactor `TwitchIrcServer`, making it abstracted. (#5421, #5435)
- [2024-06-02] Dev: Images are now loaded in worker threads. (#5431)
- [2024-06-01] Bugfix: Fixed restricted users usernames not being clickable. (#5405)
- [2024-06-01] Minor: The size of the emote popup is now saved. (#5415)
- [2024-06-01] Bugfix: Fixed tab move animation occasionally failing to start after closing a tab. (#5426)
- [2024-05-25] Dev: Update vcpkg build Qt from 6.5.0 to 6.7.0, boost from 1.83.0 to 1.85.0, openssl from 3.1.3 to 3.3.0. (#5422)
- [2024-05-25] Dev: Update Windows build from Qt 6.5.0 to Qt 6.7.1. (#5420)
- [2024-05-25] Minor: Added the ability to duplicate tabs. (#5277)
- [2024-05-25] Bugfix: Fixed a crash that could occur when logging was enabled in IRC servers that were removed. (#5419)
- [2024-05-25] Dev: Removed unused timegate settings. (#5361)
- [2024-05-22] Dev: All Lua globals now show in the `c2` global in the LuaLS metadata. (#5385)
- [2024-05-19] Dev: Reduced the amount of scale events. (#5404, #5406)
- [2024-05-18] Dev: Use Qt's high DPI scaling. (#4868, #5400)
- [2024-05-18] Minor: Added `flags.action` filter variable, allowing you to filter on `/me` messages. (#5397)
- [2024-05-13] Dev: Refactor and document `Scrollbar`. (#5334, #5393)
- [2024-05-12] Major: Improve high-DPI support on Windows. (#4868, #5391)
- [2024-05-12] Minor: Colored usernames now update on the fly when changing the "Color @usernames" setting. (#5300)
- [2024-05-11] Minor: Add option to customise Moderation buttons with images. (#5369)
- [2024-05-06] Major: Release plugins alpha. (#5288)
- [2024-05-05] Bugfix: If a network request errors with 200 OK, Qt's error code is now reported instead of the HTTP status. (#5378)
- [2024-05-05] Dev: Make printing of strings in tests easier. (#5379)
- [2024-05-04] Dev: Add doxygen build target. (#5377)
</details>
</details>