### PR TITLE
fix(cmake): use boost's own cmake config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.15)
 cmake_policy(SET CMP0087 NEW) # evaluates generator expressions in `install(CODE/SCRIPT)`
 cmake_policy(SET CMP0091 NEW) # select MSVC runtime library through `CMAKE_MSVC_RUNTIME_LIBRARY`
+if (POLICY CMP0167)
+    cmake_policy(SET CMP0167 NEW) # find Boost's own CMake config file
+endif ()
 include(FeatureSummary)
 
 list(APPEND CMAKE_MODULE_PATH


### PR DESCRIPTION
probably only active for arch linux & other newer distros
