### PR TITLE
fix: more force relayout on timeout/clear/delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Bugfix: Fixed tabs not scaling to the default scale when changing the scale from a non-default value. (#5794)
 - Bugfix: Closing a usercard will no longer cause stop-logging messages to be generated in channel logs. (#5828)
 - Bugfix: Fixed tabs not scaling to the default scale when changing the scale from a non-default value. (#5794, #5833)
-- Bugfix: Fixed deleted messages not disappearing when "Hide deleted messages" is enabled. (#5844)
+- Bugfix: Fixed deleted messages not immediately disappearing when "Hide deleted messages" is enabled. (#5844, #5854)
 - Dev: Highlight checks now use non-capturing groups for the boundaries. (#5784)
 - Dev: Updated Conan dependencies. (#5776)
 - Dev: Replaced usage of `parseTime` with `serverReceivedTime` for clearchat messages. (#5824)

--- a/src/common/Channel.cpp
+++ b/src/common/Channel.cpp
@@ -135,9 +135,6 @@ void Channel::addOrReplaceTimeout(MessagePtr message, const QDateTime &now)
             this->addMessage(msg, MessageContext::Original);
         },
         true);
-
-    // XXX: Might need the following line
-    // WindowManager::instance().repaintVisibleChatWidgets(this);
 }
 
 void Channel::addOrReplaceClearChat(MessagePtr message, const QDateTime &now)

--- a/src/common/Channel.cpp
+++ b/src/common/Channel.cpp
@@ -4,21 +4,9 @@
 #include "messages/Message.hpp"
 #include "messages/MessageBuilder.hpp"
 #include "messages/MessageSimilarity.hpp"
-#include "providers/twitch/IrcMessageHandler.hpp"
-#include "providers/twitch/TwitchIrcServer.hpp"
-#include "singletons/Emotes.hpp"
 #include "singletons/Logging.hpp"
 #include "singletons/Settings.hpp"
-#include "singletons/WindowManager.hpp"
 #include "util/ChannelHelpers.hpp"
-
-#include <QJsonArray>
-#include <QJsonDocument>
-#include <QJsonObject>
-#include <QJsonValue>
-#include <QNetworkAccessManager>
-#include <QNetworkReply>
-#include <QNetworkRequest>
 
 namespace chatterino {
 

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -468,15 +468,16 @@ void IrcMessageHandler::handleClearChatMessage(Communi::IrcMessage *message)
     {
         chan->disableAllMessages();
         chan->addOrReplaceClearChat(std::move(clearChat.message), time);
-        return;
+    }
+    else
+    {
+        chan->addOrReplaceTimeout(std::move(clearChat.message), time);
     }
 
-    chan->addOrReplaceTimeout(std::move(clearChat.message), time);
-
-    // refresh all
-    getApp()->getWindows()->repaintVisibleChatWidgets(chan.get());
     if (getSettings()->hideModerated)
     {
+        // XXX: This is expensive. We could use a layout request if the layout
+        //      would store the previous message flags.
         getApp()->getWindows()->forceLayoutChannelViews();
     }
 }

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -323,6 +323,12 @@ void TwitchIrcServer::initialize()
                 msg->flags.set(MessageFlag::PubSub);
                 chan->addOrReplaceTimeout(msg.release(),
                                           QDateTime::currentDateTime());
+                if (getSettings()->hideModerated)
+                {
+                    // XXX: This is expensive. We could use a layout request if the layout
+                    //      would store the previous message flags.
+                    getApp()->getWindows()->forceLayoutChannelViews();
+                }
             });
         });
 

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -252,6 +252,12 @@ void TwitchIrcServer::initialize()
                 auto now = QDateTime::currentDateTime();
                 chan->addOrReplaceClearChat(
                     MessageBuilder::makeClearChatMessage(now, actor), now);
+                if (getSettings()->hideModerated)
+                {
+                    // XXX: This is expensive. We could use a layout request if the layout
+                    //      would store the previous message flags.
+                    getApp()->getWindows()->forceLayoutChannelViews();
+                }
             });
         });
 

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -144,6 +144,7 @@ WindowManager::WindowManager(const Paths &paths, Settings &settings,
     this->forceLayoutChannelViewsListener.add(settings.boldUsernames);
     this->forceLayoutChannelViewsListener.add(
         settings.showBlockedTermAutomodMessages);
+    this->forceLayoutChannelViewsListener.add(settings.hideModerated);
 
     this->layoutChannelViewsListener.add(settings.timestampFormat);
     this->layoutChannelViewsListener.add(fonts.fontChanged);

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -145,6 +145,8 @@ WindowManager::WindowManager(const Paths &paths, Settings &settings,
     this->forceLayoutChannelViewsListener.add(
         settings.showBlockedTermAutomodMessages);
     this->forceLayoutChannelViewsListener.add(settings.hideModerated);
+    this->forceLayoutChannelViewsListener.add(
+        settings.streamerModeHideModActions);
 
     this->layoutChannelViewsListener.add(settings.timestampFormat);
     this->layoutChannelViewsListener.add(fonts.fontChanged);

--- a/src/util/VectorMessageSink.cpp
+++ b/src/util/VectorMessageSink.cpp
@@ -10,7 +10,10 @@ namespace chatterino {
 VectorMessageSink::VectorMessageSink(MessageSinkTraits traits,
                                      MessageFlags additionalFlags)
     : additionalFlags(additionalFlags)
-    , traits(traits){};
+    , traits(traits)
+{
+}
+
 VectorMessageSink::~VectorMessageSink() = default;
 
 void VectorMessageSink::addMessage(MessagePtr message, MessageContext ctx,


### PR DESCRIPTION
not optimized, but it means the message is hidden as soon as the message becomes disabled, instead of sometimes slightly after it becomes disabled

an alternative to the "force relayout always" is to return if any messages were disabled from the timeout/clearchat helpers
