### PR TITLE
refactor: deduplicate IRC parsing

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,6 +39,7 @@ set(SOURCE_FILES
         common/WindowDescriptors.cpp
         common/WindowDescriptors.hpp
 
+        common/enums/MessageContext.hpp
         common/enums/MessageOverflow.hpp
 
         common/network/NetworkCommon.cpp
@@ -281,6 +282,9 @@ set(SOURCE_FILES
         messages/MessageElement.cpp
         messages/MessageElement.hpp
         messages/MessageFlag.hpp
+        messages/MessageSimilarity.cpp
+        messages/MessageSimilarity.hpp
+        messages/MessageSink.hpp
         messages/MessageThread.cpp
         messages/MessageThread.hpp
 
@@ -526,6 +530,8 @@ set(SOURCE_FILES
         util/Twitch.hpp
         util/TypeName.hpp
         util/Variant.hpp
+        util/VectorMessageSink.cpp
+        util/VectorMessageSink.hpp
         util/WidgetHelpers.cpp
         util/WidgetHelpers.hpp
         util/WindowsHelper.cpp

--- a/src/common/Channel.cpp
+++ b/src/common/Channel.cpp
@@ -3,7 +3,9 @@
 #include "Application.hpp"
 #include "messages/Message.hpp"
 #include "messages/MessageBuilder.hpp"
+#include "messages/MessageSimilarity.hpp"
 #include "providers/twitch/IrcMessageHandler.hpp"
+#include "providers/twitch/TwitchIrcServer.hpp"
 #include "singletons/Emotes.hpp"
 #include "singletons/Logging.hpp"
 #include "singletons/Settings.hpp"
@@ -121,10 +123,10 @@ void Channel::addSystemMessage(const QString &contents)
     this->addMessage(msg, MessageContext::Original);
 }
 
-void Channel::addOrReplaceTimeout(MessagePtr message)
+void Channel::addOrReplaceTimeout(MessagePtr message, QTime now)
 {
     addOrReplaceChannelTimeout(
-        this->getMessageSnapshot(), std::move(message), QTime::currentTime(),
+        this->getMessageSnapshot(), std::move(message), now,
         [this](auto /*idx*/, auto msg, auto replacement) {
             this->replaceMessage(msg, replacement);
         },
@@ -288,9 +290,14 @@ void Channel::clearMessages()
 
 MessagePtr Channel::findMessage(QString messageID)
 {
+    return this->findMessageByID(messageID);
+}
+
+MessagePtr Channel::findMessageByID(QStringView messageID)
+{
     MessagePtr res;
 
-    if (auto msg = this->messages_.rfind([&messageID](const MessagePtr &msg) {
+    if (auto msg = this->messages_.rfind([messageID](const MessagePtr &msg) {
             return msg->id == messageID;
         });
         msg)
@@ -299,6 +306,19 @@ MessagePtr Channel::findMessage(QString messageID)
     }
 
     return res;
+}
+
+void Channel::applySimilarityFilters(const MessagePtr &message) const
+{
+    setSimilarityFlags(message, this->messages_.getSnapshot());
+}
+
+MessageSinkTraits Channel::sinkTraits() const
+{
+    return {
+        MessageSinkTrait::AddMentionsToGlobalChannel,
+        MessageSinkTrait::RequiresKnownChannelPointReward,
+    };
 }
 
 bool Channel::canSendMessage() const

--- a/src/common/enums/MessageContext.hpp
+++ b/src/common/enums/MessageContext.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace chatterino {
+
+/// Context of the message being added to a channel
+enum class MessageContext {
+    /// This message is the original
+    Original,
+    /// This message is a repost of a message that has already been added in a channel
+    Repost,
+};
+
+}  // namespace chatterino

--- a/src/messages/MessageSimilarity.cpp
+++ b/src/messages/MessageSimilarity.cpp
@@ -1,0 +1,51 @@
+#include "messages/MessageSimilarity.hpp"
+
+#include <algorithm>
+#include <vector>
+
+namespace chatterino::similarity::detail {
+
+float relativeSimilarity(QStringView str1, QStringView str2)
+{
+    using SizeType = QStringView::size_type;
+
+    // Longest Common Substring Problem
+    std::vector<std::vector<int>> tree(str1.size(),
+                                       std::vector<int>(str2.size(), 0));
+    int z = 0;
+
+    for (SizeType i = 0; i < str1.size(); ++i)
+    {
+        for (SizeType j = 0; j < str2.size(); ++j)
+        {
+            if (str1[i] == str2[j])
+            {
+                if (i == 0 || j == 0)
+                {
+                    tree[i][j] = 1;
+                }
+                else
+                {
+                    tree[i][j] = tree[i - 1][j - 1] + 1;
+                }
+                z = std::max(tree[i][j], z);
+            }
+            else
+            {
+                tree[i][j] = 0;
+            }
+        }
+    }
+
+    // ensure that no div by 0
+    if (z == 0)
+    {
+        return 0.F;
+    }
+
+    auto div = std::max<>({static_cast<SizeType>(1), str1.size(), str2.size()});
+
+    return float(z) / float(div);
+}
+
+}  // namespace chatterino::similarity::detail

--- a/src/messages/MessageSimilarity.hpp
+++ b/src/messages/MessageSimilarity.hpp
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "Application.hpp"
+#include "controllers/accounts/AccountController.hpp"
+#include "messages/Message.hpp"
+#include "providers/twitch/TwitchAccount.hpp"
+#include "singletons/Settings.hpp"
+
+#include <ranges>
+
+namespace chatterino::similarity::detail {
+
+float relativeSimilarity(QStringView str1, QStringView str2);
+
+float inMessages(const MessagePtr &msg,
+                 const std::ranges::bidirectional_range auto &messages)
+{
+    float similarityPercent = 0.0F;
+
+    for (const auto &prevMsg :
+         messages | std::views::reverse |
+             std::views::take(getSettings()->hideSimilarMaxMessagesToCheck))
+    {
+        if (prevMsg->parseTime.secsTo(QTime::currentTime()) >=
+            getSettings()->hideSimilarMaxDelay)
+        {
+            break;
+        }
+        if (getSettings()->hideSimilarBySameUser &&
+            msg->loginName != prevMsg->loginName)
+        {
+            continue;
+        }
+        similarityPercent = std::max(
+            similarityPercent,
+            relativeSimilarity(msg->messageText, prevMsg->messageText));
+    }
+
+    return similarityPercent;
+}
+
+}  // namespace chatterino::similarity::detail
+
+namespace chatterino {
+
+void setSimilarityFlags(const MessagePtr &message,
+                        const std::ranges::bidirectional_range auto &messages)
+{
+    if (getSettings()->similarityEnabled)
+    {
+        bool isMyself =
+            message->loginName ==
+            getApp()->getAccounts()->twitch.getCurrent()->getUserName();
+        bool hideMyself = getSettings()->hideSimilarMyself;
+
+        if (isMyself && !hideMyself)
+        {
+            return;
+        }
+
+        if (similarity::detail::inMessages(message, messages) >
+            getSettings()->similarityPercentage)
+        {
+            message->flags.set(MessageFlag::Similar);
+            if (getSettings()->colorSimilarDisabled)
+            {
+                message->flags.set(MessageFlag::Disabled);
+            }
+        }
+    }
+}
+
+}  // namespace chatterino

--- a/src/messages/MessageSink.hpp
+++ b/src/messages/MessageSink.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "common/enums/MessageContext.hpp"
+#include "messages/MessageFlag.hpp"
+
+#include <memory>
+
+class QStringView;
+class QTime;
+
+namespace chatterino {
+
+struct Message;
+using MessagePtr = std::shared_ptr<const Message>;
+
+enum class MessageSinkTrait : uint8_t {
+    None = 0,
+    AddMentionsToGlobalChannel = 1 << 0,
+    RequiresKnownChannelPointReward = 1 << 1,
+};
+using MessageSinkTraits = FlagsEnum<MessageSinkTrait>;
+
+/// A generic interface for a managed buffer of `Message`s
+class MessageSink
+{
+public:
+    virtual ~MessageSink() = default;
+
+    /// Add a message to this sink
+    ///
+    /// @param message The message to add (non-null)
+    /// @param ctx The context in which this message is being added.
+    /// @param overridingFlags
+    virtual void addMessage(
+        MessagePtr message, MessageContext ctx,
+        std::optional<MessageFlags> overridingFlags = std::nullopt) = 0;
+
+    /// Adds a timeout message or merges it into an existing one
+    virtual void addOrReplaceTimeout(MessagePtr clearchatMessage,
+                                     QTime now) = 0;
+
+    /// Flags all messages as `Disabled`
+    virtual void disableAllMessages() = 0;
+
+    /// Searches for similar messages and flags this message as similar
+    /// (based on the current settings).
+    virtual void applySimilarityFilters(const MessagePtr &message) const = 0;
+
+    /// @brief Searches for a message by an ID
+    ///
+    /// If there is no message found, an empty shared-pointer is returned.
+    virtual MessagePtr findMessageByID(QStringView id) = 0;
+
+    ///
+    virtual MessageSinkTraits sinkTraits() const = 0;
+};
+
+}  // namespace chatterino

--- a/src/providers/recentmessages/Impl.cpp
+++ b/src/providers/recentmessages/Impl.cpp
@@ -3,7 +3,9 @@
 #include "common/Env.hpp"
 #include "messages/MessageBuilder.hpp"
 #include "providers/twitch/IrcMessageHandler.hpp"
+#include "providers/twitch/TwitchChannel.hpp"
 #include "util/Helpers.hpp"
+#include "util/VectorMessageSink.hpp"
 
 #include <QJsonArray>
 #include <QUrlQuery>
@@ -40,7 +42,13 @@ std::vector<Communi::IrcMessage *> parseRecentMessages(
 std::vector<MessagePtr> buildRecentMessages(
     std::vector<Communi::IrcMessage *> &messages, Channel *channel)
 {
-    std::vector<MessagePtr> allBuiltMessages;
+    VectorMessageSink sink({}, MessageFlag::RecentMessage);
+
+    auto *twitchChannel = dynamic_cast<TwitchChannel *>(channel);
+    if (!twitchChannel)
+    {
+        return {};
+    }
 
     for (auto *message : messages)
     {
@@ -58,24 +66,16 @@ std::vector<MessagePtr> buildRecentMessages(
                 auto msg = makeSystemMessage(
                     QLocale().toString(msgDate, QLocale::LongFormat),
                     QTime(0, 0));
-                msg->flags.set(MessageFlag::RecentMessage);
-                allBuiltMessages.emplace_back(msg);
+                sink.addMessage(msg, MessageContext::Original);
             }
         }
 
-        auto builtMessages = IrcMessageHandler::parseMessageWithReply(
-            channel, message, allBuiltMessages);
-
-        for (const auto &builtMessage : builtMessages)
-        {
-            builtMessage->flags.set(MessageFlag::RecentMessage);
-            allBuiltMessages.emplace_back(builtMessage);
-        }
+        IrcMessageHandler::parseMessageInto(message, sink, twitchChannel);
 
         message->deleteLater();
     }
 
-    return allBuiltMessages;
+    return std::move(sink).takeMessages();
 }
 
 // Returns the URL to be used for querying the Recent Messages API for the

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -7,24 +7,21 @@
 #include "common/QLogging.hpp"
 #include "controllers/accounts/AccountController.hpp"
 #include "controllers/ignores/IgnoreController.hpp"
-#include "messages/LimitedQueue.hpp"
 #include "messages/Link.hpp"
 #include "messages/Message.hpp"
 #include "messages/MessageBuilder.hpp"
 #include "messages/MessageColor.hpp"
 #include "messages/MessageElement.hpp"
+#include "messages/MessageSink.hpp"
 #include "messages/MessageThread.hpp"
-#include "providers/twitch/ChannelPointReward.hpp"
 #include "providers/twitch/TwitchAccount.hpp"
 #include "providers/twitch/TwitchAccountManager.hpp"
 #include "providers/twitch/TwitchChannel.hpp"
 #include "providers/twitch/TwitchHelpers.hpp"
 #include "providers/twitch/TwitchIrcServer.hpp"
-#include "singletons/Resources.hpp"
 #include "singletons/Settings.hpp"
 #include "singletons/StreamerMode.hpp"
 #include "singletons/WindowManager.hpp"
-#include "util/ChannelHelpers.hpp"
 #include "util/FormatTime.hpp"
 #include "util/Helpers.hpp"
 #include "util/IrcHelpers.hpp"
@@ -34,7 +31,6 @@
 #include <QStringBuilder>
 
 #include <memory>
-#include <unordered_set>
 
 using namespace chatterino::literals;
 
@@ -165,50 +161,6 @@ ChannelPtr channelOrEmptyByTarget(const QString &target,
     return server.getChannelOrEmpty(channelName);
 }
 
-float relativeSimilarity(const QString &str1, const QString &str2)
-{
-    // Longest Common Substring Problem
-    std::vector<std::vector<int>> tree(str1.size(),
-                                       std::vector<int>(str2.size(), 0));
-    int z = 0;
-
-    for (int i = 0; i < str1.size(); ++i)
-    {
-        for (int j = 0; j < str2.size(); ++j)
-        {
-            if (str1[i] == str2[j])
-            {
-                if (i == 0 || j == 0)
-                {
-                    tree[i][j] = 1;
-                }
-                else
-                {
-                    tree[i][j] = tree[i - 1][j - 1] + 1;
-                }
-                if (tree[i][j] > z)
-                {
-                    z = tree[i][j];
-                }
-            }
-            else
-            {
-                tree[i][j] = 0;
-            }
-        }
-    }
-
-    // ensure that no div by 0
-    if (z == 0)
-    {
-        return 0.F;
-    }
-
-    auto div = std::max<int>(1, std::max(str1.size(), str2.size()));
-
-    return float(z) / float(div);
-}
-
 QMap<QString, QString> parseBadges(const QString &badgesString)
 {
     QMap<QString, QString> badges;
@@ -231,106 +183,6 @@ struct ReplyContext {
     std::shared_ptr<MessageThread> thread;
     MessagePtr parent;
 };
-
-[[nodiscard]] ReplyContext getReplyContext(
-    TwitchChannel *channel, Communi::IrcMessage *message,
-    const std::vector<MessagePtr> &otherLoaded)
-{
-    ReplyContext ctx;
-
-    const auto &tags = message->tags();
-    if (const auto it = tags.find("reply-thread-parent-msg-id");
-        it != tags.end())
-    {
-        const QString replyID = it.value().toString();
-        auto threadIt = channel->threads().find(replyID);
-        std::shared_ptr<MessageThread> rootThread;
-        if (threadIt != channel->threads().end())
-        {
-            auto owned = threadIt->second.lock();
-            if (owned)
-            {
-                // Thread already exists (has a reply)
-                checkThreadSubscription(tags, message->nick(), owned);
-                ctx.thread = owned;
-                rootThread = owned;
-            }
-        }
-
-        if (!rootThread)
-        {
-            MessagePtr foundMessage;
-
-            // Thread does not yet exist, find root reply and create thread.
-            // Linear search is justified by the infrequent use of replies
-            for (const auto &otherMsg : otherLoaded)
-            {
-                if (otherMsg->id == replyID)
-                {
-                    // Found root reply message
-                    foundMessage = otherMsg;
-                    break;
-                }
-            }
-
-            if (!foundMessage)
-            {
-                // We didn't find the reply root message in the otherLoaded messages
-                // which are typically the already-parsed recent messages from the
-                // Recent Messages API. We could have a really old message that
-                // still exists being replied to, so check for that here.
-                foundMessage = channel->findMessage(replyID);
-            }
-
-            if (foundMessage)
-            {
-                std::shared_ptr<MessageThread> newThread =
-                    std::make_shared<MessageThread>(foundMessage);
-                checkThreadSubscription(tags, message->nick(), newThread);
-
-                ctx.thread = newThread;
-                rootThread = newThread;
-                // Store weak reference to thread in channel
-                channel->addReplyThread(newThread);
-            }
-        }
-
-        if (const auto parentIt = tags.find("reply-parent-msg-id");
-            parentIt != tags.end())
-        {
-            const QString parentID = parentIt.value().toString();
-            if (replyID == parentID)
-            {
-                if (rootThread)
-                {
-                    ctx.parent = rootThread->root();
-                }
-            }
-            else
-            {
-                auto parentThreadIt = channel->threads().find(parentID);
-                if (parentThreadIt != channel->threads().end())
-                {
-                    auto thread = parentThreadIt->second.lock();
-                    if (thread)
-                    {
-                        ctx.parent = thread->root();
-                    }
-                }
-                else
-                {
-                    auto parent = channel->findMessage(parentID);
-                    if (parent)
-                    {
-                        ctx.parent = parent;
-                    }
-                }
-            }
-        }
-    }
-
-    return ctx;
-}
 
 std::optional<ClearChatMessage> parseClearChatMessage(
     Communi::IrcMessage *message)
@@ -370,9 +222,9 @@ std::optional<ClearChatMessage> parseClearChatMessage(
 }
 
 /**
- * Parse a single IRC NOTICE message into 0 or more Chatterino messages
+ * Parse a single IRC NOTICE message into a Chatterino message
  **/
-std::vector<MessagePtr> parseNoticeMessage(Communi::IrcNoticeMessage *message)
+MessagePtr parseNoticeMessage(Communi::IrcNoticeMessage *message)
 {
     assert(message != nullptr);
 
@@ -400,7 +252,7 @@ std::vector<MessagePtr> parseNoticeMessage(Communi::IrcNoticeMessage *message)
                                   linkColor)
             ->setLink(accountsLink);
 
-        return {builder.release()};
+        return builder.release();
     }
 
     if (message->content().startsWith("You are permanently banned "))
@@ -410,256 +262,19 @@ std::vector<MessagePtr> parseNoticeMessage(Communi::IrcNoticeMessage *message)
 
     if (message->tags().value("msg-id") == "msg_timedout")
     {
-        std::vector<MessagePtr> builtMessage;
-
         QString remainingTime =
             formatTime(message->content().split(" ").value(5));
         QString formattedMessage =
             QString("You are timed out for %1.")
                 .arg(remainingTime.isEmpty() ? "0s" : remainingTime);
 
-        builtMessage.emplace_back(makeSystemMessage(
-            formattedMessage, calculateMessageTime(message).time()));
-
-        return builtMessage;
+        return makeSystemMessage(formattedMessage,
+                                 calculateMessageTime(message).time());
     }
 
     // default case
-    std::vector<MessagePtr> builtMessages;
-
-    builtMessages.emplace_back(makeSystemMessage(
-        message->content(), calculateMessageTime(message).time()));
-
-    return builtMessages;
-}
-
-/**
- * Parse a single IRC USERNOTICE message into 0 or more Chatterino messages
- **/
-std::vector<MessagePtr> parseUserNoticeMessage(Channel *channel,
-                                               Communi::IrcMessage *message)
-{
-    assert(channel != nullptr);
-    assert(message != nullptr);
-
-    std::vector<MessagePtr> builtMessages;
-
-    auto tags = message->tags();
-    auto parameters = message->parameters();
-
-    QString msgType = tags.value("msg-id").toString();
-    bool mirrored = msgType == "sharedchatnotice";
-    if (mirrored)
-    {
-        msgType = tags.value("source-msg-id").toString();
-    }
-    else
-    {
-        auto rIt = tags.find("room-id");
-        auto sIt = tags.find("source-room-id");
-        if (rIt != tags.end() && sIt != tags.end())
-        {
-            mirrored = rIt.value().toString() != sIt.value().toString();
-        }
-    }
-
-    if (mirrored && msgType != "announcement")
-    {
-        // avoid confusing broadcasters with user payments to other channels
-        return {};
-    }
-
-    QString content;
-    if (parameters.size() >= 2)
-    {
-        content = parameters[1];
-    }
-
-    if (isIgnoredMessage({
-            .message = content,
-            .twitchUserID = tags.value("user-id").toString(),
-            .isMod = channel->isMod(),
-            .isBroadcaster = channel->isBroadcaster(),
-        }))
-    {
-        return {};
-    }
-
-    if (SPECIAL_MESSAGE_TYPES.contains(msgType))
-    {
-        // Messages are not required, so they might be empty
-        if (!content.isEmpty())
-        {
-            MessageParseArgs args;
-            args.trimSubscriberUsername = true;
-            args.allowIgnore = false;
-
-            auto [built, highlight] = MessageBuilder::makeIrcMessage(
-                channel, message, args, content, 0);
-            if (built)
-            {
-                built->flags.set(MessageFlag::Subscription);
-                built->flags.unset(MessageFlag::Highlighted);
-                if (mirrored)
-                {
-                    built->flags.set(MessageFlag::SharedMessage);
-                }
-                builtMessages.emplace_back(std::move(built));
-            }
-        }
-    }
-
-    auto it = tags.find("system-msg");
-
-    if (it != tags.end())
-    {
-        // By default, we return value of system-msg tag
-        QString messageText = it.value().toString();
-
-        if (msgType == "bitsbadgetier")
-        {
-            messageText =
-                QString("%1 just earned a new %2 Bits badge!")
-                    .arg(tags.value("display-name").toString(),
-                         kFormatNumbers(
-                             tags.value("msg-param-threshold").toInt()));
-        }
-        else if (msgType == "announcement")
-        {
-            messageText = "Announcement";
-        }
-        else if (msgType == "raid")
-        {
-            auto login = tags.value("login").toString();
-            auto displayName = tags.value("msg-param-displayName").toString();
-
-            if (!login.isEmpty() && !displayName.isEmpty())
-            {
-                MessageColor color = MessageColor::System;
-                if (auto colorTag = tags.value("color").value<QColor>();
-                    colorTag.isValid())
-                {
-                    color = MessageColor(colorTag);
-                }
-
-                auto b = MessageBuilder(
-                    raidEntryMessage, parseTagString(messageText), login,
-                    displayName, color, calculateMessageTime(message).time());
-
-                b->flags.set(MessageFlag::Subscription);
-                if (mirrored)
-                {
-                    b->flags.set(MessageFlag::SharedMessage);
-                }
-
-                auto newMessage = b.release();
-                builtMessages.emplace_back(newMessage);
-                return builtMessages;
-            }
-        }
-        else if (msgType == "subgift")
-        {
-            if (auto monthsIt = tags.find("msg-param-gift-months");
-                monthsIt != tags.end())
-            {
-                int months = monthsIt.value().toInt();
-                if (months > 1)
-                {
-                    auto plan = tags.value("msg-param-sub-plan").toString();
-                    QString name =
-                        ANONYMOUS_GIFTER_ID == tags.value("user-id").toString()
-                            ? "An anonymous user"
-                            : tags.value("display-name").toString();
-                    messageText =
-                        QString("%1 gifted %2 months of a Tier %3 sub to %4!")
-                            .arg(name, QString::number(months),
-                                 plan.isEmpty() ? '1' : plan.at(0),
-                                 tags.value("msg-param-recipient-display-name")
-                                     .toString());
-
-                    if (auto countIt = tags.find("msg-param-sender-count");
-                        countIt != tags.end())
-                    {
-                        int count = countIt.value().toInt();
-                        if (count > months)
-                        {
-                            messageText +=
-                                QString(
-                                    " They've gifted %1 months in the channel.")
-                                    .arg(QString::number(count));
-                        }
-                    }
-                }
-            }
-        }
-        else if (msgType == "sub" || msgType == "resub")
-        {
-            if (auto tenure = tags.find("msg-param-multimonth-tenure");
-                tenure != tags.end() && tenure.value().toInt() == 0)
-            {
-                int months =
-                    tags.value("msg-param-multimonth-duration").toInt();
-                if (months > 1)
-                {
-                    int tier = tags.value("msg-param-sub-plan").toInt() / 1000;
-                    messageText =
-                        QString(
-                            "%1 subscribed at Tier %2 for %3 months in advance")
-                            .arg(tags.value("display-name").toString(),
-                                 QString::number(tier),
-                                 QString::number(months));
-                    if (msgType == "resub")
-                    {
-                        int cumulative =
-                            tags.value("msg-param-cumulative-months").toInt();
-                        messageText +=
-                            QString(", reaching %1 months cumulatively so far!")
-                                .arg(QString::number(cumulative));
-                    }
-                    else
-                    {
-                        messageText += "!";
-                    }
-                }
-            }
-        }
-
-        auto b = MessageBuilder(systemMessage, parseTagString(messageText),
-                                calculateMessageTime(message).time());
-        b->flags.set(MessageFlag::Subscription);
-        if (mirrored)
-        {
-            b->flags.set(MessageFlag::SharedMessage);
-        }
-
-        auto newMessage = b.release();
-        builtMessages.emplace_back(newMessage);
-    }
-
-    return builtMessages;
-}
-
-/**
- * Parse a single IRC PRIVMSG into 0-1 Chatterino messages
- */
-std::vector<MessagePtr> parsePrivMessage(Channel *channel,
-                                         Communi::IrcPrivateMessage *message)
-{
-    assert(channel != nullptr);
-    assert(message != nullptr);
-
-    std::vector<MessagePtr> builtMessages;
-    MessageParseArgs args;
-    args.isAction = message->isAction();
-    auto [built, alert] = MessageBuilder::makeIrcMessage(channel, message, args,
-                                                         message->content(), 0);
-    if (built)
-    {
-        builtMessages.emplace_back(std::move(built));
-        MessageBuilder::triggerHighlights(channel, alert);
-    }
-
-    return builtMessages;
+    return makeSystemMessage(message->content(),
+                             calculateMessageTime(message).time());
 }
 
 }  // namespace
@@ -674,65 +289,27 @@ IrcMessageHandler &IrcMessageHandler::instance()
     return instance;
 }
 
-std::vector<MessagePtr> IrcMessageHandler::parseMessageWithReply(
-    Channel *channel, Communi::IrcMessage *message,
-    std::vector<MessagePtr> &otherLoaded)
+void IrcMessageHandler::parseMessageInto(Communi::IrcMessage *message,
+                                         MessageSink &sink,
+                                         TwitchChannel *channel)
 {
-    std::vector<MessagePtr> builtMessages;
-
     auto command = message->command();
 
     if (command == u"PRIVMSG"_s)
     {
-        auto *privMsg = dynamic_cast<Communi::IrcPrivateMessage *>(message);
-        auto *tc = dynamic_cast<TwitchChannel *>(channel);
-        if (!tc)
-        {
-            return parsePrivMessage(channel, privMsg);
-        }
-
-        QString content = privMsg->content();
-        int messageOffset = stripLeadingReplyMention(privMsg->tags(), content);
-        MessageParseArgs args;
-        auto tags = privMsg->tags();
-        if (const auto it = tags.find("custom-reward-id"); it != tags.end())
-        {
-            args.channelPointRewardId = it.value().toString();
-        }
-        args.isAction = privMsg->isAction();
-
-        auto replyCtx = getReplyContext(tc, message, otherLoaded);
-        auto [built, alert] = MessageBuilder::makeIrcMessage(
-            channel, message, args, content, messageOffset, replyCtx.thread,
-            replyCtx.parent);
-
-        if (built)
-        {
-            builtMessages.emplace_back(built);
-            MessageBuilder::triggerHighlights(channel, alert);
-        }
-
-        if (message->tags().contains(u"pinned-chat-paid-amount"_s))
-        {
-            auto ptr = MessageBuilder::buildHypeChatMessage(privMsg);
-            if (ptr)
-            {
-                builtMessages.emplace_back(std::move(ptr));
-            }
-        }
-
-        return builtMessages;
+        parsePrivMessageInto(
+            dynamic_cast<Communi::IrcPrivateMessage *>(message), sink, channel);
     }
-
-    if (command == u"USERNOTICE"_s)
+    else if (command == u"USERNOTICE"_s)
     {
-        return parseUserNoticeMessage(channel, message);
+        parseUserNoticeMessageInto(message, sink, channel);
     }
 
     if (command == u"NOTICE"_s)
     {
-        return parseNoticeMessage(
-            dynamic_cast<Communi::IrcNoticeMessage *>(message));
+        sink.addMessage(parseNoticeMessage(
+                            dynamic_cast<Communi::IrcNoticeMessage *>(message)),
+                        MessageContext::Original);
     }
 
     if (command == u"CLEARCHAT"_s)
@@ -740,32 +317,20 @@ std::vector<MessagePtr> IrcMessageHandler::parseMessageWithReply(
         auto cc = parseClearChatMessage(message);
         if (!cc)
         {
-            return builtMessages;
+            return;
         }
         auto &clearChat = *cc;
         if (clearChat.disableAllMessages)
         {
-            builtMessages.emplace_back(std::move(clearChat.message));
+            sink.addMessage(std::move(clearChat.message),
+                            MessageContext::Original);
         }
         else
         {
-            addOrReplaceChannelTimeout(
-                otherLoaded, std::move(clearChat.message),
-                calculateMessageTime(message).time(),
-                [&](auto idx, auto /*msg*/, auto &&replacement) {
-                    replacement->flags.set(MessageFlag::RecentMessage);
-                    otherLoaded[idx] = replacement;
-                },
-                [&](auto &&msg) {
-                    builtMessages.emplace_back(msg);
-                },
-                false);
+            sink.addOrReplaceTimeout(std::move(clearChat.message),
+                                     calculateMessageTime(message).time());
         }
-
-        return builtMessages;
     }
-
-    return builtMessages;
 }
 
 void IrcMessageHandler::handlePrivMessage(Communi::IrcPrivateMessage *message,
@@ -778,32 +343,41 @@ void IrcMessageHandler::handlePrivMessage(Communi::IrcPrivateMessage *message,
     }
 
     auto *twitchChannel = dynamic_cast<TwitchChannel *>(chan.get());
-
-    if (twitchChannel != nullptr)
+    if (!twitchChannel)
     {
-        auto currentUser = getApp()->getAccounts()->twitch.getCurrent();
-        if (message->tag("user-id") == currentUser->getUserId())
+        return;
+    }
+
+    parsePrivMessageInto(message, *twitchChannel, twitchChannel);
+}
+
+void IrcMessageHandler::parsePrivMessageInto(
+    Communi::IrcPrivateMessage *message, MessageSink &sink,
+    TwitchChannel *channel)
+{
+    auto currentUser = getApp()->getAccounts()->twitch.getCurrent();
+    if (message->tag("user-id") == currentUser->getUserId())
+    {
+        auto badgesTag = message->tag("badges");
+        if (badgesTag.isValid())
         {
-            auto badgesTag = message->tag("badges");
-            if (badgesTag.isValid())
-            {
-                auto parsedBadges = parseBadges(badgesTag.toString());
-                twitchChannel->setMod(parsedBadges.contains("moderator"));
-                twitchChannel->setVIP(parsedBadges.contains("vip"));
-                twitchChannel->setStaff(parsedBadges.contains("staff"));
-            }
+            auto parsedBadges = parseBadges(badgesTag.toString());
+            channel->setMod(parsedBadges.contains("moderator"));
+            channel->setVIP(parsedBadges.contains("vip"));
+            channel->setStaff(parsedBadges.contains("staff"));
         }
     }
 
-    this->addMessage(message, chan, unescapeZeroWidthJoiner(message->content()),
-                     twitchServer, false, message->isAction());
+    addMessage(message, sink, channel,
+               unescapeZeroWidthJoiner(message->content()), false,
+               message->isAction());
 
     if (message->tags().contains(u"pinned-chat-paid-amount"_s))
     {
         auto ptr = MessageBuilder::buildHypeChatMessage(message);
         if (ptr)
         {
-            chan->addMessage(ptr, MessageContext::Original);
+            sink.addMessage(ptr, MessageContext::Original);
         }
     }
 }
@@ -900,7 +474,8 @@ void IrcMessageHandler::handleClearChatMessage(Communi::IrcMessage *message)
         return;
     }
 
-    chan->addOrReplaceTimeout(std::move(clearChat.message));
+    chan->addOrReplaceTimeout(std::move(clearChat.message),
+                              calculateMessageTime(message).time());
 
     // refresh all
     getApp()->getWindows()->repaintVisibleChatWidgets(chan.get());
@@ -1040,10 +615,23 @@ void IrcMessageHandler::handleWhisperMessage(Communi::IrcMessage *ircMessage)
 void IrcMessageHandler::handleUserNoticeMessage(Communi::IrcMessage *message,
                                                 ITwitchIrcServer &twitchServer)
 {
+    auto target = message->parameter(0);
+    auto *channel = dynamic_cast<TwitchChannel *>(
+        twitchServer.getChannelOrEmpty(target).get());
+    if (!channel)
+    {
+        return;
+    }
+    parseUserNoticeMessageInto(message, *channel, channel);
+}
+
+void IrcMessageHandler::parseUserNoticeMessageInto(Communi::IrcMessage *message,
+                                                   MessageSink &sink,
+                                                   TwitchChannel *channel)
+{
     auto tags = message->tags();
     auto parameters = message->parameters();
 
-    auto target = parameters[0];
     QString msgType = tags.value("msg-id").toString();
     bool mirrored = msgType == "sharedchatnotice";
     if (mirrored)
@@ -1072,12 +660,11 @@ void IrcMessageHandler::handleUserNoticeMessage(Communi::IrcMessage *message,
         content = parameters[1];
     }
 
-    auto chn = twitchServer.getChannelOrEmpty(target);
     if (isIgnoredMessage({
             .message = content,
             .twitchUserID = tags.value("user-id").toString(),
-            .isMod = chn->isMod(),
-            .isBroadcaster = chn->isBroadcaster(),
+            .isMod = channel->isMod(),
+            .isBroadcaster = channel->isBroadcaster(),
         }))
     {
         return;
@@ -1088,7 +675,7 @@ void IrcMessageHandler::handleUserNoticeMessage(Communi::IrcMessage *message,
         // Messages are not required, so they might be empty
         if (!content.isEmpty())
         {
-            this->addMessage(message, chn, content, twitchServer, true, false);
+            addMessage(message, sink, channel, content, true, false);
         }
     }
 
@@ -1136,25 +723,7 @@ void IrcMessageHandler::handleUserNoticeMessage(Communi::IrcMessage *message,
                 }
                 auto newMessage = b.release();
 
-                QString channelName;
-
-                if (message->parameters().size() < 1)
-                {
-                    return;
-                }
-
-                if (!trimChannelName(message->parameter(0), channelName))
-                {
-                    return;
-                }
-
-                auto chan = twitchServer.getChannelOrEmpty(channelName);
-
-                if (!chan->isEmpty())
-                {
-                    chan->addMessage(newMessage, MessageContext::Original);
-                }
-
+                sink.addMessage(newMessage, MessageContext::Original);
                 return;
             }
         }
@@ -1235,124 +804,104 @@ void IrcMessageHandler::handleUserNoticeMessage(Communi::IrcMessage *message,
         }
         auto newMessage = b.release();
 
-        QString channelName;
-
-        if (message->parameters().size() < 1)
-        {
-            return;
-        }
-
-        if (!trimChannelName(message->parameter(0), channelName))
-        {
-            return;
-        }
-
-        auto chan = twitchServer.getChannelOrEmpty(channelName);
-
-        if (!chan->isEmpty())
-        {
-            chan->addMessage(newMessage, MessageContext::Original);
-        }
+        sink.addMessage(newMessage, MessageContext::Original);
     }
 }
 
 void IrcMessageHandler::handleNoticeMessage(Communi::IrcNoticeMessage *message)
 {
-    auto builtMessages = parseNoticeMessage(message);
+    auto msg = parseNoticeMessage(message);
 
-    for (const auto &msg : builtMessages)
+    QString channelName;
+    if (!trimChannelName(message->target(), channelName) ||
+        channelName == "jtv")
     {
-        QString channelName;
-        if (!trimChannelName(message->target(), channelName) ||
-            channelName == "jtv")
-        {
-            // Notice wasn't targeted at a single channel, send to all twitch
-            // channels
-            getApp()->getTwitch()->forEachChannelAndSpecialChannels(
-                [msg](const auto &c) {
-                    c->addMessage(msg, MessageContext::Original);
-                });
+        // Notice wasn't targeted at a single channel, send to all twitch
+        // channels
+        getApp()->getTwitch()->forEachChannelAndSpecialChannels(
+            [msg](const auto &c) {
+                c->addMessage(msg, MessageContext::Original);
+            });
 
+        return;
+    }
+
+    auto channel = getApp()->getTwitch()->getChannelOrEmpty(channelName);
+
+    if (channel->isEmpty())
+    {
+        qCDebug(chatterinoTwitch)
+            << "[IrcManager:handleNoticeMessage] Channel" << channelName
+            << "not found in channel manager";
+        return;
+    }
+
+    QString tags = message->tags().value("msg-id").toString();
+    if (tags == "usage_delete")
+    {
+        channel->addSystemMessage(
+            "Usage: /delete <msg-id> - Deletes the specified message. "
+            "Can't take more than one argument.");
+    }
+    else if (tags == "bad_delete_message_error")
+    {
+        channel->addSystemMessage(
+            "There was a problem deleting the message. "
+            "It might be from another channel or too old to delete.");
+    }
+    else if (tags == "host_on" || tags == "host_target_went_offline")
+    {
+        bool hostOn = (tags == "host_on");
+        QStringList parts = msg->messageText.split(QLatin1Char(' '));
+        if ((hostOn && parts.size() != 3) || (!hostOn && parts.size() != 7))
+        {
             return;
         }
-
-        auto channel = getApp()->getTwitch()->getChannelOrEmpty(channelName);
-
-        if (channel->isEmpty())
+        auto &hostedChannelName = hostOn ? parts[2] : parts[0];
+        if (hostedChannelName.size() < 2)
         {
-            qCDebug(chatterinoTwitch)
-                << "[IrcManager:handleNoticeMessage] Channel" << channelName
-                << "not found in channel manager";
             return;
         }
-
-        QString tags = message->tags().value("msg-id").toString();
-        if (tags == "usage_delete")
+        if (hostOn)
         {
-            channel->addSystemMessage(
-                "Usage: /delete <msg-id> - Deletes the specified message. "
-                "Can't take more than one argument.");
+            hostedChannelName.chop(1);
         }
-        else if (tags == "bad_delete_message_error")
-        {
-            channel->addSystemMessage(
-                "There was a problem deleting the message. "
-                "It might be from another channel or too old to delete.");
-        }
-        else if (tags == "host_on" || tags == "host_target_went_offline")
-        {
-            bool hostOn = (tags == "host_on");
-            QStringList parts = msg->messageText.split(QLatin1Char(' '));
-            if ((hostOn && parts.size() != 3) || (!hostOn && parts.size() != 7))
-            {
-                return;
-            }
-            auto &hostedChannelName = hostOn ? parts[2] : parts[0];
-            if (hostedChannelName.size() < 2)
-            {
-                return;
-            }
-            if (hostOn)
-            {
-                hostedChannelName.chop(1);
-            }
-            channel->addMessage(MessageBuilder::makeHostingSystemMessage(
-                                    hostedChannelName, hostOn),
-                                MessageContext::Original);
-        }
-        else if (tags == "room_mods" || tags == "vips_success")
-        {
-            // /mods and /vips
-            // room_mods: The moderators of this channel are: ampzyh, antichriststollen, apa420, ...
-            // vips_success: The VIPs of this channel are: 8008, aiden, botfactory, ...
+        channel->addMessage(
+            MessageBuilder::makeHostingSystemMessage(hostedChannelName, hostOn),
+            MessageContext::Original);
+    }
+    else if (tags == "room_mods" || tags == "vips_success")
+    {
+        // /mods and /vips
+        // room_mods: The moderators of this channel are: ampzyh, antichriststollen, apa420, ...
+        // vips_success: The VIPs of this channel are: 8008, aiden, botfactory, ...
 
-            QString noticeText = msg->messageText;
-            if (tags == "vips_success")
-            {
-                // this one has a trailing period, need to get rid of it.
-                noticeText.chop(1);
-            }
-
-            QStringList msgParts = noticeText.split(':');
-            MessageBuilder builder;
-
-            auto *tc = dynamic_cast<TwitchChannel *>(channel.get());
-            assert(tc != nullptr &&
-                   "IrcMessageHandler::handleNoticeMessage. Twitch specific "
-                   "functionality called in non twitch channel");
-
-            auto users = msgParts.at(1)
-                             .mid(1)  // there is a space before the first user
-                             .split(", ");
-            users.sort(Qt::CaseInsensitive);
-            channel->addMessage(MessageBuilder::makeListOfUsersMessage(
-                                    msgParts.at(0), users, tc),
-                                MessageContext::Original);
-        }
-        else
+        QString noticeText = msg->messageText;
+        if (tags == "vips_success")
         {
-            channel->addMessage(msg, MessageContext::Original);
+            // this one has a trailing period, need to get rid of it.
+            noticeText.chop(1);
         }
+
+        QStringList msgParts = noticeText.split(':');
+        MessageBuilder builder;
+
+        auto *tc = dynamic_cast<TwitchChannel *>(channel.get());
+        assert(tc != nullptr &&
+               "IrcMessageHandler::handleNoticeMessage. Twitch specific "
+               "functionality called in non twitch channel");
+
+        auto users = msgParts.at(1)
+                         .mid(1)  // there is a space before the first user
+                         .split(", ");
+        users.sort(Qt::CaseInsensitive);
+        channel->addMessage(
+            MessageBuilder::makeListOfUsersMessage(msgParts.at(0), users, tc),
+            MessageContext::Original);
+    }
+    else
+    {
+        channel->addMessage(msg, MessageContext::Original);
     }
 }
 
@@ -1405,76 +954,12 @@ void IrcMessageHandler::handlePartMessage(Communi::IrcMessage *message)
     }
 }
 
