### PR TITLE
feat: improve automod blocked term messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Minor: When blocking a channel, Chatterino will now warn you about that action. (#5615)
 - Minor: Indicate when subscriptions and resubscriptions are for multiple months. (#5642)
 - Minor: Added a setting to control whether or not to show "Blocked Term" automod messages. (#5690)
+- Minor: Improved AutoMod messaging when messages are blocked due to containing blocked terms. (#5699)
 - Minor: Proxy URL information is now included in the `/debug-env` command. (#5648)
 - Minor: Make raid entry message usernames clickable. (#5651)
 - Minor: Tabs unhighlight when their content is read in other tabs. (#5649)

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -149,6 +149,8 @@ bool shouldSendHelixChat()
 
 namespace chatterino {
 
+using namespace literals;
+
 TwitchIrcServer::TwitchIrcServer()
     : whispersChannel(new Channel("/whispers", Channel::Type::TwitchWhispers))
     , mentionsChannel(new Channel("/mentions", Channel::Type::TwitchMentions))
@@ -504,25 +506,21 @@ void TwitchIrcServer::initialize()
                                 if (hideBlockedTerms)
                                 {
                                     action.reason =
-                                        u"matched " %
-                                        QString::number(
-                                            numBlockedTermsMatched) %
-                                        u" blocked term" %
-                                        (numBlockedTermsMatched > 1 ? u"s"
-                                                                    : u"");
+                                        u"matches %1 blocked term%2"_s.arg(
+                                            numBlockedTermsMatched,
+                                            numBlockedTermsMatched > 1 ? 's'
+                                                                       : "");
                                 }
                                 else
                                 {
                                     action.reason =
-                                        u"matched " %
-                                        QString::number(
-                                            numBlockedTermsMatched) %
-                                        u" blocked term" %
-                                        (numBlockedTermsMatched > 1 ? u"s"
-                                                                    : u"") %
-                                        u": \"" %
-                                        msg.blockedTermsFound.join(u"\", \"") %
-                                        u"\"";
+                                        u"matches %1 blocked term%2 \"%3\""_s
+                                            .arg(numBlockedTermsMatched,
+                                                 numBlockedTermsMatched > 1
+                                                     ? 's'
+                                                     : "",
+                                                 msg.blockedTermsFound.join(
+                                                     u"\", \""));
                                 }
                             }
                             else

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -507,7 +507,7 @@ void TwitchIrcServer::initialize()
                                     action.reason =
                                         u"matches %1 blocked term%2"_s.arg(
                                             numBlockedTermsMatched,
-                                            numBlockedTermsMatched > 1 ? 's'
+                                            numBlockedTermsMatched > 1 ? u"s"
                                                                        : "");
                                 }
                                 else
@@ -516,7 +516,7 @@ void TwitchIrcServer::initialize()
                                         u"matches %1 blocked term%2 \"%3\""_s
                                             .arg(numBlockedTermsMatched,
                                                  numBlockedTermsMatched > 1
-                                                     ? 's'
+                                                     ? u"s"
                                                      : "",
                                                  msg.blockedTermsFound.join(
                                                      u"\", \""));

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -33,7 +33,6 @@
 #include <pajlada/signals/signalholder.hpp>
 #include <QCoreApplication>
 #include <QMetaEnum>
-#include <QStringBuilder>
 
 #include <cassert>
 #include <functional>

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -505,21 +505,22 @@ void TwitchIrcServer::initialize()
                                 if (hideBlockedTerms)
                                 {
                                     action.reason =
-                                        u"matches %1 blocked term%2"_s.arg(
-                                            numBlockedTermsMatched,
-                                            numBlockedTermsMatched > 1 ? u"s"
-                                                                       : "");
+                                        u"matches %1 blocked term%2"_s
+                                            .arg(numBlockedTermsMatched)
+                                            .arg(numBlockedTermsMatched > 1
+                                                     ? u"s"
+                                                     : u"");
                                 }
                                 else
                                 {
                                     action.reason =
                                         u"matches %1 blocked term%2 \"%3\""_s
-                                            .arg(numBlockedTermsMatched,
-                                                 numBlockedTermsMatched > 1
+                                            .arg(numBlockedTermsMatched)
+                                            .arg(numBlockedTermsMatched > 1
                                                      ? u"s"
-                                                     : "",
-                                                 msg.blockedTermsFound.join(
-                                                     u"\", \""));
+                                                     : u"")
+                                            .arg(msg.blockedTermsFound.join(
+                                                u"\", \""));
                                 }
                             }
                             else

--- a/src/providers/twitch/pubsubmessages/AutoMod.cpp
+++ b/src/providers/twitch/pubsubmessages/AutoMod.cpp
@@ -2,6 +2,8 @@
 
 #include "util/QMagicEnum.hpp"
 
+#include <QJsonArray>
+
 namespace chatterino {
 
 PubSubAutoModQueueMessage::PubSubAutoModQueueMessage(const QJsonObject &root)
@@ -9,6 +11,7 @@ PubSubAutoModQueueMessage::PubSubAutoModQueueMessage(const QJsonObject &root)
     , data(root.value("data").toObject())
     , status(this->data.value("status").toString())
 {
+    qInfo() << "XXX: automod message over pubsub:" << root;
     auto oType = qmagicenum::enumCast<Type>(this->typeString);
     if (oType.has_value())
     {
@@ -41,6 +44,27 @@ PubSubAutoModQueueMessage::PubSubAutoModQueueMessage(const QJsonObject &root)
         messageSender.value("display_name").toString();
     this->senderUserChatColor =
         QColor(messageSender.value("chat_color").toString());
+
+    if (this->reason == Reason::BlockedTerm)
+    {
+        // Attempt to read the blocked term(s) that caused this message to be blocked
+        const auto caughtMessageReason =
+            data.value("caught_message_reason").toObject();
+        const auto blockedTermFailure =
+            caughtMessageReason.value("blocked_term_failure").toObject();
+        const auto termsFound =
+            blockedTermFailure.value("terms_found").toArray();
+
+        for (const auto &termValue : termsFound)
+        {
+            const auto term = termValue.toObject();
+            const auto termText = term.value("text").toString();
+            if (!termText.isEmpty())
+            {
+                this->blockedTermsFound.push_back(termText);
+            }
+        }
+    }
 }
 
 }  // namespace chatterino

--- a/src/providers/twitch/pubsubmessages/AutoMod.cpp
+++ b/src/providers/twitch/pubsubmessages/AutoMod.cpp
@@ -11,7 +11,6 @@ PubSubAutoModQueueMessage::PubSubAutoModQueueMessage(const QJsonObject &root)
     , data(root.value("data").toObject())
     , status(this->data.value("status").toString())
 {
-    qInfo() << "XXX: automod message over pubsub:" << root;
     auto oType = qmagicenum::enumCast<Type>(this->typeString);
     if (oType.has_value())
     {

--- a/src/providers/twitch/pubsubmessages/AutoMod.hpp
+++ b/src/providers/twitch/pubsubmessages/AutoMod.hpp
@@ -4,6 +4,7 @@
 #include <QColor>
 #include <QJsonObject>
 #include <QString>
+#include <QStringList>
 
 namespace chatterino {
 
@@ -39,6 +40,8 @@ struct PubSubAutoModQueueMessage {
     QString senderUserLogin;
     QString senderUserDisplayName;
     QColor senderUserChatColor;
+
+    QStringList blockedTermsFound;
 
     PubSubAutoModQueueMessage() = default;
     explicit PubSubAutoModQueueMessage(const QJsonObject &root);

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -347,6 +347,10 @@ public:
         "/streamerMode/supressLiveNotifications", false};
     BoolSetting streamerModeSuppressInlineWhispers = {
         "/streamerMode/suppressInlineWhispers", true};
+    BoolSetting streamerModeHideBlockedTermText = {
+        "/streamerMode/hideBlockedTermText",
+        true,
+    };
 
     /// Ignored Phrases
     QStringSetting ignoredPhraseReplace = {"/ignore/ignoredPhraseReplace",

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -675,6 +675,11 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     layout.addCheckbox(
         "Hide moderation actions", s.streamerModeHideModActions, false,
         "Hide bans, timeouts, and automod messages from appearing in chat.");
+    layout.addCheckbox(
+        "Hide blocked terms", s.streamerModeHideBlockedTermText, false,
+        "Hide blocked terms from showing up in places like AutoMod messages. "
+        "This can be useful in case you have some blocked terms that you don't "
+        "want to show on stream.");
     layout.addCheckbox("Mute mention sounds", s.streamerModeMuteMentions, false,
                        "Mute your ping sound from playing.");
     layout.addCheckbox(


### PR DESCRIPTION
Top two AutoMod messages when streamer mode is enabled & the default-enabled "Hide blocked terms" under Streamer Mode is enabled, bottom two is when that is disabled.

![image](https://github.com/user-attachments/assets/8a81b04e-6ee7-4668-8c05-4a082d048cb8)
