### PR TITLE
feat(eventsub): implement (shared chat) delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 - Bugfix: Fixed the input font not immediately updating when zooming in/out. (#5960)
 - Bugfix: Fixed color input thinking blue is also red. (#5982)
 - Dev: Subscriptions to PubSub channel points redemption topics now use no auth token, making it continue to work during PubSub shutdown. (#5947)
-- Dev: Add initial experimental EventSub support. (#5837, #5895, #5897, #5904, #5910, #5903, #5915, #5916, #5930, #5935, #5932, #5943, #5952, #5953, #5968, #5973, #5974, #5980, #5981, #5985, #5990, #5992)
+- Dev: Add initial experimental EventSub support. (#5837, #5895, #5897, #5904, #5910, #5903, #5915, #5916, #5930, #5935, #5932, #5943, #5952, #5953, #5968, #5973, #5974, #5980, #5981, #5985, #5990, #5992, #5993)
 - Dev: Remove unneeded platform specifier for toasts. (#5914)
 - Dev: Highlight checks now use non-capturing groups for the boundaries. (#5784)
 - Dev: Removed unused PubSub whisper code. (#5898)

--- a/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/payloads/channel-moderate-v2.hpp
+++ b/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/payloads/channel-moderate-v2.hpp
@@ -257,13 +257,14 @@ struct Unraid {
 struct Delete {
     static constexpr std::string_view TAG = "delete";
 
-    std::string userID;
-    std::string userLogin;
-    std::string userName;
-    std::string messageID;
-    std::string messageBody;
+    String userID;
+    String userLogin;
+    String userName;
+    String messageID;
+    String messageBody;
 };
-struct SharedChatDelete : public Ban {
+
+struct SharedChatDelete : public Delete {
     static constexpr std::string_view TAG = "shared_chat_delete";
 };
 

--- a/lib/twitch-eventsub-ws/src/generated/payloads/channel-moderate-v2.cpp
+++ b/lib/twitch-eventsub-ws/src/generated/payloads/channel-moderate-v2.cpp
@@ -771,7 +771,7 @@ boost::json::result_for<Delete, boost::json::value>::type tag_invoke(
         EVENTSUB_BAIL_HERE(error::Kind::FieldMissing);
     }
 
-    auto userID = boost::json::try_value_to<std::string>(*jvuserID);
+    auto userID = boost::json::try_value_to<String>(*jvuserID);
 
     if (userID.has_error())
     {
@@ -784,7 +784,7 @@ boost::json::result_for<Delete, boost::json::value>::type tag_invoke(
         EVENTSUB_BAIL_HERE(error::Kind::FieldMissing);
     }
 
-    auto userLogin = boost::json::try_value_to<std::string>(*jvuserLogin);
+    auto userLogin = boost::json::try_value_to<String>(*jvuserLogin);
 
     if (userLogin.has_error())
     {
@@ -797,7 +797,7 @@ boost::json::result_for<Delete, boost::json::value>::type tag_invoke(
         EVENTSUB_BAIL_HERE(error::Kind::FieldMissing);
     }
 
-    auto userName = boost::json::try_value_to<std::string>(*jvuserName);
+    auto userName = boost::json::try_value_to<String>(*jvuserName);
 
     if (userName.has_error())
     {
@@ -810,7 +810,7 @@ boost::json::result_for<Delete, boost::json::value>::type tag_invoke(
         EVENTSUB_BAIL_HERE(error::Kind::FieldMissing);
     }
 
-    auto messageID = boost::json::try_value_to<std::string>(*jvmessageID);
+    auto messageID = boost::json::try_value_to<String>(*jvmessageID);
 
     if (messageID.has_error())
     {
@@ -823,7 +823,7 @@ boost::json::result_for<Delete, boost::json::value>::type tag_invoke(
         EVENTSUB_BAIL_HERE(error::Kind::FieldMissing);
     }
 
-    auto messageBody = boost::json::try_value_to<std::string>(*jvmessageBody);
+    auto messageBody = boost::json::try_value_to<String>(*jvmessageBody);
 
     if (messageBody.has_error())
     {
@@ -843,7 +843,7 @@ boost::json::result_for<SharedChatDelete, boost::json::value>::type tag_invoke(
     boost::json::try_value_to_tag<SharedChatDelete> /* tag */,
     const boost::json::value &jvRoot)
 {
-    auto base = boost::json::try_value_to<Ban>(jvRoot);
+    auto base = boost::json::try_value_to<Delete>(jvRoot);
     if (base.has_error())
     {
         return base.error();

--- a/src/providers/twitch/eventsub/MessageBuilder.cpp
+++ b/src/providers/twitch/eventsub/MessageBuilder.cpp
@@ -166,4 +166,51 @@ void makeModerateMessage(
     builder->timeoutUser = action.userLogin.qt();
 }
 
+void makeModerateMessage(
+    EventSubMessageBuilder &builder,
+    const lib::payload::channel_moderate::v2::Event &event,
+    const lib::payload::channel_moderate::v2::Delete &action)
+{
+    builder.message().flags.set(MessageFlag::DoNotTriggerNotification);
+
+    QString text;
+    bool isShared = event.isFromSharedChat();
+
+    builder.appendUser(event.moderatorUserName, event.moderatorUserLogin, text);
+    builder.emplaceSystemTextAndUpdate("deleted message from", text);
+    builder.appendUser(action.userName, action.userLogin, text);
+
+    if (isShared)
+    {
+        builder.emplaceSystemTextAndUpdate("in", text);
+        builder.appendUser(*event.sourceBroadcasterUserName,
+                           *event.sourceBroadcasterUserLogin, text);
+    }
+
+    builder.emplaceSystemTextAndUpdate("saying:", text);
+
+    if (action.messageBody.view().length() > 50)
+    {
+        builder
+            .emplace<TextElement>(action.messageBody.qt().left(50) + "…",
+                                  MessageElementFlag::Text, MessageColor::Text)
+            ->setLink({Link::JumpToMessage, action.messageID.qt()});
+
+        text.append(action.messageBody.qt().left(50) + "…");
+    }
+    else
+    {
+        builder
+            .emplace<TextElement>(action.messageBody.qt(),
+                                  MessageElementFlag::Text, MessageColor::Text)
+            ->setLink({Link::JumpToMessage, action.messageID.qt()});
+
+        text.append(action.messageBody.qt());
+    }
+
+    builder->messageText = text;
+    builder->searchText = text;
+    builder->timeoutUser = action.userLogin.qt();
+}
+
 }  // namespace chatterino::eventsub

--- a/src/providers/twitch/eventsub/MessageBuilder.hpp
+++ b/src/providers/twitch/eventsub/MessageBuilder.hpp
@@ -54,4 +54,10 @@ void makeModerateMessage(
     const lib::payload::channel_moderate::v2::Event &event,
     const lib::payload::channel_moderate::v2::Unban &action);
 
+/// <MODERATOR> deleted message from <USER>[ in <CHANNEL>] saying: <MESSAGE>
+void makeModerateMessage(
+    EventSubMessageBuilder &builder,
+    const lib::payload::channel_moderate::v2::Event &event,
+    const lib::payload::channel_moderate::v2::Delete &action);
+
 }  // namespace chatterino::eventsub

--- a/tests/snapshots/EventSub/channel-moderate/delete-long.json
+++ b/tests/snapshots/EventSub/channel-moderate/delete-long.json
@@ -1,0 +1,174 @@
+{
+    "input": {
+        "action": "delete",
+        "automod_terms": null,
+        "ban": null,
+        "broadcaster_user_id": "11148817",
+        "broadcaster_user_login": "pajlada",
+        "broadcaster_user_name": "pajlada",
+        "delete": {
+            "message_body": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "message_id": "4b596dd8-8ab1-4ea1-9f1f-d0b5e1dc9868",
+            "user_id": "117166826",
+            "user_login": "testaccount_420",
+            "user_name": "테스트계정420"
+        },
+        "followers": null,
+        "mod": null,
+        "moderator_user_id": "117166826",
+        "moderator_user_login": "testaccount_420",
+        "moderator_user_name": "테스트계정420",
+        "raid": null,
+        "shared_chat_ban": null,
+        "shared_chat_delete": null,
+        "shared_chat_timeout": null,
+        "shared_chat_unban": null,
+        "shared_chat_untimeout": null,
+        "slow": null,
+        "source_broadcaster_user_id": null,
+        "source_broadcaster_user_login": null,
+        "source_broadcaster_user_name": null,
+        "timeout": null,
+        "unban": null,
+        "unban_request": null,
+        "unmod": null,
+        "unraid": null,
+        "untimeout": null,
+        "unvip": null,
+        "vip": null,
+        "warn": null
+    },
+    "output": [
+        {
+            "badgeInfos": {
+            },
+            "badges": [
+            ],
+            "channelName": "",
+            "count": 1,
+            "displayName": "",
+            "elements": [
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "ChatMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "0:00"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "00:00:00",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "MentionElement",
+                    "userColor": "System",
+                    "userLoginName": "testaccount_420",
+                    "words": [
+                        "테스트계정420"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "deleted",
+                        "message",
+                        "from"
+                    ]
+                },
+                {
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "MentionElement",
+                    "userColor": "System",
+                    "userLoginName": "testaccount_420",
+                    "words": [
+                        "테스트계정420"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "saying:"
+                    ]
+                },
+                {
+                    "color": "Text",
+                    "flags": "Text",
+                    "link": {
+                        "type": "JumpToMessage",
+                        "value": "4b596dd8-8ab1-4ea1-9f1f-d0b5e1dc9868"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa…"
+                    ]
+                }
+            ],
+            "flags": "System|Timeout|DoNotTriggerNotification",
+            "id": "",
+            "localizedName": "",
+            "loginName": "testaccount_420",
+            "messageText": "testaccount_420 deleted message from testaccount_420 saying: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa…",
+            "searchText": "testaccount_420 deleted message from testaccount_420 saying: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa…",
+            "serverReceivedTime": "1970-01-01T00:00:00Z",
+            "timeoutUser": "testaccount_420",
+            "userID": "",
+            "usernameColor": "#ff000000"
+        }
+    ]
+}

--- a/tests/snapshots/EventSub/channel-moderate/delete.json
+++ b/tests/snapshots/EventSub/channel-moderate/delete.json
@@ -1,0 +1,174 @@
+{
+    "input": {
+        "action": "delete",
+        "automod_terms": null,
+        "ban": null,
+        "broadcaster_user_id": "11148817",
+        "broadcaster_user_login": "pajlada",
+        "broadcaster_user_name": "pajlada",
+        "delete": {
+            "message_body": "asd",
+            "message_id": "2da2e2d6-61fc-4ee7-8ac4-1586b52b0ff6",
+            "user_id": "117166826",
+            "user_login": "testaccount_420",
+            "user_name": "테스트계정420"
+        },
+        "followers": null,
+        "mod": null,
+        "moderator_user_id": "117166826",
+        "moderator_user_login": "testaccount_420",
+        "moderator_user_name": "테스트계정420",
+        "raid": null,
+        "shared_chat_ban": null,
+        "shared_chat_delete": null,
+        "shared_chat_timeout": null,
+        "shared_chat_unban": null,
+        "shared_chat_untimeout": null,
+        "slow": null,
+        "source_broadcaster_user_id": null,
+        "source_broadcaster_user_login": null,
+        "source_broadcaster_user_name": null,
+        "timeout": null,
+        "unban": null,
+        "unban_request": null,
+        "unmod": null,
+        "unraid": null,
+        "untimeout": null,
+        "unvip": null,
+        "vip": null,
+        "warn": null
+    },
+    "output": [
+        {
+            "badgeInfos": {
+            },
+            "badges": [
+            ],
+            "channelName": "",
+            "count": 1,
+            "displayName": "",
+            "elements": [
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "ChatMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "0:00"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "00:00:00",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "MentionElement",
+                    "userColor": "System",
+                    "userLoginName": "testaccount_420",
+                    "words": [
+                        "테스트계정420"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "deleted",
+                        "message",
+                        "from"
+                    ]
+                },
+                {
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "MentionElement",
+                    "userColor": "System",
+                    "userLoginName": "testaccount_420",
+                    "words": [
+                        "테스트계정420"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "saying:"
+                    ]
+                },
+                {
+                    "color": "Text",
+                    "flags": "Text",
+                    "link": {
+                        "type": "JumpToMessage",
+                        "value": "2da2e2d6-61fc-4ee7-8ac4-1586b52b0ff6"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "asd"
+                    ]
+                }
+            ],
+            "flags": "System|Timeout|DoNotTriggerNotification",
+            "id": "",
+            "localizedName": "",
+            "loginName": "testaccount_420",
+            "messageText": "testaccount_420 deleted message from testaccount_420 saying: asd",
+            "searchText": "testaccount_420 deleted message from testaccount_420 saying: asd",
+            "serverReceivedTime": "1970-01-01T00:00:00Z",
+            "timeoutUser": "testaccount_420",
+            "userID": "",
+            "usernameColor": "#ff000000"
+        }
+    ]
+}

--- a/tests/snapshots/EventSub/channel-moderate/shared-delete-long.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-delete-long.json
@@ -1,0 +1,207 @@
+{
+    "input": {
+        "action": "shared_chat_delete",
+        "automod_terms": null,
+        "ban": null,
+        "broadcaster_user_id": "11148817",
+        "broadcaster_user_login": "pajlada",
+        "broadcaster_user_name": "pajlada",
+        "delete": null,
+        "followers": null,
+        "mod": null,
+        "moderator_user_id": "117166826",
+        "moderator_user_login": "testaccount_420",
+        "moderator_user_name": "테스트계정420",
+        "raid": null,
+        "shared_chat_ban": null,
+        "shared_chat_delete": {
+            "message_body": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "message_id": "620bf9d6-0fd1-4f84-a294-6a0db8e5a536",
+            "user_id": "117166826",
+            "user_login": "testaccount_420",
+            "user_name": "테스트계정420"
+        },
+        "shared_chat_timeout": null,
+        "shared_chat_unban": null,
+        "shared_chat_untimeout": null,
+        "slow": null,
+        "source_broadcaster_user_id": "159849156",
+        "source_broadcaster_user_login": "bajlada",
+        "source_broadcaster_user_name": "BajLada",
+        "timeout": null,
+        "unban": null,
+        "unban_request": null,
+        "unmod": null,
+        "unraid": null,
+        "untimeout": null,
+        "unvip": null,
+        "vip": null,
+        "warn": null
+    },
+    "output": [
+        {
+            "badgeInfos": {
+            },
+            "badges": [
+            ],
+            "channelName": "",
+            "count": 1,
+            "displayName": "",
+            "elements": [
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "ChatMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "0:00"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "00:00:00",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "MentionElement",
+                    "userColor": "System",
+                    "userLoginName": "testaccount_420",
+                    "words": [
+                        "테스트계정420"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "deleted",
+                        "message",
+                        "from"
+                    ]
+                },
+                {
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "MentionElement",
+                    "userColor": "System",
+                    "userLoginName": "testaccount_420",
+                    "words": [
+                        "테스트계정420"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "in"
+                    ]
+                },
+                {
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "MentionElement",
+                    "userColor": "System",
+                    "userLoginName": "bajlada",
+                    "words": [
+                        "BajLada"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "saying:"
+                    ]
+                },
+                {
+                    "color": "Text",
+                    "flags": "Text",
+                    "link": {
+                        "type": "JumpToMessage",
+                        "value": "620bf9d6-0fd1-4f84-a294-6a0db8e5a536"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa…"
+                    ]
+                }
+            ],
+            "flags": "System|Timeout|DoNotTriggerNotification",
+            "id": "",
+            "localizedName": "",
+            "loginName": "testaccount_420",
+            "messageText": "testaccount_420 deleted message from testaccount_420 in bajlada saying: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa…",
+            "searchText": "testaccount_420 deleted message from testaccount_420 in bajlada saying: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa…",
+            "serverReceivedTime": "1970-01-01T00:00:00Z",
+            "timeoutUser": "testaccount_420",
+            "userID": "",
+            "usernameColor": "#ff000000"
+        }
+    ]
+}

--- a/tests/snapshots/EventSub/channel-moderate/shared-delete.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-delete.json
@@ -1,0 +1,207 @@
+{
+    "input": {
+        "action": "shared_chat_delete",
+        "automod_terms": null,
+        "ban": null,
+        "broadcaster_user_id": "11148817",
+        "broadcaster_user_login": "pajlada",
+        "broadcaster_user_name": "pajlada",
+        "delete": null,
+        "followers": null,
+        "mod": null,
+        "moderator_user_id": "117166826",
+        "moderator_user_login": "testaccount_420",
+        "moderator_user_name": "테스트계정420",
+        "raid": null,
+        "shared_chat_ban": null,
+        "shared_chat_delete": {
+            "message_body": "dfg",
+            "message_id": "105f63c6-7a50-4ab3-b705-c626154e2ee9",
+            "user_id": "117166826",
+            "user_login": "testaccount_420",
+            "user_name": "테스트계정420"
+        },
+        "shared_chat_timeout": null,
+        "shared_chat_unban": null,
+        "shared_chat_untimeout": null,
+        "slow": null,
+        "source_broadcaster_user_id": "159849156",
+        "source_broadcaster_user_login": "bajlada",
+        "source_broadcaster_user_name": "BajLada",
+        "timeout": null,
+        "unban": null,
+        "unban_request": null,
+        "unmod": null,
+        "unraid": null,
+        "untimeout": null,
+        "unvip": null,
+        "vip": null,
+        "warn": null
+    },
+    "output": [
+        {
+            "badgeInfos": {
+            },
+            "badges": [
+            ],
+            "channelName": "",
+            "count": 1,
+            "displayName": "",
+            "elements": [
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "ChatMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "0:00"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "00:00:00",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "MentionElement",
+                    "userColor": "System",
+                    "userLoginName": "testaccount_420",
+                    "words": [
+                        "테스트계정420"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "deleted",
+                        "message",
+                        "from"
+                    ]
+                },
+                {
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "MentionElement",
+                    "userColor": "System",
+                    "userLoginName": "testaccount_420",
+                    "words": [
+                        "테스트계정420"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "in"
+                    ]
+                },
+                {
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "MentionElement",
+                    "userColor": "System",
+                    "userLoginName": "bajlada",
+                    "words": [
+                        "BajLada"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "saying:"
+                    ]
+                },
+                {
+                    "color": "Text",
+                    "flags": "Text",
+                    "link": {
+                        "type": "JumpToMessage",
+                        "value": "105f63c6-7a50-4ab3-b705-c626154e2ee9"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "dfg"
+                    ]
+                }
+            ],
+            "flags": "System|Timeout|DoNotTriggerNotification",
+            "id": "",
+            "localizedName": "",
+            "loginName": "testaccount_420",
+            "messageText": "testaccount_420 deleted message from testaccount_420 in bajlada saying: dfg",
+            "searchText": "testaccount_420 deleted message from testaccount_420 in bajlada saying: dfg",
+            "serverReceivedTime": "1970-01-01T00:00:00Z",
+            "timeoutUser": "testaccount_420",
+            "userID": "",
+            "usernameColor": "#ff000000"
+        }
+    ]
+}


### PR DESCRIPTION
Towards #5908

Implements:
 - Delete  
   
![image](https://github.com/user-attachments/assets/671ea348-fd99-424a-8ff4-302bcc90ba2c)
![image](https://github.com/user-attachments/assets/ace8fa6c-8545-43d4-8171-9ec02ea43c97)


 - Shared chat delete (we didn't handle this in PubSub)
 
![image](https://github.com/user-attachments/assets/4767012c-e1cb-4cb6-8aba-00bafdb2cd5e)
![image](https://github.com/user-attachments/assets/be1bbf35-76bf-4f9e-bd50-c0ad29ae7672)



Will add changelog entry after the chat modes PR is merged in