### PR TITLE
fix(eventsub): don't require pip if venv works

### DIFF
--- a/lib/twitch-eventsub-ws/cmake/GenerateJson.cmake
+++ b/lib/twitch-eventsub-ws/cmake/GenerateJson.cmake
@@ -49,10 +49,13 @@ function(_make_and_use_venv)
     message(STATUS "Installing requirements from ${arg_REQUIREMENTS}")
     execute_process(
         COMMAND "${Python3_EXECUTABLE}" -m pip install -r "${arg_REQUIREMENTS}"
-        COMMAND_ERROR_IS_FATAL ANY
+        RESULT_VARIABLE _pip_output
         OUTPUT_QUIET
         ERROR_QUIET
     )
+    if(NOT _pip_output EQUAL 0)
+        return()
+    endif()
     set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${arg_REQUIREMENTS}")
 
     set(${arg_OUT_PYTHON_EXE} "${Python3_EXECUTABLE}" PARENT_SCOPE)


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
If a venv can be created, we expect pip to work. Looks like that's now always the case.