### PR TITLE
Deduplicate emotes by name in smart tab emote completion strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - Minor: Tabs unhighlight when their content is read in other tabs. (#5649)
 - Minor: Made usernames in bits and sub messages clickable. (#5686)
 - Minor: Mentions of FrankerFaceZ and BetterTTV in settings are standardized as such. (#5698)
+- Minor: Emote names are no longer duplicated when using smarter emote completion. (#5698)
 - Bugfix: Fixed tab move animation occasionally failing to start after closing a tab. (#5426, #5612)
 - Bugfix: If a network request errors with 200 OK, Qt's error code is now reported instead of the HTTP status. (#5378)
 - Bugfix: Fixed restricted users usernames not being clickable. (#5405)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@
 - Minor: Tabs unhighlight when their content is read in other tabs. (#5649)
 - Minor: Made usernames in bits and sub messages clickable. (#5686)
 - Minor: Mentions of FrankerFaceZ and BetterTTV in settings are standardized as such. (#5698)
-- Minor: Emote names are no longer duplicated when using smarter emote completion. (#5698)
+- Minor: Emote names are no longer duplicated when using smarter emote completion. (#5705)
 - Bugfix: Fixed tab move animation occasionally failing to start after closing a tab. (#5426, #5612)
 - Bugfix: If a network request errors with 200 OK, Qt's error code is now reported instead of the HTTP status. (#5378)
 - Bugfix: Fixed restricted users usernames not being clickable. (#5405)

--- a/src/controllers/completion/TabCompletionModel.cpp
+++ b/src/controllers/completion/TabCompletionModel.cpp
@@ -43,11 +43,15 @@ void TabCompletionModel::updateResults(const QString &query,
                 query, fullTextContent, cursorPosition, isFirstWord);
         if (done)
         {
+            auto uniqueResults = std::unique(results.begin(), results.end());
+            results.erase(uniqueResults, results.end());
             this->setStringList(results);
             return;
         }
 #endif
         this->source_->addToStringList(results, 0, isFirstWord);
+        auto uniqueResults = std::unique(results.begin(), results.end());
+        results.erase(uniqueResults, results.end());
         this->setStringList(results);
     }
 }


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

This PR makes it so if there are multiple emotes with the same name (for example from different sources) and you are using the "smarter emote completion" option, when tabbing through them it no longer cycles through all the instances of the same name.

Originally I changed this in `SmartEmoteStrategy`, but this ended up removing duplicates from the : dropdown menu as well, which is not something we want I believe. Now it's deduplicated specifically in `TabCompletionModel` regardless of the emote strategy, but I think this should be fine as it's a cheap operation.