### PR TITLE
feat: make usernames in USERNOTICEs clickable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Minor: Proxy URL information is now included in the `/debug-env` command. (#5648)
 - Minor: Make raid entry message usernames clickable. (#5651)
 - Minor: Tabs unhighlight when their content is read in other tabs. (#5649)
+- Minor: Made usernames in bits and sub messages clickable. (#5686)
 - Bugfix: Fixed tab move animation occasionally failing to start after closing a tab. (#5426, #5612)
 - Bugfix: If a network request errors with 200 OK, Qt's error code is now reported instead of the HTTP status. (#5378)
 - Bugfix: Fixed restricted users usernames not being clickable. (#5405)

--- a/src/messages/MessageBuilder.hpp
+++ b/src/messages/MessageBuilder.hpp
@@ -52,8 +52,6 @@ namespace linkparser {
 
 struct SystemMessageTag {
 };
-struct RaidEntryMessageTag {
-};
 struct TimeoutMessageTag {
 };
 struct LiveUpdatesUpdateEmoteMessageTag {
@@ -69,7 +67,6 @@ struct ImageUploaderResultTag {
 
 // NOLINTBEGIN(readability-identifier-naming)
 const SystemMessageTag systemMessage{};
-const RaidEntryMessageTag raidEntryMessage{};
 const TimeoutMessageTag timeoutMessage{};
 const LiveUpdatesUpdateEmoteMessageTag liveUpdatesUpdateEmoteMessage{};
 const LiveUpdatesRemoveEmoteMessageTag liveUpdatesRemoveEmoteMessage{};

--- a/src/messages/MessageBuilder.hpp
+++ b/src/messages/MessageBuilder.hpp
@@ -109,9 +109,6 @@ public:
 
     MessageBuilder(SystemMessageTag, const QString &text,
                    const QTime &time = QTime::currentTime());
-    MessageBuilder(RaidEntryMessageTag, const QString &text,
-                   const QString &loginName, const QString &displayName,
-                   const MessageColor &userColor, const QTime &time);
     MessageBuilder(TimeoutMessageTag, const QString &timeoutUser,
                    const QString &sourceUser, const QString &systemMessageText,
                    int times, const QTime &time = QTime::currentTime());
@@ -254,6 +251,15 @@ public:
         QString::size_type messageOffset,
         const std::shared_ptr<MessageThread> &thread = {},
         const MessagePtr &parent = {});
+
+    static MessagePtrMut makeSystemMessageWithUser(
+        const QString &text, const QString &loginName,
+        const QString &displayName, const MessageColor &userColor,
+        const QTime &time);
+
+    static MessagePtrMut makeSubgiftMessage(const QString &text,
+                                            const QVariantMap &tags,
+                                            const QTime &time);
 
 private:
     struct TextState {

--- a/tests/snapshots/IrcMessageHandler/bitsbadge.json
+++ b/tests/snapshots/IrcMessageHandler/bitsbadge.json
@@ -38,8 +38,9 @@
                     "type": "TimestampElement"
                 },
                 {
-                    "color": "System",
-                    "flags": "Text",
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
                     "link": {
                         "type": "None",
                         "value": ""
@@ -47,7 +48,9 @@
                     "style": "ChatMedium",
                     "tooltip": "",
                     "trailingSpace": true,
-                    "type": "TextElement",
+                    "type": "MentionElement",
+                    "userColor": "#ffff4500",
+                    "userLoginName": "whoopiix",
                     "words": [
                         "whoopiix"
                     ]

--- a/tests/snapshots/IrcMessageHandler/sub-first-gift.json
+++ b/tests/snapshots/IrcMessageHandler/sub-first-gift.json
@@ -38,8 +38,9 @@
                     "type": "TimestampElement"
                 },
                 {
-                    "color": "System",
-                    "flags": "Text",
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
                     "link": {
                         "type": "None",
                         "value": ""
@@ -47,7 +48,9 @@
                     "style": "ChatMedium",
                     "tooltip": "",
                     "trailingSpace": true,
-                    "type": "TextElement",
+                    "type": "MentionElement",
+                    "userColor": "#ff00ff7f",
+                    "userLoginName": "hyperbolicxd",
                     "words": [
                         "hyperbolicxd"
                     ]
@@ -143,6 +146,24 @@
                     ]
                 },
                 {
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": false,
+                    "type": "MentionElement",
+                    "userColor": "System",
+                    "userLoginName": "quote_if_nam",
+                    "words": [
+                        "quote_if_nam"
+                    ]
+                },
+                {
                     "color": "System",
                     "flags": "Text",
                     "link": {
@@ -154,7 +175,7 @@
                     "trailingSpace": true,
                     "type": "TextElement",
                     "words": [
-                        "quote_if_nam!"
+                        "!"
                     ]
                 },
                 {

--- a/tests/snapshots/IrcMessageHandler/sub-first-time.json
+++ b/tests/snapshots/IrcMessageHandler/sub-first-time.json
@@ -38,8 +38,9 @@
                     "type": "TimestampElement"
                 },
                 {
-                    "color": "System",
-                    "flags": "Text",
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
                     "link": {
                         "type": "None",
                         "value": ""
@@ -47,7 +48,9 @@
                     "style": "ChatMedium",
                     "tooltip": "",
                     "trailingSpace": true,
-                    "type": "TextElement",
+                    "type": "MentionElement",
+                    "userColor": "#ff0000ff",
+                    "userLoginName": "byebyeheart",
                     "words": [
                         "byebyeheart"
                     ]

--- a/tests/snapshots/IrcMessageHandler/sub-gift.json
+++ b/tests/snapshots/IrcMessageHandler/sub-gift.json
@@ -38,8 +38,9 @@
                     "type": "TimestampElement"
                 },
                 {
-                    "color": "System",
-                    "flags": "Text",
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
                     "link": {
                         "type": "None",
                         "value": ""
@@ -47,7 +48,9 @@
                     "style": "ChatMedium",
                     "tooltip": "",
                     "trailingSpace": true,
-                    "type": "TextElement",
+                    "type": "MentionElement",
+                    "userColor": "#ff0000ff",
+                    "userLoginName": "tww2",
                     "words": [
                         "TWW2"
                     ]
@@ -143,6 +146,24 @@
                     ]
                 },
                 {
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": false,
+                    "type": "MentionElement",
+                    "userColor": "System",
+                    "userLoginName": "mr_woodchuck",
+                    "words": [
+                        "Mr_Woodchuck"
+                    ]
+                },
+                {
                     "color": "System",
                     "flags": "Text",
                     "link": {
@@ -154,7 +175,7 @@
                     "trailingSpace": true,
                     "type": "TextElement",
                     "words": [
-                        "Mr_Woodchuck!"
+                        "!"
                     ]
                 }
             ],

--- a/tests/snapshots/IrcMessageHandler/sub-message.json
+++ b/tests/snapshots/IrcMessageHandler/sub-message.json
@@ -290,8 +290,9 @@
                     "type": "TimestampElement"
                 },
                 {
-                    "color": "System",
-                    "flags": "Text",
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
                     "link": {
                         "type": "None",
                         "value": ""
@@ -299,7 +300,9 @@
                     "style": "ChatMedium",
                     "tooltip": "",
                     "trailingSpace": true,
-                    "type": "TextElement",
+                    "type": "MentionElement",
+                    "userColor": "#ff008000",
+                    "userLoginName": "ronni",
                     "words": [
                         "ronni"
                     ]

--- a/tests/snapshots/IrcMessageHandler/sub-multi-month-anon-gift.json
+++ b/tests/snapshots/IrcMessageHandler/sub-multi-month-anon-gift.json
@@ -218,6 +218,24 @@
                     ]
                 },
                 {
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": false,
+                    "type": "MentionElement",
+                    "userColor": "System",
+                    "userLoginName": "mohammadrezadh",
+                    "words": [
+                        "MohammadrezaDH"
+                    ]
+                },
+                {
                     "color": "System",
                     "flags": "Text",
                     "link": {
@@ -229,7 +247,7 @@
                     "trailingSpace": true,
                     "type": "TextElement",
                     "words": [
-                        "MohammadrezaDH!"
+                        "!"
                     ]
                 }
             ],

--- a/tests/snapshots/IrcMessageHandler/sub-multi-month-gift-count.json
+++ b/tests/snapshots/IrcMessageHandler/sub-multi-month-gift-count.json
@@ -38,8 +38,9 @@
                     "type": "TimestampElement"
                 },
                 {
-                    "color": "System",
-                    "flags": "Text",
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
                     "link": {
                         "type": "None",
                         "value": ""
@@ -47,7 +48,9 @@
                     "style": "ChatMedium",
                     "tooltip": "",
                     "trailingSpace": true,
-                    "type": "TextElement",
+                    "type": "MentionElement",
+                    "userColor": "#ffff8ea3",
+                    "userLoginName": "inatsufn",
                     "words": [
                         "iNatsuFN"
                     ]
@@ -188,6 +191,24 @@
                     ]
                 },
                 {
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": false,
+                    "type": "MentionElement",
+                    "userColor": "System",
+                    "userLoginName": "kimmi_tm",
+                    "words": [
+                        "kimmi_tm"
+                    ]
+                },
+                {
                     "color": "System",
                     "flags": "Text",
                     "link": {
@@ -199,7 +220,7 @@
                     "trailingSpace": true,
                     "type": "TextElement",
                     "words": [
-                        "kimmi_tm!"
+                        "!"
                     ]
                 },
                 {

--- a/tests/snapshots/IrcMessageHandler/sub-multi-month-gift.json
+++ b/tests/snapshots/IrcMessageHandler/sub-multi-month-gift.json
@@ -38,8 +38,9 @@
                     "type": "TimestampElement"
                 },
                 {
-                    "color": "System",
-                    "flags": "Text",
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
                     "link": {
                         "type": "None",
                         "value": ""
@@ -47,7 +48,9 @@
                     "style": "ChatMedium",
                     "tooltip": "",
                     "trailingSpace": true,
-                    "type": "TextElement",
+                    "type": "MentionElement",
+                    "userColor": "#ffeb078d",
+                    "userLoginName": "lucidfoxx",
                     "words": [
                         "Lucidfoxx"
                     ]
@@ -188,6 +191,24 @@
                     ]
                 },
                 {
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": false,
+                    "type": "MentionElement",
+                    "userColor": "System",
+                    "userLoginName": "ogprodigy",
+                    "words": [
+                        "OGprodigy"
+                    ]
+                },
+                {
                     "color": "System",
                     "flags": "Text",
                     "link": {
@@ -199,7 +220,7 @@
                     "trailingSpace": true,
                     "type": "TextElement",
                     "words": [
-                        "OGprodigy!"
+                        "!"
                     ]
                 }
             ],

--- a/tests/snapshots/IrcMessageHandler/sub-multi-month-resub.json
+++ b/tests/snapshots/IrcMessageHandler/sub-multi-month-resub.json
@@ -38,8 +38,9 @@
                     "type": "TimestampElement"
                 },
                 {
-                    "color": "System",
-                    "flags": "Text",
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
                     "link": {
                         "type": "None",
                         "value": ""
@@ -47,7 +48,9 @@
                     "style": "ChatMedium",
                     "tooltip": "",
                     "trailingSpace": true,
-                    "type": "TextElement",
+                    "type": "MentionElement",
+                    "userColor": "#ff0000ff",
+                    "userLoginName": "calm__like_a_tom",
                     "words": [
                         "calm__like_a_tom"
                     ]

--- a/tests/snapshots/IrcMessageHandler/sub-multi-month.json
+++ b/tests/snapshots/IrcMessageHandler/sub-multi-month.json
@@ -38,8 +38,9 @@
                     "type": "TimestampElement"
                 },
                 {
-                    "color": "System",
-                    "flags": "Text",
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
                     "link": {
                         "type": "None",
                         "value": ""
@@ -47,7 +48,9 @@
                     "style": "ChatMedium",
                     "tooltip": "",
                     "trailingSpace": true,
-                    "type": "TextElement",
+                    "type": "MentionElement",
+                    "userColor": "System",
+                    "userLoginName": "foly__",
                     "words": [
                         "foly__"
                     ]

--- a/tests/snapshots/IrcMessageHandler/sub-no-message.json
+++ b/tests/snapshots/IrcMessageHandler/sub-no-message.json
@@ -38,8 +38,9 @@
                     "type": "TimestampElement"
                 },
                 {
-                    "color": "System",
-                    "flags": "Text",
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
                     "link": {
                         "type": "None",
                         "value": ""
@@ -47,7 +48,9 @@
                     "style": "ChatMedium",
                     "tooltip": "",
                     "trailingSpace": true,
-                    "type": "TextElement",
+                    "type": "MentionElement",
+                    "userColor": "#ffcc00c2",
+                    "userLoginName": "cspice",
                     "words": [
                         "cspice"
                     ]
@@ -158,8 +161,9 @@
                     ]
                 },
                 {
-                    "color": "System",
-                    "flags": "Text",
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
                     "link": {
                         "type": "None",
                         "value": ""
@@ -167,7 +171,9 @@
                     "style": "ChatMedium",
                     "tooltip": "",
                     "trailingSpace": true,
-                    "type": "TextElement",
+                    "type": "MentionElement",
+                    "userColor": "#ffcc00c2",
+                    "userLoginName": "cspice",
                     "words": [
                         "cspice"
                     ]


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

Does what the title says. For subgifts, there's a special case, since their messages include two usernames.

Fixes #2673