### PR TITLE
fix: force quit miniaudio thread after 1s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Bugfix: Fixed announcements not showing up in mentions tab. (#5857)
 - Bugfix: Fixed the reply button showing for inline whispers and announcements. (#5863)
 - Bugfix: Fixed suspicious user treatment update messages not being searchable. (#5865)
+- Bugfix: Ensure miniaudio backend exits even if it doesn't exit cleanly. (#5896)
 - Dev: Add initial experimental EventSub support. (#5837, #5895)
 - Dev: Highlight checks now use non-capturing groups for the boundaries. (#5784)
 - Dev: Updated Conan dependencies. (#5776)

--- a/src/controllers/sound/MiniaudioBackend.hpp
+++ b/src/controllers/sound/MiniaudioBackend.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "controllers/sound/ISoundController.hpp"
+#include "util/OnceFlag.hpp"
 #include "util/ThreadGuard.hpp"
 
 #include <boost/asio.hpp>
@@ -59,6 +60,7 @@ private:
     boost::asio::executor_work_guard<boost::asio::io_context::executor_type>
         workGuard;
     std::unique_ptr<std::thread> audioThread;
+    OnceFlag stoppedFlag;
     boost::asio::steady_timer sleepTimer;
 
     bool initialized{false};


### PR DESCRIPTION
tested by not destroying the work guard
