### PR TITLE
Chatterino warning fixes

### DIFF
--- a/src/singletons/StreamerMode.cpp
+++ b/src/singletons/StreamerMode.cpp
@@ -143,7 +143,7 @@ bool isBroadcasterSoftwareActive()
     }
 
 #else
-#    warning Unsupported OS: Broadcasting software can't be detected
+#    warning Unsupported OS: Broadcasting software can\'t be detected
 #endif
     return false;
 }

--- a/tests/src/AccessGuard.cpp
+++ b/tests/src/AccessGuard.cpp
@@ -42,8 +42,6 @@ TEST(AccessGuardLocker, ConcurrentUsage)
     std::shared_mutex m;
     int e = 0;
 
-    auto startTime = std::chrono::steady_clock::now();
-
     auto w = [&e, &m] {
         std::mt19937_64 eng{std::random_device{}()};
         std::uniform_int_distribution<> dist{1, 4};
@@ -58,7 +56,8 @@ TEST(AccessGuardLocker, ConcurrentUsage)
         {
             SharedAccessGuard<int> guard(e, m);
             std::this_thread::sleep_for(std::chrono::milliseconds{dist(eng)});
-            int hehe = *guard;
+            volatile int hehe = *guard;
+            (void)hehe;
         }
     };
 


### PR DESCRIPTION
This fixes the warnings inside Chatterino code with GCC 14 on Linux (which progresses #4825 forward)

Note that sol2 may still have a stubborn `-Wmaybe-uninitialized` warning even after this change