### PR TITLE
feat(eventsub): use special flag and timestamps from metadata

### DIFF
--- a/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/messages/metadata.hpp
+++ b/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/messages/metadata.hpp
@@ -2,6 +2,7 @@
 
 #include <boost/json.hpp>
 
+#include <chrono>
 #include <optional>
 #include <string>
 
@@ -23,8 +24,8 @@ namespace chatterino::eventsub::lib::messages {
 struct Metadata {
     std::string messageID;
     std::string messageType;
-    // TODO: should this be chronofied?
-    std::string messageTimestamp;
+    /// json_tag=AsISO8601
+    std::chrono::system_clock::time_point messageTimestamp;
 
     std::optional<std::string> subscriptionType;
     std::optional<std::string> subscriptionVersion;

--- a/src/messages/MessageFlag.hpp
+++ b/src/messages/MessageFlag.hpp
@@ -56,6 +56,8 @@ enum class MessageFlag : std::int64_t {
     AutoModBlockedTerm = (1LL << 38),
     /// The message is a full clear chat message (/clear)
     ClearChat = (1LL << 39),
+    /// The message is built from EventSub
+    EventSub = (1LL << 40),
 };
 using MessageFlags = FlagsEnum<MessageFlag>;
 

--- a/src/providers/twitch/eventsub/Connection.cpp
+++ b/src/providers/twitch/eventsub/Connection.cpp
@@ -148,11 +148,9 @@ void Connection::onChannelModerate(
         return;
     }
 
-    auto now = QDateTime::currentDateTime();
-    if (getApp()->isTest())
-    {
-        now = QDateTime::fromSecsSinceEpoch(0).toUTC();
-    }
+    auto now = QDateTime::fromStdTimePoint(
+        std::chrono::time_point_cast<std::chrono::milliseconds>(
+            metadata.messageTimestamp));
 
     std::visit(
         [&](auto &&action) {

--- a/src/providers/twitch/eventsub/MessageBuilder.cpp
+++ b/src/providers/twitch/eventsub/MessageBuilder.cpp
@@ -41,8 +41,8 @@ EventSubMessageBuilder::EventSubMessageBuilder(TwitchChannel *channel,
                                                const QDateTime &time)
     : channel(channel)
 {
-    this->emplace<TimestampElement>();
-    this->message().flags.set(MessageFlag::System);
+    this->emplace<TimestampElement>(time.time());
+    this->message().flags.set(MessageFlag::System, MessageFlag::EventSub);
     this->message().flags.set(MessageFlag::Timeout);  // do we need this?
     this->message().serverReceivedTime = time;
 }

--- a/tests/snapshots/EventSub/channel-moderate/ban-reason.json
+++ b/tests/snapshots/EventSub/channel-moderate/ban-reason.json
@@ -60,7 +60,7 @@
                         "trailingSpace": true,
                         "type": "TextElement",
                         "words": [
-                            "0:00"
+                            "12:31"
                         ]
                     },
                     "flags": "Timestamp",
@@ -69,7 +69,7 @@
                         "type": "None",
                         "value": ""
                     },
-                    "time": "00:00:00",
+                    "time": "12:31:47",
                     "tooltip": "",
                     "trailingSpace": true,
                     "type": "TimestampElement"
@@ -157,13 +157,13 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout",
+            "flags": "System|Timeout|EventSub",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",
             "messageText": "nerixyz banned uint128: my reason ",
             "searchText": "nerixyz banned uint128: my reason ",
-            "serverReceivedTime": "1970-01-01T00:00:00Z",
+            "serverReceivedTime": "2024-05-14T12:31:47Z",
             "timeoutUser": "uint128",
             "userID": "",
             "usernameColor": "#ff000000"

--- a/tests/snapshots/EventSub/channel-moderate/ban.json
+++ b/tests/snapshots/EventSub/channel-moderate/ban.json
@@ -60,7 +60,7 @@
                         "trailingSpace": true,
                         "type": "TextElement",
                         "words": [
-                            "0:00"
+                            "12:31"
                         ]
                     },
                     "flags": "Timestamp",
@@ -69,7 +69,7 @@
                         "type": "None",
                         "value": ""
                     },
