### PR TITLE
feat: Search improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Minor: Remove incognito browser support for `opera/launcher` (this should no longer be a thing). (#5805)
 - Minor: Remove incognito browser support for `iexplore`, because internet explorer is EOL. (#5810)
 - Minor: When (re-)connecting, visible channels are now joined first. (#5850)
+- Minor: Made global search in settings more advanced. (#5874)
 - Bugfix: Fixed a potential way to escape the Lua Plugin sandbox. (#5846)
 - Bugfix: Fixed a crash relating to Lua HTTP. (#5800)
 - Bugfix: Fixed a crash that could occur on Linux and macOS when clicking "Install" from the update prompt. (#5818)

--- a/src/widgets/helper/EditableModelView.cpp
+++ b/src/widgets/helper/EditableModelView.cpp
@@ -150,26 +150,37 @@ void EditableModelView::addRegexHelpLink()
     this->addCustomButton(regexHelpLabel);
 }
 
-void EditableModelView::filterSearchResults(QString *query,
-                                            std::vector<int> *columnSelect)
+bool EditableModelView::filterSearchResults(const QString &query,
+                                            std::vector<int> &columnSelect)
 {
+    bool searchFoundSomething = false;
     auto rowAmount = this->model_->rowCount();
+
+    // make sure to show the page even if the table is empty,
+    // but only if we aren't search something
+    if (rowAmount == 0 && query.isEmpty())
+    {
+        return true;
+    }
+
     for (int i = 0; i < rowAmount; i++)
     {
-        tableView_->showRow(i);
+        tableView_->hideRow(i);
     }
-    for (int j : *columnSelect)
+    for (int j : columnSelect)
     {
         for (int i = 0; i < rowAmount; i++)
         {
             QModelIndex idx = model_->index(i, j);
             QVariant a = model_->data(idx);
-            if (!a.toString().contains(*query, Qt::CaseInsensitive))
+            if (a.toString().contains(query, Qt::CaseInsensitive))
             {
-                tableView_->hideRow(i);
+                tableView_->showRow(i);
+                searchFoundSomething = true;
             }
         }
     }
+    return searchFoundSomething;
 }
 
 void EditableModelView::filterSearchResultsHotkey(

--- a/src/widgets/helper/EditableModelView.cpp
+++ b/src/widgets/helper/EditableModelView.cpp
@@ -150,6 +150,51 @@ void EditableModelView::addRegexHelpLink()
     this->addCustomButton(regexHelpLabel);
 }
 
+void EditableModelView::filterSearchResults(QString *query,
+                                            std::vector<int> *columnSelect)
+{
+    auto rowAmount = this->model_->rowCount();
+    for (int i = 0; i < rowAmount; i++)
+    {
+        tableView_->showRow(i);
+    }
+    for (int j : *columnSelect)
+    {
+        for (int i = 0; i < rowAmount; i++)
+        {
+            QModelIndex idx = model_->index(i, j);
+            QVariant a = model_->data(idx);
+            if (!a.toString().contains(*query, Qt::CaseInsensitive))
+            {
+                tableView_->hideRow(i);
+            }
+        }
+    }
+}
+
+void EditableModelView::filterSearchResultsHotkey(
+    const QKeySequence *keySequenceQuery)
+{
+    auto rowAmount = this->model_->rowCount();
+    for (int i = 0; i < rowAmount; i++)
+    {
+        tableView_->hideRow(i);
+    }
+    for (int i = 0; i < rowAmount; i++)
+    {
+        QModelIndex idx = model_->index(i, 1);
+        QVariant a = model_->data(idx);
+        auto seq = qvariant_cast<QKeySequence>(a);
+
+        // todo: Make this fuzzy match, right now only exact matches happen
+        // so ctrl+f won't match ctrl+shift+f shortcuts
+        if (keySequenceQuery->matches(seq) != QKeySequence::NoMatch)
+        {
+            tableView_->showRow(i);
+        }
+    }
+}
+
 void EditableModelView::moveRow(int dir)
 {
     auto selected = this->getTableView()->selectionModel()->selectedRows(0);

--- a/src/widgets/helper/EditableModelView.cpp
+++ b/src/widgets/helper/EditableModelView.cpp
@@ -151,7 +151,7 @@ void EditableModelView::addRegexHelpLink()
 }
 
 bool EditableModelView::filterSearchResults(const QString &query,
-                                            std::vector<int> &columnSelect)
+                                            std::span<const int> columnSelect)
 {
     bool searchFoundSomething = false;
     auto rowAmount = this->model_->rowCount();
@@ -184,7 +184,7 @@ bool EditableModelView::filterSearchResults(const QString &query,
 }
 
 void EditableModelView::filterSearchResultsHotkey(
-    const QKeySequence *keySequenceQuery)
+    const QKeySequence &keySequenceQuery)
 {
     auto rowAmount = this->model_->rowCount();
     for (int i = 0; i < rowAmount; i++)
@@ -199,7 +199,7 @@ void EditableModelView::filterSearchResultsHotkey(
 
         // todo: Make this fuzzy match, right now only exact matches happen
         // so ctrl+f won't match ctrl+shift+f shortcuts
-        if (keySequenceQuery->matches(seq) != QKeySequence::NoMatch)
+        if (keySequenceQuery.matches(seq) != QKeySequence::NoMatch)
         {
             tableView_->showRow(i);
         }

--- a/src/widgets/helper/EditableModelView.hpp
+++ b/src/widgets/helper/EditableModelView.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <pajlada/signals/signal.hpp>
+#include <QKeySequence>
 #include <QWidget>
 
 class QAbstractTableModel;
@@ -24,6 +25,9 @@ public:
 
     void addCustomButton(QWidget *widget);
     void addRegexHelpLink();
+
+    void filterSearchResults(QString *query, std::vector<int> *columnSelect);
+    void filterSearchResultsHotkey(const QKeySequence *keySequenceQuery);
 
 private:
     QTableView *tableView_{};

--- a/src/widgets/helper/EditableModelView.hpp
+++ b/src/widgets/helper/EditableModelView.hpp
@@ -27,8 +27,8 @@ public:
     void addRegexHelpLink();
 
     bool filterSearchResults(const QString &query,
-                             std::vector<int> &columnSelect);
-    void filterSearchResultsHotkey(const QKeySequence *keySequenceQuery);
+                             std::span<const int> columnSelect);
+    void filterSearchResultsHotkey(const QKeySequence &keySequenceQuery);
 
 private:
     QTableView *tableView_{};

--- a/src/widgets/helper/EditableModelView.hpp
+++ b/src/widgets/helper/EditableModelView.hpp
@@ -26,7 +26,8 @@ public:
     void addCustomButton(QWidget *widget);
     void addRegexHelpLink();
 
-    void filterSearchResults(QString *query, std::vector<int> *columnSelect);
+    bool filterSearchResults(const QString &query,
+                             std::vector<int> &columnSelect);
     void filterSearchResultsHotkey(const QKeySequence *keySequenceQuery);
 
 private:

--- a/src/widgets/settingspages/AccountsPage.cpp
+++ b/src/widgets/settingspages/AccountsPage.cpp
@@ -68,9 +68,9 @@ AccountsPage::AccountsPage()
 
 bool AccountsPage::filterElements(const QString &query)
 {
-    auto *fields = new std::vector<int>{0, 1};
+    std::array fields{0, 1};
 
-    return view_->filterSearchResults(query, *fields);
+    return view_->filterSearchResults(query, fields);
 }
 
 }  // namespace chatterino

--- a/src/widgets/settingspages/AccountsPage.cpp
+++ b/src/widgets/settingspages/AccountsPage.cpp
@@ -24,22 +24,21 @@ AccountsPage::AccountsPage()
     LayoutCreator<AccountsPage> layoutCreator(this);
     auto layout = layoutCreator.emplace<QVBoxLayout>().withoutMargin();
 
-    EditableModelView *view =
-        layout
-            .emplace<EditableModelView>(
-                app->getAccounts()->createModel(nullptr), false)
-            .getElement();
+    this->view_ = layout
+                      .emplace<EditableModelView>(
+                          app->getAccounts()->createModel(nullptr), false)
+                      .getElement();
 
-    view->getTableView()->horizontalHeader()->setVisible(false);
-    view->getTableView()->horizontalHeader()->setStretchLastSection(true);
+    view_->getTableView()->horizontalHeader()->setVisible(false);
+    view_->getTableView()->horizontalHeader()->setStretchLastSection(true);
 
     // We can safely ignore this signal connection since we own the view
-    std::ignore = view->addButtonPressed.connect([this] {
+    std::ignore = view_->addButtonPressed.connect([this] {
         LoginDialog d(this);
         d.exec();
     });
 
-    view->getTableView()->setStyleSheet("background: #333");
+    view_->getTableView()->setStyleSheet("background: #333");
 
     //    auto buttons = layout.emplace<QDialogButtonBox>();
     //    {
@@ -65,6 +64,13 @@ AccountsPage::AccountsPage()
 
     //        getApp()->getAccounts()->Twitch.removeUser(selectedUser);
     //    });
+}
+
+bool AccountsPage::filterElements(const QString &query)
+{
+    auto *fields = new std::vector<int>{0, 1};
+
+    return view_->filterSearchResults(query, *fields);
 }
 
 }  // namespace chatterino

--- a/src/widgets/settingspages/AccountsPage.cpp
+++ b/src/widgets/settingspages/AccountsPage.cpp
@@ -29,16 +29,17 @@ AccountsPage::AccountsPage()
                           app->getAccounts()->createModel(nullptr), false)
                       .getElement();
 
-    view_->getTableView()->horizontalHeader()->setVisible(false);
-    view_->getTableView()->horizontalHeader()->setStretchLastSection(true);
+    this->view_->getTableView()->horizontalHeader()->setVisible(false);
+    this->view_->getTableView()->horizontalHeader()->setStretchLastSection(
+        true);
 
     // We can safely ignore this signal connection since we own the view
-    std::ignore = view_->addButtonPressed.connect([this] {
+    std::ignore = this->view_->addButtonPressed.connect([this] {
         LoginDialog d(this);
         d.exec();
     });
 
-    view_->getTableView()->setStyleSheet("background: #333");
+    this->view_->getTableView()->setStyleSheet("background: #333");
 
     //    auto buttons = layout.emplace<QDialogButtonBox>();
     //    {
@@ -70,7 +71,7 @@ bool AccountsPage::filterElements(const QString &query)
 {
     std::array fields{0, 1};
 
-    return view_->filterSearchResults(query, fields);
+    return this->view_->filterSearchResults(query, fields);
 }
 
 }  // namespace chatterino

--- a/src/widgets/settingspages/AccountsPage.hpp
+++ b/src/widgets/settingspages/AccountsPage.hpp
@@ -8,15 +8,19 @@ namespace chatterino {
 
 class AccountSwitchWidget;
 
+class EditableModelView;
+
 class AccountsPage : public SettingsPage
 {
 public:
     AccountsPage();
+    bool filterElements(const QString &query) override;
 
 private:
     QPushButton *addButton_{};
     QPushButton *removeButton_{};
     AccountSwitchWidget *accountSwitchWidget_{};
+    EditableModelView *view_;
 };
 
 }  // namespace chatterino

--- a/src/widgets/settingspages/CommandPage.cpp
+++ b/src/widgets/settingspages/CommandPage.cpp
@@ -87,16 +87,16 @@ CommandPage::CommandPage()
     LayoutCreator<CommandPage> layoutCreator(this);
     auto layout = layoutCreator.setLayoutType<QVBoxLayout>();
 
-    view_ = layout
-                .emplace<EditableModelView>(
-                    getApp()->getCommands()->createModel(nullptr))
-                .getElement();
+    this->view_ = layout
+                      .emplace<EditableModelView>(
+                          getApp()->getCommands()->createModel(nullptr))
+                      .getElement();
 
-    view_->setTitles({"Trigger", "Command", "Show In\nMessage Menu"});
-    view_->getTableView()->horizontalHeader()->setSectionResizeMode(
+    this->view_->setTitles({"Trigger", "Command", "Show In\nMessage Menu"});
+    this->view_->getTableView()->horizontalHeader()->setSectionResizeMode(
         1, QHeaderView::Stretch);
-    // We can safely ignore this signal connection since we own the view_
-    std::ignore = view_->addButtonPressed.connect([] {
+    // We can safely ignore this signal connection since we own the this->view_
+    std::ignore = this->view_->addButtonPressed.connect([] {
         getApp()->getCommands()->items.append(
             Command{"/command", "I made a new command HeyGuys"});
     });
@@ -105,7 +105,7 @@ CommandPage::CommandPage()
     if (QFile(c1settingsPath()).exists())
     {
         auto *button = new QPushButton("Import commands from Chatterino 1");
-        view_->addCustomButton(button);
+        this->view_->addCustomButton(button);
 
         QObject::connect(button, &QPushButton::clicked, this, [] {
             QFile c1settings(c1settingsPath());
@@ -169,7 +169,7 @@ bool CommandPage::filterElements(const QString &query)
 {
     std::array fields{0, 1};
 
-    return view_->filterSearchResults(query, fields);
+    return this->view_->filterSearchResults(query, fields);
 }
 
 }  // namespace chatterino

--- a/src/widgets/settingspages/CommandPage.cpp
+++ b/src/widgets/settingspages/CommandPage.cpp
@@ -33,17 +33,17 @@ QString c1settingsPath()
     return combinePath(qgetenv("appdata"), "Chatterino\\Custom\\Commands.txt");
 }
 
-void checkCommandDuplicates(EditableModelView *view_, QLabel *duplicateWarning)
+void checkCommandDuplicates(EditableModelView *view, QLabel *duplicateWarning)
 {
     bool foundDuplicateTrigger = false;
 
     // Maps command triggers to model row indices
     std::unordered_map<QString, std::vector<int>> commands;
 
-    for (int i = 0; i < view_->getModel()->rowCount(); i++)
+    for (int i = 0; i < view->getModel()->rowCount(); i++)
     {
         QString commandTrigger =
-            view_->getModel()->index(i, 0).data().toString();
+            view->getModel()->index(i, 0).data().toString();
         commands[commandTrigger].push_back(i);
     }
 
@@ -57,16 +57,14 @@ void checkCommandDuplicates(EditableModelView *view_, QLabel *duplicateWarning)
 
             for (const auto &rowIndex : rowIndices)
             {
-                view_->getModel()->setData(
-                    view_->getModel()->index(rowIndex, 0), QColor("yellow"),
-                    Qt::ForegroundRole);
+                view->getModel()->setData(view->getModel()->index(rowIndex, 0),
+                                          QColor("yellow"), Qt::ForegroundRole);
             }
         }
         else
         {
-            view_->getModel()->setData(
-                view_->getModel()->index(rowIndices[0], 0), QColor("white"),
-                Qt::ForegroundRole);
+            view->getModel()->setData(view->getModel()->index(rowIndices[0], 0),
+                                      QColor("white"), Qt::ForegroundRole);
         }
     }
 
@@ -169,9 +167,9 @@ CommandPage::CommandPage()
 
 bool CommandPage::filterElements(const QString &query)
 {
-    auto *fields = new std::vector<int>{0, 1};
+    std::array fields{0, 1};
 
-    return view_->filterSearchResults(query, *fields);
+    return view_->filterSearchResults(query, fields);
 }
 
 }  // namespace chatterino

--- a/src/widgets/settingspages/CommandPage.hpp
+++ b/src/widgets/settingspages/CommandPage.hpp
@@ -6,13 +6,17 @@
 
 namespace chatterino {
 
+class EditableModelView;
+
 class CommandPage : public SettingsPage
 {
 public:
     CommandPage();
+    bool filterElements(const QString &query) override;
 
 private:
     QTimer commandsEditTimer_;
+    EditableModelView *view_;
 };
 
 }  // namespace chatterino

--- a/src/widgets/settingspages/FiltersPage.cpp
+++ b/src/widgets/settingspages/FiltersPage.cpp
@@ -131,9 +131,9 @@ void FiltersPage::tableCellClicked(const QModelIndex &clicked,
 
 bool FiltersPage::filterElements(const QString &query)
 {
-    auto *fields = new std::vector<int>{0, 1};
+    std::array fields{0, 1};
 
-    return view_->filterSearchResults(query, *fields);
+    return view_->filterSearchResults(query, fields);
 }
 
 }  // namespace chatterino

--- a/src/widgets/settingspages/FiltersPage.cpp
+++ b/src/widgets/settingspages/FiltersPage.cpp
@@ -25,27 +25,26 @@ FiltersPage::FiltersPage()
     layout.emplace<QLabel>(
         "Selectively display messages in Splits using channel filters. Set "
         "filters under a Split menu.");
-    EditableModelView *view =
-        layout
-            .emplace<EditableModelView>(
-                (new FilterModel(nullptr))
-                    ->initialized(&getSettings()->filterRecords))
-            .getElement();
+    view_ = layout
+                .emplace<EditableModelView>(
+                    (new FilterModel(nullptr))
+                        ->initialized(&getSettings()->filterRecords))
+                .getElement();
 
-    view->setTitles({"Name", "Filter", "Valid"});
-    view->getTableView()->horizontalHeader()->setSectionResizeMode(
+    view_->setTitles({"Name", "Filter", "Valid"});
+    view_->getTableView()->horizontalHeader()->setSectionResizeMode(
         QHeaderView::Interactive);
-    view->getTableView()->horizontalHeader()->setSectionResizeMode(
+    view_->getTableView()->horizontalHeader()->setSectionResizeMode(
         1, QHeaderView::Stretch);
 
-    QTimer::singleShot(1, [view] {
-        view->getTableView()->resizeColumnsToContents();
-        view->getTableView()->setColumnWidth(0, 150);
-        view->getTableView()->setColumnWidth(2, 125);
+    QTimer::singleShot(1, [this] {
+        view_->getTableView()->resizeColumnsToContents();
+        view_->getTableView()->setColumnWidth(0, 150);
+        view_->getTableView()->setColumnWidth(2, 125);
     });
 
-    // We can safely ignore this signal connection since we own the view
-    std::ignore = view->addButtonPressed.connect([this] {
+    // We can safely ignore this signal connection since we own the view_
+    std::ignore = view_->addButtonPressed.connect([this] {
         ChannelFilterEditorDialog d(this->window());
         if (d.exec() == QDialog::Accepted)
         {
@@ -59,11 +58,11 @@ FiltersPage::FiltersPage()
         getSettings()->filterRecords.append(std::make_shared<FilterRecord>(
             "My filter", "message.content contains \"hello\""));
     });
-    view->addCustomButton(quickAddButton);
+    view_->addCustomButton(quickAddButton);
 
-    QObject::connect(view->getTableView(), &QTableView::clicked,
-                     [this, view](const QModelIndex &clicked) {
-                         this->tableCellClicked(clicked, view);
+    QObject::connect(view_->getTableView(), &QTableView::clicked,
+                     [this](const QModelIndex &clicked) {
+                         this->tableCellClicked(clicked, view_);
                      });
 
     auto *filterHelpLabel =
@@ -71,7 +70,7 @@ FiltersPage::FiltersPage()
                                "style='color:#99f'>filter info</span></a>")
                        .arg(FILTERS_DOCUMENTATION));
     filterHelpLabel->setOpenExternalLinks(true);
-    view->addCustomButton(filterHelpLabel);
+    view_->addCustomButton(filterHelpLabel);
 
     layout.append(
         this->createCheckBox("Do not filter my own messages",
@@ -84,7 +83,7 @@ void FiltersPage::onShow()
 }
 
 void FiltersPage::tableCellClicked(const QModelIndex &clicked,
-                                   EditableModelView *view)
+                                   EditableModelView *view_)
 {
     // valid column
     if (clicked.column() == 2)
@@ -92,7 +91,7 @@ void FiltersPage::tableCellClicked(const QModelIndex &clicked,
         QMessageBox popup(this->window());
 
         auto filterText =
-            view->getModel()->data(clicked.siblingAtColumn(1)).toString();
+            view_->getModel()->data(clicked.siblingAtColumn(1)).toString();
         auto filterResult = filters::Filter::fromString(filterText);
 
         if (std::holds_alternative<filters::Filter>(filterResult))
@@ -128,6 +127,13 @@ void FiltersPage::tableCellClicked(const QModelIndex &clicked,
 
         popup.exec();
     }
+}
+
+bool FiltersPage::filterElements(const QString &query)
+{
+    auto *fields = new std::vector<int>{0, 1};
+
+    return view_->filterSearchResults(query, *fields);
 }
 
 }  // namespace chatterino

--- a/src/widgets/settingspages/FiltersPage.cpp
+++ b/src/widgets/settingspages/FiltersPage.cpp
@@ -25,26 +25,26 @@ FiltersPage::FiltersPage()
     layout.emplace<QLabel>(
         "Selectively display messages in Splits using channel filters. Set "
         "filters under a Split menu.");
-    view_ = layout
-                .emplace<EditableModelView>(
-                    (new FilterModel(nullptr))
-                        ->initialized(&getSettings()->filterRecords))
-                .getElement();
+    this->view_ = layout
+                      .emplace<EditableModelView>(
+                          (new FilterModel(nullptr))
+                              ->initialized(&getSettings()->filterRecords))
+                      .getElement();
 
-    view_->setTitles({"Name", "Filter", "Valid"});
-    view_->getTableView()->horizontalHeader()->setSectionResizeMode(
+    this->view_->setTitles({"Name", "Filter", "Valid"});
+    this->view_->getTableView()->horizontalHeader()->setSectionResizeMode(
         QHeaderView::Interactive);
-    view_->getTableView()->horizontalHeader()->setSectionResizeMode(
+    this->view_->getTableView()->horizontalHeader()->setSectionResizeMode(
         1, QHeaderView::Stretch);
 
     QTimer::singleShot(1, [this] {
-        view_->getTableView()->resizeColumnsToContents();
-        view_->getTableView()->setColumnWidth(0, 150);
-        view_->getTableView()->setColumnWidth(2, 125);
+        this->view_->getTableView()->resizeColumnsToContents();
+        this->view_->getTableView()->setColumnWidth(0, 150);
+        this->view_->getTableView()->setColumnWidth(2, 125);
     });
 
-    // We can safely ignore this signal connection since we own the view_
-    std::ignore = view_->addButtonPressed.connect([this] {
+    // We can safely ignore this signal connection since we own the this->view_
+    std::ignore = this->view_->addButtonPressed.connect([this] {
         ChannelFilterEditorDialog d(this->window());
         if (d.exec() == QDialog::Accepted)
         {
@@ -58,11 +58,11 @@ FiltersPage::FiltersPage()
         getSettings()->filterRecords.append(std::make_shared<FilterRecord>(
             "My filter", "message.content contains \"hello\""));
     });
-    view_->addCustomButton(quickAddButton);
+    this->view_->addCustomButton(quickAddButton);
 
     QObject::connect(view_->getTableView(), &QTableView::clicked,
                      [this](const QModelIndex &clicked) {
-                         this->tableCellClicked(clicked, view_);
+                         this->tableCellClicked(clicked, this->view_);
                      });
 
     auto *filterHelpLabel =
@@ -70,7 +70,7 @@ FiltersPage::FiltersPage()
                                "style='color:#99f'>filter info</span></a>")
                        .arg(FILTERS_DOCUMENTATION));
     filterHelpLabel->setOpenExternalLinks(true);
-    view_->addCustomButton(filterHelpLabel);
+    this->view_->addCustomButton(filterHelpLabel);
 
     layout.append(
         this->createCheckBox("Do not filter my own messages",
@@ -90,8 +90,9 @@ void FiltersPage::tableCellClicked(const QModelIndex &clicked,
     {
         QMessageBox popup(this->window());
 
-        auto filterText =
-            view_->getModel()->data(clicked.siblingAtColumn(1)).toString();
+        auto filterText = this->view_->getModel()
+                              ->data(clicked.siblingAtColumn(1))
+                              .toString();
         auto filterResult = filters::Filter::fromString(filterText);
 
         if (std::holds_alternative<filters::Filter>(filterResult))
@@ -133,7 +134,7 @@ bool FiltersPage::filterElements(const QString &query)
 {
     std::array fields{0, 1};
 
-    return view_->filterSearchResults(query, fields);
+    return this->view_->filterSearchResults(query, fields);
 }
 
 }  // namespace chatterino

--- a/src/widgets/settingspages/FiltersPage.hpp
+++ b/src/widgets/settingspages/FiltersPage.hpp
@@ -16,11 +16,13 @@ public:
     FiltersPage();
 
     void onShow() final;
+    bool filterElements(const QString &query) override;
 
 private:
     void tableCellClicked(const QModelIndex &clicked, EditableModelView *view);
 
     QStringListModel userListModel_;
+    EditableModelView *view_;
 };
 
 }  // namespace chatterino

--- a/src/widgets/settingspages/HighlightingPage.cpp
+++ b/src/widgets/settingspages/HighlightingPage.cpp
@@ -65,37 +65,38 @@ HighlightingPage::HighlightingPage()
                     "Message highlights are prioritized over badge highlights "
                     "and user highlights.");
 
-                viewMessages_ =
+                this->viewMessages_ =
                     highlights
                         .emplace<EditableModelView>(
                             (new HighlightModel(nullptr))
                                 ->initialized(
                                     &getSettings()->highlightedMessages))
                         .getElement();
-                viewMessages_->addRegexHelpLink();
-                viewMessages_->setTitles({"Pattern", "Show in\nMentions",
-                                          "Flash\ntaskbar", "Enable\nregex",
-                                          "Case-\nsensitive", "Play\nsound",
-                                          "Custom\nsound", "Color"});
-                viewMessages_->getTableView()
+                this->viewMessages_->addRegexHelpLink();
+                this->viewMessages_->setTitles(
+                    {"Pattern", "Show in\nMentions", "Flash\ntaskbar",
+                     "Enable\nregex", "Case-\nsensitive", "Play\nsound",
+                     "Custom\nsound", "Color"});
+                this->viewMessages_->getTableView()
                     ->horizontalHeader()
                     ->setSectionResizeMode(QHeaderView::Fixed);
-                viewMessages_->getTableView()
+                this->viewMessages_->getTableView()
                     ->horizontalHeader()
                     ->setSectionResizeMode(0, QHeaderView::Stretch);
-                viewMessages_->getTableView()->setItemDelegateForColumn(
+                this->viewMessages_->getTableView()->setItemDelegateForColumn(
                     HighlightModel::Column::Color,
                     new ColorItemDelegate(viewMessages_));
 
                 // fourtf: make class extrend BaseWidget and add this to
                 // dpiChanged
                 QTimer::singleShot(1, [this] {
-                    viewMessages_->getTableView()->resizeColumnsToContents();
-                    viewMessages_->getTableView()->setColumnWidth(0, 400);
+                    this->viewMessages_->getTableView()
+                        ->resizeColumnsToContents();
+                    this->viewMessages_->getTableView()->setColumnWidth(0, 400);
                 });
 
-                // We can safely ignore this signal connection since we own the viewMessages_
-                std::ignore = viewMessages_->addButtonPressed.connect([] {
+                // We can safely ignore this signal connection since we own the this->viewMessages_
+                std::ignore = this->viewMessages_->addButtonPressed.connect([] {
                     getSettings()->highlightedMessages.append(HighlightPhrase{
                         "my phrase", true, true, false, false, false, "",
                         *ColorProvider::instance().color(
@@ -103,9 +104,9 @@ HighlightingPage::HighlightingPage()
                 });
 
                 QObject::connect(
-                    viewMessages_->getTableView(), &QTableView::clicked,
+                    this->viewMessages_->getTableView(), &QTableView::clicked,
                     [this](const QModelIndex &clicked) {
-                        this->tableCellClicked(clicked, viewMessages_,
+                        this->tableCellClicked(clicked, this->viewMessages_,
                                                HighlightTab::Messages);
                     });
             }
@@ -117,43 +118,45 @@ HighlightingPage::HighlightingPage()
                     "certain users.\n"
                     "User highlights are prioritized over badge highlights, "
                     "but under message highlights.");
-                viewUsers_ =
+                this->viewUsers_ =
                     pingUsers
                         .emplace<EditableModelView>(
                             (new UserHighlightModel(nullptr))
                                 ->initialized(&getSettings()->highlightedUsers))
                         .getElement();
 
-                viewUsers_->addRegexHelpLink();
-                viewUsers_->getTableView()->horizontalHeader()->hideSection(
-                    HighlightModel::Column::UseRegex);
-                viewUsers_->getTableView()->horizontalHeader()->hideSection(
-                    HighlightModel::Column::CaseSensitive);
+                this->viewUsers_->addRegexHelpLink();
+                this->viewUsers_->getTableView()
+                    ->horizontalHeader()
+                    ->hideSection(HighlightModel::Column::UseRegex);
+                this->viewUsers_->getTableView()
+                    ->horizontalHeader()
+                    ->hideSection(HighlightModel::Column::CaseSensitive);
                 // Case-sensitivity doesn't make sense for user names so it is
                 // set to "false" by default & the column is hidden
-                viewUsers_->setTitles({"Username", "Show in\nMentions",
-                                       "Flash\ntaskbar", "Enable\nregex",
-                                       "Case-\nsensitive", "Play\nsound",
-                                       "Custom\nsound", "Color"});
-                viewUsers_->getTableView()
+                this->viewUsers_->setTitles({"Username", "Show in\nMentions",
+                                             "Flash\ntaskbar", "Enable\nregex",
+                                             "Case-\nsensitive", "Play\nsound",
+                                             "Custom\nsound", "Color"});
+                this->viewUsers_->getTableView()
                     ->horizontalHeader()
                     ->setSectionResizeMode(QHeaderView::Fixed);
-                viewUsers_->getTableView()
+                this->viewUsers_->getTableView()
                     ->horizontalHeader()
                     ->setSectionResizeMode(0, QHeaderView::Stretch);
-                viewUsers_->getTableView()->setItemDelegateForColumn(
+                this->viewUsers_->getTableView()->setItemDelegateForColumn(
                     UserHighlightModel::Column::Color,
                     new ColorItemDelegate(viewUsers_));
 
                 // fourtf: make class extrend BaseWidget and add this to
                 // dpiChanged
                 QTimer::singleShot(1, [this] {
-                    viewUsers_->getTableView()->resizeColumnsToContents();
-                    viewUsers_->getTableView()->setColumnWidth(0, 200);
+                    this->viewUsers_->getTableView()->resizeColumnsToContents();
+                    this->viewUsers_->getTableView()->setColumnWidth(0, 200);
                 });
 
-                // We can safely ignore this signal connection since we own the viewUsers_
-                std::ignore = viewUsers_->addButtonPressed.connect([] {
+                // We can safely ignore this signal connection since we own the this->viewUsers_
+                std::ignore = this->viewUsers_->addButtonPressed.connect([] {
                     getSettings()->highlightedUsers.append(HighlightPhrase{
                         "highlighted user", true, true, false, false, false, "",
                         *ColorProvider::instance().color(
@@ -161,9 +164,9 @@ HighlightingPage::HighlightingPage()
                 });
 
                 QObject::connect(
-                    viewUsers_->getTableView(), &QTableView::clicked,
+                    this->viewUsers_->getTableView(), &QTableView::clicked,
                     [this](const QModelIndex &clicked) {
-                        this->tableCellClicked(clicked, viewUsers_,
+                        this->tableCellClicked(clicked, this->viewUsers_,
                                                HighlightTab::Users);
                     });
             }
@@ -175,58 +178,60 @@ HighlightingPage::HighlightingPage()
                     "user badges.\n"
                     "Badge highlights are prioritzed under user and message "
                     "highlights.");
-                viewBadges_ =
+                this->viewBadges_ =
                     badgeHighlights
                         .emplace<EditableModelView>(
                             (new BadgeHighlightModel(nullptr))
                                 ->initialized(
                                     &getSettings()->highlightedBadges))
                         .getElement();
-                viewBadges_->setTitles({"Name", "Show In\nMentions",
-                                        "Flash\ntaskbar", "Play\nsound",
-                                        "Custom\nsound", "Color"});
-                viewBadges_->getTableView()
+                this->viewBadges_->setTitles({"Name", "Show In\nMentions",
+                                              "Flash\ntaskbar", "Play\nsound",
+                                              "Custom\nsound", "Color"});
+                this->viewBadges_->getTableView()
                     ->horizontalHeader()
                     ->setSectionResizeMode(QHeaderView::Fixed);
-                viewBadges_->getTableView()
+                this->viewBadges_->getTableView()
                     ->horizontalHeader()
                     ->setSectionResizeMode(0, QHeaderView::Stretch);
-                viewBadges_->getTableView()->setItemDelegateForColumn(
+                this->viewBadges_->getTableView()->setItemDelegateForColumn(
                     BadgeHighlightModel::Column::Color,
                     new ColorItemDelegate(viewBadges_));
 
                 // fourtf: make class extrend BaseWidget and add this to
                 // dpiChanged
                 QTimer::singleShot(1, [this] {
-                    viewBadges_->getTableView()->resizeColumnsToContents();
-                    viewBadges_->getTableView()->setColumnWidth(0, 200);
+                    this->viewBadges_->getTableView()
+                        ->resizeColumnsToContents();
+                    this->viewBadges_->getTableView()->setColumnWidth(0, 200);
                 });
 
-                // We can safely ignore this signal connection since we own the viewBadges_
-                std::ignore = viewBadges_->addButtonPressed.connect([this] {
-                    auto d = std::make_shared<BadgePickerDialog>(
-                        availableBadges, this);
+                // We can safely ignore this signal connection since we own the this->viewBadges_
+                std::ignore =
+                    this->viewBadges_->addButtonPressed.connect([this] {
+                        auto d = std::make_shared<BadgePickerDialog>(
+                            availableBadges, this);
 
-                    d->setWindowTitle("Choose badge");
-                    if (d->exec() == QDialog::Accepted)
-                    {
-                        auto s = d->getSelection();
-                        if (!s)
+                        d->setWindowTitle("Choose badge");
+                        if (d->exec() == QDialog::Accepted)
                         {
-                            return;
+                            auto s = d->getSelection();
+                            if (!s)
+                            {
+                                return;
+                            }
+                            getSettings()->highlightedBadges.append(
+                                HighlightBadge{s->badgeName(), s->displayName(),
+                                               false, false, false, "",
+                                               *ColorProvider::instance().color(
+                                                   ColorType::SelfHighlight)});
                         }
-                        getSettings()->highlightedBadges.append(
-                            HighlightBadge{s->badgeName(), s->displayName(),
-                                           false, false, false, "",
-                                           *ColorProvider::instance().color(
-                                               ColorType::SelfHighlight)});
-                    }
-                });
+                    });
 
                 QObject::connect(
-                    viewBadges_->getTableView(), &QTableView::clicked,
+                    this->viewBadges_->getTableView(), &QTableView::clicked,
                     [this](const QModelIndex &clicked) {
-                        this->tableCellClicked(clicked, viewBadges_,
+                        this->tableCellClicked(clicked, this->viewBadges_,
                                                HighlightTab::Badges);
                     });
             }
@@ -237,34 +242,35 @@ HighlightingPage::HighlightingPage()
                 disabledUsers.emplace<QLabel>(
                     "Disable notification sounds and highlights from certain "
                     "users (e.g. bots).");
-                viewBlacklistedUsers_ =
+                this->viewBlacklistedUsers_ =
                     disabledUsers
                         .emplace<EditableModelView>(
                             (new HighlightBlacklistModel(nullptr))
                                 ->initialized(&getSettings()->blacklistedUsers))
                         .getElement();
 
-                viewBlacklistedUsers_->addRegexHelpLink();
-                viewBlacklistedUsers_->setTitles({"Username", "Enable\nregex"});
-                viewBlacklistedUsers_->getTableView()
+                this->viewBlacklistedUsers_->addRegexHelpLink();
+                this->viewBlacklistedUsers_->setTitles(
+                    {"Username", "Enable\nregex"});
+                this->viewBlacklistedUsers_->getTableView()
                     ->horizontalHeader()
                     ->setSectionResizeMode(QHeaderView::Fixed);
-                viewBlacklistedUsers_->getTableView()
+                this->viewBlacklistedUsers_->getTableView()
                     ->horizontalHeader()
                     ->setSectionResizeMode(0, QHeaderView::Stretch);
 
                 // fourtf: make class extrend BaseWidget and add this to
                 // dpiChanged
                 QTimer::singleShot(1, [this] {
-                    viewBlacklistedUsers_->getTableView()
+                    this->viewBlacklistedUsers_->getTableView()
                         ->resizeColumnsToContents();
-                    viewBlacklistedUsers_->getTableView()->setColumnWidth(0,
-                                                                          200);
+                    this->viewBlacklistedUsers_->getTableView()->setColumnWidth(
+                        0, 200);
                 });
 
-                // We can safely ignore this signal connection since we own the viewBlacklistedUsers_
+                // We can safely ignore this signal connection since we own the this->viewBlacklistedUsers_
                 std::ignore =
-                    viewBlacklistedUsers_->addButtonPressed.connect([] {
+                    this->viewBlacklistedUsers_->addButtonPressed.connect([] {
                         getSettings()->blacklistedUsers.append(
                             HighlightBlacklistUser{"blacklisted user", false});
                     });
@@ -340,21 +346,20 @@ HighlightingPage::HighlightingPage()
 }
 
 void HighlightingPage::openSoundDialog(const QModelIndex &clicked,
-                                       EditableModelView *view_,
-                                       int soundColumn)
+                                       EditableModelView *view, int soundColumn)
 {
     auto fileUrl = QFileDialog::getOpenFileUrl(this, tr("Open Sound"), QUrl(),
                                                tr("Audio Files (*.mp3 *.wav)"));
-    view_->getModel()->setData(clicked, fileUrl, Qt::UserRole);
-    view_->getModel()->setData(clicked, fileUrl.fileName(), Qt::DisplayRole);
+    view->getModel()->setData(clicked, fileUrl, Qt::UserRole);
+    view->getModel()->setData(clicked, fileUrl.fileName(), Qt::DisplayRole);
 }
 
 void HighlightingPage::openColorDialog(const QModelIndex &clicked,
-                                       EditableModelView *view_,
+                                       EditableModelView *view,
                                        HighlightTab tab)
 {
     auto initial =
-        view_->getModel()->data(clicked, Qt::DecorationRole).value<QColor>();
+        view->getModel()->data(clicked, Qt::DecorationRole).value<QColor>();
 
     auto *dialog = new ColorPickerDialog(initial, this);
     // TODO: The QModelIndex clicked is technically not safe to persist here since the model
@@ -363,15 +368,15 @@ void HighlightingPage::openColorDialog(const QModelIndex &clicked,
                      [=](auto selected) {
                          if (selected.isValid())
                          {
-                             view_->getModel()->setData(clicked, selected,
-                                                        Qt::DecorationRole);
+                             view->getModel()->setData(clicked, selected,
+                                                       Qt::DecorationRole);
                          }
                      });
     dialog->show();
 }
 
 void HighlightingPage::tableCellClicked(const QModelIndex &clicked,
-                                        EditableModelView *view_,
+                                        EditableModelView *view,
                                         HighlightTab tab)
 {
     if (!clicked.flags().testFlag(Qt::ItemIsEnabled))
@@ -387,11 +392,11 @@ void HighlightingPage::tableCellClicked(const QModelIndex &clicked,
 
             if (clicked.column() == Column::SoundPath)
             {
-                this->openSoundDialog(clicked, view_, Column::SoundPath);
+                this->openSoundDialog(clicked, view, Column::SoundPath);
             }
             else if (clicked.column() == Column::Color)
             {
-                this->openColorDialog(clicked, view_, tab);
+                this->openColorDialog(clicked, view, tab);
             }
         }
         break;
@@ -400,11 +405,11 @@ void HighlightingPage::tableCellClicked(const QModelIndex &clicked,
             using Column = BadgeHighlightModel::Column;
             if (clicked.column() == Column::SoundPath)
             {
-                this->openSoundDialog(clicked, view_, Column::SoundPath);
+                this->openSoundDialog(clicked, view, Column::SoundPath);
             }
             else if (clicked.column() == Column::Color)
             {
-                this->openColorDialog(clicked, view_, tab);
+                this->openColorDialog(clicked, view, tab);
             }
         }
         break;
@@ -415,17 +420,18 @@ bool HighlightingPage::filterElements(const QString &query)
 {
     std::array fields{0};
 
-    bool matchMessages = viewMessages_->filterSearchResults(query, fields);
+    bool matchMessages =
+        this->viewMessages_->filterSearchResults(query, fields);
     this->tabWidget_->setTabVisible(0, matchMessages);
 
-    bool matchUsers = viewUsers_->filterSearchResults(query, fields);
+    bool matchUsers = this->viewUsers_->filterSearchResults(query, fields);
     this->tabWidget_->setTabVisible(1, matchUsers);
 
-    bool matchBadges = viewBadges_->filterSearchResults(query, fields);
+    bool matchBadges = this->viewBadges_->filterSearchResults(query, fields);
     this->tabWidget_->setTabVisible(2, matchBadges);
 
     bool matchBlacklistedUsers =
-        viewBlacklistedUsers_->filterSearchResults(query, fields);
+        this->viewBlacklistedUsers_->filterSearchResults(query, fields);
     this->tabWidget_->setTabVisible(3, matchBlacklistedUsers);
 
     return matchMessages || matchUsers || matchBadges || matchBlacklistedUsers;

--- a/src/widgets/settingspages/HighlightingPage.cpp
+++ b/src/widgets/settingspages/HighlightingPage.cpp
@@ -53,8 +53,8 @@ HighlightingPage::HighlightingPage()
         // getSettings()->enableHighlights));
 
         // TABS
-        tabsWidget_ = new QTabWidget();
-        auto tabs = layout.append(tabsWidget_);
+        this->tabWidget_ = new QTabWidget();
+        auto tabs = layout.append(tabWidget_);
         {
             // HIGHLIGHTS
             auto highlights = tabs.appendTab(new QVBoxLayout, "Messages");
@@ -416,17 +416,17 @@ bool HighlightingPage::filterElements(const QString &query)
     auto *fields = new std::vector<int>{0};
 
     bool matchMessages = viewMessages_->filterSearchResults(query, *fields);
-    tabsWidget_->setTabVisible(0, matchMessages);
+    this->tabWidget_->setTabVisible(0, matchMessages);
 
     bool matchUsers = viewUsers_->filterSearchResults(query, *fields);
-    tabsWidget_->setTabVisible(1, matchUsers);
+    this->tabWidget_->setTabVisible(1, matchUsers);
 
     bool matchBadges = viewBadges_->filterSearchResults(query, *fields);
-    tabsWidget_->setTabVisible(2, matchBadges);
+    this->tabWidget_->setTabVisible(2, matchBadges);
 
     bool matchBlacklistedUsers =
         viewBlacklistedUsers_->filterSearchResults(query, *fields);
-    tabsWidget_->setTabVisible(3, matchBlacklistedUsers);
+    this->tabWidget_->setTabVisible(3, matchBlacklistedUsers);
 
     return matchMessages || matchUsers || matchBadges || matchBlacklistedUsers;
 }

--- a/src/widgets/settingspages/HighlightingPage.cpp
+++ b/src/widgets/settingspages/HighlightingPage.cpp
@@ -53,8 +53,8 @@ HighlightingPage::HighlightingPage()
         // getSettings()->enableHighlights));
 
         // TABS
-        this->tabWidget_ = new QTabWidget();
-        auto tabs = layout.append(tabWidget_);
+        auto tabs = layout.emplace<QTabWidget>();
+        this->tabWidget_ = &*tabs;
         {
             // HIGHLIGHTS
             auto highlights = tabs.appendTab(new QVBoxLayout, "Messages");
@@ -413,19 +413,19 @@ void HighlightingPage::tableCellClicked(const QModelIndex &clicked,
 
 bool HighlightingPage::filterElements(const QString &query)
 {
-    auto *fields = new std::vector<int>{0};
+    std::array fields{0};
 
-    bool matchMessages = viewMessages_->filterSearchResults(query, *fields);
+    bool matchMessages = viewMessages_->filterSearchResults(query, fields);
     this->tabWidget_->setTabVisible(0, matchMessages);
 
-    bool matchUsers = viewUsers_->filterSearchResults(query, *fields);
+    bool matchUsers = viewUsers_->filterSearchResults(query, fields);
     this->tabWidget_->setTabVisible(1, matchUsers);
 
-    bool matchBadges = viewBadges_->filterSearchResults(query, *fields);
+    bool matchBadges = viewBadges_->filterSearchResults(query, fields);
     this->tabWidget_->setTabVisible(2, matchBadges);
 
     bool matchBlacklistedUsers =
-        viewBlacklistedUsers_->filterSearchResults(query, *fields);
+        viewBlacklistedUsers_->filterSearchResults(query, fields);
     this->tabWidget_->setTabVisible(3, matchBlacklistedUsers);
 
     return matchMessages || matchUsers || matchBadges || matchBlacklistedUsers;

--- a/src/widgets/settingspages/HighlightingPage.hpp
+++ b/src/widgets/settingspages/HighlightingPage.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "util/LayoutCreator.hpp"
 #include "widgets/settingspages/SettingsPage.hpp"
 
 #include <QAbstractTableModel>
@@ -16,9 +17,16 @@ class HighlightingPage : public SettingsPage
 {
 public:
     HighlightingPage();
+    bool filterElements(const QString &query) override;
 
 private:
     enum HighlightTab { Messages = 0, Users = 1, Badges = 2, Blacklist = 3 };
+
+    QTabWidget *tabsWidget_;
+    EditableModelView *viewMessages_;
+    EditableModelView *viewUsers_;
+    EditableModelView *viewBadges_;
+    EditableModelView *viewBlacklistedUsers_;
 
     QTimer disabledUsersChangedTimer_;
 

--- a/src/widgets/settingspages/HighlightingPage.hpp
+++ b/src/widgets/settingspages/HighlightingPage.hpp
@@ -22,7 +22,7 @@ public:
 private:
     enum HighlightTab { Messages = 0, Users = 1, Badges = 2, Blacklist = 3 };
 
-    QTabWidget *tabsWidget_;
+    QTabWidget *tabWidget_;
     EditableModelView *viewMessages_;
     EditableModelView *viewUsers_;
     EditableModelView *viewBadges_;

--- a/src/widgets/settingspages/IgnoresPage.cpp
+++ b/src/widgets/settingspages/IgnoresPage.cpp
@@ -142,9 +142,9 @@ void IgnoresPage::onShow()
 
 bool IgnoresPage::filterElements(const QString &query)
 {
-    auto *fields = new std::vector<int>{0, 4};
+    std::array fields{0, 4};
 
-    bool matchMessages = viewMessages_->filterSearchResults(query, *fields);
+    bool matchMessages = viewMessages_->filterSearchResults(query, fields);
     this->tabWidget_->setTabVisible(0, matchMessages);
 
     return matchMessages;

--- a/src/widgets/settingspages/IgnoresPage.cpp
+++ b/src/widgets/settingspages/IgnoresPage.cpp
@@ -45,26 +45,29 @@ IgnoresPage::IgnoresPage()
 void IgnoresPage::addPhrasesTab(LayoutCreator<QVBoxLayout> layout)
 {
     layout.emplace<QLabel>("Ignore messages based certain patterns.");
-    viewMessages_ = layout
-                        .emplace<EditableModelView>(
-                            (new IgnoreModel(nullptr))
-                                ->initialized(&getSettings()->ignoredMessages))
-                        .getElement();
-    viewMessages_->setTitles(
+    this->viewMessages_ =
+        layout
+            .emplace<EditableModelView>(
+                (new IgnoreModel(nullptr))
+                    ->initialized(&getSettings()->ignoredMessages))
+            .getElement();
+    this->viewMessages_->setTitles(
         {"Pattern", "Regex", "Case-sensitive", "Block", "Replacement"});
-    viewMessages_->getTableView()->horizontalHeader()->setSectionResizeMode(
-        QHeaderView::Fixed);
-    viewMessages_->getTableView()->horizontalHeader()->setSectionResizeMode(
-        0, QHeaderView::Stretch);
-    viewMessages_->addRegexHelpLink();
+    this->viewMessages_->getTableView()
+        ->horizontalHeader()
+        ->setSectionResizeMode(QHeaderView::Fixed);
+    this->viewMessages_->getTableView()
+        ->horizontalHeader()
+        ->setSectionResizeMode(0, QHeaderView::Stretch);
+    this->viewMessages_->addRegexHelpLink();
 
     QTimer::singleShot(1, [this] {
-        viewMessages_->getTableView()->resizeColumnsToContents();
-        viewMessages_->getTableView()->setColumnWidth(0, 200);
+        this->viewMessages_->getTableView()->resizeColumnsToContents();
+        this->viewMessages_->getTableView()->setColumnWidth(0, 200);
     });
 
-    // We can safely ignore this signal connection since we own the viewMessages_
-    std::ignore = viewMessages_->addButtonPressed.connect([] {
+    // We can safely ignore this signal connection since we own thethis->viewMessages_
+    std::ignore = this->viewMessages_->addButtonPressed.connect([] {
         getSettings()->ignoredMessages.append(
             IgnorePhrase{"my pattern", false, false,
                          getSettings()->ignoredPhraseReplace.getValue(), true});
@@ -144,7 +147,8 @@ bool IgnoresPage::filterElements(const QString &query)
 {
     std::array fields{0, 4};
 
-    bool matchMessages = viewMessages_->filterSearchResults(query, fields);
+    bool matchMessages =
+        this->viewMessages_->filterSearchResults(query, fields);
     this->tabWidget_->setTabVisible(0, matchMessages);
 
     return matchMessages;

--- a/src/widgets/settingspages/IgnoresPage.cpp
+++ b/src/widgets/settingspages/IgnoresPage.cpp
@@ -33,8 +33,8 @@ IgnoresPage::IgnoresPage()
     LayoutCreator<IgnoresPage> layoutCreator(this);
     auto layout = layoutCreator.setLayoutType<QVBoxLayout>();
 
-    this->tabWidget_ = new QTabWidget();
-    auto tabs = layout.append(this->tabWidget_);
+    auto tabs = layout.emplace<QTabWidget>();
+    this->tabWidget_ = &*tabs;
 
     addPhrasesTab(tabs.appendTab(new QVBoxLayout, "Messages"));
     addUsersTab(*this, tabs.appendTab(new QVBoxLayout, "Users"),

--- a/src/widgets/settingspages/IgnoresPage.cpp
+++ b/src/widgets/settingspages/IgnoresPage.cpp
@@ -33,8 +33,8 @@ IgnoresPage::IgnoresPage()
     LayoutCreator<IgnoresPage> layoutCreator(this);
     auto layout = layoutCreator.setLayoutType<QVBoxLayout>();
 
-    tabsWidget_ = new QTabWidget();
-    auto tabs = layout.append(tabsWidget_);
+    this->tabWidget_ = new QTabWidget();
+    auto tabs = layout.append(this->tabWidget_);
 
     addPhrasesTab(tabs.appendTab(new QVBoxLayout, "Messages"));
     addUsersTab(*this, tabs.appendTab(new QVBoxLayout, "Users"),
@@ -145,7 +145,7 @@ bool IgnoresPage::filterElements(const QString &query)
     auto *fields = new std::vector<int>{0, 4};
 
     bool matchMessages = viewMessages_->filterSearchResults(query, *fields);
-    tabsWidget_->setTabVisible(0, matchMessages);
+    this->tabWidget_->setTabVisible(0, matchMessages);
 
     return matchMessages;
 }

--- a/src/widgets/settingspages/IgnoresPage.hpp
+++ b/src/widgets/settingspages/IgnoresPage.hpp
@@ -22,7 +22,7 @@ public:
 
 private:
     QStringListModel userListModel_;
-    QTabWidget *tabsWidget_;
+    QTabWidget *tabWidget_;
     EditableModelView *viewMessages_;
 
     void addPhrasesTab(LayoutCreator<QVBoxLayout> layout);

--- a/src/widgets/settingspages/IgnoresPage.hpp
+++ b/src/widgets/settingspages/IgnoresPage.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "util/LayoutCreator.hpp"
 #include "widgets/settingspages/SettingsPage.hpp"
 
 #include <QStringListModel>
@@ -8,6 +9,8 @@ class QVBoxLayout;
 
 namespace chatterino {
 
+class EditableModelView;
+
 class IgnoresPage : public SettingsPage
 {
 public:
@@ -15,8 +18,14 @@ public:
 
     void onShow() final;
 
+    bool filterElements(const QString &query) override;
+
 private:
     QStringListModel userListModel_;
+    QTabWidget *tabsWidget_;
+    EditableModelView *viewMessages_;
+
+    void addPhrasesTab(LayoutCreator<QVBoxLayout> layout);
 };
 
 }  // namespace chatterino

--- a/src/widgets/settingspages/KeyboardSettingsPage.cpp
+++ b/src/widgets/settingspages/KeyboardSettingsPage.cpp
@@ -11,6 +11,7 @@
 
 #include <QFormLayout>
 #include <QHeaderView>
+#include <QKeySequenceEdit>
 #include <QLabel>
 #include <QMessageBox>
 #include <QTableView>
@@ -77,6 +78,17 @@ KeyboardSettingsPage::KeyboardSettingsPage()
                      [view, model](const QModelIndex &clicked) {
                          tableCellClicked(clicked, view, model);
                      });
+
+    auto *keySequenceInput = new QKeySequenceEdit(this);
+    keySequenceInput->setClearButtonEnabled(true);
+    auto *searchText = new QLabel("Search keybind:", this);
+
+    QObject::connect(keySequenceInput, &QKeySequenceEdit::keySequenceChanged,
+                     [view](const QKeySequence &keySequence) {
+                         view->filterSearchResultsHotkey(&keySequence);
+                     });
+    view->addCustomButton(searchText);
+    view->addCustomButton(keySequenceInput);
 
     auto *resetEverything = new QPushButton("Reset to defaults");
     QObject::connect(resetEverything, &QPushButton::clicked, [this]() {

--- a/src/widgets/settingspages/KeyboardSettingsPage.cpp
+++ b/src/widgets/settingspages/KeyboardSettingsPage.cpp
@@ -52,18 +52,19 @@ KeyboardSettingsPage::KeyboardSettingsPage()
     auto layout = layoutCreator.emplace<QVBoxLayout>();
 
     auto *model = getApp()->getHotkeys()->createModel(nullptr);
-    view_ = layout.emplace<EditableModelView>(model).getElement();
+    this->view_ = layout.emplace<EditableModelView>(model).getElement();
 
-    view_->setTitles({"Hotkey name", "Keybinding"});
-    view_->getTableView()->horizontalHeader()->setVisible(true);
-    view_->getTableView()->horizontalHeader()->setStretchLastSection(false);
-    view_->getTableView()->horizontalHeader()->setSectionResizeMode(
+    this->view_->setTitles({"Hotkey name", "Keybinding"});
+    this->view_->getTableView()->horizontalHeader()->setVisible(true);
+    this->view_->getTableView()->horizontalHeader()->setStretchLastSection(
+        false);
+    this->view_->getTableView()->horizontalHeader()->setSectionResizeMode(
         QHeaderView::ResizeToContents);
-    view_->getTableView()->horizontalHeader()->setSectionResizeMode(
+    this->view_->getTableView()->horizontalHeader()->setSectionResizeMode(
         1, QHeaderView::Stretch);
 
-    // We can safely ignore this signal connection since we own the view_
-    std::ignore = view_->addButtonPressed.connect([] {
+    // We can safely ignore this signal connection since we own the this->view_
+    std::ignore = this->view_->addButtonPressed.connect([] {
         EditHotkeyDialog dialog(nullptr);
         bool wasAccepted = dialog.exec() == 1;
 
@@ -77,7 +78,7 @@ KeyboardSettingsPage::KeyboardSettingsPage()
 
     QObject::connect(view_->getTableView(), &QTableView::doubleClicked,
                      [this, model](const QModelIndex &clicked) {
-                         tableCellClicked(clicked, view_, model);
+                         tableCellClicked(clicked, this->view_, model);
                      });
 
     auto *keySequenceInput = new QKeySequenceEdit(this);
@@ -89,10 +90,10 @@ KeyboardSettingsPage::KeyboardSettingsPage()
 
     QObject::connect(keySequenceInput, &QKeySequenceEdit::keySequenceChanged,
                      [this](const QKeySequence &keySequence) {
-                         view_->filterSearchResultsHotkey(keySequence);
+                         this->view_->filterSearchResultsHotkey(keySequence);
                      });
-    view_->addCustomButton(searchText);
-    view_->addCustomButton(keySequenceInput);
+    this->view_->addCustomButton(searchText);
+    this->view_->addCustomButton(keySequenceInput);
 
     auto *resetEverything = new QPushButton("Reset to defaults");
     QObject::connect(resetEverything, &QPushButton::clicked, [this]() {
@@ -106,7 +107,7 @@ KeyboardSettingsPage::KeyboardSettingsPage()
             getApp()->getHotkeys()->resetToDefaults();
         }
     });
-    view_->addCustomButton(resetEverything);
+    this->view_->addCustomButton(resetEverything);
 
     // We only check this once since a user *should* not have the ability to create a new hotkey with a deprecated or removed action
     // However, we also don't update this after the user has deleted a hotkey. This is a big lift that should probably be solved on the model level rather
@@ -149,7 +150,7 @@ bool KeyboardSettingsPage::filterElements(const QString &query)
 {
     std::array fields{0, 1};
 
-    return view_->filterSearchResults(query, fields);
+    return this->view_->filterSearchResults(query, fields);
 }
 
 }  // namespace chatterino

--- a/src/widgets/settingspages/KeyboardSettingsPage.cpp
+++ b/src/widgets/settingspages/KeyboardSettingsPage.cpp
@@ -16,6 +16,8 @@
 #include <QMessageBox>
 #include <QTableView>
 
+#include <array>
+
 namespace {
 
 using namespace chatterino;
@@ -87,7 +89,7 @@ KeyboardSettingsPage::KeyboardSettingsPage()
 
     QObject::connect(keySequenceInput, &QKeySequenceEdit::keySequenceChanged,
                      [this](const QKeySequence &keySequence) {
-                         view_->filterSearchResultsHotkey(&keySequence);
+                         view_->filterSearchResultsHotkey(keySequence);
                      });
     view_->addCustomButton(searchText);
     view_->addCustomButton(keySequenceInput);
@@ -145,9 +147,9 @@ KeyboardSettingsPage::KeyboardSettingsPage()
 
 bool KeyboardSettingsPage::filterElements(const QString &query)
 {
-    auto *fields = new std::vector<int>{0, 1};
+    std::array fields{0, 1};
 
-    return view_->filterSearchResults(query, *fields);
+    return view_->filterSearchResults(query, fields);
 }
 
 }  // namespace chatterino

--- a/src/widgets/settingspages/KeyboardSettingsPage.cpp
+++ b/src/widgets/settingspages/KeyboardSettingsPage.cpp
@@ -79,7 +79,10 @@ KeyboardSettingsPage::KeyboardSettingsPage()
                      });
 
     auto *keySequenceInput = new QKeySequenceEdit(this);
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 4, 0)
     keySequenceInput->setClearButtonEnabled(true);
+#endif
     auto *searchText = new QLabel("Search keybind:", this);
 
     QObject::connect(keySequenceInput, &QKeySequenceEdit::keySequenceChanged,

--- a/src/widgets/settingspages/KeyboardSettingsPage.hpp
+++ b/src/widgets/settingspages/KeyboardSettingsPage.hpp
@@ -11,6 +11,10 @@ class KeyboardSettingsPage : public SettingsPage
 {
 public:
     KeyboardSettingsPage();
+    bool filterElements(const QString &query) override;
+
+private:
+    EditableModelView *view_;
 };
 
 }  // namespace chatterino

--- a/src/widgets/settingspages/ModerationPage.cpp
+++ b/src/widgets/settingspages/ModerationPage.cpp
@@ -380,13 +380,13 @@ void ModerationPage::selectModerationActions()
 
 bool ModerationPage::filterElements(const QString &query)
 {
-    auto *fields = new std::vector<int>{0};
+    std::array fields{0};
 
-    bool matchLogs = viewLogs_->filterSearchResults(query, *fields);
+    bool matchLogs = viewLogs_->filterSearchResults(query, fields);
     tabWidget_->setTabVisible(0, matchLogs);
 
     bool matchModerationButtons =
-        viewModerationButtons_->filterSearchResults(query, *fields);
+        viewModerationButtons_->filterSearchResults(query, fields);
     tabWidget_->setTabVisible(1, matchModerationButtons);
 
     return matchLogs || matchModerationButtons;

--- a/src/widgets/settingspages/ModerationPage.cpp
+++ b/src/widgets/settingspages/ModerationPage.cpp
@@ -256,12 +256,12 @@ ModerationPage::ModerationPage()
 
                         loadPixmapFromUrl(
                             {fileUrl.toString()},
-                            [clicked, viewModerationButtons_ =
-                                          viewModerationButtonsTemp](
+                            [clicked,
+                             viewModerationButtons = viewModerationButtonsTemp](
                                 const QPixmap &pixmap) {
-                                postToThread([clicked, viewModerationButtons_,
+                                postToThread([clicked, viewModerationButtons,
                                               pixmap]() {
-                                    if (viewModerationButtons_.isNull())
+                                    if (viewModerationButtons.isNull())
                                     {
                                         return;
                                     }

--- a/src/widgets/settingspages/ModerationPage.cpp
+++ b/src/widgets/settingspages/ModerationPage.cpp
@@ -266,7 +266,7 @@ ModerationPage::ModerationPage()
                                         return;
                                     }
 
-                                    viewModerationButtons_->getModel()->setData(
+                                    viewModerationButtons->getModel()->setData(
                                         clicked, pixmap, Qt::DecorationRole);
                                 });
                             });

--- a/src/widgets/settingspages/ModerationPage.cpp
+++ b/src/widgets/settingspages/ModerationPage.cpp
@@ -174,19 +174,22 @@ ModerationPage::ModerationPage()
                     getSettings()->enableLogging);
             });
 
-        viewLogs_ = logs.emplace<EditableModelView>(
-                            (new ChannelLoggingModel(nullptr))
-                                ->initialized(&getSettings()->loggedChannels))
-                        .getElement();
+        this->viewLogs_ =
+            logs.emplace<EditableModelView>(
+                    (new ChannelLoggingModel(nullptr))
+                        ->initialized(&getSettings()->loggedChannels))
+                .getElement();
 
-        viewLogs_->setTitles({"Twitch channels"});
-        viewLogs_->getTableView()->horizontalHeader()->setSectionResizeMode(
-            QHeaderView::Fixed);
-        viewLogs_->getTableView()->horizontalHeader()->setSectionResizeMode(
-            0, QHeaderView::Stretch);
+        this->viewLogs_->setTitles({"Twitch channels"});
+        this->viewLogs_->getTableView()
+            ->horizontalHeader()
+            ->setSectionResizeMode(QHeaderView::Fixed);
+        this->viewLogs_->getTableView()
+            ->horizontalHeader()
+            ->setSectionResizeMode(0, QHeaderView::Stretch);
 
         // We can safely ignore this signal connection since we own the view
-        std::ignore = viewLogs_->addButtonPressed.connect([] {
+        std::ignore = this->viewLogs_->addButtonPressed.connect([] {
             getSettings()->loggedChannels.append(ChannelLog("channel"));
         });
 
@@ -213,46 +216,46 @@ ModerationPage::ModerationPage()
         //                         getSettings()->timeoutAction));
         //        }
 
-        viewModerationButtons_ =
+        this->viewModerationButtons_ =
             modMode
                 .emplace<EditableModelView>(
                     (new ModerationActionModel(nullptr))
                         ->initialized(&getSettings()->moderationActions))
                 .getElement();
 
-        viewModerationButtons_->setTitles({"Action", "Icon"});
-        viewModerationButtons_->getTableView()
+        this->viewModerationButtons_->setTitles({"Action", "Icon"});
+        this->viewModerationButtons_->getTableView()
             ->horizontalHeader()
             ->setSectionResizeMode(QHeaderView::Fixed);
-        viewModerationButtons_->getTableView()
+        this->viewModerationButtons_->getTableView()
             ->horizontalHeader()
             ->setSectionResizeMode(0, QHeaderView::Stretch);
-        viewModerationButtons_->getTableView()->setItemDelegateForColumn(
+        this->viewModerationButtons_->getTableView()->setItemDelegateForColumn(
             ModerationActionModel::Column::Icon,
             new IconDelegate(viewModerationButtons_));
         QObject::connect(
-            viewModerationButtons_->getTableView(), &QTableView::clicked,
+            this->viewModerationButtons_->getTableView(), &QTableView::clicked,
             [this](const QModelIndex &clicked) {
                 if (clicked.column() == ModerationActionModel::Column::Icon)
                 {
                     auto fileUrl = QFileDialog::getOpenFileUrl(
                         this, "Open Image", QUrl(),
                         "Image Files (*.png *.jpg *.jpeg)");
-                    viewModerationButtons_->getModel()->setData(
+                    this->viewModerationButtons_->getModel()->setData(
                         clicked, fileUrl, Qt::UserRole);
-                    viewModerationButtons_->getModel()->setData(
+                    this->viewModerationButtons_->getModel()->setData(
                         clicked, fileUrl.fileName(), Qt::DisplayRole);
                     // Clear the icon if the user canceled the dialog
                     if (fileUrl.isEmpty())
                     {
-                        viewModerationButtons_->getModel()->setData(
+                        this->viewModerationButtons_->getModel()->setData(
                             clicked, QVariant(), Qt::DecorationRole);
                     }
                     else
                     {
-                        // QPointer will be cleared when viewModerationButtons_ is destroyed
+                        // QPointer will be cleared whenthis->viewModerationButtons_ is destroyed
                         QPointer<EditableModelView> viewModerationButtonsTemp =
-                            viewModerationButtons_;
+                            this->viewModerationButtons_;
 
                         loadPixmapFromUrl(
                             {fileUrl.toString()},
@@ -274,11 +277,12 @@ ModerationPage::ModerationPage()
                 }
             });
 
-        // We can safely ignore this signal connection since we own the viewModerationButtons_
-        std::ignore = viewModerationButtons_->addButtonPressed.connect([] {
-            getSettings()->moderationActions.append(
-                ModerationAction("/timeout {user.name} 300"));
-        });
+        // We can safely ignore this signal connection since we own thethis->viewModerationButtons_
+        std::ignore =
+            this->viewModerationButtons_->addButtonPressed.connect([] {
+                getSettings()->moderationActions.append(
+                    ModerationAction("/timeout {user.name} 300"));
+            });
     }
 
     this->addModerationButtonSettings(tabs.getElement());
@@ -382,11 +386,11 @@ bool ModerationPage::filterElements(const QString &query)
 {
     std::array fields{0};
 
-    bool matchLogs = viewLogs_->filterSearchResults(query, fields);
+    bool matchLogs = this->viewLogs_->filterSearchResults(query, fields);
     tabWidget_->setTabVisible(0, matchLogs);
 
     bool matchModerationButtons =
-        viewModerationButtons_->filterSearchResults(query, fields);
+        this->viewModerationButtons_->filterSearchResults(query, fields);
     tabWidget_->setTabVisible(1, matchModerationButtons);
 
     return matchLogs || matchModerationButtons;

--- a/src/widgets/settingspages/ModerationPage.hpp
+++ b/src/widgets/settingspages/ModerationPage.hpp
@@ -9,18 +9,24 @@ class QPushButton;
 
 namespace chatterino {
 
+class EditableModelView;
+
 class ModerationPage : public SettingsPage
 {
 public:
     ModerationPage();
 
     void selectModerationActions();
+    bool filterElements(const QString &query) override;
 
 private:
     void addModerationButtonSettings(QTabWidget *);
 
     QTimer itemsChangedTimer_;
     QTabWidget *tabWidget_{};
+
+    EditableModelView *viewLogs_;
+    EditableModelView *viewModerationButtons_;
 
     std::vector<QLineEdit *> durationInputs_;
     std::vector<QComboBox *> unitInputs_;

--- a/src/widgets/settingspages/NicknamesPage.cpp
+++ b/src/widgets/settingspages/NicknamesPage.cpp
@@ -51,9 +51,9 @@ NicknamesPage::NicknamesPage()
 
 bool NicknamesPage::filterElements(const QString &query)
 {
-    auto *fields = new std::vector<int>{0, 1};
+    std::array fields{0, 1};
 
-    return view_->filterSearchResults(query, *fields);
+    return view_->filterSearchResults(query, fields);
 }
 
 }  // namespace chatterino

--- a/src/widgets/settingspages/NicknamesPage.cpp
+++ b/src/widgets/settingspages/NicknamesPage.cpp
@@ -22,31 +22,38 @@ NicknamesPage::NicknamesPage()
         "filters."
         "\nWith those features you will still need to use the user's original "
         "name.");
-    EditableModelView *view =
-        layout
-            .emplace<EditableModelView>(
-                (new NicknamesModel(nullptr))
-                    ->initialized(&getSettings()->nicknames))
-            .getElement();
+    view_ = layout
+                .emplace<EditableModelView>(
+                    (new NicknamesModel(nullptr))
+                        ->initialized(&getSettings()->nicknames))
+                .getElement();
 
-    view->setTitles({"Username", "Nickname", "Enable regex", "Case-sensitive"});
-    view->getTableView()->horizontalHeader()->setSectionResizeMode(
+    view_->setTitles(
+        {"Username", "Nickname", "Enable regex", "Case-sensitive"});
+    view_->getTableView()->horizontalHeader()->setSectionResizeMode(
         QHeaderView::Fixed);
-    view->getTableView()->horizontalHeader()->setSectionResizeMode(
+    view_->getTableView()->horizontalHeader()->setSectionResizeMode(
         0, QHeaderView::Stretch);
-    view->getTableView()->horizontalHeader()->setSectionResizeMode(
+    view_->getTableView()->horizontalHeader()->setSectionResizeMode(
         1, QHeaderView::Stretch);
 
-    // We can safely ignore this signal connection since we own the view
-    std::ignore = view->addButtonPressed.connect([] {
+    // We can safely ignore this signal connection since we own the view_
+    std::ignore = view_->addButtonPressed.connect([] {
         getSettings()->nicknames.append(
             Nickname{"Username", "Nickname", false, false});
     });
 
-    QTimer::singleShot(1, [view] {
-        view->getTableView()->resizeColumnsToContents();
-        view->getTableView()->setColumnWidth(0, 200);
+    QTimer::singleShot(1, [this] {
+        view_->getTableView()->resizeColumnsToContents();
+        view_->getTableView()->setColumnWidth(0, 200);
     });
+}
+
+bool NicknamesPage::filterElements(const QString &query)
+{
+    auto *fields = new std::vector<int>{0, 1};
+
+    return view_->filterSearchResults(query, *fields);
 }
 
 }  // namespace chatterino

--- a/src/widgets/settingspages/NicknamesPage.cpp
+++ b/src/widgets/settingspages/NicknamesPage.cpp
@@ -22,30 +22,30 @@ NicknamesPage::NicknamesPage()
         "filters."
         "\nWith those features you will still need to use the user's original "
         "name.");
-    view_ = layout
-                .emplace<EditableModelView>(
-                    (new NicknamesModel(nullptr))
-                        ->initialized(&getSettings()->nicknames))
-                .getElement();
+    this->view_ = layout
+                      .emplace<EditableModelView>(
+                          (new NicknamesModel(nullptr))
+                              ->initialized(&getSettings()->nicknames))
+                      .getElement();
 
-    view_->setTitles(
+    this->view_->setTitles(
         {"Username", "Nickname", "Enable regex", "Case-sensitive"});
-    view_->getTableView()->horizontalHeader()->setSectionResizeMode(
+    this->view_->getTableView()->horizontalHeader()->setSectionResizeMode(
         QHeaderView::Fixed);
-    view_->getTableView()->horizontalHeader()->setSectionResizeMode(
+    this->view_->getTableView()->horizontalHeader()->setSectionResizeMode(
         0, QHeaderView::Stretch);
-    view_->getTableView()->horizontalHeader()->setSectionResizeMode(
+    this->view_->getTableView()->horizontalHeader()->setSectionResizeMode(
         1, QHeaderView::Stretch);
 
-    // We can safely ignore this signal connection since we own the view_
-    std::ignore = view_->addButtonPressed.connect([] {
+    // We can safely ignore this signal connection since we own the this->view_
+    std::ignore = this->view_->addButtonPressed.connect([] {
         getSettings()->nicknames.append(
             Nickname{"Username", "Nickname", false, false});
     });
 
     QTimer::singleShot(1, [this] {
-        view_->getTableView()->resizeColumnsToContents();
-        view_->getTableView()->setColumnWidth(0, 200);
+        this->view_->getTableView()->resizeColumnsToContents();
+        this->view_->getTableView()->setColumnWidth(0, 200);
     });
 }
 
@@ -53,7 +53,7 @@ bool NicknamesPage::filterElements(const QString &query)
 {
     std::array fields{0, 1};
 
-    return view_->filterSearchResults(query, fields);
+    return this->view_->filterSearchResults(query, fields);
 }
 
 }  // namespace chatterino

--- a/src/widgets/settingspages/NicknamesPage.hpp
+++ b/src/widgets/settingspages/NicknamesPage.hpp
@@ -4,10 +4,16 @@
 
 namespace chatterino {
 
+class EditableModelView;
+
 class NicknamesPage : public SettingsPage
 {
 public:
     NicknamesPage();
+    bool filterElements(const QString &query) override;
+
+private:
+    EditableModelView *view_;
 };
 
 }  // namespace chatterino

--- a/src/widgets/settingspages/NotificationPage.cpp
+++ b/src/widgets/settingspages/NotificationPage.cpp
@@ -99,21 +99,23 @@ NotificationPage::NotificationPage()
                                       getApp()->getNotifications()->createModel(
                                           nullptr, Platform::Twitch))
                                   .getElement();
-                view_->setTitles({"Twitch channels"});
-                view_->setValidationRegexp(twitchUserNameRegexp());
+                this->view_->setTitles({"Twitch channels"});
+                this->view_->setValidationRegexp(twitchUserNameRegexp());
 
-                view_->getTableView()->horizontalHeader()->setSectionResizeMode(
-                    QHeaderView::Fixed);
-                view_->getTableView()->horizontalHeader()->setSectionResizeMode(
-                    0, QHeaderView::Stretch);
+                this->view_->getTableView()
+                    ->horizontalHeader()
+                    ->setSectionResizeMode(QHeaderView::Fixed);
+                this->view_->getTableView()
+                    ->horizontalHeader()
+                    ->setSectionResizeMode(0, QHeaderView::Stretch);
 
                 QTimer::singleShot(1, [this] {
-                    view_->getTableView()->resizeColumnsToContents();
-                    view_->getTableView()->setColumnWidth(0, 200);
+                    this->view_->getTableView()->resizeColumnsToContents();
+                    this->view_->getTableView()->setColumnWidth(0, 200);
                 });
 
-                // We can safely ignore this signal connection since we own the view_
-                std::ignore = view_->addButtonPressed.connect([] {
+                // We can safely ignore this signal connection since we own the this->view_
+                std::ignore = this->view_->addButtonPressed.connect([] {
                     getApp()->getNotifications()->addChannelNotification(
                         "channel", Platform::Twitch);
                 });
@@ -152,7 +154,7 @@ bool NotificationPage::filterElements(const QString &query)
 {
     std::array fields{0, 1};
 
-    return view_->filterSearchResults(query, fields);
+    return this->view_->filterSearchResults(query, fields);
 }
 
 }  // namespace chatterino

--- a/src/widgets/settingspages/NotificationPage.cpp
+++ b/src/widgets/settingspages/NotificationPage.cpp
@@ -94,27 +94,26 @@ NotificationPage::NotificationPage()
                     "These are the channels for which you will be informed "
                     "when they go live:");
 
-                EditableModelView *view =
-                    twitchChannels
-                        .emplace<EditableModelView>(
-                            getApp()->getNotifications()->createModel(
-                                nullptr, Platform::Twitch))
-                        .getElement();
-                view->setTitles({"Twitch channels"});
-                view->setValidationRegexp(twitchUserNameRegexp());
+                this->view_ = twitchChannels
+                                  .emplace<EditableModelView>(
+                                      getApp()->getNotifications()->createModel(
+                                          nullptr, Platform::Twitch))
+                                  .getElement();
+                view_->setTitles({"Twitch channels"});
+                view_->setValidationRegexp(twitchUserNameRegexp());
 
-                view->getTableView()->horizontalHeader()->setSectionResizeMode(
+                view_->getTableView()->horizontalHeader()->setSectionResizeMode(
                     QHeaderView::Fixed);
-                view->getTableView()->horizontalHeader()->setSectionResizeMode(
+                view_->getTableView()->horizontalHeader()->setSectionResizeMode(
                     0, QHeaderView::Stretch);
 
-                QTimer::singleShot(1, [view] {
-                    view->getTableView()->resizeColumnsToContents();
-                    view->getTableView()->setColumnWidth(0, 200);
+                QTimer::singleShot(1, [this] {
+                    view_->getTableView()->resizeColumnsToContents();
+                    view_->getTableView()->setColumnWidth(0, 200);
                 });
 
-                // We can safely ignore this signal connection since we own the view
-                std::ignore = view->addButtonPressed.connect([] {
+                // We can safely ignore this signal connection since we own the view_
+                std::ignore = view_->addButtonPressed.connect([] {
                     getApp()->getNotifications()->addChannelNotification(
                         "channel", Platform::Twitch);
                 });
@@ -148,4 +147,12 @@ QComboBox *NotificationPage::createToastReactionComboBox()
 
     return toastReactionOptions;
 }
+
+bool NotificationPage::filterElements(const QString &query)
+{
+    auto *fields = new std::vector<int>{0, 1};
+
+    return view_->filterSearchResults(query, *fields);
+}
+
 }  // namespace chatterino

--- a/src/widgets/settingspages/NotificationPage.cpp
+++ b/src/widgets/settingspages/NotificationPage.cpp
@@ -150,9 +150,9 @@ QComboBox *NotificationPage::createToastReactionComboBox()
 
 bool NotificationPage::filterElements(const QString &query)
 {
-    auto *fields = new std::vector<int>{0, 1};
+    std::array fields{0, 1};
 
-    return view_->filterSearchResults(query, *fields);
+    return view_->filterSearchResults(query, fields);
 }
 
 }  // namespace chatterino

--- a/src/widgets/settingspages/NotificationPage.hpp
+++ b/src/widgets/settingspages/NotificationPage.hpp
@@ -6,13 +6,17 @@ class QComboBox;
 
 namespace chatterino {
 
+class EditableModelView;
+
 class NotificationPage : public SettingsPage
 {
 public:
     NotificationPage();
+    bool filterElements(const QString &query) override;
 
 private:
     QComboBox *createToastReactionComboBox();
+    EditableModelView *view_;
 };
 
 }  // namespace chatterino


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
This pr adds the functionality of searching for fields on the tables we have in the settings pages. You can for example search for the name you gave a hotkey and it'll show up. Or you can search for "whisper" and find that you have a highlight for it in the highlights tab!

Partially fixes #5872