### PR TITLE
refactor(eventsub): use backoff over retry count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Bugfix: Fixed color input thinking blue is also red. (#5982)
 - Bugfix: Fixed an issue where commands would sometimes reset if Chatterino was improperly shut down. (#6011)
 - Dev: Subscriptions to PubSub channel points redemption topics now use no auth token, making it continue to work during PubSub shutdown. (#5947)
-- Dev: Add initial experimental EventSub support. (#5837, #5895, #5897, #5904, #5910, #5903, #5915, #5916, #5930, #5935, #5932, #5943, #5952, #5953, #5968, #5973, #5974, #5980, #5981, #5985, #5990, #5992, #5993, #5996, #5995, #6000, #6001, #6002, #6003, #6005, #6007, #6010, #6008, #6012, #6013, #6015, #6017, #6027, #6028, #6035)
+- Dev: Add initial experimental EventSub support. (#5837, #5895, #5897, #5904, #5910, #5903, #5915, #5916, #5930, #5935, #5932, #5943, #5952, #5953, #5968, #5973, #5974, #5980, #5981, #5985, #5990, #5992, #5993, #5996, #5995, #6000, #6001, #6002, #6003, #6005, #6007, #6010, #6008, #6012, #6013, #6015, #6017, #6027, #6028, #6035, #6036)
 - Dev: Remove unneeded platform specifier for toasts. (#5914)
 - Dev: Highlight checks now use non-capturing groups for the boundaries. (#5784)
 - Dev: Removed unused PubSub whisper code. (#5898)


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
From https://github.com/Chatterino/chatterino2/pull/6035: if there's no connection, we should retry indefinitely.

Thinking a bit more about this, I came to the conclusion that we don't need the retry count at all but a backoff for each subscription. This makes the code a bit simpler.

Three semi-related changes:
- If Helix returns _403 Forbidden_, we can mark the request as failed (no need to retry). We might need to retry if we get a _429 Too Many Requests_. Unfortunately, that status is also used if a subscription already exists ([docs](https://dev.twitch.tv/docs/api/reference/#create-eventsub-subscription)).
- If someone unsubscribed and immediately subscribed again, we could've discarded the subscription request if it came in while we were `Unsubscribing`. To detect this, we check when marking a request as unsubscribed if there are any more references. If so, we subscribe again.
- Used a `boost::asio::system_timer`, because the `boost::asio::deadline_timer` is deprecated (and doesn't support `std::chrono`).