### PR TITLE
fix: use static version of 7tv badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 - Bugfix: Fixed event emotes not showing up in autocomplete and popups. (#5239, #5580, #5582, #5632)
 - Bugfix: Fixed tab visibility being controllable in the emote popup. (#5530)
 - Bugfix: Fixed account switch not being saved if no other settings were changed. (#5558)
+- Bugfix: Fixed 7TV badges being inadvertently animated. (#5674)
 - Bugfix: Fixed some tooltips not being readable. (#5578)
 - Bugfix: Fixed log files being locked longer than needed. (#5592)
 - Bugfix: Fixed global badges not showing in anonymous mode. (#5599)

--- a/src/providers/seventv/SeventvBadges.cpp
+++ b/src/providers/seventv/SeventvBadges.cpp
@@ -59,7 +59,7 @@ void SeventvBadges::registerBadge(const QJsonObject &badgeJson)
 
     auto emote = Emote{
         .name = EmoteName{},
-        .images = SeventvEmotes::createImageSet(badgeJson),
+        .images = SeventvEmotes::createImageSet(badgeJson, true),
         .tooltip = Tooltip{badgeJson["tooltip"].toString()},
         .homePage = Url{},
         .id = EmoteId{badgeID},

--- a/src/providers/seventv/SeventvEmotes.hpp
+++ b/src/providers/seventv/SeventvEmotes.hpp
@@ -153,8 +153,10 @@ public:
      * Creates an image set from a 7TV emote or badge.
      *
      * @param emoteData { host: { files: [], url } }
+     * @param useStatic use static version if possible
      */
-    static ImageSet createImageSet(const QJsonObject &emoteData);
+    static ImageSet createImageSet(const QJsonObject &emoteData,
+                                   bool useStatic);
 
 private:
     Atomic<std::shared_ptr<const EmoteMap>> global_;


### PR DESCRIPTION
webp versions of badges are now animated, which was not the intent when they were originally included

we now use the `static_name` field in the badge response to use the static version of the badge

Fixes #5673