### PR TITLE
fix: animate emotes when overlay is open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Major: Add option to show pronouns in user card. (#5442, #5583)
 - Major: Release plugins alpha. (#5288)
 - Major: Improve high-DPI support on Windows. (#4868, #5391)
-- Major: Added transparent overlay window (default keybind: <kbd>CTRL</kbd> + <kbd>ALT</kbd> + <kbd>N</kbd>). (#4746, #5643)
+- Major: Added transparent overlay window (default keybind: <kbd>CTRL</kbd> + <kbd>ALT</kbd> + <kbd>N</kbd>). (#4746, #5643, #5659)
 - Minor: Removed the Ctrl+Shift+L hotkey for toggling the "live only" tab visibility state. (#5530)
 - Minor: Add support for Shared Chat messages. Shared chat messages can be filtered with the `flags.shared` filter variable, or with search using `is:shared`. Some messages like subscriptions are filtered on purpose to avoid confusion for the broadcaster. If you have both channels participating in Shared Chat open, only one of the message triggering your highlight will trigger. (#5606, #5625)
 - Minor: Moved tab visibility control to a submenu, without any toggle actions. (#5530)

--- a/src/singletons/helper/GifTimer.cpp
+++ b/src/singletons/helper/GifTimer.cpp
@@ -26,6 +26,7 @@ void GIFTimer::initialize()
 
     QObject::connect(&this->timer, &QTimer::timeout, [this] {
         if (getSettings()->animationsWhenFocused &&
+            this->openOverlayWindows_ == 0 &&
             QApplication::activeWindow() == nullptr)
         {
             return;

--- a/src/singletons/helper/GifTimer.hpp
+++ b/src/singletons/helper/GifTimer.hpp
@@ -18,9 +18,21 @@ public:
         return this->position_;
     }
 
+    void registerOpenOverlayWindow()
+    {
+        this->openOverlayWindows_++;
+    }
+
+    void unregisterOpenOverlayWindow()
+    {
+        assert(this->openOverlayWindows_ >= 1);
+        this->openOverlayWindows_--;
+    }
+
 private:
     QTimer timer;
     long unsigned position_{};
+    size_t openOverlayWindows_ = 0;
 };
 
 }  // namespace chatterino

--- a/src/widgets/OverlayWindow.cpp
+++ b/src/widgets/OverlayWindow.cpp
@@ -4,6 +4,7 @@
 #include "common/FlagsEnum.hpp"
 #include "common/Literals.hpp"
 #include "controllers/hotkeys/HotkeyController.hpp"
+#include "singletons/Emotes.hpp"
 #include "singletons/Settings.hpp"
 #include "singletons/WindowManager.hpp"
 #include "widgets/BaseWidget.hpp"
@@ -166,6 +167,7 @@ OverlayWindow::OverlayWindow(IndirectChannel channel,
 
     this->addShortcuts();
     this->triggerFirstActivation();
+    getApp()->getEmotes()->getGIFTimer().registerOpenOverlayWindow();
 }
 
 OverlayWindow::~OverlayWindow()
@@ -173,6 +175,7 @@ OverlayWindow::~OverlayWindow()
 #ifdef Q_OS_WIN
     ::DestroyCursor(this->sizeAllCursor_);
 #endif
+    getApp()->getEmotes()->getGIFTimer().unregisterOpenOverlayWindow();
 }
 
 void OverlayWindow::applyTheme()


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

This will animate emotes if an overlay window is open even if the "animate only when Chatterino is focused" setting is on. This will also animate emotes in the other open windows, but that's due to the design of animated emotes in Chatterino (i.e. we can't control if emotes are animated for a specific view/window).
