### PR TITLE
feat(eventsub): implement timeout stacking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 - Bugfix: Fixed color input thinking blue is also red. (#5982)
 - Bugfix: Fixed an issue where commands would sometimes reset if Chatterino was improperly shut down. (#6011)
 - Dev: Subscriptions to PubSub channel points redemption topics now use no auth token, making it continue to work during PubSub shutdown. (#5947)
-- Dev: Add initial experimental EventSub support. (#5837, #5895, #5897, #5904, #5910, #5903, #5915, #5916, #5930, #5935, #5932, #5943, #5952, #5953, #5968, #5973, #5974, #5980, #5981, #5985, #5990, #5992, #5993, #5996, #5995, #6000, #6001, #6002, #6003, #6005, #6007, #6010, #6008, #6012)
+- Dev: Add initial experimental EventSub support. (#5837, #5895, #5897, #5904, #5910, #5903, #5915, #5916, #5930, #5935, #5932, #5943, #5952, #5953, #5968, #5973, #5974, #5980, #5981, #5985, #5990, #5992, #5993, #5996, #5995, #6000, #6001, #6002, #6003, #6005, #6007, #6010, #6008, #6012, #6013)
 - Dev: Remove unneeded platform specifier for toasts. (#5914)
 - Dev: Highlight checks now use non-capturing groups for the boundaries. (#5784)
 - Dev: Removed unused PubSub whisper code. (#5898)

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -630,7 +630,8 @@ MessagePtrMut MessageBuilder::makeSubgiftMessage(const QString &text,
 
 MessageBuilder::MessageBuilder(TimeoutMessageTag, const QString &timeoutUser,
                                const QString &sourceUser,
-                               const QString &systemMessageText, int times,
+                               const QString &channel,
+                               const QString &systemMessageText, uint32_t times,
                                const QDateTime &time)
     : MessageBuilder()
 {
@@ -645,20 +646,38 @@ MessageBuilder::MessageBuilder(TimeoutMessageTag, const QString &timeoutUser,
         ->setLink(
             {Link::UserInfo, timeoutUserIsFirst ? timeoutUser : sourceUser});
 
+    auto appendUser = [&](const QString &name) {
+        auto pos = remainder.indexOf(name);
+        if (pos > 0)
+        {
+            QString start = remainder.mid(0, pos - 1);
+            remainder = remainder.mid(pos + name.length());
+
+            this->emplaceSystemTextAndUpdate(start, messageText);
+            auto *el = this->emplaceSystemTextAndUpdate(name, messageText)
+                           ->setLink({Link::UserInfo, name});
+            if (remainder.startsWith(' '))
+            {
+                remainder.removeFirst();
+            }
+            else
+            {
+                assert(messageText.endsWith(' '));
+                messageText.removeLast();
+                el->setTrailingSpace(false);
+            }
+        }
+    };
+
     if (!sourceUser.isEmpty())
     {
         // the second username in the message
-        const auto &targetUsername =
-            timeoutUserIsFirst ? sourceUser : timeoutUser;
-        int userPos = remainder.indexOf(targetUsername);
+        appendUser(timeoutUserIsFirst ? sourceUser : timeoutUser);
+    }
 
-        QString mid = remainder.mid(0, userPos - 1);
-        QString username = remainder.mid(userPos, targetUsername.length());
-        remainder = remainder.mid(userPos + targetUsername.length() + 1);
-
-        this->emplaceSystemTextAndUpdate(mid, messageText);
-        this->emplaceSystemTextAndUpdate(username, messageText)
-            ->setLink({Link::UserInfo, username});
+    if (!channel.isEmpty())
+    {
+        appendUser(channel);
     }
 
     this->emplaceSystemTextAndUpdate(

--- a/src/messages/MessageBuilder.hpp
+++ b/src/messages/MessageBuilder.hpp
@@ -107,8 +107,9 @@ public:
     MessageBuilder(SystemMessageTag, const QString &text,
                    const QTime &time = QTime::currentTime());
     MessageBuilder(TimeoutMessageTag, const QString &timeoutUser,
-                   const QString &sourceUser, const QString &systemMessageText,
-                   int times, const QDateTime &time);
+                   const QString &sourceUser, const QString &channel,
+                   const QString &systemMessageText, uint32_t times,
+                   const QDateTime &time);
     MessageBuilder(TimeoutMessageTag, const QString &username,
                    const QString &durationInSeconds, bool multipleTimes,
                    const QDateTime &time);

--- a/tests/snapshots/EventSub/channel-moderate/shared-timeout-stacking-diff-sources.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-timeout-stacking-diff-sources.json
@@ -1,0 +1,617 @@
+{
+    "input": [
+        {
+            "__timestamp": "2025-02-22T17:54:04.523432776Z",
+            "action": "shared_chat_timeout",
+            "automod_terms": null,
+            "ban": null,
+            "broadcaster_user_id": "11148817",
+            "broadcaster_user_login": "pajlada",
+            "broadcaster_user_name": "pajlada",
+            "delete": null,
+            "followers": null,
+            "mod": null,
+            "moderator_user_id": "129546453",
+            "moderator_user_login": "nerixyz",
+            "moderator_user_name": "nerixyz",
+            "raid": null,
+            "shared_chat_ban": null,
+            "shared_chat_delete": null,
+            "shared_chat_timeout": {
+                "expires_at": "2025-02-22T18:04:04.502931622Z",
+                "reason": "",
+                "user_id": "141981764",
+                "user_login": "twitchdev",
+                "user_name": "TwitchDev"
+            },
+            "shared_chat_unban": null,
+            "shared_chat_untimeout": null,
+            "slow": null,
+            "source_broadcaster_user_id": "117166826",
+            "source_broadcaster_user_login": "testaccount_420",
+            "source_broadcaster_user_name": "테스트계정420",
+            "timeout": null,
+            "unban": null,
+            "unban_request": null,
+            "unmod": null,
+            "unraid": null,
+            "untimeout": null,
+            "unvip": null,
+            "vip": null,
+            "warn": null
+        },
+        {
+            "__timestamp": "2025-02-22T17:54:05.523432776Z",
+            "action": "shared_chat_timeout",
+            "automod_terms": null,
+            "ban": null,
+            "broadcaster_user_id": "11148817",
+            "broadcaster_user_login": "pajlada",
+            "broadcaster_user_name": "pajlada",
+            "delete": null,
+            "followers": null,
+            "mod": null,
+            "moderator_user_id": "129546453",
+            "moderator_user_login": "nerixyz",
+            "moderator_user_name": "nerixyz",
+            "raid": null,
+            "shared_chat_ban": null,
+            "shared_chat_delete": null,
+            "shared_chat_timeout": {
+                "expires_at": "2025-02-22T18:04:05.502931622Z",
+                "reason": "",
+                "user_id": "141981764",
+                "user_login": "twitchdev",
+                "user_name": "TwitchDev"
+            },
+            "shared_chat_unban": null,
+            "shared_chat_untimeout": null,
+            "slow": null,
+            "source_broadcaster_user_id": "117166826",
+            "source_broadcaster_user_login": "testaccount_420",
+            "source_broadcaster_user_name": "테스트계정420",
+            "timeout": null,
+            "unban": null,
+            "unban_request": null,
+            "unmod": null,
+            "unraid": null,
+            "untimeout": null,
+            "unvip": null,
+            "vip": null,
+            "warn": null
+        },
+        {
+            "__timestamp": "2025-02-22T17:54:06.523432776Z",
+            "action": "timeout",
+            "automod_terms": null,
+            "ban": null,
+            "broadcaster_user_id": "11148817",
+            "broadcaster_user_login": "pajlada",
+            "broadcaster_user_name": "pajlada",
+            "delete": null,
+            "followers": null,
+            "mod": null,
+            "moderator_user_id": "129546453",
+            "moderator_user_login": "nerixyz",
+            "moderator_user_name": "nerixyz",
+            "raid": null,
+            "shared_chat_ban": null,
+            "shared_chat_delete": null,
+            "shared_chat_timeout": null,
+            "shared_chat_unban": null,
+            "shared_chat_untimeout": null,
+            "slow": null,
+            "source_broadcaster_user_id": null,
+            "source_broadcaster_user_login": null,
+            "source_broadcaster_user_name": null,
+            "timeout": {
+                "expires_at": "2025-02-22T18:04:06.502931622Z",
+                "reason": "",
+                "user_id": "141981764",
+                "user_login": "twitchdev",
+                "user_name": "TwitchDev"
+            },
+            "unban": null,
+            "unban_request": null,
+            "unmod": null,
+            "unraid": null,
+            "untimeout": null,
+            "unvip": null,
+            "vip": null,
+            "warn": null
+        },
+        {
+            "__timestamp": "2025-02-22T17:54:07.523432776Z",
+            "action": "shared_chat_timeout",
+            "automod_terms": null,
+            "ban": null,
+            "broadcaster_user_id": "11148817",
+            "broadcaster_user_login": "pajlada",
+            "broadcaster_user_name": "pajlada",
+            "delete": null,
+            "followers": null,
+            "mod": null,
+            "moderator_user_id": "129546453",
+            "moderator_user_login": "nerixyz",
+            "moderator_user_name": "nerixyz",
+            "raid": null,
+            "shared_chat_ban": null,
+            "shared_chat_delete": null,
+            "shared_chat_timeout": {
+                "expires_at": "2025-02-22T18:04:07.502931622Z",
+                "reason": "",
+                "user_id": "141981764",
+                "user_login": "twitchdev",
+                "user_name": "TwitchDev"
+            },
+            "shared_chat_unban": null,
+            "shared_chat_untimeout": null,
+            "slow": null,
+            "source_broadcaster_user_id": "22484632",
+            "source_broadcaster_user_login": "forsen",
+            "source_broadcaster_user_name": "forsen",
+            "timeout": null,
+            "unban": null,
+            "unban_request": null,
+            "unmod": null,
+            "unraid": null,
+            "untimeout": null,
+            "unvip": null,
+            "vip": null,
+            "warn": null
+        }
+    ],
+    "output": [
+        {
+            "badgeInfos": {
+            },
+            "badges": [
+            ],
+            "channelName": "testaccount_420",
+            "count": 2,
+            "displayName": "",
+            "elements": [
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "ChatMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "17:54"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "17:54:05",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "nerixyz"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "nerixyz"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "timed",
+                        "out"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "twitchdev"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "twitchdev"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "for",
+                        "10m",
+                        "in"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "testaccount_420"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": false,
+                    "type": "TextElement",
+                    "words": [
+                        "testaccount_420"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        ".",
+                        "(2",
+                        "times)"
+                    ]
+                }
+            ],
+            "flags": "System|Timeout|PubSub|SharedMessage|EventSub",
+            "id": "",
+            "localizedName": "",
+            "loginName": "",
+            "messageText": "nerixyz timed out twitchdev for 10m in testaccount_420. (2 times) ",
+            "searchText": "nerixyz timed out twitchdev for 10m in testaccount_420. (2 times) ",
+            "serverReceivedTime": "2025-02-22T17:54:05Z",
+            "timeoutUser": "twitchdev",
+            "userID": "",
+            "usernameColor": "#ff000000"
+        },
+        {
+            "badgeInfos": {
+            },
+            "badges": [
+            ],
+            "channelName": "",
+            "count": 1,
+            "displayName": "",
+            "elements": [
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "ChatMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "17:54"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "17:54:06",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "nerixyz"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "nerixyz"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "timed",
+                        "out"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "twitchdev"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "twitchdev"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "for"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": false,
+                    "type": "TextElement",
+                    "words": [
+                        "10m"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "."
+                    ]
+                }
+            ],
+            "flags": "System|Timeout|PubSub|EventSub",
+            "id": "",
+            "localizedName": "",
+            "loginName": "nerixyz",
+            "messageText": "nerixyz timed out twitchdev for 10m. ",
+            "searchText": "nerixyz timed out twitchdev for 10m. ",
+            "serverReceivedTime": "2025-02-22T17:54:06Z",
+            "timeoutUser": "twitchdev",
+            "userID": "",
+            "usernameColor": "#ff000000"
+        },
+        {
+            "badgeInfos": {
+            },
+            "badges": [
+            ],
+            "channelName": "forsen",
+            "count": 1,
+            "displayName": "",
+            "elements": [
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "ChatMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "17:54"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "17:54:07",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "nerixyz"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "nerixyz"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "timed",
+                        "out"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "twitchdev"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "twitchdev"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "for"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "10m"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "in"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "forsen"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": false,
+                    "type": "TextElement",
+                    "words": [
+                        "forsen"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "."
+                    ]
+                }
+            ],
+            "flags": "System|Timeout|PubSub|SharedMessage|EventSub",
+            "id": "",
+            "localizedName": "",
+            "loginName": "nerixyz",
+            "messageText": "nerixyz timed out twitchdev for 10m in forsen. ",
+            "searchText": "nerixyz timed out twitchdev for 10m in forsen. ",
+            "serverReceivedTime": "2025-02-22T17:54:07Z",
+            "timeoutUser": "twitchdev",
+            "userID": "",
+            "usernameColor": "#ff000000"
+        }
+    ]
+}

--- a/tests/snapshots/EventSub/channel-moderate/shared-timeout-stacking-diff-sources2.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-timeout-stacking-diff-sources2.json
@@ -1,0 +1,438 @@
+{
+    "input": [
+        {
+            "__timestamp": "2025-02-22T17:54:04.523432776Z",
+            "action": "shared_chat_timeout",
+            "automod_terms": null,
+            "ban": null,
+            "broadcaster_user_id": "11148817",
+            "broadcaster_user_login": "pajlada",
+            "broadcaster_user_name": "pajlada",
+            "delete": null,
+            "followers": null,
+            "mod": null,
+            "moderator_user_id": "129546453",
+            "moderator_user_login": "nerixyz",
+            "moderator_user_name": "nerixyz",
+            "raid": null,
+            "shared_chat_ban": null,
+            "shared_chat_delete": null,
+            "shared_chat_timeout": {
+                "expires_at": "2025-02-22T18:04:04.502931622Z",
+                "reason": "",
+                "user_id": "141981764",
+                "user_login": "twitchdev",
+                "user_name": "TwitchDev"
+            },
+            "shared_chat_unban": null,
+            "shared_chat_untimeout": null,
+            "slow": null,
+            "source_broadcaster_user_id": "117166826",
+            "source_broadcaster_user_login": "testaccount_420",
+            "source_broadcaster_user_name": "테스트계정420",
+            "timeout": null,
+            "unban": null,
+            "unban_request": null,
+            "unmod": null,
+            "unraid": null,
+            "untimeout": null,
+            "unvip": null,
+            "vip": null,
+            "warn": null
+        },
+        {
+            "__timestamp": "2025-02-22T17:54:05.523432776Z",
+            "action": "shared_chat_timeout",
+            "automod_terms": null,
+            "ban": null,
+            "broadcaster_user_id": "11148817",
+            "broadcaster_user_login": "pajlada",
+            "broadcaster_user_name": "pajlada",
+            "delete": null,
+            "followers": null,
+            "mod": null,
+            "moderator_user_id": "129546453",
+            "moderator_user_login": "nerixyz",
+            "moderator_user_name": "nerixyz",
+            "raid": null,
+            "shared_chat_ban": null,
+            "shared_chat_delete": null,
+            "shared_chat_timeout": {
+                "expires_at": "2025-02-22T18:04:05.502931622Z",
+                "reason": "",
+                "user_id": "141981764",
+                "user_login": "twitchdev",
+                "user_name": "TwitchDev"
+            },
+            "shared_chat_unban": null,
+            "shared_chat_untimeout": null,
+            "slow": null,
+            "source_broadcaster_user_id": "117166826",
+            "source_broadcaster_user_login": "testaccount_420",
+            "source_broadcaster_user_name": "테스트계정420",
+            "timeout": null,
+            "unban": null,
+            "unban_request": null,
+            "unmod": null,
+            "unraid": null,
+            "untimeout": null,
+            "unvip": null,
+            "vip": null,
+            "warn": null
+        },
+        {
+            "__timestamp": "2025-02-22T17:54:06.523432776Z",
+            "action": "shared_chat_timeout",
+            "automod_terms": null,
+            "ban": null,
+            "broadcaster_user_id": "11148817",
+            "broadcaster_user_login": "pajlada",
+            "broadcaster_user_name": "pajlada",
+            "delete": null,
+            "followers": null,
+            "mod": null,
+            "moderator_user_id": "129546453",
+            "moderator_user_login": "nerixyz",
+            "moderator_user_name": "nerixyz",
+            "raid": null,
+            "shared_chat_ban": null,
+            "shared_chat_delete": null,
+            "shared_chat_timeout": {
+                "expires_at": "2025-02-22T18:04:06.502931622Z",
+                "reason": "",
+                "user_id": "141981764",
+                "user_login": "twitchdev",
+                "user_name": "TwitchDev"
+            },
+            "shared_chat_unban": null,
+            "shared_chat_untimeout": null,
+            "slow": null,
+            "source_broadcaster_user_id": "22484632",
+            "source_broadcaster_user_login": "forsen",
+            "source_broadcaster_user_name": "forsen",
+            "timeout": null,
+            "unban": null,
+            "unban_request": null,
+            "unmod": null,
+            "unraid": null,
+            "untimeout": null,
+            "unvip": null,
+            "vip": null,
+            "warn": null
+        }
+    ],
+    "output": [
+        {
+            "badgeInfos": {
+            },
+            "badges": [
+            ],
+            "channelName": "testaccount_420",
+            "count": 2,
+            "displayName": "",
+            "elements": [
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "ChatMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "17:54"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "17:54:05",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "nerixyz"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "nerixyz"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "timed",
+                        "out"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "twitchdev"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "twitchdev"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "for",
+                        "10m",
+                        "in"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "testaccount_420"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": false,
+                    "type": "TextElement",
+                    "words": [
+                        "testaccount_420"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        ".",
+                        "(2",
+                        "times)"
+                    ]
+                }
+            ],
+            "flags": "System|Timeout|PubSub|SharedMessage|EventSub",
+            "id": "",
+            "localizedName": "",
+            "loginName": "",
+            "messageText": "nerixyz timed out twitchdev for 10m in testaccount_420. (2 times) ",
+            "searchText": "nerixyz timed out twitchdev for 10m in testaccount_420. (2 times) ",
+            "serverReceivedTime": "2025-02-22T17:54:05Z",
+            "timeoutUser": "twitchdev",
+            "userID": "",
+            "usernameColor": "#ff000000"
+        },
+        {
+            "badgeInfos": {
+            },
+            "badges": [
+            ],
+            "channelName": "forsen",
+            "count": 1,
+            "displayName": "",
+            "elements": [
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "ChatMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "17:54"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "17:54:06",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "nerixyz"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "nerixyz"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "timed",
+                        "out"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "twitchdev"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "twitchdev"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "for"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "10m"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "in"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "forsen"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": false,
+                    "type": "TextElement",
+                    "words": [
+                        "forsen"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "."
+                    ]
+                }
+            ],
+            "flags": "System|Timeout|PubSub|SharedMessage|EventSub",
+            "id": "",
+            "localizedName": "",
+            "loginName": "nerixyz",
+            "messageText": "nerixyz timed out twitchdev for 10m in forsen. ",
+            "searchText": "nerixyz timed out twitchdev for 10m in forsen. ",
+            "serverReceivedTime": "2025-02-22T17:54:06Z",
+            "timeoutUser": "twitchdev",
+            "userID": "",
+            "usernameColor": "#ff000000"
+        }
+    ]
+}

--- a/tests/snapshots/EventSub/channel-moderate/shared-timeout-stacking.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-timeout-stacking.json
@@ -1,0 +1,408 @@
+{
+    "input": [
+        {
+            "__timestamp": "2025-02-22T17:54:04.523432776Z",
+            "action": "shared_chat_timeout",
+            "automod_terms": null,
+            "ban": null,
+            "broadcaster_user_id": "11148817",
+            "broadcaster_user_login": "pajlada",
+            "broadcaster_user_name": "pajlada",
+            "delete": null,
+            "followers": null,
+            "mod": null,
+            "moderator_user_id": "129546453",
+            "moderator_user_login": "nerixyz",
+            "moderator_user_name": "nerixyz",
+            "raid": null,
+            "shared_chat_ban": null,
+            "shared_chat_delete": null,
+            "shared_chat_timeout": {
+                "expires_at": "2025-02-22T18:04:04.502931622Z",
+                "reason": "",
+                "user_id": "141981764",
+                "user_login": "twitchdev",
+                "user_name": "TwitchDev"
+            },
+            "shared_chat_unban": null,
+            "shared_chat_untimeout": null,
+            "slow": null,
+            "source_broadcaster_user_id": "117166826",
+            "source_broadcaster_user_login": "testaccount_420",
+            "source_broadcaster_user_name": "테스트계정420",
+            "timeout": null,
+            "unban": null,
+            "unban_request": null,
+            "unmod": null,
+            "unraid": null,
+            "untimeout": null,
+            "unvip": null,
+            "vip": null,
+            "warn": null
+        },
+        {
+            "__timestamp": "2025-02-22T17:54:05.523432776Z",
+            "action": "shared_chat_timeout",
+            "automod_terms": null,
+            "ban": null,
+            "broadcaster_user_id": "11148817",
+            "broadcaster_user_login": "pajlada",
+            "broadcaster_user_name": "pajlada",
+            "delete": null,
+            "followers": null,
+            "mod": null,
+            "moderator_user_id": "129546453",
+            "moderator_user_login": "nerixyz",
+            "moderator_user_name": "nerixyz",
+            "raid": null,
+            "shared_chat_ban": null,
+            "shared_chat_delete": null,
+            "shared_chat_timeout": {
+                "expires_at": "2025-02-22T18:04:05.502931622Z",
+                "reason": "",
+                "user_id": "141981764",
+                "user_login": "twitchdev",
+                "user_name": "TwitchDev"
+            },
+            "shared_chat_unban": null,
+            "shared_chat_untimeout": null,
+            "slow": null,
+            "source_broadcaster_user_id": "117166826",
+            "source_broadcaster_user_login": "testaccount_420",
+            "source_broadcaster_user_name": "테스트계정420",
+            "timeout": null,
+            "unban": null,
+            "unban_request": null,
+            "unmod": null,
+            "unraid": null,
+            "untimeout": null,
+            "unvip": null,
+            "vip": null,
+            "warn": null
+        },
+        {
+            "__timestamp": "2025-02-22T17:54:06.523432776Z",
+            "action": "shared_chat_timeout",
+            "automod_terms": null,
+            "ban": null,
+            "broadcaster_user_id": "11148817",
+            "broadcaster_user_login": "pajlada",
+            "broadcaster_user_name": "pajlada",
+            "delete": null,
+            "followers": null,
+            "mod": null,
+            "moderator_user_id": "129546453",
+            "moderator_user_login": "nerixyz",
+            "moderator_user_name": "nerixyz",
+            "raid": null,
+            "shared_chat_ban": null,
+            "shared_chat_delete": null,
+            "shared_chat_timeout": {
+                "expires_at": "2025-02-22T18:04:06.502931622Z",
+                "reason": "",
+                "user_id": "141981764",
+                "user_login": "twitchdev",
+                "user_name": "TwitchDev"
+            },
+            "shared_chat_unban": null,
+            "shared_chat_untimeout": null,
+            "slow": null,
+            "source_broadcaster_user_id": null,
+            "source_broadcaster_user_login": null,
+            "source_broadcaster_user_name": null,
+            "timeout": null,
+            "unban": null,
+            "unban_request": null,
+            "unmod": null,
+            "unraid": null,
+            "untimeout": null,
+            "unvip": null,
+            "vip": null,
+            "warn": null
+        }
+    ],
+    "output": [
+        {
+            "badgeInfos": {
+            },
+            "badges": [
+            ],
+            "channelName": "testaccount_420",
+            "count": 2,
+            "displayName": "",
+            "elements": [
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "ChatMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "17:54"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "17:54:05",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "nerixyz"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "nerixyz"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "timed",
+                        "out"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "twitchdev"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "twitchdev"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "for",
+                        "10m",
+                        "in"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "testaccount_420"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": false,
+                    "type": "TextElement",
+                    "words": [
+                        "testaccount_420"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        ".",
+                        "(2",
+                        "times)"
+                    ]
+                }
+            ],
+            "flags": "System|Timeout|PubSub|SharedMessage|EventSub",
+            "id": "",
+            "localizedName": "",
+            "loginName": "",
+            "messageText": "nerixyz timed out twitchdev for 10m in testaccount_420. (2 times) ",
+            "searchText": "nerixyz timed out twitchdev for 10m in testaccount_420. (2 times) ",
+            "serverReceivedTime": "2025-02-22T17:54:05Z",
+            "timeoutUser": "twitchdev",
+            "userID": "",
+            "usernameColor": "#ff000000"
+        },
+        {
+            "badgeInfos": {
+            },
+            "badges": [
+            ],
+            "channelName": "",
+            "count": 1,
+            "displayName": "",
+            "elements": [
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "ChatMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "17:54"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "17:54:06",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "nerixyz"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "nerixyz"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "timed",
+                        "out"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "twitchdev"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "twitchdev"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "for"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": false,
+                    "type": "TextElement",
+                    "words": [
+                        "10m"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "."
+                    ]
+                }
+            ],
+            "flags": "System|Timeout|PubSub|EventSub",
+            "id": "",
+            "localizedName": "",
+            "loginName": "nerixyz",
+            "messageText": "nerixyz timed out twitchdev for 10m. ",
+            "searchText": "nerixyz timed out twitchdev for 10m. ",
+            "serverReceivedTime": "2025-02-22T17:54:06Z",
+            "timeoutUser": "twitchdev",
+            "userID": "",
+            "usernameColor": "#ff000000"
+        }
+    ]
+}

--- a/tests/snapshots/EventSub/channel-moderate/shared-timeout.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-timeout.json
@@ -45,7 +45,7 @@
             },
             "badges": [
             ],
-            "channelName": "",
+            "channelName": "testaccount_420",
             "count": 1,
             "displayName": "",
             "elements": [
@@ -77,19 +77,16 @@
                     "type": "TimestampElement"
                 },
                 {
-                    "color": "Text",
-                    "fallbackColor": "System",
-                    "flags": "Text|Mention",
+                    "color": "System",
+                    "flags": "Text",
                     "link": {
-                        "type": "None",
-                        "value": ""
+                        "type": "UserInfo",
+                        "value": "nerixyz"
                     },
                     "style": "ChatMedium",
                     "tooltip": "",
                     "trailingSpace": true,
-                    "type": "MentionElement",
-                    "userColor": "System",
-                    "userLoginName": "nerixyz",
+                    "type": "TextElement",
                     "words": [
                         "nerixyz"
                     ]
@@ -111,21 +108,18 @@
                     ]
                 },
                 {
-                    "color": "Text",
-                    "fallbackColor": "System",
-                    "flags": "Text|Mention",
+                    "color": "System",
+                    "flags": "Text",
                     "link": {
-                        "type": "None",
-                        "value": ""
+                        "type": "UserInfo",
+                        "value": "twitchdev"
                     },
                     "style": "ChatMedium",
                     "tooltip": "",
                     "trailingSpace": true,
-                    "type": "MentionElement",
-                    "userColor": "System",
-                    "userLoginName": "twitchdev",
+                    "type": "TextElement",
                     "words": [
-                        "TwitchDev"
+                        "twitchdev"
                     ]
                 },
                 {
@@ -174,21 +168,18 @@
                     ]
                 },
                 {
-                    "color": "Text",
-                    "fallbackColor": "System",
-                    "flags": "Text|Mention",
+                    "color": "System",
+                    "flags": "Text",
                     "link": {
-                        "type": "None",
-                        "value": ""
+                        "type": "UserInfo",
+                        "value": "testaccount_420"
                     },
                     "style": "ChatMedium",
                     "tooltip": "",
                     "trailingSpace": false,
-                    "type": "MentionElement",
-                    "userColor": "System",
-                    "userLoginName": "testaccount_420",
+                    "type": "TextElement",
                     "words": [
-                        "테스트계정420"
+                        "testaccount_420"
                     ]
                 },
                 {
@@ -207,7 +198,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|EventSub",
+            "flags": "System|Timeout|PubSub|SharedMessage|EventSub",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/timeout-stacking-reason.json
+++ b/tests/snapshots/EventSub/channel-moderate/timeout-stacking-reason.json
@@ -1,0 +1,393 @@
+{
+    "input": [
+        {
+            "__timestamp": "2025-02-22T17:53:49.800959069Z",
+            "action": "timeout",
+            "automod_terms": null,
+            "ban": null,
+            "broadcaster_user_id": "11148817",
+            "broadcaster_user_login": "pajlada",
+            "broadcaster_user_name": "pajlada",
+            "delete": null,
+            "followers": null,
+            "mod": null,
+            "moderator_user_id": "129546453",
+            "moderator_user_login": "nerixyz",
+            "moderator_user_name": "nerixyz",
+            "raid": null,
+            "shared_chat_ban": null,
+            "shared_chat_delete": null,
+            "shared_chat_timeout": null,
+            "shared_chat_unban": null,
+            "shared_chat_untimeout": null,
+            "slow": null,
+            "source_broadcaster_user_id": null,
+            "source_broadcaster_user_login": null,
+            "source_broadcaster_user_name": null,
+            "timeout": {
+                "expires_at": "2025-02-22T17:53:50.782129948Z",
+                "reason": "pajlada",
+                "user_id": "141981764",
+                "user_login": "twitchdev",
+                "user_name": "TwitchDev"
+            },
+            "unban": null,
+            "unban_request": null,
+            "unmod": null,
+            "unraid": null,
+            "untimeout": null,
+            "unvip": null,
+            "vip": null,
+            "warn": null
+        },
+        {
+            "__timestamp": "2025-02-22T17:53:50.800959069Z",
+            "action": "timeout",
+            "automod_terms": null,
+            "ban": null,
+            "broadcaster_user_id": "11148817",
+            "broadcaster_user_login": "pajlada",
+            "broadcaster_user_name": "pajlada",
+            "delete": null,
+            "followers": null,
+            "mod": null,
+            "moderator_user_id": "129546453",
+            "moderator_user_login": "nerixyz",
+            "moderator_user_name": "nerixyz",
+            "raid": null,
+            "shared_chat_ban": null,
+            "shared_chat_delete": null,
+            "shared_chat_timeout": null,
+            "shared_chat_unban": null,
+            "shared_chat_untimeout": null,
+            "slow": null,
+            "source_broadcaster_user_id": null,
+            "source_broadcaster_user_login": null,
+            "source_broadcaster_user_name": null,
+            "timeout": {
+                "expires_at": "2025-02-22T17:53:51.782129948Z",
+                "reason": "pajlada",
+                "user_id": "141981764",
+                "user_login": "twitchdev",
+                "user_name": "TwitchDev"
+            },
+            "unban": null,
+            "unban_request": null,
+            "unmod": null,
+            "unraid": null,
+            "untimeout": null,
+            "unvip": null,
+            "vip": null,
+            "warn": null
+        },
+        {
+            "__timestamp": "2025-02-22T17:54:50.800959069Z",
+            "action": "timeout",
+            "automod_terms": null,
+            "ban": null,
+            "broadcaster_user_id": "11148817",
+            "broadcaster_user_login": "pajlada",
+            "broadcaster_user_name": "pajlada",
+            "delete": null,
+            "followers": null,
+            "mod": null,
+            "moderator_user_id": "129546453",
+            "moderator_user_login": "nerixyz",
+            "moderator_user_name": "nerixyz",
+            "raid": null,
+            "shared_chat_ban": null,
+            "shared_chat_delete": null,
+            "shared_chat_timeout": null,
+            "shared_chat_unban": null,
+            "shared_chat_untimeout": null,
+            "slow": null,
+            "source_broadcaster_user_id": null,
+            "source_broadcaster_user_login": null,
+            "source_broadcaster_user_name": null,
+            "timeout": {
+                "expires_at": "2025-02-22T17:54:51.782129948Z",
+                "reason": "pajlada",
+                "user_id": "141981764",
+                "user_login": "twitchdev",
+                "user_name": "TwitchDev"
+            },
+            "unban": null,
+            "unban_request": null,
+            "unmod": null,
+            "unraid": null,
+            "untimeout": null,
+            "unvip": null,
+            "vip": null,
+            "warn": null
+        }
+    ],
+    "output": [
+        {
+            "badgeInfos": {
+            },
+            "badges": [
+            ],
+            "channelName": "",
+            "count": 2,
+            "displayName": "",
+            "elements": [
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "ChatMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "17:53"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "17:53:50",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "nerixyz"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "nerixyz"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "timed",
+                        "out"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "twitchdev"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "twitchdev"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "for",
+                        "1s:",
+                        "pajlada",
+                        "(2",
+                        "times)"
+                    ]
+                }
+            ],
+            "flags": "System|Timeout|PubSub|EventSub",
+            "id": "",
+            "localizedName": "",
+            "loginName": "",
+            "messageText": "nerixyz timed out twitchdev for 1s: pajlada (2 times) ",
+            "searchText": "nerixyz timed out twitchdev for 1s: pajlada (2 times) ",
+            "serverReceivedTime": "2025-02-22T17:53:50Z",
+            "timeoutUser": "twitchdev",
+            "userID": "",
+            "usernameColor": "#ff000000"
+        },
+        {
+            "badgeInfos": {
+            },
+            "badges": [
+            ],
+            "channelName": "",
+            "count": 1,
+            "displayName": "",
+            "elements": [
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "ChatMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "17:54"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "17:54:50",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "nerixyz"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "nerixyz"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "timed",
+                        "out"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "twitchdev"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "twitchdev"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "for"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": false,
+                    "type": "TextElement",
+                    "words": [
+                        "1s"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        ":"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "pajlada"
+                    ]
+                }
+            ],
+            "flags": "System|Timeout|PubSub|EventSub",
+            "id": "",
+            "localizedName": "",
+            "loginName": "nerixyz",
+            "messageText": "nerixyz timed out twitchdev for 1s: pajlada ",
+            "searchText": "nerixyz timed out twitchdev for 1s: pajlada ",
+            "serverReceivedTime": "2025-02-22T17:54:50Z",
+            "timeoutUser": "twitchdev",
+            "userID": "",
+            "usernameColor": "#ff000000"
+        }
+    ]
+}

