### PR TITLE
Fixed a potential way to escape the Lua Plugin sandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Minor: Treat all browsers starting with `firefox` as a Firefox browser. (#5805)
 - Minor: Remove incognito browser support for `opera/launcher` (this should no longer be a thing). (#5805)
 - Minor: Remove incognito browser support for `iexplore`, because internet explorer is EOL. (#5810)
+- Bugfix: Fixed a potential way to escape the Lua Plugin sandbox. (#5846)
 - Bugfix: Fixed a crash relating to Lua HTTP. (#5800)
 - Bugfix: Fixed a crash that could occur on Linux and macOS when clicking "Install" from the update prompt. (#5818)
 - Bugfix: Fixed missing word wrap in update popup. (#5811)

--- a/src/controllers/plugins/LuaAPI.cpp
+++ b/src/controllers/plugins/LuaAPI.cpp
@@ -264,6 +264,11 @@ void g_print(ThisPluginState L, sol::variadic_args args)
     logHelper(L, L.plugin(), stream, args);
 }
 
+void package_loadlib(sol::variadic_args args)
+{
+    throw std::runtime_error("package.loadlib: this function is a stub!");
+}
+
 }  // namespace chatterino::lua::api
 // NOLINTEND(*vararg)
 #endif

--- a/src/controllers/plugins/LuaAPI.hpp
+++ b/src/controllers/plugins/LuaAPI.hpp
@@ -128,6 +128,8 @@ void c2_later(ThisPluginState L, sol::protected_function callback, int time);
 // These ones are global
 sol::variadic_results g_load(ThisPluginState s, sol::object data);
 void g_print(ThisPluginState L, sol::variadic_args args);
+
+void package_loadlib(sol::variadic_args args);
 // NOLINTEND(readability-identifier-naming)
 
 // This is for require() exposed as an element of package.searchers

--- a/src/controllers/plugins/PluginController.cpp
+++ b/src/controllers/plugins/PluginController.cpp
@@ -244,6 +244,9 @@ void PluginController::initSol(sol::state_view &lua, Plugin *plugin)
     io.set_function("write", &lua::api::io_write);
     io.set_function("popen", &lua::api::io_popen);
     io.set_function("tmpfile", &lua::api::io_tmpfile);
+
+    sol::table package = g["package"];
+    package.set_function("loadlib", &lua::api::package_loadlib);
 }
 
 void PluginController::load(const QFileInfo &index, const QDir &pluginDir,


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
I fucked up by not blocking off `package.loadlib`.
![image](https://github.com/user-attachments/assets/ebf8353c-a3c2-4afd-acb7-c28544b2a55f)