-                    "time": "00:00:00",
+                    "time": "12:31:47",
                     "tooltip": "",
                     "trailingSpace": true,
                     "type": "TimestampElement"
@@ -141,13 +141,13 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout",
+            "flags": "System|Timeout|EventSub",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",
             "messageText": "nerixyz banned uint128. ",
             "searchText": "nerixyz banned uint128. ",
-            "serverReceivedTime": "1970-01-01T00:00:00Z",
+            "serverReceivedTime": "2024-05-14T12:31:47Z",
             "timeoutUser": "uint128",
             "userID": "",
             "usernameColor": "#ff000000"

--- a/tests/snapshots/EventSub/channel-moderate/clear.json
+++ b/tests/snapshots/EventSub/channel-moderate/clear.json
@@ -55,7 +55,7 @@
                         "trailingSpace": true,
                         "type": "TextElement",
                         "words": [
-                            "0:00"
+                            "12:31"
                         ]
                     },
                     "flags": "Timestamp",
@@ -64,7 +64,7 @@
                         "type": "None",
                         "value": ""
                     },
-                    "time": "00:00:00",
+                    "time": "12:31:47",
                     "tooltip": "",
                     "trailingSpace": true,
                     "type": "TimestampElement"
@@ -111,7 +111,7 @@
             "loginName": "",
             "messageText": "nerixyz cleared the chat. ",
             "searchText": "nerixyz cleared the chat. ",
-            "serverReceivedTime": "1970-01-01T00:00:00Z",
+            "serverReceivedTime": "2024-05-14T12:31:47Z",
             "timeoutUser": "nerixyz",
             "userID": "",
             "usernameColor": "#ff000000"

--- a/tests/snapshots/EventSub/channel-moderate/emoteonly-off.json
+++ b/tests/snapshots/EventSub/channel-moderate/emoteonly-off.json
@@ -55,7 +55,7 @@
                         "trailingSpace": true,
                         "type": "TextElement",
                         "words": [
-                            "0:00"
+                            "12:31"
                         ]
                     },
                     "flags": "Timestamp",
@@ -64,7 +64,7 @@
                         "type": "None",
                         "value": ""
                     },
-                    "time": "00:00:00",
+                    "time": "12:31:47",
                     "tooltip": "",
                     "trailingSpace": true,
                     "type": "TimestampElement"
@@ -148,13 +148,13 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout",
+            "flags": "System|Timeout|EventSub",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",
             "messageText": "nerixyz turned off emote-only mode. ",
             "searchText": "nerixyz turned off emote-only mode. ",
-            "serverReceivedTime": "1970-01-01T00:00:00Z",
+            "serverReceivedTime": "2024-05-14T12:31:47Z",
             "timeoutUser": "",
             "userID": "",
             "usernameColor": "#ff000000"

--- a/tests/snapshots/EventSub/channel-moderate/emoteonly.json
+++ b/tests/snapshots/EventSub/channel-moderate/emoteonly.json
@@ -55,7 +55,7 @@
                         "trailingSpace": true,
                         "type": "TextElement",
                         "words": [
-                            "0:00"
+                            "12:31"
                         ]
                     },
                     "flags": "Timestamp",
@@ -64,7 +64,7 @@
                         "type": "None",
                         "value": ""
                     },
-                    "time": "00:00:00",
+                    "time": "12:31:47",
                     "tooltip": "",
                     "trailingSpace": true,
                     "type": "TimestampElement"
@@ -148,13 +148,13 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout",
+            "flags": "System|Timeout|EventSub",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",
             "messageText": "nerixyz turned on emote-only mode. ",
             "searchText": "nerixyz turned on emote-only mode. ",
-            "serverReceivedTime": "1970-01-01T00:00:00Z",
+            "serverReceivedTime": "2024-05-14T12:31:47Z",
             "timeoutUser": "",
             "userID": "",
             "usernameColor": "#ff000000"

--- a/tests/snapshots/EventSub/channel-moderate/followers-0s.json
+++ b/tests/snapshots/EventSub/channel-moderate/followers-0s.json
@@ -57,7 +57,7 @@
                         "trailingSpace": true,
                         "type": "TextElement",
                         "words": [
-                            "0:00"
+                            "12:31"
                         ]
                     },
                     "flags": "Timestamp",
