### PR TITLE
fix: escape 7TV emote names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 - Bugfix: Fixed incorrect message being disabled in some cases upon approving or denying an automod caught message. (#5611)
 - Bugfix: Fixed double-click selection not working when clicking outside a message. (#5617)
 - Bugfix: Fixed emotes starting with ":" not tab-completing. (#5603)
+- Bugfix: Fixed 7TV emotes messing with Qt's HTML. (#5677)
 - Dev: Update Windows build from Qt 6.5.0 to Qt 6.7.1. (#5420)
 - Dev: Update vcpkg build Qt from 6.5.0 to 6.7.0, boost from 1.83.0 to 1.85.0, openssl from 3.1.3 to 3.3.0. (#5422)
 - Dev: Unsingletonize `ISoundController`. (#5462)

--- a/src/providers/seventv/SeventvEmotes.cpp
+++ b/src/providers/seventv/SeventvEmotes.cpp
@@ -79,7 +79,8 @@ bool isZeroWidthRecommended(const QJsonObject &emoteData)
 Tooltip createTooltip(const QString &name, const QString &author, bool isGlobal)
 {
     return Tooltip{QString("%1<br>%2 7TV Emote<br>By: %3")
-                       .arg(name, isGlobal ? "Global" : "Channel",
+                       .arg(name.toHtmlEscaped(),
+                            isGlobal ? "Global" : "Channel",
                             author.isEmpty() ? "<deleted>" : author)};
 }
 
@@ -87,7 +88,8 @@ Tooltip createAliasedTooltip(const QString &name, const QString &baseName,
                              const QString &author, bool isGlobal)
 {
     return Tooltip{QString("%1<br>Alias of %2<br>%3 7TV Emote<br>By: %4")
-                       .arg(name, baseName, isGlobal ? "Global" : "Channel",
+                       .arg(name.toHtmlEscaped(), baseName.toHtmlEscaped(),
+                            isGlobal ? "Global" : "Channel",
                             author.isEmpty() ? "<deleted>" : author)};
 }
 


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

7TV emotes allow `<` and `>` now, so we need to escape the names. 