### PR TITLE
fix(eventsub): Respect "Hide moderation actions"

### DIFF
--- a/mocks/include/mocks/DisabledStreamerMode.hpp
+++ b/mocks/include/mocks/DisabledStreamerMode.hpp
@@ -10,6 +10,11 @@ public:
         return false;
     }
 
+    bool shouldHideModActions() const override
+    {
+        return false;
+    }
+
     void start() override
     {
     }

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -729,6 +729,7 @@ MessageBuilder::MessageBuilder(TimeoutMessageTag, const QString &username,
 
     this->message().flags.set(MessageFlag::System);
     this->message().flags.set(MessageFlag::Timeout);
+    this->message().flags.set(MessageFlag::ModerationAction);
     this->message().flags.set(MessageFlag::DoNotTriggerNotification);
     this->message().timeoutUser = username;
 
@@ -747,6 +748,7 @@ MessageBuilder::MessageBuilder(const BanAction &action, const QDateTime &time,
     this->emplace<TimestampElement>();
     this->message().flags.set(MessageFlag::System);
     this->message().flags.set(MessageFlag::Timeout);
+    this->message().flags.set(MessageFlag::ModerationAction);
     this->message().timeoutUser = action.target.login;
     this->message().loginName = action.source.login;
     this->message().count = count;
@@ -1464,7 +1466,7 @@ MessagePtr MessageBuilder::makeDeletionMessageFromIRC(
     builder.emplace<TimestampElement>();
     builder.message().flags.set(MessageFlag::System);
     builder.message().flags.set(MessageFlag::DoNotTriggerNotification);
-    builder.message().flags.set(MessageFlag::Timeout);
+    builder.message().flags.set(MessageFlag::ModerationAction);
     // TODO(mm2pl): If or when jumping to a single message gets implemented a link,
     // add a link to the originalMessage
     builder.emplace<TextElement>("A message from", MessageElementFlag::Text,
@@ -1503,7 +1505,7 @@ MessagePtr MessageBuilder::makeDeletionMessageFromPubSub(
     builder.emplace<TimestampElement>();
     builder.message().flags.set(MessageFlag::System);
     builder.message().flags.set(MessageFlag::DoNotTriggerNotification);
-    builder.message().flags.set(MessageFlag::Timeout);
+    builder.message().flags.set(MessageFlag::ModerationAction);
 
     builder
         .emplace<TextElement>(action.source.login, MessageElementFlag::Username,
@@ -1710,7 +1712,7 @@ std::pair<MessagePtr, MessagePtr> MessageBuilder::makeAutomodMessage(
     builder.message().loginName = "automod";
     builder.message().channelName = channelName;
     builder.message().flags.set(MessageFlag::PubSub);
-    builder.message().flags.set(MessageFlag::Timeout);
+    builder.message().flags.set(MessageFlag::ModerationAction);
     builder.message().flags.set(MessageFlag::AutoMod);
     builder.message().flags.set(MessageFlag::AutoModOffendingMessageHeader);
 
@@ -1761,7 +1763,7 @@ std::pair<MessagePtr, MessagePtr> MessageBuilder::makeAutomodMessage(
     builder2.emplace<TwitchModerationElement>();
     builder2.message().loginName = action.target.login;
     builder2.message().flags.set(MessageFlag::PubSub);
-    builder2.message().flags.set(MessageFlag::Timeout);
+    builder2.message().flags.set(MessageFlag::ModerationAction);
     builder2.message().flags.set(MessageFlag::AutoMod);
     builder2.message().flags.set(MessageFlag::AutoModOffendingMessage);
 
@@ -2063,9 +2065,9 @@ MessagePtrMut MessageBuilder::makeClearChatMessage(const QDateTime &now,
     builder.emplace<TimestampElement>(now.time());
     builder->count = count;
     builder->serverReceivedTime = now;
-    builder.message().flags.set(MessageFlag::System,
-                                MessageFlag::DoNotTriggerNotification,
-                                MessageFlag::ClearChat);
+    builder.message().flags.set(
+        MessageFlag::System, MessageFlag::DoNotTriggerNotification,
+        MessageFlag::ClearChat, MessageFlag::ModerationAction);
 
     QString messageText;
     if (actor.isEmpty())

--- a/src/messages/MessageFlag.hpp
+++ b/src/messages/MessageFlag.hpp
@@ -58,6 +58,13 @@ enum class MessageFlag : std::int64_t {
     ClearChat = (1LL << 39),
     /// The message is built from EventSub
     EventSub = (1LL << 40),
+    /// The message is a moderation action.
+    /// Example messages that would count as moderation actions:
+    ///  - forsen has been banned
+    ///  - forsen deleted message from forsen
+    ///  - forsen added "blockedterm" as a blocked term
+    ///  - Your message is being checked by mods and has not been sent
+    ModerationAction = (1LL << 41),
 };
 using MessageFlags = FlagsEnum<MessageFlag>;
 

--- a/src/messages/layouts/MessageLayout.cpp
+++ b/src/messages/layouts/MessageLayout.cpp
@@ -173,8 +173,7 @@ void MessageLayout::actuallyLayout(const MessageLayoutContext &ctx)
             // This is only the case for the moderation messages that don't get filtered during creation.
             // We should decide which is the correct method & apply that everywhere
             if (hideModerationActions ||
-                (getSettings()->streamerModeHideModActions &&
-                 getApp()->getStreamerMode()->isEnabled()))
+                getApp()->getStreamerMode()->shouldHideModActions())
             {
                 continue;
             }

--- a/src/messages/layouts/MessageLayout.cpp
+++ b/src/messages/layouts/MessageLayout.cpp
@@ -169,9 +169,16 @@ void MessageLayout::actuallyLayout(const MessageLayoutContext &ctx)
         if (this->message_->flags.has(MessageFlag::Timeout) ||
             this->message_->flags.has(MessageFlag::Untimeout))
         {
-            // NOTE: This hides the message but it will make the message re-appear if moderation message hiding is no longer active, and the layout is re-laid-out.
-            // This is only the case for the moderation messages that don't get filtered during creation.
-            // We should decide which is the correct method & apply that everywhere
+            assert(this->message_->flags.has(MessageFlag::ModerationAction));
+            if (hideModerationActions ||
+                getApp()->getStreamerMode()->shouldHideModActions())
+            {
+                continue;
+            }
+        }
+
+        if (this->message_->flags.has(MessageFlag::ModerationAction))
+        {
             if (hideModerationActions ||
                 getApp()->getStreamerMode()->shouldHideModActions())
             {
@@ -514,7 +521,8 @@ bool MessageLayout::isReplyable() const
 
     if (this->message_->flags.hasAny(
             {MessageFlag::System, MessageFlag::Subscription,
-             MessageFlag::Timeout, MessageFlag::Whisper}))
+             MessageFlag::Timeout, MessageFlag::Whisper,
+             MessageFlag::ModerationAction}))
     {
         return false;
     }

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -431,9 +431,10 @@ void TwitchIrcServer::initialize()
                 return;
             }
 
-            if (getSettings()->streamerModeHideModActions &&
-                getApp()->getStreamerMode()->isEnabled())
+            if (getApp()->getStreamerMode()->shouldHideModActions())
             {
+                // NOTE: This completely stops the building of this action, rathern than only hiding it.
+                // If the user disabled streamer mode or the setting, there will be messages missing
                 return;
             }
 
@@ -476,9 +477,10 @@ void TwitchIrcServer::initialize()
                 return;
             }
 
-            if (getSettings()->streamerModeHideModActions &&
-                getApp()->getStreamerMode()->isEnabled())
+            if (getApp()->getStreamerMode()->shouldHideModActions())
             {
+                // NOTE: This completely stops the building of this action, rathern than only hiding it.
+                // If the user disabled streamer mode or the setting, there will be messages missing
                 return;
             }
 
@@ -680,9 +682,10 @@ void TwitchIrcServer::initialize()
     this->connections_.managedConnect(
         getApp()->getTwitchPubSub()->moderation.automodUserMessage,
         [this](const auto &action) {
-            if (getSettings()->streamerModeHideModActions &&
-                getApp()->getStreamerMode()->isEnabled())
+            if (getApp()->getStreamerMode()->shouldHideModActions())
             {
+                // NOTE: This completely stops the building of this action, rathern than only hiding it.
+                // If the user disabled streamer mode or the setting, there will be messages missing
                 return;
             }
             auto chan = this->getChannelOrEmptyByID(action.roomID);

--- a/src/providers/twitch/eventsub/Connection.cpp
+++ b/src/providers/twitch/eventsub/Connection.cpp
@@ -281,9 +281,10 @@ void Connection::onChannelSuspiciousUserMessage(
         return;
     }
 
-    if (getSettings()->streamerModeHideModActions &&
-        getApp()->getStreamerMode()->isEnabled())
+    if (getApp()->getStreamerMode()->shouldHideModActions())
     {
+        // NOTE: This completely stops the building of this action, rathern than only hiding it.
+        // If the user disabled streamer mode or the setting, there will be messages missing
         return;
     }
 
@@ -324,6 +325,13 @@ void Connection::onChannelSuspiciousUserUpdate(
         qCDebug(LOG) << "Channel Suspicious User Update for broadcaster we're "
                         "not interested in"
                      << payload.event.broadcasterUserLogin.qt();
+        return;
+    }
+
+    if (getApp()->getStreamerMode()->shouldHideModActions())
+    {
+        // NOTE: This completely stops the building of this action, rathern than only hiding it.
+        // If the user disabled streamer mode or the setting, there will be messages missing
         return;
     }
 

--- a/src/providers/twitch/eventsub/MessageHandlers.cpp
+++ b/src/providers/twitch/eventsub/MessageHandlers.cpp
@@ -45,7 +45,8 @@ void handleModerateMessage(
     EventSubMessageBuilder builder(chan, time);
     builder->loginName = event.moderatorUserLogin.qt();
     // pretend we're pubsub
-    builder->flags.set(MessageFlag::PubSub);
+    builder->flags.set(MessageFlag::PubSub, MessageFlag::Timeout,
+                       MessageFlag::ModerationAction);
 
     QString text;
     bool isShared = event.isFromSharedChat();

--- a/src/singletons/StreamerMode.cpp
+++ b/src/singletons/StreamerMode.cpp
@@ -202,6 +202,11 @@ bool StreamerMode::isEnabled() const
     return this->private_->isEnabled();
 }
 
+bool StreamerMode::shouldHideModActions() const
+{
+    return getSettings()->streamerModeHideModActions && this->isEnabled();
+}
+
 void StreamerMode::start()
 {
     this->private_->start();

--- a/src/singletons/StreamerMode.hpp
+++ b/src/singletons/StreamerMode.hpp
@@ -20,6 +20,9 @@ public:
 
     [[nodiscard]] virtual bool isEnabled() const = 0;
 
+    /// Returns true if streamer mode is enabled & the settings to hide mod actions is enabled
+    [[nodiscard]] virtual bool shouldHideModActions() const = 0;
+
     virtual void start() = 0;
 
 Q_SIGNALS:
@@ -38,6 +41,8 @@ public:
     StreamerMode &operator=(StreamerMode &&) = delete;
 
     bool isEnabled() const override;
+
+    bool shouldHideModActions() const override;
 
     void start() override;
 

--- a/src/util/ChannelHelpers.hpp
+++ b/src/util/ChannelHelpers.hpp
@@ -55,8 +55,8 @@ void addOrReplaceChannelTimeout(const Buf &buffer, MessagePtr message,
         if (timeoutStackStyle == TimeoutStackStyle::DontStackBeyondUserMessage)
         {
             if (s->loginName == message->timeoutUser &&
-                s->flags.hasNone({MessageFlag::Disabled, MessageFlag::Timeout,
-                                  MessageFlag::Untimeout}))
+                s->flags.hasNone(
+                    {MessageFlag::Disabled, MessageFlag::ModerationAction}))
             {
                 break;
             }
@@ -114,8 +114,8 @@ void addOrReplaceChannelTimeout(const Buf &buffer, MessagePtr message,
         {
             auto &s = buffer[i];
             if (s->loginName == message->timeoutUser &&
-                s->flags.hasNone({MessageFlag::Timeout, MessageFlag::Untimeout,
-                                  MessageFlag::Whisper}))
+                s->flags.hasNone(
+                    {MessageFlag::ModerationAction, MessageFlag::Whisper}))
             {
                 // FOURTF: disabled for now
                 // PAJLADA: Shitty solution described in Message.hpp

--- a/tests/snapshots/EventSub/automod-message-hold/automod-category.json
+++ b/tests/snapshots/EventSub/automod-message-hold/automod-category.json
@@ -136,7 +136,7 @@
                     ]
                 }
             ],
-            "flags": "Timeout|PubSub|AutoMod|AutoModOffendingMessageHeader|EventSub",
+            "flags": "PubSub|AutoMod|AutoModOffendingMessageHeader|EventSub|ModerationAction",
             "id": "automod_19d067ff-89b5-4790-a720-97599894eb6b",
             "localizedName": "",
             "loginName": "automod",
@@ -242,7 +242,7 @@
                     ]
                 }
             ],
-            "flags": "Timeout|PubSub|AutoMod|AutoModOffendingMessage|EventSub",
+            "flags": "PubSub|AutoMod|AutoModOffendingMessage|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/automod-message-hold/blocked-term-enclosed.json
+++ b/tests/snapshots/EventSub/automod-message-hold/blocked-term-enclosed.json
@@ -148,7 +148,7 @@
                     ]
                 }
             ],
-            "flags": "Timeout|PubSub|AutoMod|AutoModOffendingMessageHeader|AutoModBlockedTerm|EventSub",
+            "flags": "PubSub|AutoMod|AutoModOffendingMessageHeader|AutoModBlockedTerm|EventSub|ModerationAction",
             "id": "automod_0cbb6e48-1606-46c6-b1ac-c97626e1c5cb",
             "localizedName": "",
             "loginName": "automod",
@@ -256,7 +256,7 @@
                     ]
                 }
             ],
