### PR TITLE
fix(7TV): ignore `entitlement.reset`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@
 - Dev: Refactored IRC message building. (#5663)
 - Dev: Fixed some compiler warnings. (#5672)
 - Dev: Unified parsing of historic and live IRC messages. (#5678)
+- Dev: 7TV's `entitlement.reset` is now explicitly ignored. (#5685)
 
 ## 2.5.1
 

--- a/src/providers/seventv/SeventvEventAPI.cpp
+++ b/src/providers/seventv/SeventvEventAPI.cpp
@@ -233,6 +233,10 @@ void SeventvEventAPI::handleDispatch(const Dispatch &dispatch)
             }
         }
         break;
+        case SubscriptionType::ResetEntitlement: {
+            // unhandled (not clear what we'd do here yet)
+        }
+        break;
         default: {
             qCDebug(chatterinoSeventvEventAPI)
                 << "Unknown subscription type:"

--- a/src/providers/seventv/eventapi/Subscription.hpp
+++ b/src/providers/seventv/eventapi/Subscription.hpp
@@ -27,6 +27,7 @@ enum class SubscriptionType {
     CreateEntitlement,
     UpdateEntitlement,
     DeleteEntitlement,
+    ResetEntitlement,
 
     INVALID,
 };
@@ -119,6 +120,8 @@ constexpr magic_enum::customize::customize_t magic_enum::customize::enum_name<
             return "entitlement.update";
         case SubscriptionType::DeleteEntitlement:
             return "entitlement.delete";
+        case SubscriptionType::ResetEntitlement:
+            return "entitlement.reset";
 
         default:
             return default_tag;


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

We currently log something like "Unknown subscription type: INVALID". This just adds the event type to the known ones and silently ignores the event. `entitlement.reset` is pushed every time a user without 7TV cosmetics updates their presence. As most users don't have cosmetics, it's really spammy. I don't see a big reason to handle it. In my opinion, we should handle it once there's a bug that would be fixed by handling the event (keep in mind: we didn't need this in the past).