### PR TITLE
fix: hide scrollbar highlights in overlay window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+- Bugfix: Fixed scrollbar highlights being visible in overlay windows. (#5769)
+
 ## 2.5.2-beta.1
 
 - Major: Add option to show pronouns in user card. (#5442, #5583)

--- a/src/widgets/OverlayWindow.cpp
+++ b/src/widgets/OverlayWindow.cpp
@@ -127,6 +127,7 @@ OverlayWindow::OverlayWindow(IndirectChannel channel,
         this->channelView_.setChannel(this->channel_.get());
     });
     this->channelView_.scrollbar()->setHideThumb(true);
+    this->channelView_.scrollbar()->setHideHighlights(true);
 
     this->setAutoFillBackground(false);
     this->resize(300, 500);

--- a/src/widgets/Scrollbar.cpp
+++ b/src/widgets/Scrollbar.cpp
@@ -495,9 +495,20 @@ bool Scrollbar::shouldShowThumb() const
     return !(this->hideThumb || this->settingHideThumb);
 }
 
+void Scrollbar::setHideHighlights(bool hideHighlights)
+{
+    if (this->hideHighlights == hideHighlights)
+    {
+        return;
+    }
+
+    this->hideHighlights = hideHighlights;
+    this->update();
+}
+
 bool Scrollbar::shouldShowHighlights() const
 {
-    return !this->settingHideHighlights;
+    return !(this->hideHighlights || this->settingHideHighlights);
 }
 
 bool Scrollbar::shouldHandleMouseEvents() const

--- a/src/widgets/Scrollbar.hpp
+++ b/src/widgets/Scrollbar.hpp
@@ -133,6 +133,8 @@ public:
     /// Returns true if we should show the thumb (the handle you can drag)
     bool shouldShowThumb() const;
 
+    void setHideHighlights(bool hideHighlights);
+
     /// Returns true if we should show the highlights
     bool shouldShowHighlights() const;
 
@@ -180,10 +182,13 @@ private:
     boost::circular_buffer<ScrollbarHighlight> highlights_;
 
     bool atBottom_{true};
+    /// This takes precedence over `settingHideThumb`
     bool hideThumb{false};
     /// Controlled by the "Hide scrollbar thumb" setting
     bool settingHideThumb{false};
 
+    /// This takes precedence over `settingHideHighlights`
+    bool hideHighlights = false;
     /// Controlled by the "Hide scrollbar highlights" setting
     bool settingHideHighlights{false};
 


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

See: https://github.com/Chatterino/chatterino2/discussions/5633#discussioncomment-11450313

There's no point in showing the highlights if you can't scroll to them.