### PR TITLE
fix: only hide messages from restricted users, not all suspicious users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Minor: Overlay windows now inherit the global zoom level and can be zoomed independently. (#6016)
 - Minor: The `/watching` channel is now supported on all platforms. (#6031, #6043)
 - Minor: The font weight of chat messages can now be changed. (#6037)
-- Minor: Messages from suspicious users can now be hidden when in streamer mode. This is enabled by default. (#6042)
+- Minor: Messages from restricted users can now be hidden when in streamer mode. This is enabled by default. (#6042, #6049)
 - Bugfix: Fixed a potential way to escape the Lua Plugin sandbox. (#5846)
 - Bugfix: Fixed a crash relating to Lua HTTP. (#5800)
 - Bugfix: Fixed a crash that could occur on Linux and macOS when clicking "Install" from the update prompt. (#5818)

--- a/mocks/include/mocks/DisabledStreamerMode.hpp
+++ b/mocks/include/mocks/DisabledStreamerMode.hpp
@@ -15,7 +15,7 @@ public:
         return false;
     }
 
-    bool shouldHideSuspiciousUsers() const override
+    bool shouldHideRestrictedUsers() const override
     {
         return false;
     }

--- a/src/messages/layouts/MessageLayout.cpp
+++ b/src/messages/layouts/MessageLayout.cpp
@@ -166,13 +166,12 @@ void MessageLayout::actuallyLayout(const MessageLayoutContext &ctx)
             continue;
         }
 
-        if (this->message_->flags.hasAny(MessageFlag::RestrictedMessage,
-                                         MessageFlag::MonitoredMessage))
+        if (this->message_->flags.has(MessageFlag::RestrictedMessage))
         {
-            if (getApp()->getStreamerMode()->shouldHideSuspiciousUsers())
+            if (getApp()->getStreamerMode()->shouldHideRestrictedUsers())
             {
                 // Message is being hidden because the source is a
-                // restricted or monitored user
+                // restricted user
                 continue;
             }
         }

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -362,8 +362,8 @@ public:
         "/streamerMode/hideViewerCountAndDuration", false};
     BoolSetting streamerModeHideModActions = {"/streamerMode/hideModActions",
                                               true};
-    BoolSetting streamerModeHideSuspiciousUsers = {
-        "/streamerMode/hideSuspiciousUsers",
+    BoolSetting streamerModeHideRestrictedUsers = {
+        "/streamerMode/hideRestrictedUsers",
         true,
     };
     BoolSetting streamerModeMuteMentions = {"/streamerMode/muteMentions", true};

--- a/src/singletons/StreamerMode.cpp
+++ b/src/singletons/StreamerMode.cpp
@@ -207,9 +207,9 @@ bool StreamerMode::shouldHideModActions() const
     return getSettings()->streamerModeHideModActions && this->isEnabled();
 }
 
-bool StreamerMode::shouldHideSuspiciousUsers() const
+bool StreamerMode::shouldHideRestrictedUsers() const
 {
-    return getSettings()->streamerModeHideSuspiciousUsers && this->isEnabled();
+    return getSettings()->streamerModeHideRestrictedUsers && this->isEnabled();
 }
 
 void StreamerMode::start()

--- a/src/singletons/StreamerMode.hpp
+++ b/src/singletons/StreamerMode.hpp
@@ -23,8 +23,8 @@ public:
     /// Returns true if streamer mode is enabled & the settings to hide mod actions is enabled
     [[nodiscard]] virtual bool shouldHideModActions() const = 0;
 
-    /// Returns true if streamer mode is enabled & the settings to hide messages from suspicious users is enabled
-    [[nodiscard]] virtual bool shouldHideSuspiciousUsers() const = 0;
+    /// Returns true if streamer mode is enabled & the settings to hide messages from restricted users is enabled
+    [[nodiscard]] virtual bool shouldHideRestrictedUsers() const = 0;
 
     virtual void start() = 0;
 
@@ -46,7 +46,7 @@ public:
     bool isEnabled() const override;
 
     bool shouldHideModActions() const override;
-    bool shouldHideSuspiciousUsers() const override;
+    bool shouldHideRestrictedUsers() const override;
 
     void start() override;
 

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -148,7 +148,7 @@ WindowManager::WindowManager(const Paths &paths, Settings &settings,
     this->forceLayoutChannelViewsListener.add(
         settings.streamerModeHideModActions);
     this->forceLayoutChannelViewsListener.add(
-        settings.streamerModeHideSuspiciousUsers);
+        settings.streamerModeHideRestrictedUsers);
 
     this->layoutChannelViewsListener.add(settings.timestampFormat);
     this->layoutChannelViewsListener.add(fonts.fontChanged);

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -733,10 +733,10 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         "Hide moderation actions", s.streamerModeHideModActions, false,
         "Hide bans, timeouts, and automod messages from appearing in chat.");
 
-    SettingWidget::checkbox("Hide messages from suspicious users",
-                            s.streamerModeHideSuspiciousUsers)
-        ->setTooltip("Suspicious users are users who are marked as either "
-                     "restricted or monitored by you or Twitch's AutoMod")
+    SettingWidget::checkbox("Hide messages from restricted users",
+                            s.streamerModeHideRestrictedUsers)
+        ->setTooltip("Restricted users can be marked by you, your moderators, "
+                     "or Twitch's AutoMod")
         ->addTo(layout);
 
     layout.addCheckbox(


### PR DESCRIPTION
it's probably best to leave this setting solo'd out as restricted users
so monitored users can get their own behaviour in their own setting later

<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
