### PR TITLE
Disable QT keywords to avoid clashes with other libraries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Bugfix: Fixed suspicious user treatment update messages not being searchable. (#5865)
 - Dev: Highlight checks now use non-capturing groups for the boundaries. (#5784)
 - Dev: Updated Conan dependencies. (#5776)
+- Dev: Disable QT keywords (i.e. `emit`, `slots`, and `signals`). (#5882)
 - Dev: Replaced usage of `parseTime` with `serverReceivedTime` for clearchat messages. (#5824, #5855)
 - Dev: Support Boost 1.87. (#5832)
 - Dev: Words from `TextElement`s are now combined where possible. (#5847)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,7 @@ set(VERSION_PROJECT "${LIBRARY_PROJECT}-version")
 set(EXECUTABLE_PROJECT "${PROJECT_NAME}")
 add_compile_definitions(QT_DISABLE_DEPRECATED_BEFORE=0x050F00)
 add_compile_definitions(QT_WARN_DEPRECATED_UP_TO=0x050F00)
+add_compile_definitions(QT_NO_KEYWORDS)
 
 # registers the native messageing host
 option(CHATTERINO_DEBUG_NATIVE_MESSAGES "Debug native messages" OFF)

--- a/src/common/SignalVectorModel.hpp
+++ b/src/common/SignalVectorModel.hpp
@@ -182,7 +182,7 @@ public:
 
             QVector<int> roles = QVector<int>();
             roles.append(role);
-            dataChanged(index, index, roles);
+            this->dataChanged(index, index, roles);
         }
 
         return true;

--- a/src/common/SignalVectorModel.hpp
+++ b/src/common/SignalVectorModel.hpp
@@ -182,7 +182,7 @@ public:
 
             QVector<int> roles = QVector<int>();
             roles.append(role);
-            emit dataChanged(index, index, roles);
+            dataChanged(index, index, roles);
         }
 
         return true;
@@ -218,7 +218,7 @@ public:
 
         this->headerData_[section][role] = value;
 
-        emit this->headerDataChanged(Qt::Horizontal, section, section);
+        this->headerDataChanged(Qt::Horizontal, section, section);
         return true;
     }
 

--- a/src/common/network/NetworkPrivate.cpp
+++ b/src/common/network/NetworkPrivate.cpp
@@ -54,7 +54,7 @@ void loadUncached(std::shared_ptr<NetworkData> &&data)
     QObject::connect(&requester, &NetworkRequester::requestUrl, worker,
                      &NetworkTask::run);
 
-    emit requester.requestUrl();
+    requester.requestUrl();
 }
 
 void loadCached(std::shared_ptr<NetworkData> &&data)

--- a/src/common/network/NetworkPrivate.hpp
+++ b/src/common/network/NetworkPrivate.hpp
@@ -21,7 +21,7 @@ class NetworkRequester : public QObject
 {
     Q_OBJECT
 
-signals:
+Q_SIGNALS:
     void requestUrl();
 };
 

--- a/src/common/network/NetworkTask.hpp
+++ b/src/common/network/NetworkTask.hpp
@@ -29,7 +29,7 @@ public:
     NetworkTask &operator=(NetworkTask &&) = delete;
 
     // NOLINTNEXTLINE(readability-redundant-access-specifiers)
-public slots:
+public Q_SLOTS:
     void run();
 
 private:
@@ -43,7 +43,7 @@ private:
     QTimer *timer_{};         // parent: this
 
     // NOLINTNEXTLINE(readability-redundant-access-specifiers)
-private slots:
+private Q_SLOTS:
     void timeout();
     void finished();
 };

--- a/src/providers/links/LinkInfo.hpp
+++ b/src/providers/links/LinkInfo.hpp
@@ -116,7 +116,7 @@ public:
     /// @see #hasThumbnail(), #thumbnail()
     void setThumbnail(ImagePtr thumbnail);
 
-signals:
+Q_SIGNALS:
     /// @brief Emitted when this link's state changes
     ///
     /// @param state The new state

--- a/src/singletons/StreamerMode.hpp
+++ b/src/singletons/StreamerMode.hpp
@@ -22,7 +22,7 @@ public:
 
     virtual void start() = 0;
 
-signals:
+Q_SIGNALS:
     void changed(bool enabled);
 };
 

--- a/src/singletons/Toasts.cpp
+++ b/src/singletons/Toasts.cpp
@@ -57,7 +57,7 @@ private:
     QFile file_;
     QNetworkReply *reply_{};
 
-signals:
+Q_SIGNALS:
     void downloadComplete();
 };
 
