### PR TITLE
feat: stack `/clear` messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unversioned
 
+- Minor: `/clear` messages are now stacked like timeouts. (#5806)
 - Bugfix: Fixed a crash relating to Lua HTTP. (#5800)
 
 ## 2.5.2

--- a/src/common/Channel.cpp
+++ b/src/common/Channel.cpp
@@ -139,6 +139,18 @@ void Channel::addOrReplaceTimeout(MessagePtr message, QTime now)
     // WindowManager::instance().repaintVisibleChatWidgets(this);
 }
 
+void Channel::addOrReplaceClearChat(MessagePtr message, QTime now)
+{
+    addOrReplaceChannelClear(
+        this->getMessageSnapshot(), std::move(message), now,
+        [this](auto /*idx*/, auto msg, auto replacement) {
+            this->replaceMessage(msg, replacement);
+        },
+        [this](auto msg) {
+            this->addMessage(msg, MessageContext::Original);
+        });
+}
+
 void Channel::disableAllMessages()
 {
     LimitedQueueSnapshot<MessagePtr> snapshot = this->getMessageSnapshot();

--- a/src/common/Channel.hpp
+++ b/src/common/Channel.hpp
@@ -92,6 +92,7 @@ public:
     void fillInMissingMessages(const std::vector<MessagePtr> &messages);
 
     void addOrReplaceTimeout(MessagePtr message, QTime now) final;
+    void addOrReplaceClearChat(MessagePtr message, QTime now) final;
     void disableAllMessages() final;
     void replaceMessage(const MessagePtr &message,
                         const MessagePtr &replacement);

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -1986,6 +1986,46 @@ MessagePtr MessageBuilder::makeLowTrustUpdateMessage(
     return builder.release();
 }
 
+MessagePtrMut MessageBuilder::makeClearChatMessage(QTime now,
+                                                   const QString &actor,
+                                                   uint32_t count)
+{
+    MessageBuilder builder;
+    builder.emplace<TimestampElement>(now);
+    builder->count = count;
+    builder->parseTime = now;
+    builder.message().flags.set(MessageFlag::System,
+                                MessageFlag::DoNotTriggerNotification,
+                                MessageFlag::ClearChat);
+
+    QString messageText;
+    if (actor.isEmpty())
+    {
+        builder.emplaceSystemTextAndUpdate(
+            "Chat has been cleared by a moderator.", messageText);
+    }
+    else
+    {
+        builder.message().flags.set(MessageFlag::PubSub);
+        builder.emplace<MentionElement>(actor, actor, MessageColor::System,
+                                        MessageColor::System);
+        messageText = actor + ' ';
+        builder.emplaceSystemTextAndUpdate("cleared the chat.", messageText);
+        builder->timeoutUser = actor;
+    }
+
+    if (count > 1)
+    {
+        builder.emplaceSystemTextAndUpdate(
+            '(' % QString::number(count) % u" times)", messageText);
+    }
+
+    builder->messageText = messageText;
+    builder->searchText = messageText;
+
+    return builder.release();
+}
+
 std::pair<MessagePtrMut, HighlightAlert> MessageBuilder::makeIrcMessage(
     /* mutable */ Channel *channel, const Communi::IrcMessage *ircMessage,
     const MessageParseArgs &args, /* mutable */ QString content,

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -53,6 +53,7 @@
 #include <QDateTime>
 #include <QDebug>
 #include <QFileInfo>
+#include <QStringBuilder>
 #include <QTimeZone>
 
 #include <algorithm>

--- a/src/messages/MessageBuilder.hpp
+++ b/src/messages/MessageBuilder.hpp
@@ -258,6 +258,12 @@ public:
                                             const QVariantMap &tags,
                                             const QTime &time);
 
+    /// "Chat has been cleared by a moderator." or "{actor} cleared the chat."
+    /// @param actor The user who cleared the chat (empty if unknown)
+    /// @param count How many times this message has been received already
+    static MessagePtrMut makeClearChatMessage(QTime now, const QString &actor,
+                                              uint32_t count = 1);
+
 private:
     struct TextState {
         TwitchChannel *twitchChannel = nullptr;

--- a/src/messages/MessageFlag.hpp
+++ b/src/messages/MessageFlag.hpp
@@ -54,6 +54,8 @@ enum class MessageFlag : std::int64_t {
     SharedMessage = (1LL << 37),
     /// AutoMod message that showed up due to containing a blocked term in the channel
     AutoModBlockedTerm = (1LL << 38),
+    /// The message is a full clear chat message (/clear)
+    ClearChat = (1LL << 39),
 };
 using MessageFlags = FlagsEnum<MessageFlag>;
 

--- a/src/messages/MessageSink.hpp
+++ b/src/messages/MessageSink.hpp
@@ -48,6 +48,11 @@ public:
     virtual void addOrReplaceTimeout(MessagePtr clearchatMessage,
                                      QTime now) = 0;
 
+    /// Adds a clear chat message (for the entire chat) or merges it into an
+    /// existing one
+    virtual void addOrReplaceClearChat(MessagePtr clearchatMessage,
+                                       QTime now) = 0;
+
     /// Flags all messages as `Disabled`
     virtual void disableAllMessages() = 0;
 

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -247,11 +247,10 @@ void TwitchIrcServer::initialize()
                 return;
             }
 
-            QString text =
-                QString("%1 cleared the chat.").arg(action.source.login);
-
-            postToThread([chan, text] {
-                chan->addSystemMessage(text);
+            postToThread([chan, actor{action.source.login}] {
+                auto now = QTime::currentTime();
+                chan->addOrReplaceClearChat(
+                    MessageBuilder::makeClearChatMessage(now, actor), now);
             });
         });
 

--- a/src/util/VectorMessageSink.cpp
+++ b/src/util/VectorMessageSink.cpp
@@ -38,6 +38,20 @@ void VectorMessageSink::addOrReplaceTimeout(MessagePtr clearchatMessage,
         false);
 }
 
+void VectorMessageSink::addOrReplaceClearChat(MessagePtr clearchatMessage,
+                                              QTime now)
+{
+    addOrReplaceChannelClear(
+        this->messages_, std::move(clearchatMessage), now,
+        [&](auto idx, auto /*msg*/, auto &&replacement) {
+            replacement->flags.set(this->additionalFlags);
+            this->messages_[idx] = replacement;
+        },
+        [&](auto &&msg) {
+            this->messages_.emplace_back(msg);
+        });
+}
+
 void VectorMessageSink::disableAllMessages()
 {
     if (this->additionalFlags.has(MessageFlag::RecentMessage))

--- a/src/util/VectorMessageSink.hpp
+++ b/src/util/VectorMessageSink.hpp
@@ -15,6 +15,7 @@ public:
         MessagePtr message, MessageContext ctx,
         std::optional<MessageFlags> overridingFlags = std::nullopt) override;
     void addOrReplaceTimeout(MessagePtr clearchatMessage, QTime now) override;
+    void addOrReplaceClearChat(MessagePtr clearchatMessage, QTime now) override;
 
     void disableAllMessages() override;
 

--- a/tests/snapshots/IrcMessageHandler/clearchat-stack-always.json
+++ b/tests/snapshots/IrcMessageHandler/clearchat-stack-always.json
@@ -1,0 +1,238 @@
+{
+    "input": "@tmi-sent-ts=1736369068441;rm-received-ts=1736369068532;historical=1;room-id=111448817 :tmi.twitch.tv CLEARCHAT #pajlada",
+    "output": [
+        {
+            "badgeInfos": {
+            },
+            "badges": [
+            ],
+            "channelName": "",
+            "count": 4,
+            "displayName": "",
+            "elements": [
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "ChatMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "20:44"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "20:44:28",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "Chat",
+                        "has",
+                        "been",
+                        "cleared",
+                        "by",
+                        "a",
+                        "moderator."
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "(4",
+                        "times)"
+                    ]
+                }
+            ],
+            "flags": "System|DoNotTriggerNotification|ClearChat",
+            "id": "",
+            "localizedName": "",
+            "loginName": "",
+            "messageText": "Chat has been cleared by a moderator. (4 times) ",
+            "searchText": "Chat has been cleared by a moderator. (4 times) ",
+            "serverReceivedTime": "",
+            "timeoutUser": "",
+            "usernameColor": "#ff000000"
+        },
+        {
+            "badgeInfos": {
+            },
+            "badges": [
+                "broadcaster"
+            ],
+            "channelName": "pajlada",
+            "count": 1,
+            "displayName": "nerixyz",
+            "elements": [
+                {
+                    "color": "System",
+                    "flags": "ChannelName",
+                    "link": {
+                        "type": "JumpToChannel",
+                        "value": "pajlada"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "#pajlada"
+                    ]
+                },
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "ChatMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "20:44"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "20:44:24",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "flags": "ModeratorTools",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TwitchModerationElement"
+                },
+                {
+                    "emote": {
+                        "images": {
+                            "1x": "https://static-cdn.jtvnw.net/badges/v1/5527c58c-fb7d-422d-b71b-f309dcb85cc1/1",
+                            "2x": "https://static-cdn.jtvnw.net/badges/v1/5527c58c-fb7d-422d-b71b-f309dcb85cc1/2",
+                            "3x": "https://static-cdn.jtvnw.net/badges/v1/5527c58c-fb7d-422d-b71b-f309dcb85cc1/3"
+                        },
+                        "name": "",
+                        "tooltip": "Broadcaster"
+                    },
+                    "flags": "BadgeChannelAuthority",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "tooltip": "Broadcaster",
+                    "trailingSpace": true,
+                    "type": "BadgeElement"
+                },
+                {
+                    "color": "#ffff0000",
+                    "flags": "Username",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "nerixyz"
+                    },
+                    "style": "ChatMediumBold",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "nerixyz:"
+                    ]
+                },
+                {
+                    "color": "Text",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "def"
+                    ]
+                },
+                {
+                    "background": "#ffa0a0a4",
+                    "flags": "ReplyButton",
+                    "link": {
+                        "type": "ReplyToMessage",
+                        "value": "50e33ac9-4e54-4503-9a35-a621ef114b82"
+                    },
+                    "padding": 2,
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "CircularImageElement",
+                    "url": ""
+                }
+            ],
+            "flags": "Disabled|Collapsed",
+            "id": "50e33ac9-4e54-4503-9a35-a621ef114b82",
+            "localizedName": "",
+            "loginName": "nerixyz",
+            "messageText": "def",
+            "searchText": "nerixyz  nerixyz: def ",
+            "serverReceivedTime": "2025-01-08T20:44:24Z",
+            "timeoutUser": "",
+            "usernameColor": "#ffff0000"
+        }
+    ],
+    "params": {
+        "nAdditional": 2,
+        "prevMessages": [
+            "@room-id=111448817;rm-received-ts=1736369059298;rm-deleted=1;tmi-sent-ts=1736369059196;historical=1 :tmi.twitch.tv CLEARCHAT #pajlada",
+            "@historical=1;tmi-sent-ts=1736369062841;room-id=111448817;rm-received-ts=1736369062932;rm-deleted=1 :tmi.twitch.tv CLEARCHAT #pajlada",
+            "@room-id=111448817;rm-deleted=1;returning-chatter=0;rm-received-ts=1736369064768;subscriber=0;tmi-sent-ts=1736369064631;color=#FF0000;flags=;turbo=0;user-type=;emotes=;id=50e33ac9-4e54-4503-9a35-a621ef114b82;mod=0;historical=1;user-id=129546453;first-msg=0;badge-info=;badges=broadcaster/1;display-name=nerixyz :nerixyz!nerixyz@nerixyz.tmi.twitch.tv PRIVMSG #pajlada def",
+            "@historical=1;room-id=111448817;rm-received-ts=1736369067491;rm-deleted=1;tmi-sent-ts=1736369067400 :tmi.twitch.tv CLEARCHAT #pajlada"
+        ]
+    },
+    "settings": {
+        "moderation": {
+            "timeoutStackStyle": 0
+        }
+    }
+}

