### PR TITLE
deps: update crash handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - Dev: BTTV emotes are now loaded as WEBP. (#5957)
 - Dev: Reduced time we wait for PubSub connections to cleanly exit from 1s to 100ms. (#6019)
 - Dev: Added snapshot tests for EventSub. (#5965)
+- Dev: Updated crashpad. (#6026)
 
 ## 2.5.2
 


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

Updates the crash handler to https://github.com/Chatterino/crash-handler/commit/7d9811b107d65a6afa3e11ff0370ca38b8060746 (all changes: https://github.com/Chatterino/crash-handler/compare/9753fe802710b2df00f2287ec2e1ca78c251d085...7d9811b107d65a6afa3e11ff0370ca38b8060746).

This means Windows users can now build Chatterino with `clang-cl`.