### PR TITLE
fix(emote-popup): ignore null gemometry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Minor: Colored usernames now update on the fly when changing the "Color @usernames" setting. (#5300)
 - Minor: Added `flags.action` filter variable, allowing you to filter on `/me` messages. (#5397)
 - Minor: Added the ability for `/ban`, `/timeout`, `/unban`, and `/untimeout` to specify multiple channels to duplicate the action to. Example: `/timeout --channel id:11148817 --channel testaccount_420 forsen 7m game complaining`. (#5402)
-- Minor: The size of the emote popup is now saved. (#5415)
+- Minor: The size of the emote popup is now saved. (#5415, #5751)
 - Minor: Added the ability to duplicate tabs. (#5277)
 - Minor: Improved error messages for channel update commands. (#5429)
 - Minor: Moderators can now see when users are warned. (#5441)

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -639,7 +639,11 @@ void EmotePopup::filterEmotes(const QString &searchText)
 
 void EmotePopup::saveBounds() const
 {
-    getApp()->getWindows()->setEmotePopupBounds(this->getBounds());
+    auto bounds = this->getBounds();
+    if (!bounds.isNull())
+    {
+        getApp()->getWindows()->setEmotePopupBounds(bounds);
+    }
 }
 
 void EmotePopup::resizeEvent(QResizeEvent *event)


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

On Windows, the `currentBounds` are initially zero. When opening the popup, a `resizeEvent` is triggered - at this point, the `currentBounds` are still zero. This makes sure we never save that initial position. This also reveals that #5415 did **not** fix #5414.

Fixes #5414.