### PR TITLE
chore: Specify qtkeychain branch to `chatterino-cmake`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,6 +20,7 @@
 [submodule "lib/qtkeychain"]
 	path = lib/qtkeychain
 	url = https://github.com/Chatterino/qtkeychain
+	branch = chatterino-cmake
 [submodule "lib/websocketpp"]
 	path = lib/websocketpp
 	url = https://github.com/zaphoyd/websocketpp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@
 - Dev: Emojis now use flags instead of a set of strings for capabilities. (#5616)
 - Dev: Move plugins to Sol2. (#5622, #5682)
 - Dev: Clarified our Lua dependency's version. (#5693)
+- Dev: Specified qtkeychain dependency version. (#5695)
 - Dev: Refactored static `MessageBuilder` helpers to standalone functions. (#5652)
 - Dev: Decoupled reply parsing from `MessageBuilder`. (#5660, #5668)
 - Dev: Refactored IRC message building. (#5663)


### PR DESCRIPTION
Related to #5693
Updating the qtkeychain submodule causes
```
src\common\Credentials.cpp(27): fatal error C1083: Cannot open include file: 'keychain.h': No such file or directory
``` 
Specifically `CMAKE_BUILD` gets incorrectly set.
https://github.com/Chatterino/chatterino2/blob/03cdd98c2edec699e13f7bc0a975519de82d5d4f/src/common/Credentials.cpp#L20