### PR TITLE
fix: don't force 96 dpi

### DIFF
--- a/src/RunGui.cpp
+++ b/src/RunGui.cpp
@@ -77,8 +77,6 @@ namespace {
     void initQt()
     {
         // set up the QApplication flags
-        QApplication::setAttribute(Qt::AA_Use96Dpi, true);
-
 #ifdef Q_OS_WIN32
         // Avoid promoting child widgets to child windows
         // This causes bugs with frameless windows as not all child events


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

Setting [`AA_Use96Dpi`](https://doc.qt.io/qt-6/qt.html#ApplicationAttribute-enum) would fix fonts to a specific pixel/point size ([usage in Qt](https://github.com/search?q=repo%3Aqt%2Fqtbase+AA_Use96Dpi+NOT+path%3Atest&type=code)). We want the fonts to scale and use the scale provided by the OS. I only tested this on Windows.

TODO: list stuff to test

Fixes #5411.