### PR TITLE
Add skip-clang-tidy feature

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   review:
-    if: contains(github.event.pull_request.labels.*.name, 'skip-clang-tidy')
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-clang-tidy') }}
     name: "clang-tidy ${{ matrix.os }}, Qt ${{ matrix.qt-version }})"
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -10,6 +10,7 @@ concurrency:
 
 jobs:
   review:
+    if: contains(github.event.pull_request.labels.*.name, 'skip-clang-tidy')
     name: "clang-tidy ${{ matrix.os }}, Qt ${{ matrix.qt-version }})"
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
Allows to skip clang-tidy workflow.