### PR TITLE
fix: only use window scale in children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Bugfix: Fixed a crash relating to Lua HTTP. (#5800)
 - Bugfix: Fixed a crash that could occur on Linux and macOS when clicking "Install" from the update prompt. (#5818)
 - Bugfix: Fixed missing word wrap in update popup. (#5811)
-- Bugfix: Fixed tabs not scaling to the default scale when changing the scale from a non-default value. (#5794)
+- Bugfix: Fixed tabs not scaling to the default scale when changing the scale from a non-default value. (#5794, #5833)
 - Dev: Highlight checks now use non-capturing groups for the boundaries. (#5784)
 - Dev: Updated Conan dependencies. (#5776)
 

--- a/src/widgets/BaseWidget.cpp
+++ b/src/widgets/BaseWidget.cpp
@@ -19,8 +19,13 @@ namespace chatterino {
 BaseWidget::BaseWidget(QWidget *parent, Qt::WindowFlags f)
     : QWidget(parent, f)
     , theme(getApp()->getThemes())
-    , scale_(this->scale())
 {
+    auto *baseWidget = dynamic_cast<BaseWidget *>(this->window());
+    if (baseWidget && baseWidget != this)
+    {
+        this->scale_ = baseWidget->scale_;
+    }
+
     this->signalHolder_.managedConnect(this->theme->updated, [this]() {
         this->themeChangedEvent();
 


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
Bug I introduced in https://github.com/Chatterino/chatterino2/pull/5794, where the window would call `scale()`, which would attempt to load `scale_` from itself, but that's the variable it wanted to initialize, so now it read garbage and initialized that variable to garbage and then subsequent reads from `scale_` would yield that garbage until the window loaded the scale setting.

Not sure if that's the cause of #5831 (I couldn't replicate this[^1]).

[^1]: Not the exact issue that is. On MSVC, the scale was initialized to a negative value, meaning that calls to `setMinimumSize` would print an error in Qt.