### PR TITLE
ci: set test cmake build job count to logical processor count

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
             -DCHATTERINO_GENERATE_COVERAGE=On \
             -DCMAKE_BUILD_TYPE=Debug \
             ..
-          cmake --build .
+          cmake --build . -j $(nproc)
         working-directory: build-test
 
       - name: Download and extract Twitch PubSub Server Test


### PR DESCRIPTION
This PR aims to increase (depending on hardware) the amount of parallel build jobs used when building chatterino inside of the ubuntu test suite. Currently it's running a single build job, which partially explains the long run times.