### PR TITLE
chore: disable Qt5 builds in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,6 @@ concurrency:
 env:
   C2_ENABLE_LTO: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/bugfix-release/') || startsWith(github.ref, 'refs/heads/release/') }}
   CHATTERINO_REQUIRE_CLEAN_GIT: On
-  C2_BUILD_WITH_QT6: Off
   CONAN_VERSION: 2.11.0
 
 jobs:
@@ -143,7 +142,7 @@ jobs:
         include:
           # macOS
           - os: macos-13
-            qt-version: 5.15.2
+            qt-version: 6.7.1
             force-lto: false
             plugins: true
             skip-artifact: false
@@ -155,36 +154,18 @@ jobs:
             plugins: true
             skip-artifact: false
             skip-crashpad: false
-          # Windows 7/8
-          - os: windows-latest
-            qt-version: 5.15.2
-            force-lto: false
-            plugins: true
-            skip-artifact: false
-            skip-crashpad: true
 
       fail-fast: false
     env:
       C2_ENABLE_LTO: ${{ matrix.force-lto }}
       C2_PLUGINS: ${{ matrix.plugins }}
       C2_ENABLE_CRASHPAD: ${{ matrix.skip-crashpad == false }}
-      C2_BUILD_WITH_QT6: ${{ startsWith(matrix.qt-version, '6.') }}
-      C2_USE_OPENSSL3: ${{ startsWith(matrix.qt-version, '6.') && 'True' || 'False' }}
-      C2_CONAN_CACHE_SUFFIX: ${{ startsWith(matrix.qt-version, '6.') && '-QT6' || '' }}
 
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0 # allows for tags access
-
-      - name: Install Qt5
-        if: startsWith(matrix.qt-version, '5.')
-        uses: jurplel/install-qt-action@v4.1.1
-        with:
-          cache: true
-          cache-key-prefix: ${{ runner.os }}-QtCache-${{ matrix.qt-version }}-v2
-          version: ${{ matrix.qt-version }}
 
       - name: Install Qt6
         if: startsWith(matrix.qt-version, '6.')
@@ -216,7 +197,7 @@ jobs:
         if: startsWith(matrix.os, 'windows')
         uses: actions/cache@v4
         with:
-          key: ${{ runner.os }}-conan-user-${{ hashFiles('**/conanfile.py') }}${{ env.C2_CONAN_CACHE_SUFFIX }}
+          key: ${{ runner.os }}-conan-user-${{ hashFiles('**/conanfile.py') }}-QT6
           path: ~/.conan2/
 
       - name: Install Conan (Windows)
@@ -243,7 +224,7 @@ jobs:
               -c tools.cmake.cmaketoolchain:generator="NMake Makefiles" `
               -b missing `
               --output-folder=. `
-              -o with_openssl3="$Env:C2_USE_OPENSSL3"
+              -o with_openssl3="True"
         shell: powershell
 
       - name: Build (Windows)
@@ -259,7 +240,6 @@ jobs:
               -DBUILD_WITH_CRASHPAD="$Env:C2_ENABLE_CRASHPAD" `
               -DCHATTERINO_LTO="$Env:C2_ENABLE_LTO" `
               -DCHATTERINO_PLUGINS="$Env:C2_PLUGINS" `
-              -DBUILD_WITH_QT6="$Env:C2_BUILD_WITH_QT6" `
               -DFORCE_JSON_GENERATION=On `
               ..
           set cl=/MP
@@ -329,7 +309,6 @@ jobs:
               -DUSE_PRECOMPILED_HEADERS=OFF \
               -DCHATTERINO_LTO="$C2_ENABLE_LTO" \
               -DCHATTERINO_PLUGINS="$C2_PLUGINS" \
-              -DBUILD_WITH_QT6="$C2_BUILD_WITH_QT6" \
               -DFORCE_JSON_GENERATION=Off \
               ..
           make -j"$(sysctl -n hw.logicalcpu)"
@@ -378,12 +357,6 @@ jobs:
           name: chatterino-windows-x86-64-Qt-6.7.1-symbols.pdb.7z
           path: release-artifacts/
 
-      - uses: actions/download-artifact@v4
-        name: Windows Qt5.15.2
-        with:
-          name: chatterino-windows-x86-64-Qt-5.15.2.zip
-          path: release-artifacts/
-
       # Linux
       - uses: actions/download-artifact@v4
         name: Linux AppImage
@@ -412,15 +385,6 @@ jobs:
       - name: Copy flatpakref
         run: |
           cp .CI/chatterino-nightly.flatpakref release-artifacts/