--- a/tests/snapshots/IrcMessageHandler/clearchat-stack-always.json
+++ b/tests/snapshots/IrcMessageHandler/clearchat-stack-always.json
@@ -1,5 +1,5 @@
 {
-    "input": "@tmi-sent-ts=1736369068441;rm-received-ts=1736369068532;historical=1;room-id=111448817 :tmi.twitch.tv CLEARCHAT #pajlada",
+    "input": "@tmi-sent-ts=1736678514028;room-id=11148817;badges=;badge-info=;flags=;user-type=;emotes= :tmi.twitch.tv CLEARCHAT #pajlada",
     "output": [
         {
             "badgeInfos": {
@@ -23,7 +23,7 @@
                         "trailingSpace": true,
                         "type": "TextElement",
                         "words": [
-                            "20:44"
+                            "10:41"
                         ]
                     },
                     "flags": "Timestamp",
@@ -32,7 +32,7 @@
                         "type": "None",
                         "value": ""
                     },
-                    "time": "20:44:28",
+                    "time": "10:41:54",
                     "tooltip": "",
                     "trailingSpace": true,
                     "type": "TimestampElement"
@@ -87,13 +87,16 @@
         },
         {
             "badgeInfos": {
+                "subscriber": "108"
             },
             "badges": [
-                "broadcaster"
+                "broadcaster",
+                "subscriber",
+                "partner"
             ],
             "channelName": "pajlada",
             "count": 1,
-            "displayName": "nerixyz",
+            "displayName": "pajlada",
             "elements": [
                 {
                     "color": "System",
@@ -123,7 +126,7 @@
                         "trailingSpace": true,
                         "type": "TextElement",
                         "words": [
-                            "20:44"
+                            "10:41"
                         ]
                     },
                     "flags": "Timestamp",
@@ -132,20 +135,10 @@
                         "type": "None",
                         "value": ""
                     },
-                    "time": "20:44:24",
+                    "time": "10:41:52",
                     "tooltip": "",
                     "trailingSpace": true,
                     "type": "TimestampElement"
-                },
-                {
-                    "flags": "ModeratorTools",
-                    "link": {
-                        "type": "None",
-                        "value": ""
-                    },
-                    "tooltip": "",
-                    "trailingSpace": true,
-                    "type": "TwitchModerationElement"
                 },
                 {
                     "emote": {
@@ -167,18 +160,57 @@
                     "type": "BadgeElement"
                 },
                 {
-                    "color": "#ffff0000",
+                    "emote": {
+                        "images": {
+                            "1x": "https://chatterino.com/tb-1",
+                            "2x": "https://chatterino.com/tb-2",
+                            "3x": "https://chatterino.com/tb-3"
+                        },
+                        "name": "",
+                        "tooltip": "Subscriber"
+                    },
+                    "flags": "BadgeSubscription",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "tooltip": "Subscriber (Tier 3, 108 months)",
+                    "trailingSpace": true,
+                    "type": "BadgeElement"
+                },
+                {
+                    "emote": {
+                        "homePage": "https://blog.twitch.tv/2017/04/24/the-verified-badge-is-here-13381bc05735",
+                        "images": {
+                            "1x": "https://static-cdn.jtvnw.net/badges/v1/d12a2e27-16f6-41d0-ab77-b780518f00a3/1",
+                            "2x": "https://static-cdn.jtvnw.net/badges/v1/d12a2e27-16f6-41d0-ab77-b780518f00a3/2",
+                            "3x": "https://static-cdn.jtvnw.net/badges/v1/d12a2e27-16f6-41d0-ab77-b780518f00a3/3"
+                        },
+                        "name": "",
+                        "tooltip": "Verified"
+                    },
+                    "flags": "BadgeVanity",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "tooltip": "Verified",
+                    "trailingSpace": true,
+                    "type": "BadgeElement"
+                },
+                {
+                    "color": "#ffcc44ff",
                     "flags": "Username",
                     "link": {
                         "type": "UserInfo",
-                        "value": "nerixyz"
+                        "value": "pajlada"
                     },
                     "style": "ChatMediumBold",
                     "tooltip": "",
                     "trailingSpace": true,
                     "type": "TextElement",
                     "words": [
-                        "nerixyz:"
+                        "pajlada:"
                     ]
                 },
                 {
@@ -193,7 +225,7 @@
                     "trailingSpace": true,
                     "type": "TextElement",
                     "words": [
-                        "def"
+                        "asd"
                     ]
                 },
                 {
@@ -201,7 +233,7 @@
                     "flags": "ReplyButton",
                     "link": {
                         "type": "ReplyToMessage",
-                        "value": "50e33ac9-4e54-4503-9a35-a621ef114b82"
+                        "value": "b4f3ac1d-6335-4567-bb8d-e76dfd83f7e3"
                     },
                     "padding": 2,
                     "tooltip": "",
@@ -210,24 +242,24 @@
                     "url": ""
                 }
             ],
-            "flags": "Disabled|Collapsed",
-            "id": "50e33ac9-4e54-4503-9a35-a621ef114b82",
+            "flags": "Collapsed",
+            "id": "b4f3ac1d-6335-4567-bb8d-e76dfd83f7e3",
             "localizedName": "",
-            "loginName": "nerixyz",
-            "messageText": "def",
-            "searchText": "nerixyz  nerixyz: def ",
-            "serverReceivedTime": "2025-01-08T20:44:24Z",
+            "loginName": "pajlada",
+            "messageText": "asd",
+            "searchText": "pajlada  pajlada: asd ",
+            "serverReceivedTime": "2025-01-12T10:41:52Z",
             "timeoutUser": "",
-            "usernameColor": "#ffff0000"
+            "usernameColor": "#ffcc44ff"
         }
     ],
     "params": {
         "nAdditional": 2,
         "prevMessages": [
-            "@room-id=111448817;rm-received-ts=1736369059298;rm-deleted=1;tmi-sent-ts=1736369059196;historical=1 :tmi.twitch.tv CLEARCHAT #pajlada",
-            "@historical=1;tmi-sent-ts=1736369062841;room-id=111448817;rm-received-ts=1736369062932;rm-deleted=1 :tmi.twitch.tv CLEARCHAT #pajlada",
-            "@room-id=111448817;rm-deleted=1;returning-chatter=0;rm-received-ts=1736369064768;subscriber=0;tmi-sent-ts=1736369064631;color=#FF0000;flags=;turbo=0;user-type=;emotes=;id=50e33ac9-4e54-4503-9a35-a621ef114b82;mod=0;historical=1;user-id=129546453;first-msg=0;badge-info=;badges=broadcaster/1;display-name=nerixyz :nerixyz!nerixyz@nerixyz.tmi.twitch.tv PRIVMSG #pajlada def",
-            "@historical=1;room-id=111448817;rm-received-ts=1736369067491;rm-deleted=1;tmi-sent-ts=1736369067400 :tmi.twitch.tv CLEARCHAT #pajlada"
+            "@tmi-sent-ts=1736678508224;room-id=11148817;badges=;badge-info=;flags=;user-type=;emotes= :tmi.twitch.tv CLEARCHAT #pajlada",
+            "@tmi-sent-ts=1736678509397;room-id=11148817;badges=;badge-info=;flags=;user-type=;emotes= :tmi.twitch.tv CLEARCHAT #pajlada",
+            "@tmi-sent-ts=1736678511185;room-id=11148817;badges=;badge-info=;flags=;user-type=;emotes= :tmi.twitch.tv CLEARCHAT #pajlada",
+            "@tmi-sent-ts=1736678512806;subscriber=1;id=b4f3ac1d-6335-4567-bb8d-e76dfd83f7e3;room-id=11148817;user-id=11148817;display-name=pajlada;badges=broadcaster/1,subscriber/3072,partner/1;badge-info=subscriber/108;color=#CC44FF;flags=;user-type=;emotes= :pajlada!pajlada@pajlada.tmi.twitch.tv PRIVMSG #pajlada :asd"
         ]
     },
     "settings": {

--- a/tests/snapshots/IrcMessageHandler/clearchat-stack-never.json
+++ b/tests/snapshots/IrcMessageHandler/clearchat-stack-never.json
@@ -1,5 +1,5 @@
 {
-    "input": "@room-id=11148817;rm-received-ts=1729627607652;tmi-sent-ts=1729627607545;historical=1 :tmi.twitch.tv CLEARCHAT #pajlada",
+    "input": "@tmi-sent-ts=1736369068441;rm-received-ts=1736369068532;historical=1;room-id=111448817 :tmi.twitch.tv CLEARCHAT #pajlada",
     "output": [
         {
             "badgeInfos": {
@@ -23,7 +23,7 @@
                         "trailingSpace": true,
                         "type": "TextElement",
                         "words": [
-                            "20:06"
+                            "20:44"
                         ]
                     },
                     "flags": "Timestamp",
@@ -32,7 +32,7 @@
                         "type": "None",
                         "value": ""
                     },
-                    "time": "20:06:47",
+                    "time": "20:44:28",
                     "tooltip": "",
                     "trailingSpace": true,
                     "type": "TimestampElement"
@@ -69,5 +69,18 @@
             "timeoutUser": "",
             "usernameColor": "#ff000000"
         }
-    ]
+    ],
+    "params": {
+        "prevMessages": [
+            "@room-id=111448817;rm-received-ts=1736369059298;rm-deleted=1;tmi-sent-ts=1736369059196;historical=1 :tmi.twitch.tv CLEARCHAT #pajlada",
+            "@historical=1;tmi-sent-ts=1736369062841;room-id=111448817;rm-received-ts=1736369062932;rm-deleted=1 :tmi.twitch.tv CLEARCHAT #pajlada",
+            "@room-id=111448817;rm-deleted=1;returning-chatter=0;rm-received-ts=1736369064768;subscriber=0;tmi-sent-ts=1736369064631;color=#FF0000;flags=;turbo=0;user-type=;emotes=;id=50e33ac9-4e54-4503-9a35-a621ef114b82;mod=0;historical=1;user-id=129546453;first-msg=0;badge-info=;badges=broadcaster/1;display-name=nerixyz :nerixyz!nerixyz@nerixyz.tmi.twitch.tv PRIVMSG #pajlada def",
+            "@historical=1;room-id=111448817;rm-received-ts=1736369067491;rm-deleted=1;tmi-sent-ts=1736369067400 :tmi.twitch.tv CLEARCHAT #pajlada"
+        ]
+    },
+    "settings": {
+        "moderation": {
+            "timeoutStackStyle": 2
+        }
+    }
 }

