### PR TITLE
fix(test/once-flag): loosen requirement for tight timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,7 +135,7 @@
 - Dev: Unified parsing of historic and live IRC messages. (#5678)
 - Dev: 7TV's `entitlement.reset` is now explicitly ignored. (#5685)
 - Dev: Qt 6.8 and later now default to the GDI fontengine. (#5710)
-- Dev: Moved to condition variables when shutting down worker threads. (#5721)
+- Dev: Moved to condition variables when shutting down worker threads. (#5721, #5733)
 
 ## 2.5.1
 

--- a/tests/src/OnceFlag.cpp
+++ b/tests/src/OnceFlag.cpp
@@ -48,7 +48,7 @@ TEST(OnceFlag, waitFor)
     ASSERT_TRUE(stoppedFlag.waitFor(std::chrono::milliseconds{200}));
     auto stop = std::chrono::system_clock::now();
 
-    ASSERT_LT(stop - start, std::chrono::milliseconds{150});
+    ASSERT_LT(stop - start, std::chrono::milliseconds{200});
 
     start = std::chrono::system_clock::now();
     ASSERT_TRUE(stoppedFlag.waitFor(std::chrono::milliseconds{1000}));


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

https://github.com/Chatterino/chatterino2/actions/runs/11999441698/job/33447346229 had 165, 192, 185, and 161ms as the duration for `stop - start` (the previous assert was fine), so let's loosen the requirement to not take longer than the specified timeout.