### PR TITLE
chore: cleanup some parts of qmagicenum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@
 - Dev: Refactored `MessageBuilder` to be a single class. (#5548)
 - Dev: Recent changes are now shown in the nightly release description. (#5553, #5554)
 - Dev: The timer for `StreamerMode` is now destroyed on the correct thread. (#5571)
+- Dev: Cleanup some parts of the `magic_enum` adaptation for Qt. (#5587)
 
 ## 2.5.1
 

--- a/tests/src/QMagicEnum.cpp
+++ b/tests/src/QMagicEnum.cpp
@@ -27,6 +27,8 @@ enum class MyFlag {
     Two = 2,
     Four = 4,
     Eight = 8,
+    TwoPow9 = 512,
+    TwoPow10 = 1024,
 };
 using MyFlags = chatterino::FlagsEnum<MyFlag>;
 
@@ -130,7 +132,8 @@ TEST(QMagicEnum, flags)
     static_assert(checkConst(MyFlag::Eight, u"Eight"));
     static_assert(checkConst(MyFlag::Eight, u"Eight"));
     static_assert(eq(enumName(static_cast<MyFlag>(16)), u""));
-    static_assert(checkValues<MyFlag>({u"One", u"Two", u"Four", u"Eight"}));
+    static_assert(checkValues<MyFlag>(
+        {u"One", u"Two", u"Four", u"Eight", u"TwoPow9", u"TwoPow10"}));
 }
 
 TEST(QMagicEnum, enumNameString)


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

- Removes `enable_if`s over concepts (return types are a bit more readable this way)
- Ports `magic_enum`'s [`is_nothrow_invocable`](https://github.com/Neargye/magic_enum/blob/dae6bbf16c363e9ead4e628a47fdb02956a634f3/include/magic_enum/magic_enum.hpp#L334-L344) to predicates over `QChar`
- Adds some comments to the storage
- Moves static string construction to `detail`
- Removes usage of `magic_enum::detail::enum_subtype` - this is resolved by `magic_enum` (except for `enumFlagsName`, where we verify the type)
- Removes `inline` for `constexpr` functions
- Adds two more members to the flags test that live outside the regular enum range (-128…128)