### PR TITLE
fix(hotkeys): remove (self-)buddy from `argumentsDescription`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Dev: Replaced usage of `parseTime` with `serverReceivedTime` for clearchat messages. (#5824, #5855)
 - Dev: Support Boost 1.87. (#5832)
 - Dev: Words from `TextElement`s are now combined where possible. (#5847)
+- Dev: Fixed assertion failure when closing the edit-hotkey dialog. (#5869)
 
 ## 2.5.2
 

--- a/src/widgets/dialogs/EditHotkeyDialog.ui
+++ b/src/widgets/dialogs/EditHotkeyDialog.ui
@@ -140,9 +140,6 @@ see this message :)</string>
        <property name="text">
         <string>You should never see this message :)</string>
        </property>
-       <property name="buddy">
-        <cstring>argumentsDescription</cstring>
-       </property>
       </widget>
      </item>
      <item row="6" column="1">


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
A label can't be a buddy to itself. This causes an assertion failure when deleting the label (closing the edit-hotkey dialog).