### PR TITLE
refactor(eventsub): more references, less const

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 - Bugfix: Fixed search in emote popup not always working correctly. (#5946)
 - Bugfix: Fixed channel point redemptions with messages not showing up if PubSub is disconnected. (#5948)
 - Dev: Subscriptions to PubSub channel points redemption topics now use no auth token, making it continue to work during PubSub shutdown. (#5947)
-- Dev: Add initial experimental EventSub support. (#5837, #5895, #5897, #5904, #5910, #5903, #5915, #5916, #5930, #5935, #5932, #5943, #5952)
+- Dev: Add initial experimental EventSub support. (#5837, #5895, #5897, #5904, #5910, #5903, #5915, #5916, #5930, #5935, #5932, #5943, #5952, #5953)
 - Dev: Remove unneeded platform specifier for toasts. (#5914)
 - Dev: Highlight checks now use non-capturing groups for the boundaries. (#5784)
 - Dev: Removed unused PubSub whisper code. (#5898)

--- a/lib/twitch-eventsub-ws/benchmarks/src/parse.cpp
+++ b/lib/twitch-eventsub-ws/benchmarks/src/parse.cpp
@@ -14,7 +14,8 @@ using namespace chatterino::eventsub::lib;
 std::vector<boost::beast::flat_buffer> readMessages()
 {
     QFile file(":/bench/messages.ndjson");
-    assert(file.open(QFile::ReadOnly));
+    bool ok = file.open(QFile::ReadOnly);
+    assert(ok);
 
     std::vector<boost::beast::flat_buffer> messages;
     while (!file.atEnd())
@@ -41,67 +42,71 @@ public:
     NoopListener() = default;
 
     // NOLINTBEGIN(cppcoreguidelines-pro-type-const-cast)
-    void onSessionWelcome(messages::Metadata metadata,
-                          payload::session_welcome::Payload payload) override
+    void onSessionWelcome(
+        const messages::Metadata &metadata,
+        const payload::session_welcome::Payload &payload) override
     {
         benchmark::DoNotOptimize(&metadata);
         benchmark::DoNotOptimize(&payload);
     }
 
-    void onNotification(messages::Metadata metadata,
+    void onNotification(const messages::Metadata &metadata,
                         const boost::json::value &jv) override
     {
         benchmark::DoNotOptimize(&metadata);
         benchmark::DoNotOptimize(&jv);
     }
 
-    void onChannelBan(messages::Metadata metadata,
-                      payload::channel_ban::v1::Payload payload) override
+    void onChannelBan(const messages::Metadata &metadata,
+                      const payload::channel_ban::v1::Payload &payload) override
     {
         benchmark::DoNotOptimize(&metadata);
         benchmark::DoNotOptimize(&payload);
     }
 
-    void onStreamOnline(messages::Metadata metadata,
-                        payload::stream_online::v1::Payload payload) override
+    void onStreamOnline(
+        const messages::Metadata &metadata,
+        const payload::stream_online::v1::Payload &payload) override
     {
         benchmark::DoNotOptimize(&metadata);
         benchmark::DoNotOptimize(&payload);
     }
 
-    void onStreamOffline(messages::Metadata metadata,
-                         payload::stream_offline::v1::Payload payload) override
+    void onStreamOffline(
+        const messages::Metadata &metadata,
+        const payload::stream_offline::v1::Payload &payload) override
     {
         benchmark::DoNotOptimize(&metadata);
         benchmark::DoNotOptimize(&payload);
     }
 
     void onChannelChatNotification(
-        messages::Metadata metadata,
-        payload::channel_chat_notification::v1::Payload payload) override
+        const messages::Metadata &metadata,
+        const payload::channel_chat_notification::v1::Payload &payload) override
     {
         benchmark::DoNotOptimize(&metadata);
         benchmark::DoNotOptimize(&payload);
     }
 
-    void onChannelUpdate(messages::Metadata metadata,
-                         payload::channel_update::v1::Payload payload) override
+    void onChannelUpdate(
+        const messages::Metadata &metadata,
+        const payload::channel_update::v1::Payload &payload) override
     {
         benchmark::DoNotOptimize(&metadata);
         benchmark::DoNotOptimize(&payload);
     }
 
     void onChannelChatMessage(
-        messages::Metadata metadata,
-        payload::channel_chat_message::v1::Payload payload) override
+        const messages::Metadata &metadata,
+        const payload::channel_chat_message::v1::Payload &payload) override
     {
         benchmark::DoNotOptimize(&metadata);
         benchmark::DoNotOptimize(&payload);
     }
 
     void onChannelModerate(
-        messages::Metadata metadata,
-        payload::channel_moderate::v2::Payload payload) override
+        const messages::Metadata &metadata,
+        const payload::channel_moderate::v2::Payload &payload) override
     {
         benchmark::DoNotOptimize(&metadata);
         benchmark::DoNotOptimize(&payload);

--- a/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/listener.hpp
+++ b/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/listener.hpp
@@ -18,39 +18,40 @@ public:
     virtual ~Listener() = default;
 
     virtual void onSessionWelcome(
-        messages::Metadata metadata,
-        payload::session_welcome::Payload payload) = 0;
+        const messages::Metadata &metadata,
+        const payload::session_welcome::Payload &payload) = 0;
 
-    virtual void onNotification(messages::Metadata metadata,
+    virtual void onNotification(const messages::Metadata &metadata,
                                 const boost::json::value &jv) = 0;
 
     // Subscription types
-    virtual void onChannelBan(messages::Metadata metadata,
-                              payload::channel_ban::v1::Payload payload) = 0;
+    virtual void onChannelBan(
+        const messages::Metadata &metadata,
+        const payload::channel_ban::v1::Payload &payload) = 0;
 
     virtual void onStreamOnline(
-        messages::Metadata metadata,
-        payload::stream_online::v1::Payload payload) = 0;
+        const messages::Metadata &metadata,
+        const payload::stream_online::v1::Payload &payload) = 0;
 
     virtual void onStreamOffline(
-        messages::Metadata metadata,
-        payload::stream_offline::v1::Payload payload) = 0;
+        const messages::Metadata &metadata,
+        const payload::stream_offline::v1::Payload &payload) = 0;
 
     virtual void onChannelChatNotification(
-        messages::Metadata metadata,
-        payload::channel_chat_notification::v1::Payload payload) = 0;
+        const messages::Metadata &metadata,
+        const payload::channel_chat_notification::v1::Payload &payload) = 0;
 
     virtual void onChannelUpdate(
-        messages::Metadata metadata,
-        payload::channel_update::v1::Payload payload) = 0;
+        const messages::Metadata &metadata,
+        const payload::channel_update::v1::Payload &payload) = 0;
 
     virtual void onChannelChatMessage(
-        messages::Metadata metadata,
-        payload::channel_chat_message::v1::Payload payload) = 0;
+        const messages::Metadata &metadata,
+        const payload::channel_chat_message::v1::Payload &payload) = 0;
 
     virtual void onChannelModerate(
-        messages::Metadata metadata,
-        payload::channel_moderate::v2::Payload payload) = 0;
+        const messages::Metadata &metadata,
+        const payload::channel_moderate::v2::Payload &payload) = 0;
 
     // Add your new subscription types above this line
 };

--- a/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/messages/metadata.hpp
+++ b/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/messages/metadata.hpp
@@ -21,13 +21,13 @@ namespace chatterino::eventsub::lib::messages {
 */
 
 struct Metadata {
-    const std::string messageID;
-    const std::string messageType;
+    std::string messageID;
+    std::string messageType;
     // TODO: should this be chronofied?
-    const std::string messageTimestamp;
+    std::string messageTimestamp;
 
-    const std::optional<std::string> subscriptionType;
-    const std::optional<std::string> subscriptionVersion;
+    std::optional<std::string> subscriptionType;
+    std::optional<std::string> subscriptionVersion;
 };
 
 #include "twitch-eventsub-ws/messages/metadata.inc"

--- a/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/payloads/channel-ban-v1.hpp
+++ b/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/payloads/channel-ban-v1.hpp
@@ -91,9 +91,9 @@ struct Event {
 };
 
 struct Payload {
-    const subscription::Subscription subscription;
+    subscription::Subscription subscription;
 
-    const Event event;
+    Event event;
 };
 
 #include "twitch-eventsub-ws/payloads/channel-ban-v1.inc"

--- a/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/payloads/channel-chat-message-v1.hpp
+++ b/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/payloads/channel-chat-message-v1.hpp
@@ -135,9 +135,9 @@ struct Event {
 };
 
 struct Payload {
-    const subscription::Subscription subscription;
+    subscription::Subscription subscription;
 
-    const Event event;
+    Event event;
 };
 
 #include "twitch-eventsub-ws/payloads/channel-chat-message-v1.inc"

--- a/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/payloads/channel-chat-notification-v1.hpp
+++ b/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/payloads/channel-chat-notification-v1.hpp
@@ -190,9 +190,9 @@ struct Event {
 };
 
 struct Payload {
-    const subscription::Subscription subscription;
+    subscription::Subscription subscription;
 
-    const Event event;
+    Event event;
 };
 
 #include "twitch-eventsub-ws/payloads/channel-chat-notification-v1.inc"

--- a/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/payloads/channel-update-v1.hpp
+++ b/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/payloads/channel-update-v1.hpp
@@ -10,31 +10,31 @@ namespace chatterino::eventsub::lib::payload::channel_update::v1 {
 
 struct Event {
     // The broadcaster's user ID
-    const std::string broadcasterUserID;
+    std::string broadcasterUserID;
     // The broadcaster's user login
-    const std::string broadcasterUserLogin;
+    std::string broadcasterUserLogin;
     // The broadcaster's user display name
-    const std::string broadcasterUserName;
+    std::string broadcasterUserName;
 
     // The channel's stream title
-    const std::string title;
+    std::string title;
 
     // The channel's broadcast language
-    const std::string language;
+    std::string language;
 
     // The channels category ID
-    const std::string categoryID;
+    std::string categoryID;
     // The category name
-    const std::string categoryName;
+    std::string categoryName;
 
     // A boolean identifying whether the channel is flagged as mature
-    const bool isMature;
+    bool isMature;
 };
 
 struct Payload {
-    const subscription::Subscription subscription;
+    subscription::Subscription subscription;
 
-    const Event event;
+    Event event;
 };
 
 #include "twitch-eventsub-ws/payloads/channel-update-v1.inc"

--- a/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/payloads/session-welcome.hpp
+++ b/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/payloads/session-welcome.hpp
@@ -23,7 +23,7 @@ namespace chatterino::eventsub::lib::payload::session_welcome {
 
 /// json_inner=session
 struct Payload {
-    const std::string id;
+    std::string id;
 };
 
 #include "twitch-eventsub-ws/payloads/session-welcome.inc"

--- a/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/payloads/stream-offline-v1.hpp
+++ b/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/payloads/stream-offline-v1.hpp
@@ -10,17 +10,17 @@ namespace chatterino::eventsub::lib::payload::stream_offline::v1 {
 
 struct Event {
     // The broadcaster's user ID
-    const std::string broadcasterUserID;
+    std::string broadcasterUserID;
     // The broadcaster's user login
-    const std::string broadcasterUserLogin;
+    std::string broadcasterUserLogin;
     // The broadcaster's user display name
-    const std::string broadcasterUserName;
+    std::string broadcasterUserName;
 };
 
 struct Payload {
-    const subscription::Subscription subscription;
+    subscription::Subscription subscription;
 
-    const Event event;
+    Event event;
 };
 
 #include "twitch-eventsub-ws/payloads/stream-offline-v1.inc"

--- a/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/payloads/stream-online-v1.hpp
+++ b/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/payloads/stream-online-v1.hpp
@@ -10,27 +10,27 @@ namespace chatterino::eventsub::lib::payload::stream_online::v1 {
 
 struct Event {
     // The ID of the stream
-    const std::string id;
+    std::string id;
 
     // The broadcaster's user ID
-    const std::string broadcasterUserID;
+    std::string broadcasterUserID;
     // The broadcaster's user login
-    const std::string broadcasterUserLogin;
+    std::string broadcasterUserLogin;
     // The broadcaster's user display name
-    const std::string broadcasterUserName;
+    std::string broadcasterUserName;
 
     // The stream type (e.g. live, playlist, watch_party)
-    const std::string type;
+    std::string type;
 
     // The timestamp at which the stream went online
     // TODO: chronofy?
-    const std::string startedAt;
+    std::string startedAt;
 };
 
 struct Payload {
-    const subscription::Subscription subscription;
+    subscription::Subscription subscription;
 
-    const Event event;
+    Event event;
 };
 
 #include "twitch-eventsub-ws/payloads/stream-online-v1.inc"

--- a/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/payloads/subscription.hpp
+++ b/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/payloads/subscription.hpp
@@ -33,23 +33,23 @@ namespace chatterino::eventsub::lib::payload::subscription {
 */
 
 struct Transport {
-    const std::string method;
-    const std::string sessionID;
+    std::string method;
+    std::string sessionID;
 };
 
 struct Subscription {
-    const std::string id;
-    const std::string status;
-    const std::string type;
-    const std::string version;
+    std::string id;
+    std::string status;
+    std::string type;
+    std::string version;
 
     // TODO: How do we map condition here? vector of key/value pairs?
 
-    const Transport transport;
+    Transport transport;
 
     // TODO: chronofy?
-    const std::string createdAt;
-    const int cost;
+    std::string createdAt;
+    int cost;
 };
 
 #include "twitch-eventsub-ws/payloads/subscription.inc"

--- a/lib/twitch-eventsub-ws/src/session.cpp
+++ b/lib/twitch-eventsub-ws/src/session.cpp
@@ -32,15 +32,16 @@ using EventSubSubscription = std::pair<std::string, std::string>;
 
 using NotificationHandlers = std::unordered_map<
     EventSubSubscription,
-    std::function<boost::system::error_code(
-        messages::Metadata, boost::json::value, std::unique_ptr<Listener> &)>,
+    std::function<boost::system::error_code(const messages::Metadata &,
+                                            const boost::json::value &,
+                                            std::unique_ptr<Listener> &)>,
     boost::hash<EventSubSubscription>>;
 
-using MessageHandlers =
-    std::unordered_map<std::string, std::function<boost::system::error_code(
-                                        messages::Metadata, boost::json::value,
-                                        std::unique_ptr<Listener> &,
-                                        const NotificationHandlers &)>>;
+using MessageHandlers = std::unordered_map<
+    std::string,
+    std::function<boost::system::error_code(
+        const messages::Metadata &, const boost::json::value &,
+        std::unique_ptr<Listener> &, const NotificationHandlers &)>>;
 
 namespace {
 
@@ -153,7 +154,7 @@ namespace {
                 {
                     return oPayload.error();
                 }
-                listener->onChannelModerate(metadata, std::move(*oPayload));
+                listener->onChannelModerate(metadata, *oPayload);
                 return boost::system::error_code{};
             },
         },

--- a/lib/twitch-eventsub-ws/tests/src/parse.cpp
+++ b/lib/twitch-eventsub-ws/tests/src/parse.cpp
@@ -55,51 +55,55 @@ boost::beast::flat_buffer readToFlatBuffer(const std::filesystem::path &path)
 
 class NoOpListener : public chatterino::eventsub::lib::Listener
 {
-    void onSessionWelcome(messages::Metadata metadata,
-                          payload::session_welcome::Payload payload) override
+    void onSessionWelcome(
+        const messages::Metadata &metadata,
+        const payload::session_welcome::Payload &payload) override
     {
     }
 
-    void onNotification(messages::Metadata metadata,
+    void onNotification(const messages::Metadata &metadata,
                         const boost::json::value &jv) override
     {
     }
 
-    void onChannelBan(messages::Metadata metadata,
-                      payload::channel_ban::v1::Payload payload) override
+    void onChannelBan(const messages::Metadata &metadata,
+                      const payload::channel_ban::v1::Payload &payload) override
     {
     }
 
-    void onStreamOnline(messages::Metadata metadata,
-                        payload::stream_online::v1::Payload payload) override
+    void onStreamOnline(
+        const messages::Metadata &metadata,
+        const payload::stream_online::v1::Payload &payload) override
     {
     }
 
-    void onStreamOffline(messages::Metadata metadata,
-                         payload::stream_offline::v1::Payload payload) override
+    void onStreamOffline(
+        const messages::Metadata &metadata,
+        const payload::stream_offline::v1::Payload &payload) override
     {
     }
 
     void onChannelChatNotification(
-        messages::Metadata metadata,
-        payload::channel_chat_notification::v1::Payload payload) override
+        const messages::Metadata &metadata,
+        const payload::channel_chat_notification::v1::Payload &payload) override
     {
     }
 
-    void onChannelUpdate(messages::Metadata metadata,
-                         payload::channel_update::v1::Payload payload) override
+    void onChannelUpdate(
+        const messages::Metadata &metadata,
+        const payload::channel_update::v1::Payload &payload) override
     {
     }
 
     void onChannelChatMessage(
-        messages::Metadata metadata,
-        payload::channel_chat_message::v1::Payload payload) override
+        const messages::Metadata &metadata,
+        const payload::channel_chat_message::v1::Payload &payload) override
     {
     }
 
     void onChannelModerate(
-        messages::Metadata metadata,
-        payload::channel_moderate::v2::Payload payload) override
+        const messages::Metadata &metadata,
+        const payload::channel_moderate::v2::Payload &payload) override
     {
     }
 };

--- a/src/providers/twitch/eventsub/Connection.cpp
+++ b/src/providers/twitch/eventsub/Connection.cpp
@@ -28,8 +28,8 @@ const auto &LOG = chatterinoTwitchEventSub;
 namespace chatterino::eventsub {
 
 void Connection::onSessionWelcome(
-    lib::messages::Metadata metadata,
-    lib::payload::session_welcome::Payload payload)
+    const lib::messages::Metadata &metadata,
+    const lib::payload::session_welcome::Payload &payload)
 {
     (void)metadata;
     qCDebug(LOG) << "On session welcome:" << payload.id.c_str();
@@ -37,7 +37,7 @@ void Connection::onSessionWelcome(
     this->sessionID = QString::fromStdString(payload.id);
 }
 
-void Connection::onNotification(lib::messages::Metadata metadata,
+void Connection::onNotification(const lib::messages::Metadata &metadata,
                                 const boost::json::value &jv)
 {
     (void)metadata;
@@ -45,8 +45,9 @@ void Connection::onNotification(lib::messages::Metadata metadata,
     qCDebug(LOG) << "on notification: " << jsonString.c_str();
 }
 
-void Connection::onChannelBan(lib::messages::Metadata metadata,
-                              lib::payload::channel_ban::v1::Payload payload)
+void Connection::onChannelBan(
+    const lib::messages::Metadata &metadata,
+    const lib::payload::channel_ban::v1::Payload &payload)
 {
     (void)metadata;
 
@@ -91,8 +92,8 @@ void Connection::onChannelBan(lib::messages::Metadata metadata,
 }
 
 void Connection::onStreamOnline(
-    lib::messages::Metadata metadata,
-    lib::payload::stream_online::v1::Payload payload)
+    const lib::messages::Metadata &metadata,
+    const lib::payload::stream_online::v1::Payload &payload)
 {
     (void)metadata;
     qCDebug(LOG) << "On stream online event for channel"
@@ -100,8 +101,8 @@ void Connection::onStreamOnline(
 }
 
 void Connection::onStreamOffline(
-    lib::messages::Metadata metadata,
-    lib::payload::stream_offline::v1::Payload payload)
+    const lib::messages::Metadata &metadata,
+    const lib::payload::stream_offline::v1::Payload &payload)
 {
     (void)metadata;
     qCDebug(LOG) << "On stream offline event for channel"
@@ -109,8 +110,8 @@ void Connection::onStreamOffline(
 }
 
 void Connection::onChannelChatNotification(
-    lib::messages::Metadata metadata,
-    lib::payload::channel_chat_notification::v1::Payload payload)
+    const lib::messages::Metadata &metadata,
+    const lib::payload::channel_chat_notification::v1::Payload &payload)
 {
     (void)metadata;
     qCDebug(LOG) << "On channel chat notification for"
@@ -118,8 +119,8 @@ void Connection::onChannelChatNotification(
 }
 
 void Connection::onChannelUpdate(
-    lib::messages::Metadata metadata,
-    lib::payload::channel_update::v1::Payload payload)
+    const lib::messages::Metadata &metadata,
+    const lib::payload::channel_update::v1::Payload &payload)
 {
     (void)metadata;
     qCDebug(LOG) << "On channel update for"
@@ -127,8 +128,8 @@ void Connection::onChannelUpdate(
 }
 
 void Connection::onChannelChatMessage(
-    lib::messages::Metadata metadata,
-    lib::payload::channel_chat_message::v1::Payload payload)
+    const lib::messages::Metadata &metadata,
+    const lib::payload::channel_chat_message::v1::Payload &payload)
 {
     (void)metadata;
 
@@ -137,8 +138,8 @@ void Connection::onChannelChatMessage(
 }
 
 void Connection::onChannelModerate(
-    lib::messages::Metadata metadata,
-    lib::payload::channel_moderate::v2::Payload payload)
+    const lib::messages::Metadata &metadata,
+    const lib::payload::channel_moderate::v2::Payload &payload)
 {
     (void)metadata;
 

--- a/src/providers/twitch/eventsub/Connection.hpp
+++ b/src/providers/twitch/eventsub/Connection.hpp
@@ -15,38 +15,41 @@ class Connection final : public lib::Listener
 {
 public:
     void onSessionWelcome(
-        lib::messages::Metadata metadata,
-        lib::payload::session_welcome::Payload payload) override;
+        const lib::messages::Metadata &metadata,
+        const lib::payload::session_welcome::Payload &payload) override;
 
-    void onNotification(lib::messages::Metadata metadata,
+    void onNotification(const lib::messages::Metadata &metadata,
                         const boost::json::value &jv) override;
 
-    void onChannelBan(lib::messages::Metadata metadata,
-                      lib::payload::channel_ban::v1::Payload payload) override;
+    void onChannelBan(
+        const lib::messages::Metadata &metadata,
+        const lib::payload::channel_ban::v1::Payload &payload) override;
 
     void onStreamOnline(
-        lib::messages::Metadata metadata,
-        lib::payload::stream_online::v1::Payload payload) override;
+        const lib::messages::Metadata &metadata,
+        const lib::payload::stream_online::v1::Payload &payload) override;
 
     void onStreamOffline(
-        lib::messages::Metadata metadata,
-        lib::payload::stream_offline::v1::Payload payload) override;
+        const lib::messages::Metadata &metadata,
+        const lib::payload::stream_offline::v1::Payload &payload) override;
 
     void onChannelChatNotification(
-        lib::messages::Metadata metadata,
-        lib::payload::channel_chat_notification::v1::Payload payload) override;
+        const lib::messages::Metadata &metadata,
+        const lib::payload::channel_chat_notification::v1::Payload &payload)
+        override;
 
     void onChannelUpdate(
-        lib::messages::Metadata metadata,
-        lib::payload::channel_update::v1::Payload payload) override;
+        const lib::messages::Metadata &metadata,
+        const lib::payload::channel_update::v1::Payload &payload) override;
 
     void onChannelChatMessage(
-        lib::messages::Metadata metadata,
-        lib::payload::channel_chat_message::v1::Payload payload) override;
+        const lib::messages::Metadata &metadata,
+        const lib::payload::channel_chat_message::v1::Payload &payload)
+        override;
 
     void onChannelModerate(
-        lib::messages::Metadata metadata,
-        lib::payload::channel_moderate::v2::Payload payload) override;
+        const lib::messages::Metadata &metadata,
+        const lib::payload::channel_moderate::v2::Payload &payload) override;
 
     QString getSessionID() const;
 


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
- The references account for most of the improvement here. Previously, we had to copy the structs in the functions.
- Removing `const` from members restores the default move constructor. With `const`, the struct can't be moved and needs to be copied.

`twitch-eventsub-ws-benchmark --benchmark_repetitions=10 --benchmark_time_unit=ms`:
<details><summary>Before</summary>

```text
---------------------------------------------------------------------------
Benchmark                                 Time             CPU   Iterations
---------------------------------------------------------------------------
BM_ParseAndHandleMessages             0.225 ms        0.220 ms         3200
BM_ParseAndHandleMessages             0.221 ms        0.215 ms         3200
BM_ParseAndHandleMessages             0.215 ms        0.215 ms         3200
BM_ParseAndHandleMessages             0.216 ms        0.220 ms         3200
BM_ParseAndHandleMessages             0.214 ms        0.215 ms         3200
BM_ParseAndHandleMessages             0.214 ms        0.210 ms         3200
BM_ParseAndHandleMessages             0.214 ms        0.215 ms         3200
BM_ParseAndHandleMessages             0.215 ms        0.215 ms         3200
BM_ParseAndHandleMessages             0.215 ms        0.215 ms         3200
BM_ParseAndHandleMessages             0.215 ms        0.215 ms         3200
BM_ParseAndHandleMessages_mean        0.216 ms        0.215 ms           10
BM_ParseAndHandleMessages_median      0.215 ms        0.215 ms           10
BM_ParseAndHandleMessages_stddev      0.004 ms        0.003 ms           10
BM_ParseAndHandleMessages_cv           1.65 %          1.29 %            10
```
</details> 

<details><summary>After</summary>

```text
---------------------------------------------------------------------------
Benchmark                                 Time             CPU   Iterations
---------------------------------------------------------------------------
BM_ParseAndHandleMessages             0.122 ms        0.115 ms         6400
BM_ParseAndHandleMessages             0.111 ms        0.110 ms         6400
BM_ParseAndHandleMessages             0.105 ms        0.107 ms         6400
BM_ParseAndHandleMessages             0.106 ms        0.105 ms         6400
BM_ParseAndHandleMessages             0.106 ms        0.103 ms         6400
BM_ParseAndHandleMessages             0.105 ms        0.105 ms         6400
BM_ParseAndHandleMessages             0.105 ms        0.107 ms         6400
BM_ParseAndHandleMessages             0.105 ms        0.105 ms         6400
BM_ParseAndHandleMessages             0.105 ms        0.105 ms         6400
BM_ParseAndHandleMessages             0.105 ms        0.105 ms         6400
BM_ParseAndHandleMessages_mean        0.108 ms        0.107 ms           10
BM_ParseAndHandleMessages_median      0.105 ms        0.105 ms           10
BM_ParseAndHandleMessages_stddev      0.005 ms        0.003 ms           10
BM_ParseAndHandleMessages_cv           4.84 %          3.25 %            10
```
</details> 

The parsing of JSON into a `boost::json::value` now takes up the most amount of time (about 60%). We could try to generate code to parse directly into a struct with `boost::json::parse_into`. This is much more complex, because we need to generate a SAX handler and correctly dispatch for each struct. We can't use Boost.JSON's handlers (they expect Boost.Describe-d structs).