### PR TITLE
fix: ensure timer doesn't run if the QuickSwitcherPopup is dead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 - Bugfix: Fixed event emotes not showing up in autocomplete and popups. (#5239, #5580, #5582, #5632)
 - Bugfix: Fixed tab visibility being controllable in the emote popup. (#5530)
 - Bugfix: Fixed account switch not being saved if no other settings were changed. (#5558)
+- Bugfix: Fixed a crash that could occur when handling the quick switcher popup really quickly. (#5687)
 - Bugfix: Fixed 7TV badges being inadvertently animated. (#5674)
 - Bugfix: Fixed some tooltips not being readable. (#5578)
 - Bugfix: Fixed log files being locked longer than needed. (#5592)

--- a/src/widgets/dialogs/switcher/QuickSwitcherPopup.cpp
+++ b/src/widgets/dialogs/switcher/QuickSwitcherPopup.cpp
@@ -141,7 +141,7 @@ void QuickSwitcherPopup::updateSuggestions(const QString &text)
      * Timeout interval 0 means the call will be delayed until all window events
      * have been processed (cf. https://doc.qt.io/qt-5/qtimer.html#interval-prop).
      */
-    QTimer::singleShot(0, [this] {
+    QTimer::singleShot(0, this, [this] {
         this->adjustSize();
     });
 }


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
