### PR TITLE
feat: launch arg to start logged in as a supplied user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Minor: Removed experimental IRC support. (#5547)
 - Minor: Moderators can now see which mods start and cancel raids. (#5563)
 - Minor: The emote popup now reloads when Twitch emotes are reloaded. (#5580)
+- Minor: Added `--login <username>` CLI argument to specify which account to start logged in as. (#5626)
 - Bugfix: Fixed tab move animation occasionally failing to start after closing a tab. (#5426, #5612)
 - Bugfix: If a network request errors with 200 OK, Qt's error code is now reported instead of the HTTP status. (#5378)
 - Bugfix: Fixed restricted users usernames not being clickable. (#5405)

--- a/src/common/Args.cpp
+++ b/src/common/Args.cpp
@@ -117,6 +117,13 @@ Args::Args(const QApplication &app, const Paths &paths)
         "safe-mode", "Starts Chatterino without loading Plugins and always "
                      "show the settings button.");
 
+    QCommandLineOption loginOption(
+        "login",
+        "Starts Chatterino logged in as the account matching the supplied "
+        "username. If the supplied username does not match any account "
+        "Chatterino starts logged in as anonymous.",
+        "username");
+
     // Channel layout
     auto channelLayout = QCommandLineOption(
         {"c", "channels"},
@@ -142,6 +149,7 @@ Args::Args(const QApplication &app, const Paths &paths)
         parentWindowIdOption,
         verboseOption,
         safeModeOption,
+        loginOption,
         channelLayout,
         activateOption,
     });
@@ -197,6 +205,11 @@ Args::Args(const QApplication &app, const Paths &paths)
         this->safeMode = true;
     }
 
+    if (parser.isSet(loginOption))
+    {
+        this->initialLogin = parser.value(loginOption);
+    }
+
     if (parser.isSet(activateOption))
     {
         this->activateChannel =
@@ -206,6 +219,7 @@ Args::Args(const QApplication &app, const Paths &paths)
     this->currentArguments_ = extractCommandLine(parser, {
                                                              verboseOption,
                                                              safeModeOption,
+                                                             loginOption,
                                                              channelLayout,
                                                              activateOption,
                                                          });

--- a/src/common/Args.hpp
+++ b/src/common/Args.hpp
@@ -60,6 +60,7 @@ public:
     bool dontLoadMainWindow{};
     std::optional<WindowLayout> customChannelLayout;
     std::optional<Channel> activateChannel;
+    std::optional<QString> initialLogin;
     bool verbose{};
     bool safeMode{};
 

--- a/src/providers/twitch/TwitchAccountManager.cpp
+++ b/src/providers/twitch/TwitchAccountManager.cpp
@@ -1,5 +1,7 @@
 #include "providers/twitch/TwitchAccountManager.hpp"
 
+#include "Application.hpp"
+#include "common/Args.hpp"
 #include "common/Common.hpp"
 #include "common/QLogging.hpp"
 #include "providers/twitch/api/Helix.hpp"
@@ -144,6 +146,10 @@ void TwitchAccountManager::reloadUsers()
 
 void TwitchAccountManager::load()
 {
+    if (getApp()->getArgs().initialLogin.has_value()) {
+        this->currentUsername = getApp()->getArgs().initialLogin.value();
+    }
+
     this->reloadUsers();
 
     this->currentUsername.connect([this](const QString &newUsername) {

--- a/src/providers/twitch/TwitchAccountManager.cpp
+++ b/src/providers/twitch/TwitchAccountManager.cpp
@@ -146,7 +146,8 @@ void TwitchAccountManager::reloadUsers()
 
 void TwitchAccountManager::load()
 {
-    if (getApp()->getArgs().initialLogin.has_value()) {
+    if (getApp()->getArgs().initialLogin.has_value())
+    {
         this->currentUsername = getApp()->getArgs().initialLogin.value();
     }
 


### PR DESCRIPTION
Add a new optional launch arg , `--login <username>`, that allows a user to specify which account they want to start Chatterino logged in as. If an account with the supplied username does not exist, then it starts anonymous. This arg is essentially equivalent to modifying `current` in `settings.json` before launch.

I tried to implement similar to how channel args are applied in `WindowManager` by applying the username in `TwitchAccountManager`, but I don't know if it would be preferred to elevate it to `AccountController` instead. I did not implement the platform specificity that the `channel` and `activate` options have. 

I don't know if this is worth noting, but a side effect is that if the user never switches accounts, the `current` saved in `setting.json` will be set to whatever username they provided.