### PR TITLE
fix: don't initialize GIFTimer in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@
 - Dev: Refactored legacy Unicode zero-width-joiner replacement. (#5594)
 - Dev: The JSON output when copying a message (<kbd>SHIFT</kbd> + right-click) is now more extensive. (#5600)
 - Dev: Twitch messages are now sent using Twitch's Helix API instead of IRC by default. (#5607)
+- Dev: `GIFTimer` is no longer initialized in tests. (#5608)
 
 ## 2.5.1
 

--- a/benchmarks/src/RecentMessages.cpp
+++ b/benchmarks/src/RecentMessages.cpp
@@ -4,6 +4,7 @@
 #include "messages/Emote.hpp"
 #include "mocks/BaseApplication.hpp"
 #include "mocks/DisabledStreamerMode.hpp"
+#include "mocks/Emotes.hpp"
 #include "mocks/LinkResolver.hpp"
 #include "mocks/TwitchIrcServer.hpp"
 #include "mocks/UserData.hpp"
@@ -16,7 +17,6 @@
 #include "providers/seventv/SeventvEmotes.hpp"
 #include "providers/twitch/TwitchBadges.hpp"
 #include "providers/twitch/TwitchChannel.hpp"
-#include "singletons/Emotes.hpp"
 #include "singletons/Resources.hpp"
 
 #include <benchmark/benchmark.h>
@@ -111,7 +111,7 @@ public:
     }
 
     AccountController accounts;
-    Emotes emotes;
+    mock::Emotes emotes;
     mock::UserDataController userData;
     mock::MockTwitchIrcServer twitch;
     mock::EmptyLinkResolver linkResolver;

--- a/mocks/include/mocks/Emotes.hpp
+++ b/mocks/include/mocks/Emotes.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "singletons/Emotes.hpp"
+
+namespace chatterino::mock {
+
+class Emotes : public IEmotes
+{
+public:
+    Emotes()
+    {
+        this->emojis.load();
+        // don't initialize GIFTimer
+    }
+
+    ITwitchEmotes *getTwitchEmotes() override
+    {
+        return &this->twitch;
+    }
+
+    IEmojis *getEmojis() override
+    {
+        return &this->emojis;
+    }
+
+    GIFTimer &getGIFTimer() override
+    {
+        return this->gifTimer;
+    }
+
+private:
+    TwitchEmotes twitch;
+    Emojis emojis;
+
+    GIFTimer gifTimer;
+};
+
+}  // namespace chatterino::mock

--- a/tests/src/Commands.cpp
+++ b/tests/src/Commands.cpp
@@ -4,12 +4,12 @@
 #include "controllers/commands/CommandController.hpp"
 #include "controllers/commands/common/ChannelAction.hpp"
 #include "mocks/BaseApplication.hpp"
+#include "mocks/Emotes.hpp"
 #include "mocks/Helix.hpp"
 #include "mocks/Logging.hpp"
 #include "mocks/TwitchIrcServer.hpp"
 #include "providers/twitch/TwitchAccount.hpp"
 #include "providers/twitch/TwitchChannel.hpp"
-#include "singletons/Emotes.hpp"
 #include "singletons/Settings.hpp"
 #include "Test.hpp"
 
@@ -59,7 +59,7 @@ public:
     AccountController accounts;
     CommandController commands;
     mock::MockTwitchIrcServer twitch;
-    Emotes emotes;
+    mock::Emotes emotes;
 };
 
 }  // namespace

--- a/tests/src/Filters.cpp
+++ b/tests/src/Filters.cpp
@@ -7,6 +7,7 @@
 #include "mocks/BaseApplication.hpp"
 #include "mocks/Channel.hpp"
 #include "mocks/ChatterinoBadges.hpp"
+#include "mocks/Emotes.hpp"
 #include "mocks/EmptyApplication.hpp"
 #include "mocks/Logging.hpp"
 #include "mocks/TwitchIrcServer.hpp"
@@ -14,7 +15,6 @@
 #include "providers/ffz/FfzBadges.hpp"
 #include "providers/seventv/SeventvBadges.hpp"
 #include "providers/twitch/TwitchBadge.hpp"
-#include "singletons/Emotes.hpp"
 #include "Test.hpp"
 
 #include <QColor>