-            "flags": "Timeout|PubSub|AutoMod|AutoModOffendingMessage|AutoModBlockedTerm|EventSub",
+            "flags": "PubSub|AutoMod|AutoModOffendingMessage|AutoModBlockedTerm|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/automod-message-hold/blocked-term.json
+++ b/tests/snapshots/EventSub/automod-message-hold/blocked-term.json
@@ -142,7 +142,7 @@
                     ]
                 }
             ],
-            "flags": "Timeout|PubSub|AutoMod|AutoModOffendingMessageHeader|AutoModBlockedTerm|EventSub",
+            "flags": "PubSub|AutoMod|AutoModOffendingMessageHeader|AutoModBlockedTerm|EventSub|ModerationAction",
             "id": "automod_c0fac418-25a9-41b8-adf3-5bd637fca1e1",
             "localizedName": "",
             "loginName": "automod",
@@ -248,7 +248,7 @@
                     ]
                 }
             ],
-            "flags": "Timeout|PubSub|AutoMod|AutoModOffendingMessage|AutoModBlockedTerm|EventSub",
+            "flags": "PubSub|AutoMod|AutoModOffendingMessage|AutoModBlockedTerm|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/automod-message-hold/blocked-terms-4.json
+++ b/tests/snapshots/EventSub/automod-message-hold/blocked-terms-4.json
@@ -194,7 +194,7 @@
                     ]
                 }
             ],
