### PR TITLE
feat(eventsub): implement automod message update

### DIFF
--- a/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/payloads/automod-message-update-v2.hpp
+++ b/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/payloads/automod-message-update-v2.hpp
@@ -3,6 +3,7 @@
 #include "twitch-eventsub-ws/payloads/automod-message.hpp"
 #include "twitch-eventsub-ws/payloads/structured-message.hpp"
 #include "twitch-eventsub-ws/payloads/subscription.hpp"
+#include "twitch-eventsub-ws/string.hpp"
 
 #include <boost/json.hpp>
 
@@ -12,9 +13,9 @@ namespace chatterino::eventsub::lib::payload::automod_message_update::v2 {
 
 struct Event {
     // Broadcaster of the channel the message was sent in
-    std::string broadcasterUserID;
-    std::string broadcasterUserLogin;
-    std::string broadcasterUserName;
+    String broadcasterUserID;
+    String broadcasterUserLogin;
+    String broadcasterUserName;
 
     // User who sent the message
     std::string userID;
@@ -26,7 +27,7 @@ struct Event {
     std::string moderatorUserLogin;
     std::string moderatorUserName;
 
-    std::string messageID;
+    String messageID;
     chat::Message message;
 
     // "Approved", "Denied", or "Expired"

--- a/lib/twitch-eventsub-ws/src/generated/payloads/automod-message-update-v2.cpp
+++ b/lib/twitch-eventsub-ws/src/generated/payloads/automod-message-update-v2.cpp
@@ -25,7 +25,7 @@ boost::json::result_for<Event, boost::json::value>::type tag_invoke(
     }
 
     auto broadcasterUserID =
-        boost::json::try_value_to<std::string>(*jvbroadcasterUserID);
+        boost::json::try_value_to<String>(*jvbroadcasterUserID);
 
     if (broadcasterUserID.has_error())
     {
@@ -40,7 +40,7 @@ boost::json::result_for<Event, boost::json::value>::type tag_invoke(
     }
 
     auto broadcasterUserLogin =
-        boost::json::try_value_to<std::string>(*jvbroadcasterUserLogin);
+        boost::json::try_value_to<String>(*jvbroadcasterUserLogin);
 
     if (broadcasterUserLogin.has_error())
     {
@@ -55,7 +55,7 @@ boost::json::result_for<Event, boost::json::value>::type tag_invoke(
     }
 
     auto broadcasterUserName =
-        boost::json::try_value_to<std::string>(*jvbroadcasterUserName);
+        boost::json::try_value_to<String>(*jvbroadcasterUserName);
 
     if (broadcasterUserName.has_error())
     {
@@ -149,7 +149,7 @@ boost::json::result_for<Event, boost::json::value>::type tag_invoke(
         EVENTSUB_BAIL_HERE(error::Kind::FieldMissing);
     }
 
-    auto messageID = boost::json::try_value_to<std::string>(*jvmessageID);
+    auto messageID = boost::json::try_value_to<String>(*jvmessageID);
 
     if (messageID.has_error())
     {

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -1522,6 +1522,22 @@ void TwitchChannel::refreshPubSub()
                         },
                     },
             });
+        this->eventSubAutomodMessageUpdateHandle =
+            getApp()->getEventSub()->subscribe(eventsub::SubscriptionRequest{
+                .subscriptionType = "automod.message.update",
+                .subscriptionVersion = "2",
+                .conditions =
+                    {
+                        {
+                            "broadcaster_user_id",
+                            roomId,
+                        },
+                        {
+                            "moderator_user_id",
+                            currentAccount->getUserId(),
+                        },
+                    },
+            });
         this->eventSubSuspiciousUserMessageHandle =
             getApp()->getEventSub()->subscribe(eventsub::SubscriptionRequest{
                 .subscriptionType = "channel.suspicious_user.message",
@@ -1542,6 +1558,8 @@ void TwitchChannel::refreshPubSub()
     else
     {
         this->eventSubChannelModerateHandle.reset();
+        this->eventSubAutomodMessageHoldHandle.reset();
+        this->eventSubAutomodMessageUpdateHandle.reset();
         this->eventSubSuspiciousUserMessageHandle.reset();
     }
     getApp()->getTwitchPubSub()->listenToChannelPointRewards(roomId);

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -510,6 +510,7 @@ private:
 
     eventsub::SubscriptionHandle eventSubChannelModerateHandle;
     eventsub::SubscriptionHandle eventSubAutomodMessageHoldHandle;
+    eventsub::SubscriptionHandle eventSubAutomodMessageUpdateHandle;
     eventsub::SubscriptionHandle eventSubSuspiciousUserMessageHandle;
 
     friend class TwitchIrcServer;

--- a/tests/snapshots/EventSub/automod-message-update/approved.json
+++ b/tests/snapshots/EventSub/automod-message-update/approved.json
@@ -1,0 +1,297 @@
+{
+    "input": [
+        {
+            "__subscription": "automod-message-hold",
+            "automod": {
+                "boundaries": [
+                    {
+                        "end_pos": 2,
+                        "start_pos": 0
+                    }
+                ],
+                "category": "swearing",
+                "level": 4
+            },
+            "blocked_term": null,
+            "broadcaster_user_id": "11148817",
+            "broadcaster_user_login": "pajlada",
+            "broadcaster_user_name": "pajlada",
+            "held_at": "2025-02-28T16:15:15.008668809Z",
+            "message": {
+                "fragments": [
+                    {
+                        "cheermote": null,
+                        "emote": null,
+                        "text": "ass",
+                        "type": "text"
+                    }
+                ],
+                "text": "ass"
+            },
+            "message_id": "19d067ff-89b5-4790-a720-97599894eb6b",
+            "reason": "automod",
+            "user_id": "129546453",
+            "user_login": "nerixyz",
+            "user_name": "nerixyz"
+        },
+        {
+            "automod": {
+                "boundaries": [
+                    {
+                        "end_pos": 2,
+                        "start_pos": 0
+                    }
+                ],
+                "category": "swearing",
+                "level": 4
+            },
+            "blocked_term": null,
+            "broadcaster_user_id": "11148817",
+            "broadcaster_user_login": "pajlada",
+            "broadcaster_user_name": "pajlada",
+            "held_at": "2025-02-28T16:15:15.008668809Z",
+            "message": {
+                "fragments": [
+                    {
+                        "cheermote": null,
+                        "emote": null,
+                        "text": "ass",
+                        "type": "text"
+                    }
+                ],
+                "text": "ass"
+            },
+            "message_id": "19d067ff-89b5-4790-a720-97599894eb6b",
+            "moderator_user_id": "489584266",
+            "moderator_user_login": "uint128",
+            "moderator_user_name": "uint128",
+            "reason": "automod",
+            "status": "approved",
+            "user_id": "129546453",
+            "user_login": "nerixyz",
+            "user_name": "nerixyz"
+        }
+    ],
+    "output": [
+        {
+            "badgeInfos": {
+            },
+            "badges": [
+            ],
+            "channelName": "pajlada",
+            "count": 1,
+            "displayName": "",
+            "elements": [
+                {
+                    "emote": {
+                        "homePage": "https://dashboard.twitch.tv/settings/moderation/automod",
+                        "images": {
+                            "1x": ""
+                        },
+                        "name": "",
+                        "tooltip": "AutoMod"
+                    },
+                    "flags": "BadgeChannelAuthority",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "tooltip": "AutoMod",
+                    "trailingSpace": true,
+                    "type": "BadgeElement"
+                },
+                {
+                    "color": "#ff0000ff",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMediumBold",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "AutoMod:"
+                    ]
+                },
+                {
+                    "color": "Text",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "Held",
+                        "a",
+                        "message",
+                        "for",
+                        "reason:",
+                        "swearing",
+                        "level",
+                        "4.",
+                        "Allow",
+                        "will",
+                        "post",
+                        "it",
+                        "in",
+                        "chat.",
+                        ""
+                    ]
+                },
+                {
+                    "color": "#ff00ff00",
+                    "flags": "Text",
+                    "link": {
+                        "type": "AutoModAllow",
+                        "value": "19d067ff-89b5-4790-a720-97599894eb6b"
+                    },
+                    "style": "ChatMediumBold",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "Allow"
+                    ]
+                },
+                {
+                    "color": "#ffff0000",
+                    "flags": "Text",
+                    "link": {
+                        "type": "AutoModDeny",
+                        "value": "19d067ff-89b5-4790-a720-97599894eb6b"
+                    },
+                    "style": "ChatMediumBold",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "",
+                        "Deny"
+                    ]
+                }
+            ],
+            "flags": "Timeout|Disabled|PubSub|AutoMod|AutoModOffendingMessageHeader|EventSub",
+            "id": "automod_19d067ff-89b5-4790-a720-97599894eb6b",
+            "localizedName": "",
+            "loginName": "automod",
+            "messageText": "AutoMod: Held a message for reason: swearing level 4. Allow will post it in chat. Allow Deny",
+            "searchText": "AutoMod: Held a message for reason: swearing level 4. Allow will post it in chat. Allow Deny",
+            "serverReceivedTime": "2024-05-14T12:31:47Z",
+            "timeoutUser": "",
+            "userID": "",
+            "usernameColor": "#ff000000"
+        },
+        {
+            "badgeInfos": {
+            },
+            "badges": [
+            ],
+            "channelName": "pajlada",
+            "count": 1,
+            "displayName": "",
+            "elements": [
+                {
+                    "color": "System",
+                    "flags": "ChannelName",
+                    "link": {
+                        "type": "JumpToChannel",
+                        "value": "pajlada"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "#pajlada"
+                    ]
+                },
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "ChatMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "12:31"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "12:31:47",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "flags": "ModeratorTools",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TwitchModerationElement"
+                },
+                {
+                    "color": "Text",
+                    "fallbackColor": "Text",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "MentionElement",
+                    "userColor": "Text",
+                    "userLoginName": "nerixyz",
+                    "words": [
+                        "nerixyz:"
+                    ]
+                },
+                {
+                    "color": "Text",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "ass"
+                    ]
+                }
+            ],
+            "flags": "Timeout|PubSub|AutoMod|AutoModOffendingMessage|EventSub",
+            "id": "",
+            "localizedName": "",
+            "loginName": "nerixyz",
+            "messageText": "nerixyz: ass",
+            "searchText": "nerixyz: ass",
+            "serverReceivedTime": "2024-05-14T12:31:47Z",
+            "timeoutUser": "",
+            "userID": "",
+            "usernameColor": "#ff000000"
+        }
+    ]
+}

