### PR TITLE
refactor: use some more SettingWidget & restyle external tools page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - Dev: Fixed duplicate CMake configure in clean builds. (#5940)
 - Dev: BTTV emotes are now loaded as WEBP. (#5957)
 - Dev: Reduced time we wait for PubSub connections to cleanly exit from 1s to 100ms. (#6019)
+- Dev: Refactored some settings styles/APIs. (#6023)
 - Dev: Added snapshot tests for EventSub. (#5965)
 
 ## 2.5.2

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -76,6 +76,15 @@ enum class ShowModerationState : int {
     Never = 1,
 };
 
+enum class StreamLinkPreferredQuality : std::uint8_t {
+    Choose,
+    Source,
+    High,
+    Medium,
+    Low,
+    AudioOnly,
+};
+
 enum StreamerModeSetting {
     Disabled = 0,
     Enabled = 1,
@@ -538,8 +547,10 @@ public:
     BoolSetting streamlinkUseCustomPath = {"/external/streamlink/useCustomPath",
                                            false};
     QStringSetting streamlinkPath = {"/external/streamlink/customPath", ""};
-    QStringSetting preferredQuality = {"/external/streamlink/quality",
-                                       "Choose"};
+    EnumStringSetting<StreamLinkPreferredQuality> preferredQuality = {
+        "/external/streamlink/quality",
+        StreamLinkPreferredQuality::Choose,
+    };
     QStringSetting streamlinkOpts = {"/external/streamlink/options", ""};
 
     // Custom URI Scheme
@@ -700,3 +711,26 @@ private:
 Settings *getSettings();
 
 }  // namespace chatterino
+
+template <>
+constexpr magic_enum::customize::customize_t
+    magic_enum::customize::enum_name<chatterino::StreamLinkPreferredQuality>(
+        chatterino::StreamLinkPreferredQuality value) noexcept
+{
+    using chatterino::StreamLinkPreferredQuality;
+    switch (value)
+    {
+        case chatterino::StreamLinkPreferredQuality::Choose:
+        case chatterino::StreamLinkPreferredQuality::Source:
+        case chatterino::StreamLinkPreferredQuality::High:
+        case chatterino::StreamLinkPreferredQuality::Medium:
+        case chatterino::StreamLinkPreferredQuality::Low:
+            return default_tag;
+
+        case chatterino::StreamLinkPreferredQuality::AudioOnly:
+            return "Audio only";
+
+        default:
+            return default_tag;
+    }
+}

--- a/src/util/StreamLink.cpp
+++ b/src/util/StreamLink.cpp
@@ -199,10 +199,9 @@ void openStreamlinkForChannel(const QString &channel)
 
     QString channelURL = "twitch.tv/" + channel;
 
-    QString preferredQuality = getSettings()->preferredQuality.getValue();
-    preferredQuality = preferredQuality.toLower();
+    auto preferredQuality = getSettings()->preferredQuality.getEnum();
 
-    if (preferredQuality == "choose")
+    if (preferredQuality == StreamLinkPreferredQuality::Choose)
     {
         getStreamQualities(channelURL, [=](QStringList qualityOptions) {
             QualityPopup::showDialog(channelURL, qualityOptions);
@@ -218,22 +217,22 @@ void openStreamlinkForChannel(const QString &channel)
     // Streamlink qualities to exclude
     QString exclude;
 
-    if (preferredQuality == "high")
+    if (preferredQuality == StreamLinkPreferredQuality::High)
     {
         exclude = ">720p30";
         quality = "high,best";
     }
-    else if (preferredQuality == "medium")
+    else if (preferredQuality == StreamLinkPreferredQuality::Medium)
     {
         exclude = ">540p30";
         quality = "medium,best";
     }
-    else if (preferredQuality == "low")
+    else if (preferredQuality == StreamLinkPreferredQuality::Low)
     {
         exclude = ">360p30";
         quality = "low,best";
     }
-    else if (preferredQuality == "audio only")
+    else if (preferredQuality == StreamLinkPreferredQuality::AudioOnly)
     {
         quality = "audio,audio_only";
     }

--- a/src/widgets/settingspages/ExternalToolsPage.hpp
+++ b/src/widgets/settingspages/ExternalToolsPage.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "widgets/settingspages/GeneralPageView.hpp"
 #include "widgets/settingspages/SettingsPage.hpp"
 
 namespace chatterino {
@@ -8,6 +9,13 @@ class ExternalToolsPage : public SettingsPage
 {
 public:
     ExternalToolsPage();
+
+    bool filterElements(const QString &query) override;
+
+private:
+    void initLayout(GeneralPageView &layout);
+
+    GeneralPageView *view;
 };
 
 }  // namespace chatterino

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -309,8 +309,10 @@ void GeneralPage::initLayout(GeneralPageView &layout)
                            .arg(settingsSeq.toString(
                                QKeySequence::SequenceFormat::NativeText));
         }
-        layout.addCheckbox("Show preferences button" + shortcut,
-                           s.hidePreferencesButton, true);
+
+        SettingWidget::inverseCheckbox("Show preferences button" + shortcut,
+                                       s.hidePreferencesButton)
+            ->addTo(layout);
 
         SettingWidget::inverseCheckbox("Show user button", s.hideUserButton)
             ->addTo(layout);

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -95,7 +95,7 @@ GeneralPage::GeneralPage()
 {
     auto *y = new QVBoxLayout;
     auto *x = new QHBoxLayout;
-    auto *view = new GeneralPageView;
+    auto *view = GeneralPageView::withNavigation(this);
     this->view_ = view;
     x->addWidget(view);
     auto *z = new QFrame;

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -470,8 +470,10 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         ->addKeywords({"scroll bar"})
         ->addTo(layout);
 
-    layout.addCheckbox("Hide scrollbar highlights", s.hideScrollbarHighlights,
-                       false);
+    SettingWidget::checkbox("Hide scrollbar highlights",
+                            s.hideScrollbarHighlights)
+        ->addKeywords({"scroll bar"})
+        ->addTo(layout);
 
     layout.addTitle("Messages");
     layout.addCheckbox(

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -476,9 +476,12 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         ->addTo(layout);
 
     layout.addTitle("Messages");
-    layout.addCheckbox(
-        "Separate with lines", s.separateMessages, false,
-        "Adds a line between each message to help better tell them apart.");
+
+    SettingWidget::checkbox("Separate with lines", s.separateMessages)
+        ->setTooltip(
+            "Adds a line between each message to help better tell them apart.")
+        ->addTo(layout);
+
     layout.addCheckbox("Alternate background color", s.alternateMessages, false,
                        "Slightly change the background behind every other "
                        "message to help better tell them apart.");

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1117,9 +1117,12 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     }
 #endif
 
-    layout.addCheckbox(
-        "Show moderation messages", s.hideModerationActions, true,
-        "Show messages for timeouts, bans, and other moderator actions.");
+    SettingWidget::inverseCheckbox("Show moderation messages",
+                                   s.hideModerationActions)
+        ->setTooltip(
+            "Show messages for timeouts, bans, and other moderator actions.")
+        ->addTo(layout);
+
     layout.addCheckbox("Show deletions of single messages",
                        s.hideDeletionActions, true,
                        "Show when a single message is deleted.\ne.g. A message "

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1061,11 +1061,20 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         true,
         "The final scale of the messages in the overlay is computed by "
         "multiplying this zoom factor with the global zoom level.");
-    layout.addIntInput(
-        "Background opacity (0-255)", s.overlayBackgroundOpacity, 0, 255, 1,
-        "Controls the opacity of the (possibly alternating) background behind "
-        "messages. The color is set through the current theme. 255 corresponds "
-        "to a fully opaque background.");
+
+    SettingWidget::intInput("Background opacity (0-255)",
+                            s.overlayBackgroundOpacity,
+                            {
+                                .min = 0,
+                                .max = 255,
+                                .singleStep = 1,
+                            })
+        ->setTooltip(
+            "Controls the opacity of the (possibly alternating) background "
+            "behind messages. The color is set through the current theme. 255 "
+            "corresponds to a fully opaque background.")
+        ->addTo(layout);
+
     layout.addCheckbox("Enable Shadow", s.enableOverlayShadow, false,
                        "Enables a drop shadow on the overlay. This will use "
                        "more processing power.");

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -311,7 +311,9 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         }
         layout.addCheckbox("Show preferences button" + shortcut,
                            s.hidePreferencesButton, true);
-        layout.addCheckbox("Show user button", s.hideUserButton, true);
+
+        SettingWidget::inverseCheckbox("Show user button", s.hideUserButton)
+            ->addTo(layout);
     }
     layout.addCheckbox("Mark tabs with live channels", s.showTabLive, false,
                        "Shows a red dot in the top right corner of a tab to "

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1103,15 +1103,14 @@ void GeneralPage::initLayout(GeneralPageView &layout)
                            s.openLinksIncognito);
     }
 
-    layout.addCustomCheckbox(
+    SettingWidget::customCheckbox(
         "Restart on crash (requires restart)",
-        [] {
-            return getApp()->getCrashHandler()->shouldRecover();
-        },
+        getApp()->getCrashHandler()->shouldRecover(),
         [](bool on) {
-            return getApp()->getCrashHandler()->saveShouldRecover(on);
-        },
-        "When possible, restart Chatterino if the program crashes");
+            getApp()->getCrashHandler()->saveShouldRecover(on);
+        })
+        ->setTooltip("When possible, restart Chatterino if the program crashes")
+        ->addTo(layout);
 
 #if defined(Q_OS_LINUX) && !defined(NO_QTKEYCHAIN)
     if (!getApp()->getPaths().isPortable())

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -487,9 +487,11 @@ void GeneralPage::initLayout(GeneralPageView &layout)
                      "message to help better tell them apart.")
         ->addTo(layout);
 
-    layout.addCheckbox("Hide deleted messages", s.hideModerated, false,
-                       "When enabled, messages deleted by moderators will "
-                       "be hidden.");
+    SettingWidget::checkbox("Hide deleted messages", s.hideModerated)
+        ->setTooltip(
+            "When enabled, messages deleted by moderators will be hidden.")
+        ->addTo(layout);
+
     layout.addDropdown<QString>(
         "Timestamp format",
         {"Disable", "h:mm", "hh:mm", "h:mm a", "hh:mm a", "h:mm:ss", "hh:mm:ss",

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1127,10 +1127,12 @@ void GeneralPage::initLayout(GeneralPageView &layout)
             "Show messages for timeouts, bans, and other moderator actions.")
         ->addTo(layout);
 
-    layout.addCheckbox("Show deletions of single messages",
-                       s.hideDeletionActions, true,
-                       "Show when a single message is deleted.\ne.g. A message "
-                       "from TreuKS was deleted: abc");
+    SettingWidget::inverseCheckbox("Show deletions of single messages",
+                                   s.hideDeletionActions)
+        ->setTooltip("Show when a single message is deleted.\ne.g. A message "
+                     "from TreuKS was deleted: abc")
+        ->addTo(layout);
+
     layout.addCheckbox(
         "Colorize users without color set (gray names)", s.colorizeNicknames,
         false,

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -464,10 +464,11 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         },
         false);
 
-    layout.addCheckbox(
-        "Hide scrollbar thumb", s.hideScrollbarThumb, false,
-        "Hiding the scrollbar thumb (the handle you can drag) will disable "
-        "all mouse interaction in the scrollbar.");
+    SettingWidget::checkbox("Hide scrollbar thumb", s.hideScrollbarThumb)
+        ->setTooltip("Hiding the scrollbar thumb (the handle you can drag) "
+                     "will disable all mouse interaction in the scrollbar.")
+        ->addKeywords({"scroll bar"})
+        ->addTo(layout);
 
     layout.addCheckbox("Hide scrollbar highlights", s.hideScrollbarHighlights,
                        false);

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -275,8 +275,9 @@ void GeneralPage::initLayout(GeneralPageView &layout)
             "reply to a message regardless of this setting.")
         ->addTo(layout);
 
-    layout.addCheckbox("Show message reply button", s.showReplyButton, false,
-                       "Show a reply button next to every chat message");
+    SettingWidget::checkbox("Show message reply button", s.showReplyButton)
+        ->setTooltip("Show a reply button next to every chat message")
+        ->addTo(layout);
 
     auto removeTabSeq = getApp()->getHotkeys()->getDisplaySequence(
         HotkeyCategory::Window, "removeTab");

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1068,9 +1068,10 @@ void GeneralPage::initLayout(GeneralPageView &layout)
                        1,
                        "Controls the opacity of the added drop shadow. 255 "
                        "corresponds to a fully opaque shadow.");
-    layout.addColorButton("Shadow color",
-                          QColor(getSettings()->overlayShadowColor.getValue()),
-                          getSettings()->overlayShadowColor);
+
+    SettingWidget::colorButton("Shadow color", s.overlayShadowColor)
+        ->addTo(layout);
+
     layout
         .addIntInput("Shadow radius", s.overlayShadowRadius, 0, 40, 1,
                      "Controls how far the shadow is spread (the blur "

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -549,9 +549,8 @@ void GeneralPage::initLayout(GeneralPageView &layout)
             }
         },
         false);
