### PR TITLE
fix: show rewards early, replace later

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Bugfix: Fixed the reply button showing for inline whispers and announcements. (#5863)
 - Bugfix: Fixed suspicious user treatment update messages not being searchable. (#5865)
 - Bugfix: Ensure miniaudio backend exits even if it doesn't exit cleanly. (#5896)
+- Bugfix: Fixed channel point redemptions with messages not showing up if PubSub is disconnected. (#5948)
 - Dev: Add initial experimental EventSub support. (#5837, #5895, #5897, #5904, #5910, #5903, #5915, #5916, #5930, #5935, #5932, #5943)
 - Dev: Remove unneeded platform specifier for toasts. (#5914)
 - Dev: Highlight checks now use non-capturing groups for the boundaries. (#5784)

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -2135,6 +2135,7 @@ std::pair<MessagePtrMut, HighlightAlert> MessageBuilder::makeIrcMessage(
             builder.appendChannelPointRewardMessage(*reward, channel->isMod(),
                                                     channel->isBroadcaster());
         }
+        builder->flags.set(MessageFlag::RedeemedChannelPointReward);
     }
 
     builder.appendChannelName(channel);

--- a/src/messages/MessageSink.hpp
+++ b/src/messages/MessageSink.hpp
@@ -22,9 +22,9 @@ enum class MessageSinkTrait : uint8_t {
     /// added to the global mentions channel when encountered.
     AddMentionsToGlobalChannel = 1 << 0,
 
-    /// A channel-point redemption whose reward is not yet known should not be
-    /// added to this sink, but queued in the corresponding TwitchChannel
-    /// (`addQueuedRedemption`).
+    /// A channel-point redemption whose reward is not yet known should be
+    /// queued in the corresponding TwitchChannel (`addQueuedRedemption`) and
+    /// the message should be replaced later.
     RequiresKnownChannelPointReward = 1 << 1,
 };
 using MessageSinkTraits = FlagsEnum<MessageSinkTrait>;

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -1010,7 +1010,6 @@ void IrcMessageHandler::addMessage(Communi::IrcMessage *message,
                                      "callback since reward is not known:"
                                   << rewardId;
         chan->addQueuedRedemption(rewardId, originalContent, message);
-        return;
     }
     args.channelPointRewardId = rewardId;
 

--- a/tests/snapshots/IrcMessageHandler/reward-unknown.json
+++ b/tests/snapshots/IrcMessageHandler/reward-unknown.json
@@ -109,7 +109,7 @@
                     "url": ""
                 }
             ],
-            "flags": "Collapsed",
+            "flags": "Collapsed|RedeemedChannelPointReward",
             "id": "4d409401-f692-4dd1-9295-f21350f86860",
             "localizedName": "",
             "loginName": "nerixyz",


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

Regarding #5928. We will show redemptions when they come through IRC regardless of whether we know the reward or we don't. If we don't know the reward, we save the message to be rebuilt later. When the reward comes in through PubSub, we replace the previous message. The queued rewards are currently limited to 16.