### PR TITLE
refactor(eventsub): Allow for skipping generation of json implementations

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,6 +20,7 @@ task:
         -DUSE_SYSTEM_QTKEYCHAIN="ON" \
         -DCMAKE_BUILD_TYPE="release" \
         -DCMAKE_EXPORT_COMPILE_COMMANDS="ON" \
+        -DSKIP_JSON_GENERATION="ON" \
         ..
     cat compile_commands.json
     make -j $(getconf _NPROCESSORS_ONLN)

--- a/BUILDING_ON_FREEBSD.md
+++ b/BUILDING_ON_FREEBSD.md
@@ -15,7 +15,7 @@ FreeBSD 15.0-SNAP.
    mkdir build
    cd build
    ```
-1. Generate build files. To enable Lua plugins in your build add `-DCHATTERINO_PLUGINS=ON` to this command.
+1. Generate build files. To enable Lua plugins in your build add `-DCHATTERINO_PLUGINS=ON` to this command. Generating JSON implementation of EventSub blobs is slow (something to do with Python), if you're impatient you can enable the `-DSKIP_JSON_GENERATION=On` option.
    ```sh
    cmake ..
    ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - Bugfix: Fixed the reply button showing for inline whispers and announcements. (#5863)
 - Bugfix: Fixed suspicious user treatment update messages not being searchable. (#5865)
 - Bugfix: Ensure miniaudio backend exits even if it doesn't exit cleanly. (#5896)
-- Dev: Add initial experimental EventSub support. (#5837, #5895, #5897)
+- Dev: Add initial experimental EventSub support. (#5837, #5895, #5897, #5904)
 - Dev: Highlight checks now use non-capturing groups for the boundaries. (#5784)
 - Dev: Removed unused PubSub whisper code. (#5898)
 - Dev: Updated Conan dependencies. (#5776)

--- a/lib/twitch-eventsub-ws/CMakeLists.txt
+++ b/lib/twitch-eventsub-ws/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(OpenSSL REQUIRED)
 
 option(BUILD_WITH_QT6 "Build with Qt6" On)
 option(FORCE_JSON_GENERATION "Make sure JSON implementations are generated at build time" Off)
+option(SKIP_JSON_GENERATION "Skip JSON implementations generation at build time" Off)
 
 if (BUILD_WITH_QT6)
     set(MAJOR_QT_VERSION "6")

--- a/lib/twitch-eventsub-ws/src/CMakeLists.txt
+++ b/lib/twitch-eventsub-ws/src/CMakeLists.txt
@@ -2,6 +2,7 @@ generate_json_impls(
     OUTPUT_SOURCES eventsub_generated_sources
     BASE_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/.."
     FORCE ${FORCE_JSON_GENERATION}
+    SKIP ${SKIP_JSON_GENERATION}
     HEADERS
         include/twitch-eventsub-ws/messages/metadata.hpp
 


### PR DESCRIPTION
This can be done using the `SKIP_JSON_GENERATION` flag (off by default)

<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
