### PR TITLE
feat: send messages over Helix by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@
 - Dev: Refactored `static`s in headers to only be present once in the final app. (#5588)
 - Dev: Refactored legacy Unicode zero-width-joiner replacement. (#5594)
 - Dev: The JSON output when copying a message (<kbd>SHIFT</kbd> + right-click) is now more extensive. (#5600)
+- Dev: Twitch messages are now sent using Twitch's Helix API instead of IRC by default. (#5607)
 
 ## 2.5.1
 

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -132,14 +132,14 @@ bool shouldSendHelixChat()
 {
     switch (getSettings()->chatSendProtocol)
     {
+        case ChatSendProtocol::Default:
         case ChatSendProtocol::Helix:
             return true;
-        case ChatSendProtocol::Default:
         case ChatSendProtocol::IRC:
             return false;
         default:
             assert(false && "Invalid chat protocol value");
-            return false;
+            return true;
     }
 }
 

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -9,6 +9,7 @@
 
 #include <magic_enum/magic_enum.hpp>
 #include <QJsonDocument>
+#include <QStringBuilder>
 
 namespace {
 

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -3015,8 +3015,13 @@ void Helix::sendChatMessage(
             }
 
             const auto obj = result.parseJson();
-            auto message =
-                obj["message"].toString(u"Twitch internal server error"_s);
+            auto message = obj["message"].toString();
+
+            if (message.isEmpty())
+            {
+                message = u"Twitch internal server error (" %
+                          result.formatError() % ')';
+            }
 
             switch (*result.status())
             {


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

I've been using Helix as the send protocol ever since it got added, and didn't notice more bugs. The main advantage over IRC is that users get better feedback on dropped messages (although it often returns some generic reason).

Sometimes, Twitch returns 500 with an empty message. Now, every time Twitch returns an empty message, we assume an internal server error.

In the future, we could disable the write-connection if the settings allow it.