### PR TITLE
build(conan): 👷 update version and dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -222,6 +222,7 @@ jobs:
               -c tools.cmake.cmaketoolchain:generator="NMake Makefiles" `
               -b missing `
               --output-folder=. `
+              -c user.openssl:windows_use_jom=True `
               -o with_openssl3="$Env:C2_USE_OPENSSL3"
         shell: powershell
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,9 +19,7 @@ env:
   C2_ENABLE_LTO: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/bugfix-release/') || startsWith(github.ref, 'refs/heads/release/') }}
   CHATTERINO_REQUIRE_CLEAN_GIT: On
   C2_BUILD_WITH_QT6: Off
-  # Last known good conan version
-  # 2.0.3 has a bug on Windows (conan-io/conan#13606)
-  CONAN_VERSION: 2.0.2
+  CONAN_VERSION: 2.11.0
 
 jobs:
   build-ubuntu-docker:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -222,7 +222,6 @@ jobs:
               -c tools.cmake.cmaketoolchain:generator="NMake Makefiles" `
               -b missing `
               --output-folder=. `
-              -c user.openssl:windows_use_jom=True `
               -o with_openssl3="$Env:C2_USE_OPENSSL3"
         shell: powershell
 

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -10,9 +10,7 @@ env:
   TWITCH_PUBSUB_SERVER_TAG: v1.0.7
   HTTPBOX_TAG: v0.2.1
   QT_QPA_PLATFORM: minimal
-  # Last known good conan version
-  # 2.0.3 has a bug on Windows (conan-io/conan#13606)
-  CONAN_VERSION: 2.0.2
+  CONAN_VERSION: 2.11.0
 
 concurrency:
   group: test-windows-${{ github.ref }}

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -102,7 +102,6 @@ jobs:
               -c tools.cmake.cmaketoolchain:generator="NMake Makefiles" `
               -b missing `
               --output-folder=. `
-              -c user.openssl:windows_use_jom=True `
               -o with_openssl3="$Env:C2_USE_OPENSSL3"
 
       # The Windows runners currently use an older version of the CRT

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -102,6 +102,7 @@ jobs:
               -c tools.cmake.cmaketoolchain:generator="NMake Makefiles" `
               -b missing `
               --output-folder=. `
+              -c user.openssl:windows_use_jom=True `
               -o with_openssl3="$Env:C2_USE_OPENSSL3"
 
       # The Windows runners currently use an older version of the CRT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Bugfix: Fixed scrollbar highlights being visible in overlay windows. (#5769)
 - Bugfix: Make macos fonts look the same as v2.5.1. (#5775)
 - Dev: Hard-code Boost 1.86.0 in macos CI builders. (#5774)
+- Dev: Updated Conan dependencies. (#5776)
 
 ## 2.5.2-beta.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unversioned
 
 - Bugfix: Fixed a crash relating to Lua HTTP. (#5800)
+- Dev: Updated Conan dependencies. (#5776)
 
 ## 2.5.2
 
@@ -14,7 +15,6 @@
 - Bugfix: Fixed some Twitch emotes containing HTML entities. (#5786)
 - Bugfix: Fixed the same blocked term showing up more than once. (#5789)
 - Dev: Hard-code Boost 1.86.0 in macos CI builders. (#5774)
-- Dev: Updated Conan dependencies. (#5776)
 
 ## 2.5.2-beta.1
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,11 +1,12 @@
 from conan import ConanFile
 from conan.tools.files import copy
+from conan.tools.cmake import CMakeToolchain
 from os import path
 
 
 class Chatterino(ConanFile):
     name = "Chatterino"
-    requires = "boost/1.83.0"
+    requires = "boost/1.86.0"
     settings = "os", "compiler", "build_type", "arch"
     default_options = {
         "with_benchmark": False,
@@ -18,18 +19,29 @@ class Chatterino(ConanFile):
         # Qt is built with OpenSSL 3 from version 6.5.0 onwards
         "with_openssl3": [True, False],
     }
-    generators = "CMakeDeps", "CMakeToolchain"
+    generators = "CMakeDeps"
 
     def requirements(self):
         if self.options.get_safe("with_benchmark", False):
-            self.requires("benchmark/1.7.1")
+            self.requires("benchmark/1.9.0")
 
         if self.options.get_safe("with_openssl3", False):
-            self.requires("openssl/3.2.0")
+            self.requires("openssl/3.3.2")
         else:
             self.requires("openssl/1.1.1t")
 
     def generate(self):
+        tc = CMakeToolchain(self)
+        tc.blocks.remove("compilers")
+        tc.blocks.remove("cmake_flags_init")
+        tc.blocks.remove("cppstd")
+        tc.blocks.remove("libcxx")
+        tc.blocks.remove("generic_system")
+        tc.blocks.remove("user_toolchain")
+        tc.blocks.remove("output_dirs")
+        tc.blocks.remove("apple_system")
+        tc.generate()
+
         def copy_bin(dep, selector, subdir):
             src = path.realpath(dep.cpp_info.bindirs[0])
             dst = path.realpath(path.join(self.build_folder, subdir))


### PR DESCRIPTION
`CMakeToolchain` now includes more stuff that we don't need (e.g. it sets `CMAKE_CXX_COMPILER`). We remove these settings.

In a followup PR, I'll use conan for boost on macOS in CI (I did that for chatterino7 already). This brings a 🚀 **25 minute decrease** 🚀 in CI time ⚡ (you don't want to miss this 🔥).