### PR TITLE
fix: escape more 7tv things

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bugfix: Fixed scrollbar highlights being visible in overlay windows. (#5769)
 - Bugfix: Make macos fonts look the same as v2.5.1. (#5775)
+- Bugfix: Fixed 7TV usernames messing with Qt's HTML (#5780)
 - Dev: Hard-code Boost 1.86.0 in macos CI builders. (#5774)
 
 ## 2.5.2-beta.1

--- a/src/providers/seventv/SeventvEmotes.cpp
+++ b/src/providers/seventv/SeventvEmotes.cpp
@@ -81,7 +81,8 @@ Tooltip createTooltip(const QString &name, const QString &author, bool isGlobal)
     return Tooltip{QString("%1<br>%2 7TV Emote<br>By: %3")
                        .arg(name.toHtmlEscaped(),
                             isGlobal ? "Global" : "Channel",
-                            author.isEmpty() ? "<deleted>" : author)};
+                            author.isEmpty() ? "&lt;deleted&gt;"
+                                             : author.toHtmlEscaped())};
 }
 
 Tooltip createAliasedTooltip(const QString &name, const QString &baseName,
@@ -90,7 +91,8 @@ Tooltip createAliasedTooltip(const QString &name, const QString &baseName,
     return Tooltip{QString("%1<br>Alias of %2<br>%3 7TV Emote<br>By: %4")
                        .arg(name.toHtmlEscaped(), baseName.toHtmlEscaped(),
                             isGlobal ? "Global" : "Channel",
-                            author.isEmpty() ? "<deleted>" : author)};
+                            author.isEmpty() ? "&lt;deleted&gt;"
+                                             : author.toHtmlEscaped())};
 }
 
 CreateEmoteResult createEmote(const QJsonObject &activeEmote,


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
7TV users can choose any username now. I love it.

Also used `&lt;` and `&gt;` where we put `<` and `>` into the HTML. We should think about a more "automatic" solution at some point (e.g. tooltip builder).