### PR TITLE
fix: unescape Twitch emotes even more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Bugfix: Make macos fonts look the same as v2.5.1. (#5775)
 - Bugfix: Fixed 7TV usernames messing with Qt's HTML (#5780)
 - Bugfix: Fixed BTTV emotes occasionally showing the wrong author. (#5783)
+- Bugfix: Fixed some Twitch emotes containing HTML entities. (#5786)
 - Dev: Hard-code Boost 1.86.0 in macos CI builders. (#5774)
 
 ## 2.5.2-beta.1

--- a/src/providers/twitch/TwitchEmotes.cpp
+++ b/src/providers/twitch/TwitchEmotes.cpp
@@ -426,8 +426,8 @@ QString TwitchEmotes::cleanUpEmoteCode(const QString &dirtyEmoteCode)
     cleanCode.detach();
 
     static QMap<QString, QString> emoteNameReplacements{
-        {"[oO](_|\\.)[oO]", "O_o"}, {"\\&gt\\;\\(", "&gt;("},
-        {"\\&lt\\;3", "&lt;3"},     {"\\:-?(o|O)", ":O"},
+        {"[oO](_|\\.)[oO]", "O_o"}, {"\\&gt\\;\\(", ">("},
+        {"\\&lt\\;3", "<3"},        {"\\:-?(o|O)", ":O"},
         {"\\:-?(p|P)", ":P"},       {"\\:-?[\\\\/]", ":/"},
         {"\\:-?[z|Z|\\|]", ":Z"},   {"\\:-?\\(", ":("},
         {"\\:-?\\)", ":)"},         {"\\:-?D", ":D"},


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

The code I changed (introduced in #861) never ran before #5239 (tested 03b0e4881feb6dc7893c45d986406df198d15611). So yea, this does another layer of unescaping, essentially.

Fixes #5785.