### PR TITLE
revert: use helix as the default chat send protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,7 +123,6 @@
 - Dev: Refactored legacy Unicode zero-width-joiner replacement. (#5594)
 - Dev: The JSON output when copying a message (<kbd>SHIFT</kbd> + right-click) is now more extensive. (#5600)
 - Dev: Added more tests for message building. (#5598, #5654, #5656, #5671)
-- Dev: Twitch messages are now sent using Twitch's Helix API instead of IRC by default. (#5607)
 - Dev: `GIFTimer` is no longer initialized in tests. (#5608)
 - Dev: Emojis now use flags instead of a set of strings for capabilities. (#5616)
 - Dev: Move plugins to Sol2. (#5622, #5682)

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -132,14 +132,14 @@ bool shouldSendHelixChat()
 {
     switch (getSettings()->chatSendProtocol)
     {
-        case ChatSendProtocol::Default:
         case ChatSendProtocol::Helix:
             return true;
+        case ChatSendProtocol::Default:
         case ChatSendProtocol::IRC:
             return false;
         default:
             assert(false && "Invalid chat protocol value");
-            return true;
+            return false;
     }
 }
 


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
Essentially reverts https://github.com/Chatterino/chatterino2/pull/5607 (not quite but almost).

Rationale: Twitch doesn't provide good errors for the Helix API. See [uservoice](https://twitch.uservoice.com/forums/310213-developers/suggestions/48972260-improve-error-messages-for-send-chat-message), https://github.com/Chatterino/chatterino2/issues/5675, and https://github.com/twitchdev/issues/issues/1019.

See also: https://github.com/Chatterino/chatterino2/issues/1600#issuecomment-2495453370 (not correct until this PR is merged) and https://github.com/Chatterino/chatterino2/issues/5675#issuecomment-2436363418.