-            "flags": "Timeout|PubSub|AutoMod|AutoModOffendingMessageHeader|AutoModBlockedTerm|EventSub",
+            "flags": "PubSub|AutoMod|AutoModOffendingMessageHeader|AutoModBlockedTerm|EventSub|ModerationAction",
             "id": "automod_45a63ca1-1b0c-46ef-9075-d112f9a9f376",
             "localizedName": "",
             "loginName": "automod",
@@ -306,7 +306,7 @@
                     ]
                 }
             ],
-            "flags": "Timeout|PubSub|AutoMod|AutoModOffendingMessage|AutoModBlockedTerm|EventSub",
+            "flags": "PubSub|AutoMod|AutoModOffendingMessage|AutoModBlockedTerm|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/automod-message-hold/localized-name.json
+++ b/tests/snapshots/EventSub/automod-message-hold/localized-name.json
@@ -136,7 +136,7 @@
                     ]
                 }
             ],
-            "flags": "Timeout|PubSub|AutoMod|AutoModOffendingMessageHeader|EventSub",
+            "flags": "PubSub|AutoMod|AutoModOffendingMessageHeader|EventSub|ModerationAction",
             "id": "automod_19d067ff-89b5-4790-a720-97599894eb6b",
             "localizedName": "",
             "loginName": "automod",
