### PR TITLE
fix: reuse one channel for emote search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Bugfix: Fixed the reply button showing for inline whispers and announcements. (#5863)
 - Bugfix: Fixed suspicious user treatment update messages not being searchable. (#5865)
 - Bugfix: Ensure miniaudio backend exits even if it doesn't exit cleanly. (#5896)
+- Bugfix: Fixed search in emote popup not always working correctly. (#5946)
 - Dev: Add initial experimental EventSub support. (#5837, #5895, #5897, #5904, #5910, #5903, #5915, #5916, #5930, #5935, #5932, #5943)
 - Dev: Remove unneeded platform specifier for toasts. (#5914)
 - Dev: Highlight checks now use non-capturing groups for the boundaries. (#5784)

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -430,6 +430,8 @@ void EmotePopup::loadChannel(ChannelPtr channel)
         std::make_shared<Channel>("", Channel::Type::None));
     this->channelEmotesView_->setChannel(
         std::make_shared<Channel>("", Channel::Type::None));
+    this->searchView_->setChannel(
+        std::make_shared<Channel>("", Channel::Type::None));
 
     this->reloadEmotes();
 }
@@ -606,7 +608,8 @@ void EmotePopup::filterEmotes(const QString &searchText)
 
         return;
     }
-    auto searchChannel = std::make_shared<Channel>("", Channel::Type::None);
+    auto searchChannel = this->searchView_->underlyingChannel();
+    searchChannel->clearMessages();
 
     // true in special channels like /mentions
     if (this->channel_->isTwitchChannel())
@@ -631,8 +634,6 @@ void EmotePopup::filterEmotes(const QString &searchText)
     {
         loadEmojis(*searchChannel, filteredEmojis, "Emojis");
     }
-
-    this->searchView_->setChannel(searchChannel);
 
     this->notebook_->hide();
     this->searchView_->show();


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

Does the same as #5580, but for the search channel. We reuse a single channel (and view) for the search.

Fixes #5945.