### PR TITLE
fix: make suspicious treatment updates searchable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Bugfix: Fixed tabs not scaling to the default scale when changing the scale from a non-default value. (#5794, #5833)
 - Bugfix: Fixed deleted messages not immediately disappearing when "Hide deleted messages" is enabled. (#5844, #5854)
 - Bugfix: Fixed announcements not showing up in mentions tab. (#5857)
+- Bugfix: Fixed suspicious user treatment update messages not being searchable. (#5865)
 - Dev: Highlight checks now use non-capturing groups for the boundaries. (#5784)
 - Dev: Updated Conan dependencies. (#5776)
 - Dev: Replaced usage of `parseTime` with `serverReceivedTime` for clearchat messages. (#5824, #5855)

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -1967,6 +1967,7 @@ MessagePtr MessageBuilder::makeLowTrustUpdateMessage(
                               MessageColor::System, FontStyle::ChatMediumBold)
         ->setLink({Link::UserInfo, action.updatedByUserLogin});
 
+    QString text;
     assert(action.treatment != PubSubLowTrustUsersMessage::Treatment::INVALID);
     switch (action.treatment)
     {
@@ -1982,6 +1983,9 @@ MessagePtr MessageBuilder::makeLowTrustUpdateMessage(
             builder.emplace<TextElement>("from the suspicious user list.",
                                          MessageElementFlag::Text,
                                          MessageColor::System);
+            text = QString("%1 removed %2 from the suspicious user list.")
+                       .arg(action.updatedByUserDisplayName,
+                            action.suspiciousUserDisplayName);
         }
         break;
 
@@ -1997,6 +2001,9 @@ MessagePtr MessageBuilder::makeLowTrustUpdateMessage(
             builder.emplace<TextElement>("as a monitored suspicious chatter.",
                                          MessageElementFlag::Text,
                                          MessageColor::System);
+            text = QString("%1 added %2 as a monitored suspicious chatter.")
+                       .arg(action.updatedByUserDisplayName,
+                            action.suspiciousUserDisplayName);
         }
         break;
 
@@ -2012,6 +2019,9 @@ MessagePtr MessageBuilder::makeLowTrustUpdateMessage(
             builder.emplace<TextElement>("as a restricted suspicious chatter.",
                                          MessageElementFlag::Text,
                                          MessageColor::System);
+            text = QString("%1 added %2 as a restricted suspicious chatter.")
+                       .arg(action.updatedByUserDisplayName,
+                            action.suspiciousUserDisplayName);
         }
         break;
 
@@ -2021,6 +2031,8 @@ MessagePtr MessageBuilder::makeLowTrustUpdateMessage(
             break;
     }
 
+    builder->messageText = text;
+    builder->searchText = text;
     return builder.release();
 }
 


### PR DESCRIPTION
`searchText` was not populated for pubsub notif of (un)monitor/(un)restrict