@@ -66,7 +66,7 @@
                         "type": "None",
                         "value": ""
                     },
-                    "time": "00:00:00",
+                    "time": "12:31:47",
                     "tooltip": "",
                     "trailingSpace": true,
                     "type": "TimestampElement"
@@ -150,13 +150,13 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout",
+            "flags": "System|Timeout|EventSub",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",
             "messageText": "nerixyz turned on followers-only mode. ",
             "searchText": "nerixyz turned on followers-only mode. ",
-            "serverReceivedTime": "1970-01-01T00:00:00Z",
+            "serverReceivedTime": "2024-05-14T12:31:47Z",
             "timeoutUser": "",
             "userID": "",
             "usernameColor": "#ff000000"

--- a/tests/snapshots/EventSub/channel-moderate/followers-off.json
+++ b/tests/snapshots/EventSub/channel-moderate/followers-off.json
@@ -55,7 +55,7 @@
                         "trailingSpace": true,
                         "type": "TextElement",
                         "words": [
-                            "0:00"
+                            "12:31"
                         ]
                     },
                     "flags": "Timestamp",
@@ -64,7 +64,7 @@
                         "type": "None",
                         "value": ""
                     },
-                    "time": "00:00:00",
+                    "time": "12:31:47",
                     "tooltip": "",
                     "trailingSpace": true,
                     "type": "TimestampElement"
@@ -148,13 +148,13 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout",
+            "flags": "System|Timeout|EventSub",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",
             "messageText": "nerixyz turned off followers-only mode. ",
             "searchText": "nerixyz turned off followers-only mode. ",
-            "serverReceivedTime": "1970-01-01T00:00:00Z",
+            "serverReceivedTime": "2024-05-14T12:31:47Z",
             "timeoutUser": "",
             "userID": "",
             "usernameColor": "#ff000000"

--- a/tests/snapshots/EventSub/channel-moderate/followers.json
+++ b/tests/snapshots/EventSub/channel-moderate/followers.json
@@ -57,7 +57,7 @@
                         "trailingSpace": true,
                         "type": "TextElement",
                         "words": [
-                            "0:00"
+                            "12:31"
                         ]
                     },
                     "flags": "Timestamp",
@@ -66,7 +66,7 @@
                         "type": "None",
                         "value": ""
                     },
-                    "time": "00:00:00",
+                    "time": "12:31:47",
                     "tooltip": "",
                     "trailingSpace": true,
                     "type": "TimestampElement"
@@ -166,13 +166,13 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout",
+            "flags": "System|Timeout|EventSub",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",
             "messageText": "nerixyz turned on followers-only mode. (15 minutes) ",
             "searchText": "nerixyz turned on followers-only mode. (15 minutes) ",
-            "serverReceivedTime": "1970-01-01T00:00:00Z",
+            "serverReceivedTime": "2024-05-14T12:31:47Z",
             "timeoutUser": "",
             "userID": "",
             "usernameColor": "#ff000000"

--- a/tests/snapshots/EventSub/channel-moderate/shared-ban-reason.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-ban-reason.json
@@ -60,7 +60,7 @@
                         "trailingSpace": true,
                         "type": "TextElement",
                         "words": [
-                            "0:00"
+                            "12:31"
                         ]
                     },
                     "flags": "Timestamp",
@@ -69,7 +69,7 @@
                         "type": "None",
                         "value": ""
                     },
-                    "time": "00:00:00",
+                    "time": "12:31:47",
                     "tooltip": "",
                     "trailingSpace": true,
                     "type": "TimestampElement"
@@ -191,13 +191,13 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout",
+            "flags": "System|Timeout|EventSub",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",
             "messageText": "nerixyz banned twitchdev in testaccount_420: a reason 😂 ",
             "searchText": "nerixyz banned twitchdev in testaccount_420: a reason 😂 ",
-            "serverReceivedTime": "1970-01-01T00:00:00Z",
+            "serverReceivedTime": "2024-05-14T12:31:47Z",
             "timeoutUser": "twitchdev",
             "userID": "",
             "usernameColor": "#ff000000"

