### PR TITLE
feat: allow custom chat font weight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Minor: Added Linux support for Live Notifications toasts. (#5881, #5971, #5976)
 - Minor: Messages can now be deleted from the context menu in a channel. (#5956)
 - Minor: Overlay windows now inherit the global zoom level and can be zoomed independently. (#6016)
+- Minor: The font weight of chat messages can now be changed. (#6037)
 - Bugfix: Fixed a potential way to escape the Lua Plugin sandbox. (#5846)
 - Bugfix: Fixed a crash relating to Lua HTTP. (#5800)
 - Bugfix: Fixed a crash that could occur on Linux and macOS when clicking "Install" from the update prompt. (#5818)

--- a/src/singletons/Fonts.cpp
+++ b/src/singletons/Fonts.cpp
@@ -12,7 +12,7 @@ namespace {
 
 using namespace chatterino;
 
-int getBoldness()
+int getUsernameBoldness()
 {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     // From qfont.cpp
@@ -55,6 +55,121 @@ int getBoldness()
     return getSettings()->boldScale.getValue();
 #endif
 }
+
+float fontSize(FontStyle style)
+{
+    auto chatSize = [] {
+        return static_cast<float>(getSettings()->chatFontSize);
+    };
+    switch (style)
+    {
+        case FontStyle::ChatSmall:
+            return 0.6F * chatSize();
+        case FontStyle::ChatMediumSmall:
+            return 0.8F * chatSize();
+        case FontStyle::ChatMedium:
+        case FontStyle::ChatMediumBold:
+        case FontStyle::ChatMediumItalic:
+            return chatSize();
+        case FontStyle::ChatLarge:
+            return 1.2F * chatSize();
+        case FontStyle::ChatVeryLarge:
+            return 1.4F * chatSize();
+
+        case FontStyle::Tiny:
+            return 8;
+        case FontStyle::UiMedium:
+        case FontStyle::UiMediumBold:
+        case FontStyle::UiTabs:
+        case FontStyle::EndType:
+            return 9;
+    }
+
+    assert(false);
+    return 9;
+}
+
+int fontWeight(FontStyle style)
+{
+    switch (style)
+    {
+        case FontStyle::ChatSmall:
+        case FontStyle::ChatMediumSmall:
+        case FontStyle::ChatMedium:
+        case FontStyle::ChatMediumItalic:
+        case FontStyle::ChatLarge:
+        case FontStyle::ChatVeryLarge:
+            return getSettings()->chatFontWeight.getValue();
+
+        case FontStyle::ChatMediumBold:
+            return getUsernameBoldness();
+
+        case FontStyle::Tiny:
+        case FontStyle::UiMedium:
+        case FontStyle::UiTabs:
+        case FontStyle::EndType:
+            return QFont::Normal;
+
+        case FontStyle::UiMediumBold:
+            return QFont::Bold;
+    }
+
+    assert(false);
+    return QFont::Normal;
+}
+
+bool isItalic(FontStyle style)
+{
+    switch (style)
+    {
+        case FontStyle::Tiny:
+        case FontStyle::ChatSmall:
+        case FontStyle::ChatMediumSmall:
+        case FontStyle::ChatMedium:
+        case FontStyle::ChatMediumBold:
+        case FontStyle::ChatLarge:
+        case FontStyle::ChatVeryLarge:
+        case FontStyle::UiMedium:
+        case FontStyle::UiMediumBold:
+        case FontStyle::UiTabs:
+        case FontStyle::EndType:
+            return false;
+
+        case FontStyle::ChatMediumItalic:
+            return true;
+    }
+
+    assert(false);
+    return false;
+}
+
+QString fontFamily(FontStyle style)
+{
+    switch (style)
+    {
+        case FontStyle::Tiny:
+            return QStringLiteral("Monospace");
+
+        case FontStyle::ChatSmall:
+        case FontStyle::ChatMediumSmall:
+        case FontStyle::ChatMedium:
+        case FontStyle::ChatMediumBold:
+        case FontStyle::ChatMediumItalic:
+        case FontStyle::ChatLarge:
+        case FontStyle::ChatVeryLarge:
+            return getSettings()->chatFontFamily.getValue();
+
+        case FontStyle::UiMedium:
+        case FontStyle::UiMediumBold:
+        case FontStyle::UiTabs:
+        case FontStyle::EndType:
+            return QStringLiteral(DEFAULT_FONT_FAMILY);
+    }
+
+    assert(false);
+    return QStringLiteral(DEFAULT_FONT_FAMILY);
+}
+
 }  // namespace
 
 namespace chatterino {
@@ -74,6 +189,7 @@ Fonts::Fonts(Settings &settings)
     });
     this->fontChangedListener.addSetting(settings.chatFontFamily);
     this->fontChangedListener.addSetting(settings.chatFontSize);
+    this->fontChangedListener.addSetting(settings.chatFontWeight);
     this->fontChangedListener.addSetting(settings.boldScale);
 }
 
@@ -105,7 +221,7 @@ Fonts::FontData &Fonts::getOrCreateFontData(FontStyle type, float scale)
     }
 
     // emplace new element
-    auto result = map.emplace(scale, this->createFontData(type, scale));
+    auto result = map.emplace(scale, Fonts::createFontData(type, scale));
     assert(result.second);
 
     return result.first->second;
@@ -113,75 +229,12 @@ Fonts::FontData &Fonts::getOrCreateFontData(FontStyle type, float scale)
 
 Fonts::FontData Fonts::createFontData(FontStyle type, float scale)
 {
-    auto *settings = getSettings();
-
-    // check if it's a chat (scale the setting)
-    if (type >= FontStyle::ChatStart && type <= FontStyle::ChatEnd)
-    {
-        static std::unordered_map<FontStyle, ChatFontData> sizeScale{
-            {FontStyle::ChatSmall, {0.6f, false, QFont::Normal}},
-            {FontStyle::ChatMediumSmall, {0.8f, false, QFont::Normal}},
-            {FontStyle::ChatMedium, {1, false, QFont::Normal}},
-            {FontStyle::ChatMediumBold,
-             {1, false, QFont::Weight(getBoldness())}},
-            {FontStyle::ChatMediumItalic, {1, true, QFont::Normal}},
-            {FontStyle::ChatLarge, {1.2f, false, QFont::Normal}},
-            {FontStyle::ChatVeryLarge, {1.4f, false, QFont::Normal}},
-        };
-        sizeScale[FontStyle::ChatMediumBold] = {1, false,
-                                                QFont::Weight(getBoldness())};
-        auto data = sizeScale[type];
-        return FontData(
-            QFont(settings->chatFontFamily.getValue(),
-                  int(settings->chatFontSize.getValue() * data.scale * scale),
-                  data.weight, data.italic));
-    }
-
-    // normal Ui font (use pt size)
-    {
-        static std::unordered_map<FontStyle, UiFontData> defaultSize{
-            {
-                FontStyle::Tiny,
-                {
-                    8,
-                    "Monospace",
-                    false,
-                    QFont::Normal,
-                },
-            },
-            {
-                FontStyle::UiMedium,
-                {
-                    9,
-                    DEFAULT_FONT_FAMILY,
-                    false,
-                    QFont::Normal,
-                },
-            },
-            {
-                FontStyle::UiMediumBold,
-                {
-                    9,
-                    DEFAULT_FONT_FAMILY,
-                    false,
-                    QFont::Bold,
-                },
-            },
-            {
-                FontStyle::UiTabs,
-                {
-                    9,
-                    DEFAULT_FONT_FAMILY,
-                    false,
-                    QFont::Normal,
-                },
-            },
-        };
-
-        UiFontData &data = defaultSize[type];
-        QFont font(data.name, int(data.size * scale), data.weight, data.italic);
-        return FontData(font);
-    }
+    return QFont{
+        fontFamily(type),
+        static_cast<int>(fontSize(type) * scale),
+        fontWeight(type),
+        isItalic(type),
+    };
 }
 
 }  // namespace chatterino

--- a/src/singletons/Fonts.hpp
+++ b/src/singletons/Fonts.hpp
@@ -63,18 +63,17 @@ private:
     struct ChatFontData {
         float scale;
         bool italic;
-        QFont::Weight weight;
     };
 
     struct UiFontData {
         float size;
         const char *name;
         bool italic;
-        QFont::Weight weight;
+        int weight;
     };
 
     FontData &getOrCreateFontData(FontStyle type, float scale);
-    FontData createFontData(FontStyle type, float scale);
+    static FontData createFontData(FontStyle type, float scale);
 
     std::vector<std::unordered_map<float, FontData>> fontsByType_;
 

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -167,6 +167,10 @@ public:
         "/appearance/currentFontSize",
         DEFAULT_FONT_SIZE,
     };
+    IntSetting chatFontWeight = {
+        "/appearance/currentFontWeight",
+        QFont::Normal,
+    };
     BoolSetting hideReplyContext = {"/appearance/hideReplyContext", false};
     BoolSetting showReplyButton = {"/appearance/showReplyButton", false};
     BoolSetting stripReplyMention = {"/appearance/stripReplyMention", true};

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -189,6 +189,16 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         [](auto args) {
             return fuzzyToInt(args.value, 10);
         });
+    layout.addDropdown<int>(
+        "Font weight",
+        {"100", "200", "300", "400", "500", "600", "700", "800", "900"},
+        s.chatFontWeight,
+        [](auto val) {
+            return QString::number(val);
+        },
+        [](auto args) {
+            return fuzzyToInt(args.value, 400);
+        });
     layout.addDropdown<float>(
         "Zoom", ZOOM_LEVELS, s.uiScale,
         [](auto val) {


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

Since I always used GDI as the font engine, I never noticed that it parses some weights (styles) of fonts as different families (e.g. there's "Segoe UI", "Segoe UI Bold", "Segoe UI Light"). DirectWrite doesn't do that, and properly combines them into one font family ("Segoe UI" with "Normal", "Bold", and "Light" styles). My selected chat font has a different weight than 400 (normal) and I'd like to keep that.

This PR adds a setting to customize the weight of the chat font. Some font engines support variable fonts, and we should allow for customization of this. The setting takes an OpenType font weight that is directly passed to Qt.

Since this touches `Fonts.cpp`, I refactored that a bit to have "getter" functions that each resolve a font property (family, size, weight, italic).

Future work: The font dialog should automatically set the selected font weight and size.