-    layout.addColorButton("Line color",
-                          QColor(getSettings()->lastMessageColor.getValue()),
-                          getSettings()->lastMessageColor);
+
+    SettingWidget::colorButton("Line color", s.lastMessageColor)->addTo(layout);
 
     layout.addTitle("Emotes");
     layout.addCheckbox("Enable", s.enableEmoteImages);

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -482,9 +482,11 @@ void GeneralPage::initLayout(GeneralPageView &layout)
             "Adds a line between each message to help better tell them apart.")
         ->addTo(layout);
 
-    layout.addCheckbox("Alternate background color", s.alternateMessages, false,
-                       "Slightly change the background behind every other "
-                       "message to help better tell them apart.");
+    SettingWidget::checkbox("Alternate background color", s.alternateMessages)
+        ->setTooltip("Slightly change the background behind every other "
+                     "message to help better tell them apart.")
+        ->addTo(layout);
+
     layout.addCheckbox("Hide deleted messages", s.hideModerated, false,
                        "When enabled, messages deleted by moderators will "
                        "be hidden.");

--- a/src/widgets/settingspages/GeneralPageView.cpp
+++ b/src/widgets/settingspages/GeneralPageView.cpp
@@ -132,7 +132,7 @@ TitleLabel *GeneralPageView::addTitle(const QString &title)
         this->navigationLayout_->addWidget(navLabel);
 
         QObject::connect(
-            navLabel, &NavigationLabel::leftMouseUp, label, [=, this] {
+            navLabel, &NavigationLabel::leftMouseUp, label, [this, label] {
                 this->contentScrollArea_->verticalScrollBar()->setValue(
                     label->y());
             });

--- a/src/widgets/settingspages/GeneralPageView.cpp
+++ b/src/widgets/settingspages/GeneralPageView.cpp
@@ -262,43 +262,6 @@ ComboBox *GeneralPageView::addDropdown(
     return combo;
 }
 
-ColorButton *GeneralPageView::addColorButton(
-    const QString &text, const QColor &color,
-    pajlada::Settings::Setting<QString> &setting, QString toolTipText)
-{
-    auto *colorButton = new ColorButton(color);
-    auto *layout = new QHBoxLayout();
-    auto *label = new QLabel(text + ":");
-
-    layout->addWidget(label);
-    layout->addStretch(1);
-    layout->addWidget(colorButton);
-
-    this->addToolTip(*label, toolTipText);
-    this->addLayout(layout);
-
-    QObject::connect(
-        colorButton, &ColorButton::clicked, [this, &setting, colorButton]() {
-            auto *dialog = new ColorPickerDialog(QColor(setting), this);
-            // colorButton & setting are never deleted and the signal is deleted
-            // once the dialog is closed
-            QObject::connect(dialog, &ColorPickerDialog::colorConfirmed, this,
-                             [&setting, colorButton](auto selected) {
-                                 if (selected.isValid())
-                                 {
-                                     setting = selected.name(QColor::HexArgb);
-                                     colorButton->setColor(selected);
-                                 }
-                             });
-            dialog->show();
-        });
-
-    this->groups_.back().widgets.push_back({label, {text}});
-    this->groups_.back().widgets.push_back({colorButton, {text}});
-
-    return colorButton;
-}
-
 QSpinBox *GeneralPageView::addIntInput(const QString &text, IntSetting &setting,
                                        int min, int max, int step,
                                        QString toolTipText)

--- a/src/widgets/settingspages/GeneralPageView.cpp
+++ b/src/widgets/settingspages/GeneralPageView.cpp
@@ -71,7 +71,7 @@ GeneralPageView *GeneralPageView::withNavigation(QWidget *parent)
     return view;
 }
 
