### PR TITLE
fix: some tooltips not being readable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - Bugfix: Fixed janky selection for messages with RTL segments (selection is still wrong, but consistently wrong). (#5525)
 - Bugfix: Fixed tab visibility being controllable in the emote popup. (#5530)
 - Bugfix: Fixed account switch not being saved if no other settings were changed. (#5558)
+- Bugfix: Fixed some tooltips not being readable. (#5578)
 - Dev: Update Windows build from Qt 6.5.0 to Qt 6.7.1. (#5420)
 - Dev: Update vcpkg build Qt from 6.5.0 to 6.7.0, boost from 1.83.0 to 1.85.0, openssl from 3.1.3 to 3.3.0. (#5422)
 - Dev: Unsingletonize `ISoundController`. (#5462)

--- a/src/RunGui.cpp
+++ b/src/RunGui.cpp
@@ -49,7 +49,7 @@ namespace {
         dark.setColor(QPalette::Base, QColor("#333"));
         dark.setColor(QPalette::AlternateBase, QColor("#444"));
         dark.setColor(QPalette::ToolTipBase, Qt::white);
-        dark.setColor(QPalette::ToolTipText, Qt::white);
+        dark.setColor(QPalette::ToolTipText, Qt::black);
         dark.setColor(QPalette::Dark, QColor(35, 35, 35));
         dark.setColor(QPalette::Shadow, QColor(20, 20, 20));
         dark.setColor(QPalette::Button, QColor(70, 70, 70));


### PR DESCRIPTION
our "budget fusion palette" had the same color for the tooltip
background as the tooltip text

<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