--- a/tests/snapshots/EventSub/automod-message-update/denied.json
+++ b/tests/snapshots/EventSub/automod-message-update/denied.json
@@ -1,0 +1,297 @@
+{
+    "input": [
+        {
+            "__subscription": "automod-message-hold",
+            "automod": {
+                "boundaries": [
+                    {
+                        "end_pos": 2,
+                        "start_pos": 0
+                    }
+                ],
+                "category": "swearing",
+                "level": 4
+            },
+            "blocked_term": null,
+            "broadcaster_user_id": "11148817",
+            "broadcaster_user_login": "pajlada",
+            "broadcaster_user_name": "pajlada",
+            "held_at": "2025-02-28T16:15:15.008668809Z",
+            "message": {
+                "fragments": [
+                    {
+                        "cheermote": null,
+                        "emote": null,
+                        "text": "ass",
+                        "type": "text"
+                    }
+                ],
+                "text": "ass"
+            },
+            "message_id": "19d067ff-89b5-4790-a720-97599894eb6b",
+            "reason": "automod",
+            "user_id": "129546453",
+            "user_login": "nerixyz",
+            "user_name": "nerixyz"
+        },
+        {
+            "automod": {
+                "boundaries": [
+                    {
+                        "end_pos": 2,
+                        "start_pos": 0
+                    }
+                ],
+                "category": "swearing",
+                "level": 4
+            },
+            "blocked_term": null,
+            "broadcaster_user_id": "11148817",
+            "broadcaster_user_login": "pajlada",
+            "broadcaster_user_name": "pajlada",
+            "held_at": "2025-02-28T16:15:15.008668809Z",
+            "message": {
+                "fragments": [
+                    {
+                        "cheermote": null,
+                        "emote": null,
+                        "text": "ass",
+                        "type": "text"
+                    }
+                ],
+                "text": "ass"
+            },
+            "message_id": "19d067ff-89b5-4790-a720-97599894eb6b",
+            "moderator_user_id": "489584266",
+            "moderator_user_login": "uint128",
+            "moderator_user_name": "uint128",
+            "reason": "automod",
+            "status": "denied",
+            "user_id": "129546453",
+            "user_login": "nerixyz",
+            "user_name": "nerixyz"
+        }
+    ],
+    "output": [
+        {
+            "badgeInfos": {
+            },
+            "badges": [
+            ],
+            "channelName": "pajlada",
+            "count": 1,
+            "displayName": "",
+            "elements": [
+                {
+                    "emote": {
+                        "homePage": "https://dashboard.twitch.tv/settings/moderation/automod",
+                        "images": {
+                            "1x": ""
+                        },
+                        "name": "",
+                        "tooltip": "AutoMod"
+                    },
+                    "flags": "BadgeChannelAuthority",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "tooltip": "AutoMod",
+                    "trailingSpace": true,
+                    "type": "BadgeElement"
+                },
+                {
+                    "color": "#ff0000ff",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMediumBold",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "AutoMod:"
+                    ]
+                },
+                {
+                    "color": "Text",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "Held",
+                        "a",
+                        "message",
+                        "for",
+                        "reason:",
+                        "swearing",
+                        "level",
+                        "4.",
+                        "Allow",
+                        "will",
+                        "post",
+                        "it",
+                        "in",
+                        "chat.",
+                        ""
+                    ]
+                },
+                {
+                    "color": "#ff00ff00",
+                    "flags": "Text",
+                    "link": {
+                        "type": "AutoModAllow",
+                        "value": "19d067ff-89b5-4790-a720-97599894eb6b"
+                    },
+                    "style": "ChatMediumBold",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "Allow"
+                    ]
+                },
+                {
+                    "color": "#ffff0000",
+                    "flags": "Text",
+                    "link": {
+                        "type": "AutoModDeny",
+                        "value": "19d067ff-89b5-4790-a720-97599894eb6b"
+                    },
+                    "style": "ChatMediumBold",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "",
+                        "Deny"
+                    ]
+                }
+            ],
+            "flags": "Timeout|Disabled|PubSub|AutoMod|AutoModOffendingMessageHeader|EventSub",
+            "id": "automod_19d067ff-89b5-4790-a720-97599894eb6b",
+            "localizedName": "",
+            "loginName": "automod",
+            "messageText": "AutoMod: Held a message for reason: swearing level 4. Allow will post it in chat. Allow Deny",
+            "searchText": "AutoMod: Held a message for reason: swearing level 4. Allow will post it in chat. Allow Deny",
+            "serverReceivedTime": "2024-05-14T12:31:47Z",
+            "timeoutUser": "",
+            "userID": "",
+            "usernameColor": "#ff000000"
+        },
+        {
+            "badgeInfos": {
+            },
+            "badges": [
+            ],
+            "channelName": "pajlada",
+            "count": 1,
+            "displayName": "",
+            "elements": [
+                {
+                    "color": "System",
+                    "flags": "ChannelName",
+                    "link": {
+                        "type": "JumpToChannel",
+                        "value": "pajlada"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "#pajlada"
+                    ]
+                },
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "ChatMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "12:31"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "12:31:47",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "flags": "ModeratorTools",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TwitchModerationElement"
+                },
+                {
+                    "color": "Text",
+                    "fallbackColor": "Text",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "MentionElement",
+                    "userColor": "Text",
+                    "userLoginName": "nerixyz",
+                    "words": [
+                        "nerixyz:"
+                    ]
+                },
+                {
+                    "color": "Text",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "ass"
+                    ]
+                }
+            ],
+            "flags": "Timeout|PubSub|AutoMod|AutoModOffendingMessage|EventSub",
+            "id": "",
+            "localizedName": "",
+            "loginName": "nerixyz",
+            "messageText": "nerixyz: ass",
+            "searchText": "nerixyz: ass",
+            "serverReceivedTime": "2024-05-14T12:31:47Z",
+            "timeoutUser": "",
+            "userID": "",
+            "usernameColor": "#ff000000"
+        }
+    ]
+}

