### PR TITLE
fix: initial scrollbar behaviour in inactive tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,7 +142,7 @@
 - Dev: 7TV's `entitlement.reset` is now explicitly ignored. (#5685)
 - Dev: Qt 6.8 and later now default to the GDI fontengine. (#5710)
 - Dev: Moved to condition variables when shutting down worker threads. (#5721, #5733)
-- Dev: Reduced layouts in channel views when setting a channel. (#5737, #5748)
+- Dev: Reduced layouts in channel views when setting a channel. (#5737, #5748, #5757)
 
 ## 2.5.1
 

--- a/src/widgets/Scrollbar.hpp
+++ b/src/widgets/Scrollbar.hpp
@@ -179,7 +179,7 @@ private:
 
     boost::circular_buffer<ScrollbarHighlight> highlights_;
 
-    bool atBottom_{false};
+    bool atBottom_{true};
     bool hideThumb{false};
     /// Controlled by the "Hide scrollbar thumb" setting
     bool settingHideThumb{false};


### PR DESCRIPTION
Channel views could sometimes have their scrollbar be at the top instead
of bottom when they were first activated if it had messages in it

Scrollbars now assume their default behaviour is: "I'm scrolled down to the bottom" - this seems reasonable & fixes the issue
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
