### PR TITLE
chore(ci): bump macos runners from 13 to 14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,7 @@ jobs:
       matrix:
         include:
           # macOS
-          - os: macos-13
+          - os: macos-14
             qt-version: 6.7.1
             force-lto: false
             plugins: true

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-13]
+        os: [macos-14]
         qt-version: [6.7.1]
         plugins: [true]
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Dev: Replaced usage of `parseTime` with `serverReceivedTime` for clearchat messages. (#5824, #5855)
 - Dev: Support Boost 1.87. (#5832)
 - Dev: Stopped building Qt5 builds in CI. (#5933)
+- Dev: Updated CI macOS versions from 13 to 14. (#5934)
 - Dev: Words from `TextElement`s are now combined where possible. (#5847)
 - Dev: Fixed assertion failure when closing the edit-hotkey dialog. (#5869)
 - Dev: Updated `qtkeychain` to 0.15.0. (#5871)


### PR DESCRIPTION
From https://github.com/Chatterino/chatterino2/pull/5933#discussion_r1947909689