--- a/tests/snapshots/EventSub/automod-message-update/expired.json
+++ b/tests/snapshots/EventSub/automod-message-update/expired.json
@@ -1,0 +1,297 @@
+{
+    "input": [
+        {
+            "__subscription": "automod-message-hold",
+            "automod": {
+                "boundaries": [
+                    {
+                        "end_pos": 2,
+                        "start_pos": 0
+                    }
+                ],
+                "category": "swearing",
+                "level": 4
+            },
+            "blocked_term": null,
+            "broadcaster_user_id": "11148817",
+            "broadcaster_user_login": "pajlada",
+            "broadcaster_user_name": "pajlada",
+            "held_at": "2025-02-28T16:15:15.008668809Z",
+            "message": {
+                "fragments": [
+                    {
+                        "cheermote": null,
+                        "emote": null,
+                        "text": "ass",
+                        "type": "text"
+                    }
+                ],
+                "text": "ass"
+            },
+            "message_id": "19d067ff-89b5-4790-a720-97599894eb6b",
+            "reason": "automod",
+            "user_id": "129546453",
+            "user_login": "nerixyz",
+            "user_name": "nerixyz"
+        },
+        {
+            "automod": {
+                "boundaries": [
+                    {
+                        "end_pos": 2,
+                        "start_pos": 0
+                    }
+                ],
+                "category": "swearing",
+                "level": 4
+            },
+            "blocked_term": null,
+            "broadcaster_user_id": "11148817",
+            "broadcaster_user_login": "pajlada",
+            "broadcaster_user_name": "pajlada",
+            "held_at": "2025-02-28T16:15:15.008668809Z",
+            "message": {
+                "fragments": [
+                    {
+                        "cheermote": null,
+                        "emote": null,
+                        "text": "ass",
+                        "type": "text"
+                    }
+                ],
+                "text": "ass"
+            },
+            "message_id": "19d067ff-89b5-4790-a720-97599894eb6b",
+            "moderator_user_id": "489584266",
+            "moderator_user_login": "uint128",
+            "moderator_user_name": "uint128",
+            "reason": "automod",
+            "status": "expired",
+            "user_id": "129546453",
+            "user_login": "nerixyz",
+            "user_name": "nerixyz"
+        }
+    ],
+    "output": [
+        {
+            "badgeInfos": {
+            },
+            "badges": [
+            ],
+            "channelName": "pajlada",
+            "count": 1,
+            "displayName": "",
+            "elements": [
+                {
+                    "emote": {
+                        "homePage": "https://dashboard.twitch.tv/settings/moderation/automod",
+                        "images": {
+                            "1x": ""
+                        },
+                        "name": "",
+                        "tooltip": "AutoMod"
+                    },
+                    "flags": "BadgeChannelAuthority",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "tooltip": "AutoMod",
+                    "trailingSpace": true,
+                    "type": "BadgeElement"
+                },
+                {
+                    "color": "#ff0000ff",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMediumBold",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "AutoMod:"
+                    ]
+                },
+                {
+                    "color": "Text",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "Held",
+                        "a",
+                        "message",
+                        "for",
+                        "reason:",
+                        "swearing",
+                        "level",
+                        "4.",
+                        "Allow",
+                        "will",
+                        "post",
+                        "it",
+                        "in",
+                        "chat.",
+                        ""
+                    ]
+                },
+                {
+                    "color": "#ff00ff00",
+                    "flags": "Text",
+                    "link": {
+                        "type": "AutoModAllow",
+                        "value": "19d067ff-89b5-4790-a720-97599894eb6b"
+                    },
+                    "style": "ChatMediumBold",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "Allow"
+                    ]
+                },
+                {
+                    "color": "#ffff0000",
+                    "flags": "Text",
+                    "link": {
+                        "type": "AutoModDeny",
+                        "value": "19d067ff-89b5-4790-a720-97599894eb6b"
+                    },
+                    "style": "ChatMediumBold",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "",
+                        "Deny"
+                    ]
+                }
+            ],
+            "flags": "Timeout|Disabled|PubSub|AutoMod|AutoModOffendingMessageHeader|EventSub",
+            "id": "automod_19d067ff-89b5-4790-a720-97599894eb6b",
+            "localizedName": "",
+            "loginName": "automod",
+            "messageText": "AutoMod: Held a message for reason: swearing level 4. Allow will post it in chat. Allow Deny",
+            "searchText": "AutoMod: Held a message for reason: swearing level 4. Allow will post it in chat. Allow Deny",
+            "serverReceivedTime": "2024-05-14T12:31:47Z",
+            "timeoutUser": "",
+            "userID": "",
+            "usernameColor": "#ff000000"
+        },
+        {
+            "badgeInfos": {
+            },
+            "badges": [
+            ],
+            "channelName": "pajlada",
+            "count": 1,
+            "displayName": "",
+            "elements": [
+                {
+                    "color": "System",
+                    "flags": "ChannelName",
+                    "link": {
+                        "type": "JumpToChannel",
+                        "value": "pajlada"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "#pajlada"
+                    ]
+                },
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "ChatMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "12:31"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "12:31:47",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "flags": "ModeratorTools",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TwitchModerationElement"
+                },
+                {
+                    "color": "Text",
+                    "fallbackColor": "Text",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "MentionElement",
+                    "userColor": "Text",
+                    "userLoginName": "nerixyz",
+                    "words": [
+                        "nerixyz:"
+                    ]
+                },
+                {
+                    "color": "Text",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "ass"
+                    ]
+                }
+            ],
+            "flags": "Timeout|PubSub|AutoMod|AutoModOffendingMessage|EventSub",
+            "id": "",
+            "localizedName": "",
+            "loginName": "nerixyz",
+            "messageText": "nerixyz: ass",
+            "searchText": "nerixyz: ass",
+            "serverReceivedTime": "2024-05-14T12:31:47Z",
+            "timeoutUser": "",
+            "userID": "",
+            "usernameColor": "#ff000000"
+        }
+    ]
+}