--- a/tests/snapshots/EventSub/channel-moderate/shared-ban.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-ban.json
@@ -60,7 +60,7 @@
                         "trailingSpace": true,
                         "type": "TextElement",
                         "words": [
-                            "0:00"
+                            "12:31"
                         ]
                     },
                     "flags": "Timestamp",
@@ -69,7 +69,7 @@
                         "type": "None",
                         "value": ""
                     },
-                    "time": "00:00:00",
+                    "time": "12:31:47",
                     "tooltip": "",
                     "trailingSpace": true,
                     "type": "TimestampElement"
@@ -174,13 +174,13 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout",
+            "flags": "System|Timeout|EventSub",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",
             "messageText": "nerixyz banned twitchdev in testaccount_420. ",
             "searchText": "nerixyz banned twitchdev in testaccount_420. ",
-            "serverReceivedTime": "1970-01-01T00:00:00Z",
+            "serverReceivedTime": "2024-05-14T12:31:47Z",
             "timeoutUser": "twitchdev",
             "userID": "",
             "usernameColor": "#ff000000"

--- a/tests/snapshots/EventSub/channel-moderate/shared-unban.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-unban.json
@@ -59,7 +59,7 @@
                         "trailingSpace": true,
                         "type": "TextElement",
                         "words": [
-                            "0:00"
+                            "12:31"
                         ]
                     },
                     "flags": "Timestamp",
@@ -68,7 +68,7 @@
                         "type": "None",
                         "value": ""
                     },
-                    "time": "00:00:00",
+                    "time": "12:31:47",
                     "tooltip": "",
                     "trailingSpace": true,
                     "type": "TimestampElement"
@@ -173,13 +173,13 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout",
+            "flags": "System|Timeout|EventSub",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",
             "messageText": "nerixyz unbanned uint128 in testaccount_420. ",
             "searchText": "nerixyz unbanned uint128 in testaccount_420. ",
-            "serverReceivedTime": "1970-01-01T00:00:00Z",
+            "serverReceivedTime": "2024-05-14T12:31:47Z",
             "timeoutUser": "uint128",
             "userID": "",
             "usernameColor": "#ff000000"

--- a/tests/snapshots/EventSub/channel-moderate/slow-off.json
+++ b/tests/snapshots/EventSub/channel-moderate/slow-off.json
@@ -55,7 +55,7 @@
                         "trailingSpace": true,
                         "type": "TextElement",
                         "words": [
-                            "0:00"
+                            "12:31"
                         ]
                     },
                     "flags": "Timestamp",
@@ -64,7 +64,7 @@
                         "type": "None",
                         "value": ""
                     },
-                    "time": "00:00:00",
+                    "time": "12:31:47",
                     "tooltip": "",
                     "trailingSpace": true,
                     "type": "TimestampElement"
@@ -148,13 +148,13 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout",
+            "flags": "System|Timeout|EventSub",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",
             "messageText": "nerixyz turned off slow mode. ",
             "searchText": "nerixyz turned off slow mode. ",
-            "serverReceivedTime": "1970-01-01T00:00:00Z",
+            "serverReceivedTime": "2024-05-14T12:31:47Z",
             "timeoutUser": "",
             "userID": "",
             "usernameColor": "#ff000000"

--- a/tests/snapshots/EventSub/channel-moderate/slow.json
+++ b/tests/snapshots/EventSub/channel-moderate/slow.json
@@ -57,7 +57,7 @@
                         "trailingSpace": true,
                         "type": "TextElement",
                         "words": [
-                            "0:00"
+                            "12:31"
                         ]
                     },
                     "flags": "Timestamp",
@@ -66,7 +66,7 @@
                         "type": "None",
                         "value": ""
                     },
-                    "time": "00:00:00",
+                    "time": "12:31:47",
                     "tooltip": "",
                     "trailingSpace": true,
                     "type": "TimestampElement"
@@ -166,13 +166,13 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout",
+            "flags": "System|Timeout|EventSub",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",
             "messageText": "nerixyz turned on slow mode. (10 seconds) ",
             "searchText": "nerixyz turned on slow mode. (10 seconds) ",
-            "serverReceivedTime": "1970-01-01T00:00:00Z",
+            "serverReceivedTime": "2024-05-14T12:31:47Z",
             "timeoutUser": "",
             "userID": "",
             "usernameColor": "#ff000000"