@@ -242,7 +242,7 @@
                     ]
                 }
             ],
-            "flags": "Timeout|PubSub|AutoMod|AutoModOffendingMessage|EventSub",
+            "flags": "PubSub|AutoMod|AutoModOffendingMessage|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "testaccount_420",

--- a/tests/snapshots/EventSub/automod-message-update/approved.json
+++ b/tests/snapshots/EventSub/automod-message-update/approved.json
@@ -176,7 +176,7 @@
                     ]
                 }
             ],
-            "flags": "Timeout|Disabled|PubSub|AutoMod|AutoModOffendingMessageHeader|EventSub",
+            "flags": "Disabled|PubSub|AutoMod|AutoModOffendingMessageHeader|EventSub|ModerationAction",
             "id": "automod_19d067ff-89b5-4790-a720-97599894eb6b",
             "localizedName": "",
             "loginName": "automod",
@@ -282,7 +282,7 @@
                     ]
                 }
             ],
-            "flags": "Timeout|PubSub|AutoMod|AutoModOffendingMessage|EventSub",
+            "flags": "PubSub|AutoMod|AutoModOffendingMessage|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/automod-message-update/denied.json
+++ b/tests/snapshots/EventSub/automod-message-update/denied.json
@@ -176,7 +176,7 @@
                     ]
                 }
             ],
