### PR TITLE
fix: clear WinToast on exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 - Bugfix: Fixed grammar in the user highlight page. (#5602)
 - Bugfix: Fixed incorrect message being disabled in some cases upon approving or denying an automod caught message. (#5611)
 - Bugfix: Fixed double-click selection not working when clicking outside a message. (#5617)
+- Bugfix: Fixed a potential rare crash that could occur on Windows if a toast was about to fire just as we were shutting down. (#5728)
 - Bugfix: Fixed emotes starting with ":" not tab-completing. (#5603)
 - Bugfix: Fixed 7TV emotes messing with Qt's HTML. (#5677)
 - Bugfix: Fixed incorrect messages getting replaced visually. (#5683)

--- a/src/singletons/Toasts.cpp
+++ b/src/singletons/Toasts.cpp
@@ -65,17 +65,17 @@ signals:
 
 namespace chatterino {
 
+#ifdef Q_OS_WIN
+using WinToastLib::WinToast;
+using WinToastLib::WinToastTemplate;
+#endif
+
 Toasts::~Toasts()
 {
 #ifdef Q_OS_WIN
     WinToast::instance()->clear();
 #endif
 }
-
-#ifdef Q_OS_WIN
-using WinToastLib::WinToast;
-using WinToastLib::WinToastTemplate;
-#endif
 
 bool Toasts::isEnabled()
 {

--- a/src/singletons/Toasts.cpp
+++ b/src/singletons/Toasts.cpp
@@ -65,6 +65,13 @@ signals:
 
 namespace chatterino {
 
+Toasts::~Toasts()
+{
+#ifdef Q_OS_WIN
+    WinToast::instance()->clear();
+#endif
+}
+
 #ifdef Q_OS_WIN
 using WinToastLib::WinToast;
 using WinToastLib::WinToastTemplate;

--- a/src/singletons/Toasts.hpp
+++ b/src/singletons/Toasts.hpp
@@ -3,6 +3,8 @@
 #include <pajlada/settings/setting.hpp>
 #include <QString>
 
+#include <cstdint>
+
 namespace chatterino {
 
 enum class Platform : uint8_t;
@@ -17,6 +19,8 @@ enum class ToastReaction {
 class Toasts final
 {
 public:
+    ~Toasts();
+
     void sendChannelNotification(const QString &channelName,
                                  const QString &channelTitle, Platform p);
     static QString findStringFromReaction(const ToastReaction &reaction);


### PR DESCRIPTION
this might fix a rare crash on shutdown on Windows

There's still room for other crashes (e.g. if TwitchChannel calls `getApp()->getNotifications()` during shutdown), but this patches a tiny hole at least.

Fixes #5601
