### PR TITLE
fix: check application in 7TV event-api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+- Bugfix: Fixed a crash in the 7TV EventApi when closing Chatterino. (#5768)
+
 ## 2.5.2-beta.1
 
 - Major: Add option to show pronouns in user card. (#5442, #5583)

--- a/src/providers/seventv/SeventvEventAPI.cpp
+++ b/src/providers/seventv/SeventvEventAPI.cpp
@@ -363,7 +363,13 @@ void SeventvEventAPI::onUserUpdate(const Dispatch &dispatch)
 
 void SeventvEventAPI::onCosmeticCreate(const CosmeticCreateDispatch &cosmetic)
 {
-    auto *badges = getApp()->getSeventvBadges();
+    auto *app = tryGetApp();
+    if (!app)
+    {
+        return;  // shutting down
+    }
+
+    auto *badges = app->getSeventvBadges();
     switch (cosmetic.kind)
     {
         case CosmeticKind::Badge: {
@@ -378,7 +384,13 @@ void SeventvEventAPI::onCosmeticCreate(const CosmeticCreateDispatch &cosmetic)
 void SeventvEventAPI::onEntitlementCreate(
     const EntitlementCreateDeleteDispatch &entitlement)
 {
-    auto *badges = getApp()->getSeventvBadges();
+    auto *app = tryGetApp();
+    if (!app)
+    {
+        return;  // shutting down
+    }
+
+    auto *badges = app->getSeventvBadges();
     switch (entitlement.kind)
     {
         case CosmeticKind::Badge: {
@@ -394,7 +406,13 @@ void SeventvEventAPI::onEntitlementCreate(
 void SeventvEventAPI::onEntitlementDelete(
     const EntitlementCreateDeleteDispatch &entitlement)
 {
-    auto *badges = getApp()->getSeventvBadges();
+    auto *app = tryGetApp();
+    if (!app)
+    {
+        return;  // shutting down
+    }
+
+    auto *badges = app->getSeventvBadges();
     switch (entitlement.kind)
     {
         case CosmeticKind::Badge: {


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

Towards https://github.com/Chatterino/chatterino2/issues/5724.

The crashes in the 7TV event-api when exiting are the most frequent in my experience. So let's make sure they don't happen. As mentioned in the linked issue, this should only be considered a temporary solution. Once we figured out how we structure `Application` and `getApp`, we should be able to make this proper.
