### PR TITLE
fix: use non-capturing group for highlight boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Bugfix: Fixed a crash that could occur on Linux and macOS when clicking "Install" from the update prompt. (#5818)
 - Bugfix: Fixed missing word wrap in update popup. (#5811)
 - Bugfix: Fixed tabs not scaling to the default scale when changing the scale from a non-default value. (#5794)
+- Dev: Highlight checks now use non-capturing groups for the boundaries. (#5784)
 - Dev: Updated Conan dependencies. (#5776)
 
 ## 2.5.2
@@ -22,7 +23,6 @@
 - Bugfix: Fixed some Twitch emotes containing HTML entities. (#5786)
 - Bugfix: Fixed the same blocked term showing up more than once. (#5789)
 - Dev: Hard-code Boost 1.86.0 in macos CI builders. (#5774)
-- Dev: Highlight checks now use non-capturing groups for the boundaries. (#5784)
 
 ## 2.5.2-beta.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Bugfix: Fixed 7TV usernames messing with Qt's HTML (#5780)
 - Bugfix: Fixed BTTV emotes occasionally showing the wrong author. (#5783)
 - Dev: Hard-code Boost 1.86.0 in macos CI builders. (#5774)
+- Dev: Highlight checks now use non-capturing groups for the boundaries. (#5784)
 
 ## 2.5.2-beta.1
 

--- a/src/controllers/highlights/HighlightPhrase.cpp
+++ b/src/controllers/highlights/HighlightPhrase.cpp
@@ -1,11 +1,13 @@
 #include "controllers/highlights/HighlightPhrase.hpp"
 
+#include <QStringBuilder>
+
 namespace chatterino {
 
 namespace {
 
-    const QString REGEX_START_BOUNDARY("(\\b|\\s|^)");
-    const QString REGEX_END_BOUNDARY("(\\b|\\s|$)");
+    constexpr QStringView REGEX_START_BOUNDARY(u"(?:\\b|\\s|^)");
+    constexpr QStringView REGEX_END_BOUNDARY(u"(?:\\b|\\s|$)");
 
 }  // namespace
 
@@ -46,7 +48,7 @@ HighlightPhrase::HighlightPhrase(const QString &pattern, bool showInMentions,
     , soundUrl_(soundUrl)
     , regex_(isRegex_
                  ? pattern
-                 : REGEX_START_BOUNDARY + QRegularExpression::escape(pattern) +
+                 : REGEX_START_BOUNDARY % QRegularExpression::escape(pattern) %
                        REGEX_END_BOUNDARY,
              QRegularExpression::UseUnicodePropertiesOption |
                  (isCaseSensitive_ ? QRegularExpression::NoPatternOption
@@ -69,7 +71,7 @@ HighlightPhrase::HighlightPhrase(const QString &pattern, bool showInMentions,
     , color_(std::move(color))
     , regex_(isRegex_
                  ? pattern
-                 : REGEX_START_BOUNDARY + QRegularExpression::escape(pattern) +
+                 : REGEX_START_BOUNDARY % QRegularExpression::escape(pattern) %
                        REGEX_END_BOUNDARY,
              QRegularExpression::UseUnicodePropertiesOption |
                  (isCaseSensitive_ ? QRegularExpression::NoPatternOption


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

We never use the capturing groups, so we can discard them. Would be even better if Qt had something like "isMatch()", but we can only dream.