### PR TITLE
chore: remove dead code and get rid of MSVC warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - Dev: BTTV emotes are now loaded as WEBP. (#5957)
 - Dev: Reduced time we wait for PubSub connections to cleanly exit from 1s to 100ms. (#6019)
 - Dev: Added snapshot tests for EventSub. (#5965)
+- Dev: Removed dead code and some MSVC warnings. (#6024)
 
 ## 2.5.2
 

--- a/src/common/Channel.cpp
+++ b/src/common/Channel.cpp
@@ -283,9 +283,9 @@ void Channel::replaceMessage(size_t hint, const MessagePtr &message,
     }
 }
 
-void Channel::disableMessage(QString messageID)
+void Channel::disableMessage(const QString &messageID)
 {
-    auto msg = this->findMessage(messageID);
+    auto msg = this->findMessageByID(messageID);
     if (msg != nullptr)
     {
         msg->flags.set(MessageFlag::Disabled);
@@ -296,11 +296,6 @@ void Channel::clearMessages()
 {
     this->messages_.clear();
     this->messagesCleared.invoke();
-}
-
-MessagePtr Channel::findMessage(QString messageID)
-{
-    return this->findMessageByID(messageID);
 }
 
 MessagePtr Channel::findMessageByID(QStringView messageID)

--- a/src/common/Channel.hpp
+++ b/src/common/Channel.hpp
@@ -99,13 +99,11 @@ public:
     void replaceMessage(size_t index, const MessagePtr &replacement);
     void replaceMessage(size_t hint, const MessagePtr &message,
                         const MessagePtr &replacement);
-    void disableMessage(QString messageID);
+    void disableMessage(const QString &messageID);
 
     /// Removes all messages from this channel and invokes #messagesCleared
     void clearMessages();
 
-    [[deprecated("Use findMessageByID instead")]] MessagePtr findMessage(
-        QString messageID);
     MessagePtr findMessageByID(QStringView messageID) final;
 
     bool hasMessages() const;

--- a/src/controllers/commands/builtin/twitch/DeleteMessages.cpp
+++ b/src/controllers/commands/builtin/twitch/DeleteMessages.cpp
@@ -2,12 +2,10 @@
 
 #include "Application.hpp"
 #include "common/Channel.hpp"
-#include "common/network/NetworkResult.hpp"
 #include "controllers/accounts/AccountController.hpp"
 #include "controllers/commands/CommandContext.hpp"
 #include "messages/Message.hpp"
 #include "messages/MessageBuilder.hpp"
-#include "providers/twitch/api/Helix.hpp"
 #include "providers/twitch/TwitchAccount.hpp"
 #include "providers/twitch/TwitchChannel.hpp"
 
@@ -91,7 +89,7 @@ QString deleteOneMessage(const CommandContext &ctx)
         return "";
     }
 
-    auto msg = ctx.channel->findMessage(messageID);
+    auto msg = ctx.channel->findMessageByID(messageID);
     if (msg != nullptr)
     {
         if (msg->loginName == ctx.channel->getName() &&

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -512,7 +512,7 @@ void IrcMessageHandler::handleClearMessageMessage(Communi::IrcMessage *message)
 
     QString targetID = tags.value("target-msg-id").toString();
 
-    auto msg = chan->findMessage(targetID);
+    auto msg = chan->findMessageByID(targetID);
     if (msg == nullptr)
     {
         return;

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -924,9 +924,9 @@ void UserInfoPopup::updateUserData()
         // get ignoreHighlights state
         bool isIgnoringHighlights = false;
         const auto &vector = getSettings()->blacklistedUsers.raw();
-        for (const auto &user : vector)
+        for (const auto &blockedUser : vector)
         {
-            if (this->userName_ == user.getPattern())
+            if (this->userName_ == blockedUser.getPattern())
             {
                 isIgnoringHighlights = true;
                 break;

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -372,36 +372,7 @@ QString SplitInput::handleSendMessage(const std::vector<QString> &arguments)
     auto *tc = dynamic_cast<TwitchChannel *>(c.get());
     if (!tc)
     {
-        // Reply to message
-        auto tc = dynamic_cast<TwitchChannel *>(c.get());
-        if (!tc)
-        {
-            // this should not fail
-            return "";
-        }
-
-        QString message = this->ui_.textEdit->toPlainText();
-
-        if (this->enableInlineReplying_)
-        {
-            // Remove @username prefix that is inserted when doing inline replies
-            message.remove(0, this->replyTarget_->displayName.length() +
-                                  1);  // remove "@username"
-
-            if (!message.isEmpty() && message.at(0) == ' ')
-            {
-                message.remove(0, 1);  // remove possible space
-            }
-        }
-
-        message = message.replace('\n', ' ');
-        QString sendMessage =
-            getApp()->getCommands()->execCommand(message, c, false);
-
-        // Reply within TwitchChannel
-        tc->sendReply(sendMessage, this->replyTarget_->id);
-
-        this->postMessageSend(message, arguments);
+        // this should not fail
         return "";
     }
 


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234."
-->

- Removed `Channel::findMessage` (deprecated) and migrated uses to `findMessageByID`
- Removed (effectively[^1]) dead code in `SplitInput::handleSendMessage`
- Renamed loop variable to avoid shadowing function parameter

[^1]: Reason for why it's dead: we check the same pointer twice and return if it's null. The only way this code could potentially run is if the pointer was modified in-between from another thread. I don't think that was the intention.