-            "flags": "Timeout|Disabled|PubSub|AutoMod|AutoModOffendingMessageHeader|EventSub",
+            "flags": "Disabled|PubSub|AutoMod|AutoModOffendingMessageHeader|EventSub|ModerationAction",
             "id": "automod_19d067ff-89b5-4790-a720-97599894eb6b",
             "localizedName": "",
             "loginName": "automod",
@@ -282,7 +282,7 @@
                     ]
                 }
             ],
-            "flags": "Timeout|PubSub|AutoMod|AutoModOffendingMessage|EventSub",
+            "flags": "PubSub|AutoMod|AutoModOffendingMessage|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/automod-message-update/expired.json
+++ b/tests/snapshots/EventSub/automod-message-update/expired.json
@@ -176,7 +176,7 @@
                     ]
                 }
             ],
-            "flags": "Timeout|Disabled|PubSub|AutoMod|AutoModOffendingMessageHeader|EventSub",
+            "flags": "Disabled|PubSub|AutoMod|AutoModOffendingMessageHeader|EventSub|ModerationAction",
             "id": "automod_19d067ff-89b5-4790-a720-97599894eb6b",
             "localizedName": "",
             "loginName": "automod",
@@ -282,7 +282,7 @@
                     ]
                 }
             ],
-            "flags": "Timeout|PubSub|AutoMod|AutoModOffendingMessage|EventSub",
+            "flags": "PubSub|AutoMod|AutoModOffendingMessage|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-chat-user-message-hold/message-held.json
+++ b/tests/snapshots/EventSub/channel-chat-user-message-hold/message-held.json
@@ -90,7 +90,7 @@
                     ]
                 }
             ],
-            "flags": "Timeout|PubSub|AutoMod|EventSub",
+            "flags": "PubSub|AutoMod|EventSub",
             "id": "automod_e39e3c58-3d25-49fd-8c94-e776ef57a7f8",
             "localizedName": "",
             "loginName": "automod",

--- a/tests/snapshots/EventSub/channel-chat-user-message-update/message-approved.json
+++ b/tests/snapshots/EventSub/channel-chat-user-message-update/message-approved.json
@@ -83,7 +83,7 @@
                     ]
                 }
             ],
-            "flags": "Timeout|PubSub|AutoMod|EventSub",
+            "flags": "PubSub|AutoMod|EventSub",
             "id": "automod_5686ec52-e02c-4042-ac21-1dfd8cab0f9f",
             "localizedName": "",
             "loginName": "automod",

--- a/tests/snapshots/EventSub/channel-chat-user-message-update/message-denied.json
+++ b/tests/snapshots/EventSub/channel-chat-user-message-update/message-denied.json
@@ -89,7 +89,7 @@
                     ]
                 }
             ],
-            "flags": "Timeout|PubSub|AutoMod|EventSub",
+            "flags": "PubSub|AutoMod|EventSub",
             "id": "automod_fc90dc3b-0634-41c3-8365-f40719f076ab",
             "localizedName": "",
             "loginName": "automod",

--- a/tests/snapshots/EventSub/channel-moderate/add-blocked-term-three.json
+++ b/tests/snapshots/EventSub/channel-moderate/add-blocked-term-three.json
@@ -192,7 +192,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|EventSub",
+            "flags": "System|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/add-blocked-term.json
+++ b/tests/snapshots/EventSub/channel-moderate/add-blocked-term.json
@@ -202,7 +202,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|EventSub",
+            "flags": "System|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/add-permitted-term-two.json
+++ b/tests/snapshots/EventSub/channel-moderate/add-permitted-term-two.json
@@ -190,7 +190,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|EventSub",
+            "flags": "System|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/add-permitted-term.json
+++ b/tests/snapshots/EventSub/channel-moderate/add-permitted-term.json
@@ -202,7 +202,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|EventSub",
+            "flags": "System|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/ban-reason.json
+++ b/tests/snapshots/EventSub/channel-moderate/ban-reason.json
@@ -157,7 +157,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|EventSub",
+            "flags": "System|Timeout|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/ban.json
+++ b/tests/snapshots/EventSub/channel-moderate/ban.json
@@ -141,7 +141,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|EventSub",
+            "flags": "System|Timeout|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/clear.json
+++ b/tests/snapshots/EventSub/channel-moderate/clear.json
@@ -105,7 +105,7 @@
                     ]
                 }
             ],
