### PR TITLE
fix: only clear reply target when inline replying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 - Minor: Improve appearance of reply button. (#5491)
 - Minor: Introduce HTTP API for plugins. (#5383, #5492, #5494)
 - Minor: Support more Firefox variants for incognito link opening. (#5503)
-- Minor: Replying to a message will now display the message being replied to. (#4350, #5519)
+- Minor: Replying to a message will now display the message being replied to. (#4350, #5519, #5586)
 - Minor: Links can now have prefixes and suffixes such as parentheses. (#5486, #5515)
 - Minor: Added support for scrolling in splits with touchscreen panning gestures. (#5524)
 - Minor: Removed experimental IRC support. (#5547)

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -1223,7 +1223,10 @@ void SplitInput::clearInput()
     this->currMsg_ = "";
     this->ui_.textEdit->setText("");
     this->ui_.textEdit->moveCursor(QTextCursor::Start);
-    this->clearReplyTarget();
+    if (this->enableInlineReplying_)
+    {
+        this->clearReplyTarget();
+    }
 }
 
 void SplitInput::clearReplyTarget()


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

In https://github.com/Chatterino/chatterino2/pull/4350/files#diff-28a2425a552a515ae2556b51b50f4e3102c012c67dfa291cd13b52e1406e2417L1151-L1154, a method to clear the reply target was added where it was cleared "inline" before. However, there was a check whether inline replying was enabled (i.e. the mode where messages show above the input). This check was removed and this PR re-adds it.

Fixes #5584.