--- a/tests/snapshots/EventSub/channel-moderate/timeout-stacking.json
+++ b/tests/snapshots/EventSub/channel-moderate/timeout-stacking.json
@@ -1,0 +1,377 @@
+{
+    "input": [
+        {
+            "__timestamp": "2025-02-22T17:53:49.800959069Z",
+            "action": "timeout",
+            "automod_terms": null,
+            "ban": null,
+            "broadcaster_user_id": "11148817",
+            "broadcaster_user_login": "pajlada",
+            "broadcaster_user_name": "pajlada",
+            "delete": null,
+            "followers": null,
+            "mod": null,
+            "moderator_user_id": "129546453",
+            "moderator_user_login": "nerixyz",
+            "moderator_user_name": "nerixyz",
+            "raid": null,
+            "shared_chat_ban": null,
+            "shared_chat_delete": null,
+            "shared_chat_timeout": null,
+            "shared_chat_unban": null,
+            "shared_chat_untimeout": null,
+            "slow": null,
+            "source_broadcaster_user_id": null,
+            "source_broadcaster_user_login": null,
+            "source_broadcaster_user_name": null,
+            "timeout": {
+                "expires_at": "2025-02-22T17:53:50.782129948Z",
+                "reason": "",
+                "user_id": "141981764",
+                "user_login": "twitchdev",
+                "user_name": "TwitchDev"
+            },
+            "unban": null,
+            "unban_request": null,
+            "unmod": null,
+            "unraid": null,
+            "untimeout": null,
+            "unvip": null,
+            "vip": null,
+            "warn": null
+        },
+        {
+            "__timestamp": "2025-02-22T17:53:50.800959069Z",
+            "action": "timeout",
+            "automod_terms": null,
+            "ban": null,
+            "broadcaster_user_id": "11148817",
+            "broadcaster_user_login": "pajlada",
+            "broadcaster_user_name": "pajlada",
+            "delete": null,
+            "followers": null,
+            "mod": null,
+            "moderator_user_id": "129546453",
+            "moderator_user_login": "nerixyz",
+            "moderator_user_name": "nerixyz",
+            "raid": null,
+            "shared_chat_ban": null,
+            "shared_chat_delete": null,
+            "shared_chat_timeout": null,
+            "shared_chat_unban": null,
+            "shared_chat_untimeout": null,
+            "slow": null,
+            "source_broadcaster_user_id": null,
+            "source_broadcaster_user_login": null,
+            "source_broadcaster_user_name": null,
+            "timeout": {
+                "expires_at": "2025-02-22T17:53:51.782129948Z",
+                "reason": "",
+                "user_id": "141981764",
+                "user_login": "twitchdev",
+                "user_name": "TwitchDev"
+            },
+            "unban": null,
+            "unban_request": null,
+            "unmod": null,
+            "unraid": null,
+            "untimeout": null,
+            "unvip": null,
+            "vip": null,
+            "warn": null
+        },
+        {
+            "__timestamp": "2025-02-22T17:54:50.800959069Z",
+            "action": "timeout",
+            "automod_terms": null,
+            "ban": null,
+            "broadcaster_user_id": "11148817",
+            "broadcaster_user_login": "pajlada",
+            "broadcaster_user_name": "pajlada",
+            "delete": null,
+            "followers": null,
+            "mod": null,
+            "moderator_user_id": "129546453",
+            "moderator_user_login": "nerixyz",
+            "moderator_user_name": "nerixyz",
+            "raid": null,
+            "shared_chat_ban": null,
+            "shared_chat_delete": null,
+            "shared_chat_timeout": null,
+            "shared_chat_unban": null,
+            "shared_chat_untimeout": null,
+            "slow": null,
+            "source_broadcaster_user_id": null,
+            "source_broadcaster_user_login": null,
+            "source_broadcaster_user_name": null,
+            "timeout": {
+                "expires_at": "2025-02-22T17:54:51.782129948Z",
+                "reason": "",
+                "user_id": "141981764",
+                "user_login": "twitchdev",
+                "user_name": "TwitchDev"
+            },
+            "unban": null,
+            "unban_request": null,
+            "unmod": null,
+            "unraid": null,
+            "untimeout": null,
+            "unvip": null,
+            "vip": null,
+            "warn": null
+        }
+    ],
+    "output": [
+        {
+            "badgeInfos": {
+            },
+            "badges": [
+            ],
+            "channelName": "",
+            "count": 2,
+            "displayName": "",
+            "elements": [
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "ChatMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "17:53"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "17:53:50",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "nerixyz"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "nerixyz"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "timed",
+                        "out"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "twitchdev"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "twitchdev"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "for",
+                        "1s.",
+                        "(2",
+                        "times)"
+                    ]
+                }
+            ],
+            "flags": "System|Timeout|PubSub|EventSub",
+            "id": "",
+            "localizedName": "",
+            "loginName": "",
+            "messageText": "nerixyz timed out twitchdev for 1s. (2 times) ",
+            "searchText": "nerixyz timed out twitchdev for 1s. (2 times) ",
+            "serverReceivedTime": "2025-02-22T17:53:50Z",
+            "timeoutUser": "twitchdev",
+            "userID": "",
+            "usernameColor": "#ff000000"
+        },
+        {
+            "badgeInfos": {
+            },
+            "badges": [
+            ],
+            "channelName": "",
+            "count": 1,
+            "displayName": "",
+            "elements": [
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "ChatMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "17:54"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "17:54:50",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "nerixyz"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "nerixyz"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "timed",
+                        "out"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "twitchdev"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "twitchdev"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "for"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": false,
+                    "type": "TextElement",
+                    "words": [
+                        "1s"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "."
+                    ]
+                }
+            ],
+            "flags": "System|Timeout|PubSub|EventSub",
+            "id": "",
+            "localizedName": "",
+            "loginName": "nerixyz",
+            "messageText": "nerixyz timed out twitchdev for 1s. ",
+            "searchText": "nerixyz timed out twitchdev for 1s. ",
+            "serverReceivedTime": "2025-02-22T17:54:50Z",
+            "timeoutUser": "twitchdev",
+            "userID": "",
+            "usernameColor": "#ff000000"
+        }
+    ]
+}