--- a/tests/snapshots/IrcMessageHandler/clearchat-stack-no-user.json
+++ b/tests/snapshots/IrcMessageHandler/clearchat-stack-no-user.json
@@ -1,5 +1,5 @@
 {
-    "input": "@room-id=11148817;rm-received-ts=1729627607652;tmi-sent-ts=1729627607545;historical=1 :tmi.twitch.tv CLEARCHAT #pajlada",
+    "input": "@tmi-sent-ts=1736369068441;rm-received-ts=1736369068532;historical=1;room-id=111448817 :tmi.twitch.tv CLEARCHAT #pajlada",
     "output": [
         {
             "badgeInfos": {
@@ -7,7 +7,7 @@
             "badges": [
             ],
             "channelName": "",
-            "count": 1,
+            "count": 2,
             "displayName": "",
             "elements": [
                 {
@@ -23,7 +23,7 @@
                         "trailingSpace": true,
                         "type": "TextElement",
                         "words": [
-                            "20:06"
+                            "20:44"
                         ]
                     },
                     "flags": "Timestamp",
@@ -32,7 +32,7 @@
                         "type": "None",
                         "value": ""
                     },
-                    "time": "20:06:47",
+                    "time": "20:44:28",
                     "tooltip": "",
                     "trailingSpace": true,
                     "type": "TimestampElement"
@@ -57,17 +57,42 @@
                         "a",
                         "moderator."
                     ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "(2",
+                        "times)"
+                    ]
                 }
             ],
             "flags": "System|DoNotTriggerNotification|ClearChat",
             "id": "",
             "localizedName": "",
             "loginName": "",
-            "messageText": "Chat has been cleared by a moderator. ",
-            "searchText": "Chat has been cleared by a moderator. ",
+            "messageText": "Chat has been cleared by a moderator. (2 times) ",
+            "searchText": "Chat has been cleared by a moderator. (2 times) ",
             "serverReceivedTime": "",
             "timeoutUser": "",
             "usernameColor": "#ff000000"
         }
