### PR TITLE
fix: don't add sets without emotes when searching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@
 - Bugfix: Fixed splits staying paused after unfocusing Chatterino in certain configurations. (#5504)
 - Bugfix: Links with invalid characters in the domain are no longer detected. (#5509)
 - Bugfix: Fixed janky selection for messages with RTL segments (selection is still wrong, but consistently wrong). (#5525)
-- Bugfix: Fixed event emotes not showing up in autocomplete and popups. (#5239, #5580)
+- Bugfix: Fixed event emotes not showing up in autocomplete and popups. (#5239, #5580, #5582)
 - Bugfix: Fixed tab visibility being controllable in the emote popup. (#5530)
 - Bugfix: Fixed account switch not being saved if no other settings were changed. (#5558)
 - Bugfix: Fixed some tooltips not being readable. (#5578)


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

Emote-sets were always added after they were filtered, even if they didn't contain any emotes.
Also, some mini fixes to avoid copies where possible and the correct display of follower emotes.

Fixes #5581.