### PR TITLE
consolidate firefox incognitobrowser logic (and deprecate opera/launcher)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unversioned
 
-- Minor: Treat all browsers starting with `firefox` as a Firefox browser (#5805)
+- Minor: Treat all browsers starting with `firefox` as a Firefox browser. (#5805)
+- Minor: Remove incognito browser support for `opera/launcher` (this should no longer be a thing). (#5805)
 - Bugfix: Fixed a crash relating to Lua HTTP. (#5800)
 - Dev: Updated Conan dependencies. (#5776)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unversioned
 
+- Minor: Treat all browsers starting with `firefox` as a Firefox browser (#5805)
 - Bugfix: Fixed a crash relating to Lua HTTP. (#5800)
 
 ## 2.5.2

--- a/src/util/IncognitoBrowser.cpp
+++ b/src/util/IncognitoBrowser.cpp
@@ -16,8 +16,8 @@ using namespace chatterino;
 QString getPrivateArg(const QString &exePath)
 {
     struct Entry {
-        QString exe{};
-        QString arg{};
+        QString exe;
+        QString arg;
     };
 
     static std::vector<Entry> lut{
@@ -48,7 +48,9 @@ QString getPrivateArg(const QString &exePath)
     for (const auto &entry : lut)
     {
         if (exe == entry.exe)
+        {
             return entry.arg;
+        }
     }
 
     // catch all mozilla distributed variants

--- a/src/util/IncognitoBrowser.cpp
+++ b/src/util/IncognitoBrowser.cpp
@@ -32,26 +32,26 @@ QString getPrivateSwitch(const QString &browserExecutable)
 
     // the browser executable may be a full path, strip it to its basename and
     // compare case insensitively
-    auto lowercasedExecutable =
+    auto lowercasedBrowserExecutable =
         QFileInfo(browserExecutable).baseName().toLower();
 
 #ifdef Q_OS_WINDOWS
-    if (lowercasedExecutable.endsWith(".exe"))
+    if (lowercasedBrowserExecutable.endsWith(".exe"))
     {
-        lowercasedExecutable.chop(4);
+        lowercasedBrowserExecutable.chop(4);
     }
 #endif
 
     for (const auto &switch_ : switches)
     {
-        if (lowercasedExecutable == switch_.first)
+        if (lowercasedBrowserExecutable == switch_.first)
         {
             return switch_.second;
         }
     }
 
     // catch all mozilla distributed variants
-    if (lowercasedExecutable.startsWith("firefox"))
+    if (lowercasedBrowserExecutable.startsWith("firefox"))
     {
         return "-private-window";
     }

--- a/src/util/IncognitoBrowser.cpp
+++ b/src/util/IncognitoBrowser.cpp
@@ -31,7 +31,6 @@ QString getPrivateArg(const QString &exePath)
         {"opera\\launcher", "--private"},
         {"iexplore", "-private"},
         {"msedge", "-inprivate"},
-        {"firefox-esr", "-private-window"},
         {"chromium", "-incognito"},
         {"brave", "-incognito"},
     };

--- a/src/util/IncognitoBrowser.cpp
+++ b/src/util/IncognitoBrowser.cpp
@@ -71,7 +71,6 @@ QString getPrivateSwitch(const QString &browserExecutable)
         {"google-chrome-stable", "-incognito"},
         {"vivaldi", "-incognito"},
         {"opera", "-newprivatetab"},
-        {"opera\\launcher", "--private"},
         {"iexplore", "-private"},
         {"msedge", "-inprivate"},
         {"chromium", "-incognito"},

--- a/src/util/IncognitoBrowser.hpp
+++ b/src/util/IncognitoBrowser.hpp
@@ -2,6 +2,12 @@
 
 #include <QString>
 
+namespace chatterino::incognitobrowser::detail {
+
+QString getPrivateSwitch(const QString &browserExecutable);
+
+}  // namespace chatterino::incognitobrowser::detail
+
 namespace chatterino {
 
 bool supportsIncognitoLinks();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,6 +52,7 @@ set(test_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/src/TwitchIrc.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/IgnoreController.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/OnceFlag.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/IncognitoBrowser.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/lib/Snapshot.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/lib/Snapshot.hpp
     # Add your new file above this line!

--- a/tests/src/IncognitoBrowser.cpp
+++ b/tests/src/IncognitoBrowser.cpp
@@ -11,17 +11,12 @@ TEST(IncognitoBrowser, getPrivateSwitch)
     ASSERT_EQ(getPrivateSwitch("firefox.exe"), "-private-window");
     ASSERT_EQ(getPrivateSwitch("firefox"), "-private-window");
     ASSERT_EQ(getPrivateSwitch("firefox-forsen-version"), "-private-window");
-    ASSERT_EQ(getPrivateSwitch("C:/Program Files/Firefox/firefox.exe"),
-              "-private-window");
 
     ASSERT_EQ(getPrivateSwitch("chrome.exe"), "-incognito");
     ASSERT_EQ(getPrivateSwitch("google-chrome-stable"), "-incognito");
 
-    ASSERT_EQ(getPrivateSwitch(
-                  "C:/Users/pajlada/AppData/Local/Programs/Opera GX/opera.exe"),
-              "-newprivatetab");
-    ASSERT_EQ(getPrivateSwitch("C:/Opera/opera.exe"), "-newprivatetab");
-    ASSERT_EQ(getPrivateSwitch("C:/Opera/opera\\launcher.exe"), "--private");
+    ASSERT_EQ(getPrivateSwitch("opera.exe"), "-newprivatetab");
+    ASSERT_EQ(getPrivateSwitch("opera\\launcher.exe"), "--private");
 
     ASSERT_EQ(getPrivateSwitch("unsupportedBrowser.exe"), "");
 }

--- a/tests/src/IncognitoBrowser.cpp
+++ b/tests/src/IncognitoBrowser.cpp
@@ -1,0 +1,27 @@
+#include "util/IncognitoBrowser.hpp"
+
+#include "Test.hpp"
+
+using namespace chatterino;
+
+TEST(IncognitoBrowser, getPrivateSwitch)
+{
+    using namespace chatterino::incognitobrowser::detail;
+
+    ASSERT_EQ(getPrivateSwitch("firefox.exe"), "-private-window");
+    ASSERT_EQ(getPrivateSwitch("firefox"), "-private-window");
+    ASSERT_EQ(getPrivateSwitch("firefox-forsen-version"), "-private-window");
+    ASSERT_EQ(getPrivateSwitch("C:/Program Files/Firefox/firefox.exe"),
+              "-private-window");
+
+    ASSERT_EQ(getPrivateSwitch("chrome.exe"), "-incognito");
+    ASSERT_EQ(getPrivateSwitch("google-chrome-stable"), "-incognito");
+
+    ASSERT_EQ(getPrivateSwitch(
+                  "C:/Users/pajlada/AppData/Local/Programs/Opera GX/opera.exe"),
+              "-newprivatetab");
+    ASSERT_EQ(getPrivateSwitch("C:/Opera/opera.exe"), "-newprivatetab");
+    ASSERT_EQ(getPrivateSwitch("C:/Opera/opera\\launcher.exe"), "--private");
+
+    ASSERT_EQ(getPrivateSwitch("unsupportedBrowser.exe"), "");
+}

--- a/tests/src/IncognitoBrowser.cpp
+++ b/tests/src/IncognitoBrowser.cpp
@@ -16,7 +16,6 @@ TEST(IncognitoBrowser, getPrivateSwitch)
     ASSERT_EQ(getPrivateSwitch("google-chrome-stable"), "-incognito");
 
     ASSERT_EQ(getPrivateSwitch("opera.exe"), "-newprivatetab");
-    ASSERT_EQ(getPrivateSwitch("opera\\launcher.exe"), "--private");
 
     ASSERT_EQ(getPrivateSwitch("unsupportedBrowser.exe"), "");
 }


### PR DESCRIPTION
Mozilla’s firefox-nightly apt package now points to firefox-bin in its desktop file, catch all firefox variants by mozilla with one if statement

not sure what the changelog should be