### PR TITLE
Fix: Resolved OAuth Token not saving after re-authing #5901

### DIFF
--- a/src/widgets/dialogs/LoginDialog.cpp
+++ b/src/widgets/dialogs/LoginDialog.cpp
@@ -68,6 +68,7 @@ namespace {
 
         getApp()->getAccounts()->twitch.reloadUsers();
         getApp()->getAccounts()->twitch.currentUsername = username;
+        getSettings()->requestSave();
         return true;
     }
 


### PR DESCRIPTION
<!--
    OAuth token does not get updated automatically. Every time Chatterino prompts the token, it expired and forced to re-sign into Twitch.
    Fix: Added 'getSettings()->requestSave()' line 71, chatterino2/src/widgets/dialogs/LoginDialog.cpp
    "Fixes #5901.".
-->
