### PR TITLE
fix: remove cosmetic allowCommandsAtEnd setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@
 - Dev: Update vcpkg build Qt from 6.5.0 to 6.7.0, boost from 1.83.0 to 1.85.0, openssl from 3.1.3 to 3.3.0. (#5422)
 - Dev: Unsingletonize `ISoundController`. (#5462)
 - Dev: Use Qt's high DPI scaling. (#4868, #5400)
+- Dev: Removed cosmetic "Also match the trigger at the end of the message" setting. (#5745)
 - Dev: Add doxygen build target. (#5377)
 - Dev: Make printing of strings in tests easier. (#5379)
 - Dev: Refactor and document `Scrollbar`. (#5334, #5393)

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -295,9 +295,6 @@ public:
     BoolSetting mentionUsersWithComma = {"/behaviour/mentionUsersWithComma",
                                          true};
 
-    /// Commands
-    BoolSetting allowCommandsAtEnd = {"/commands/allowCommandsAtEnd", false};
-
     /// Emotes
     BoolSetting scaleEmotesByLineHeight = {"/emotes/scaleEmotesByLineHeight",
                                            false};

--- a/src/widgets/settingspages/CommandPage.cpp
+++ b/src/widgets/settingspages/CommandPage.cpp
@@ -123,10 +123,6 @@ CommandPage::CommandPage()
         });
     }
 
-    layout.append(
-        this->createCheckBox("Also match the trigger at the end of the message",
-                             getSettings()->allowCommandsAtEnd));
-
     QLabel *text = layout.emplace<QLabel>(HELP_TEXT).getElement();
     text->setWordWrap(true);
     text->setStyleSheet("color: #bbb");


### PR DESCRIPTION
Any new functionality we'd want to add here would probably not be what
people who checked this setting actually wanted it do be. It's best to
start fresh if we want to add similar functionality.

Fixes #2308

<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
