### PR TITLE
fix(toasts): only clear if initialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@
 - Bugfix: Fixed incorrect message being disabled in some cases upon approving or denying an automod caught message. (#5611)
 - Bugfix: Fixed network requests timing out despite them not being in flight for that long, for Qt 6.3+ where we have the technology. (#5729)
 - Bugfix: Fixed double-click selection not working when clicking outside a message. (#5617)
-- Bugfix: Fixed a potential rare crash that could occur on Windows if a toast was about to fire just as we were shutting down. (#5728)
+- Bugfix: Fixed a rare crash that could occur on Windows if a toast was about to fire just as we were shutting down. (#5728, #5752)
 - Bugfix: Fixed emotes starting with ":" not tab-completing. (#5603)
 - Bugfix: Fixed 7TV emotes messing with Qt's HTML. (#5677)
 - Bugfix: Fixed incorrect messages getting replaced visually. (#5683)

--- a/src/singletons/Toasts.cpp
+++ b/src/singletons/Toasts.cpp
@@ -73,7 +73,10 @@ using WinToastLib::WinToastTemplate;
 Toasts::~Toasts()
 {
 #ifdef Q_OS_WIN
-    WinToast::instance()->clear();
+    if (this->initialized_)
+    {
+        WinToast::instance()->clear();
+    }
 #endif
 }
 


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

If we clear the toasts when they're uninitialized, a winrt error is "thrown" in another thread, because we didn't configure the app user model ID yet. This PR fixes that.