### PR TITLE
chore: allow unreleased-lines to be reused on other files

### DIFF
--- a/.CI/format-recent-changes.py
+++ b/.CI/format-recent-changes.py
@@ -16,37 +16,43 @@ LINE_REGEX = re.compile(
 )
 VERSION_REGEX = re.compile(r"^#+\s*v?\d")
 
-# contains lines in the form of
-# {commit-sha} (<{email}>\s+{date}\s+{line-no}) {line}
-p = subprocess.run(
-    ["git", "blame", "-e", "--date=iso", "../CHANGELOG.md"],
-    cwd=os.path.dirname(os.path.realpath(__file__)),
-    text=True,
-    check=True,
-    capture_output=True,
-)
 
-unreleased_lines: list[tuple[datetime, str]] = []
-for line in p.stdout.splitlines():
-    if not line:
-        continue
-    m = LINE_REGEX.match(line)
-    assert m, f"Failed to match '{line}'"
-    content = m.group("content")
+def get_unreleased_lines(file: str):
+    # contains lines in the form of
+    # {commit-sha} (<{email}>\s+{date}\s+{line-no}) {line}
+    p = subprocess.run(
+        ["git", "blame", "-e", "--date=iso", file],
+        cwd=os.path.dirname(os.path.realpath(__file__)),
+        text=True,
+        check=True,
+        capture_output=True,
+    )
 
-    if not content:
-        continue
-    if content.startswith("#"):
-        if VERSION_REGEX.match(content):
-            break
-        continue  # ignore lines with '#'
+    unreleased_lines: list[tuple[datetime, str]] = []
+    for line in p.stdout.splitlines():
+        if not line:
+            continue
+        m = LINE_REGEX.match(line)
+        assert m, f"Failed to match '{line}'"
+        content = m.group("content")
 
-    d = datetime.fromisoformat(m.group("date"))
-    d = d.astimezone(tz=timezone.utc)
-    content = content.replace("- ", f"- [{d.strftime('%Y-%m-%d')}] ", 1)
-    unreleased_lines.append((d, content))
+        if not content:
+            continue
+        if content.startswith("#"):
+            if VERSION_REGEX.match(content):
+                break
+            continue  # ignore lines with '#'
 
-unreleased_lines.sort(key=lambda it: it[0], reverse=True)
+        d = datetime.fromisoformat(m.group("date"))
+        d = d.astimezone(tz=timezone.utc)
+        content = content.replace("- ", f"- [{d.strftime('%Y-%m-%d')}] ", 1)
+        unreleased_lines.append((d, content))
+
+    unreleased_lines.sort(key=lambda it: it[0], reverse=True)
+    return unreleased_lines
+
+
+unreleased_lines = get_unreleased_lines("../CHANGELOG.md")
 
 if len(unreleased_lines) == 0:
     print("No changes since last release.")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,7 @@
 - Dev: Moved some responsibility away from Application into WindowManager. (#5551)
 - Dev: Fixed benchmarks segfaulting on run. (#5559)
 - Dev: Refactored `MessageBuilder` to be a single class. (#5548)
-- Dev: Recent changes are now shown in the nightly release description. (#5553, #5554)
+- Dev: Recent changes are now shown in the nightly release description. (#5553, #5554, #5593)
 - Dev: The timer for `StreamerMode` is now destroyed on the correct thread. (#5571)
 - Dev: Cleanup some parts of the `magic_enum` adaptation for Qt. (#5587)
 


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

Not really useful here, but I intend to re-use this functionality in 7TV's Chatterino7 fork. To reduce merge conflicts, I'm making some changes to the generator here (only wrapping the parsing in a function).