### PR TITLE
feat(eventsub): Add support for `/(un)raid`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 - Bugfix: Fixed the input font not immediately updating when zooming in/out. (#5960)
 - Bugfix: Fixed color input thinking blue is also red. (#5982)
 - Dev: Subscriptions to PubSub channel points redemption topics now use no auth token, making it continue to work during PubSub shutdown. (#5947)
-- Dev: Add initial experimental EventSub support. (#5837, #5895, #5897, #5904, #5910, #5903, #5915, #5916, #5930, #5935, #5932, #5943, #5952, #5953, #5968, #5973, #5974, #5980, #5981, #5985, #5990, #5992, #5993, #5996, #5995, #6000)
+- Dev: Add initial experimental EventSub support. (#5837, #5895, #5897, #5904, #5910, #5903, #5915, #5916, #5930, #5935, #5932, #5943, #5952, #5953, #5968, #5973, #5974, #5980, #5981, #5985, #5990, #5992, #5993, #5996, #5995, #6000, #6002)
 - Dev: Remove unneeded platform specifier for toasts. (#5914)
 - Dev: Highlight checks now use non-capturing groups for the boundaries. (#5784)
 - Dev: Removed unused PubSub whisper code. (#5898)

--- a/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/payloads/channel-moderate-v2.hpp
+++ b/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/payloads/channel-moderate-v2.hpp
@@ -231,9 +231,9 @@ struct SharedChatUntimeout : public Untimeout {
 struct Raid {
     static constexpr std::string_view TAG = "raid";
 
-    std::string userID;
-    std::string userLogin;
-    std::string userName;
+    String userID;
+    String userLogin;
+    String userName;
 
     int viewerCount;
 };
@@ -245,9 +245,9 @@ struct Raid {
 struct Unraid {
     static constexpr std::string_view TAG = "unraid";
 
-    std::string userID;
-    std::string userLogin;
-    std::string userName;
+    String userID;
+    String userLogin;
+    String userName;
 };
 
 /* message deleted

--- a/lib/twitch-eventsub-ws/src/generated/payloads/channel-moderate-v2.cpp
+++ b/lib/twitch-eventsub-ws/src/generated/payloads/channel-moderate-v2.cpp
@@ -647,7 +647,7 @@ boost::json::result_for<Raid, boost::json::value>::type tag_invoke(
         EVENTSUB_BAIL_HERE(error::Kind::FieldMissing);
     }
 
-    auto userID = boost::json::try_value_to<std::string>(*jvuserID);
+    auto userID = boost::json::try_value_to<String>(*jvuserID);
 
     if (userID.has_error())
     {
@@ -660,7 +660,7 @@ boost::json::result_for<Raid, boost::json::value>::type tag_invoke(
         EVENTSUB_BAIL_HERE(error::Kind::FieldMissing);
     }
 
-    auto userLogin = boost::json::try_value_to<std::string>(*jvuserLogin);
+    auto userLogin = boost::json::try_value_to<String>(*jvuserLogin);
 
     if (userLogin.has_error())
     {
@@ -673,7 +673,7 @@ boost::json::result_for<Raid, boost::json::value>::type tag_invoke(
         EVENTSUB_BAIL_HERE(error::Kind::FieldMissing);
     }
 
-    auto userName = boost::json::try_value_to<std::string>(*jvuserName);
+    auto userName = boost::json::try_value_to<String>(*jvuserName);
 
     if (userName.has_error())
     {
@@ -719,7 +719,7 @@ boost::json::result_for<Unraid, boost::json::value>::type tag_invoke(
         EVENTSUB_BAIL_HERE(error::Kind::FieldMissing);
     }
 
-    auto userID = boost::json::try_value_to<std::string>(*jvuserID);
+    auto userID = boost::json::try_value_to<String>(*jvuserID);
 
     if (userID.has_error())
     {
@@ -732,7 +732,7 @@ boost::json::result_for<Unraid, boost::json::value>::type tag_invoke(
         EVENTSUB_BAIL_HERE(error::Kind::FieldMissing);
     }
 
-    auto userLogin = boost::json::try_value_to<std::string>(*jvuserLogin);
+    auto userLogin = boost::json::try_value_to<String>(*jvuserLogin);
 
     if (userLogin.has_error())
     {
@@ -745,7 +745,7 @@ boost::json::result_for<Unraid, boost::json::value>::type tag_invoke(
         EVENTSUB_BAIL_HERE(error::Kind::FieldMissing);
     }
 
-    auto userName = boost::json::try_value_to<std::string>(*jvuserName);
+    auto userName = boost::json::try_value_to<String>(*jvuserName);
 
     if (userName.has_error())
     {

--- a/src/providers/twitch/eventsub/MessageBuilder.cpp
+++ b/src/providers/twitch/eventsub/MessageBuilder.cpp
@@ -388,4 +388,35 @@ void makeModerateMessage(
     builder.message().searchText = text;
 }
 
+void makeModerateMessage(EventSubMessageBuilder &builder,
+                         const lib::payload::channel_moderate::v2::Event &event,
+                         const lib::payload::channel_moderate::v2::Raid &action)
+{
+    QString text;
+
+    builder.appendUser(event.moderatorUserName, event.moderatorUserLogin, text);
+    builder.emplaceSystemTextAndUpdate("initiated a raid to", text);
+    builder.appendUser(action.userName, action.userLogin, text, false);
+    builder.emplaceSystemTextAndUpdate(".", text);
+
+    builder.message().messageText = text;
+    builder.message().searchText = text;
+}
+
+void makeModerateMessage(
+    EventSubMessageBuilder &builder,
+    const lib::payload::channel_moderate::v2::Event &event,
+    const lib::payload::channel_moderate::v2::Unraid &action)
+{
+    QString text;
+
+    builder.appendUser(event.moderatorUserName, event.moderatorUserLogin, text);
+    builder.emplaceSystemTextAndUpdate("canceled the raid to", text);
+    builder.appendUser(action.userName, action.userLogin, text, false);
+    builder.emplaceSystemTextAndUpdate(".", text);
+
+    builder.message().messageText = text;
+    builder.message().searchText = text;
+}
+
 }  // namespace chatterino::eventsub

--- a/src/providers/twitch/eventsub/MessageBuilder.hpp
+++ b/src/providers/twitch/eventsub/MessageBuilder.hpp
@@ -122,4 +122,16 @@ void makeModerateMessage(
     const lib::payload::channel_moderate::v2::Event &event,
     const lib::payload::channel_moderate::v2::AutomodTerms &action);
 
+/// <MODERATOR> initiated a raid to <CHANNEL>.
+void makeModerateMessage(
+    EventSubMessageBuilder &builder,
+    const lib::payload::channel_moderate::v2::Event &event,
+    const lib::payload::channel_moderate::v2::Raid &action);
+
+/// <MODERATOR> canceled the raid to <CHANNEL>.
+void makeModerateMessage(
+    EventSubMessageBuilder &builder,
+    const lib::payload::channel_moderate::v2::Event &event,
+    const lib::payload::channel_moderate::v2::Unraid &action);
+
 }  // namespace chatterino::eventsub

--- a/tests/snapshots/EventSub/channel-moderate/raid.json
+++ b/tests/snapshots/EventSub/channel-moderate/raid.json
@@ -1,0 +1,159 @@
+{
+    "input": {
+        "action": "raid",
+        "automod_terms": null,
+        "ban": null,
+        "broadcaster_user_id": "11148817",
+        "broadcaster_user_login": "pajlada",
+        "broadcaster_user_name": "pajlada",
+        "delete": null,
+        "followers": null,
+        "mod": null,
+        "moderator_user_id": "11148817",
+        "moderator_user_login": "pajlada",
+        "moderator_user_name": "pajlada",
+        "raid": {
+            "user_id": "159849156",
+            "user_login": "bajlada",
+            "user_name": "BajLada",
+            "viewer_count": 0
+        },
+        "shared_chat_ban": null,
+        "shared_chat_delete": null,
+        "shared_chat_timeout": null,
+        "shared_chat_unban": null,
+        "shared_chat_untimeout": null,
+        "slow": null,
+        "source_broadcaster_user_id": null,
+        "source_broadcaster_user_login": null,
+        "source_broadcaster_user_name": null,
+        "timeout": null,
+        "unban": null,
+        "unban_request": null,
+        "unmod": null,
+        "unraid": null,
+        "untimeout": null,
+        "unvip": null,
+        "vip": null,
+        "warn": null
+    },
+    "output": [
+        {
+            "badgeInfos": {
+            },
+            "badges": [
+            ],
+            "channelName": "",
+            "count": 1,
+            "displayName": "",
+            "elements": [
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "ChatMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "12:31"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "12:31:47",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "MentionElement",
+                    "userColor": "System",
+                    "userLoginName": "pajlada",
+                    "words": [
+                        "pajlada"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "initiated",
+                        "a",
+                        "raid",
+                        "to"
+                    ]
+                },
+                {
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": false,
+                    "type": "MentionElement",
+                    "userColor": "System",
+                    "userLoginName": "bajlada",
+                    "words": [
+                        "BajLada"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "."
+                    ]
+                }
+            ],
+            "flags": "System|Timeout|EventSub",
+            "id": "",
+            "localizedName": "",
+            "loginName": "pajlada",
+            "messageText": "pajlada initiated a raid to bajlada. ",
+            "searchText": "pajlada initiated a raid to bajlada. ",
+            "serverReceivedTime": "2024-05-14T12:31:47Z",
+            "timeoutUser": "",
+            "userID": "",
+            "usernameColor": "#ff000000"
+        }
+    ]
+}

--- a/tests/snapshots/EventSub/channel-moderate/unraid.json
+++ b/tests/snapshots/EventSub/channel-moderate/unraid.json
@@ -1,0 +1,158 @@
+{
+    "input": {
+        "action": "unraid",
+        "automod_terms": null,
+        "ban": null,
+        "broadcaster_user_id": "11148817",
+        "broadcaster_user_login": "pajlada",
+        "broadcaster_user_name": "pajlada",
+        "delete": null,
+        "followers": null,
+        "mod": null,
+        "moderator_user_id": "11148817",
+        "moderator_user_login": "pajlada",
+        "moderator_user_name": "pajlada",
+        "raid": null,
+        "shared_chat_ban": null,
+        "shared_chat_delete": null,
+        "shared_chat_timeout": null,
+        "shared_chat_unban": null,
+        "shared_chat_untimeout": null,
+        "slow": null,
+        "source_broadcaster_user_id": null,
+        "source_broadcaster_user_login": null,
+        "source_broadcaster_user_name": null,
+        "timeout": null,
+        "unban": null,
+        "unban_request": null,
+        "unmod": null,
+        "unraid": {
+            "user_id": "159849156",
+            "user_login": "bajlada",
+            "user_name": "BajLada"
+        },
+        "untimeout": null,
+        "unvip": null,
+        "vip": null,
+        "warn": null
+    },
+    "output": [
+        {
+            "badgeInfos": {
+            },
+            "badges": [
+            ],
+            "channelName": "",
+            "count": 1,
+            "displayName": "",
+            "elements": [
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "ChatMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "12:31"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "12:31:47",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "MentionElement",
+                    "userColor": "System",
+                    "userLoginName": "pajlada",
+                    "words": [
+                        "pajlada"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "canceled",
+                        "the",
+                        "raid",
+                        "to"
+                    ]
+                },
+                {
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": false,
+                    "type": "MentionElement",
+                    "userColor": "System",
+                    "userLoginName": "bajlada",
+                    "words": [
+                        "BajLada"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "."
+                    ]
+                }
+            ],
+            "flags": "System|Timeout|EventSub",
+            "id": "",
+            "localizedName": "",
+            "loginName": "pajlada",
+            "messageText": "pajlada canceled the raid to bajlada. ",
+            "searchText": "pajlada canceled the raid to bajlada. ",
+            "serverReceivedTime": "2024-05-14T12:31:47Z",
+            "timeoutUser": "",
+            "userID": "",
+            "usernameColor": "#ff000000"
+        }
+    ]
+}


### PR DESCRIPTION
### `/raid`

Looks the same as from PubSub (first line is PubSub, second line is EventSub)
![raid](https://github.com/user-attachments/assets/1da3f1db-eccd-4796-a678-e5cb50148313)

### `/unraid`

Since we have the info, I've added the channel we've cancelled the raid to (first line is PubSub, second line is EventSub)
![unraid](https://github.com/user-attachments/assets/3d93d128-9563-440d-9bcc-c4bff84fad4e)