--- a/tests/snapshots/EventSub/channel-moderate/subscribers-off.json
+++ b/tests/snapshots/EventSub/channel-moderate/subscribers-off.json
@@ -55,7 +55,7 @@
                         "trailingSpace": true,
                         "type": "TextElement",
                         "words": [
-                            "0:00"
+                            "12:31"
                         ]
                     },
                     "flags": "Timestamp",
@@ -64,7 +64,7 @@
                         "type": "None",
                         "value": ""
                     },
-                    "time": "00:00:00",
+                    "time": "12:31:47",
                     "tooltip": "",
                     "trailingSpace": true,
                     "type": "TimestampElement"
@@ -148,13 +148,13 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout",
+            "flags": "System|Timeout|EventSub",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",
             "messageText": "nerixyz turned off subscribers-only mode. ",
             "searchText": "nerixyz turned off subscribers-only mode. ",
-            "serverReceivedTime": "1970-01-01T00:00:00Z",
+            "serverReceivedTime": "2024-05-14T12:31:47Z",
             "timeoutUser": "",
             "userID": "",
             "usernameColor": "#ff000000"

--- a/tests/snapshots/EventSub/channel-moderate/subscribers.json
+++ b/tests/snapshots/EventSub/channel-moderate/subscribers.json
@@ -55,7 +55,7 @@
                         "trailingSpace": true,
                         "type": "TextElement",
                         "words": [
-                            "0:00"
+                            "12:31"
                         ]
                     },
                     "flags": "Timestamp",
@@ -64,7 +64,7 @@
                         "type": "None",
                         "value": ""
                     },
-                    "time": "00:00:00",
+                    "time": "12:31:47",
                     "tooltip": "",
                     "trailingSpace": true,
                     "type": "TimestampElement"
@@ -148,13 +148,13 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout",
+            "flags": "System|Timeout|EventSub",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",
             "messageText": "nerixyz turned on subscribers-only mode. ",
             "searchText": "nerixyz turned on subscribers-only mode. ",
-            "serverReceivedTime": "1970-01-01T00:00:00Z",
+            "serverReceivedTime": "2024-05-14T12:31:47Z",
             "timeoutUser": "",
             "userID": "",
             "usernameColor": "#ff000000"

--- a/tests/snapshots/EventSub/channel-moderate/unban.json
+++ b/tests/snapshots/EventSub/channel-moderate/unban.json
@@ -59,7 +59,7 @@
                         "trailingSpace": true,
                         "type": "TextElement",
                         "words": [
-                            "0:00"
+                            "12:31"
                         ]
                     },
                     "flags": "Timestamp",
@@ -68,7 +68,7 @@
                         "type": "None",
                         "value": ""
                     },
-                    "time": "00:00:00",
+                    "time": "12:31:47",
                     "tooltip": "",
                     "trailingSpace": true,
                     "type": "TimestampElement"
@@ -140,13 +140,13 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout",
+            "flags": "System|Timeout|EventSub",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",
             "messageText": "nerixyz unbanned uint128. ",
             "searchText": "nerixyz unbanned uint128. ",
-            "serverReceivedTime": "1970-01-01T00:00:00Z",
+            "serverReceivedTime": "2024-05-14T12:31:47Z",
             "timeoutUser": "uint128",
             "userID": "",
             "usernameColor": "#ff000000"

--- a/tests/snapshots/EventSub/channel-moderate/uniquechat-off.json
+++ b/tests/snapshots/EventSub/channel-moderate/uniquechat-off.json
@@ -55,7 +55,7 @@
                         "trailingSpace": true,
                         "type": "TextElement",
                         "words": [
-                            "0:00"
+                            "12:31"
                         ]
                     },
                     "flags": "Timestamp",
@@ -64,7 +64,7 @@
                         "type": "None",
                         "value": ""
                     },
-                    "time": "00:00:00",
+                    "time": "12:31:47",
                     "tooltip": "",
                     "trailingSpace": true,
                     "type": "TimestampElement"
@@ -148,13 +148,13 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout",
+            "flags": "System|Timeout|EventSub",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",
             "messageText": "nerixyz turned off unique-chat mode. ",
             "searchText": "nerixyz turned off unique-chat mode. ",
