### PR TITLE
fix: macos font multiplier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unversioned
 
 - Bugfix: Fixed scrollbar highlights being visible in overlay windows. (#5769)
+- Bugfix: Make macos fonts look the same as v2.5.1. (#5775)
 - Dev: Hard-code Boost 1.86.0 in macos CI builders. (#5774)
 
 ## 2.5.2-beta.1

--- a/src/singletons/Fonts.cpp
+++ b/src/singletons/Fonts.cpp
@@ -139,20 +139,13 @@ Fonts::FontData Fonts::createFontData(FontStyle type, float scale)
 
     // normal Ui font (use pt size)
     {
-#ifdef Q_OS_MAC
-        constexpr float multiplier = 0.8f;
-#else
-        constexpr float multiplier = 1.f;
-#endif
-
         static std::unordered_map<FontStyle, UiFontData> defaultSize{
             {FontStyle::Tiny, {8, "Monospace", false, QFont::Normal}},
             {FontStyle::UiMedium,
-             {int(9 * multiplier), DEFAULT_FONT_FAMILY, false, QFont::Normal}},
+             {9, DEFAULT_FONT_FAMILY, false, QFont::Normal}},
             {FontStyle::UiMediumBold,
-             {int(9 * multiplier), DEFAULT_FONT_FAMILY, false, QFont::Bold}},
-            {FontStyle::UiTabs,
-             {int(9 * multiplier), DEFAULT_FONT_FAMILY, false, QFont::Normal}},
+             {9, DEFAULT_FONT_FAMILY, false, QFont::Bold}},
+            {FontStyle::UiTabs, {9, DEFAULT_FONT_FAMILY, false, QFont::Normal}},
         };
 
         UiFontData &data = defaultSize[type];

--- a/src/singletons/Fonts.cpp
+++ b/src/singletons/Fonts.cpp
@@ -140,12 +140,42 @@ Fonts::FontData Fonts::createFontData(FontStyle type, float scale)
     // normal Ui font (use pt size)
     {
         static std::unordered_map<FontStyle, UiFontData> defaultSize{
-            {FontStyle::Tiny, {8, "Monospace", false, QFont::Normal}},
-            {FontStyle::UiMedium,
-             {9, DEFAULT_FONT_FAMILY, false, QFont::Normal}},
-            {FontStyle::UiMediumBold,
-             {9, DEFAULT_FONT_FAMILY, false, QFont::Bold}},
-            {FontStyle::UiTabs, {9, DEFAULT_FONT_FAMILY, false, QFont::Normal}},
+            {
+                FontStyle::Tiny,
+                {
+                    8,
+                    "Monospace",
+                    false,
+                    QFont::Normal,
+                },
+            },
+            {
+                FontStyle::UiMedium,
+                {
+                    9,
+                    DEFAULT_FONT_FAMILY,
+                    false,
+                    QFont::Normal,
+                },
+            },
+            {
+                FontStyle::UiMediumBold,
+                {
+                    9,
+                    DEFAULT_FONT_FAMILY,
+                    false,
+                    QFont::Bold,
+                },
+            },
+            {
+                FontStyle::UiTabs,
+                {
+                    9,
+                    DEFAULT_FONT_FAMILY,
+                    false,
+                    QFont::Normal,
+                },
+            },
         };
 
         UiFontData &data = defaultSize[type];


### PR DESCRIPTION
Top: Chatterino 2.5.1
Middle: current master with this patch applied
Bottom: current master

![image](https://github.com/user-attachments/assets/c5083467-66ef-41f4-acf6-c4dd5579332a)