-            "flags": "System|DoNotTriggerNotification|PubSub|ClearChat",
+            "flags": "System|DoNotTriggerNotification|PubSub|ClearChat|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "",

--- a/tests/snapshots/EventSub/channel-moderate/delete-long.json
+++ b/tests/snapshots/EventSub/channel-moderate/delete-long.json
@@ -159,7 +159,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|DoNotTriggerNotification|EventSub",
+            "flags": "System|DoNotTriggerNotification|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "testaccount_420",

--- a/tests/snapshots/EventSub/channel-moderate/delete.json
+++ b/tests/snapshots/EventSub/channel-moderate/delete.json
@@ -159,7 +159,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|DoNotTriggerNotification|EventSub",
+            "flags": "System|DoNotTriggerNotification|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "testaccount_420",

--- a/tests/snapshots/EventSub/channel-moderate/emoteonly-off.json
+++ b/tests/snapshots/EventSub/channel-moderate/emoteonly-off.json
@@ -148,7 +148,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|EventSub",
+            "flags": "System|EventSub",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/emoteonly.json
+++ b/tests/snapshots/EventSub/channel-moderate/emoteonly.json
@@ -148,7 +148,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|EventSub",
+            "flags": "System|EventSub",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/followers-0s.json
+++ b/tests/snapshots/EventSub/channel-moderate/followers-0s.json
@@ -150,7 +150,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|EventSub",
+            "flags": "System|EventSub",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/followers-off.json
+++ b/tests/snapshots/EventSub/channel-moderate/followers-off.json
@@ -148,7 +148,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|EventSub",
+            "flags": "System|EventSub",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/followers.json
+++ b/tests/snapshots/EventSub/channel-moderate/followers.json
@@ -166,7 +166,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|EventSub",
+            "flags": "System|EventSub",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/mod.json
+++ b/tests/snapshots/EventSub/channel-moderate/mod.json
@@ -140,7 +140,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|EventSub",
+            "flags": "System|EventSub",
             "id": "",
             "localizedName": "",
             "loginName": "uint128",

--- a/tests/snapshots/EventSub/channel-moderate/raid.json
+++ b/tests/snapshots/EventSub/channel-moderate/raid.json
@@ -144,7 +144,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|EventSub",
+            "flags": "System|EventSub",
             "id": "",
             "localizedName": "",
             "loginName": "pajlada",

--- a/tests/snapshots/EventSub/channel-moderate/remove-blocked-term-four.json
+++ b/tests/snapshots/EventSub/channel-moderate/remove-blocked-term-four.json
@@ -194,7 +194,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|EventSub",
+            "flags": "System|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/remove-blocked-term.json
+++ b/tests/snapshots/EventSub/channel-moderate/remove-blocked-term.json
@@ -202,7 +202,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|EventSub",
+            "flags": "System|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/remove-permitted-term-from-automod.json
+++ b/tests/snapshots/EventSub/channel-moderate/remove-permitted-term-from-automod.json
@@ -202,7 +202,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|EventSub",
+            "flags": "System|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/remove-permitted-term.json
+++ b/tests/snapshots/EventSub/channel-moderate/remove-permitted-term.json
@@ -202,7 +202,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|EventSub",
+            "flags": "System|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/shared-ban-reason.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-ban-reason.json
@@ -191,7 +191,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|EventSub",
+            "flags": "System|Timeout|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/shared-ban.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-ban.json
@@ -174,7 +174,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|EventSub",
+            "flags": "System|Timeout|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/shared-delete-long.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-delete-long.json
@@ -192,7 +192,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|DoNotTriggerNotification|EventSub",
+            "flags": "System|DoNotTriggerNotification|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "testaccount_420",

--- a/tests/snapshots/EventSub/channel-moderate/shared-delete.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-delete.json
@@ -192,7 +192,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|DoNotTriggerNotification|EventSub",
+            "flags": "System|DoNotTriggerNotification|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "testaccount_420",

