### PR TITLE
chore: standardize references to FrankerFaceZ & BetterTTV in settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Minor: Make raid entry message usernames clickable. (#5651)
 - Minor: Tabs unhighlight when their content is read in other tabs. (#5649)
 - Minor: Made usernames in bits and sub messages clickable. (#5686)
+- Minor: Mentions of FrankerFaceZ in settings are now standardized as such. (#5698)
 - Bugfix: Fixed tab move animation occasionally failing to start after closing a tab. (#5426, #5612)
 - Bugfix: If a network request errors with 200 OK, Qt's error code is now reported instead of the HTTP status. (#5378)
 - Bugfix: Fixed restricted users usernames not being clickable. (#5405)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@
 - Minor: Make raid entry message usernames clickable. (#5651)
 - Minor: Tabs unhighlight when their content is read in other tabs. (#5649)
 - Minor: Made usernames in bits and sub messages clickable. (#5686)
-- Minor: Mentions of FrankerFaceZ in settings are now standardized as such. (#5698)
+- Minor: Mentions of FrankerFaceZ and BetterTTV in settings are standardized as such. (#5698)
 - Bugfix: Fixed tab move animation occasionally failing to start after closing a tab. (#5426, #5612)
 - Bugfix: If a network request errors with 200 OK, Qt's error code is now reported instead of the HTTP status. (#5378)
 - Bugfix: Fixed restricted users usernames not being clickable. (#5405)

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -614,12 +614,16 @@ void GeneralPage::initLayout(GeneralPageView &layout)
                            "Google",
                        },
                        s.emojiSet);
-    layout.addCheckbox("Show BetterTTV global emotes", s.enableBTTVGlobalEmotes);
-    layout.addCheckbox("Show BetterTTV channel emotes", s.enableBTTVChannelEmotes);
+    layout.addCheckbox("Show BetterTTV global emotes",
+                       s.enableBTTVGlobalEmotes);
+    layout.addCheckbox("Show BetterTTV channel emotes",
+                       s.enableBTTVChannelEmotes);
     layout.addCheckbox("Enable BetterTTV live emote updates (requires restart)",
                        s.enableBTTVLiveUpdates);
-    layout.addCheckbox("Show FrankerFaceZ global emotes", s.enableFFZGlobalEmotes);
-    layout.addCheckbox("Show FrankerFaceZ channel emotes", s.enableFFZChannelEmotes);
+    layout.addCheckbox("Show FrankerFaceZ global emotes",
+                       s.enableFFZGlobalEmotes);
+    layout.addCheckbox("Show FrankerFaceZ channel emotes",
+                       s.enableFFZChannelEmotes);
     layout.addCheckbox("Show 7TV global emotes", s.enableSevenTVGlobalEmotes);
     layout.addCheckbox("Show 7TV channel emotes", s.enableSevenTVChannelEmotes);
     layout.addCheckbox("Enable 7TV live emote updates (requires restart)",

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -618,8 +618,8 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     layout.addCheckbox("Show BTTV channel emotes", s.enableBTTVChannelEmotes);
     layout.addCheckbox("Enable BTTV live emote updates (requires restart)",
                        s.enableBTTVLiveUpdates);
-    layout.addCheckbox("Show FFZ global emotes", s.enableFFZGlobalEmotes);
-    layout.addCheckbox("Show FFZ channel emotes", s.enableFFZChannelEmotes);
+    layout.addCheckbox("Show FrankerFaceZ global emotes", s.enableFFZGlobalEmotes);
+    layout.addCheckbox("Show FrankerFaceZ channel emotes", s.enableFFZChannelEmotes);
     layout.addCheckbox("Show 7TV global emotes", s.enableSevenTVGlobalEmotes);
     layout.addCheckbox("Show 7TV channel emotes", s.enableSevenTVChannelEmotes);
     layout.addCheckbox("Enable 7TV live emote updates (requires restart)",

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -614,9 +614,9 @@ void GeneralPage::initLayout(GeneralPageView &layout)
                            "Google",
                        },
                        s.emojiSet);
-    layout.addCheckbox("Show BTTV global emotes", s.enableBTTVGlobalEmotes);
-    layout.addCheckbox("Show BTTV channel emotes", s.enableBTTVChannelEmotes);
-    layout.addCheckbox("Enable BTTV live emote updates (requires restart)",
+    layout.addCheckbox("Show BetterTTV global emotes", s.enableBTTVGlobalEmotes);
+    layout.addCheckbox("Show BetterTTV channel emotes", s.enableBTTVChannelEmotes);
+    layout.addCheckbox("Enable BetterTTV live emote updates (requires restart)",
                        s.enableBTTVLiveUpdates);
     layout.addCheckbox("Show FrankerFaceZ global emotes", s.enableFFZGlobalEmotes);
     layout.addCheckbox("Show FrankerFaceZ channel emotes", s.enableFFZChannelEmotes);


### PR DESCRIPTION
started because half the FFZ settings were `ffz` and the other half were `frankerfacez` so if you're used to searching ffz sometimes you don't get the setting you want, but if we update ffz we should update bttv also
now i know what you're thinking, doesn't this make it worse for everyone, and yeah it does lol got u, but standardization

anyway we're respecting branding now and it pushes pajlada towards implementing search tags to restore `bttv` and `ffz` search