### PR TITLE
feat(eventsub): reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Bugfix: Fixed color input thinking blue is also red. (#5982)
 - Bugfix: Fixed an issue where commands would sometimes reset if Chatterino was improperly shut down. (#6011)
 - Dev: Subscriptions to PubSub channel points redemption topics now use no auth token, making it continue to work during PubSub shutdown. (#5947)
-- Dev: Add initial experimental EventSub support. (#5837, #5895, #5897, #5904, #5910, #5903, #5915, #5916, #5930, #5935, #5932, #5943, #5952, #5953, #5968, #5973, #5974, #5980, #5981, #5985, #5990, #5992, #5993, #5996, #5995, #6000, #6001, #6002, #6003, #6005, #6007, #6010, #6008, #6012, #6013, #6015, #6017, #6027, #6028)
+- Dev: Add initial experimental EventSub support. (#5837, #5895, #5897, #5904, #5910, #5903, #5915, #5916, #5930, #5935, #5932, #5943, #5952, #5953, #5968, #5973, #5974, #5980, #5981, #5985, #5990, #5992, #5993, #5996, #5995, #6000, #6001, #6002, #6003, #6005, #6007, #6010, #6008, #6012, #6013, #6015, #6017, #6027, #6028, #6035)
 - Dev: Remove unneeded platform specifier for toasts. (#5914)
 - Dev: Highlight checks now use non-capturing groups for the boundaries. (#5784)
 - Dev: Removed unused PubSub whisper code. (#5898)

--- a/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/listener.hpp
+++ b/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/listener.hpp
@@ -30,6 +30,10 @@ public:
     virtual void onNotification(const messages::Metadata &metadata,
                                 const boost::json::value &jv) = 0;
 
+    virtual void onClose(
+        std::unique_ptr<Listener> self,
+        const std::optional<std::string> & /* reconnectUrl */) {};
+
     // Subscription types
     virtual void onChannelBan(
         const messages::Metadata &metadata,

--- a/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/payloads/session-welcome.hpp
+++ b/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/payloads/session-welcome.hpp
@@ -24,6 +24,7 @@ namespace chatterino::eventsub::lib::payload::session_welcome {
 /// json_inner=session
 struct Payload {
     std::string id;
+    std::optional<std::string> reconnectURL;
 };
 
 #include "twitch-eventsub-ws/payloads/session-welcome.inc"

--- a/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/session.hpp
+++ b/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/session.hpp
@@ -22,20 +22,8 @@ boost::system::error_code handleMessage(
     std::unique_ptr<Listener> &listener,
     const boost::beast::flat_buffer &buffer);
 
-// Sends a WebSocket message and prints the response
 class Session : public std::enable_shared_from_this<Session>
 {
-    boost::asio::ip::tcp::resolver resolver;
-    boost::beast::websocket::stream<
-        boost::beast::ssl_stream<boost::beast::tcp_stream>>
-        ws;
-    boost::beast::flat_buffer buffer;
-    std::string host;
-    std::string port;
-    std::string path;
-    std::string userAgent;
-    std::unique_ptr<Listener> listener;
-
 public:
     // Resolver and socket require an io_context
     explicit Session(boost::asio::io_context &ioc,
@@ -65,6 +53,19 @@ private:
     void onRead(boost::beast::error_code ec, std::size_t bytes_transferred);
 
     void onClose(boost::beast::error_code ec);
+
+    void fail(boost::beast::error_code ec, std::string_view op);
+
+    boost::asio::ip::tcp::resolver resolver;
+    boost::beast::websocket::stream<
+        boost::beast::ssl_stream<boost::beast::tcp_stream>>
+        ws;
+    boost::beast::flat_buffer buffer;
+    std::string host;
+    std::string port;
+    std::string path;
+    std::string userAgent;
+    std::unique_ptr<Listener> listener;
 };
 
 }  // namespace chatterino::eventsub::lib

--- a/lib/twitch-eventsub-ws/src/generated/payloads/session-welcome.cpp
+++ b/lib/twitch-eventsub-ws/src/generated/payloads/session-welcome.cpp
@@ -42,8 +42,23 @@ boost::json::result_for<Payload, boost::json::value>::type tag_invoke(
         return id.error();
     }
 
+    std::optional<std::string> reconnectURL = std::nullopt;
+    const auto *jvreconnectURL = root.if_contains("reconnect_url");
+    if (jvreconnectURL != nullptr && !jvreconnectURL->is_null())
+    {
+        auto treconnectURL =
+            boost::json::try_value_to<std::string>(*jvreconnectURL);
+
+        if (treconnectURL.has_error())
+        {
+            return treconnectURL.error();
+        }
+        reconnectURL = std::move(treconnectURL.value());
+    }
+
     return Payload{
         .id = std::move(id.value()),
+        .reconnectURL = std::move(reconnectURL),
     };
 }
 

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -592,7 +592,6 @@ pronouns::Pronouns *Application::getPronouns()
 
 eventsub::IController *Application::getEventSub()
 {
-    assertInGuiThread();
     assert(this->eventSub);
 
     return this->eventSub.get();

--- a/src/common/Args.cpp
+++ b/src/common/Args.cpp
@@ -140,6 +140,12 @@ Args::Args(const QApplication &app, const Paths &paths)
         "specified, Twitch is assumed.",
         "t:channel");
 
+#ifndef NDEBUG
+    QCommandLineOption useLocalEventsubOption(
+        "use-local-eventsub",
+        "Use the local eventsub server at 127.0.0.1:3012.");
+#endif
+
     parser.addOptions({
         {{"V", "version"}, "Displays version information."},
         crashRecoveryOption,
@@ -152,6 +158,9 @@ Args::Args(const QApplication &app, const Paths &paths)
         loginOption,
         channelLayout,
         activateOption,
+#ifndef NDEBUG
+        useLocalEventsubOption,
+#endif
     });
 
     if (!parser.parse(app.arguments()))
@@ -215,6 +224,13 @@ Args::Args(const QApplication &app, const Paths &paths)
         this->activateChannel =
             parseActivateOption(parser.value(activateOption));
     }
+
+#ifndef NDEBUG
+    if (parser.isSet(useLocalEventsubOption))
+    {
+        this->useLocalEventsub = true;
+    }
+#endif
 
     this->currentArguments_ = extractCommandLine(parser, {
                                                              verboseOption,

--- a/src/common/Args.hpp
+++ b/src/common/Args.hpp
@@ -64,6 +64,11 @@ public:
     bool verbose{};
     bool safeMode{};
 
+#ifndef NDEBUG
+    // twitch event websocket start-server --ssl --port 3012
+    bool useLocalEventsub = false;
+#endif
+
     QStringList currentArguments() const;
 
 private:

--- a/src/common/network/NetworkPrivate.hpp
+++ b/src/common/network/NetworkPrivate.hpp
@@ -53,6 +53,9 @@ public:
     /// By default, there's no explicit timeout for the request.
     /// To set a timeout, use NetworkRequest's timeout method
     std::optional<std::chrono::milliseconds> timeout{};
+#ifndef NDEBUG
+    bool ignoreSslErrors = false;  // for local eventsub
+#endif
 
     QString getHash();
 

--- a/src/common/network/NetworkRequest.cpp
+++ b/src/common/network/NetworkRequest.cpp
@@ -215,4 +215,12 @@ NetworkRequest NetworkRequest::json(const QByteArray &payload) &&
         .header("Accept", "application/json");
 }
 
+#ifndef NDEBUG
+NetworkRequest NetworkRequest::ignoreSslErrors(bool ignore) &&
+{
+    this->data->ignoreSslErrors = ignore;
+    return std::move(*this);
+}
+#endif
+
 }  // namespace chatterino

--- a/src/common/network/NetworkRequest.hpp
+++ b/src/common/network/NetworkRequest.hpp
@@ -76,6 +76,10 @@ public:
     NetworkRequest json(const QJsonDocument &document) &&;
     NetworkRequest json(const QByteArray &payload) &&;
 
+#ifndef NDEBUG
+    NetworkRequest ignoreSslErrors(bool ignore) &&;
+#endif
+
     void execute();
 
 private:

--- a/src/common/network/NetworkTask.cpp
+++ b/src/common/network/NetworkTask.cpp
@@ -61,6 +61,16 @@ void NetworkTask::run()
 
     QObject::connect(this->reply_, &QNetworkReply::finished, this,
                      &NetworkTask::finished);
+
+#ifndef NDEBUG
+    if (this->data_->ignoreSslErrors)
+    {
+        QObject::connect(this->reply_, &QNetworkReply::sslErrors, this,
+                         [this](const auto &errors) {
+                             this->reply_->ignoreSslErrors(errors);
+                         });
+    }
+#endif
 }
 
 QNetworkReply *NetworkTask::createReply()

--- a/src/providers/twitch/eventsub/Connection.hpp
+++ b/src/providers/twitch/eventsub/Connection.hpp
@@ -21,6 +21,9 @@ public:
     void onNotification(const lib::messages::Metadata &metadata,
                         const boost::json::value &jv) override;
 
+    void onClose(std::unique_ptr<lib::Listener> self,
+                 const std::optional<std::string> &reconnectURL) override;
+
     void onChannelBan(
         const lib::messages::Metadata &metadata,
         const lib::payload::channel_ban::v1::Payload &payload) override;
@@ -85,7 +88,7 @@ public:
 
     bool isSubscribedTo(const SubscriptionRequest &request) const;
     void markRequestSubscribed(const SubscriptionRequest &request);
-    // TODO: Add an "markRequestUnsubscribed" method
+    void markRequestUnsubscribed(const SubscriptionRequest &request);
 
 private:
     QString sessionID;

--- a/src/providers/twitch/eventsub/Controller.hpp
+++ b/src/providers/twitch/eventsub/Controller.hpp
@@ -17,6 +17,7 @@
 #include <optional>
 #include <string>
 #include <thread>
+#include <unordered_set>
 
 namespace chatterino::eventsub {
 

--- a/src/providers/twitch/eventsub/Controller.hpp
+++ b/src/providers/twitch/eventsub/Controller.hpp
@@ -44,6 +44,11 @@ public:
     /// create a new connection and queue up the subscription to run again after X seconds.
     [[nodiscard]] virtual SubscriptionHandle subscribe(
         const SubscriptionRequest &request) = 0;
+
+    virtual void reconnectConnection(
+        std::unique_ptr<lib::Listener> connection,
+        const std::optional<std::string> &reconnectURL,
+        const std::unordered_set<SubscriptionRequest> &subs) = 0;
 };
 
 class Controller : public IController
@@ -59,10 +64,17 @@ public:
     [[nodiscard]] SubscriptionHandle subscribe(
         const SubscriptionRequest &request) override;
 
+    void reconnectConnection(
+        std::unique_ptr<lib::Listener> connection,
+        const std::optional<std::string> &reconnectURL,
+        const std::unordered_set<SubscriptionRequest> &subs) override;
+
 private:
     void subscribe(const SubscriptionRequest &request, bool isRetry);
 
     void createConnection();
+    void createConnection(std::string host, std::string port, std::string path,
+                          std::unique_ptr<lib::Listener> listener);
     void registerConnection(std::weak_ptr<lib::Session> &&connection);
 
     void retrySubscription(const SubscriptionRequest &request,
@@ -76,6 +88,8 @@ private:
     void markRequestFailed(const SubscriptionRequest &request);
 
     void markRequestUnsubscribed(const SubscriptionRequest &request);
+
+    void clearConnections();
 
     const std::string userAgent;
 
@@ -154,6 +168,11 @@ public:
         (void)request;
         return {};
     }
+
+    void reconnectConnection(
+        std::unique_ptr<lib::Listener> connection,
+        const std::optional<std::string> &reconnectURL,
+        const std::unordered_set<SubscriptionRequest> &subs) override;
 };
 
 }  // namespace chatterino::eventsub


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
Towards https://github.com/Chatterino/chatterino2/issues/5908.

When we disconnect, or we're asked to reconnect, we should reconnect. A `Session` can now be orphaned, because we want to transplant the listener. That's mostly it. If we don't have a reconnect URL and are disconnected, we reset all the subscriptions a connection was subscribed to and try to subscribe again.

You can try this with the Twitch CLI. I opened https://redirect.github.com/twitchdev/twitch-cli/pull/347 to have at least one event that we use in there. Otherwise, you can also edit some event in `TwitchChannel` to use `channel.ban`.

```shell
twitch event websocket start-server --ssl --port 3012 # start local server
chatterino --use-local-eventsub # start chatterino
twitch event websocket close --reason=4000 --session=<id> # disconnect without preserving subs
twitch event websocket reconnect  # reconnect while preserving subs
twitch event trigger automod-message-hold -T websocket # trigger an event (should only trigger once)
```

I converted the local eventsub thing into an argument, because it needs to use the local server for subscribing to EventSub. To avoid a qbittorrent situation, this is limited to debug builds.