-float IrcMessageHandler::similarity(
-    const MessagePtr &msg, const LimitedQueueSnapshot<MessagePtr> &messages)
-{
-    float similarityPercent = 0.0F;
-    int checked = 0;
-
-    for (int i = 1; i <= messages.size(); ++i)
-    {
-        if (checked >= getSettings()->hideSimilarMaxMessagesToCheck)
-        {
-            break;
-        }
-        const auto &prevMsg = messages[messages.size() - i];
-        if (prevMsg->parseTime.secsTo(QTime::currentTime()) >=
-            getSettings()->hideSimilarMaxDelay)
-        {
-            break;
-        }
-        if (getSettings()->hideSimilarBySameUser &&
-            msg->loginName != prevMsg->loginName)
-        {
-            continue;
-        }
-        ++checked;
-        similarityPercent = std::max(
-            similarityPercent,
-            relativeSimilarity(msg->messageText, prevMsg->messageText));
-    }
-
-    return similarityPercent;
-}
-
-void IrcMessageHandler::setSimilarityFlags(const MessagePtr &message,
-                                           const ChannelPtr &channel)
-{
-    if (getSettings()->similarityEnabled)
-    {
-        bool isMyself =
-            message->loginName ==
-            getApp()->getAccounts()->twitch.getCurrent()->getUserName();
-        bool hideMyself = getSettings()->hideSimilarMyself;
-
-        if (isMyself && !hideMyself)
-        {
-            return;
-        }
-
-        if (IrcMessageHandler::similarity(message,
-                                          channel->getMessageSnapshot()) >
-            getSettings()->similarityPercentage)
-        {
-            message->flags.set(MessageFlag::Similar, true);
-            if (getSettings()->colorSimilarDisabled)
-            {
-                message->flags.set(MessageFlag::Disabled, true);
-            }
-        }
-    }
-}
-
 void IrcMessageHandler::addMessage(Communi::IrcMessage *message,
-                                   const ChannelPtr &chan,
-                                   const QString &originalContent,
-                                   ITwitchIrcServer &server, bool isSub,
+                                   MessageSink &sink, TwitchChannel *channel,
+                                   const QString &originalContent, bool isSub,
                                    bool isAction)
 {
-    if (chan->isEmpty())
-    {
-        return;
-    }
+    assert(channel);
 
     MessageParseArgs args;
     if (isSub)
@@ -1483,13 +968,11 @@ void IrcMessageHandler::addMessage(Communi::IrcMessage *message,
         args.trimSubscriberUsername = true;
     }
 
-    if (chan->isBroadcaster())
+    if (channel->isBroadcaster())
     {
         args.isStaffOrBroadcaster = true;
     }
     args.isAction = isAction;
-
-    auto *channel = dynamic_cast<TwitchChannel *>(chan.get());
 
     const auto &tags = message->tags();
     QString rewardId;
@@ -1506,7 +989,10 @@ void IrcMessageHandler::addMessage(Communi::IrcMessage *message,
             rewardId = msgId;
         }
     }
