### PR TITLE
fix: invalidate buffers on `WM_DPICHANGED`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Major: Add option to show pronouns in user card. (#5442, #5583)
 - Major: Release plugins alpha. (#5288)
-- Major: Improve high-DPI support on Windows. (#4868, #5391)
+- Major: Improve high-DPI support on Windows. (#4868, #5391, #5664)
 - Major: Added transparent overlay window (default keybind: <kbd>CTRL</kbd> + <kbd>ALT</kbd> + <kbd>N</kbd>). (#4746, #5643, #5659)
 - Minor: Removed the Ctrl+Shift+L hotkey for toggling the "live only" tab visibility state. (#5530)
 - Minor: Add support for Shared Chat messages. Shared chat messages can be filtered with the `flags.shared` filter variable, or with search using `is:shared`. Some messages like subscriptions are filtered on purpose to avoid confusion for the broadcaster. If you have both channels participating in Shared Chat open, only one of the message triggering your highlight will trigger. (#5606, #5625)

--- a/src/widgets/BaseWindow.cpp
+++ b/src/widgets/BaseWindow.cpp
@@ -876,6 +876,14 @@ bool BaseWindow::nativeEvent(const QByteArray &eventType, void *message,
         }
         break;
 
+        case WM_DPICHANGED: {
+            // wait for Qt to process this message
+            postToThread([] {
+                getApp()->getWindows()->invalidateChannelViewBuffers();
+            });
+        }
+        break;
+
         case WM_NCLBUTTONDOWN:
         case WM_NCLBUTTONUP: {
             // WM_NCLBUTTON{DOWN, UP} gets called when the left mouse button


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->


Our `ChannelView`s don't notice when the DPI changes, so we have to reset their buffers when the DPI changes. However, we have to wait for Qt to process the event. This might do a bit too much (if multiple windows are open), but shouldn't be too heavy, since it only does that once.