### PR TITLE
fix(eventsub): infer `AsISO8601` for chrono time point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 - Bugfix: Fixed color input thinking blue is also red. (#5982)
 - Bugfix: Fixed an issue where commands would sometimes reset if Chatterino was improperly shut down. (#6011)
 - Dev: Subscriptions to PubSub channel points redemption topics now use no auth token, making it continue to work during PubSub shutdown. (#5947)
-- Dev: Add initial experimental EventSub support. (#5837, #5895, #5897, #5904, #5910, #5903, #5915, #5916, #5930, #5935, #5932, #5943, #5952, #5953, #5968, #5973, #5974, #5980, #5981, #5985, #5990, #5992, #5993, #5996, #5995, #6000, #6001, #6002, #6003, #6005, #6007, #6010, #6008, #6012, #6013, #6015, #6017)
+- Dev: Add initial experimental EventSub support. (#5837, #5895, #5897, #5904, #5910, #5903, #5915, #5916, #5930, #5935, #5932, #5943, #5952, #5953, #5968, #5973, #5974, #5980, #5981, #5985, #5990, #5992, #5993, #5996, #5995, #6000, #6001, #6002, #6003, #6005, #6007, #6010, #6008, #6012, #6013, #6015, #6017, #6027)
 - Dev: Remove unneeded platform specifier for toasts. (#5914)
 - Dev: Highlight checks now use non-capturing groups for the boundaries. (#5784)
 - Dev: Removed unused PubSub whisper code. (#5898)

--- a/lib/twitch-eventsub-ws/ast/lib/member.py
+++ b/lib/twitch-eventsub-ws/ast/lib/member.py
@@ -85,9 +85,18 @@ class Member:
 
         self.dont_fail_on_deserialization: bool = False
 
+        self._infer_tags()
+
+    def _infer_tags(self) -> None:
+        match self.type_name:
+            case "std::chrono::system_clock::time_point":
+                assert self.tag is None
+                self.tag = "AsISO8601"
+
     def apply_comment_commands(self, comment_commands: CommentCommands) -> None:
         self.json_name = comment_commands.apply_name_transform(self.json_name)
-        self.tag = comment_commands.tag
+        if comment_commands.tag is not None:
+            self.tag = comment_commands.tag
         self.dont_fail_on_deserialization = comment_commands.dont_fail_on_deserialization
 
     @staticmethod

--- a/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/messages/metadata.hpp
+++ b/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/messages/metadata.hpp
@@ -24,7 +24,6 @@ namespace chatterino::eventsub::lib::messages {
 struct Metadata {
     std::string messageID;
     std::string messageType;
-    /// json_tag=AsISO8601
     std::chrono::system_clock::time_point messageTimestamp;
 
     std::optional<std::string> subscriptionType;

--- a/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/payloads/channel-ban-v1.hpp
+++ b/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/payloads/channel-ban-v1.hpp
@@ -78,11 +78,9 @@ struct Event {
     bool isPermanent;
 
     // Time point when the timeout or ban took place
-    /// json_tag=AsISO8601
     std::chrono::system_clock::time_point bannedAt;
 
     // Time point when the timeout will end
-    /// json_tag=AsISO8601
     std::optional<std::chrono::system_clock::time_point> endsAt;
 
     // Returns the duration of the timeout

--- a/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/payloads/channel-moderate-v2.hpp
+++ b/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/payloads/channel-moderate-v2.hpp
@@ -202,7 +202,6 @@ struct Timeout {
     String userLogin;
     String userName;
     String reason;
-    /// json_tag=AsISO8601
     std::chrono::system_clock::time_point expiresAt;
 };
 struct SharedChatTimeout : public Timeout {


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

When we read a type, we try to infer its tag. Comment commands can still overwrite it. Nothing in the templates needs to change.

Fixes #5912.