### PR TITLE
feat: Print proxy URL information in `/debug-env` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 - Minor: The emote popup now reloads when Twitch emotes are reloaded. (#5580)
 - Minor: Added `--login <username>` CLI argument to specify which account to start logged in as. (#5626)
 - Minor: Indicate when subscriptions and resubscriptions are for multiple months. (#5642)
-- Minor: Print proxy URL information in `/debug-env` command (#5648)
+- Minor: Proxy URL information is now included in the `/debug-env` command. (#5648)
 - Bugfix: Fixed tab move animation occasionally failing to start after closing a tab. (#5426, #5612)
 - Bugfix: If a network request errors with 200 OK, Qt's error code is now reported instead of the HTTP status. (#5378)
 - Bugfix: Fixed restricted users usernames not being clickable. (#5405)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Minor: The emote popup now reloads when Twitch emotes are reloaded. (#5580)
 - Minor: Added `--login <username>` CLI argument to specify which account to start logged in as. (#5626)
 - Minor: Indicate when subscriptions and resubscriptions are for multiple months. (#5642)
+- Minor: Print proxy URL information in `/debug-env` command (#5648)
 - Bugfix: Fixed tab move animation occasionally failing to start after closing a tab. (#5426, #5612)
 - Bugfix: If a network request errors with 200 OK, Qt's error code is now reported instead of the HTTP status. (#5378)
 - Bugfix: Fixed restricted users usernames not being clickable. (#5405)

--- a/src/controllers/commands/builtin/chatterino/Debugging.cpp
+++ b/src/controllers/commands/builtin/chatterino/Debugging.cpp
@@ -79,6 +79,7 @@ QString listEnvironmentVariables(const CommandContext &ctx)
     QStringList debugMessages{
         "recentMessagesApiUrl: " + env.recentMessagesApiUrl,
         "linkResolverUrl: " + env.linkResolverUrl,
+        "proxyUrl: " + env.proxyUrl.value_or("N/A"),
         "twitchServerHost: " + env.twitchServerHost,
         "twitchServerPort: " + QString::number(env.twitchServerPort),
         "twitchServerSecure: " + QString::number(env.twitchServerSecure),


### PR DESCRIPTION
- Fixes #5640 
- The proxy url gets printed as: "proxyUrl: N/A" if it is empty

<img width="588" alt="image" src="https://github.com/user-attachments/assets/416f636a-d06a-4ed7-8cd6-188c75801b5b">
