### PR TITLE
Update filenames for Ubuntu to Qt 6.7.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-20.04
-            container: ghcr.io/wissididom/chatterino2-build-ubuntu-20.04:latest
+            container: ghcr.io/chatterino/chatterino2-build-ubuntu-20.04:latest
             qt-version: 6.7.2
             force-lto: false
             plugins: true
@@ -41,7 +41,7 @@ jobs:
             build-appimage: false
             build-deb: true
           - os: ubuntu-22.04
-            container: ghcr.io/wissididom/chatterino2-build-ubuntu-22.04:latest
+            container: ghcr.io/chatterino/chatterino2-build-ubuntu-22.04:latest
             qt-version: 6.7.2
             force-lto: false
             plugins: true
@@ -50,7 +50,7 @@ jobs:
             build-appimage: true
             build-deb: true
           - os: ubuntu-24.04
-            container: ghcr.io/wissididom/chatterino2-build-ubuntu-24.04:latest
+            container: ghcr.io/chatterino/chatterino2-build-ubuntu-24.04:latest
             qt-version: 6.7.2
             force-lto: false
             plugins: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,8 +32,8 @@ jobs:
       matrix:
         include:
           - os: ubuntu-20.04
-            container: ghcr.io/chatterino/chatterino2-build-ubuntu-20.04:latest
-            qt-version: 6.6.1
+            container: ghcr.io/wissididom/chatterino2-build-ubuntu-20.04:latest
+            qt-version: 6.7.2
             force-lto: false
             plugins: true
             skip-artifact: false
@@ -41,8 +41,8 @@ jobs:
             build-appimage: false
             build-deb: true
           - os: ubuntu-22.04
-            container: ghcr.io/chatterino/chatterino2-build-ubuntu-22.04:latest
-            qt-version: 6.6.1
+            container: ghcr.io/wissididom/chatterino2-build-ubuntu-22.04:latest
+            qt-version: 6.7.2
             force-lto: false
             plugins: true
             skip-artifact: false
@@ -50,8 +50,8 @@ jobs:
             build-appimage: true
             build-deb: true
           - os: ubuntu-24.04
-            container: ghcr.io/chatterino/chatterino2-build-ubuntu-24.04:latest
-            qt-version: 6.6.1
+            container: ghcr.io/wissididom/chatterino2-build-ubuntu-24.04:latest
+            qt-version: 6.7.2
             force-lto: false
             plugins: true
             skip-artifact: false
@@ -369,25 +369,25 @@ jobs:
       - uses: actions/download-artifact@v4
         name: Linux AppImage
         with:
-          name: Chatterino-x86_64-Qt-6.6.1.AppImage
+          name: Chatterino-x86_64-Qt-6.7.2.AppImage
           path: release-artifacts/
 
       - uses: actions/download-artifact@v4
         name: Ubuntu 20.04 deb
         with:
-          name: Chatterino-ubuntu-20.04-Qt-6.6.1.deb
+          name: Chatterino-ubuntu-20.04-Qt-6.7.2.deb
           path: release-artifacts/
 
       - uses: actions/download-artifact@v4
         name: Ubuntu 22.04 deb
         with:
-          name: Chatterino-ubuntu-22.04-Qt-6.6.1.deb
+          name: Chatterino-ubuntu-22.04-Qt-6.7.2.deb
           path: release-artifacts/
 
       - uses: actions/download-artifact@v4
         name: Ubuntu 24.04 deb
         with:
-          name: Chatterino-ubuntu-24.04-Qt-6.6.1.deb
+          name: Chatterino-ubuntu-24.04-Qt-6.7.2.deb
           path: release-artifacts/
 
       - name: Copy flatpakref


### PR DESCRIPTION
Related to https://github.com/Chatterino/docker/pull/12. Afaik this PR just updates the filenames for the artifacts and the Qt version for the builds themselves are configured in the docker container, so in the linked PR.