### PR TITLE
Add compact tabs to settings and implement them

### DIFF
--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -168,6 +168,7 @@ public:
     FloatSetting boldScale = {"/appearance/boldScale", 63};
     BoolSetting showTabCloseButton = {"/appearance/showTabCloseButton", true};
     BoolSetting showTabLive = {"/appearance/showTabLiveButton", true};
+    BoolSetting compactTabs = {"/appearance/compactTabs", false};
     BoolSetting hidePreferencesButton = {"/appearance/hidePreferencesButton",
                                          false};
     BoolSetting hideUserButton = {"/appearance/hideUserButton", false};

--- a/src/widgets/helper/NotebookTab.hpp
+++ b/src/widgets/helper/NotebookTab.hpp
@@ -82,7 +82,7 @@ public:
     void moveAnimated(QPoint targetPos, bool animated = true);
 
     QRect getDesiredRect() const;
-    void hideTabXChanged();
+    void tabSizeChanged();
 
     void growWidth(int width);
     int normalTabWidth() const;

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -289,6 +289,8 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         "When disabled, the x to close a tab will be hidden.\nTabs can still "
         "be closed by right-clicking or pressing " +
             removeTabShortcut + ".");
+    layout.addCheckbox("Compact tabs", s.compactTabs, false,
+                       "When enabled, tabs will have less width than normal.");
     layout.addCheckbox("Always on top", s.windowTopMost, false,
                        "Always keep Chatterino as the top window.");
 #ifdef USEWINSDK


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
Fixes #5807
I did find a bug regarding the tab width not adjusting properly when using left and right tab mode when switching this setting or the "Show tab close button". But the setting will take effect after either changing the layout location back and forth or restarting chatterino.

The numbers used here are what I found looks the best while keeping other settings such as the tab close button still looking good. I have not tested this on scaling, would probably be good if someone who has that tests this pr.
![26-01-2025_21_24_39](https://github.com/user-attachments/assets/cd31acb5-05a9-4e7c-986f-0ac5885535a9) ![26-01-2025_21_24_49](https://github.com/user-attachments/assets/8e61c7e6-78a4-4f59-a1e5-7442a4743a36) ![26-01-2025_21_25_06](https://github.com/user-attachments/assets/18e59e7c-ebbf-481a-ae67-2b4f2d357e21) ![26-01-2025_21_24_58](https://github.com/user-attachments/assets/a5f6f48f-02ff-4d25-a82b-171d77e17d37) 
<pre>     default              compact         show tab close              show tab close compact</pre>