-void GeneralPageView::addWidget(QWidget *widget, QStringList keywords)
+void GeneralPageView::addWidget(QWidget *widget, const QStringList &keywords)
 {
     this->contentLayout_->addWidget(widget);
     if (!this->groups_.empty())

--- a/src/widgets/settingspages/GeneralPageView.cpp
+++ b/src/widgets/settingspages/GeneralPageView.cpp
@@ -95,6 +95,11 @@ void GeneralPageView::registerWidget(QWidget *widget,
     }
 }
 
+void GeneralPageView::pushWidget(QWidget *widget)
+{
+    this->contentLayout_->addWidget(widget);
+}
+
 void GeneralPageView::addLayout(QLayout *layout)
 {
     this->contentLayout_->addLayout(layout);

--- a/src/widgets/settingspages/GeneralPageView.cpp
+++ b/src/widgets/settingspages/GeneralPageView.cpp
@@ -82,13 +82,15 @@ void GeneralPageView::addWidget(QWidget *widget, const QStringList &keywords)
 }
 
 void GeneralPageView::registerWidget(QWidget *widget,
-                                     const QStringList &keywords)
+                                     const QStringList &keywords,
+                                     QWidget *parentElement)
 {
     if (!this->groups_.empty())
     {
         this->groups_.back().widgets.push_back({
             .element = widget,
             .keywords = keywords,
+            .parentElement = parentElement,
         });
     }
 }