-    if (!rewardId.isEmpty() && !channel->isChannelPointRewardKnown(rewardId))
+    if (!rewardId.isEmpty() &&
+        sink.sinkTraits().has(
+            MessageSinkTrait::RequiresKnownChannelPointReward) &&
+        !channel->isChannelPointRewardKnown(rewardId))
     {
         // Need to wait for pubsub reward notification
         qCDebug(chatterinoTwitch) << "TwitchChannel reward added ADD "
@@ -1539,7 +1025,7 @@ void IrcMessageHandler::addMessage(Communi::IrcMessage *message,
         else
         {
             // Thread does not yet exist, find root reply and create thread.
-            auto root = channel->findMessage(replyID);
+            auto root = sink.findMessageByID(replyID);
             if (root)
             {
                 // Found root reply message
@@ -1577,7 +1063,7 @@ void IrcMessageHandler::addMessage(Communi::IrcMessage *message,
                 }
                 else
                 {
-                    auto parent = channel->findMessage(parentID);
+                    auto parent = sink.findMessageByID(parentID);
                     if (parent)
                     {
                         replyCtx.parent = parent;
@@ -1600,7 +1086,7 @@ void IrcMessageHandler::addMessage(Communi::IrcMessage *message,
             msg->flags.unset(MessageFlag::Highlighted);
         }
 
-        IrcMessageHandler::setSimilarityFlags(msg, chan);
+        sink.applySimilarityFilters(msg);
 
         if (!msg->flags.has(MessageFlag::Similar) ||
             (!getSettings()->hideSimilar &&
@@ -1612,17 +1098,15 @@ void IrcMessageHandler::addMessage(Communi::IrcMessage *message,
         const auto highlighted = msg->flags.has(MessageFlag::Highlighted);
         const auto showInMentions = msg->flags.has(MessageFlag::ShowInMentions);
 
-        if (highlighted && showInMentions)
+        if (highlighted && showInMentions &&
+            sink.sinkTraits().has(MessageSinkTrait::AddMentionsToGlobalChannel))
         {
-            server.getMentionsChannel()->addMessage(msg,
-                                                    MessageContext::Original);
+            getApp()->getTwitch()->getMentionsChannel()->addMessage(
+                msg, MessageContext::Original);
         }
 
-        chan->addMessage(msg, MessageContext::Original);
-        if (auto *chatters = dynamic_cast<ChannelChatters *>(chan.get()))
-        {
-            chatters->addRecentChatter(msg->displayName);
-        }
+        sink.addMessage(msg, MessageContext::Original);
+        channel->addRecentChatter(msg->displayName);
     }
 }
 

--- a/src/providers/twitch/IrcMessageHandler.hpp
+++ b/src/providers/twitch/IrcMessageHandler.hpp
@@ -16,6 +16,7 @@ struct Message;
 using MessagePtr = std::shared_ptr<const Message>;
 class TwitchChannel;
 class TwitchMessageBuilder;
+class MessageSink;
 
 struct ClearChatMessage {
     MessagePtr message;
@@ -33,30 +34,35 @@ public:
      * Parse an IRC message into 0 or more Chatterino messages
      * Takes previously loaded messages into consideration to add reply contexts
      **/
-    static std::vector<MessagePtr> parseMessageWithReply(
-        Channel *channel, Communi::IrcMessage *message,
-        std::vector<MessagePtr> &otherLoaded);
+    static void parseMessageInto(Communi::IrcMessage *message,
+                                 MessageSink &sink, TwitchChannel *channel);
 
     void handlePrivMessage(Communi::IrcPrivateMessage *message,
                            ITwitchIrcServer &twitchServer);
+    static void parsePrivMessageInto(Communi::IrcPrivateMessage *message,
+                                     MessageSink &sink, TwitchChannel *channel);
 
     void handleRoomStateMessage(Communi::IrcMessage *message);
     void handleClearChatMessage(Communi::IrcMessage *message);
     void handleClearMessageMessage(Communi::IrcMessage *message);
     void handleUserStateMessage(Communi::IrcMessage *message);
-    void handleWhisperMessage(Communi::IrcMessage *ircMessage);
 
+    void handleWhisperMessage(Communi::IrcMessage *ircMessage);
     void handleUserNoticeMessage(Communi::IrcMessage *message,
                                  ITwitchIrcServer &twitchServer);
+    static void parseUserNoticeMessageInto(Communi::IrcMessage *message,
+                                           MessageSink &sink,
+                                           TwitchChannel *channel);
 
     void handleNoticeMessage(Communi::IrcNoticeMessage *message);
 
     void handleJoinMessage(Communi::IrcMessage *message);
     void handlePartMessage(Communi::IrcMessage *message);
 
-    void addMessage(Communi::IrcMessage *message, const ChannelPtr &chan,
-                    const QString &originalContent, ITwitchIrcServer &server,
-                    bool isSub, bool isAction);
+    static void addMessage(Communi::IrcMessage *message, MessageSink &sink,
+                           TwitchChannel *channel,
+                           const QString &originalContent, bool isSub,
+                           bool isAction);
 
 private:
     static float similarity(const MessagePtr &msg,

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -452,8 +452,8 @@ void TwitchChannel::addChannelPointReward(const ChannelPointReward &reward)
                 if (reward.id == msg.rewardID)
                 {
                     IrcMessageHandler::instance().addMessage(
-                        msg.message.get(), shared_from_this(),
-                        msg.originalContent, *server, false, false);
+                        msg.message.get(), *this, this, msg.originalContent,
+                        false, false);
                     return true;
                 }
                 return false;

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -312,7 +312,7 @@ void TwitchIrcServer::initialize()
             postToThread([chan, action] {
                 MessageBuilder msg(action);
                 msg->flags.set(MessageFlag::PubSub);
-                chan->addOrReplaceTimeout(msg.release());
+                chan->addOrReplaceTimeout(msg.release(), QTime::currentTime());
             });
         });
 

--- a/src/util/VectorMessageSink.cpp
+++ b/src/util/VectorMessageSink.cpp
@@ -1,0 +1,86 @@
+#include "util/VectorMessageSink.hpp"
+
+#include "messages/MessageSimilarity.hpp"
+#include "util/ChannelHelpers.hpp"
+
+#include <cassert>
+
+namespace chatterino {
+
+VectorMessageSink::VectorMessageSink(MessageSinkTraits traits,
+                                     MessageFlags additionalFlags)
+    : additionalFlags(additionalFlags)
+    , traits(traits) {};
+VectorMessageSink::~VectorMessageSink() = default;
+
+void VectorMessageSink::addMessage(MessagePtr message, MessageContext ctx,
+                                   std::optional<MessageFlags> overridingFlags)
+{
+    assert(!overridingFlags.has_value());
+    assert(ctx == MessageContext::Original);
+
+    message->flags.set(this->additionalFlags);
+    this->messages_.emplace_back(std::move(message));
+}
+
+void VectorMessageSink::addOrReplaceTimeout(MessagePtr clearchatMessage,
+                                            QTime now)
+{
+    addOrReplaceChannelTimeout(
+        this->messages_, std::move(clearchatMessage), now,
+        [&](auto idx, auto /*msg*/, auto &&replacement) {
+            replacement->flags.set(this->additionalFlags);
+            this->messages_[idx] = replacement;
+        },
+        [&](auto &&msg) {
+            this->messages_.emplace_back(msg);
+        },
+        false);
+}
+
+void VectorMessageSink::disableAllMessages()
+{
+    if (this->additionalFlags.has(MessageFlag::RecentMessage))
+    {
+        return;  // don't disable recent messages
+    }
+
+    for (const auto &msg : this->messages_)
+    {
+        msg->flags.set(MessageFlag::Disabled);
+    }
+}
+
+void VectorMessageSink::applySimilarityFilters(const MessagePtr &message) const
+{
+    setSimilarityFlags(message, this->messages_);
+}
+
+MessagePtr VectorMessageSink::findMessageByID(QStringView id)
+{
+    for (const auto &msg : this->messages_ | std::views::reverse)
+    {
+        if (msg->id == id)
+        {
+            return msg;
+        }
+    }
+    return {};
+}
+
+const std::vector<MessagePtr> &VectorMessageSink::messages() const
+{
+    return this->messages_;
+}
+
+std::vector<MessagePtr> VectorMessageSink::takeMessages() &&
+{
+    return std::move(this->messages_);
+}
+
+MessageSinkTraits VectorMessageSink::sinkTraits() const
+{
+    return this->traits;
+}
+
+}  // namespace chatterino

--- a/src/util/VectorMessageSink.hpp
+++ b/src/util/VectorMessageSink.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "messages/MessageSink.hpp"
+
+namespace chatterino {
+
+class VectorMessageSink final : public MessageSink
+{
+public:
+    VectorMessageSink(MessageSinkTraits traits = {},
+                      MessageFlags additionalFlags = {});
+    ~VectorMessageSink() override;
+
+    void addMessage(
+        MessagePtr message, MessageContext ctx,
+        std::optional<MessageFlags> overridingFlags = std::nullopt) override;
+    void addOrReplaceTimeout(MessagePtr clearchatMessage, QTime now) override;
+
+    void disableAllMessages() override;
+
+    void applySimilarityFilters(const MessagePtr &message) const override;
+
+    MessagePtr findMessageByID(QStringView id) override;
+
+    MessageSinkTraits sinkTraits() const override;
+
+    const std::vector<MessagePtr> &messages() const;
+    std::vector<MessagePtr> takeMessages() &&;
+
+private:
+    std::vector<MessagePtr> messages_;
+    MessageFlags additionalFlags;
+    MessageSinkTraits traits;
+};
+
+}  // namespace chatterino

--- a/tests/snapshots/IrcMessageHandler/announcement.json
+++ b/tests/snapshots/IrcMessageHandler/announcement.json
@@ -180,6 +180,7 @@
                 }
             ],
             "flags": "Collapsed|Subscription",
+            "highlightColor": "#64c466ff",
             "id": "8c26e1ab-b50c-4d9d-bc11-3fd57a941d90",
             "localizedName": "",
             "loginName": "supinic",

--- a/tests/snapshots/IrcMessageHandler/reply-child.json
+++ b/tests/snapshots/IrcMessageHandler/reply-child.json
@@ -80,7 +80,7 @@
                     "trailingSpace": true,
                     "type": "SingleLineTextElement",
                     "words": [
-                        "a"
+                        "b"
                     ]
                 },
                 {
@@ -169,6 +169,7 @@
             "localizedName": "",
             "loginName": "nerixyz",
             "messageText": "c",
+            "replyParent": "474f19ab-a1b0-410a-877a-5b0e2ae8be6d",
             "replyThread": {
                 "replies": [
                     "474f19ab-a1b0-410a-877a-5b0e2ae8be6d",

--- a/tests/snapshots/IrcMessageHandler/shared-chat-announcement.json
+++ b/tests/snapshots/IrcMessageHandler/shared-chat-announcement.json
@@ -256,6 +256,7 @@
                 }
             ],
             "flags": "Collapsed|Subscription|SharedMessage",
+            "highlightColor": "#64c466ff",
             "id": "01cd601f-bc3f-49d5-ab4b-136fa9d6ec22",
             "localizedName": "",
             "loginName": "lahoooo",

--- a/tests/snapshots/IrcMessageHandler/sub-message.json
+++ b/tests/snapshots/IrcMessageHandler/sub-message.json
@@ -243,6 +243,7 @@
                 }
             ],
             "flags": "Collapsed|Subscription",
+            "highlightColor": "#64c466ff",
             "id": "db25007f-7a18-43eb-9379-80131e44d633",
             "localizedName": "",
             "loginName": "ronni",


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

This deduplicates the code for parsing historical vs. live messages. It introduces a `MessageSink` which hold some traits (some behavior as to how messages should be added). It is modelled after the `Channel`, which is why it has the `addMessage` signature. Ideally, I'd want to make a new function that _just_ takes a message, but I couldn't come up with a good name (because ultimately, it will add a message to the sink). An alternative could be to make `MessageSink` a wrapper around `Channel`.

This should make it easier to parse specific messages (e.g. subs) without introducing differences between recent and live messages.