### PR TITLE
feat: indicate which mods start and cancel raids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Minor: Links can now have prefixes and suffixes such as parentheses. (#5486, #5515)
 - Minor: Added support for scrolling in splits with touchscreen panning gestures. (#5524)
 - Minor: Removed experimental IRC support. (#5547)
+- Minor: Moderators can now see which mods start and cancel raids. (#5563)
 - Bugfix: Fixed tab move animation occasionally failing to start after closing a tab. (#5426)
 - Bugfix: If a network request errors with 200 OK, Qt's error code is now reported instead of the HTTP status. (#5378)
 - Bugfix: Fixed restricted users usernames not being clickable. (#5405)

--- a/src/controllers/commands/builtin/twitch/Raid.cpp
+++ b/src/controllers/commands/builtin/twitch/Raid.cpp
@@ -201,8 +201,8 @@ QString cancelRaid(const CommandContext &ctx)
 
     getHelix()->cancelRaid(
         ctx.twitchChannel->roomId(),
-        [channel{ctx.channel}] {
-            channel->addSystemMessage("You cancelled the raid.");
+        [] {
+            // do nothing
         },
         [channel{ctx.channel}](auto error, auto message) {
             auto errorMessage = formatCancelRaidError(error, message);

--- a/src/controllers/commands/builtin/twitch/Raid.cpp
+++ b/src/controllers/commands/builtin/twitch/Raid.cpp
@@ -152,9 +152,8 @@ QString startRaid(const CommandContext &ctx)
          channel{ctx.channel}](const HelixUser &targetUser) {
             getHelix()->startRaid(
                 twitchChannel->roomId(), targetUser.id,
-                [channel, targetUser] {
-                    channel->addSystemMessage(QString("You started to raid %1.")
-                                                  .arg(targetUser.displayName));
+                [] {
+                    // do nothing
                 },
                 [channel, targetUser](auto error, auto message) {
                     auto errorMessage = formatStartRaidError(error, message);

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -880,6 +880,24 @@ MessageBuilder::MessageBuilder(const WarnAction &action)
     this->message().searchText = text;
 }
 
+MessageBuilder::MessageBuilder(const RaidAction &action)
+    : MessageBuilder()
+{
+    this->emplace<TimestampElement>();
+    this->message().flags.set(MessageFlag::System);
+
+    QString text;
+
+    this->emplaceSystemTextAndUpdate(action.source.login, text)
+        ->setLink({Link::UserInfo, "id:" + action.source.id});
+    this->emplaceSystemTextAndUpdate("initiated a raid to", text);
+    this->emplaceSystemTextAndUpdate(action.target + ".", text)
+        ->setLink({Link::UserInfo, action.target});
+
+    this->message().messageText = text;
+    this->message().searchText = text;
+}
+
 MessageBuilder::MessageBuilder(const AutomodUserAction &action)
     : MessageBuilder()
 {

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -898,6 +898,22 @@ MessageBuilder::MessageBuilder(const RaidAction &action)
     this->message().searchText = text;
 }
 
+MessageBuilder::MessageBuilder(const UnraidAction &action)
+    : MessageBuilder()
+{
+    this->emplace<TimestampElement>();
+    this->message().flags.set(MessageFlag::System);
+
+    QString text;
+
+    this->emplaceSystemTextAndUpdate(action.source.login, text)
+        ->setLink({Link::UserInfo, "id:" + action.source.id});
+    this->emplaceSystemTextAndUpdate("cancelled the raid.", text);
+
+    this->message().messageText = text;
+    this->message().searchText = text;
+}
+
 MessageBuilder::MessageBuilder(const AutomodUserAction &action)
     : MessageBuilder()
 {

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -908,7 +908,7 @@ MessageBuilder::MessageBuilder(const UnraidAction &action)
 
     this->emplaceSystemTextAndUpdate(action.source.login, text)
         ->setLink({Link::UserInfo, "id:" + action.source.id});
-    this->emplaceSystemTextAndUpdate("cancelled the raid.", text);
+    this->emplaceSystemTextAndUpdate("canceled the raid.", text);
 
     this->message().messageText = text;
     this->message().searchText = text;

--- a/src/messages/MessageBuilder.hpp
+++ b/src/messages/MessageBuilder.hpp
@@ -23,6 +23,7 @@ namespace chatterino {
 struct BanAction;
 struct UnbanAction;
 struct WarnAction;
+struct RaidAction;
 struct AutomodAction;
 struct AutomodUserAction;
 struct AutomodInfoAction;
@@ -127,6 +128,7 @@ public:
     MessageBuilder(const BanAction &action, uint32_t count = 1);
     MessageBuilder(const UnbanAction &action);
     MessageBuilder(const WarnAction &action);
+    MessageBuilder(const RaidAction &action);
     MessageBuilder(const AutomodUserAction &action);
 
     MessageBuilder(LiveUpdatesAddEmoteMessageTag, const QString &platform,

--- a/src/messages/MessageBuilder.hpp
+++ b/src/messages/MessageBuilder.hpp
@@ -24,6 +24,7 @@ struct BanAction;
 struct UnbanAction;
 struct WarnAction;
 struct RaidAction;
+struct UnraidAction;
 struct AutomodAction;
 struct AutomodUserAction;
 struct AutomodInfoAction;
@@ -129,6 +130,7 @@ public:
     MessageBuilder(const UnbanAction &action);
     MessageBuilder(const WarnAction &action);
     MessageBuilder(const RaidAction &action);
+    MessageBuilder(const UnraidAction &action);
     MessageBuilder(const AutomodUserAction &action);
 
     MessageBuilder(LiveUpdatesAddEmoteMessageTag, const QString &platform,

--- a/src/providers/twitch/PubSubActions.hpp
+++ b/src/providers/twitch/PubSubActions.hpp
@@ -178,6 +178,10 @@ struct RaidAction : PubSubAction {
     QString target;
 };
 
+struct UnraidAction : PubSubAction {
+    using PubSubAction::PubSubAction;
+};
+
 struct WarnAction : PubSubAction {
     using PubSubAction::PubSubAction;
 

--- a/src/providers/twitch/PubSubActions.hpp
+++ b/src/providers/twitch/PubSubActions.hpp
@@ -172,6 +172,12 @@ struct AutomodInfoAction : PubSubAction {
     } type;
 };
 
+struct RaidAction : PubSubAction {
+    using PubSubAction::PubSubAction;
+
+    QString target;
+};
+
 struct WarnAction : PubSubAction {
     using PubSubAction::PubSubAction;
 

--- a/src/providers/twitch/PubSubManager.cpp
+++ b/src/providers/twitch/PubSubManager.cpp
@@ -346,7 +346,7 @@ PubSub::PubSub(const QString &host, std::chrono::seconds pingInterval)
         action.source.id = data.value("created_by_user_id").toString();
         action.source.login = data.value("created_by").toString();
 
-        this->moderation.raidCancelled.invoke(action);
+        this->moderation.raidCanceled.invoke(action);
     };
 
     /*

--- a/src/providers/twitch/PubSubManager.cpp
+++ b/src/providers/twitch/PubSubManager.cpp
@@ -339,6 +339,16 @@ PubSub::PubSub(const QString &host, std::chrono::seconds pingInterval)
         this->moderation.raidStarted.invoke(action);
     };
 
+    this->moderationActionHandlers["unraid"] = [this](const auto &data,
+                                                    const auto &roomID) {
+        UnraidAction action(data, roomID);
+
+        action.source.id = data.value("created_by_user_id").toString();
+        action.source.login = data.value("created_by").toString();
+
+        this->moderation.raidCancelled.invoke(action);
+    };
+
     /*
     // This handler is no longer required as we use the automod-queue topic now
     this->moderationActionHandlers["automod_rejected"] =

--- a/src/providers/twitch/PubSubManager.cpp
+++ b/src/providers/twitch/PubSubManager.cpp
@@ -320,6 +320,25 @@ PubSub::PubSub(const QString &host, std::chrono::seconds pingInterval)
         this->moderation.userWarned.invoke(action);
     };
 
+    this->moderationActionHandlers["raid"] = [this](const auto &data,
+                                                    const auto &roomID) {
+        RaidAction action(data, roomID);
+
+        action.source.id = data.value("created_by_user_id").toString();
+        action.source.login = data.value("created_by").toString();
+
+        const auto args = data.value("args").toArray();
+
+        if (args.isEmpty())
+        {
+            return;
+        }
+
+        action.target = args[0].toString();
+
+        this->moderation.raidStarted.invoke(action);
+    };
+
     /*
     // This handler is no longer required as we use the automod-queue topic now
     this->moderationActionHandlers["automod_rejected"] =

--- a/src/providers/twitch/PubSubManager.cpp
+++ b/src/providers/twitch/PubSubManager.cpp
@@ -340,7 +340,7 @@ PubSub::PubSub(const QString &host, std::chrono::seconds pingInterval)
     };
 
     this->moderationActionHandlers["unraid"] = [this](const auto &data,
-                                                    const auto &roomID) {
+                                                      const auto &roomID) {
         UnraidAction action(data, roomID);
 
         action.source.id = data.value("created_by_user_id").toString();

--- a/src/providers/twitch/PubSubManager.hpp
+++ b/src/providers/twitch/PubSubManager.hpp
@@ -45,6 +45,7 @@ struct AutomodAction;
 struct AutomodUserAction;
 struct AutomodInfoAction;
 struct RaidAction;
+struct UnraidAction;
 struct WarnAction;
 struct PubSubLowTrustUsersMessage;
 struct PubSubWhisperMessage;
@@ -106,6 +107,7 @@ public:
         Signal<ModerationStateAction> moderationStateChanged;
 
         Signal<RaidAction> raidStarted;
+        Signal<UnraidAction> raidCancelled;
 
         Signal<BanAction> userBanned;
         Signal<UnbanAction> userUnbanned;

--- a/src/providers/twitch/PubSubManager.hpp
+++ b/src/providers/twitch/PubSubManager.hpp
@@ -107,7 +107,7 @@ public:
         Signal<ModerationStateAction> moderationStateChanged;
 
         Signal<RaidAction> raidStarted;
-        Signal<UnraidAction> raidCancelled;
+        Signal<UnraidAction> raidCanceled;
 
         Signal<BanAction> userBanned;
         Signal<UnbanAction> userUnbanned;

--- a/src/providers/twitch/PubSubManager.hpp
+++ b/src/providers/twitch/PubSubManager.hpp
@@ -44,6 +44,7 @@ struct PubSubAutoModQueueMessage;
 struct AutomodAction;
 struct AutomodUserAction;
 struct AutomodInfoAction;
+struct RaidAction;
 struct WarnAction;
 struct PubSubLowTrustUsersMessage;
 struct PubSubWhisperMessage;
@@ -103,6 +104,8 @@ public:
         Signal<DeleteAction> messageDeleted;
         Signal<ModeChangedAction> modeChanged;
         Signal<ModerationStateAction> moderationStateChanged;
+
+        Signal<RaidAction> raidStarted;
 
         Signal<BanAction> userBanned;
         Signal<UnbanAction> userUnbanned;

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -666,6 +666,23 @@ void TwitchIrcServer::initialize()
         });
 
     this->connections_.managedConnect(
+        getApp()->getTwitchPubSub()->moderation.raidCancelled,
+        [this](const auto &action) {
+            auto chan = this->getChannelOrEmptyByID(action.roomID);
+
+            if (chan->isEmpty())
+            {
+                return;
+            }
+
+            auto msg = MessageBuilder(action).release();
+
+            postToThread([chan, msg] {
+                chan->addMessage(msg, MessageContext::Original);
+            });
+        });
+
+    this->connections_.managedConnect(
         getApp()->getTwitchPubSub()->pointReward.redeemed, [this](auto &data) {
             QString channelId = data.value("channel_id").toString();
             if (channelId.isEmpty())

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -649,6 +649,23 @@ void TwitchIrcServer::initialize()
         });
 
     this->connections_.managedConnect(
+        getApp()->getTwitchPubSub()->moderation.raidStarted,
+        [this](const auto &action) {
+            auto chan = this->getChannelOrEmptyByID(action.roomID);
+
+            if (chan->isEmpty())
+            {
+                return;
+            }
+
+            auto msg = MessageBuilder(action).release();
+
+            postToThread([chan, msg] {
+                chan->addMessage(msg, MessageContext::Original);
+            });
+        });
+
+    this->connections_.managedConnect(
         getApp()->getTwitchPubSub()->pointReward.redeemed, [this](auto &data) {
             QString channelId = data.value("channel_id").toString();
             if (channelId.isEmpty())

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -666,7 +666,7 @@ void TwitchIrcServer::initialize()
         });
 
     this->connections_.managedConnect(
-        getApp()->getTwitchPubSub()->moderation.raidCancelled,
+        getApp()->getTwitchPubSub()->moderation.raidCanceled,
         [this](const auto &action) {
             auto chan = this->getChannelOrEmptyByID(action.roomID);
 


### PR DESCRIPTION
useful for mods/broadcaster; unfortunately non-mods would need an unofficial topic to know when raid has started

![image](https://github.com/user-attachments/assets/f2441ce3-44de-43d8-b894-20df2402502e)
