### PR TITLE
feat: globally suppress highlight notifications

### DIFF
--- a/src/controllers/hotkeys/ActionNames.hpp
+++ b/src/controllers/hotkeys/ActionNames.hpp
@@ -340,6 +340,9 @@ inline const std::map<HotkeyCategory, ActionDefinitionMap> actionNames{
               .argumentsPromptHover = "Should the tabs be enabled, disabled, "
                                       "toggled, or live-only.",
           }},
+         // TODO(jupjohn): allow passing a toggle arg to this
+         {"toggleGlobalNotificationSuppression",
+          ActionDefinition{"Toggle notification suppression"}},
      }},
 };
 

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -162,6 +162,12 @@ void actuallyTriggerHighlights(const QString &channelName, bool playSound,
         return;
     }
 
+    if (getSettings()->globallySuppressNotifications)
+    {
+        // Notifications are globally suppressed, ignore it.
+        return;
+    }
+
     const bool hasFocus = (QApplication::focusWidget() != nullptr);
     const bool resolveFocus =
         !hasFocus || getSettings()->highlightAlwaysPlaySound;

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -487,6 +487,9 @@ public:
     BoolSetting suppressInitialLiveNotification = {
         "/notifications/suppressInitialLive", false};
 
+    BoolSetting globallySuppressNotifications = {
+        "/notifications/globalSuppression", false};
+
     BoolSetting notificationToast = {"/notifications/enableToast", false};
     IntSetting openFromToast = {"/notifications/openFromToast",
                                 static_cast<int>(ToastReaction::OpenInBrowser)};

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -674,7 +674,11 @@ void Window::addShortcuts()
 
              return "";
          }},
-    };
+        {"toggleGlobalNotificationSuppression",
+         [](const std::vector<QString> &) -> QString {
+             getSettings()->globallySuppressNotifications = true;
+             return "";
+         }}};
 
     this->addDebugStuff(actions);
 


### PR DESCRIPTION
This PR aims to implement global suppression of highlight notifications through a "Do Not Disturb"-like feature. I wanted to get this out of my head before I lost interest in it.

TODO:
- [ ] Allow for separate key binds to toggle on/off (just through arguments)
- [ ] Implement notebook tab/split header toggle
- [ ] Add some kind of visual indicator (might de-scope, will discuss)

Fixes #5628.