### PR TITLE
feat(eventsub): implement AutoMod term actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 - Bugfix: Fixed the input font not immediately updating when zooming in/out. (#5960)
 - Bugfix: Fixed color input thinking blue is also red. (#5982)
 - Dev: Subscriptions to PubSub channel points redemption topics now use no auth token, making it continue to work during PubSub shutdown. (#5947)
-- Dev: Add initial experimental EventSub support. (#5837, #5895, #5897, #5904, #5910, #5903, #5915, #5916, #5930, #5935, #5932, #5943, #5952, #5953, #5968, #5973, #5974, #5980, #5981, #5985, #5990, #5992, #5993, #5996, #5995)
+- Dev: Add initial experimental EventSub support. (#5837, #5895, #5897, #5904, #5910, #5903, #5915, #5916, #5930, #5935, #5932, #5943, #5952, #5953, #5968, #5973, #5974, #5980, #5981, #5985, #5990, #5992, #5993, #5996, #5995, #6000)
 - Dev: Remove unneeded platform specifier for toasts. (#5914)
 - Dev: Highlight checks now use non-capturing groups for the boundaries. (#5784)
 - Dev: Removed unused PubSub whisper code. (#5898)

--- a/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/payloads/channel-moderate-v2.hpp
+++ b/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/payloads/channel-moderate-v2.hpp
@@ -282,11 +282,11 @@ struct AutomodTerms {
     static constexpr std::string_view FIELD = "automod_terms";
 
     // either add or remove
-    std::string action;
+    String action;
     // either blocked or permitted
-    std::string list;
+    String list;
 
-    std::vector<std::string> terms;
+    std::vector<String> terms;
     bool fromAutomod;
 };
 

--- a/lib/twitch-eventsub-ws/src/generated/payloads/channel-moderate-v2.cpp
+++ b/lib/twitch-eventsub-ws/src/generated/payloads/channel-moderate-v2.cpp
@@ -872,7 +872,7 @@ boost::json::result_for<AutomodTerms, boost::json::value>::type tag_invoke(
         EVENTSUB_BAIL_HERE(error::Kind::FieldMissing);
     }
 
-    auto action = boost::json::try_value_to<std::string>(*jvaction);
+    auto action = boost::json::try_value_to<String>(*jvaction);
 
     if (action.has_error())
     {
@@ -885,19 +885,19 @@ boost::json::result_for<AutomodTerms, boost::json::value>::type tag_invoke(
         EVENTSUB_BAIL_HERE(error::Kind::FieldMissing);
     }
 
-    auto list = boost::json::try_value_to<std::string>(*jvlist);
+    auto list = boost::json::try_value_to<String>(*jvlist);
 
     if (list.has_error())
     {
         return list.error();
     }
 
-    std::vector<std::string> vterms;
+    std::vector<chatterino::eventsub::lib::String> vterms;
     const auto *jvterms = root.if_contains("terms");
     if (jvterms != nullptr && !jvterms->is_null())
     {
-        auto terms =
-            boost::json::try_value_to<std::vector<std::string>>(*jvterms);
+        auto terms = boost::json::try_value_to<
+            std::vector<chatterino::eventsub::lib::String>>(*jvterms);
         if (terms.has_error())
         {
             return terms.error();

--- a/src/providers/twitch/eventsub/MessageBuilder.cpp
+++ b/src/providers/twitch/eventsub/MessageBuilder.cpp
@@ -325,4 +325,67 @@ void makeModerateMessage(
     makeModeMessage(builder, event, u"unique-chat"_s, false);
 }
 
+void makeModerateMessage(
+    EventSubMessageBuilder &builder,
+    const lib::payload::channel_moderate::v2::Event &event,
+    const lib::payload::channel_moderate::v2::AutomodTerms &action)
+{
+    QString text;
+
+    builder.appendUser(event.moderatorUserName, event.moderatorUserLogin, text);
+    if (action.action == "add")
+    {
+        builder.emplaceSystemTextAndUpdate(u"added"_s, text);
+    }
+    else
+    {
+        builder.emplaceSystemTextAndUpdate(u"removed"_s, text);
+    }
+
+    QString terms;
+    for (size_t i = 0; i < action.terms.size(); i++)
+    {
+        if (i != 0)
+        {
+            if (i == action.terms.size() - 1)
+            {
+                if (action.terms.size() == 2)
+                {
+                    terms.append(u" and ");
+                }
+                else
+                {
+                    terms.append(u", and ");
+                }
+            }
+            else
+            {
+                terms.append(u", ");
+            }
+        }
+        terms.append(u'"');
+        terms.append(action.terms[i].qt());
+        terms.append(u'"');
+    }
+    builder.emplaceSystemTextAndUpdate(terms, text);
+    builder.emplaceSystemTextAndUpdate(u"as"_s, text);
+    if (action.terms.size() == 1)
+    {
+        builder.emplaceSystemTextAndUpdate(u"a"_s, text);
+    }
+    builder.emplaceSystemTextAndUpdate(action.list.qt(), text);
+    if (action.terms.size() == 1)
+    {
+        builder.emplaceSystemTextAndUpdate(u"term"_s, text);
+    }
+    else
+    {
+        builder.emplaceSystemTextAndUpdate(u"terms"_s, text);
+    }
+    builder.emplaceSystemTextAndUpdate(u"on AutoMod."_s, text);
+
+    builder.message().messageText = text;
+    builder.message().searchText = text;
+}
+
 }  // namespace chatterino::eventsub

--- a/src/providers/twitch/eventsub/MessageBuilder.hpp
+++ b/src/providers/twitch/eventsub/MessageBuilder.hpp
@@ -116,4 +116,10 @@ void makeModerateMessage(
     const lib::payload::channel_moderate::v2::Event &event,
     const lib::payload::channel_moderate::v2::UniquechatOff &action);
 
+/// <MODERATOR> {added/removed} <TERMS...> as (a) {blocked/permitted} term(s) on AutoMod.
+void makeModerateMessage(
+    EventSubMessageBuilder &builder,
+    const lib::payload::channel_moderate::v2::Event &event,
+    const lib::payload::channel_moderate::v2::AutomodTerms &action);
+
 }  // namespace chatterino::eventsub

--- a/tests/snapshots/EventSub/channel-moderate/add-blocked-term-three.json
+++ b/tests/snapshots/EventSub/channel-moderate/add-blocked-term-three.json
@@ -1,0 +1,207 @@
+{
+    "input": {
+        "action": "add_blocked_term",
+        "automod_terms": {
+            "action": "add",
+            "from_automod": false,
+            "list": "blocked",
+            "terms": [
+                "my phrase",
+                "two",
+                "three"
+            ]
+        },
+        "ban": null,
+        "broadcaster_user_id": "11148817",
+        "broadcaster_user_login": "pajlada",
+        "broadcaster_user_name": "pajlada",
+        "delete": null,
+        "followers": null,
+        "mod": null,
+        "moderator_user_id": "129546453",
+        "moderator_user_login": "nerixyz",
+        "moderator_user_name": "nerixyz",
+        "raid": null,
+        "shared_chat_ban": null,
+        "shared_chat_delete": null,
+        "shared_chat_timeout": null,
+        "shared_chat_unban": null,
+        "shared_chat_untimeout": null,
+        "slow": null,
+        "source_broadcaster_user_id": null,
+        "source_broadcaster_user_login": null,
+        "source_broadcaster_user_name": null,
+        "timeout": null,
+        "unban": null,
+        "unban_request": null,
+        "unmod": null,
+        "unraid": null,
+        "untimeout": null,
+        "unvip": null,
+        "vip": null,
+        "warn": null
+    },
+    "output": [
+        {
+            "badgeInfos": {
+            },
+            "badges": [
+            ],
+            "channelName": "",
+            "count": 1,
+            "displayName": "",
+            "elements": [
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "ChatMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "12:31"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "12:31:47",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "MentionElement",
+                    "userColor": "System",
+                    "userLoginName": "nerixyz",
+                    "words": [
+                        "nerixyz"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "added"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "\"my",
+                        "phrase\",",
+                        "\"two\",",
+                        "and",
+                        "\"three\""
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "as"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "blocked"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "terms"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "on",
+                        "AutoMod."
+                    ]
+                }
+            ],
+            "flags": "System|Timeout|EventSub",
+            "id": "",
+            "localizedName": "",
+            "loginName": "nerixyz",
+            "messageText": "nerixyz added \"my phrase\", \"two\", and \"three\" as blocked terms on AutoMod. ",
+            "searchText": "nerixyz added \"my phrase\", \"two\", and \"three\" as blocked terms on AutoMod. ",
+            "serverReceivedTime": "2024-05-14T12:31:47Z",
+            "timeoutUser": "",
+            "userID": "",
+            "usernameColor": "#ff000000"
+        }
+    ]
+}

--- a/tests/snapshots/EventSub/channel-moderate/add-blocked-term.json
+++ b/tests/snapshots/EventSub/channel-moderate/add-blocked-term.json
@@ -1,0 +1,217 @@
+{
+    "input": {
+        "action": "add_blocked_term",
+        "automod_terms": {
+            "action": "add",
+            "from_automod": false,
+            "list": "blocked",
+            "terms": [
+                "my phrase"
+            ]
+        },
+        "ban": null,
+        "broadcaster_user_id": "11148817",
+        "broadcaster_user_login": "pajlada",
+        "broadcaster_user_name": "pajlada",
+        "delete": null,
+        "followers": null,
+        "mod": null,
+        "moderator_user_id": "129546453",
+        "moderator_user_login": "nerixyz",
+        "moderator_user_name": "nerixyz",
+        "raid": null,
+        "shared_chat_ban": null,
+        "shared_chat_delete": null,
+        "shared_chat_timeout": null,
+        "shared_chat_unban": null,
+        "shared_chat_untimeout": null,
+        "slow": null,
+        "source_broadcaster_user_id": null,
+        "source_broadcaster_user_login": null,
+        "source_broadcaster_user_name": null,
+        "timeout": null,
+        "unban": null,
+        "unban_request": null,
+        "unmod": null,
+        "unraid": null,
+        "untimeout": null,
+        "unvip": null,
+        "vip": null,
+        "warn": null
+    },
+    "output": [
+        {
+            "badgeInfos": {
+            },
+            "badges": [
+            ],
+            "channelName": "",
+            "count": 1,
+            "displayName": "",
+            "elements": [
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "ChatMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "12:31"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "12:31:47",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "MentionElement",
+                    "userColor": "System",
+                    "userLoginName": "nerixyz",
+                    "words": [
+                        "nerixyz"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "added"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "\"my",
+                        "phrase\""
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "as"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "a"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "blocked"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "term"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "on",
+                        "AutoMod."
+                    ]
+                }
+            ],
+            "flags": "System|Timeout|EventSub",
+            "id": "",
+            "localizedName": "",
+            "loginName": "nerixyz",
+            "messageText": "nerixyz added \"my phrase\" as a blocked term on AutoMod. ",
+            "searchText": "nerixyz added \"my phrase\" as a blocked term on AutoMod. ",
+            "serverReceivedTime": "2024-05-14T12:31:47Z",
+            "timeoutUser": "",
+            "userID": "",
+            "usernameColor": "#ff000000"
+        }
+    ]
+}

--- a/tests/snapshots/EventSub/channel-moderate/add-permitted-term-two.json
+++ b/tests/snapshots/EventSub/channel-moderate/add-permitted-term-two.json
@@ -1,0 +1,205 @@
+{
+    "input": {
+        "action": "add_permitted_term",
+        "automod_terms": {
+            "action": "add",
+            "from_automod": false,
+            "list": "permitted",
+            "terms": [
+                "my phrase",
+                "two"
+            ]
+        },
+        "ban": null,
+        "broadcaster_user_id": "11148817",
+        "broadcaster_user_login": "pajlada",
+        "broadcaster_user_name": "pajlada",
+        "delete": null,
+        "followers": null,
+        "mod": null,
+        "moderator_user_id": "129546453",
+        "moderator_user_login": "nerixyz",
+        "moderator_user_name": "nerixyz",
+        "raid": null,
+        "shared_chat_ban": null,
+        "shared_chat_delete": null,
+        "shared_chat_timeout": null,
+        "shared_chat_unban": null,
+        "shared_chat_untimeout": null,
+        "slow": null,
+        "source_broadcaster_user_id": null,
+        "source_broadcaster_user_login": null,
+        "source_broadcaster_user_name": null,
+        "timeout": null,
+        "unban": null,
+        "unban_request": null,
+        "unmod": null,
+        "unraid": null,
+        "untimeout": null,
+        "unvip": null,
+        "vip": null,
+        "warn": null
+    },
+    "output": [
+        {
+            "badgeInfos": {
+            },
+            "badges": [
+            ],
+            "channelName": "",
+            "count": 1,
+            "displayName": "",
+            "elements": [
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "ChatMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "12:31"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "12:31:47",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "MentionElement",
+                    "userColor": "System",
+                    "userLoginName": "nerixyz",
+                    "words": [
+                        "nerixyz"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "added"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "\"my",
+                        "phrase\"",
+                        "and",
+                        "\"two\""
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "as"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "permitted"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "terms"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "on",
+                        "AutoMod."
+                    ]
+                }
+            ],
+            "flags": "System|Timeout|EventSub",
+            "id": "",
+            "localizedName": "",
+            "loginName": "nerixyz",
+            "messageText": "nerixyz added \"my phrase\" and \"two\" as permitted terms on AutoMod. ",
+            "searchText": "nerixyz added \"my phrase\" and \"two\" as permitted terms on AutoMod. ",
+            "serverReceivedTime": "2024-05-14T12:31:47Z",
+            "timeoutUser": "",
+            "userID": "",
+            "usernameColor": "#ff000000"
+        }
+    ]
+}

--- a/tests/snapshots/EventSub/channel-moderate/add-permitted-term.json
+++ b/tests/snapshots/EventSub/channel-moderate/add-permitted-term.json
@@ -1,0 +1,217 @@
+{
+    "input": {
+        "action": "add_permitted_term",
+        "automod_terms": {
+            "action": "add",
+            "from_automod": false,
+            "list": "permitted",
+            "terms": [
+                "my phrase"
+            ]
+        },
+        "ban": null,
+        "broadcaster_user_id": "11148817",
+        "broadcaster_user_login": "pajlada",
+        "broadcaster_user_name": "pajlada",
+        "delete": null,
+        "followers": null,
+        "mod": null,
+        "moderator_user_id": "129546453",
+        "moderator_user_login": "nerixyz",
+        "moderator_user_name": "nerixyz",
+        "raid": null,
+        "shared_chat_ban": null,
+        "shared_chat_delete": null,
+        "shared_chat_timeout": null,
+        "shared_chat_unban": null,
+        "shared_chat_untimeout": null,
+        "slow": null,
+        "source_broadcaster_user_id": null,
+        "source_broadcaster_user_login": null,
+        "source_broadcaster_user_name": null,
+        "timeout": null,
+        "unban": null,
+        "unban_request": null,
+        "unmod": null,
+        "unraid": null,
+        "untimeout": null,
+        "unvip": null,
+        "vip": null,
+        "warn": null
+    },
+    "output": [
+        {
+            "badgeInfos": {
+            },
+            "badges": [
+            ],
+            "channelName": "",
+            "count": 1,
+            "displayName": "",
+            "elements": [
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "ChatMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "12:31"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "12:31:47",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "MentionElement",
+                    "userColor": "System",
+                    "userLoginName": "nerixyz",
+                    "words": [
+                        "nerixyz"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "added"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "\"my",
+                        "phrase\""
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "as"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "a"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "permitted"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "term"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "on",
+                        "AutoMod."
+                    ]
+                }
+            ],
+            "flags": "System|Timeout|EventSub",
+            "id": "",
+            "localizedName": "",
+            "loginName": "nerixyz",
+            "messageText": "nerixyz added \"my phrase\" as a permitted term on AutoMod. ",
+            "searchText": "nerixyz added \"my phrase\" as a permitted term on AutoMod. ",
+            "serverReceivedTime": "2024-05-14T12:31:47Z",
+            "timeoutUser": "",
+            "userID": "",
+            "usernameColor": "#ff000000"
+        }
+    ]
+}

--- a/tests/snapshots/EventSub/channel-moderate/remove-blocked-term-four.json
+++ b/tests/snapshots/EventSub/channel-moderate/remove-blocked-term-four.json
@@ -1,0 +1,209 @@
+{
+    "input": {
+        "action": "remove_blocked_term",
+        "automod_terms": {
+            "action": "remove",
+            "from_automod": false,
+            "list": "blocked",
+            "terms": [
+                "my phrase",
+                "term",
+                "wow",
+                "🥲"
+            ]
+        },
+        "ban": null,
+        "broadcaster_user_id": "11148817",
+        "broadcaster_user_login": "pajlada",
+        "broadcaster_user_name": "pajlada",
+        "delete": null,
+        "followers": null,
+        "mod": null,
+        "moderator_user_id": "129546453",
+        "moderator_user_login": "nerixyz",
+        "moderator_user_name": "nerixyz",
+        "raid": null,
+        "shared_chat_ban": null,
+        "shared_chat_delete": null,
+        "shared_chat_timeout": null,
+        "shared_chat_unban": null,
+        "shared_chat_untimeout": null,
+        "slow": null,
+        "source_broadcaster_user_id": null,
+        "source_broadcaster_user_login": null,
+        "source_broadcaster_user_name": null,
+        "timeout": null,
+        "unban": null,
+        "unban_request": null,
+        "unmod": null,
+        "unraid": null,
+        "untimeout": null,
+        "unvip": null,
+        "vip": null,
+        "warn": null
+    },
+    "output": [
+        {
+            "badgeInfos": {
+            },
+            "badges": [
+            ],
+            "channelName": "",
+            "count": 1,
+            "displayName": "",
+            "elements": [
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "ChatMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "12:31"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "12:31:47",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "MentionElement",
+                    "userColor": "System",
+                    "userLoginName": "nerixyz",
+                    "words": [
+                        "nerixyz"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "removed"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "\"my",
+                        "phrase\",",
+                        "\"term\",",
+                        "\"wow\",",
+                        "and",
+                        "\"🥲\""
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "as"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "blocked"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "terms"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "on",
+                        "AutoMod."
+                    ]
+                }
+            ],
+            "flags": "System|Timeout|EventSub",
+            "id": "",
+            "localizedName": "",
+            "loginName": "nerixyz",
+            "messageText": "nerixyz removed \"my phrase\", \"term\", \"wow\", and \"🥲\" as blocked terms on AutoMod. ",
+            "searchText": "nerixyz removed \"my phrase\", \"term\", \"wow\", and \"🥲\" as blocked terms on AutoMod. ",
+            "serverReceivedTime": "2024-05-14T12:31:47Z",
+            "timeoutUser": "",
+            "userID": "",
+            "usernameColor": "#ff000000"
+        }
+    ]
+}

--- a/tests/snapshots/EventSub/channel-moderate/remove-blocked-term.json
+++ b/tests/snapshots/EventSub/channel-moderate/remove-blocked-term.json
@@ -1,0 +1,217 @@
+{
+    "input": {
+        "action": "remove_blocked_term",
+        "automod_terms": {
+            "action": "remove",
+            "from_automod": false,
+            "list": "blocked",
+            "terms": [
+                "my phrase"
+            ]
+        },
+        "ban": null,
+        "broadcaster_user_id": "11148817",
+        "broadcaster_user_login": "pajlada",
+        "broadcaster_user_name": "pajlada",
+        "delete": null,
+        "followers": null,
+        "mod": null,
+        "moderator_user_id": "129546453",
+        "moderator_user_login": "nerixyz",
+        "moderator_user_name": "nerixyz",
+        "raid": null,
+        "shared_chat_ban": null,
+        "shared_chat_delete": null,
+        "shared_chat_timeout": null,
+        "shared_chat_unban": null,
+        "shared_chat_untimeout": null,
+        "slow": null,
+        "source_broadcaster_user_id": null,
+        "source_broadcaster_user_login": null,
+        "source_broadcaster_user_name": null,
+        "timeout": null,
+        "unban": null,
+        "unban_request": null,
+        "unmod": null,
+        "unraid": null,
+        "untimeout": null,
+        "unvip": null,
+        "vip": null,
+        "warn": null
+    },
+    "output": [
+        {
+            "badgeInfos": {
+            },
+            "badges": [
+            ],
+            "channelName": "",
+            "count": 1,
+            "displayName": "",
+            "elements": [
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "ChatMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "12:31"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "12:31:47",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "MentionElement",
+                    "userColor": "System",
+                    "userLoginName": "nerixyz",
+                    "words": [
+                        "nerixyz"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "removed"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "\"my",
+                        "phrase\""
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "as"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "a"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "blocked"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "term"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "on",
+                        "AutoMod."
+                    ]
+                }
+            ],
+            "flags": "System|Timeout|EventSub",
+            "id": "",
+            "localizedName": "",
+            "loginName": "nerixyz",
+            "messageText": "nerixyz removed \"my phrase\" as a blocked term on AutoMod. ",
+            "searchText": "nerixyz removed \"my phrase\" as a blocked term on AutoMod. ",
+            "serverReceivedTime": "2024-05-14T12:31:47Z",
+            "timeoutUser": "",
+            "userID": "",
+            "usernameColor": "#ff000000"
+        }
+    ]
+}

--- a/tests/snapshots/EventSub/channel-moderate/remove-permitted-term-from-automod.json
+++ b/tests/snapshots/EventSub/channel-moderate/remove-permitted-term-from-automod.json
@@ -1,0 +1,217 @@
+{
+    "input": {
+        "action": "remove_permitted_term",
+        "automod_terms": {
+            "action": "remove",
+            "from_automod": true,
+            "list": "permitted",
+            "terms": [
+                "my phrase"
+            ]
+        },
+        "ban": null,
+        "broadcaster_user_id": "11148817",
+        "broadcaster_user_login": "pajlada",
+        "broadcaster_user_name": "pajlada",
+        "delete": null,
+        "followers": null,
+        "mod": null,
+        "moderator_user_id": "129546453",
+        "moderator_user_login": "nerixyz",
+        "moderator_user_name": "nerixyz",
+        "raid": null,
+        "shared_chat_ban": null,
+        "shared_chat_delete": null,
+        "shared_chat_timeout": null,
+        "shared_chat_unban": null,
+        "shared_chat_untimeout": null,
+        "slow": null,
+        "source_broadcaster_user_id": null,
+        "source_broadcaster_user_login": null,
+        "source_broadcaster_user_name": null,
+        "timeout": null,
+        "unban": null,
+        "unban_request": null,
+        "unmod": null,
+        "unraid": null,
+        "untimeout": null,
+        "unvip": null,
+        "vip": null,
+        "warn": null
+    },
+    "output": [
+        {
+            "badgeInfos": {
+            },
+            "badges": [
+            ],
+            "channelName": "",
+            "count": 1,
+            "displayName": "",
+            "elements": [
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "ChatMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "12:31"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "12:31:47",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "MentionElement",
+                    "userColor": "System",
+                    "userLoginName": "nerixyz",
+                    "words": [
+                        "nerixyz"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "removed"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "\"my",
+                        "phrase\""
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "as"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "a"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "permitted"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "term"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "on",
+                        "AutoMod."
+                    ]
+                }
+            ],
+            "flags": "System|Timeout|EventSub",
+            "id": "",
+            "localizedName": "",
+            "loginName": "nerixyz",
+            "messageText": "nerixyz removed \"my phrase\" as a permitted term on AutoMod. ",
+            "searchText": "nerixyz removed \"my phrase\" as a permitted term on AutoMod. ",
+            "serverReceivedTime": "2024-05-14T12:31:47Z",
+            "timeoutUser": "",
+            "userID": "",
+            "usernameColor": "#ff000000"
+        }
+    ]
+}

--- a/tests/snapshots/EventSub/channel-moderate/remove-permitted-term.json
+++ b/tests/snapshots/EventSub/channel-moderate/remove-permitted-term.json
@@ -1,0 +1,217 @@
+{
+    "input": {
+        "action": "remove_permitted_term",
+        "automod_terms": {
+            "action": "remove",
+            "from_automod": false,
+            "list": "permitted",
+            "terms": [
+                "my phrase"
+            ]
+        },
+        "ban": null,
+        "broadcaster_user_id": "11148817",
+        "broadcaster_user_login": "pajlada",
+        "broadcaster_user_name": "pajlada",
+        "delete": null,
+        "followers": null,
+        "mod": null,
+        "moderator_user_id": "129546453",
+        "moderator_user_login": "nerixyz",
+        "moderator_user_name": "nerixyz",
+        "raid": null,
+        "shared_chat_ban": null,
+        "shared_chat_delete": null,
+        "shared_chat_timeout": null,
+        "shared_chat_unban": null,
+        "shared_chat_untimeout": null,
+        "slow": null,
+        "source_broadcaster_user_id": null,
+        "source_broadcaster_user_login": null,
+        "source_broadcaster_user_name": null,
+        "timeout": null,
+        "unban": null,
+        "unban_request": null,
+        "unmod": null,
+        "unraid": null,
+        "untimeout": null,
+        "unvip": null,
+        "vip": null,
+        "warn": null
+    },
+    "output": [
+        {
+            "badgeInfos": {
+            },
+            "badges": [
+            ],
+            "channelName": "",
+            "count": 1,
+            "displayName": "",
+            "elements": [
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "ChatMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "12:31"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "12:31:47",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "MentionElement",
+                    "userColor": "System",
+                    "userLoginName": "nerixyz",
+                    "words": [
+                        "nerixyz"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "removed"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "\"my",
+                        "phrase\""
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "as"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "a"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "permitted"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "term"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "on",
+                        "AutoMod."
+                    ]
+                }
+            ],
+            "flags": "System|Timeout|EventSub",
+            "id": "",
+            "localizedName": "",
+            "loginName": "nerixyz",
+            "messageText": "nerixyz removed \"my phrase\" as a permitted term on AutoMod. ",
+            "searchText": "nerixyz removed \"my phrase\" as a permitted term on AutoMod. ",
+            "serverReceivedTime": "2024-05-14T12:31:47Z",
+            "timeoutUser": "",
+            "userID": "",
+            "usernameColor": "#ff000000"
+        }
+    ]
+}


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

Implements builders for `{add,remove}_{permitted,blocked}_term` actions in `channel.moderate`. I don't use `AutomodTerms.fromAutomod`. 

Towards https://github.com/Chatterino/chatterino2/issues/5908.