### PR TITLE
feat: add setting to hide blocked term automod messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Minor: Added `--login <username>` CLI argument to specify which account to start logged in as. (#5626)
 - Minor: When blocking a channel, Chatterino will now warn you about that action. (#5615)
 - Minor: Indicate when subscriptions and resubscriptions are for multiple months. (#5642)
+- Minor: Added a setting to control whether or not to show "Blocked Term" automod messages. (#5690)
 - Minor: Proxy URL information is now included in the `/debug-env` command. (#5648)
 - Minor: Make raid entry message usernames clickable. (#5651)
 - Minor: Tabs unhighlight when their content is read in other tabs. (#5649)

--- a/src/common/ChatterinoSetting.hpp
+++ b/src/common/ChatterinoSetting.hpp
@@ -6,6 +6,10 @@
 #include <QSize>
 #include <QString>
 
+#include <memory>
+#include <string>
+#include <type_traits>
+
 namespace chatterino {
 
 void _registerSetting(std::weak_ptr<pajlada::Settings::SettingData> setting);

--- a/src/common/ChatterinoSetting.hpp
+++ b/src/common/ChatterinoSetting.hpp
@@ -148,6 +148,9 @@ struct IsChatterinoSettingT : std::false_type {
 template <typename T>
 struct IsChatterinoSettingT<ChatterinoSetting<T>> : std::true_type {
 };
+template <typename T>
+struct IsChatterinoSettingT<EnumStringSetting<T>> : std::true_type {
+};
 
 template <typename T>
 concept IsChatterinoSetting = IsChatterinoSettingT<T>::value;

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -26,6 +26,7 @@
 #include "providers/twitch/api/Helix.hpp"
 #include "providers/twitch/ChannelPointReward.hpp"
 #include "providers/twitch/PubSubActions.hpp"
+#include "providers/twitch/pubsubmessages/AutoMod.hpp"
 #include "providers/twitch/TwitchAccount.hpp"
 #include "providers/twitch/TwitchBadge.hpp"
 #include "providers/twitch/TwitchBadges.hpp"
@@ -1636,6 +1637,12 @@ std::pair<MessagePtr, MessagePtr> MessageBuilder::makeAutomodMessage(
     const AutomodAction &action, const QString &channelName)
 {
     MessageBuilder builder, builder2;
+
+    if (action.reasonCode == PubSubAutoModQueueMessage::Reason::BlockedTerm)
+    {
+        builder.message().flags.set(MessageFlag::AutoModBlockedTerm);
+        builder2.message().flags.set(MessageFlag::AutoModBlockedTerm);
+    }
 
     //
     // Builder for AutoMod message with explanation

--- a/src/messages/MessageFlag.hpp
+++ b/src/messages/MessageFlag.hpp
@@ -52,6 +52,8 @@ enum class MessageFlag : std::int64_t {
     Action = (1LL << 36),
     /// The message is sent in a different source channel as part of a Shared Chat session
     SharedMessage = (1LL << 37),
+    /// AutoMod message that showed up due to containing a blocked term in the channel
+    AutoModBlockedTerm = (1LL << 38),
 };
 using MessageFlags = FlagsEnum<MessageFlag>;
 

--- a/src/messages/layouts/MessageLayout.cpp
+++ b/src/messages/layouts/MessageLayout.cpp
@@ -141,6 +141,9 @@ void MessageLayout::actuallyLayout(const MessageLayoutContext &ctx)
 
     bool hideModerated = getSettings()->hideModerated;
     bool hideModerationActions = getSettings()->hideModerationActions;
+    bool hideBlockedTermAutomodMessages =
+        getSettings()->showBlockedTermAutomodMessages.getEnum() ==
+        ShowModerationState::Never;
     bool hideSimilar = getSettings()->hideSimilar;
     bool hideReplies = !ctx.flags.has(MessageElementFlag::RepliedMessage);
 
@@ -150,6 +153,12 @@ void MessageLayout::actuallyLayout(const MessageLayoutContext &ctx)
     for (const auto &element : this->message_->elements)
     {
         if (hideModerated && this->message_->flags.has(MessageFlag::Disabled))
+        {
+            continue;
+        }
+
+        if (hideBlockedTermAutomodMessages &&
+            this->message_->flags.has(MessageFlag::AutoModBlockedTerm))
         {
             continue;
         }

--- a/src/messages/layouts/MessageLayout.cpp
+++ b/src/messages/layouts/MessageLayout.cpp
@@ -160,12 +160,18 @@ void MessageLayout::actuallyLayout(const MessageLayoutContext &ctx)
         if (hideBlockedTermAutomodMessages &&
             this->message_->flags.has(MessageFlag::AutoModBlockedTerm))
         {
+            // NOTE: This hides the message but it will make the message re-appear if moderation message hiding is no longer active, and the layout is re-laid-out.
+            // This is only the case for the moderation messages that don't get filtered during creation.
+            // We should decide which is the correct method & apply that everywhere
             continue;
         }
 
         if (this->message_->flags.has(MessageFlag::Timeout) ||
             this->message_->flags.has(MessageFlag::Untimeout))
         {
+            // NOTE: This hides the message but it will make the message re-appear if moderation message hiding is no longer active, and the layout is re-laid-out.
+            // This is only the case for the moderation messages that don't get filtered during creation.
+            // We should decide which is the correct method & apply that everywhere
             if (hideModerationActions ||
                 (getSettings()->streamerModeHideModActions &&
                  getApp()->getStreamerMode()->isEnabled()))

--- a/src/providers/twitch/PubSubActions.hpp
+++ b/src/providers/twitch/PubSubActions.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "providers/twitch/pubsubmessages/AutoMod.hpp"
+
 #include <QColor>
 #include <QDebug>
 #include <QJsonObject>
@@ -143,6 +145,7 @@ struct AutomodAction : PubSubAction {
     QString message;
 
     QString reason;
+    PubSubAutoModQueueMessage::Reason reasonCode;
 
     QString msgID;
 };

--- a/src/providers/twitch/PubSubManager.cpp
+++ b/src/providers/twitch/PubSubManager.cpp
@@ -349,40 +349,6 @@ PubSub::PubSub(const QString &host, std::chrono::seconds pingInterval)
         this->moderation.raidCanceled.invoke(action);
     };
 
-    /*
-    // This handler is no longer required as we use the automod-queue topic now
-    this->moderationActionHandlers["automod_rejected"] =
-        [this](const auto &data, const auto &roomID) {
-            AutomodAction action(data, roomID);
-
-            action.source.id = data.value("created_by_user_id").toString();
-            action.source.login = data.value("created_by").toString();
-
-            action.target.id = data.value("target_user_id").toString();
-
-            const auto args = data.value("args").toArray();
-
-            if (args.isEmpty())
-            {
-                return;
-            }
-
-            action.msgID = data.value("msg_id").toString();
-
-            if (action.msgID.isEmpty())
-            {
-                // Missing required msg_id parameter
-                return;
-            }
-
-            action.target.login = args[0].toString();
-            action.message = args[1].toString();  // May be omitted
-            action.reason = args[2].toString();   // May be omitted
-
-            this->moderation.autoModMessageBlocked.invoke(action);
-        };
-    */
-
     this->moderationActionHandlers["automod_message_rejected"] =
         [this](const auto &data, const auto &roomID) {
             AutomodInfoAction action(data, roomID);

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -494,6 +494,7 @@ void TwitchIrcServer::initialize()
 
                         action.msgID = msg.messageID;
                         action.message = msg.messageText;
+                        action.reasonCode = msg.reason;
 
                         // this message also contains per-word automod data, which could be implemented
 

--- a/src/providers/twitch/pubsubmessages/AutoMod.cpp
+++ b/src/providers/twitch/pubsubmessages/AutoMod.cpp
@@ -15,6 +15,10 @@ PubSubAutoModQueueMessage::PubSubAutoModQueueMessage(const QJsonObject &root)
         this->type = oType.value();
     }
 
+    this->reason =
+        qmagicenum::enumCast<Reason>(data.value("reason_code").toString())
+            .value_or(Reason::INVALID);
+
     auto contentClassification =
         data.value("content_classification").toObject();
 

--- a/src/providers/twitch/pubsubmessages/AutoMod.hpp
+++ b/src/providers/twitch/pubsubmessages/AutoMod.hpp
@@ -13,8 +13,17 @@ struct PubSubAutoModQueueMessage {
 
         INVALID,
     };
+
+    enum class Reason {
+        AutoMod,
+        BlockedTerm,
+
+        INVALID,
+    };
+
     QString typeString;
     Type type = Type::INVALID;
+    Reason reason = Reason::INVALID;
 
     QJsonObject data;
 
@@ -46,6 +55,23 @@ constexpr magic_enum::customize::customize_t magic_enum::customize::enum_name<
     {
         case chatterino::PubSubAutoModQueueMessage::Type::AutoModCaughtMessage:
             return "automod_caught_message";
+
+        default:
+            return default_tag;
+    }
+}
+
+template <>
+constexpr magic_enum::customize::customize_t magic_enum::customize::enum_name<
+    chatterino::PubSubAutoModQueueMessage::Reason>(
+    chatterino::PubSubAutoModQueueMessage::Reason value) noexcept
+{
+    switch (value)
+    {
+        case chatterino::PubSubAutoModQueueMessage::Reason::AutoMod:
+            return "AutoModCaughtMessageReason";
+        case chatterino::PubSubAutoModQueueMessage::Reason::BlockedTerm:
+            return "BlockedTermCaughtMessageReason";
 
         default:
             return default_tag;

--- a/src/providers/twitch/pubsubmessages/AutoMod.hpp
+++ b/src/providers/twitch/pubsubmessages/AutoMod.hpp
@@ -30,7 +30,7 @@ struct PubSubAutoModQueueMessage {
     QString status;
 
     QString contentCategory;
-    int contentLevel;
+    int contentLevel{};
 
     QString messageID;
     QString messageText;

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -69,6 +69,13 @@ enum class ChatSendProtocol : int {
     Helix = 2,
 };
 
+enum class ShowModerationState : int {
+    // Always show this moderation-related item
+    Always = 0,
+    // Never show this moderation-related item
+    Never = 1,
+};
+
 enum StreamerModeSetting {
     Disabled = 0,
     Enabled = 1,
@@ -345,6 +352,10 @@ public:
     IntSetting timeoutStackStyle = {
         "/moderation/timeoutStackStyle",
         static_cast<int>(TimeoutStackStyle::Default)};
+    EnumStringSetting<ShowModerationState> showBlockedTermAutomodMessages = {
+        "/moderation/showBlockedTermAutomodMessages",
+        ShowModerationState::Always,
+    };
 
     /// Highlighting
     //    BoolSetting enableHighlights = {"/highlighting/enabled", true};

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -140,6 +140,8 @@ WindowManager::WindowManager(const Paths &paths, Settings &settings,
     this->forceLayoutChannelViewsListener.add(settings.enableRedeemedHighlight);
     this->forceLayoutChannelViewsListener.add(settings.colorUsernames);
     this->forceLayoutChannelViewsListener.add(settings.boldUsernames);
+    this->forceLayoutChannelViewsListener.add(
+        settings.showBlockedTermAutomodMessages);
 
     this->layoutChannelViewsListener.add(settings.timestampFormat);
     this->layoutChannelViewsListener.add(fonts.fontChanged);

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1167,6 +1167,14 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     layout.addIntInput("Usercard scrollback limit (requires restart)",
                        s.scrollbackUsercardLimit, 100, 100000, 100);
 
+    layout.addDropdownEnumClass<ShowModerationState>(
+        "Show blocked term automod messages",
+        qmagicenum::enumNames<ShowModerationState>(),
+        s.showBlockedTermAutomodMessages,
+        "Show messages that are blocked by AutoMod for containing a public "
+        "blocked term in the current channel.",
+        {});
+
     layout.addDropdown<int>(
         "Stack timeouts", {"Stack", "Stack until timeout", "Don't stack"},
         s.timeoutStackStyle,


### PR DESCRIPTION
Blocked terms can be added at https://dashboard.twitch.tv/settings/moderation/blocked-terms (replace with your username). Twitch fairly recently made messages blocked by blocked terms show up as automod messages. This PR aims to make this customizable, just like it is in Twitch Web Chat.

This is controlled with the new setting "Show blocked term automod messages"
![image](https://github.com/user-attachments/assets/acb0ed6a-4a69-4c91-9400-c60cf30054fa)

I left it as an enum with two options because I see a near future where this can have the option "Only in streamer mode" or something like that

Instead of not adding the message to the channel view, it does add it but it's not laid out, thus making it hidden. This is how some other moderation action messages work, and I didn't want this PR to be the PR to solidify this behaviour, or figure out which is correct, so I left a comment for future adventurers.