@@ -314,7 +314,7 @@ AvatarDownloader::AvatarDownloader(const QString &avatarURL,
         {
             this->file_.close();
         }
-        emit downloadComplete();
+        downloadComplete();
         this->deleteLater();
     });
 }

--- a/src/widgets/BaseWindow.hpp
+++ b/src/widgets/BaseWindow.hpp
@@ -89,7 +89,7 @@ public:
 
     static bool supportsCustomWindowFrame();
 
-signals:
+Q_SIGNALS:
     void topMostChanged(bool topMost);
 
 protected:

--- a/src/widgets/dialogs/ColorPickerDialog.cpp
+++ b/src/widgets/dialogs/ColorPickerDialog.cpp
@@ -136,7 +136,7 @@ ColorPickerDialog::ColorPickerDialog(QColor color, QWidget *parent)
         new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
 
     QObject::connect(buttonBox, &QDialogButtonBox::accepted, this, [this] {
-        emit this->colorConfirmed(this->color());
+        this->colorConfirmed(this->color());
         this->close();
     });
     QObject::connect(buttonBox, &QDialogButtonBox::rejected, this,
@@ -156,7 +156,7 @@ void ColorPickerDialog::setColor(const QColor &color)
         return;
     }
     this->color_ = color;
-    emit this->colorChanged(color);
+    this->colorChanged(color);
 }
 
 }  // namespace chatterino

--- a/src/widgets/dialogs/ColorPickerDialog.hpp
+++ b/src/widgets/dialogs/ColorPickerDialog.hpp
@@ -13,11 +13,11 @@ public:
 
     QColor color() const;
 
-signals:
+Q_SIGNALS:
     void colorChanged(QColor color);
     void colorConfirmed(QColor color);
 
-public slots:
+public Q_SLOTS:
     void setColor(const QColor &color);
 
 private:

--- a/src/widgets/dialogs/EditHotkeyDialog.hpp
+++ b/src/widgets/dialogs/EditHotkeyDialog.hpp
@@ -25,7 +25,7 @@ public:
 
     std::shared_ptr<Hotkey> data();
 
