### PR TITLE
fix: only remove logging channels if we added them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Bugfix: Fixed a crash that could occur on Linux and macOS when clicking "Install" from the update prompt. (#5818)
 - Bugfix: Fixed missing word wrap in update popup. (#5811)
 - Bugfix: Fixed tabs not scaling to the default scale when changing the scale from a non-default value. (#5794)
+- Bugfix: Closing a usercard will no longer cause stop-logging messages to be generated in channel logs. (#5828)
 - Dev: Highlight checks now use non-capturing groups for the boundaries. (#5784)
 - Dev: Updated Conan dependencies. (#5776)
 

--- a/src/common/Channel.cpp
+++ b/src/common/Channel.cpp
@@ -41,7 +41,7 @@ Channel::Channel(const QString &name, Type type)
 Channel::~Channel()
 {
     auto *app = tryGetApp();
-    if (app)
+    if (app && this->anythingLogged_)
     {
         app->getChatLogger()->closeChannel(this->name_, this->platform_);
     }
@@ -106,6 +106,7 @@ void Channel::addMessage(MessagePtr message, MessageContext context,
             getApp()->getChatLogger()->addMessage(this->name_, message,
                                                   this->platform_,
                                                   this->getCurrentStreamID());
+            this->anythingLogged_ = true;
         }
     }
 

--- a/src/common/Channel.hpp
+++ b/src/common/Channel.hpp
@@ -143,6 +143,7 @@ private:
     const QString name_;
     LimitedQueue<MessagePtr> messages_;
     Type type_;
+    bool anythingLogged_ = false;
     QTimer clearCompletionModelTimer_;
 };
 


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

The backing channels for channel-views in usercards have a name set. So when we close them, they will attempt to close all logging channels with that name. This PR fixes that by only closing a logging channel if we ever added anything to it (i.e. if we created the channel).

- Fixes #5827