### PR TITLE
fix: only unpause if a selected page exists

### DIFF
--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -113,25 +113,21 @@ bool Window::event(QEvent *event)
         }
 
         case QEvent::WindowDeactivate: {
-            for (const auto &split :
-                 this->notebook_->getSelectedPage()->getSplits())
-            {
-                split->unpause();
-            }
-
             auto *page = this->notebook_->getSelectedPage();
 
-            if (page != nullptr)
+            if (!page)
             {
-                std::vector<Split *> splits = page->getSplits();
-
-                for (Split *split : splits)
-                {
-                    split->updateLastReadMessage();
-                }
-
-                page->hideResizeHandles();
+                break;
             }
+
+            std::vector<Split *> splits = page->getSplits();
+            for (Split *split : splits)
+            {
+                split->unpause();
+                split->updateLastReadMessage();
+            }
+
+            page->hideResizeHandles();
         }
         break;
 


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

The selected page can be `nullptr`. Unfocusing a window without any tabs would segfault.

Fixes #5636.