@@ -339,6 +341,10 @@ bool GeneralPageView::filterElements(const QString &query)
             for (auto &&widget : group.widgets)
             {
                 widget.element->show();
+                if (widget.parentElement != nullptr)
+                {
+                    widget.parentElement->show();
+                }
             }
 
             group.title->show();
@@ -384,11 +390,19 @@ bool GeneralPageView::filterElements(const QString &query)
                     {
                         currentSubtitleVisible = true;
                         widget.element->show();
+                        if (widget.parentElement != nullptr)
+                        {
+                            widget.parentElement->show();
+                        }
                         groupAny = true;
                         break;
                     }
 
                     widget.element->hide();
+                    if (widget.parentElement != nullptr)
+                    {
+                        widget.parentElement->hide();
+                    }
                 }
             }
 

--- a/src/widgets/settingspages/GeneralPageView.cpp
+++ b/src/widgets/settingspages/GeneralPageView.cpp
@@ -1,6 +1,7 @@
 #include "widgets/settingspages/GeneralPageView.hpp"
 
 #include "Application.hpp"
+#include "common/QLogging.hpp"
 #include "util/LayoutHelper.hpp"
 #include "util/RapidJsonSerializeQString.hpp"
 #include "widgets/dialogs/ColorPickerDialog.hpp"