--- a/tests/snapshots/EventSub/channel-moderate/timeout.json
+++ b/tests/snapshots/EventSub/channel-moderate/timeout.json
@@ -77,19 +77,16 @@
                     "type": "TimestampElement"
                 },
                 {
-                    "color": "Text",
-                    "fallbackColor": "System",
-                    "flags": "Text|Mention",
+                    "color": "System",
+                    "flags": "Text",
                     "link": {
-                        "type": "None",
-                        "value": ""
+                        "type": "UserInfo",
+                        "value": "nerixyz"
                     },
                     "style": "ChatMedium",
                     "tooltip": "",
                     "trailingSpace": true,
-                    "type": "MentionElement",
-                    "userColor": "System",
-                    "userLoginName": "nerixyz",
+                    "type": "TextElement",
                     "words": [
                         "nerixyz"
                     ]
@@ -111,21 +108,18 @@
                     ]
                 },
                 {
-                    "color": "Text",
-                    "fallbackColor": "System",
-                    "flags": "Text|Mention",
+                    "color": "System",
+                    "flags": "Text",
                     "link": {
-                        "type": "None",
-                        "value": ""
+                        "type": "UserInfo",
+                        "value": "twitchdev"
                     },
                     "style": "ChatMedium",
                     "tooltip": "",
                     "trailingSpace": true,
-                    "type": "MentionElement",
-                    "userColor": "System",
-                    "userLoginName": "twitchdev",
+                    "type": "TextElement",
                     "words": [
-                        "TwitchDev"
+                        "twitchdev"
                     ]
                 },
                 {
@@ -189,12 +183,12 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|EventSub",
+            "flags": "System|Timeout|PubSub|EventSub",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",
-            "messageText": "nerixyz timed out twitchdev for 1s : test ",
-            "searchText": "nerixyz timed out twitchdev for 1s : test ",
+            "messageText": "nerixyz timed out twitchdev for 1s: test ",
+            "searchText": "nerixyz timed out twitchdev for 1s: test ",
             "serverReceivedTime": "2025-02-22T17:53:49Z",
             "timeoutUser": "twitchdev",
             "userID": "",

--- a/tests/src/EventSubMessages.cpp
+++ b/tests/src/EventSubMessages.cpp
@@ -24,7 +24,7 @@ namespace {
 ///
 /// When adding a test, start with `{ "input": {...} }` and set this to `true`
 /// to generate an initial snapshot. Make sure to verify the output!
-constexpr bool UPDATE_SNAPSHOTS = false;
+constexpr bool UPDATE_SNAPSHOTS = true;
 
 const QString CATEGORY = u"EventSub"_s;
 

--- a/tests/src/EventSubMessages.cpp
+++ b/tests/src/EventSubMessages.cpp
@@ -24,7 +24,7 @@ namespace {
 ///
 /// When adding a test, start with `{ "input": {...} }` and set this to `true`
 /// to generate an initial snapshot. Make sure to verify the output!
-constexpr bool UPDATE_SNAPSHOTS = true;
+constexpr bool UPDATE_SNAPSHOTS = false;
 
 const QString CATEGORY = u"EventSub"_s;
 


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

Towards https://github.com/Chatterino/chatterino2/issues/5908.

I can't live without timeout stacking, so I had to implement it. Yes, it's not pretty, but maybe we can fix this soon-ish (with a bigger extra data).

The logic for stacking is as follows:

- Find a past timeout message that looks like the to-be-added message:
	- Either both of them are from shared chat and from the same channel _or_ neither is from shared chat
	- Both must time out the same user.
- If one message is from PubSub (or EventSub), use that one and drop the other one
- Otherwise, generate a new message with (count + 1) and the same parameters

For this to work, all names must be the login names.