### PR TITLE
fix: orphan `FramelessDraggable`s too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 - Bugfix: Fixed a crash when tab completing while having an invalid plugin loaded. (#5401)
 - Bugfix: Fixed windows on Windows not saving correctly when snapping them to the edges. (#5478)
 - Bugfix: Fixed user info card popups adding duplicate line to log files. (#5499)
-- Bugfix: Fixed tooltips and input completion popups not working after moving a split. (#5541)
+- Bugfix: Fixed tooltips and input completion popups not working after moving a split. (#5541, #5576)
 - Bugfix: Fixed rare issue on shutdown where the client would hang. (#5557)
 - Bugfix: Fixed `/clearmessages` not working with more than one window. (#5489)
 - Bugfix: Fixed splits staying paused after unfocusing Chatterino in certain configurations. (#5504)

--- a/src/widgets/BaseWindow.cpp
+++ b/src/widgets/BaseWindow.cpp
@@ -505,7 +505,7 @@ bool BaseWindow::event(QEvent *event)
     }
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
-    if (this->flags_.has(DontFocus) || this->flags_.has(Dialog))
+    if (this->flags_.hasAny(DontFocus, Dialog, FramelessDraggable))
     {
         // This certain windows (e.g. TooltipWidget, input completion widget, and the search popup) retains their nullptr parent
         // NOTE that this currently does not retain their original transient parent (which is the window it was created under)


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

Fixes https://github.com/Chatterino/chatterino2/issues/5574. On non Linux OSs, `popupFlagsCloseAutomatically` doesn't include `Dialog` but includes `FramelessDraggable`. So that's added to the flags of windows we're considering to orphan.

In https://github.com/Chatterino/chatterino2/issues/5432#issuecomment-2320902867 I mentioned that I can't replicate the underlying issue on 6.8.0. This is either a bug or a feature (not sure).