### PR TITLE
fix: scroll to bottom when setting a channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,7 +138,7 @@
 - Dev: 7TV's `entitlement.reset` is now explicitly ignored. (#5685)
 - Dev: Qt 6.8 and later now default to the GDI fontengine. (#5710)
 - Dev: Moved to condition variables when shutting down worker threads. (#5721, #5733)
-- Dev: Reduced layouts in channel views when setting a channel. (#5737)
+- Dev: Reduced layouts in channel views when setting a channel. (#5737, #5748)
 
 ## 2.5.1
 

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -168,10 +168,11 @@ void addTwitchEmoteSets(const std::shared_ptr<const EmoteMap> &local,
 void loadEmojis(ChannelView &view, const std::vector<EmojiPtr> &emojiMap)
 {
     ChannelPtr emojiChannel(new Channel("", Channel::Type::None));
+    // set the channel first to make sure the scrollbar is at the top
+    view.setChannel(emojiChannel);
+
     emojiChannel->addMessage(makeEmojiMessage(emojiMap),
                              MessageContext::Original);
-
-    view.setChannel(emojiChannel);
 }
 
 void loadEmojis(Channel &channel, const std::vector<EmojiPtr> &emojiMap,

--- a/src/widgets/dialogs/ReplyThreadPopup.cpp
+++ b/src/widgets/dialogs/ReplyThreadPopup.cpp
@@ -237,9 +237,6 @@ void ReplyThreadPopup::addMessagesFromThread()
             sourceChannel->getName(), Channel::Type::None);
     }
 
-    this->ui_.threadView->setChannel(this->virtualChannel_);
-    this->ui_.threadView->setSourceChannel(sourceChannel);
-
     auto rootOverrideFlags =
         std::optional<MessageFlags>(this->thread_->root()->flags);
     rootOverrideFlags->set(MessageFlag::DoNotLog);
@@ -257,6 +254,9 @@ void ReplyThreadPopup::addMessagesFromThread()
                                               overrideFlags);
         }
     }
+
+    this->ui_.threadView->setChannel(this->virtualChannel_);
+    this->ui_.threadView->setSourceChannel(sourceChannel);
 
     this->messageConnection_ =
         std::make_unique<pajlada::Signals::ScopedConnection>(

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1074,6 +1074,13 @@ void ChannelView::setChannel(const ChannelPtr &underlyingChannel)
     this->updateID();
 
     this->queueLayout();
+    if (!this->isVisible() && !this->scrollBar_->isVisible())
+    {
+        // If we're not visible and the scrollbar is not (yet) visible,
+        // we need to make sure that it's at the bottom when this view is laid
+        // out later.
+        this->scrollBar_->scrollToBottom();
+    }
     this->queueUpdate();
 
     // Notifications


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
In https://github.com/Chatterino/chatterino2/pull/5737 I changed `performLayout` to `queueLayout` in `ChannelView::setChannel`. This causes usercards and reply thread popups to have their scrollbar at the top when opened (specifically, [this](https://github.com/Chatterino/chatterino2/blob/06d0160b350950f46d033942b3e58a5fdfcbdfe0/src/widgets/helper/ChannelView.cpp#L675-L677) would resolve to `true` before, because the scrollbar was still hidden).
This PR fixes that. For the various channel views, we need to make sure that they're properly initialized. For emojis, we need to make sure the view starts at the top, so we set the channel first and then add messages. On the other hand, for reply thread popups, we want to scroll to the bottom, hence we set the (virtual) channel after adding all messages.

I don't want to revert https://github.com/Chatterino/chatterino2/pull/5737 just because we relied on that initial layout.