### PR TITLE
fix: address clang-tidy warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - Bugfix: Fixed the reply button showing for inline whispers and announcements. (#5863)
 - Bugfix: Fixed suspicious user treatment update messages not being searchable. (#5865)
 - Bugfix: Ensure miniaudio backend exits even if it doesn't exit cleanly. (#5896)
-- Dev: Add initial experimental EventSub support. (#5837, #5895, #5897, #5904, #5910, #5903)
+- Dev: Add initial experimental EventSub support. (#5837, #5895, #5897, #5904, #5910, #5903, #5915)
 - Dev: Highlight checks now use non-capturing groups for the boundaries. (#5784)
 - Dev: Removed unused PubSub whisper code. (#5898)
 - Dev: Updated Conan dependencies. (#5776)

--- a/lib/twitch-eventsub-ws/ast/lib/member.py
+++ b/lib/twitch-eventsub-ws/ast/lib/member.py
@@ -56,7 +56,11 @@ def _is_trivially_copyable(type: clang.cindex.Type) -> bool:
 
 class Member:
     def __init__(
-        self, name: str, member_type: MemberType = MemberType.BASIC, type_name: str = "?", trivial: bool = False
+        self,
+        name: str,
+        member_type: MemberType = MemberType.BASIC,
+        type_name: str = "?",
+        trivial: bool = False,
     ) -> None:
         self.name = name
         self.json_name = name

--- a/lib/twitch-eventsub-ws/ast/lib/templates/enum-implementation.tmpl
+++ b/lib/twitch-eventsub-ws/ast/lib/templates/enum-implementation.tmpl
@@ -1,5 +1,5 @@
 boost::json::result_for<{{enum.full_name}}, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<{{enum.full_name}}>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<{{enum.full_name}}> /* tag */, const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_string())
     {

--- a/lib/twitch-eventsub-ws/ast/lib/templates/field-optional.tmpl
+++ b/lib/twitch-eventsub-ws/ast/lib/templates/field-optional.tmpl
@@ -21,7 +21,11 @@ if (jv{{field.name}} != nullptr && !jv{{field.name}}->is_null())
     {
         return t{{field.name}}.error();
     }
+    {% if field.trivial -%}
+    {{field.name}} = t{{field.name}}.value();
+    {%- else -%}
     {{field.name}} = std::move(t{{field.name}}.value());
+    {%- endif %}
     {% endif %}
 }
 

--- a/lib/twitch-eventsub-ws/ast/lib/templates/field-vector.tmpl
+++ b/lib/twitch-eventsub-ws/ast/lib/templates/field-vector.tmpl
@@ -6,7 +6,7 @@ if (jv{{field.name}} == nullptr)
 {
     {% include 'error-missing-field.tmpl' indent content %}
 }
-const auto {{field.name}} = boost::json::try_value_to<std::vector<{{field.type_name}}>>(*jv{{field.name}});
+auto {{field.name}} = boost::json::try_value_to<std::vector<{{field.type_name}}>>(*jv{{field.name}});
 if ({{field.name}}.has_error())
 {
     {% include 'error-failed-to-deserialize.tmpl' indent content %}

--- a/lib/twitch-eventsub-ws/ast/lib/templates/initializer-basic.tmpl
+++ b/lib/twitch-eventsub-ws/ast/lib/templates/initializer-basic.tmpl
@@ -1,1 +1,5 @@
+{%- if field.trivial -%}
+.{{field.name}} = {{field.name}}.value(),
+{%- else -%}
 .{{field.name}} = std::move({{field.name}}.value()),
+{%- endif -%}

--- a/lib/twitch-eventsub-ws/ast/lib/templates/initializer-optional.tmpl
+++ b/lib/twitch-eventsub-ws/ast/lib/templates/initializer-optional.tmpl
@@ -1,1 +1,5 @@
+{%- if field.trivial -%}
+.{{field.name}} = {{field.name}},
+{%- else -%}
 .{{field.name}} = std::move({{field.name}}),
+{%- endif -%}

--- a/lib/twitch-eventsub-ws/ast/lib/templates/initializer-vector.tmpl
+++ b/lib/twitch-eventsub-ws/ast/lib/templates/initializer-vector.tmpl
@@ -1,1 +1,1 @@
-.{{field.name}} = {{field.name}}.value(),
+.{{field.name}} = std::move({{field.name}}.value()),

--- a/lib/twitch-eventsub-ws/ast/lib/templates/struct-implementation.tmpl
+++ b/lib/twitch-eventsub-ws/ast/lib/templates/struct-implementation.tmpl
@@ -1,5 +1,5 @@
 boost::json::result_for<{{struct.full_name}}, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<{{struct.full_name}}>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<{{struct.full_name}}> /* tag */, const boost::json::value &jvRoot)
 {
     {% if struct.inner_root %}
     if (!jvRoot.is_object())
@@ -18,7 +18,7 @@ boost::json::result_for<{{struct.full_name}}, boost::json::value>::type tag_invo
         EVENTSUB_BAIL_HERE(error::Kind::ExpectedObject);
     }
     const auto &root = jvInnerRoot->get_object();
-    {% else %}
+    {% elif struct.members|length %}
     if (!jvRoot.is_object())
     {
         EVENTSUB_BAIL_HERE(error::Kind::ExpectedObject);
@@ -27,6 +27,9 @@ boost::json::result_for<{{struct.full_name}}, boost::json::value>::type tag_invo
     {% endif %}
 
 {% for field in struct.members %}
+    {% if field.trivial -%}
+    static_assert(std::is_trivially_copyable_v<std::remove_reference_t<decltype(std::declval<{{struct.full_name}}>().{{field.name}})>>);
+    {%- endif -%}
     {% if field.member_type == MemberType.BASIC -%}
     {% include 'field-basic.tmpl' indent content %}
     {%- elif field.member_type == MemberType.VECTOR -%}

--- a/lib/twitch-eventsub-ws/src/generated/messages/metadata.cpp
+++ b/lib/twitch-eventsub-ws/src/generated/messages/metadata.cpp
@@ -8,7 +8,8 @@
 namespace chatterino::eventsub::lib::messages {
 
 boost::json::result_for<Metadata, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Metadata>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Metadata> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {

--- a/lib/twitch-eventsub-ws/src/generated/payloads/channel-ban-v1.cpp
+++ b/lib/twitch-eventsub-ws/src/generated/payloads/channel-ban-v1.cpp
@@ -8,7 +8,8 @@
 namespace chatterino::eventsub::lib::payload::channel_ban::v1 {
 
 boost::json::result_for<Event, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Event>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Event> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {
@@ -154,6 +155,8 @@ boost::json::result_for<Event, boost::json::value>::type tag_invoke(
         return reason.error();
     }
 
+    static_assert(std::is_trivially_copyable_v<std::remove_reference_t<
+                      decltype(std::declval<Event>().isPermanent)>>);
     const auto *jvisPermanent = root.if_contains("is_permanent");
     if (jvisPermanent == nullptr)
     {
@@ -167,6 +170,9 @@ boost::json::result_for<Event, boost::json::value>::type tag_invoke(
         return isPermanent.error();
     }
 
+    static_assert(
+        std::is_trivially_copyable_v<
+            std::remove_reference_t<decltype(std::declval<Event>().bannedAt)>>);
     const auto *jvbannedAt = root.if_contains("banned_at");
     if (jvbannedAt == nullptr)
     {
@@ -182,6 +188,9 @@ boost::json::result_for<Event, boost::json::value>::type tag_invoke(
         return bannedAt.error();
     }
 
+    static_assert(
+        std::is_trivially_copyable_v<
+            std::remove_reference_t<decltype(std::declval<Event>().endsAt)>>);
     std::optional<std::chrono::system_clock::time_point> endsAt = std::nullopt;
     const auto *jvendsAt = root.if_contains("ends_at");
     if (jvendsAt != nullptr && !jvendsAt->is_null())
@@ -194,7 +203,7 @@ boost::json::result_for<Event, boost::json::value>::type tag_invoke(
         {
             return tendsAt.error();
         }
-        endsAt = std::move(tendsAt.value());
+        endsAt = tendsAt.value();
     }
 
     return Event{
@@ -208,14 +217,15 @@ boost::json::result_for<Event, boost::json::value>::type tag_invoke(
         .userLogin = std::move(userLogin.value()),
         .userName = std::move(userName.value()),
         .reason = std::move(reason.value()),
-        .isPermanent = std::move(isPermanent.value()),
-        .bannedAt = std::move(bannedAt.value()),
-        .endsAt = std::move(endsAt),
+        .isPermanent = isPermanent.value(),
+        .bannedAt = bannedAt.value(),
+        .endsAt = endsAt,
     };
 }
 
 boost::json::result_for<Payload, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Payload>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Payload> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {

--- a/lib/twitch-eventsub-ws/src/generated/payloads/channel-chat-message-v1.cpp
+++ b/lib/twitch-eventsub-ws/src/generated/payloads/channel-chat-message-v1.cpp
@@ -8,7 +8,8 @@
 namespace chatterino::eventsub::lib::payload::channel_chat_message::v1 {
 
 boost::json::result_for<Badge, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Badge>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Badge> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {
@@ -63,7 +64,8 @@ boost::json::result_for<Badge, boost::json::value>::type tag_invoke(
 }
 
 boost::json::result_for<Cheermote, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Cheermote>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Cheermote> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {
@@ -84,6 +86,9 @@ boost::json::result_for<Cheermote, boost::json::value>::type tag_invoke(
         return prefix.error();
     }
 
+    static_assert(
+        std::is_trivially_copyable_v<
+            std::remove_reference_t<decltype(std::declval<Cheermote>().bits)>>);
     const auto *jvbits = root.if_contains("bits");
     if (jvbits == nullptr)
     {
@@ -97,6 +102,9 @@ boost::json::result_for<Cheermote, boost::json::value>::type tag_invoke(
         return bits.error();
     }
 
+    static_assert(
+        std::is_trivially_copyable_v<
+            std::remove_reference_t<decltype(std::declval<Cheermote>().tier)>>);
     const auto *jvtier = root.if_contains("tier");
     if (jvtier == nullptr)
     {
@@ -112,13 +120,14 @@ boost::json::result_for<Cheermote, boost::json::value>::type tag_invoke(
 
     return Cheermote{
         .prefix = std::move(prefix.value()),
-        .bits = std::move(bits.value()),
-        .tier = std::move(tier.value()),
+        .bits = bits.value(),
+        .tier = tier.value(),
     };
 }
 
 boost::json::result_for<Emote, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Emote>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Emote> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {
@@ -170,7 +179,7 @@ boost::json::result_for<Emote, boost::json::value>::type tag_invoke(
     {
         EVENTSUB_BAIL_HERE(error::Kind::FieldMissing);
     }
-    const auto format =
+    auto format =
         boost::json::try_value_to<std::vector<std::string>>(*jvformat);
     if (format.has_error())
     {
@@ -181,12 +190,13 @@ boost::json::result_for<Emote, boost::json::value>::type tag_invoke(
         .id = std::move(id.value()),
         .emoteSetID = std::move(emoteSetID.value()),
         .ownerID = std::move(ownerID.value()),
-        .format = format.value(),
+        .format = std::move(format.value()),
     };
 }
 
 boost::json::result_for<Mention, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Mention>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Mention> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {
@@ -241,7 +251,7 @@ boost::json::result_for<Mention, boost::json::value>::type tag_invoke(
 }
 
 boost::json::result_for<MessageFragment, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<MessageFragment>,
+    boost::json::try_value_to_tag<MessageFragment> /* tag */,
     const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
@@ -325,7 +335,8 @@ boost::json::result_for<MessageFragment, boost::json::value>::type tag_invoke(
 }
 
 boost::json::result_for<Message, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Message>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Message> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {
@@ -351,7 +362,7 @@ boost::json::result_for<Message, boost::json::value>::type tag_invoke(
     {
         EVENTSUB_BAIL_HERE(error::Kind::FieldMissing);
     }
-    const auto fragments =
+    auto fragments =
         boost::json::try_value_to<std::vector<MessageFragment>>(*jvfragments);
     if (fragments.has_error())
     {
@@ -360,12 +371,13 @@ boost::json::result_for<Message, boost::json::value>::type tag_invoke(
 
     return Message{
         .text = std::move(text.value()),
-        .fragments = fragments.value(),
+        .fragments = std::move(fragments.value()),
     };
 }
 
 boost::json::result_for<Cheer, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Cheer>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Cheer> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {
@@ -373,6 +385,9 @@ boost::json::result_for<Cheer, boost::json::value>::type tag_invoke(
     }
     const auto &root = jvRoot.get_object();
 
+    static_assert(
+        std::is_trivially_copyable_v<
+            std::remove_reference_t<decltype(std::declval<Cheer>().bits)>>);
     const auto *jvbits = root.if_contains("bits");
     if (jvbits == nullptr)
     {
@@ -387,12 +402,13 @@ boost::json::result_for<Cheer, boost::json::value>::type tag_invoke(
     }
 
     return Cheer{
-        .bits = std::move(bits.value()),
+        .bits = bits.value(),
     };
 }
 
 boost::json::result_for<Reply, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Reply>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Reply> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {
@@ -538,7 +554,8 @@ boost::json::result_for<Reply, boost::json::value>::type tag_invoke(
 }
 
 boost::json::result_for<Event, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Event>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Event> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {
@@ -650,8 +667,7 @@ boost::json::result_for<Event, boost::json::value>::type tag_invoke(
     {
         EVENTSUB_BAIL_HERE(error::Kind::FieldMissing);
     }
-    const auto badges =
-        boost::json::try_value_to<std::vector<Badge>>(*jvbadges);
+    auto badges = boost::json::try_value_to<std::vector<Badge>>(*jvbadges);
     if (badges.has_error())
     {
         return badges.error();
@@ -696,6 +712,9 @@ boost::json::result_for<Event, boost::json::value>::type tag_invoke(
         return message.error();
     }
 
+    static_assert(
+        std::is_trivially_copyable_v<
+            std::remove_reference_t<decltype(std::declval<Event>().cheer)>>);
     std::optional<Cheer> cheer = std::nullopt;
     const auto *jvcheer = root.if_contains("cheer");
     if (jvcheer != nullptr && !jvcheer->is_null())
@@ -706,7 +725,7 @@ boost::json::result_for<Event, boost::json::value>::type tag_invoke(
         {
             return tcheer.error();
         }
-        cheer = std::move(tcheer.value());
+        cheer = tcheer.value();
     }
 
     std::optional<Reply> reply = std::nullopt;
@@ -748,18 +767,19 @@ boost::json::result_for<Event, boost::json::value>::type tag_invoke(
         .chatterUserLogin = std::move(chatterUserLogin.value()),
         .chatterUserName = std::move(chatterUserName.value()),
         .color = std::move(color.value()),
-        .badges = badges.value(),
+        .badges = std::move(badges.value()),
         .messageID = std::move(messageID.value()),
         .messageType = std::move(messageType.value()),
         .message = std::move(message.value()),
-        .cheer = std::move(cheer),
+        .cheer = cheer,
         .reply = std::move(reply),
         .channelPointsCustomRewardID = std::move(channelPointsCustomRewardID),
     };
 }
 
 boost::json::result_for<Payload, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Payload>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Payload> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {

--- a/lib/twitch-eventsub-ws/src/generated/payloads/channel-chat-notification-v1.cpp
+++ b/lib/twitch-eventsub-ws/src/generated/payloads/channel-chat-notification-v1.cpp
@@ -8,7 +8,8 @@
 namespace chatterino::eventsub::lib::payload::channel_chat_notification::v1 {
 
 boost::json::result_for<Badge, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Badge>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Badge> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {
@@ -63,7 +64,8 @@ boost::json::result_for<Badge, boost::json::value>::type tag_invoke(
 }
 
 boost::json::result_for<Cheermote, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Cheermote>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Cheermote> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {
@@ -84,6 +86,9 @@ boost::json::result_for<Cheermote, boost::json::value>::type tag_invoke(
         return prefix.error();
     }
 
+    static_assert(
+        std::is_trivially_copyable_v<
+            std::remove_reference_t<decltype(std::declval<Cheermote>().bits)>>);
     const auto *jvbits = root.if_contains("bits");
     if (jvbits == nullptr)
     {
@@ -97,6 +102,9 @@ boost::json::result_for<Cheermote, boost::json::value>::type tag_invoke(
         return bits.error();
     }
 
+    static_assert(
+        std::is_trivially_copyable_v<
+            std::remove_reference_t<decltype(std::declval<Cheermote>().tier)>>);
     const auto *jvtier = root.if_contains("tier");
     if (jvtier == nullptr)
     {
@@ -112,13 +120,14 @@ boost::json::result_for<Cheermote, boost::json::value>::type tag_invoke(
 
     return Cheermote{
         .prefix = std::move(prefix.value()),
-        .bits = std::move(bits.value()),
-        .tier = std::move(tier.value()),
+        .bits = bits.value(),
+        .tier = tier.value(),
     };
 }
 
 boost::json::result_for<Emote, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Emote>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Emote> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {
@@ -170,7 +179,7 @@ boost::json::result_for<Emote, boost::json::value>::type tag_invoke(
     {
         EVENTSUB_BAIL_HERE(error::Kind::FieldMissing);
     }
-    const auto format =
+    auto format =
         boost::json::try_value_to<std::vector<std::string>>(*jvformat);
     if (format.has_error())
     {
@@ -181,12 +190,13 @@ boost::json::result_for<Emote, boost::json::value>::type tag_invoke(
         .id = std::move(id.value()),
         .emoteSetID = std::move(emoteSetID.value()),
         .ownerID = std::move(ownerID.value()),
-        .format = format.value(),
+        .format = std::move(format.value()),
     };
 }
 
 boost::json::result_for<Mention, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Mention>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Mention> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {
@@ -241,7 +251,7 @@ boost::json::result_for<Mention, boost::json::value>::type tag_invoke(
 }
 
 boost::json::result_for<MessageFragment, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<MessageFragment>,
+    boost::json::try_value_to_tag<MessageFragment> /* tag */,
     const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
@@ -325,7 +335,7 @@ boost::json::result_for<MessageFragment, boost::json::value>::type tag_invoke(
 }
 
 boost::json::result_for<Subcription, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Subcription>,
+    boost::json::try_value_to_tag<Subcription> /* tag */,
     const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
@@ -347,6 +357,8 @@ boost::json::result_for<Subcription, boost::json::value>::type tag_invoke(
         return subTier.error();
     }
 
+    static_assert(std::is_trivially_copyable_v<std::remove_reference_t<
+                      decltype(std::declval<Subcription>().isPrime)>>);
     const auto *jvisPrime = root.if_contains("is_prime");
     if (jvisPrime == nullptr)
     {
@@ -360,6 +372,8 @@ boost::json::result_for<Subcription, boost::json::value>::type tag_invoke(
         return isPrime.error();
     }
 
+    static_assert(std::is_trivially_copyable_v<std::remove_reference_t<
+                      decltype(std::declval<Subcription>().durationMonths)>>);
     const auto *jvdurationMonths = root.if_contains("duration_months");
     if (jvdurationMonths == nullptr)
     {
@@ -375,13 +389,13 @@ boost::json::result_for<Subcription, boost::json::value>::type tag_invoke(
 
     return Subcription{
         .subTier = std::move(subTier.value()),
-        .isPrime = std::move(isPrime.value()),
-        .durationMonths = std::move(durationMonths.value()),
+        .isPrime = isPrime.value(),
+        .durationMonths = durationMonths.value(),
     };
 }
 
 boost::json::result_for<Resubscription, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Resubscription>,
+    boost::json::try_value_to_tag<Resubscription> /* tag */,
     const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
@@ -390,6 +404,9 @@ boost::json::result_for<Resubscription, boost::json::value>::type tag_invoke(
     }
     const auto &root = jvRoot.get_object();
 
+    static_assert(
+        std::is_trivially_copyable_v<std::remove_reference_t<
+            decltype(std::declval<Resubscription>().cumulativeMonths)>>);
     const auto *jvcumulativeMonths = root.if_contains("cumulative_months");
     if (jvcumulativeMonths == nullptr)
     {
@@ -403,6 +420,9 @@ boost::json::result_for<Resubscription, boost::json::value>::type tag_invoke(
         return cumulativeMonths.error();
     }
 
+    static_assert(
+        std::is_trivially_copyable_v<std::remove_reference_t<
+            decltype(std::declval<Resubscription>().durationMonths)>>);
     const auto *jvdurationMonths = root.if_contains("duration_months");
     if (jvdurationMonths == nullptr)
     {
@@ -416,6 +436,8 @@ boost::json::result_for<Resubscription, boost::json::value>::type tag_invoke(
         return durationMonths.error();
     }
 
+    static_assert(std::is_trivially_copyable_v<std::remove_reference_t<
+                      decltype(std::declval<Resubscription>().streakMonths)>>);
     std::optional<int> streakMonths = std::nullopt;
     const auto *jvstreakMonths = root.if_contains("streak_months");
     if (jvstreakMonths != nullptr && !jvstreakMonths->is_null())
@@ -426,7 +448,7 @@ boost::json::result_for<Resubscription, boost::json::value>::type tag_invoke(
         {
             return tstreakMonths.error();
         }
-        streakMonths = std::move(tstreakMonths.value());
+        streakMonths = tstreakMonths.value();
     }
 
     const auto *jvsubTier = root.if_contains("sub_tier");
@@ -442,6 +464,8 @@ boost::json::result_for<Resubscription, boost::json::value>::type tag_invoke(
         return subTier.error();
     }
 
+    static_assert(std::is_trivially_copyable_v<std::remove_reference_t<
+                      decltype(std::declval<Resubscription>().isPrime)>>);
     const auto *jvisPrime = root.if_contains("is_prime");
     if (jvisPrime == nullptr)
     {
@@ -455,6 +479,8 @@ boost::json::result_for<Resubscription, boost::json::value>::type tag_invoke(
         return isPrime.error();
     }
 
+    static_assert(std::is_trivially_copyable_v<std::remove_reference_t<
+                      decltype(std::declval<Resubscription>().isGift)>>);
     const auto *jvisGift = root.if_contains("is_gift");
     if (jvisGift == nullptr)
     {
@@ -468,6 +494,9 @@ boost::json::result_for<Resubscription, boost::json::value>::type tag_invoke(
         return isGift.error();
     }
 
+    static_assert(
+        std::is_trivially_copyable_v<std::remove_reference_t<
+            decltype(std::declval<Resubscription>().gifterIsAnonymous)>>);
     const auto *jvgifterIsAnonymous = root.if_contains("gifter_is_anonymous");
     if (jvgifterIsAnonymous == nullptr)
     {
@@ -525,13 +554,13 @@ boost::json::result_for<Resubscription, boost::json::value>::type tag_invoke(
     }
 
     return Resubscription{
-        .cumulativeMonths = std::move(cumulativeMonths.value()),
-        .durationMonths = std::move(durationMonths.value()),
-        .streakMonths = std::move(streakMonths),
+        .cumulativeMonths = cumulativeMonths.value(),
+        .durationMonths = durationMonths.value(),
+        .streakMonths = streakMonths,
         .subTier = std::move(subTier.value()),
-        .isPrime = std::move(isPrime.value()),
-        .isGift = std::move(isGift.value()),
-        .gifterIsAnonymous = std::move(gifterIsAnonymous.value()),
+        .isPrime = isPrime.value(),
+        .isGift = isGift.value(),
+        .gifterIsAnonymous = gifterIsAnonymous.value(),
         .gifterUserID = std::move(gifterUserID),
         .gifterUserName = std::move(gifterUserName),
         .gifterUserLogin = std::move(gifterUserLogin),
@@ -539,7 +568,7 @@ boost::json::result_for<Resubscription, boost::json::value>::type tag_invoke(
 }
 
 boost::json::result_for<GiftSubscription, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<GiftSubscription>,
+    boost::json::try_value_to_tag<GiftSubscription> /* tag */,
     const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
@@ -548,6 +577,9 @@ boost::json::result_for<GiftSubscription, boost::json::value>::type tag_invoke(
     }
     const auto &root = jvRoot.get_object();
 
+    static_assert(
+        std::is_trivially_copyable_v<std::remove_reference_t<
+            decltype(std::declval<GiftSubscription>().durationMonths)>>);
     const auto *jvdurationMonths = root.if_contains("duration_months");
     if (jvdurationMonths == nullptr)
     {
@@ -561,6 +593,9 @@ boost::json::result_for<GiftSubscription, boost::json::value>::type tag_invoke(
         return durationMonths.error();
     }
 
+    static_assert(
+        std::is_trivially_copyable_v<std::remove_reference_t<
+            decltype(std::declval<GiftSubscription>().cumulativeTotal)>>);
     std::optional<int> cumulativeTotal = std::nullopt;
     const auto *jvcumulativeTotal = root.if_contains("cumulative_total");
     if (jvcumulativeTotal != nullptr && !jvcumulativeTotal->is_null())
@@ -572,9 +607,12 @@ boost::json::result_for<GiftSubscription, boost::json::value>::type tag_invoke(
         {
             return tcumulativeTotal.error();
         }
-        cumulativeTotal = std::move(tcumulativeTotal.value());
+        cumulativeTotal = tcumulativeTotal.value();
     }
 
+    static_assert(
+        std::is_trivially_copyable_v<std::remove_reference_t<
+            decltype(std::declval<GiftSubscription>().streakMonths)>>);
     std::optional<int> streakMonths = std::nullopt;
     const auto *jvstreakMonths = root.if_contains("streak_months");
     if (jvstreakMonths != nullptr && !jvstreakMonths->is_null())
@@ -585,7 +623,7 @@ boost::json::result_for<GiftSubscription, boost::json::value>::type tag_invoke(
         {
             return tstreakMonths.error();
         }
-        streakMonths = std::move(tstreakMonths.value());
+        streakMonths = tstreakMonths.value();
     }
 
     const auto *jvrecipientUserID = root.if_contains("recipient_user_id");
@@ -658,9 +696,9 @@ boost::json::result_for<GiftSubscription, boost::json::value>::type tag_invoke(
     }
 
     return GiftSubscription{
-        .durationMonths = std::move(durationMonths.value()),
-        .cumulativeTotal = std::move(cumulativeTotal),
-        .streakMonths = std::move(streakMonths),
+        .durationMonths = durationMonths.value(),
+        .cumulativeTotal = cumulativeTotal,
+        .streakMonths = streakMonths,
         .recipientUserID = std::move(recipientUserID.value()),
         .recipientUserName = std::move(recipientUserName.value()),
         .recipientUserLogin = std::move(recipientUserLogin.value()),
@@ -670,8 +708,9 @@ boost::json::result_for<GiftSubscription, boost::json::value>::type tag_invoke(
 }
 
 boost::json::result_for<CommunityGiftSubscription, boost::json::value>::type
-    tag_invoke(boost::json::try_value_to_tag<CommunityGiftSubscription>,
-               const boost::json::value &jvRoot)
+    tag_invoke(
+        boost::json::try_value_to_tag<CommunityGiftSubscription> /* tag */,
+        const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {
@@ -692,6 +731,9 @@ boost::json::result_for<CommunityGiftSubscription, boost::json::value>::type
         return id.error();
     }
 
+    static_assert(
+        std::is_trivially_copyable_v<std::remove_reference_t<
+            decltype(std::declval<CommunityGiftSubscription>().total)>>);
     const auto *jvtotal = root.if_contains("total");
     if (jvtotal == nullptr)
     {
@@ -718,6 +760,9 @@ boost::json::result_for<CommunityGiftSubscription, boost::json::value>::type
         return subTier.error();
     }
 
+    static_assert(std::is_trivially_copyable_v<std::remove_reference_t<
+                      decltype(std::declval<CommunityGiftSubscription>()
+                                   .cumulativeTotal)>>);
     std::optional<int> cumulativeTotal = std::nullopt;
     const auto *jvcumulativeTotal = root.if_contains("cumulative_total");
     if (jvcumulativeTotal != nullptr && !jvcumulativeTotal->is_null())
@@ -729,19 +774,19 @@ boost::json::result_for<CommunityGiftSubscription, boost::json::value>::type
         {
             return tcumulativeTotal.error();
         }
-        cumulativeTotal = std::move(tcumulativeTotal.value());
+        cumulativeTotal = tcumulativeTotal.value();
     }
 
     return CommunityGiftSubscription{
         .id = std::move(id.value()),
-        .total = std::move(total.value()),
+        .total = total.value(),
         .subTier = std::move(subTier.value()),
-        .cumulativeTotal = std::move(cumulativeTotal),
+        .cumulativeTotal = cumulativeTotal,
     };
 }
 
 boost::json::result_for<GiftPaidUpgrade, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<GiftPaidUpgrade>,
+    boost::json::try_value_to_tag<GiftPaidUpgrade> /* tag */,
     const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
@@ -750,6 +795,9 @@ boost::json::result_for<GiftPaidUpgrade, boost::json::value>::type tag_invoke(
     }
     const auto &root = jvRoot.get_object();
 
+    static_assert(
+        std::is_trivially_copyable_v<std::remove_reference_t<
+            decltype(std::declval<GiftPaidUpgrade>().gifterIsAnonymous)>>);
     const auto *jvgifterIsAnonymous = root.if_contains("gifter_is_anonymous");
     if (jvgifterIsAnonymous == nullptr)
     {
@@ -807,7 +855,7 @@ boost::json::result_for<GiftPaidUpgrade, boost::json::value>::type tag_invoke(
     }
 
     return GiftPaidUpgrade{
-        .gifterIsAnonymous = std::move(gifterIsAnonymous.value()),
+        .gifterIsAnonymous = gifterIsAnonymous.value(),
         .gifterUserID = std::move(gifterUserID),
         .gifterUserName = std::move(gifterUserName),
         .gifterUserLogin = std::move(gifterUserLogin),
@@ -815,7 +863,7 @@ boost::json::result_for<GiftPaidUpgrade, boost::json::value>::type tag_invoke(
 }
 
 boost::json::result_for<PrimePaidUpgrade, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<PrimePaidUpgrade>,
+    boost::json::try_value_to_tag<PrimePaidUpgrade> /* tag */,
     const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
@@ -843,7 +891,8 @@ boost::json::result_for<PrimePaidUpgrade, boost::json::value>::type tag_invoke(
 }
 
 boost::json::result_for<Raid, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Raid>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Raid> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {
@@ -890,6 +939,8 @@ boost::json::result_for<Raid, boost::json::value>::type tag_invoke(
         return userLogin.error();
     }
 
+    static_assert(std::is_trivially_copyable_v<std::remove_reference_t<
+                      decltype(std::declval<Raid>().viewerCount)>>);
     const auto *jvviewerCount = root.if_contains("viewer_count");
     if (jvviewerCount == nullptr)
     {
@@ -921,25 +972,20 @@ boost::json::result_for<Raid, boost::json::value>::type tag_invoke(
         .userID = std::move(userID.value()),
         .userName = std::move(userName.value()),
         .userLogin = std::move(userLogin.value()),
-        .viewerCount = std::move(viewerCount.value()),
+        .viewerCount = viewerCount.value(),
         .profileImageURL = std::move(profileImageURL.value()),
     };
 }
 
 boost::json::result_for<Unraid, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Unraid>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Unraid> /* tag */,
+    const boost::json::value &jvRoot)
 {
-    if (!jvRoot.is_object())
-    {
-        EVENTSUB_BAIL_HERE(error::Kind::ExpectedObject);
-    }
-    const auto &root = jvRoot.get_object();
-
     return Unraid{};
 }
 
 boost::json::result_for<PayItForward, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<PayItForward>,
+    boost::json::try_value_to_tag<PayItForward> /* tag */,
     const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
@@ -948,6 +994,9 @@ boost::json::result_for<PayItForward, boost::json::value>::type tag_invoke(
     }
     const auto &root = jvRoot.get_object();
 
+    static_assert(
+        std::is_trivially_copyable_v<std::remove_reference_t<
+            decltype(std::declval<PayItForward>().gifterIsAnonymous)>>);
     const auto *jvgifterIsAnonymous = root.if_contains("gifter_is_anonymous");
     if (jvgifterIsAnonymous == nullptr)
     {
@@ -1005,7 +1054,7 @@ boost::json::result_for<PayItForward, boost::json::value>::type tag_invoke(
     }
 
     return PayItForward{
-        .gifterIsAnonymous = std::move(gifterIsAnonymous.value()),
+        .gifterIsAnonymous = gifterIsAnonymous.value(),
         .gifterUserID = std::move(gifterUserID),
         .gifterUserName = std::move(gifterUserName),
         .gifterUserLogin = std::move(gifterUserLogin),
@@ -1013,7 +1062,7 @@ boost::json::result_for<PayItForward, boost::json::value>::type tag_invoke(
 }
 
 boost::json::result_for<Announcement, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Announcement>,
+    boost::json::try_value_to_tag<Announcement> /* tag */,
     const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
@@ -1041,7 +1090,7 @@ boost::json::result_for<Announcement, boost::json::value>::type tag_invoke(
 }
 
 boost::json::result_for<CharityDonationAmount, boost::json::value>::type
-    tag_invoke(boost::json::try_value_to_tag<CharityDonationAmount>,
+    tag_invoke(boost::json::try_value_to_tag<CharityDonationAmount> /* tag */,
                const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
@@ -1050,6 +1099,8 @@ boost::json::result_for<CharityDonationAmount, boost::json::value>::type
     }
     const auto &root = jvRoot.get_object();
 
+    static_assert(std::is_trivially_copyable_v<std::remove_reference_t<
+                      decltype(std::declval<CharityDonationAmount>().value)>>);
     const auto *jvvalue = root.if_contains("value");
     if (jvvalue == nullptr)
     {
@@ -1063,6 +1114,9 @@ boost::json::result_for<CharityDonationAmount, boost::json::value>::type
         return value.error();
     }
 
+    static_assert(
+        std::is_trivially_copyable_v<std::remove_reference_t<
+            decltype(std::declval<CharityDonationAmount>().decimalPlaces)>>);
     const auto *jvdecimalPlaces = root.if_contains("decimal_places");
     if (jvdecimalPlaces == nullptr)
     {
@@ -1090,14 +1144,14 @@ boost::json::result_for<CharityDonationAmount, boost::json::value>::type
     }
 
     return CharityDonationAmount{
-        .value = std::move(value.value()),
-        .decimalPlaces = std::move(decimalPlaces.value()),
+        .value = value.value(),
+        .decimalPlaces = decimalPlaces.value(),
         .currency = std::move(currency.value()),
     };
 }
 
 boost::json::result_for<CharityDonation, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<CharityDonation>,
+    boost::json::try_value_to_tag<CharityDonation> /* tag */,
     const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
@@ -1139,7 +1193,7 @@ boost::json::result_for<CharityDonation, boost::json::value>::type tag_invoke(
 }
 
 boost::json::result_for<BitsBadgeTier, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<BitsBadgeTier>,
+    boost::json::try_value_to_tag<BitsBadgeTier> /* tag */,
     const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
@@ -1148,6 +1202,8 @@ boost::json::result_for<BitsBadgeTier, boost::json::value>::type tag_invoke(
     }
     const auto &root = jvRoot.get_object();
 
+    static_assert(std::is_trivially_copyable_v<std::remove_reference_t<
+                      decltype(std::declval<BitsBadgeTier>().tier)>>);
     const auto *jvtier = root.if_contains("tier");
     if (jvtier == nullptr)
     {
@@ -1162,12 +1218,13 @@ boost::json::result_for<BitsBadgeTier, boost::json::value>::type tag_invoke(
     }
 
     return BitsBadgeTier{
-        .tier = std::move(tier.value()),
+        .tier = tier.value(),
     };
 }
 
 boost::json::result_for<Message, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Message>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Message> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {
@@ -1193,7 +1250,7 @@ boost::json::result_for<Message, boost::json::value>::type tag_invoke(
     {
         EVENTSUB_BAIL_HERE(error::Kind::FieldMissing);
     }
-    const auto fragments =
+    auto fragments =
         boost::json::try_value_to<std::vector<MessageFragment>>(*jvfragments);
     if (fragments.has_error())
     {
@@ -1202,12 +1259,13 @@ boost::json::result_for<Message, boost::json::value>::type tag_invoke(
 
     return Message{
         .text = std::move(text.value()),
-        .fragments = fragments.value(),
+        .fragments = std::move(fragments.value()),
     };
 }
 
 boost::json::result_for<Event, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Event>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Event> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {
@@ -1301,6 +1359,8 @@ boost::json::result_for<Event, boost::json::value>::type tag_invoke(
         return chatterUserName.error();
     }
 
+    static_assert(std::is_trivially_copyable_v<std::remove_reference_t<
+                      decltype(std::declval<Event>().chatterIsAnonymous)>>);
     const auto *jvchatterIsAnonymous = root.if_contains("chatter_is_anonymous");
     if (jvchatterIsAnonymous == nullptr)
     {
@@ -1333,8 +1393,7 @@ boost::json::result_for<Event, boost::json::value>::type tag_invoke(
     {
         EVENTSUB_BAIL_HERE(error::Kind::FieldMissing);
     }
-    const auto badges =
-        boost::json::try_value_to<std::vector<Badge>>(*jvbadges);
+    auto badges = boost::json::try_value_to<std::vector<Badge>>(*jvbadges);
     if (badges.has_error())
     {
         return badges.error();
@@ -1488,6 +1547,9 @@ boost::json::result_for<Event, boost::json::value>::type tag_invoke(
         raid = std::move(traid.value());
     }
 
+    static_assert(
+        std::is_trivially_copyable_v<
+            std::remove_reference_t<decltype(std::declval<Event>().unraid)>>);
     std::optional<Unraid> unraid = std::nullopt;
     const auto *jvunraid = root.if_contains("unraid");
     if (jvunraid != nullptr && !jvunraid->is_null())
@@ -1498,7 +1560,7 @@ boost::json::result_for<Event, boost::json::value>::type tag_invoke(
         {
             return tunraid.error();
         }
-        unraid = std::move(tunraid.value());
+        unraid = tunraid.value();
     }
 
     std::optional<PayItForward> payItForward = std::nullopt;
@@ -1543,6 +1605,8 @@ boost::json::result_for<Event, boost::json::value>::type tag_invoke(
         charityDonation = std::move(tcharityDonation.value());
     }
 
+    static_assert(std::is_trivially_copyable_v<std::remove_reference_t<
+                      decltype(std::declval<Event>().bitsBadgeTier)>>);
     std::optional<BitsBadgeTier> bitsBadgeTier = std::nullopt;
     const auto *jvbitsBadgeTier = root.if_contains("bits_badge_tier");
     if (jvbitsBadgeTier != nullptr && !jvbitsBadgeTier->is_null())
@@ -1554,7 +1618,7 @@ boost::json::result_for<Event, boost::json::value>::type tag_invoke(
         {
             return tbitsBadgeTier.error();
         }
-        bitsBadgeTier = std::move(tbitsBadgeTier.value());
+        bitsBadgeTier = tbitsBadgeTier.value();
     }
 
     return Event{
@@ -1564,9 +1628,9 @@ boost::json::result_for<Event, boost::json::value>::type tag_invoke(
         .chatterUserID = std::move(chatterUserID.value()),
         .chatterUserLogin = std::move(chatterUserLogin.value()),
         .chatterUserName = std::move(chatterUserName.value()),
-        .chatterIsAnonymous = std::move(chatterIsAnonymous.value()),
+        .chatterIsAnonymous = chatterIsAnonymous.value(),
         .color = std::move(color.value()),
-        .badges = badges.value(),
+        .badges = std::move(badges.value()),
         .systemMessage = std::move(systemMessage.value()),
         .messageID = std::move(messageID.value()),
         .message = std::move(message.value()),
@@ -1578,16 +1642,17 @@ boost::json::result_for<Event, boost::json::value>::type tag_invoke(
         .giftPaidUpgrade = std::move(giftPaidUpgrade),
         .primePaidUpgrade = std::move(primePaidUpgrade),
         .raid = std::move(raid),
-        .unraid = std::move(unraid),
+        .unraid = unraid,
         .payItForward = std::move(payItForward),
         .announcement = std::move(announcement),
         .charityDonation = std::move(charityDonation),
-        .bitsBadgeTier = std::move(bitsBadgeTier),
+        .bitsBadgeTier = bitsBadgeTier,
     };
 }
 
 boost::json::result_for<Payload, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Payload>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Payload> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {

--- a/lib/twitch-eventsub-ws/src/generated/payloads/channel-moderate-v2.cpp
+++ b/lib/twitch-eventsub-ws/src/generated/payloads/channel-moderate-v2.cpp
@@ -8,7 +8,8 @@
 namespace chatterino::eventsub::lib::payload::channel_moderate::v2 {
 
 boost::json::result_for<Action, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Action>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Action> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_string())
     {
@@ -158,7 +159,8 @@ boost::json::result_for<Action, boost::json::value>::type tag_invoke(
 }
 
 boost::json::result_for<Followers, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Followers>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Followers> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {
@@ -166,6 +168,9 @@ boost::json::result_for<Followers, boost::json::value>::type tag_invoke(
     }
     const auto &root = jvRoot.get_object();
 
+    static_assert(
+        std::is_trivially_copyable_v<std::remove_reference_t<
+            decltype(std::declval<Followers>().followDurationMinutes)>>);
     const auto *jvfollowDurationMinutes =
         root.if_contains("follow_duration_minutes");
     if (jvfollowDurationMinutes == nullptr)
@@ -182,12 +187,13 @@ boost::json::result_for<Followers, boost::json::value>::type tag_invoke(
     }
 
     return Followers{
-        .followDurationMinutes = std::move(followDurationMinutes.value()),
+        .followDurationMinutes = followDurationMinutes.value(),
     };
 }
 
 boost::json::result_for<Slow, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Slow>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Slow> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {
@@ -195,6 +201,8 @@ boost::json::result_for<Slow, boost::json::value>::type tag_invoke(
     }
     const auto &root = jvRoot.get_object();
 
+    static_assert(std::is_trivially_copyable_v<std::remove_reference_t<
+                      decltype(std::declval<Slow>().waitTimeSeconds)>>);
     const auto *jvwaitTimeSeconds = root.if_contains("wait_time_seconds");
     if (jvwaitTimeSeconds == nullptr)
     {
@@ -209,12 +217,13 @@ boost::json::result_for<Slow, boost::json::value>::type tag_invoke(
     }
 
     return Slow{
-        .waitTimeSeconds = std::move(waitTimeSeconds.value()),
+        .waitTimeSeconds = waitTimeSeconds.value(),
     };
 }
 
 boost::json::result_for<Vip, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Vip>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Vip> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {
@@ -269,7 +278,8 @@ boost::json::result_for<Vip, boost::json::value>::type tag_invoke(
 }
 
 boost::json::result_for<Unvip, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Unvip>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Unvip> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {
@@ -324,7 +334,8 @@ boost::json::result_for<Unvip, boost::json::value>::type tag_invoke(
 }
 
 boost::json::result_for<Mod, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Mod>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Mod> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {
@@ -379,7 +390,8 @@ boost::json::result_for<Mod, boost::json::value>::type tag_invoke(
 }
 
 boost::json::result_for<Unmod, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Unmod>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Unmod> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {
@@ -434,7 +446,8 @@ boost::json::result_for<Unmod, boost::json::value>::type tag_invoke(
 }
 
 boost::json::result_for<Ban, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Ban>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Ban> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {
@@ -503,7 +516,8 @@ boost::json::result_for<Ban, boost::json::value>::type tag_invoke(
 }
 
 boost::json::result_for<Unban, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Unban>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Unban> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {
@@ -558,7 +572,8 @@ boost::json::result_for<Unban, boost::json::value>::type tag_invoke(
 }
 
 boost::json::result_for<Timeout, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Timeout>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Timeout> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {
@@ -641,7 +656,8 @@ boost::json::result_for<Timeout, boost::json::value>::type tag_invoke(
 }
 
 boost::json::result_for<Untimeout, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Untimeout>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Untimeout> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {
@@ -696,7 +712,8 @@ boost::json::result_for<Untimeout, boost::json::value>::type tag_invoke(
 }
 
 boost::json::result_for<Raid, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Raid>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Raid> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {
@@ -743,6 +760,8 @@ boost::json::result_for<Raid, boost::json::value>::type tag_invoke(
         return userName.error();
     }
 
+    static_assert(std::is_trivially_copyable_v<std::remove_reference_t<
+                      decltype(std::declval<Raid>().viewerCount)>>);
     const auto *jvviewerCount = root.if_contains("viewer_count");
     if (jvviewerCount == nullptr)
     {
@@ -760,12 +779,13 @@ boost::json::result_for<Raid, boost::json::value>::type tag_invoke(
         .userID = std::move(userID.value()),
         .userLogin = std::move(userLogin.value()),
         .userName = std::move(userName.value()),
-        .viewerCount = std::move(viewerCount.value()),
+        .viewerCount = viewerCount.value(),
     };
 }
 
 boost::json::result_for<Unraid, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Unraid>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Unraid> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {
@@ -820,7 +840,8 @@ boost::json::result_for<Unraid, boost::json::value>::type tag_invoke(
 }
 
 boost::json::result_for<Delete, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Delete>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Delete> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {
@@ -903,7 +924,7 @@ boost::json::result_for<Delete, boost::json::value>::type tag_invoke(
 }
 
 boost::json::result_for<AutomodTerms, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<AutomodTerms>,
+    boost::json::try_value_to_tag<AutomodTerms> /* tag */,
     const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
@@ -943,13 +964,14 @@ boost::json::result_for<AutomodTerms, boost::json::value>::type tag_invoke(
     {
         EVENTSUB_BAIL_HERE(error::Kind::FieldMissing);
     }
-    const auto terms =
-        boost::json::try_value_to<std::vector<std::string>>(*jvterms);
+    auto terms = boost::json::try_value_to<std::vector<std::string>>(*jvterms);
     if (terms.has_error())
     {
         return terms.error();
     }
 
+    static_assert(std::is_trivially_copyable_v<std::remove_reference_t<
+                      decltype(std::declval<AutomodTerms>().fromAutomod)>>);
     const auto *jvfromAutomod = root.if_contains("from_automod");
     if (jvfromAutomod == nullptr)
     {
@@ -966,13 +988,13 @@ boost::json::result_for<AutomodTerms, boost::json::value>::type tag_invoke(
     return AutomodTerms{
         .action = std::move(action.value()),
         .list = std::move(list.value()),
-        .terms = terms.value(),
-        .fromAutomod = std::move(fromAutomod.value()),
+        .terms = std::move(terms.value()),
+        .fromAutomod = fromAutomod.value(),
     };
 }
 
 boost::json::result_for<UnbanRequest, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<UnbanRequest>,
+    boost::json::try_value_to_tag<UnbanRequest> /* tag */,
     const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
@@ -981,6 +1003,8 @@ boost::json::result_for<UnbanRequest, boost::json::value>::type tag_invoke(
     }
     const auto &root = jvRoot.get_object();
 
+    static_assert(std::is_trivially_copyable_v<std::remove_reference_t<
+                      decltype(std::declval<UnbanRequest>().isApproved)>>);
     const auto *jvisApproved = root.if_contains("is_approved");
     if (jvisApproved == nullptr)
     {
@@ -1048,7 +1072,7 @@ boost::json::result_for<UnbanRequest, boost::json::value>::type tag_invoke(
     }
 
     return UnbanRequest{
-        .isApproved = std::move(isApproved.value()),
+        .isApproved = isApproved.value(),
         .userID = std::move(userID.value()),
         .userLogin = std::move(userLogin.value()),
         .userName = std::move(userName.value()),
@@ -1057,7 +1081,8 @@ boost::json::result_for<UnbanRequest, boost::json::value>::type tag_invoke(
 }
 
 boost::json::result_for<Warn, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Warn>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Warn> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {
@@ -1122,7 +1147,7 @@ boost::json::result_for<Warn, boost::json::value>::type tag_invoke(
     {
         EVENTSUB_BAIL_HERE(error::Kind::FieldMissing);
     }
-    const auto chatRulesCited =
+    auto chatRulesCited =
         boost::json::try_value_to<std::vector<std::string>>(*jvchatRulesCited);
     if (chatRulesCited.has_error())
     {
@@ -1134,12 +1159,13 @@ boost::json::result_for<Warn, boost::json::value>::type tag_invoke(
         .userLogin = std::move(userLogin.value()),
         .userName = std::move(userName.value()),
         .reason = std::move(reason.value()),
-        .chatRulesCited = chatRulesCited.value(),
+        .chatRulesCited = std::move(chatRulesCited.value()),
     };
 }
 
 boost::json::result_for<Event, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Event>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Event> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {
@@ -1285,6 +1311,9 @@ boost::json::result_for<Event, boost::json::value>::type tag_invoke(
         return moderatorUserName.error();
     }
 
+    static_assert(
+        std::is_trivially_copyable_v<
+            std::remove_reference_t<decltype(std::declval<Event>().action)>>);
     const auto *jvaction = root.if_contains("action");
     if (jvaction == nullptr)
     {
@@ -1298,6 +1327,8 @@ boost::json::result_for<Event, boost::json::value>::type tag_invoke(
         return action.error();
     }
 
+    static_assert(std::is_trivially_copyable_v<std::remove_reference_t<
+                      decltype(std::declval<Event>().followers)>>);
     std::optional<Followers> followers = std::nullopt;
     const auto *jvfollowers = root.if_contains("followers");
     if (jvfollowers != nullptr && !jvfollowers->is_null())
@@ -1308,9 +1339,12 @@ boost::json::result_for<Event, boost::json::value>::type tag_invoke(
         {
             return tfollowers.error();
         }
-        followers = std::move(tfollowers.value());
+        followers = tfollowers.value();
     }
 
+    static_assert(
+        std::is_trivially_copyable_v<
+            std::remove_reference_t<decltype(std::declval<Event>().slow)>>);
     std::optional<Slow> slow = std::nullopt;
     const auto *jvslow = root.if_contains("slow");
     if (jvslow != nullptr && !jvslow->is_null())
@@ -1321,7 +1355,7 @@ boost::json::result_for<Event, boost::json::value>::type tag_invoke(
         {
             return tslow.error();
         }
-        slow = std::move(tslow.value());
+        slow = tslow.value();
     }
 
     std::optional<Vip> vip = std::nullopt;
@@ -1576,9 +1610,9 @@ boost::json::result_for<Event, boost::json::value>::type tag_invoke(
         .moderatorUserID = std::move(moderatorUserID.value()),
         .moderatorUserLogin = std::move(moderatorUserLogin.value()),
         .moderatorUserName = std::move(moderatorUserName.value()),
-        .action = std::move(action.value()),
-        .followers = std::move(followers),
-        .slow = std::move(slow),
+        .action = action.value(),
+        .followers = followers,
+        .slow = slow,
         .vip = std::move(vip),
         .unvip = std::move(unvip),
         .unmod = std::move(unmod),
@@ -1601,7 +1635,8 @@ boost::json::result_for<Event, boost::json::value>::type tag_invoke(
 }
 
 boost::json::result_for<Payload, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Payload>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Payload> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {

--- a/lib/twitch-eventsub-ws/src/generated/payloads/channel-update-v1.cpp
+++ b/lib/twitch-eventsub-ws/src/generated/payloads/channel-update-v1.cpp
@@ -8,7 +8,8 @@
 namespace chatterino::eventsub::lib::payload::channel_update::v1 {
 
 boost::json::result_for<Event, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Event>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Event> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {
@@ -112,6 +113,9 @@ boost::json::result_for<Event, boost::json::value>::type tag_invoke(
         return categoryName.error();
     }
 
+    static_assert(
+        std::is_trivially_copyable_v<
+            std::remove_reference_t<decltype(std::declval<Event>().isMature)>>);
     const auto *jvisMature = root.if_contains("is_mature");
     if (jvisMature == nullptr)
     {
@@ -133,12 +137,13 @@ boost::json::result_for<Event, boost::json::value>::type tag_invoke(
         .language = std::move(language.value()),
         .categoryID = std::move(categoryID.value()),
         .categoryName = std::move(categoryName.value()),
-        .isMature = std::move(isMature.value()),
+        .isMature = isMature.value(),
     };
 }
 
 boost::json::result_for<Payload, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Payload>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Payload> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {

--- a/lib/twitch-eventsub-ws/src/generated/payloads/session-welcome.cpp
+++ b/lib/twitch-eventsub-ws/src/generated/payloads/session-welcome.cpp
@@ -8,7 +8,8 @@
 namespace chatterino::eventsub::lib::payload::session_welcome {
 
 boost::json::result_for<Payload, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Payload>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Payload> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {

--- a/lib/twitch-eventsub-ws/src/generated/payloads/stream-offline-v1.cpp
+++ b/lib/twitch-eventsub-ws/src/generated/payloads/stream-offline-v1.cpp
@@ -8,7 +8,8 @@
 namespace chatterino::eventsub::lib::payload::stream_offline::v1 {
 
 boost::json::result_for<Event, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Event>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Event> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {
@@ -68,7 +69,8 @@ boost::json::result_for<Event, boost::json::value>::type tag_invoke(
 }
 
 boost::json::result_for<Payload, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Payload>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Payload> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {

--- a/lib/twitch-eventsub-ws/src/generated/payloads/stream-online-v1.cpp
+++ b/lib/twitch-eventsub-ws/src/generated/payloads/stream-online-v1.cpp
@@ -8,7 +8,8 @@
 namespace chatterino::eventsub::lib::payload::stream_online::v1 {
 
 boost::json::result_for<Event, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Event>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Event> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {
@@ -110,7 +111,8 @@ boost::json::result_for<Event, boost::json::value>::type tag_invoke(
 }
 
 boost::json::result_for<Payload, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Payload>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Payload> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {

--- a/lib/twitch-eventsub-ws/src/generated/payloads/subscription.cpp
+++ b/lib/twitch-eventsub-ws/src/generated/payloads/subscription.cpp
@@ -8,7 +8,8 @@
 namespace chatterino::eventsub::lib::payload::subscription {
 
 boost::json::result_for<Transport, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Transport>, const boost::json::value &jvRoot)
+    boost::json::try_value_to_tag<Transport> /* tag */,
+    const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
     {
@@ -49,7 +50,7 @@ boost::json::result_for<Transport, boost::json::value>::type tag_invoke(
 }
 
 boost::json::result_for<Subscription, boost::json::value>::type tag_invoke(
-    boost::json::try_value_to_tag<Subscription>,
+    boost::json::try_value_to_tag<Subscription> /* tag */,
     const boost::json::value &jvRoot)
 {
     if (!jvRoot.is_object())
@@ -136,6 +137,8 @@ boost::json::result_for<Subscription, boost::json::value>::type tag_invoke(
         return createdAt.error();
     }
 
+    static_assert(std::is_trivially_copyable_v<std::remove_reference_t<
+                      decltype(std::declval<Subscription>().cost)>>);
     const auto *jvcost = root.if_contains("cost");
     if (jvcost == nullptr)
     {
@@ -156,7 +159,7 @@ boost::json::result_for<Subscription, boost::json::value>::type tag_invoke(
         .version = std::move(version.value()),
         .transport = std::move(transport.value()),
         .createdAt = std::move(createdAt.value()),
-        .cost = std::move(cost.value()),
+        .cost = cost.value(),
     };
 }
 


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
- Adds `/* tag */` to tag argument in `tag_invoke`
- Removes `std::move` for (known) trivially copyable types - we have to emulate `std::is_trivially_copyable` a bit. We have `static_assert`s to make sure that's actually true
- Uses `std::move` for vectors (they were copied before)
- Types without members won't create a `root` variable anymore

Fixes #5913.