### PR TITLE
fix: update the input style sheet when scaling

### DIFF
--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -235,6 +235,7 @@ void SplitInput::scaleChangedEvent(float scale)
     }
     this->ui_.textEdit->setFont(
         app->getFonts()->getFont(FontStyle::ChatMedium, scale));
+    this->ui_.textEdit->setStyleSheet(this->theme->splits.input.styleSheet);
     this->ui_.textEditLength->setFont(
         app->getFonts()->getFont(FontStyle::ChatMedium, scale));
     this->ui_.replyLabel->setFont(


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
From https://github.com/Chatterino/chatterino2/issues/5380#issuecomment-2661376330 (not sure if it fixes the issue).

We set a style sheet in the input. Apparently, this prevents fonts from being applied to that element's children. When setting the font, it [always takes the parent font](https://github.com/qt/qtbase/blob/cf2f10268461d7e0dbd8331fbd1c83bf66c4b8c6/src/widgets/styles/qstylesheetstyle.cpp#L6489-L6490) for some reason. Previously, the font size adjustment only worked because we [always call `themeChangedEvent` when showing a widget](https://github.com/Chatterino/chatterino2/blob/bdd903bb42ee277d016a1acbcb6f40a336d76d57/src/widgets/BaseWidget.cpp#L162) and we [set the style there](https://github.com/Chatterino/chatterino2/blob/bdd903bb42ee277d016a1acbcb6f40a336d76d57/src/widgets/splits/SplitInput.cpp#L258).