### PR TITLE
fix: set initial size of widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+- Bugfix: Fixed tabs not scaling to the default scale when changing the scale from a non-default value. (#5794)
+
 ## 2.5.2
 
 - Bugfix: Fixed a crash in the 7TV EventApi when closing Chatterino. (#5768)

--- a/src/widgets/BaseWidget.cpp
+++ b/src/widgets/BaseWidget.cpp
@@ -19,6 +19,7 @@ namespace chatterino {
 BaseWidget::BaseWidget(QWidget *parent, Qt::WindowFlags f)
     : QWidget(parent, f)
     , theme(getApp()->getThemes())
+    , scale_(this->scale())
 {
     this->signalHolder_.managedConnect(this->theme->updated, [this]() {
         this->themeChangedEvent();


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
I was trying to reproduce https://github.com/Chatterino/Chatterino2/issues/5411 and found this bug:

1. Set scale to something other than 1x (ideally something with a significant difference, so you see the bug)
2. Close Chatterino
3. Open Chatterino
4. Go into the settings and change the scale back to 1x (Default)
5. **Correct** (now): The tabs should scale correctly
  **Incorrect** (before): The tabs kinda stay the same (except for the font)

We didn't save the scale of the window when adding child widgets[^1]. So when the scale changed back to 1x, we'd assume it [was 1.0](https://github.com/Chatterino/chatterino2/blob/f53d92c77a304307256ca56e4e07ceb0471f44d4/src/widgets/BaseWidget.hpp#L57) and [return early](https://github.com/Chatterino/chatterino2/blob/f53d92c77a304307256ca56e4e07ceb0471f44d4/src/widgets/BaseWidget.cpp#L59).

I still can't reproduce https://github.com/Chatterino/Chatterino2/issues/5411. So if anyone has a hint, please put it in the issue. Thank You!

[^1]: This only works if the parent is set and if the parent has or is a window. I added `assert(dynamic_cast<BaseWindow *>(this) || dynamic_cast<BaseWidget *>(this->window()))` to test this locally. Only the settings pages don't set the parent. This is fine because they will always be at 1x.