### PR TITLE
fix: don't save commands on exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Bugfix: Fixed channel point redemptions with messages not showing up if PubSub is disconnected. (#5948)
 - Bugfix: Fixed the input font not immediately updating when zooming in/out. (#5960)
 - Bugfix: Fixed color input thinking blue is also red. (#5982)
+- Bugfix: Fixed an issue where commands would sometimes reset if Chatterino was improperly shut down. (#6011)
 - Dev: Subscriptions to PubSub channel points redemption topics now use no auth token, making it continue to work during PubSub shutdown. (#5947)
 - Dev: Add initial experimental EventSub support. (#5837, #5895, #5897, #5904, #5910, #5903, #5915, #5916, #5930, #5935, #5932, #5943, #5952, #5953, #5968, #5973, #5974, #5980, #5981, #5985, #5990, #5992, #5993, #5996, #5995, #6000, #6001, #6002, #6003, #6005, #6007, #6010)
 - Dev: Remove unneeded platform specifier for toasts. (#5914)

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -598,7 +598,6 @@ eventsub::IController *Application::getEventSub()
 
 void Application::save()
 {
-    this->commands->save();
     this->hotkeys->save();
     this->windows->save();
 }

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -299,14 +299,17 @@ CommandController::CommandController(const Paths &paths)
     // Initialize setting manager for commands.json
     auto path = combinePath(paths.settingsDirectory, "commands.json");
     this->sm_ = std::make_shared<pajlada::Settings::SettingManager>();
+    this->sm_->saveMethod =
+        pajlada::Settings::SettingManager::SaveMethod::OnlySaveIfChanged;
     this->sm_->setPath(qPrintable(path));
     this->sm_->setBackupEnabled(true);
     this->sm_->setBackupSlots(9);
 
     // Delayed initialization of the setting storing all commands
     this->commandsSetting_.reset(
-        new pajlada::Settings::Setting<std::vector<Command>>("/commands",
-                                                             this->sm_));
+        new pajlada::Settings::Setting<std::vector<Command>>(
+            "/commands", pajlada::Settings::SettingOption::CompareBeforeSet,
+            this->sm_));
 
     // Update the setting when the vector of commands has been updated (most
     // likely from the settings dialog)


### PR DESCRIPTION
also update Settings to v0.3.0, giving us the ability to more sparingly save the commands.

We can now call `CommandController::save()` as much as we want, but it'll only save if something has actually saved, thanks to the combined use of `OnlySaveOnChange` and `SettingOption::CompareBeforeSet`

Fixes #6009 
