### PR TITLE
fix: use WEBP images for BTTV emotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - Dev: Updated `qtkeychain` to 0.15.0. (#5871)
 - Dev: Updated `googletest` to 1.16.0. (#5942)
 - Dev: Fixed duplicate CMake configure in clean builds. (#5940)
+- Dev: BTTV emotes are now loaded as WEBP. (#5957)
 
 ## 2.5.2
 

--- a/src/providers/bttv/BttvEmotes.cpp
+++ b/src/providers/bttv/BttvEmotes.cpp
@@ -33,7 +33,7 @@ constexpr QStringView EMOTE_LINK_FORMAT = u"https://betterttv.com/emotes/%1";
 ///
 /// %2 being the emote size (e.g. 3x)
 constexpr QStringView EMOTE_CDN_FORMAT =
-    u"https://cdn.betterttv.net/emote/%1/%2";
+    u"https://cdn.betterttv.net/emote/%1/%2.webp";
 
 // BTTV doesn't provide any data on the size, so we assume an emote is 28x28
 constexpr QSize EMOTE_BASE_SIZE(28, 28);


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
BTTV supports WEBP for all emotes (https://github.com/night/betterttv/discussions/7313#discussioncomment-12211280). As mentioned in https://github.com/Chatterino/chatterino2/discussions/5955, WEBP provides better quality for the emotes (WEBPs are usually smaller too).

"Closes" https://github.com/Chatterino/chatterino2/discussions/5955.