### PR TITLE
feat: Add setting to hide scrollbar thumb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - Minor: Made usernames in bits and sub messages clickable. (#5686)
 - Minor: Mentions of FrankerFaceZ and BetterTTV in settings are standardized as such. (#5698)
 - Minor: Emote names are no longer duplicated when using smarter emote completion. (#5705)
+- Minor: Added a setting to hide the scrollbar thumb (the handle you can drag). Hiding the scrollbar thumb will disable mouse click & drag interactions in the scrollbar. (#5731)
 - Bugfix: Fixed tab move animation occasionally failing to start after closing a tab. (#5426, #5612)
 - Bugfix: If a network request errors with 200 OK, Qt's error code is now reported instead of the HTTP status. (#5378)
 - Bugfix: Fixed restricted users usernames not being clickable. (#5405)

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -224,6 +224,12 @@ public:
         {300, 500},
     };
 
+    // Scrollbar
+    BoolSetting hideScrollbarThumb = {
+        "/appearance/scrollbar/hideThumb",
+        false,
+    };
+
     /// Behaviour
     BoolSetting allowDuplicateMessages = {"/behaviour/allowDuplicateMessages",
                                           true};

--- a/src/widgets/OverlayWindow.cpp
+++ b/src/widgets/OverlayWindow.cpp
@@ -126,7 +126,7 @@ OverlayWindow::OverlayWindow(IndirectChannel channel,
     this->holder_.managedConnect(this->channel_.getChannelChanged(), [this]() {
         this->channelView_.setChannel(this->channel_.get());
     });
-    this->channelView_.scrollbar()->setShowThumb(false);
+    this->channelView_.scrollbar()->setHideThumb(true);
 
     this->setAutoFillBackground(false);
     this->resize(300, 500);

--- a/src/widgets/Scrollbar.cpp
+++ b/src/widgets/Scrollbar.cpp
@@ -292,7 +292,7 @@ void Scrollbar::paintEvent(QPaintEvent * /*event*/)
     bool enableElevatedMessageHighlights =
         getSettings()->enableElevatedMessageHighlight;
 
-    if (!this->shouldHideThumb())
+    if (this->shouldShowThumb())
     {
         this->thumbRect_.setX(xOffset);
 
@@ -485,14 +485,14 @@ void Scrollbar::setHideThumb(bool hideThumb)
     this->update();
 }
 
-bool Scrollbar::shouldHideThumb() const
+bool Scrollbar::shouldShowThumb() const
 {
-    return this->hideThumb || this->settingHideThumb;
+    return !(this->hideThumb || this->settingHideThumb);
 }
 
 bool Scrollbar::shouldHandleMouseEvents() const
 {
-    return !this->shouldHideThumb();
+    return this->shouldShowThumb();
 }
 
 Scrollbar::MouseLocation Scrollbar::locationOfMouseEvent(

--- a/src/widgets/Scrollbar.hpp
+++ b/src/widgets/Scrollbar.hpp
@@ -130,8 +130,8 @@ public:
 
     void setHideThumb(bool hideThumb);
 
-    /// Returns true if we should skip painting the thumb
-    bool shouldHideThumb() const;
+    /// Returns true if we should show the thumb (the handle you can drag)
+    bool shouldShowThumb() const;
 
     bool shouldHandleMouseEvents() const;
 

--- a/src/widgets/Scrollbar.hpp
+++ b/src/widgets/Scrollbar.hpp
@@ -5,6 +5,7 @@
 
 #include <boost/circular_buffer.hpp>
 #include <pajlada/signals/signal.hpp>
+#include <pajlada/signals/signalholder.hpp>
 #include <QPropertyAnimation>
 #include <QWidget>
 
@@ -127,7 +128,12 @@ public:
     /// unaffected by simultaneous shifts of minimum and maximum.
     qreal getRelativeCurrentValue() const;
 
-    void setShowThumb(bool showthumb);
+    void setHideThumb(bool hideThumb);
+
+    /// Returns true if we should skip painting the thumb
+    bool shouldHideThumb() const;
+
+    bool shouldHandleMouseEvents() const;
 
     // offset the desired value without breaking smooth scolling
     void offset(qreal value);
@@ -171,7 +177,9 @@ private:
     boost::circular_buffer<ScrollbarHighlight> highlights_;
 
     bool atBottom_{false};
-    bool showThumb_ = true;
+    bool hideThumb{false};
+    /// Controlled by the "Hide scrollbar thumb" setting
+    bool settingHideThumb{false};
 
     MouseLocation mouseOverLocation_ = MouseLocation::Outside;
     MouseLocation mouseDownLocation_ = MouseLocation::Outside;
@@ -189,6 +197,8 @@ private:
 
     pajlada::Signals::NoArgSignal currentValueChanged_;
     pajlada::Signals::NoArgSignal desiredValueChanged_;
+
+    pajlada::Signals::SignalHolder signalHolder;
 };
 
 }  // namespace chatterino

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -458,6 +458,11 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         },
         false);
 
+    layout.addCheckbox(
+        "Hide scrollbar thumb", s.hideScrollbarThumb, false,
+        "Hiding the scrollbar thumb (the handle you can drag) will disable "
+        "all mouse interaction in the scrollbar.");
+
     layout.addTitle("Messages");
     layout.addCheckbox(
         "Separate with lines", s.separateMessages, false,


### PR DESCRIPTION
Hiding the scrollbar thumb will disable all mouse click/drag interaction in the scrollbar

Fixes #3874

I have tested the overlay window to ensure I have not broken anything to do with its scrollbar handle hiding.

<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
