### PR TITLE
fix: Allow announcements to show up in /mentions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Bugfix: Closing a usercard will no longer cause stop-logging messages to be generated in channel logs. (#5828)
 - Bugfix: Fixed tabs not scaling to the default scale when changing the scale from a non-default value. (#5794, #5833)
 - Bugfix: Fixed deleted messages not immediately disappearing when "Hide deleted messages" is enabled. (#5844, #5854)
+- BugFix: Fixed announcements not showing up in mentions tab. (#5857)
 - Dev: Highlight checks now use non-capturing groups for the boundaries. (#5784)
 - Dev: Updated Conan dependencies. (#5776)
 - Dev: Replaced usage of `parseTime` with `serverReceivedTime` for clearchat messages. (#5824, #5855)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Bugfix: Closing a usercard will no longer cause stop-logging messages to be generated in channel logs. (#5828)
 - Bugfix: Fixed tabs not scaling to the default scale when changing the scale from a non-default value. (#5794, #5833)
 - Bugfix: Fixed deleted messages not immediately disappearing when "Hide deleted messages" is enabled. (#5844, #5854)
-- BugFix: Fixed announcements not showing up in mentions tab. (#5857)
+- Bugfix: Fixed announcements not showing up in mentions tab. (#5857)
 - Dev: Highlight checks now use non-capturing groups for the boundaries. (#5784)
 - Dev: Updated Conan dependencies. (#5776)
 - Dev: Replaced usage of `parseTime` with `serverReceivedTime` for clearchat messages. (#5824, #5855)

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -1097,6 +1097,8 @@ void IrcMessageHandler::addMessage(Communi::IrcMessage *message,
 
             if (tags.value("msg-id") != "announcement")
             {
+                // Announcements are currently tagged as subscriptions,
+                // but we want them to be able to show up in mentions
                 msg->flags.unset(MessageFlag::Highlighted);
             }
         }

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -1094,7 +1094,11 @@ void IrcMessageHandler::addMessage(Communi::IrcMessage *message,
         if (isSub)
         {
             msg->flags.set(MessageFlag::Subscription);
-            msg->flags.unset(MessageFlag::Highlighted);
+
+            if (tags.value("msg-id") != "announcement")
+            {
+                msg->flags.unset(MessageFlag::Highlighted);
+            }
         }
 
         sink.applySimilarityFilters(msg);

--- a/tests/snapshots/IrcMessageHandler/announcement.json
+++ b/tests/snapshots/IrcMessageHandler/announcement.json
@@ -151,7 +151,7 @@
                     "url": ""
                 }
             ],
-            "flags": "Collapsed|Subscription",
+            "flags": "Highlighted|Collapsed|Subscription",
             "highlightColor": "#64c466ff",
             "id": "8c26e1ab-b50c-4d9d-bc11-3fd57a941d90",
             "localizedName": "",


### PR DESCRIPTION
This restores the display of announcement messages in the mentions tab.

Closes #5812 

I don't like having annoucements included in `isSub` but changing that would require a larger refactor. 