@@ -81,7 +81,7 @@ public:
 
     mock::EmptyLogging logging;
     AccountController accounts;
-    Emotes emotes;
+    mock::Emotes emotes;
     mock::UserDataController userData;
     mock::MockTwitchIrcServer twitch;
     mock::ChatterinoBadges chatterinoBadges;

--- a/tests/src/InputCompletion.cpp
+++ b/tests/src/InputCompletion.cpp
@@ -8,6 +8,7 @@
 #include "messages/Emote.hpp"
 #include "mocks/BaseApplication.hpp"
 #include "mocks/Channel.hpp"
+#include "mocks/Emotes.hpp"
 #include "mocks/Helix.hpp"
 #include "mocks/Logging.hpp"
 #include "mocks/TwitchIrcServer.hpp"
@@ -79,7 +80,7 @@ public:
     mock::EmptyLogging logging;
     AccountController accounts;
     mock::MockTwitchIrcServer twitch;
-    Emotes emotes;
+    mock::Emotes emotes;
     BttvEmotes bttvEmotes;
     FfzEmotes ffzEmotes;
     SeventvEmotes seventvEmotes;

--- a/tests/src/MessageBuilder.cpp
+++ b/tests/src/MessageBuilder.cpp
@@ -7,13 +7,13 @@
 #include "mocks/Channel.hpp"
 #include "mocks/ChatterinoBadges.hpp"
 #include "mocks/DisabledStreamerMode.hpp"
+#include "mocks/Emotes.hpp"
 #include "mocks/Logging.hpp"
 #include "mocks/TwitchIrcServer.hpp"
 #include "mocks/UserData.hpp"
 #include "providers/ffz/FfzBadges.hpp"
 #include "providers/seventv/SeventvBadges.hpp"
 #include "providers/twitch/TwitchBadge.hpp"
-#include "singletons/Emotes.hpp"
 #include "Test.hpp"
 #include "util/IrcHelpers.hpp"
 
@@ -99,7 +99,7 @@ public:
 
     mock::EmptyLogging logging;
     AccountController accounts;
-    Emotes emotes;
+    mock::Emotes emotes;
     mock::UserDataController userData;
     mock::MockTwitchIrcServer twitch;
     mock::ChatterinoBadges chatterinoBadges;

--- a/tests/src/ModerationAction.cpp
+++ b/tests/src/ModerationAction.cpp
@@ -2,7 +2,7 @@
 
 #include "messages/Image.hpp"
 #include "mocks/BaseApplication.hpp"
-#include "singletons/Emotes.hpp"
+#include "mocks/Emotes.hpp"
 #include "singletons/Resources.hpp"
 #include "Test.hpp"
 
@@ -24,7 +24,7 @@ public:
         return &this->emotes;
     }
 
-    Emotes emotes;
+    mock::Emotes emotes;
 };
 
 class ModerationActionTest : public ::testing::Test

--- a/tests/src/SplitInput.cpp
+++ b/tests/src/SplitInput.cpp
@@ -62,7 +62,7 @@ public:
     WindowManager windowManager;
     AccountController accounts;
     CommandController commands;
-    mocks::Emotes emotes;
+    mock::Emotes emotes;
 };
 
 class SplitInputTest

--- a/tests/src/SplitInput.cpp
+++ b/tests/src/SplitInput.cpp
@@ -6,7 +6,7 @@
 #include "controllers/commands/CommandController.hpp"
 #include "controllers/hotkeys/HotkeyController.hpp"
 #include "mocks/BaseApplication.hpp"
-#include "singletons/Emotes.hpp"
+#include "mocks/Emotes.hpp"
 #include "singletons/Fonts.hpp"
 #include "singletons/Paths.hpp"
 #include "singletons/Settings.hpp"
@@ -62,7 +62,7 @@ public:
     WindowManager windowManager;
     AccountController accounts;
     CommandController commands;
-    Emotes emotes;
+    mocks::Emotes emotes;
 };
 
 class SplitInputTest


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

From #5603:

> While testing, I noticed that `Emotes` initializes the `GIFTimer` which could cause it to invoke the repaint event which tries to access the window manager.

Not sure what the exact conditions are, but now it can't happen anymore (my pc might be a bit slow).