### PR TITLE
feat(eventsub): don't listen to PubSub if EventSub is on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 - Bugfix: Fixed color input thinking blue is also red. (#5982)
 - Bugfix: Fixed an issue where commands would sometimes reset if Chatterino was improperly shut down. (#6011)
 - Dev: Subscriptions to PubSub channel points redemption topics now use no auth token, making it continue to work during PubSub shutdown. (#5947)
-- Dev: Add initial experimental EventSub support. (#5837, #5895, #5897, #5904, #5910, #5903, #5915, #5916, #5930, #5935, #5932, #5943, #5952, #5953, #5968, #5973, #5974, #5980, #5981, #5985, #5990, #5992, #5993, #5996, #5995, #6000, #6001, #6002, #6003, #6005, #6007, #6010, #6008, #6012, #6013)
+- Dev: Add initial experimental EventSub support. (#5837, #5895, #5897, #5904, #5910, #5903, #5915, #5916, #5930, #5935, #5932, #5943, #5952, #5953, #5968, #5973, #5974, #5980, #5981, #5985, #5990, #5992, #5993, #5996, #5995, #6000, #6001, #6002, #6003, #6005, #6007, #6010, #6008, #6012, #6013, #6015)
 - Dev: Remove unneeded platform specifier for toasts. (#5914)
 - Dev: Highlight checks now use non-capturing groups for the boundaries. (#5784)
 - Dev: Removed unused PubSub whisper code. (#5898)

--- a/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/payloads/suspicious-users.hpp
+++ b/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/payloads/suspicious-users.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <boost/json.hpp>
+
 #include <cstdint>
 
 namespace chatterino::eventsub::lib::suspicious_users {

--- a/src/providers/twitch/PubSubManager.cpp
+++ b/src/providers/twitch/PubSubManager.cpp
@@ -9,6 +9,7 @@
 #include "providers/twitch/PubSubHelpers.hpp"
 #include "providers/twitch/PubSubMessages.hpp"
 #include "providers/twitch/TwitchAccount.hpp"
+#include "singletons/Settings.hpp"
 #include "util/DebugCount.hpp"
 #include "util/Helpers.hpp"
 #include "util/RapidjsonHelpers.hpp"
@@ -618,6 +619,11 @@ void PubSub::stop()
 
 void PubSub::listenToChannelModerationActions(const QString &channelID)
 {
+    if (getSettings()->enableExperimentalEventSub)
+    {
+        return;
+    }
+
     if (this->userID_.isEmpty())
     {
         qCDebug(chatterinoPubSub) << "Unable to listen to moderation actions "
@@ -647,6 +653,11 @@ void PubSub::unlistenChannelModerationActions()
 
 void PubSub::listenToAutomod(const QString &channelID)
 {
+    if (getSettings()->enableExperimentalEventSub)
+    {
+        return;
+    }
+
     if (this->userID_.isEmpty())
     {
         qCDebug(chatterinoPubSub)
@@ -676,6 +687,11 @@ void PubSub::unlistenAutomod()
 
 void PubSub::listenToLowTrustUsers(const QString &channelID)
 {
+    if (getSettings()->enableExperimentalEventSub)
+    {
+        return;
+    }
+
     if (this->userID_.isEmpty())
     {
         qCDebug(chatterinoPubSub)


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

Towards https://github.com/Chatterino/chatterino2/issues/5908.

Since we handle all events in EventSub that PubSub had handled except channel point rewards, we can stop listening to PubSub topics if EventSub is enabled.

I did the check in the PubSub manager. It could also be done in `TwitchChannel` (where the subscriptions are initiated).