-        shell: bash
-
-      - name: Rename artifacts
-        run: |
-          ls -l
-
-          # Mark all Windows Qt5 builds as old
-          mv chatterino-windows-x86-64-Qt-5.15.2.zip chatterino-windows-old-x86-64-Qt-5.15.2.zip
-        working-directory: release-artifacts
         shell: bash
 
       - name: Setup Python

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -24,11 +24,10 @@ jobs:
     strategy:
       matrix:
         os: [macos-13]
-        qt-version: [5.15.2, 6.7.1]
+        qt-version: [6.7.1]
         plugins: [true]
       fail-fast: false
     env:
-      C2_BUILD_WITH_QT6: ${{ startsWith(matrix.qt-version, '6.') && 'ON' || 'OFF' }}
       QT_MODULES: ${{ startsWith(matrix.qt-version, '6.') && 'qt5compat qtimageformats' || '' }}
 
     steps:
@@ -36,11 +35,6 @@ jobs:
         if: matrix.plugins
         run: |
           echo "C2_PLUGINS=ON" >> "$GITHUB_ENV"
-
-      - name: Set BUILD_WITH_QT6
-        if: startsWith(matrix.qt-version, '6.')
-        run: |
-          echo "C2_BUILD_WITH_QT6=ON" >> "$GITHUB_ENV"
 
       - uses: actions/checkout@v4
         with:
@@ -76,7 +70,6 @@ jobs:
               -DBUILD_APP=OFF \
               -DUSE_PRECOMPILED_HEADERS=OFF \
               -DCHATTERINO_PLUGINS="$C2_PLUGINS" \
-              -DBUILD_WITH_QT6="$C2_BUILD_WITH_QT6" \
               ..
           make -j"$(sysctl -n hw.logicalcpu)"
 

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -23,13 +23,12 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        qt-version: [5.15.2, 6.7.1]
+        qt-version: [6.7.1]
         plugins: [true]
         skip-artifact: [false]
         skip-crashpad: [false]
       fail-fast: false
     env:
-      C2_BUILD_WITH_QT6: ${{ startsWith(matrix.qt-version, '6.') && 'ON' || 'OFF' }}
       QT_MODULES: ${{ startsWith(matrix.qt-version, '6.') && 'qt5compat qtimageformats' || '' }}
       C2_USE_OPENSSL3: ${{ startsWith(matrix.qt-version, '6.') && 'True' || 'False' }}
       C2_CONAN_CACHE_SUFFIX: ${{ startsWith(matrix.qt-version, '6.') && '-QT6' || '' }}
@@ -44,11 +43,6 @@ jobs:
         if: matrix.skip-crashpad == false
         run: |
           echo "C2_ENABLE_CRASHPAD=ON" >> "$Env:GITHUB_ENV"
-
-      - name: Set BUILD_WITH_QT6
-        if: startsWith(matrix.qt-version, '6.')
-        run: |
-          echo "C2_BUILD_WITH_QT6=ON" >> "$Env:GITHUB_ENV"
 
       - uses: actions/checkout@v4
         with:
@@ -128,7 +122,6 @@ jobs:
               -DUSE_PRECOMPILED_HEADERS=On `
               -DBUILD_WITH_CRASHPAD="$Env:C2_ENABLE_CRASHPAD" `
               -DCHATTERINO_PLUGINS="$Env:C2_PLUGINS" `
-              -DBUILD_WITH_QT6="$Env:C2_BUILD_WITH_QT6" `
               ..
           set cl=/MP
           nmake /S /NOLOGO

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Dev: Disable QT keywords (i.e. `emit`, `slots`, and `signals`). (#5882)
 - Dev: Replaced usage of `parseTime` with `serverReceivedTime` for clearchat messages. (#5824, #5855)
 - Dev: Support Boost 1.87. (#5832)
+- Dev: Stopped building Qt5 builds in CI. (#5933)
 - Dev: Words from `TextElement`s are now combined where possible. (#5847)
 - Dev: Fixed assertion failure when closing the edit-hotkey dialog. (#5869)
 - Dev: Updated `qtkeychain` to 0.15.0. (#5871)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ endif()
 if (BUILD_WITH_QT6)
     set(MAJOR_QT_VERSION "6")
 else()
+    message(WARNING "Qt5 is not supported, continue building at your own risk")
     set(MAJOR_QT_VERSION "5")
 endif()
 


### PR DESCRIPTION
The intent of this is not to remove every single ifdef qt version thing we have, but instead to stop building for Qt5 in CI.

New code we write should not have to pass Qt5 CI to be accepted in the codebase.