--- a/tests/snapshots/EventSub/channel-moderate/shared-timeout-stacking-diff-sources.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-timeout-stacking-diff-sources.json
@@ -294,7 +294,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|PubSub|SharedMessage|EventSub",
+            "flags": "System|Timeout|PubSub|SharedMessage|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "",
@@ -433,7 +433,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|PubSub|EventSub",
+            "flags": "System|Timeout|PubSub|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",
@@ -602,7 +602,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|PubSub|SharedMessage|EventSub",
+            "flags": "System|Timeout|PubSub|SharedMessage|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/shared-timeout-stacking-diff-sources2.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-timeout-stacking-diff-sources2.json
@@ -254,7 +254,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|PubSub|SharedMessage|EventSub",
+            "flags": "System|Timeout|PubSub|SharedMessage|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "",
@@ -423,7 +423,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|PubSub|SharedMessage|EventSub",
+            "flags": "System|Timeout|PubSub|SharedMessage|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/shared-timeout-stacking.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-timeout-stacking.json
@@ -254,7 +254,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|PubSub|SharedMessage|EventSub",
+            "flags": "System|Timeout|PubSub|SharedMessage|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "",
@@ -393,7 +393,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|PubSub|EventSub",
+            "flags": "System|Timeout|PubSub|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/shared-timeout.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-timeout.json
@@ -198,7 +198,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|PubSub|SharedMessage|EventSub",
+            "flags": "System|Timeout|PubSub|SharedMessage|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/shared-unban.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-unban.json
@@ -173,7 +173,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|EventSub",
+            "flags": "System|Untimeout|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/shared-untimeout.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-untimeout.json
@@ -173,7 +173,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|EventSub",
+            "flags": "System|Untimeout|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/slow-off.json
+++ b/tests/snapshots/EventSub/channel-moderate/slow-off.json
@@ -148,7 +148,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|EventSub",
+            "flags": "System|EventSub",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/slow.json
+++ b/tests/snapshots/EventSub/channel-moderate/slow.json
@@ -166,7 +166,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|EventSub",
+            "flags": "System|EventSub",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/subscribers-off.json
+++ b/tests/snapshots/EventSub/channel-moderate/subscribers-off.json
@@ -148,7 +148,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|EventSub",
+            "flags": "System|EventSub",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/subscribers.json
+++ b/tests/snapshots/EventSub/channel-moderate/subscribers.json
@@ -148,7 +148,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|EventSub",
+            "flags": "System|EventSub",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/timeout-stacking-reason.json
+++ b/tests/snapshots/EventSub/channel-moderate/timeout-stacking-reason.json
@@ -224,7 +224,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|PubSub|EventSub",
+            "flags": "System|Timeout|PubSub|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "",
@@ -378,7 +378,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|PubSub|EventSub",
+            "flags": "System|Timeout|PubSub|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/timeout-stacking.json
+++ b/tests/snapshots/EventSub/channel-moderate/timeout-stacking.json
@@ -223,7 +223,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|PubSub|EventSub",
+            "flags": "System|Timeout|PubSub|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "",
@@ -362,7 +362,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|PubSub|EventSub",
+            "flags": "System|Timeout|PubSub|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/timeout.json
+++ b/tests/snapshots/EventSub/channel-moderate/timeout.json
@@ -183,7 +183,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|PubSub|EventSub",
+            "flags": "System|Timeout|PubSub|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/unban.json
+++ b/tests/snapshots/EventSub/channel-moderate/unban.json
@@ -140,7 +140,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|EventSub",
+            "flags": "System|Untimeout|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/uniquechat-off.json
+++ b/tests/snapshots/EventSub/channel-moderate/uniquechat-off.json
@@ -148,7 +148,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|EventSub",
+            "flags": "System|EventSub",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/uniquechat.json
+++ b/tests/snapshots/EventSub/channel-moderate/uniquechat.json
@@ -148,7 +148,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|EventSub",
+            "flags": "System|EventSub",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/unmod.json
+++ b/tests/snapshots/EventSub/channel-moderate/unmod.json
@@ -140,7 +140,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|EventSub",
+            "flags": "System|EventSub",
             "id": "",
             "localizedName": "",
             "loginName": "uint128",

--- a/tests/snapshots/EventSub/channel-moderate/unraid.json
+++ b/tests/snapshots/EventSub/channel-moderate/unraid.json
@@ -143,7 +143,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|EventSub",
+            "flags": "System|EventSub",
             "id": "",
             "localizedName": "",
             "loginName": "pajlada",

--- a/tests/snapshots/EventSub/channel-moderate/untimeout.json
+++ b/tests/snapshots/EventSub/channel-moderate/untimeout.json
@@ -140,7 +140,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|EventSub",
+            "flags": "System|Untimeout|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/warn-shared.json
+++ b/tests/snapshots/EventSub/channel-moderate/warn-shared.json
@@ -159,7 +159,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|EventSub",
+            "flags": "System|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "quotrok",

