### PR TITLE
fix(bttv): use `channel` if no user was sent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Bugfix: Fixed scrollbar highlights being visible in overlay windows. (#5769)
 - Bugfix: Make macos fonts look the same as v2.5.1. (#5775)
 - Bugfix: Fixed 7TV usernames messing with Qt's HTML (#5780)
+- Bugfix: Fixed BTTV emotes occasionally showing the wrong author. (#5783)
 - Dev: Hard-code Boost 1.86.0 in macos CI builders. (#5774)
 
 ## 2.5.2-beta.1

--- a/src/providers/bttv/BttvEmotes.cpp
+++ b/src/providers/bttv/BttvEmotes.cpp
@@ -92,6 +92,10 @@ CreateEmoteResult createChannelEmote(const QString &channelDisplayName,
     auto name = EmoteName{jsonEmote.value("code").toString()};
     auto author = EmoteAuthor{
         jsonEmote.value("user").toObject().value("displayName").toString()};
+    if (author.string.isEmpty())
+    {
+        author.string = jsonEmote["channel"].toString();
+    }
 
     auto emote = Emote({
         name,


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

Weird "bug"... For some messages in BTTV's WebSocket API, the `user` object of the emote is missing even though it should be there (i.e. the author isn't the current channel, and it's not some private emote). I reproduced it the first time, but after removing the emote and adding it back, the JSON included `user`. After that, adding any emote would always include `user`. Might be a BTTV bug.

If there isn't a `user` (the author is empty), we now fall back to the `channel`. This is the login name, not the display name, but that's the best we have.

Fixes #5781.