### PR TITLE
feat: prefer visible/selected channels when joining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Minor: Treat all browsers starting with `firefox` as a Firefox browser. (#5805)
 - Minor: Remove incognito browser support for `opera/launcher` (this should no longer be a thing). (#5805)
 - Minor: Remove incognito browser support for `iexplore`, because internet explorer is EOL. (#5810)
+- Minor: When (re-)connecting, visible channels are now joined first. (#5850)
 - Bugfix: Fixed a potential way to escape the Lua Plugin sandbox. (#5846)
 - Bugfix: Fixed a crash relating to Lua HTTP. (#5800)
 - Bugfix: Fixed a crash that could occur on Linux and macOS when clicking "Install" from the update prompt. (#5818)

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -27,9 +27,6 @@
 #include "singletons/WindowManager.hpp"
 #include "util/PostToThread.hpp"
 #include "util/RatelimitBucket.hpp"
-#include "widgets/splits/Split.hpp"
-#include "widgets/splits/SplitContainer.hpp"
-#include "widgets/Window.hpp"
 
 #include <IrcCommand>
 #include <IrcMessage>
@@ -954,25 +951,11 @@ void TwitchIrcServer::onReadConnected(IrcConnection *connection)
         }
     }
 
-    // get the selected channels
-    std::set<Channel *> selected;
-    for (auto *window : getApp()->getWindows()->allWindows())
-    {
-        auto *page = window->getNotebook().getSelectedPage();
-        if (!page)
-        {
-            continue;
-        }
+    // put the visible channels first
+    auto visible = getApp()->getWindows()->getVisibleChannelNames();
 
-        for (auto *split : page->getSplits())
-        {
-            selected.emplace(split->getChannel().get());
-        }
-    }
-
-    // put the selected channels first
-    std::ranges::partition(activeChannels, [&](const auto &chan) {
-        return selected.contains(chan.get());
+    std::ranges::stable_partition(activeChannels, [&](const auto &chan) {
+        return visible.contains(chan->getName());
     });
 
     // join channels

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -38,7 +38,6 @@
 #include <cassert>
 #include <functional>
 #include <mutex>
-#include <set>
 
 using namespace std::chrono_literals;
 

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -595,6 +595,11 @@ void WindowManager::toggleAllOverlayInertia()
     }
 }
 
+std::span<Window *const> WindowManager::allWindows() const
+{
+    return std::span<Window *const>{this->windows_};
+}
+
 void WindowManager::encodeTab(SplitContainer *tab, bool isSelected,
                               QJsonObject &obj)
 {

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -595,9 +595,24 @@ void WindowManager::toggleAllOverlayInertia()
     }
 }
 
-std::span<Window *const> WindowManager::allWindows() const
+std::set<QString> WindowManager::getVisibleChannelNames() const
 {
-    return std::span<Window *const>{this->windows_};
+    std::set<QString> visible;
+    for (auto *window : this->windows_)
+    {
+        auto *page = window->getNotebook().getSelectedPage();
+        if (!page)
+        {
+            continue;
+        }
+
+        for (auto *split : page->getSplits())
+        {
+            visible.emplace(split->getChannel()->getName());
+        }
+    }
+
+    return visible;
 }
 
 void WindowManager::encodeTab(SplitContainer *tab, bool isSelected,

--- a/src/singletons/WindowManager.hpp
+++ b/src/singletons/WindowManager.hpp
@@ -9,7 +9,7 @@
 #include <QTimer>
 
 #include <memory>
-#include <span>
+#include <set>
 
 namespace chatterino {
 
@@ -132,7 +132,7 @@ public:
     /// Toggles the inertia in all open overlay windows
     void toggleAllOverlayInertia();
 
-    std::span<Window *const> allWindows() const;
+    std::set<QString> getVisibleChannelNames() const;
 
     /// Signals
     pajlada::Signals::NoArgSignal gifRepaintRequested;

--- a/src/singletons/WindowManager.hpp
+++ b/src/singletons/WindowManager.hpp
@@ -9,6 +9,7 @@
 #include <QTimer>
 
 #include <memory>
+#include <span>
 
 namespace chatterino {
 
@@ -130,6 +131,8 @@ public:
 
     /// Toggles the inertia in all open overlay windows
     void toggleAllOverlayInertia();
+
+    std::span<Window *const> allWindows() const;
 
     /// Signals
     pajlada::Signals::NoArgSignal gifRepaintRequested;


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

When we join channels because Chatterino (re-)connected, the join requests for channels that are currently selected are now put first. When starting Chatterino, this makes it seem like it's faster than before (even though it's as fast as before).

One downside of this PR is that `TwitchIrcServer` now knows about `WindowManager`, `Window`, `SplitNotebook`, `SplitContainer`, and `Split`.
An alternative would be to track the selected channels *somewhere* (i.e. add/remove them from methods in `Split` or `SplitNotebook`). I think that approach is more complex with little to no benefit.

- Fixes #3129 (it's the last item)

---

When searching for `joinBucket_` in `TwitchIrcServer`, you might find [another use](https://github.com/Chatterino/chatterino2/blob/da2384d695fa12e17b177b8372448435559070f5/src/providers/twitch/TwitchIrcServer.cpp#L1560). We don't call this when starting Chatterino, because the windows are initialized before the IRC connections (the connection isn't connected yet).