### PR TITLE
refactor: deserialize theme automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
 - Dev: Fixed benchmarks segfaulting on run. (#5559)
 - Dev: Refactored `MessageBuilder` to be a single class. (#5548)
 - Dev: Recent changes are now shown in the nightly release description. (#5553, #5554)
+- Dev: Themes are now deserialized automatically. (#5570)
 
 ## 2.5.1
 

--- a/src/singletons/Theme.cpp
+++ b/src/singletons/Theme.cpp
@@ -53,10 +53,7 @@ void parseThemeAggregate(const QJsonObject &json, const QJsonObject &fallback,
 template <typename T>
 void parseRecursive(const QJsonObject & /*parent*/,
                     const QJsonObject & /*parentFallback*/,
-                    QLatin1String /*key*/, T & /*target*/)
-{
-    static_assert(false, "Invalid data type (T)");
-}
+                    QLatin1String /*key*/, T & /*target*/) = delete;
 
 template <typename T>
 void parseRecursive(const QJsonObject &parent,

--- a/src/singletons/Theme.cpp
+++ b/src/singletons/Theme.cpp
@@ -114,6 +114,13 @@ void parseRecursive<QColor>(const QJsonObject &obj,
                                   "current theme, and no fallback value found.";
 }
 
+consteval bool shouldParse(std::string_view name, auto &&r)
+{
+    return std::ranges::none_of(r, [name](auto v) {
+        return name == v;
+    });
+}
+
 template <typename T, size_t Index>
 void parseStructMember(const QJsonObject &json, const QJsonObject &fallback,
                        T &target)
@@ -122,8 +129,7 @@ void parseStructMember(const QJsonObject &json, const QJsonObject &fallback,
     constexpr auto fieldName = boost::pfr::get_name<Index, T>();
     constexpr QLatin1String key{fieldName.data(), fieldName.size()};
 
-    if constexpr (!theme::detail::IGNORE_DESER<std::addressof(
-                      boost::pfr::get<Index>(theme::detail::fakeObject<T>()))>)
+    if constexpr (shouldParse(fieldName, theme::detail::IGNORE_DESER<T>))
     {
         parseRecursive(json, fallback, key, boost::pfr::get<Index>(target));
     }

--- a/src/singletons/Theme.hpp
+++ b/src/singletons/Theme.hpp
@@ -219,12 +219,11 @@ namespace theme::detail {
         return EXTERN_WRAPPER<T>.value;
     }
 
-    template <auto Ptr>
-    constexpr bool IGNORE_DESER = false;
+    template <typename T>
+    constexpr std::array<std::string_view, 0> IGNORE_DESER = {};
 
     template <>
-    constexpr bool IGNORE_DESER<std::addressof(
-        fakeObject<Theme::Splits::Input>().styleSheet)> = true;
+    constexpr std::array IGNORE_DESER<Theme::Splits::Input> = {"styleSheet"};
 
 }  // namespace theme::detail
 

--- a/src/singletons/Theme.hpp
+++ b/src/singletons/Theme.hpp
@@ -50,28 +50,31 @@ public:
 
     struct TabColors {
         QColor text;
-        struct {
+        struct Backgrounds {
             QColor regular;
             QColor hover;
             QColor unfocused;
-        } backgrounds;
-        struct {
+        };
+        Backgrounds backgrounds;
+        struct Line {
             QColor regular;
             QColor hover;
             QColor unfocused;
-        } line;
+        };
+        Line line;
     };
 
     QColor accent{"#00aeef"};
 
     /// WINDOW
-    struct {
+    struct Window {
         QColor background;
         QColor text;
-    } window;
+    };
+    Window window;
 
     /// TABS
-    struct {
+    struct Tabs {
         TabColors regular;
         TabColors newMessage;
         TabColors highlighted;
@@ -80,39 +83,44 @@ public:
 
         QColor liveIndicator;
         QColor rerunIndicator;
-    } tabs;
+    };
+    Tabs tabs;
 
     /// MESSAGES
-    struct {
-        struct {
+    struct Messages {
+        struct TextColors {
             QColor regular;
             QColor caret;
             QColor link;
             QColor system;
             QColor chatPlaceholder;
-        } textColors;
+        };
+        TextColors textColors;
 
-        struct {
+        struct Backgrounds {
             QColor regular;
             QColor alternate;
-        } backgrounds;
+        };
+        Backgrounds backgrounds;
 
         QColor disabled;
         QColor selection;
 
         QColor highlightAnimationStart;
         QColor highlightAnimationEnd;
-    } messages;
+    };
+    Messages messages;
 
     /// SCROLLBAR
-    struct {
+    struct Scrollbars {
         QColor background;
         QColor thumb;
         QColor thumbSelected;
-    } scrollbars;
+    };
+    Scrollbars scrollbars;
 
     /// SPLITS
-    struct {
+    struct Splits {
         QColor messageSeperator;
         QColor background;
         QColor dropPreview;
@@ -122,21 +130,24 @@ public:
         QColor resizeHandle;
         QColor resizeHandleBackground;
 
-        struct {
+        struct Header {
             QColor border;
             QColor focusedBorder;
             QColor background;
             QColor focusedBackground;
             QColor text;
             QColor focusedText;
-        } header;
+        };
+        Header header;
 
-        struct {
+        struct Input {
             QColor background;
             QColor text;
             QString styleSheet;
-        } input;
-    } splits;
+        };
+        Input input;
+    };
+    Splits splits;
 
     struct {
         QPixmap copy;
@@ -190,4 +201,31 @@ private:
 };
 
 Theme *getTheme();
+
+namespace theme::detail {
+
+    // from Boost PFR (fake_object.hpp)
+    // Used to create a reference to an object at constant evaluation
+    template <class T>
+    struct Wrapper {
+        const T value;
+    };
+
+    template <class T>
+    extern const Wrapper<T> EXTERN_WRAPPER;
+    template <class T>
+    consteval const T &fakeObject() noexcept
+    {
+        return EXTERN_WRAPPER<T>.value;
+    }
+
+    template <auto Ptr>
+    constexpr bool IGNORE_DESER = false;
+
+    template <>
+    constexpr bool IGNORE_DESER<std::addressof(
+        fakeObject<Theme::Splits::Input>().styleSheet)> = true;
+
+}  // namespace theme::detail
+
 }  // namespace chatterino


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

No more macros. Uses [Boost.PFR](https://www.boost.io/doc/libs/1_86_0/doc/html/boost_pfr.html) to get the names of fields. Hopefully this works with all compilers.