-protected slots:
+protected Q_SLOTS:
     /**
      * @brief validates the hotkey
      *

--- a/src/widgets/dialogs/switcher/QuickSwitcherPopup.hpp
+++ b/src/widgets/dialogs/switcher/QuickSwitcherPopup.hpp
@@ -26,7 +26,7 @@ public:
 protected:
     void themeChangedEvent() override;
 
-public slots:
+public Q_SLOTS:
     void updateSuggestions(const QString &text);
 
 private:

--- a/src/widgets/helper/Button.cpp
+++ b/src/widgets/helper/Button.cpp
@@ -290,7 +290,7 @@ void Button::mousePressEvent(QMouseEvent *event)
 
     this->mouseDown_ = true;
 
-    emit this->leftMousePress();
+    this->leftMousePress();
 
     if (this->menu_ && !this->menuVisible_)
     {
@@ -317,13 +317,13 @@ void Button::mouseReleaseEvent(QMouseEvent *event)
 
         if (isInside)
         {
-            emit leftClicked();
+            leftClicked();
         }
     }
 
     if (isInside)
     {
-        emit clicked(event->button());
+        clicked(event->button());
     }
 }
 

--- a/src/widgets/helper/Button.hpp
+++ b/src/widgets/helper/Button.hpp
@@ -51,7 +51,7 @@ public:
 
     void setMenu(std::unique_ptr<QMenu> menu);
 
-signals:
+Q_SIGNALS:
     void leftClicked();
     void clicked(Qt::MouseButton button);
     void leftMousePress();

--- a/src/widgets/helper/NotebookButton.cpp
+++ b/src/widgets/helper/NotebookButton.cpp
@@ -147,7 +147,7 @@ void NotebookButton::mouseReleaseEvent(QMouseEvent *event)
 
         update();
 
-        emit leftClicked();
+        leftClicked();
     }
 
     Button::mouseReleaseEvent(event);

--- a/src/widgets/helper/NotebookButton.hpp
+++ b/src/widgets/helper/NotebookButton.hpp
@@ -31,7 +31,7 @@ protected:
     void hideEvent(QHideEvent *) override;
     void showEvent(QShowEvent *) override;
 
-signals:
+Q_SIGNALS:
     void leftClicked();
 
 private:

--- a/src/widgets/helper/ResizingTextEdit.hpp
+++ b/src/widgets/helper/ResizingTextEdit.hpp
@@ -67,7 +67,7 @@ private:
 
     bool eventFilter(QObject *obj, QEvent *event) override;
 
-private slots:
+private Q_SLOTS:
     void insertCompletion(const QString &completion);
 };
 

--- a/src/widgets/helper/SettingsDialogTab.cpp
+++ b/src/widgets/helper/SettingsDialogTab.cpp
@@ -36,7 +36,7 @@ void SettingsDialogTab::setSelected(bool _selected)
     //    height: <checkbox-size>px;
 
     this->selected_ = _selected;
-    emit selectedChanged(selected_);
+    selectedChanged(selected_);
 }
 
 SettingsPage *SettingsDialogTab::page()

--- a/src/widgets/helper/SettingsDialogTab.hpp
+++ b/src/widgets/helper/SettingsDialogTab.hpp
@@ -37,7 +37,7 @@ public:
 
     const QString &name() const;
 
-signals:
+Q_SIGNALS:
     void selectedChanged(bool);
 
 private:

--- a/src/widgets/helper/SignalLabel.cpp
+++ b/src/widgets/helper/SignalLabel.cpp
@@ -9,14 +9,14 @@ SignalLabel::SignalLabel(QWidget *parent, Qt::WindowFlags f)
 
 void SignalLabel::mouseDoubleClickEvent(QMouseEvent *ev)
 {
-    emit this->mouseDoubleClick(ev);
+    this->mouseDoubleClick(ev);
 }
 
 void SignalLabel::mousePressEvent(QMouseEvent *event)
 {
     if (event->button() == Qt::LeftButton)
     {
-        emit leftMouseDown();
+        leftMouseDown();
     }
 
     event->ignore();
@@ -26,7 +26,7 @@ void SignalLabel::mouseReleaseEvent(QMouseEvent *event)
 {
     if (event->button() == Qt::LeftButton)
     {
-        emit leftMouseUp();
+        leftMouseUp();
     }
 
     event->ignore();
@@ -34,7 +34,7 @@ void SignalLabel::mouseReleaseEvent(QMouseEvent *event)
 
 void SignalLabel::mouseMoveEvent(QMouseEvent *event)
 {
-    emit this->mouseMove(event);
+    this->mouseMove(event);
     event->ignore();
 }
 

--- a/src/widgets/helper/SignalLabel.hpp
+++ b/src/widgets/helper/SignalLabel.hpp
@@ -15,7 +15,7 @@ public:
     explicit SignalLabel(QWidget *parent = nullptr, Qt::WindowFlags f = {});
     ~SignalLabel() override = default;
 
-signals:
+Q_SIGNALS:
     void mouseDoubleClick(QMouseEvent *ev);
 
     void leftMouseDown();

--- a/src/widgets/helper/color/AlphaSlider.cpp
+++ b/src/widgets/helper/color/AlphaSlider.cpp
@@ -156,7 +156,7 @@ void AlphaSlider::setAlpha(int alpha)
     this->alpha_ = alpha;
     this->color_.setAlpha(alpha);
 
-    emit this->colorChanged(this->color_);
+    this->colorChanged(this->color_);
     this->update();
 }
 

--- a/src/widgets/helper/color/AlphaSlider.hpp
+++ b/src/widgets/helper/color/AlphaSlider.hpp
@@ -15,10 +15,10 @@ public:
 
     int alpha() const;
 
-signals:
+Q_SIGNALS:
     void colorChanged(QColor color) const;
 
-public slots:
+public Q_SLOTS:
     void setColor(QColor color);
 
 protected:

--- a/src/widgets/helper/color/ColorButton.hpp
+++ b/src/widgets/helper/color/ColorButton.hpp
@@ -16,7 +16,7 @@ public:
     QColor color() const;
 
     // NOLINTNEXTLINE(readability-redundant-access-specifiers)
-public slots:
+public Q_SLOTS:
     void setColor(const QColor &color);
 
 protected:

--- a/src/widgets/helper/color/ColorInput.cpp
+++ b/src/widgets/helper/color/ColorInput.cpp
@@ -162,7 +162,7 @@ void ColorInput::emitUpdate()
 {
     this->updateComponents();
     // our components triggered this update, emit the new color
-    emit this->colorChanged(this->currentColor_);
+    this->colorChanged(this->currentColor_);
 }
 
 }  // namespace chatterino

--- a/src/widgets/helper/color/ColorInput.hpp
+++ b/src/widgets/helper/color/ColorInput.hpp
@@ -17,10 +17,10 @@ public:
 
     QColor color() const;
 
-signals:
+Q_SIGNALS:
     void colorChanged(QColor color);
 
-public slots:
+public Q_SLOTS:
     void setColor(QColor color);
 
 private:

--- a/src/widgets/helper/color/HueSlider.cpp
+++ b/src/widgets/helper/color/HueSlider.cpp
@@ -158,7 +158,7 @@ void HueSlider::setHue(int hue)
     this->color_.getHsv(&h, &s, &v, &a);
     this->color_.setHsv(this->hue_, s, v, a);
 
-    emit this->colorChanged(this->color_);
+    this->colorChanged(this->color_);
     this->update();
 }
 

--- a/src/widgets/helper/color/HueSlider.hpp
+++ b/src/widgets/helper/color/HueSlider.hpp
@@ -15,10 +15,10 @@ public:
 
     int hue() const;
 
-signals:
+Q_SIGNALS:
     void colorChanged(QColor color) const;
 
-public slots:
+public Q_SLOTS:
     void setColor(QColor color);
 
 protected:

--- a/src/widgets/helper/color/SBCanvas.cpp
+++ b/src/widgets/helper/color/SBCanvas.cpp
@@ -186,7 +186,7 @@ void SBCanvas::emitUpdatedColor()
 {
     this->color_.setHsv(this->hue_, this->saturation_, this->brightness_,
                         this->color_.alpha());
-    emit this->colorChanged(this->color_);
+    this->colorChanged(this->color_);
 }
 
 }  // namespace chatterino

--- a/src/widgets/helper/color/SBCanvas.hpp
+++ b/src/widgets/helper/color/SBCanvas.hpp
@@ -17,10 +17,10 @@ public:
     int saturation() const;
     int brightness() const;
 
-signals:
+Q_SIGNALS:
     void colorChanged(QColor color) const;
 
-public slots:
+public Q_SLOTS:
     void setColor(QColor color);
 
 protected:

--- a/src/widgets/listview/GenericListView.cpp
+++ b/src/widgets/listview/GenericListView.cpp
@@ -213,7 +213,7 @@ void GenericListView::focusPreviousCompletion()
 
 void GenericListView::requestClose()
 {
-    emit this->closeRequested();
+    this->closeRequested();
 }
 
 }  // namespace chatterino

--- a/src/widgets/listview/GenericListView.hpp
+++ b/src/widgets/listview/GenericListView.hpp
@@ -26,7 +26,7 @@ public:
 
     void refreshTheme(const Theme &theme);
 
-signals:
+Q_SIGNALS:
     void closeRequested();
 
 private:

--- a/src/widgets/splits/Split.hpp
+++ b/src/widgets/splits/Split.hpp
@@ -177,7 +177,7 @@ private:
     pajlada::Signals::SignalHolder signalHolder_;
     std::vector<boost::signals2::scoped_connection> bSignals_;
 
-public slots:
+public Q_SLOTS:
     void addSibling();
     void deleteFromContainer();
     void changeChannel();

--- a/src/widgets/splits/SplitHeader.hpp
+++ b/src/widgets/splits/SplitHeader.hpp
@@ -102,7 +102,7 @@ private:
     pajlada::Signals::SignalHolder channelConnections_;
     std::vector<boost::signals2::scoped_connection> bSignals_;
 
-public slots:
+public Q_SLOTS:
     void reloadChannelEmotes();
     void reloadSubscriberEmotes();
     void reconnect();

--- a/src/widgets/splits/SplitInput.hpp
+++ b/src/widgets/splits/SplitInput.hpp
@@ -168,7 +168,7 @@ protected:
     // set the height of the split input to 0 if we're supposed to be hidden instead
     bool hidden{false};
 
-private slots:
+private Q_SLOTS:
     void editTextChanged();
 
     friend class Split;


### PR DESCRIPTION
To be able to add libnotify support in #5881, QT keywords conflict with glib and other libraries so try disabling them.

Not sure what the feeling is on including/excluding `emit` and not using keywords. It avoids some ugliness having to undef things and redef them :slightly_smiling_face: 