### PR TITLE
fix: typo in color input selector. changed from red to blue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Bugfix: Fixed search in emote popup not always working correctly. (#5946)
 - Bugfix: Fixed channel point redemptions with messages not showing up if PubSub is disconnected. (#5948)
 - Bugfix: Fixed the input font not immediately updating when zooming in/out. (#5960)
+- Bugfix: Fixed color input thinking blue is also red. (#5982)
 - Dev: Subscriptions to PubSub channel points redemption topics now use no auth token, making it continue to work during PubSub shutdown. (#5947)
 - Dev: Add initial experimental EventSub support. (#5837, #5895, #5897, #5904, #5910, #5903, #5915, #5916, #5930, #5935, #5932, #5943, #5952, #5953, #5968, #5973, #5974, #5980)
 - Dev: Remove unneeded platform specifier for toasts. (#5914)

--- a/src/widgets/helper/color/ColorInput.cpp
+++ b/src/widgets/helper/color/ColorInput.cpp
@@ -82,7 +82,7 @@ ColorInput::ColorInput(QColor color, QWidget *parent)
     initComponent(this->green_, "Green:", [](auto &color, int value) {
         color.setGreen(value);
     });
-    initComponent(this->blue_, "Red:", [](auto &color, int value) {
+    initComponent(this->blue_, "Blue:", [](auto &color, int value) {
         color.setBlue(value);
     });
     initComponent(this->alpha_, "Alpha:", [](auto &color, int value) {


### PR DESCRIPTION
Changed the label for "Blue" back to Blue as it was incorrectly changed to "Red". This bug looks to have been introduced in commit 78a7ebb9f952d4de8fb69b95a786e570e96bdf1c.

To replicate this bug, open any of the color picker windows. One example is the "Highlights" menu. ![image](https://github.com/user-attachments/assets/1a6f8d1f-57cf-44dd-82d9-4e56f4234af6)


This pull request fixes #5979
