### PR TITLE
ci: use Python 3.12 for parsing dates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,6 +152,22 @@ jobs:
           submodules: recursive
           fetch-depth: 0 # allows for tags access
 
+      - name: Temporary test
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Format changes
+        id: format-changes
+        run: |
+          delimiter=$(openssl rand -hex 32)
+          {
+            echo "changelog<<$delimiter"
+            python3 ./.CI/format-recent-changes.py
+            echo $delimiter
+          } >> "$GITHUB_OUTPUT"
+        shell: bash
+
       - name: Install Qt5
         if: startsWith(matrix.qt-version, '5.')
         uses: jurplel/install-qt-action@v4.0.0
@@ -388,6 +404,10 @@ jobs:
           mv chatterino-windows-x86-64-Qt-5.15.2.zip chatterino-windows-old-x86-64-Qt-5.15.2.zip
         working-directory: release-artifacts
         shell: bash
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
 
       - name: Format changes
         id: format-changes

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,22 +152,6 @@ jobs:
           submodules: recursive
           fetch-depth: 0 # allows for tags access
 
-      - name: Temporary test
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Format changes
-        id: format-changes
-        run: |
-          delimiter=$(openssl rand -hex 32)
-          {
-            echo "changelog<<$delimiter"
-            python3 ./.CI/format-recent-changes.py
-            echo $delimiter
-          } >> "$GITHUB_OUTPUT"
-        shell: bash
-
       - name: Install Qt5
         if: startsWith(matrix.qt-version, '5.')
         uses: jurplel/install-qt-action@v4.0.0
@@ -405,7 +389,8 @@ jobs:
         working-directory: release-artifacts
         shell: bash
 
-      - uses: actions/setup-python@v5
+      - name: Setup Python
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@
 - Dev: Refactored a few `#define`s into `const(expr)` and cleaned includes. (#5527)
 - Dev: Added `FlagsEnum::isEmpty`. (#5550)
 - Dev: Prepared for Qt 6.8 by addressing some deprecations. (#5529)
-- Dev: Recent changes are now shown in the nightly release description. (#5553)
+- Dev: Recent changes are now shown in the nightly release description. (#5553, #5554)
 
 ## 2.5.1
 


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

Seems like the default Python version on GitHub actions is too low.

The script worked in the initial run, where I added a test: https://github.com/Chatterino/chatterino2/actions/runs/10475646096/job/29012763358?pr=5554