### PR TITLE
fix: opening a usercard from `/live` no longer makes failing ivr API call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Bugfix: Fixed announcements not showing up in mentions tab. (#5857)
 - Bugfix: Fixed the reply button showing for inline whispers and announcements. (#5863)
 - Bugfix: Fixed suspicious user treatment update messages not being searchable. (#5865)
+- Bugfix: Fixed user info popup's opened from `/live` making some network requests that always failed. (#5959)
 - Bugfix: Ensure miniaudio backend exits even if it doesn't exit cleanly. (#5896)
 - Bugfix: Fixed search in emote popup not always working correctly. (#5946)
 - Bugfix: Fixed channel point redemptions with messages not showing up if PubSub is disconnected. (#5948)

--- a/src/providers/IvrApi.cpp
+++ b/src/providers/IvrApi.cpp
@@ -15,11 +15,6 @@ void IvrApi::getSubage(QString userName, QString channelName,
 {
     assert(!userName.isEmpty() && !channelName.isEmpty());
 
-    if (channelName == "/live")
-    {
-        channelName = userName;
-    }
-
     this->makeRequest(
             QString("twitch/subage/%1/%2").arg(userName).arg(channelName), {})
         .onSuccess([successCallback, failureCallback](auto result) {

--- a/src/providers/IvrApi.cpp
+++ b/src/providers/IvrApi.cpp
@@ -15,6 +15,11 @@ void IvrApi::getSubage(QString userName, QString channelName,
 {
     assert(!userName.isEmpty() && !channelName.isEmpty());
 
+    if (channelName == "/live")
+    {
+        channelName = userName;
+    }
+
     this->makeRequest(
             QString("twitch/subage/%1/%2").arg(userName).arg(channelName), {})
         .onSuccess([successCallback, failureCallback](auto result) {

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -945,9 +945,9 @@ void UserInfoPopup::updateUserData()
         this->ui_.block->setEnabled(true);
         this->ui_.ignoreHighlights->setChecked(isIgnoringHighlights);
 
-        auto type = this->channel_->getType();
+        auto type = this->underlyingChannel_->getType();
 
-        if (type != Channel::Type::TwitchLive)
+        if (type == Channel::Type::Twitch)
         {
             // get followage and subage
             getIvr()->getSubage(

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -945,44 +945,49 @@ void UserInfoPopup::updateUserData()
         this->ui_.block->setEnabled(true);
         this->ui_.ignoreHighlights->setChecked(isIgnoringHighlights);
 
-        // get followage and subage
-        getIvr()->getSubage(
-            this->userName_, this->underlyingChannel_->getName(),
-            [this, hack](const IvrSubage &subageInfo) {
-                if (!hack.lock())
-                {
-                    return;
-                }
+        auto type = this->channel_->getType();
 
-                if (!subageInfo.followingSince.isEmpty())
-                {
-                    QDateTime followedAt = QDateTime::fromString(
-                        subageInfo.followingSince, Qt::ISODate);
-                    QString followingSince = followedAt.toString("yyyy-MM-dd");
-                    this->ui_.followageLabel->setText("❤ Following since " +
-                                                      followingSince);
-                }
+        if (type != Channel::Type::TwitchLive)
+        {
+            // get followage and subage
+            getIvr()->getSubage(
+                this->userName_, this->underlyingChannel_->getName(),
+                [this, hack](const IvrSubage &subageInfo) {
+                    if (!hack.lock())
+                    {
+                        return;
+                    }
 
-                if (subageInfo.isSubHidden)
-                {
-                    this->ui_.subageLabel->setText(
-                        "Subscription status hidden");
-                }
-                else if (subageInfo.isSubbed)
-                {
-                    this->ui_.subageLabel->setText(
-                        QString("★ Tier %1 - Subscribed for %2 months")
-                            .arg(subageInfo.subTier)
-                            .arg(subageInfo.totalSubMonths));
-                }
-                else if (subageInfo.totalSubMonths)
-                {
-                    this->ui_.subageLabel->setText(
-                        QString("★ Previously subscribed for %1 months")
-                            .arg(subageInfo.totalSubMonths));
-                }
-            },
-            [] {});
+                    if (!subageInfo.followingSince.isEmpty())
+                    {
+                        QDateTime followedAt = QDateTime::fromString(
+                            subageInfo.followingSince, Qt::ISODate);
+                        QString followingSince = followedAt.toString("yyyy-MM-dd");
+                        this->ui_.followageLabel->setText("❤ Following since " +
+                                                          followingSince);
+                    }
+
+                    if (subageInfo.isSubHidden)
+                    {
+                        this->ui_.subageLabel->setText(
+                            "Subscription status hidden");
+                    }
+                    else if (subageInfo.isSubbed)
+                    {
+                        this->ui_.subageLabel->setText(
+                            QString("★ Tier %1 - Subscribed for %2 months")
+                                .arg(subageInfo.subTier)
+                                .arg(subageInfo.totalSubMonths));
+                    }
+                    else if (subageInfo.totalSubMonths)
+                    {
+                        this->ui_.subageLabel->setText(
+                            QString("★ Previously subscribed for %1 months")
+                                .arg(subageInfo.totalSubMonths));
+                    }
+                },
+                [] {});
+        }
 
         // get pronouns
         if (getSettings()->showPronouns)

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -962,7 +962,8 @@ void UserInfoPopup::updateUserData()
                     {
                         QDateTime followedAt = QDateTime::fromString(
                             subageInfo.followingSince, Qt::ISODate);
-                        QString followingSince = followedAt.toString("yyyy-MM-dd");
+                        QString followingSince =
+                            followedAt.toString("yyyy-MM-dd");
                         this->ui_.followageLabel->setText("❤ Following since " +
                                                           followingSince);
                     }


### PR DESCRIPTION
When the channelName is "/live", the API call fails because "/live" is not a valid channelName. To fix this, replace "/live" with the userName, which is the actual channelName.