### PR TITLE
fix: make QLineEdit's less ugly in light themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Bugfix: Fixed user info popup's opened from `/live` making some network requests that always failed. (#5959)
 - Bugfix: Ensure miniaudio backend exits even if it doesn't exit cleanly. (#5896)
 - Bugfix: Fixed search in emote popup not always working correctly. (#5946)
+- Bugfix: Fixed some text inputs being dark in light themes. (#6055)
 - Bugfix: Fixed channel point redemptions with messages not showing up if PubSub is disconnected. (#5948)
 - Bugfix: Fixed the input font not immediately updating when zooming in/out. (#5960)
 - Bugfix: Fixed missing special shortcut for Windows live notifications. (#5975)

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -16,6 +16,7 @@
 #include "providers/twitch/TwitchChannel.hpp"
 #include "singletons/Emotes.hpp"
 #include "singletons/Settings.hpp"
+#include "singletons/Theme.hpp"
 #include "singletons/WindowManager.hpp"
 #include "util/Helpers.hpp"
 #include "widgets/helper/ChannelView.hpp"
@@ -315,6 +316,8 @@ EmotePopup::EmotePopup(QWidget *parent)
             }
             this->reloadEmotes();
         });
+
+    this->themeChangedEvent();
 }
 
 void EmotePopup::addShortcuts()
@@ -658,6 +661,16 @@ void EmotePopup::moveEvent(QMoveEvent *event)
 {
     this->saveBounds();
     BasePopup::moveEvent(event);
+}
+
+void EmotePopup::themeChangedEvent()
+{
+    BasePopup::themeChangedEvent();
+
+    // NOTE: This currently overrides the QLineEdit's font size.
+    // If the dialog open is when the theme is changed, things will look a bit off.
+    // This can be alleviated by us using a single application-wide style sheet for these things.
+    this->search_->setStyleSheet(this->theme->splits.input.styleSheet);
 }
 
 void EmotePopup::closeEvent(QCloseEvent *event)

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -668,7 +668,7 @@ void EmotePopup::themeChangedEvent()
     BasePopup::themeChangedEvent();
 
     // NOTE: This currently overrides the QLineEdit's font size.
-    // If the dialog open is when the theme is changed, things will look a bit off.
+    // If the dialog is open when the theme is changed, things will look a bit off.
     // This can be alleviated by us using a single application-wide style sheet for these things.
     this->search_->setStyleSheet(this->theme->splits.input.styleSheet);
 }

--- a/src/widgets/dialogs/EmotePopup.hpp
+++ b/src/widgets/dialogs/EmotePopup.hpp
@@ -28,6 +28,7 @@ public:
 protected:
     void resizeEvent(QResizeEvent *event) override;
     void moveEvent(QMoveEvent *event) override;
+    void themeChangedEvent() override;
 
 private:
     ChannelView *globalEmotesView_{};

--- a/src/widgets/dialogs/SelectChannelDialog.cpp
+++ b/src/widgets/dialogs/SelectChannelDialog.cpp
@@ -395,7 +395,7 @@ void SelectChannelDialog::themeChangedEvent()
     BaseWindow::themeChangedEvent();
 
     // NOTE: This currently overrides the QLineEdit's font size.
-    // If the dialog open is when the theme is changed, things will look a bit off.
+    // If the dialog is open when the theme is changed, things will look a bit off.
     // This can be alleviated by us using a single application-wide style sheet for these things.
     this->ui_.twitch.channelName->setStyleSheet(
         this->theme->splits.input.styleSheet);

--- a/src/widgets/dialogs/SelectChannelDialog.cpp
+++ b/src/widgets/dialogs/SelectChannelDialog.cpp
@@ -191,6 +191,8 @@ SelectChannelDialog::SelectChannelDialog(QWidget *parent)
     this->ui_.twitch.channel->setFocus();
 
     this->addShortcuts();
+
+    this->themeChangedEvent();
 }
 
 void SelectChannelDialog::ok()
@@ -392,16 +394,11 @@ void SelectChannelDialog::themeChangedEvent()
 {
     BaseWindow::themeChangedEvent();
 
-    if (this->theme->isLightTheme())
-    {
-        this->setStyleSheet(
-            "QRadioButton { color: #000 } QLabel { color: #000 }");
-    }
-    else
-    {
-        this->setStyleSheet(
-            "QRadioButton { color: #fff } QLabel { color: #fff }");
-    }
+    // NOTE: This currently overrides the QLineEdit's font size.
+    // If the dialog open is when the theme is changed, things will look a bit off.
+    // This can be alleviated by us using a single application-wide style sheet for these things.
+    this->ui_.twitch.channelName->setStyleSheet(
+        this->theme->splits.input.styleSheet);
 }
 
 void SelectChannelDialog::addShortcuts()

--- a/src/widgets/helper/SearchPopup.cpp
+++ b/src/widgets/helper/SearchPopup.cpp
@@ -220,7 +220,7 @@ void SearchPopup::themeChangedEvent()
     BasePopup::themeChangedEvent();
 
     // NOTE: This currently overrides the QLineEdit's font size.
-    // If the dialog open is when the theme is changed, things will look a bit off.
+    // If the dialog is open when the theme is changed, things will look a bit off.
     // This can be alleviated by us using a single application-wide style sheet for these things.
     this->searchInput_->setStyleSheet(this->theme->splits.input.styleSheet);
 }

--- a/src/widgets/helper/SearchPopup.cpp
+++ b/src/widgets/helper/SearchPopup.cpp
@@ -14,6 +14,7 @@
 #include "messages/search/SubstringPredicate.hpp"
 #include "messages/search/SubtierPredicate.hpp"
 #include "singletons/Settings.hpp"
+#include "singletons/Theme.hpp"
 #include "singletons/WindowManager.hpp"
 #include "widgets/helper/ChannelView.hpp"
 #include "widgets/splits/Split.hpp"
@@ -80,6 +81,8 @@ SearchPopup::SearchPopup(QWidget *parent, Split *split)
     }
     this->resize(400, 600);
     this->addShortcuts();
+
+    this->themeChangedEvent();
 }
 
 void SearchPopup::addShortcuts()
@@ -210,6 +213,16 @@ bool SearchPopup::eventFilter(QObject *object, QEvent *event)
         }
     }
     return false;
+}
+
+void SearchPopup::themeChangedEvent()
+{
+    BasePopup::themeChangedEvent();
+
+    // NOTE: This currently overrides the QLineEdit's font size.
+    // If the dialog open is when the theme is changed, things will look a bit off.
+    // This can be alleviated by us using a single application-wide style sheet for these things.
+    this->searchInput_->setStyleSheet(this->theme->splits.input.styleSheet);
 }
 
 void SearchPopup::search()

--- a/src/widgets/helper/SearchPopup.hpp
+++ b/src/widgets/helper/SearchPopup.hpp
@@ -32,6 +32,7 @@ protected:
     virtual void updateWindowTitle();
     void showEvent(QShowEvent *event) override;
     bool eventFilter(QObject *object, QEvent *event) override;
+    void themeChangedEvent() override;
 
 private:
     void initLayout();


### PR DESCRIPTION
Fixes #6022
