### PR TITLE
fix: use correct selection index when double-clicking into the void

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - Bugfix: Fixed log files being locked longer than needed. (#5592)
 - Bugfix: Fixed global badges not showing in anonymous mode. (#5599)
 - Bugfix: Fixed grammar in the user highlight page. (#5602)
+- Bugfix: Fixed double-click selection not working when clicking outside a message. (#5617)
 - Dev: Update Windows build from Qt 6.5.0 to Qt 6.7.1. (#5420)
 - Dev: Update vcpkg build Qt from 6.5.0 to 6.7.0, boost from 1.83.0 to 1.85.0, openssl from 3.1.3 to 3.3.0. (#5422)
 - Dev: Unsingletonize `ISoundController`. (#5462)

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -2707,6 +2707,10 @@ void ChannelView::mouseDoubleClickEvent(QMouseEvent *event)
 
     if (hoverLayoutElement == nullptr)
     {
+        // XXX: this is duplicate work
+        auto idx = layout->getSelectionIndex(relativePos);
+        SelectionItem item(messageIndex, idx);
+        this->doubleClickSelection_ = {item, item};
         return;
     }
 


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

From pajlada:

- Double click emote/emoji to select it
- Double click outside a message (in the void) and drag
- *Expected*: The selection starts at the nearest element - *Previous*: The selection starts at that selected emote/emoji

Technically, this fix does some duplicate work, since we did the work of looking at all elements, but shouldn't be that bad.