### PR TITLE
fix: receive redemptions despite pubsub shutdown

### DIFF
--- a/src/providers/twitch/PubSubManager.cpp
+++ b/src/providers/twitch/PubSubManager.cpp
@@ -1243,7 +1243,10 @@ void PubSub::runThread()
 void PubSub::listenToTopic(const QString &topic)
 {
     PubSubListenMessage msg({topic});
-    msg.setToken(this->token_);
+    if (!topic.startsWith("community-points-channel-v1."))
+    {
+        msg.setToken(this->token_);
+    }
 
     this->listen(std::move(msg));
 }


### PR DESCRIPTION
Related to #5928
