### PR TITLE
Enhance Chatterino's extension handling

### DIFF
--- a/src/singletons/NativeMessaging.cpp
+++ b/src/singletons/NativeMessaging.cpp
@@ -60,6 +60,18 @@ void registerNmHost(const Paths &paths)
         auto obj = getBaseDocument();
         QJsonArray allowedOriginsArr = {
             u"chrome-extension://%1/"_s.arg(EXTENSION_ID)};
+
+        // Parse additional extension IDs from settings
+        QString additionalIDs = getSettings()->additionalExtensionIDs.getValue();
+        if (!additionalIDs.isEmpty())
+        {
+            QStringList idList = additionalIDs.split(';');
+            for (const QString &id : idList)
+            {
+                allowedOriginsArr.append(u"chrome-extension://%1/"_s.arg(id));
+            }
+        }
+
         obj.insert("allowed_origins", allowedOriginsArr);
 
         registerNmManifest(paths, "/native-messaging-manifest-chrome.json",
@@ -72,6 +84,18 @@ void registerNmHost(const Paths &paths)
     {
         auto obj = getBaseDocument();
         QJsonArray allowedExtensions = {"chatterino_native@chatterino.com"};
+
+        // Parse additional extension IDs from settings
+        QString additionalIDs = getSettings()->additionalExtensionIDs.getValue();
+        if (!additionalIDs.isEmpty())
+        {
+            QStringList idList = additionalIDs.split(';');
+            for (const QString &id : idList)
+            {
+                allowedExtensions.append(id);
+            }
+        }
+
         obj.insert("allowed_extensions", allowedExtensions);
 
         registerNmManifest(paths, "/native-messaging-manifest-firefox.json",

--- a/src/singletons/NativeMessaging.cpp
+++ b/src/singletons/NativeMessaging.cpp
@@ -1,4 +1,5 @@
 #include "singletons/NativeMessaging.hpp"
+#include "singletons/Settings.hpp"
 
 #include "Application.hpp"
 #include "common/Literals.hpp"
@@ -68,7 +69,11 @@ void registerNmHost(const Paths &paths)
             QStringList idList = additionalIDs.split(';');
             for (const QString &id : idList)
             {
-                allowedOriginsArr.append(u"chrome-extension://%1/"_s.arg(id));
+                QString trimmedId = id.trimmed();
+                if (!trimmedId.isEmpty())
+                {
+                    allowedOriginsArr.append(u"chrome-extension://%1/"_s.arg(trimmedId));
+                }
             }
         }
 
@@ -92,7 +97,11 @@ void registerNmHost(const Paths &paths)
             QStringList idList = additionalIDs.split(';');
             for (const QString &id : idList)
             {
-                allowedExtensions.append(id);
+                QString trimmedId = id.trimmed();
+                if (!trimmedId.isEmpty())
+                {
+                    allowedExtensions.append(trimmedId);
+                }
             }
         }
 

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -643,6 +643,8 @@ public:
         false,
     };
 
+    QStringSetting additionalExtensionIDs = {"/nativeMessaging/additionalExtensionIDs", ""};
+
 private:
     ChatterinoSetting<std::vector<HighlightPhrase>> highlightedMessagesSetting =
         {"/highlighting/highlights"};


### PR DESCRIPTION
Enhance Chatterino's extension handling by allowing users to specify additional extension IDs.

* Add a new `QStringSetting` named `additionalExtensionIDs` in `src/singletons/Settings.hpp` to store additional extension IDs, defaulting to an empty string.
* Update `registerNmHost` function in `src/singletons/NativeMessaging.cpp` to parse the `additionalExtensionIDs` setting.
* Split the `additionalExtensionIDs` string by a delimiter (`;`) to get individual extension IDs.
* Add the parsed extension IDs to the `allowedOriginsArr` in the Chrome manifest.
* Add the parsed extension IDs to the `allowedExtensions` in the Firefox manifest.

I think it should work, not tested, made for fix: https://github.com/Chatterino/chatterino2/issues/5964

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Chatterino/chatterino2/pull/5994?shareId=8d6639c8-77f2-415d-b856-4d30f575f889).