### PR TITLE
fix: ensure overrideScale_ is initialized before scale_

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Bugfix: Fixed a crash relating to Lua HTTP. (#5800)
 - Bugfix: Fixed a crash that could occur on Linux and macOS when clicking "Install" from the update prompt. (#5818)
 - Bugfix: Fixed missing word wrap in update popup. (#5811)
-- Bugfix: Fixed tabs not scaling to the default scale when changing the scale from a non-default value. (#5794)
+- Bugfix: Fixed tabs not scaling to the default scale when changing the scale from a non-default value. (#5794, #5830)
 - Dev: Highlight checks now use non-capturing groups for the boundaries. (#5784)
 - Dev: Updated Conan dependencies. (#5776)
 

--- a/src/widgets/BaseWidget.hpp
+++ b/src/widgets/BaseWidget.hpp
@@ -54,8 +54,8 @@ protected:
     pajlada::Signals::SignalHolder signalHolder_;
 
 private:
-    float scale_{1.f};
     std::optional<float> overrideScale_;
+    float scale_{1.f};
     QSize scaleIndependantSize_;
 
     std::vector<BaseWidget *> widgets_;

--- a/src/widgets/BaseWidget.hpp
+++ b/src/widgets/BaseWidget.hpp
@@ -55,7 +55,7 @@ protected:
 
 private:
     std::optional<float> overrideScale_;
-    float scale_{1.f};
+    float scale_{1.F};
     QSize scaleIndependantSize_;
 
     std::vector<BaseWidget *> widgets_;


### PR DESCRIPTION
since we now read overrideScale_ from scale(), this order needs to be changed

<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
