### PR TITLE
fix: use upstream qtkeychain (for real this time)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,7 +19,7 @@
 	url = https://github.com/Tencent/rapidjson
 [submodule "lib/qtkeychain"]
 	path = lib/qtkeychain
-	url = https://github.com/Chatterino/qtkeychain
+	url = https://github.com/frankosterfeld/qtkeychain
 [submodule "lib/websocketpp"]
 	path = lib/websocketpp
 	url = https://github.com/Chatterino/websocketpp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Dev: Replaced usage of `parseTime` with `serverReceivedTime` for clearchat messages. (#5824, #5855)
 - Dev: Support Boost 1.87. (#5832)
 - Dev: Words from `TextElement`s are now combined where possible. (#5847)
+- Dev: Updated `qtkeychain` to 0.15.0. (#5871)
 
 ## 2.5.2
 


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
https://github.com/Chatterino/chatterino2/pull/5697#issuecomment-2458023845:
> If possible I like to make those changes together with, or after, a release

We had a release, so now we can finally use the upstream qtkeychain (`0.15.0` tag) which means `clang-cl` won't yell because of `/Wall` anymore.