-    ]
+    ],
+    "params": {
+        "nAdditional": 1,
+        "prevMessages": [
+            "@room-id=111448817;rm-received-ts=1736369059298;rm-deleted=1;tmi-sent-ts=1736369059196;historical=1 :tmi.twitch.tv CLEARCHAT #pajlada",
+            "@historical=1;tmi-sent-ts=1736369062841;room-id=111448817;rm-received-ts=1736369062932;rm-deleted=1 :tmi.twitch.tv CLEARCHAT #pajlada",
+            "@room-id=111448817;rm-deleted=1;returning-chatter=0;rm-received-ts=1736369064768;subscriber=0;tmi-sent-ts=1736369064631;color=#FF0000;flags=;turbo=0;user-type=;emotes=;id=50e33ac9-4e54-4503-9a35-a621ef114b82;mod=0;historical=1;user-id=129546453;first-msg=0;badge-info=;badges=broadcaster/1;display-name=nerixyz :nerixyz!nerixyz@nerixyz.tmi.twitch.tv PRIVMSG #pajlada def",
+            "@historical=1;room-id=111448817;rm-received-ts=1736369067491;rm-deleted=1;tmi-sent-ts=1736369067400 :tmi.twitch.tv CLEARCHAT #pajlada"
+        ]
+    }
 }

