### PR TITLE
perf: don't force-layout in `setChannel`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,7 @@
 - Dev: 7TV's `entitlement.reset` is now explicitly ignored. (#5685)
 - Dev: Qt 6.8 and later now default to the GDI fontengine. (#5710)
 - Dev: Moved to condition variables when shutting down worker threads. (#5721, #5733)
+- Dev: Reduced layouts in channel views when setting a channel. (#5737)
 
 ## 2.5.1
 

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1073,7 +1073,7 @@ void ChannelView::setChannel(const ChannelPtr &underlyingChannel)
 
     this->updateID();
 
-    this->performLayout();
+    this->queueLayout();
     this->queueUpdate();
 
     // Notifications


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

Seems like I missed that when converting to `queueLayout`. This is not a huge performance gain, as the channels are usually empty when Chatterino starts up. I noticed this in the emote popup, where the channels already contain messages. You can see attempts to load emojis there, which shouldn't happen, as that tab isn't open by default.