-            "serverReceivedTime": "1970-01-01T00:00:00Z",
+            "serverReceivedTime": "2024-05-14T12:31:47Z",
             "timeoutUser": "",
             "userID": "",
             "usernameColor": "#ff000000"

--- a/tests/snapshots/EventSub/channel-moderate/uniquechat.json
+++ b/tests/snapshots/EventSub/channel-moderate/uniquechat.json
@@ -55,7 +55,7 @@
                         "trailingSpace": true,
                         "type": "TextElement",
                         "words": [
-                            "0:00"
+                            "12:31"
                         ]
                     },
                     "flags": "Timestamp",
@@ -64,7 +64,7 @@
                         "type": "None",
                         "value": ""
                     },
-                    "time": "00:00:00",
+                    "time": "12:31:47",
                     "tooltip": "",
                     "trailingSpace": true,
                     "type": "TimestampElement"
@@ -148,13 +148,13 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout",
+            "flags": "System|Timeout|EventSub",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",
             "messageText": "nerixyz turned on unique-chat mode. ",
             "searchText": "nerixyz turned on unique-chat mode. ",
-            "serverReceivedTime": "1970-01-01T00:00:00Z",
+            "serverReceivedTime": "2024-05-14T12:31:47Z",
             "timeoutUser": "",
             "userID": "",
             "usernameColor": "#ff000000"

--- a/tests/snapshots/EventSub/channel-moderate/warn-shared.json
+++ b/tests/snapshots/EventSub/channel-moderate/warn-shared.json
@@ -60,7 +60,7 @@
                         "trailingSpace": true,
                         "type": "TextElement",
                         "words": [
-                            "0:00"
+                            "12:31"
                         ]
                     },
                     "flags": "Timestamp",
@@ -69,7 +69,7 @@
                         "type": "None",
                         "value": ""
                     },
-                    "time": "00:00:00",
+                    "time": "12:31:47",
                     "tooltip": "",
                     "trailingSpace": true,
                     "type": "TimestampElement"
@@ -159,13 +159,13 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout",
+            "flags": "System|Timeout|EventSub",
             "id": "",
             "localizedName": "",
             "loginName": "quotrok",
             "messageText": "quotrok has warned twitchdev: cut it out ",
             "searchText": "quotrok has warned twitchdev: cut it out ",
-            "serverReceivedTime": "1970-01-01T00:00:00Z",
+            "serverReceivedTime": "2024-05-14T12:31:47Z",
             "timeoutUser": "",
             "userID": "",
             "usernameColor": "#ff000000"

--- a/tests/snapshots/EventSub/channel-moderate/warn.json
+++ b/tests/snapshots/EventSub/channel-moderate/warn.json
@@ -60,7 +60,7 @@
                         "trailingSpace": true,
                         "type": "TextElement",
                         "words": [
-                            "0:00"
+                            "12:31"
                         ]
                     },
                     "flags": "Timestamp",
@@ -69,7 +69,7 @@
                         "type": "None",
                         "value": ""
                     },
-                    "time": "00:00:00",
+                    "time": "12:31:47",
                     "tooltip": "",
                     "trailingSpace": true,
                     "type": "TimestampElement"
@@ -159,13 +159,13 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout",
+            "flags": "System|Timeout|EventSub",
             "id": "",
             "localizedName": "",
             "loginName": "quotrok",
             "messageText": "quotrok has warned twitchdev: cut it out ",
             "searchText": "quotrok has warned twitchdev: cut it out ",
-            "serverReceivedTime": "1970-01-01T00:00:00Z",
+            "serverReceivedTime": "2024-05-14T12:31:47Z",
             "timeoutUser": "",
             "userID": "",
             "usernameColor": "#ff000000"


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

The metadata for an EventSub message contains a `message_timestamp`. We can use this to populate the timestamp that we add to a message (instead of using the current time). For the tests, we use a fixed timestamp. In https://github.com/Chatterino/chatterino2/pull/5995, I added a way of changing that timestamp by specifying `__timestamp`. This is only needed for timeouts and for testing stacking (future work).

To distinguish EventSub messages from others, I added a `EventSub` flag (similar to `PubSub`).