@@ -113,6 +114,12 @@ QCheckBox *GeneralPageView::addCheckbox(const QString &text,
                                         BoolSetting &setting, bool inverse,
                                         QString toolTipText)
 {
+    if (inverse)
+    {
+        qCWarning(chatterinoWidget)
+            << "use SettingWidget::inverseCheckbox instead";
+    }
+
     auto *check = new QCheckBox(text);
     this->addToolTip(*check, toolTipText);
 

--- a/src/widgets/settingspages/GeneralPageView.cpp
+++ b/src/widgets/settingspages/GeneralPageView.cpp
@@ -188,28 +188,6 @@ QCheckBox *GeneralPageView::addCheckbox(const QString &text,
     return check;
 }
 
-QCheckBox *GeneralPageView::addCustomCheckbox(const QString &text,
-                                              const std::function<bool()> &load,
-                                              std::function<void(bool)> save,
-                                              const QString &toolTipText)
-{
-    auto *check = new QCheckBox(text);
-    this->addToolTip(*check, toolTipText);
-
-    check->setChecked(load());
-
-    QObject::connect(check, &QCheckBox::toggled, this,
-                     [save = std::move(save)](bool state) {
-                         save(state);
-                     });
-
-    this->addWidget(check);
-
-    this->groups_.back().widgets.push_back({check, {text}});
-
-    return check;
-}
-
 ComboBox *GeneralPageView::addDropdown(const QString &text,
                                        const QStringList &list,
                                        QString toolTipText)

--- a/src/widgets/settingspages/GeneralPageView.cpp
+++ b/src/widgets/settingspages/GeneralPageView.cpp
@@ -4,8 +4,6 @@
 #include "common/QLogging.hpp"
 #include "util/LayoutHelper.hpp"
 #include "util/RapidJsonSerializeQString.hpp"
-#include "widgets/dialogs/ColorPickerDialog.hpp"
-#include "widgets/helper/color/ColorButton.hpp"
 #include "widgets/helper/Line.hpp"
 #include "widgets/settingspages/SettingWidget.hpp"
 

--- a/src/widgets/settingspages/GeneralPageView.hpp
+++ b/src/widgets/settingspages/GeneralPageView.hpp
@@ -110,10 +110,6 @@ public:
     /// @param inverse Inverses true to false and vice versa
     QCheckBox *addCheckbox(const QString &text, BoolSetting &setting,
                            bool inverse = false, QString toolTipText = {});
-    QCheckBox *addCustomCheckbox(const QString &text,
-                                 const std::function<bool()> &load,
-                                 std::function<void(bool)> save,
-                                 const QString &toolTipText = {});
 
     ComboBox *addDropdown(const QString &text, const QStringList &items,
                           QString toolTipText = {});

--- a/src/widgets/settingspages/GeneralPageView.hpp
+++ b/src/widgets/settingspages/GeneralPageView.hpp
@@ -120,9 +120,6 @@ public:
     ComboBox *addDropdown(const QString &text, const QStringList &items,
                           pajlada::Settings::Setting<QString> &setting,
                           bool editable = false, QString toolTipText = {});
-    ColorButton *addColorButton(const QString &text, const QColor &color,
-                                pajlada::Settings::Setting<QString> &setting,
-                                QString toolTipText = {});
     QSpinBox *addIntInput(const QString &text, IntSetting &setting, int min,
                           int max, int step, QString toolTipText = {});
     void addNavigationSpacing();

--- a/src/widgets/settingspages/GeneralPageView.hpp
+++ b/src/widgets/settingspages/GeneralPageView.hpp
@@ -97,7 +97,7 @@ public:
     static GeneralPageView *withNavigation(QWidget *parent);
     static GeneralPageView *withoutNavigation(QWidget *parent);
 
-    void addWidget(QWidget *widget, QStringList keywords = {});
+    void addWidget(QWidget *widget, const QStringList &keywords = {});
 
     /// Register the widget with the given keywords.
     /// This assumes that the widget is being held by a layout that has been added previously

--- a/src/widgets/settingspages/GeneralPageView.hpp
+++ b/src/widgets/settingspages/GeneralPageView.hpp
@@ -102,6 +102,10 @@ public:
     /// Register the widget with the given keywords.
     /// This assumes that the widget is being held by a layout that has been added previously
     void registerWidget(QWidget *widget, const QStringList &keywords);
+
+    /// Pushes the widget into the current layout
+    void pushWidget(QWidget *widget);
+
     void addLayout(QLayout *layout);
     void addStretch();
 

--- a/src/widgets/settingspages/GeneralPageView.hpp
+++ b/src/widgets/settingspages/GeneralPageView.hpp
@@ -101,7 +101,8 @@ public:
 
     /// Register the widget with the given keywords.
     /// This assumes that the widget is being held by a layout that has been added previously
-    void registerWidget(QWidget *widget, const QStringList &keywords);
+    void registerWidget(QWidget *widget, const QStringList &keywords,
+                        QWidget *parentElement);
 
     /// Pushes the widget into the current layout
     void pushWidget(QWidget *widget);
@@ -302,8 +303,13 @@ private:
     void addToolTip(QWidget &widget, QString text) const;
 
     struct Widget {
-        QWidget *element;
+        /// The element of the register widget
+        /// This can point to the label of the widget, or the action widget (e.g. the spinbox)
+        QWidget *element{};
         QStringList keywords;
+
+        /// The optional parent element of the widget (usually pointing at a SettingWidget)
+        QWidget *parentElement{};
     };
 
     struct Group {

--- a/src/widgets/settingspages/GeneralPageView.hpp
+++ b/src/widgets/settingspages/GeneralPageView.hpp
@@ -91,11 +91,17 @@ struct DropdownArgs {
 class GeneralPageView : public QWidget
 {
     Q_OBJECT
-
-public:
     GeneralPageView(QWidget *parent = nullptr);
 
+public:
+    static GeneralPageView *withNavigation(QWidget *parent);
+    static GeneralPageView *withoutNavigation(QWidget *parent);
+
     void addWidget(QWidget *widget, QStringList keywords = {});
+
+    /// Register the widget with the given keywords.
+    /// This assumes that the widget is being held by a layout that has been added previously
+    void registerWidget(QWidget *widget, const QStringList &keywords);
     void addLayout(QLayout *layout);
     void addStretch();
 
@@ -311,9 +317,9 @@ private:
         std::vector<Widget> widgets;
     };
 
-    QScrollArea *contentScrollArea_;
-    QVBoxLayout *contentLayout_;
-    QVBoxLayout *navigationLayout_;
+    QScrollArea *contentScrollArea_ = nullptr;
+    QVBoxLayout *contentLayout_ = nullptr;
+    QVBoxLayout *navigationLayout_ = nullptr;
 
     std::vector<Group> groups_;
     pajlada::Signals::SignalHolder managedConnections_;

--- a/src/widgets/settingspages/SettingWidget.cpp
+++ b/src/widgets/settingspages/SettingWidget.cpp
@@ -293,12 +293,22 @@ SettingWidget *SettingWidget::conditionallyEnabledBy(BoolSetting &setting)
 
 void SettingWidget::addTo(GeneralPageView &view)
 {
-    view.addWidget(this, this->keywords);
+    view.pushWidget(this);
+
+    if (this->label != nullptr)
+    {
+        view.registerWidget(this->label, this->keywords);
+    }
+    view.registerWidget(this->actionWidget, this->keywords);
 }
 
 void SettingWidget::addTo(GeneralPageView &view, QFormLayout *formLayout)
 {
-    view.registerWidget(this, this->keywords);
+    if (this->label != nullptr)
+    {
+        view.registerWidget(this->label, this->keywords);
+    }
+    view.registerWidget(this->actionWidget, this->keywords);
 
     formLayout->addRow(this->label, this->actionWidget);
 }

--- a/src/widgets/settingspages/SettingWidget.cpp
+++ b/src/widgets/settingspages/SettingWidget.cpp
@@ -109,6 +109,51 @@ SettingWidget *SettingWidget::customCheckbox(
     return widget;
 }
 
+SettingWidget *SettingWidget::intInput(const QString &label,
+                                       IntSetting &setting,
+                                       IntInputParams params)
+{
+    auto *widget = new SettingWidget(label);
+
+    auto *lbl = new QLabel(label + ":");
+
+    auto *input = new QSpinBox;
+    if (params.min.has_value())
+    {
+        input->setMinimum(params.min.value());
+    }
+    if (params.max.has_value())
+    {
+        input->setMaximum(params.max.value());
+    }
+    if (params.singleStep.has_value())
+    {
+        input->setSingleStep(params.singleStep.value());
+    }
+
+    widget->hLayout->addWidget(lbl);
+    widget->hLayout->addStretch(1);
+    widget->hLayout->addWidget(input);
+
+    // update when setting changes
+    setting.connect(
+        [input](const int &value, const auto &) {
+            input->setValue(value);
+        },
+        widget->managedConnections);
+
+    // update setting on value changed
+    QObject::connect(input, QOverload<int>::of(&QSpinBox::valueChanged), widget,
+                     [&setting](int newValue) {
+                         setting = newValue;
+                     });
+
+    widget->actionWidget = input;
+    widget->label = lbl;
+
+    return widget;
+}
+
 SettingWidget *SettingWidget::colorButton(const QString &label,
                                           QStringSetting &setting)
 {

--- a/src/widgets/settingspages/SettingWidget.cpp
+++ b/src/widgets/settingspages/SettingWidget.cpp
@@ -89,6 +89,26 @@ SettingWidget *SettingWidget::inverseCheckbox(const QString &label,
     return widget;
 }
 
+SettingWidget *SettingWidget::customCheckbox(
+    const QString &label, bool initialValue,
+    const std::function<void(bool)> &save)
+{
+    auto *widget = new SettingWidget(label);
+
+    auto *check = new QCheckBox(label);
+
+    widget->hLayout->addWidget(check);
+
+    check->setChecked(initialValue);
+
+    QObject::connect(check, &QCheckBox::toggled, widget, save);
+
+    widget->actionWidget = check;
+    widget->label = check;
+
+    return widget;
+}
+
 SettingWidget *SettingWidget::colorButton(const QString &label,
                                           QStringSetting &setting)
 {

--- a/src/widgets/settingspages/SettingWidget.cpp
+++ b/src/widgets/settingspages/SettingWidget.cpp
@@ -297,18 +297,18 @@ void SettingWidget::addTo(GeneralPageView &view)
 
     if (this->label != nullptr)
     {
-        view.registerWidget(this->label, this->keywords);
+        view.registerWidget(this->label, this->keywords, this);
     }
-    view.registerWidget(this->actionWidget, this->keywords);
+    view.registerWidget(this->actionWidget, this->keywords, this);
 }
 
 void SettingWidget::addTo(GeneralPageView &view, QFormLayout *formLayout)
 {
     if (this->label != nullptr)
     {
-        view.registerWidget(this->label, this->keywords);
+        view.registerWidget(this->label, this->keywords, this);
     }
-    view.registerWidget(this->actionWidget, this->keywords);
+    view.registerWidget(this->actionWidget, this->keywords, this);
 
     formLayout->addRow(this->label, this->actionWidget);
 }

--- a/src/widgets/settingspages/SettingWidget.hpp
+++ b/src/widgets/settingspages/SettingWidget.hpp
@@ -81,6 +81,8 @@ public:
 
         return widget;
     }
+    static SettingWidget *colorButton(const QString &label,
+                                      QStringSetting &setting);
 
     SettingWidget *setTooltip(QString tooltip);
     SettingWidget *setDescription(const QString &text);

--- a/src/widgets/settingspages/SettingWidget.hpp
+++ b/src/widgets/settingspages/SettingWidget.hpp
@@ -26,6 +26,12 @@ class SettingWidget : QWidget
     explicit SettingWidget(const QString &mainKeyword);
 
 public:
+    struct IntInputParams {
+        std::optional<int> min;
+        std::optional<int> max;
+        std::optional<int> singleStep;
+    };
+
     ~SettingWidget() override = default;
     SettingWidget &operator=(const SettingWidget &) = delete;
     SettingWidget &operator=(SettingWidget &&) = delete;
@@ -38,6 +44,9 @@ public:
     static SettingWidget *customCheckbox(const QString &label,
                                          bool initialValue,
                                          const std::function<void(bool)> &save);
+
+    static SettingWidget *intInput(const QString &label, IntSetting &setting,
+                                   IntInputParams params);
 
     template <typename T>
     static SettingWidget *dropdown(const QString &label,

--- a/src/widgets/settingspages/SettingWidget.hpp
+++ b/src/widgets/settingspages/SettingWidget.hpp
@@ -15,6 +15,8 @@
 #include <QtContainerFwd>
 #include <QWidget>
 
+class QFormLayout;
+
 namespace chatterino {
 
 class GeneralPageView;
@@ -96,6 +98,9 @@ public:
     }
     static SettingWidget *colorButton(const QString &label,
                                       QStringSetting &setting);
+    static SettingWidget *lineEdit(const QString &label,
+                                   QStringSetting &setting,
+                                   const QString &placeholderText = {});
 
     SettingWidget *setTooltip(QString tooltip);
     SettingWidget *setDescription(const QString &text);
@@ -105,7 +110,10 @@ public:
     /// All text from the tooltip, description, and label are already keywords
     SettingWidget *addKeywords(const QStringList &newKeywords);
 
+    SettingWidget *conditionallyEnabledBy(BoolSetting &setting);
+
     void addTo(GeneralPageView &view);
+    void addTo(GeneralPageView &view, QFormLayout *formLayout);
 
 private:
     QWidget *label = nullptr;

--- a/src/widgets/settingspages/SettingWidget.hpp
+++ b/src/widgets/settingspages/SettingWidget.hpp
@@ -35,6 +35,10 @@ public:
     static SettingWidget *checkbox(const QString &label, BoolSetting &setting);
     static SettingWidget *inverseCheckbox(const QString &label,
                                           BoolSetting &setting);
+    static SettingWidget *customCheckbox(const QString &label,
+                                         bool initialValue,
+                                         const std::function<void(bool)> &save);
+
     template <typename T>
     static SettingWidget *dropdown(const QString &label,
                                    EnumStringSetting<T> &setting)


### PR DESCRIPTION
Updated the SettingWidget class to support creating a Color Button, Custom Checkbox (checkbox that isn't backed by a setting), and Int Input

Migrated the following settings to use SettingWidget instead of the GeneralPageView creator:
- Hide scrollbar thumb
- Hide scrollbar highlights
- Separate with lines
- Alternate background color
- Hide deleted messages
- Line color
- Shadow color" from Overlay**
- Show moderation messages
- Show user button
- Show preferences button
- Show deletions of single messages
- Show message reply button
- Restart on crash (custom checkbox example)
- Background opacity (0-255) (int input example)

Changed the style of the External tools page to conform to the General page style
Got some feedback from chat, generally nothing big in its styling, but this will make it easier to swap stylings consistently in the future.

left = old, right = new

![image](https://github.com/user-attachments/assets/9a5a2125-0ac3-4b98-bdca-51e96259d603)


I've removed the GeneralPageView Color Button & Custom Checkbox support since they're currently not used and I much prefer the style of SettingWidget



In general, the SettingWidget API is more verbose, but it makes it easier for me to tell if a setting has been defined incorrectly on the settings page. Mostly what I want to get rid of with the move to SettingWidget is the hodge podge of params to the checkbox where you can accidentally make an inverse checkbox non-inverse when you want to add a tooltip