--- a/tests/snapshots/EventSub/automod-message-update/unknown-msg.json
+++ b/tests/snapshots/EventSub/automod-message-update/unknown-msg.json
@@ -1,0 +1,41 @@
+{
+    "input": {
+        "automod": {
+            "boundaries": [
+                {
+                    "end_pos": 2,
+                    "start_pos": 0
+                }
+            ],
+            "category": "swearing",
+            "level": 4
+        },
+        "blocked_term": null,
+        "broadcaster_user_id": "11148817",
+        "broadcaster_user_login": "pajlada",
+        "broadcaster_user_name": "pajlada",
+        "held_at": "2025-02-28T16:15:15.008668809Z",
+        "message": {
+            "fragments": [
+                {
+                    "cheermote": null,
+                    "emote": null,
+                    "text": "ass",
+                    "type": "text"
+                }
+            ],
+            "text": "ass"
+        },
+        "message_id": "19d067ff-89b5-4790-a720-97599894eb6b",
+        "moderator_user_id": "489584266",
+        "moderator_user_login": "uint128",
+        "moderator_user_name": "uint128",
+        "reason": "automod",
+        "status": "approved",
+        "user_id": "129546453",
+        "user_login": "nerixyz",
+        "user_name": "nerixyz"
+    },
+    "output": [
+    ]
+}


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
Towards https://github.com/Chatterino/chatterino2/issues/5908.

This handles `automod.message.update`. It's relatively simple as it only disables the original AutoMod message (adds `Disabled` flag). When testing, it's helpful to disable listening to PubSub AutoMod topics as they're usually faster than EventSub.