### PR TITLE
Update Qt for Ubuntu and Mac Tests

### DIFF
--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-13]
-        qt-version: [5.15.2, 6.5.0]
+        qt-version: [5.15.2, 6.7.1]
         plugins: [false]
       fail-fast: false
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
         include:
           - os: "ubuntu-22.04"
             container: ghcr.io/chatterino/chatterino2-build-ubuntu-22.04:latest
-            qt-version: 6.6.1
+            qt-version: 6.7.1
             plugins: true
       fail-fast: false
     env:


### PR DESCRIPTION
Since we update the ubuntu builds to 6.7.1 I thought, I'd also PR an update to the ubuntu and mac tests you our Qt6 version is the same on all platforms.

I can look into testing the Ubuntu tests locally if necessary, but I can't test the Mac tests, since I neither have a Mac nor a Hackintosh.