--- a/tests/src/IrcMessageHandler.cpp
+++ b/tests/src/IrcMessageHandler.cpp
@@ -569,6 +569,7 @@ public:
 /// - `prevMessages`: An array of past messages (used for replies)
 /// - `findAllUsernames`: A boolean controlling the equally named setting
 ///   (default: false)
+/// - `nAdditional`: Include n additional built messages (from `prevMessages`)
 TEST_P(TestIrcMessageHandlerP, Run)
 {
     auto channel = makeMockTwitchChannel(u"pajlada"_s, *snapshot);
@@ -588,7 +589,10 @@ TEST_P(TestIrcMessageHandlerP, Run)
         Communi::IrcMessage::fromData(snapshot->inputUtf8(), nullptr);
     ASSERT_NE(ircMessage, nullptr);
 
-    auto firstAddedMsg = sink.messages().size();
+    auto nAdditionalMessages = snapshot->param("nAdditional").toInt(0);
+    ASSERT_GE(sink.messages().size(), nAdditionalMessages);
+
+    auto firstAddedMsg = sink.messages().size() - nAdditionalMessages;
     IrcMessageHandler::parseMessageInto(ircMessage, sink, channel.get());
 
     QJsonArray got;


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

We stack timeouts, but not "full" clearchats. There's no use in having a chat full of "Chat has been cleared by a moderator".

This PR adds similar stacking functionality to `/clear` messages (both from PubSub and from IRC). Additionally, the user is now clickable in PubSub messages ("{actor} cleared the chat"). Tests for the different stacking settings have been added as well (it reuses the timeout stacking).