--- a/tests/snapshots/EventSub/channel-moderate/warn.json
+++ b/tests/snapshots/EventSub/channel-moderate/warn.json
@@ -159,7 +159,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|EventSub",
+            "flags": "System|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "quotrok",

--- a/tests/snapshots/EventSub/channel-suspicious-user-update/monitored.json
+++ b/tests/snapshots/EventSub/channel-suspicious-user-update/monitored.json
@@ -119,7 +119,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|DoNotTriggerNotification|EventSub",
+            "flags": "System|DoNotTriggerNotification|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "uint128",

--- a/tests/snapshots/EventSub/channel-suspicious-user-update/no-treatment.json
+++ b/tests/snapshots/EventSub/channel-suspicious-user-update/no-treatment.json
@@ -119,7 +119,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|DoNotTriggerNotification|EventSub",
+            "flags": "System|DoNotTriggerNotification|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "uint128",

--- a/tests/snapshots/EventSub/channel-suspicious-user-update/restricted.json
+++ b/tests/snapshots/EventSub/channel-suspicious-user-update/restricted.json
@@ -119,7 +119,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|DoNotTriggerNotification|EventSub",
+            "flags": "System|DoNotTriggerNotification|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "uint128",

--- a/tests/snapshots/IrcMessageHandler/clearchat-stack-always.json
+++ b/tests/snapshots/IrcMessageHandler/clearchat-stack-always.json
@@ -61,7 +61,7 @@
                     ]
                 }
             ],
-            "flags": "System|DoNotTriggerNotification|ClearChat",
+            "flags": "System|DoNotTriggerNotification|ClearChat|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "",

--- a/tests/snapshots/IrcMessageHandler/clearchat-stack-never.json
+++ b/tests/snapshots/IrcMessageHandler/clearchat-stack-never.json
@@ -59,7 +59,7 @@
                     ]
                 }
             ],
-            "flags": "System|DoNotTriggerNotification|ClearChat",
+            "flags": "System|DoNotTriggerNotification|ClearChat|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "",

--- a/tests/snapshots/IrcMessageHandler/clearchat-stack-no-user.json
+++ b/tests/snapshots/IrcMessageHandler/clearchat-stack-no-user.json
@@ -61,7 +61,7 @@
                     ]
                 }
             ],
-            "flags": "System|DoNotTriggerNotification|ClearChat",
+            "flags": "System|DoNotTriggerNotification|ClearChat|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "",

--- a/tests/snapshots/IrcMessageHandler/clearchat.json
+++ b/tests/snapshots/IrcMessageHandler/clearchat.json
@@ -59,7 +59,7 @@
                     ]
                 }
             ],
-            "flags": "System|DoNotTriggerNotification|ClearChat",
+            "flags": "System|DoNotTriggerNotification|ClearChat|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "",

--- a/tests/snapshots/IrcMessageHandler/timeout-stack-always.json
+++ b/tests/snapshots/IrcMessageHandler/timeout-stack-always.json
@@ -75,7 +75,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|DoNotTriggerNotification",
+            "flags": "System|Timeout|DoNotTriggerNotification|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "",

--- a/tests/snapshots/IrcMessageHandler/timeout-stack-never.json
+++ b/tests/snapshots/IrcMessageHandler/timeout-stack-never.json
@@ -75,7 +75,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|DoNotTriggerNotification",
+            "flags": "System|Timeout|DoNotTriggerNotification|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "",

--- a/tests/snapshots/IrcMessageHandler/timeout-stack-no-user.json
+++ b/tests/snapshots/IrcMessageHandler/timeout-stack-no-user.json
@@ -73,7 +73,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|DoNotTriggerNotification",
+            "flags": "System|Timeout|DoNotTriggerNotification|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "",
@@ -274,7 +274,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|DoNotTriggerNotification",
+            "flags": "System|Timeout|DoNotTriggerNotification|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "",

--- a/tests/snapshots/IrcMessageHandler/timeout.json
+++ b/tests/snapshots/IrcMessageHandler/timeout.json
@@ -73,7 +73,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|DoNotTriggerNotification",
+            "flags": "System|Timeout|DoNotTriggerNotification|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "",


### PR DESCRIPTION
This change is bigger than it technically needed to be.

I've added a "ModerationAction" message flag which is what's actually being used to hide messages instead of incorrectly flagging messages as `Timeout` or `Untimeout`.
This will have some consequences for message search & filters, but I believe they are all more correct than they were before.
If the user case for being able to filter on previously-timeout-filtered-messages comes up we can add more search predicates for this.
