### PR TITLE
fix: don't show reply button on inline whispers or announcements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Bugfix: Fixed tabs not scaling to the default scale when changing the scale from a non-default value. (#5794, #5833)
 - Bugfix: Fixed deleted messages not immediately disappearing when "Hide deleted messages" is enabled. (#5844, #5854)
 - Bugfix: Fixed announcements not showing up in mentions tab. (#5857)
+- Bugfix: Fixed the reply button showing for inline whispers and announcements. (#5863)
 - Dev: Highlight checks now use non-capturing groups for the boundaries. (#5784)
 - Dev: Updated Conan dependencies. (#5776)
 - Dev: Replaced usage of `parseTime` with `serverReceivedTime` for clearchat messages. (#5824, #5855)

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -2245,23 +2245,26 @@ std::pair<MessagePtrMut, HighlightAlert> MessageBuilder::makeIrcMessage(
             ColorProvider::instance().color(ColorType::Whisper);
     }
 
-    if (thread)
+    if (!args.isReceivedWhisper && tags.value("msg-id") != "announcement")
     {
-        auto &img = getResources().buttons.replyThreadDark;
-        builder
-            .emplace<CircularImageElement>(Image::fromResourcePixmap(img, 0.15),
-                                           2, Qt::gray,
-                                           MessageElementFlag::ReplyButton)
-            ->setLink({Link::ViewThread, thread->rootId()});
-    }
-    else
-    {
-        auto &img = getResources().buttons.replyDark;
-        builder
-            .emplace<CircularImageElement>(Image::fromResourcePixmap(img, 0.15),
-                                           2, Qt::gray,
-                                           MessageElementFlag::ReplyButton)
-            ->setLink({Link::ReplyToMessage, builder->id});
+        if (thread)
+        {
+            auto &img = getResources().buttons.replyThreadDark;
+            builder
+                .emplace<CircularImageElement>(
+                    Image::fromResourcePixmap(img, 0.15), 2, Qt::gray,
+                    MessageElementFlag::ReplyButton)
+                ->setLink({Link::ViewThread, thread->rootId()});
+        }
+        else
+        {
+            auto &img = getResources().buttons.replyDark;
+            builder
+                .emplace<CircularImageElement>(
+                    Image::fromResourcePixmap(img, 0.15), 2, Qt::gray,
+                    MessageElementFlag::ReplyButton)
+                ->setLink({Link::ReplyToMessage, builder->id});
+        }
     }
 
     return {builder.release(), highlight};

--- a/tests/snapshots/IrcMessageHandler/announcement.json
+++ b/tests/snapshots/IrcMessageHandler/announcement.json
@@ -136,19 +136,6 @@
                         "test",
                         "lol"
                     ]
-                },
-                {
-                    "background": "#ffa0a0a4",
-                    "flags": "ReplyButton",
-                    "link": {
-                        "type": "ReplyToMessage",
-                        "value": "8c26e1ab-b50c-4d9d-bc11-3fd57a941d90"
-                    },
-                    "padding": 2,
-                    "tooltip": "",
-                    "trailingSpace": true,
-                    "type": "CircularImageElement",
-                    "url": ""
                 }
             ],
             "flags": "Highlighted|Collapsed|Subscription",


### PR DESCRIPTION
Closes #5778.

Announcements can't be replied to as well so the button isn't added for those either.
