### PR TITLE
chore(eventsub): simplify building for system messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 - Bugfix: Fixed channel point redemptions with messages not showing up if PubSub is disconnected. (#5948)
 - Bugfix: Fixed the input font not immediately updating when zooming in/out. (#5960)
 - Dev: Subscriptions to PubSub channel points redemption topics now use no auth token, making it continue to work during PubSub shutdown. (#5947)
-- Dev: Add initial experimental EventSub support. (#5837, #5895, #5897, #5904, #5910, #5903, #5915, #5916, #5930, #5935, #5932, #5943, #5952, #5953, #5968, #5973, #5974)
+- Dev: Add initial experimental EventSub support. (#5837, #5895, #5897, #5904, #5910, #5903, #5915, #5916, #5930, #5935, #5932, #5943, #5952, #5953, #5968, #5973, #5974, #5980)
 - Dev: Remove unneeded platform specifier for toasts. (#5914)
 - Dev: Highlight checks now use non-capturing groups for the boundaries. (#5784)
 - Dev: Removed unused PubSub whisper code. (#5898)

--- a/src/providers/twitch/eventsub/MessageBuilder.hpp
+++ b/src/providers/twitch/eventsub/MessageBuilder.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "messages/Message.hpp"
+#include "messages/MessageBuilder.hpp"
 #include "providers/twitch/TwitchChannel.hpp"
 #include "twitch-eventsub-ws/payloads/channel-moderate-v2.hpp"
 
@@ -8,21 +8,38 @@
 
 namespace chatterino::eventsub {
 
+class EventSubMessageBuilder : public MessageBuilder
+{
+public:
+    EventSubMessageBuilder(TwitchChannel *channel, const QDateTime &time);
+    ~EventSubMessageBuilder();
+
+    EventSubMessageBuilder(const EventSubMessageBuilder &) = delete;
+    EventSubMessageBuilder(EventSubMessageBuilder &&) = delete;
+    EventSubMessageBuilder &operator=(const EventSubMessageBuilder &) = delete;
+    EventSubMessageBuilder &operator=(EventSubMessageBuilder &&) = delete;
+
+    void appendUser(const lib::String &userName, const lib::String &userLogin,
+                    QString &text, bool trailingSpace = true);
+
+private:
+    TwitchChannel *channel;
+};
+
 /// <BROADCASTER> has added <USER> as a VIP of this channel.
-MessagePtr makeVipMessage(
-    TwitchChannel *channel, const QDateTime &time,
-    const lib::payload::channel_moderate::v2::Event &event,
-    const lib::payload::channel_moderate::v2::Vip &action);
+void makeModerateMessage(EventSubMessageBuilder &builder,
+                         const lib::payload::channel_moderate::v2::Event &event,
+                         const lib::payload::channel_moderate::v2::Vip &action);
 
 /// <BROADCASTER> has removed <USER> as a VIP of this channel.
-MessagePtr makeUnvipMessage(
-    TwitchChannel *channel, const QDateTime &time,
+void makeModerateMessage(
+    EventSubMessageBuilder &builder,
     const lib::payload::channel_moderate::v2::Event &event,
     const lib::payload::channel_moderate::v2::Unvip &action);
 
 /// <MODERATOR> has warned <USER>: <REASON>
-MessagePtr makeWarnMessage(
-    TwitchChannel *channel, const QDateTime &time,
+void makeModerateMessage(
+    EventSubMessageBuilder &builder,
     const lib::payload::channel_moderate::v2::Event &event,
     const lib::payload::channel_moderate::v2::Warn &action);
 


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

This should make it easier to build simple system messages in the future. A new message builder is born, `EventSubMessageBuilder`. But we merged all builders some time ago? Yes, we could do this in the `MessageBuilder` as well. However, I do feel like this is a bit specific to EventSub. Especially, having `builder.appendUser(esString, esString, text)` is neat and avoids boilerplate. Note: we will need to have even more handlers if we support `channel.chat.notification`.

For more complex messages, a second function name like `onModerateMessage(chan, time, event, action)` can be used.