### PR TITLE
fix: typo in `SignalVector::operator[]` member access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - Dev: Unsingletonize `Resources2`. (#5460)
 - Dev: All Lua globals now show in the `c2` global in the LuaLS metadata. (#5385)
 - Dev: Images are now loaded in worker threads. (#5431)
+- Dev: Fixed broken `SignalVector::operator[]` implementation. (#5556)
 - Dev: Qt Creator now auto-configures Conan when loading the project and skips vcpkg. (#5305)
 - Dev: The MSVC CRT is now bundled with Chatterino as it depends on having a recent version installed. (#5447)
 - Dev: Refactor/unsingletonize `UserDataController`. (#5459)

--- a/src/common/SignalVector.hpp
+++ b/src/common/SignalVector.hpp
@@ -155,7 +155,7 @@ public:
     decltype(auto) operator[](size_t index)
     {
         assertInGuiThread();
-        return this->items[index];
+        return this->items_[index];
     }
 
     auto empty()


### PR DESCRIPTION
Discovered through a compile error (GCC-15).

```
/var/tmp/portage/net-im/chatterino-2.5.1/work/chatterino2-2.5.1/src/common/SignalVector.hpp:158:22: error: ‘class chatterino::SignalVector<T>’ has no member named ‘items’; did you mean ‘items_’? [-Wtemplate-body]
  158 |         return this->items[index];
```
