### PR TITLE
feat: run bench in ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,6 +91,12 @@ jobs:
           ctest --repeat until-pass:4 --output-on-failure
         working-directory: build-test
 
+      - name: Run benchmark
+        timeout-minutes: 2
+        run: |
+          ./bin/chatterino-benchmark --benchmark_min_time=1x
+        working-directory: build-test
+
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.5.0
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@
 - Dev: The timer for `StreamerMode` is now destroyed on the correct thread. (#5571)
 - Dev: Cleanup some parts of the `magic_enum` adaptation for Qt. (#5587)
 - Dev: Refactored `static`s in headers to only be present once in the final app. (#5588)
+- Dev: Run benchmarks in CI. (#5610)
 - Dev: Added more tests for input completion. (#5604)
 - Dev: Refactored legacy Unicode zero-width-joiner replacement. (#5594)
 - Dev: The JSON output when copying a message (<kbd>SHIFT</kbd> + right-click) is now more extensive. (#5600)

--- a/benchmarks/src/RecentMessages.cpp
+++ b/benchmarks/src/RecentMessages.cpp
@@ -6,6 +6,7 @@
 #include "mocks/DisabledStreamerMode.hpp"
 #include "mocks/Emotes.hpp"
 #include "mocks/LinkResolver.hpp"
+#include "mocks/Logging.hpp"
 #include "mocks/TwitchIrcServer.hpp"
 #include "mocks/UserData.hpp"
 #include "providers/bttv/BttvEmotes.hpp"
@@ -110,6 +111,12 @@ public:
         return &this->linkResolver;
     }
 
+    ILogging *getChatLogger() override
+    {
+        return &this->logging;
+    }
+
+    mock::EmptyLogging logging;
     AccountController accounts;
     mock::Emotes emotes;
     mock::UserDataController userData;


### PR DESCRIPTION
we only run each iteration once (essentially a benchmark dry run). this is just here to ensure we don't break benchmarks with some change we make