### PR TITLE
New default for shift+enter and shift+ctrl+enter hotkeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Bugfix: Fixed deleted messages not immediately disappearing when "Hide deleted messages" is enabled. (#5844, #5854)
 - Bugfix: Fixed announcements not showing up in mentions tab. (#5857)
 - Bugfix: Fixed suspicious user treatment update messages not being searchable. (#5865)
+- BugFix: Shift+Return and Ctrl+Shift+Return are now bound with default hotkeys. (#5868)
 - Dev: Highlight checks now use non-capturing groups for the boundaries. (#5784)
 - Dev: Updated Conan dependencies. (#5776)
 - Dev: Replaced usage of `parseTime` with `serverReceivedTime` for clearchat messages. (#5824, #5855)

--- a/src/controllers/hotkeys/HotkeyController.cpp
+++ b/src/controllers/hotkeys/HotkeyController.cpp
@@ -428,11 +428,12 @@ void HotkeyController::addDefaults(std::set<QString> &addedHotkeys)
 
             this->tryAddDefault(addedHotkeys, HotkeyCategory::SplitInput,
                                 QKeySequence("Shift+Return"), "sendMessage",
-                                std::vector<QString>(), "send message");
+                                std::vector<QString>(),
+                                "send message (with shift)");
             this->tryAddDefault(addedHotkeys, HotkeyCategory::SplitInput,
                                 QKeySequence("Ctrl+Shift+Return"),
                                 "sendMessage", {"keepInput"},
-                                "send message and keep text");
+                                "send message and keep text (with shift)");
         }
 
         this->tryAddDefault(addedHotkeys, HotkeyCategory::SplitInput,


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
Fixes #3619