### PR TITLE
feat: apply tabular number formatting to timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Minor: Add `Set highlight sounds` and `Open subscription page` split hotkeys. (#5856, #6030)
 - Minor: `/clear` messages are now stacked like timeouts. (#5806)
 - Minor: Treat all browsers starting with `firefox` as a Firefox browser. (#5805)
+- Minor: Timestamps are now monospaced. (#6062)
 - Minor: Remove incognito browser support for `opera/launcher` (this should no longer be a thing). (#5805)
 - Minor: Remove incognito browser support for `iexplore`, because internet explorer is EOL. (#5810)
 - Minor: When (re-)connecting, visible channels are now joined first. (#5850)

--- a/src/messages/MessageElement.cpp
+++ b/src/messages/MessageElement.cpp
@@ -1026,7 +1026,7 @@ TextElement *TimestampElement::formatTime(const QTime &time)
     QString format = locale.toString(time, getSettings()->timestampFormat);
 
     return new TextElement(format, MessageElementFlag::Timestamp,
-                           MessageColor::System, FontStyle::ChatMedium);
+                           MessageColor::System, FontStyle::TimestampMedium);
 }
 
 QJsonObject TimestampElement::toJson() const

--- a/src/singletons/Fonts.cpp
+++ b/src/singletons/Fonts.cpp
@@ -70,6 +70,7 @@ float fontSize(FontStyle style)
         case FontStyle::ChatMedium:
         case FontStyle::ChatMediumBold:
         case FontStyle::ChatMediumItalic:
+        case FontStyle::TimestampMedium:
             return chatSize();
         case FontStyle::ChatLarge:
             return 1.2F * chatSize();
@@ -99,6 +100,7 @@ int fontWeight(FontStyle style)
         case FontStyle::ChatMediumItalic:
         case FontStyle::ChatLarge:
         case FontStyle::ChatVeryLarge:
+        case FontStyle::TimestampMedium:
             return getSettings()->chatFontWeight.getValue();
 
         case FontStyle::ChatMediumBold:
@@ -129,6 +131,7 @@ bool isItalic(FontStyle style)
         case FontStyle::ChatMediumBold:
         case FontStyle::ChatLarge:
         case FontStyle::ChatVeryLarge:
+        case FontStyle::TimestampMedium:
         case FontStyle::UiMedium:
         case FontStyle::UiMediumBold:
         case FontStyle::UiTabs:
@@ -157,6 +160,7 @@ QString fontFamily(FontStyle style)
         case FontStyle::ChatMediumItalic:
         case FontStyle::ChatLarge:
         case FontStyle::ChatVeryLarge:
+        case FontStyle::TimestampMedium:
             return getSettings()->chatFontFamily.getValue();
 
         case FontStyle::UiMedium:
@@ -229,12 +233,27 @@ Fonts::FontData &Fonts::getOrCreateFontData(FontStyle type, float scale)
 
 Fonts::FontData Fonts::createFontData(FontStyle type, float scale)
 {
-    return QFont{
+    QFont font{
         fontFamily(type),
         static_cast<int>(fontSize(type) * scale),
         fontWeight(type),
         isItalic(type),
     };
+
+    switch (type)
+    {
+        case FontStyle::TimestampMedium: {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+            // Apply the OpenType feature `tnum` to timestamp fonts
+            // https://sparanoid.com/lab/opentype-features/#tnum
+            auto tag = QFont::Tag("tnum");
+            font.setFeature(tag, 1);
+#endif
+        }
+        break;
+    }
+
+    return font;
 }
 
 }  // namespace chatterino

--- a/src/singletons/Fonts.hpp
+++ b/src/singletons/Fonts.hpp
@@ -24,6 +24,8 @@ enum class FontStyle : uint8_t {
     ChatLarge,
     ChatVeryLarge,
 
+    TimestampMedium,
+
     UiMedium,
     UiMediumBold,
     UiTabs,

--- a/tests/snapshots/EventSub/automod-message-hold/automod-category.json
+++ b/tests/snapshots/EventSub/automod-message-hold/automod-category.json
@@ -179,7 +179,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/automod-message-hold/blocked-term-enclosed.json
+++ b/tests/snapshots/EventSub/automod-message-hold/blocked-term-enclosed.json
@@ -191,7 +191,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/automod-message-hold/blocked-term.json
+++ b/tests/snapshots/EventSub/automod-message-hold/blocked-term.json
@@ -185,7 +185,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/automod-message-hold/blocked-terms-4.json
+++ b/tests/snapshots/EventSub/automod-message-hold/blocked-terms-4.json
@@ -237,7 +237,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/automod-message-hold/localized-name.json
+++ b/tests/snapshots/EventSub/automod-message-hold/localized-name.json
@@ -179,7 +179,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/automod-message-update/approved.json
+++ b/tests/snapshots/EventSub/automod-message-update/approved.json
@@ -219,7 +219,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/automod-message-update/denied.json
+++ b/tests/snapshots/EventSub/automod-message-update/denied.json
@@ -219,7 +219,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/automod-message-update/expired.json
+++ b/tests/snapshots/EventSub/automod-message-update/expired.json
@@ -219,7 +219,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/add-blocked-term-three.json
+++ b/tests/snapshots/EventSub/channel-moderate/add-blocked-term-three.json
@@ -59,7 +59,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/add-blocked-term.json
+++ b/tests/snapshots/EventSub/channel-moderate/add-blocked-term.json
@@ -57,7 +57,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/add-permitted-term-two.json
+++ b/tests/snapshots/EventSub/channel-moderate/add-permitted-term-two.json
@@ -58,7 +58,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/add-permitted-term.json
+++ b/tests/snapshots/EventSub/channel-moderate/add-permitted-term.json
@@ -57,7 +57,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/ban-reason.json
+++ b/tests/snapshots/EventSub/channel-moderate/ban-reason.json
@@ -55,7 +55,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/ban.json
+++ b/tests/snapshots/EventSub/channel-moderate/ban.json
@@ -55,7 +55,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/clear.json
+++ b/tests/snapshots/EventSub/channel-moderate/clear.json
@@ -50,7 +50,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/delete-long.json
+++ b/tests/snapshots/EventSub/channel-moderate/delete-long.json
@@ -56,7 +56,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/delete.json
+++ b/tests/snapshots/EventSub/channel-moderate/delete.json
@@ -56,7 +56,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/emoteonly-off.json
+++ b/tests/snapshots/EventSub/channel-moderate/emoteonly-off.json
@@ -50,7 +50,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/emoteonly.json
+++ b/tests/snapshots/EventSub/channel-moderate/emoteonly.json
@@ -50,7 +50,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/followers-0s.json
+++ b/tests/snapshots/EventSub/channel-moderate/followers-0s.json
@@ -52,7 +52,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/followers-off.json
+++ b/tests/snapshots/EventSub/channel-moderate/followers-off.json
@@ -50,7 +50,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/followers.json
+++ b/tests/snapshots/EventSub/channel-moderate/followers.json
@@ -52,7 +52,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/mod.json
+++ b/tests/snapshots/EventSub/channel-moderate/mod.json
@@ -54,7 +54,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/raid.json
+++ b/tests/snapshots/EventSub/channel-moderate/raid.json
@@ -55,7 +55,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/remove-blocked-term-four.json
+++ b/tests/snapshots/EventSub/channel-moderate/remove-blocked-term-four.json
@@ -60,7 +60,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/remove-blocked-term.json
+++ b/tests/snapshots/EventSub/channel-moderate/remove-blocked-term.json
@@ -57,7 +57,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/remove-permitted-term-from-automod.json
+++ b/tests/snapshots/EventSub/channel-moderate/remove-permitted-term-from-automod.json
@@ -57,7 +57,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/remove-permitted-term.json
+++ b/tests/snapshots/EventSub/channel-moderate/remove-permitted-term.json
@@ -57,7 +57,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/shared-ban-reason.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-ban-reason.json
@@ -55,7 +55,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/shared-ban.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-ban.json
@@ -55,7 +55,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/shared-delete-long.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-delete-long.json
@@ -56,7 +56,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/shared-delete.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-delete.json
@@ -56,7 +56,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/shared-timeout-stacking-diff-sources.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-timeout-stacking-diff-sources.json
@@ -179,7 +179,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",
@@ -322,7 +322,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",
@@ -461,7 +461,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/shared-timeout-stacking-diff-sources2.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-timeout-stacking-diff-sources2.json
@@ -139,7 +139,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",
@@ -282,7 +282,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/shared-timeout-stacking.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-timeout-stacking.json
@@ -139,7 +139,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",
@@ -282,7 +282,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/shared-timeout.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-timeout.json
@@ -57,7 +57,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/shared-unban.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-unban.json
@@ -54,7 +54,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/shared-untimeout.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-untimeout.json
@@ -54,7 +54,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/slow-off.json
+++ b/tests/snapshots/EventSub/channel-moderate/slow-off.json
@@ -50,7 +50,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/slow.json
+++ b/tests/snapshots/EventSub/channel-moderate/slow.json
@@ -52,7 +52,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/subscribers-off.json
+++ b/tests/snapshots/EventSub/channel-moderate/subscribers-off.json
@@ -50,7 +50,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/subscribers.json
+++ b/tests/snapshots/EventSub/channel-moderate/subscribers.json
@@ -50,7 +50,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/timeout-stacking-reason.json
+++ b/tests/snapshots/EventSub/channel-moderate/timeout-stacking-reason.json
@@ -139,7 +139,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",
@@ -252,7 +252,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/timeout-stacking.json
+++ b/tests/snapshots/EventSub/channel-moderate/timeout-stacking.json
@@ -139,7 +139,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",
@@ -251,7 +251,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/timeout.json
+++ b/tests/snapshots/EventSub/channel-moderate/timeout.json
@@ -57,7 +57,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/unban.json
+++ b/tests/snapshots/EventSub/channel-moderate/unban.json
@@ -54,7 +54,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/uniquechat-off.json
+++ b/tests/snapshots/EventSub/channel-moderate/uniquechat-off.json
@@ -50,7 +50,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/uniquechat.json
+++ b/tests/snapshots/EventSub/channel-moderate/uniquechat.json
@@ -50,7 +50,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/unmod.json
+++ b/tests/snapshots/EventSub/channel-moderate/unmod.json
@@ -54,7 +54,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/unraid.json
+++ b/tests/snapshots/EventSub/channel-moderate/unraid.json
@@ -54,7 +54,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/untimeout.json
+++ b/tests/snapshots/EventSub/channel-moderate/untimeout.json
@@ -54,7 +54,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/warn-shared.json
+++ b/tests/snapshots/EventSub/channel-moderate/warn-shared.json
@@ -55,7 +55,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-moderate/warn.json
+++ b/tests/snapshots/EventSub/channel-moderate/warn.json
@@ -55,7 +55,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-suspicious-user-message/restricted-emote.json
+++ b/tests/snapshots/EventSub/channel-suspicious-user-message/restricted-emote.json
@@ -131,7 +131,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-suspicious-user-message/restricted.json
+++ b/tests/snapshots/EventSub/channel-suspicious-user-message/restricted.json
@@ -128,7 +128,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-suspicious-user-update/monitored.json
+++ b/tests/snapshots/EventSub/channel-suspicious-user-update/monitored.json
@@ -29,7 +29,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-suspicious-user-update/no-treatment.json
+++ b/tests/snapshots/EventSub/channel-suspicious-user-update/no-treatment.json
@@ -29,7 +29,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/EventSub/channel-suspicious-user-update/restricted.json
+++ b/tests/snapshots/EventSub/channel-suspicious-user-update/restricted.json
@@ -29,7 +29,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/action.json
+++ b/tests/snapshots/IrcMessageHandler/action.json
@@ -37,7 +37,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/all-usernames.json
+++ b/tests/snapshots/IrcMessageHandler/all-usernames.json
@@ -35,7 +35,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/announcement.json
+++ b/tests/snapshots/IrcMessageHandler/announcement.json
@@ -37,7 +37,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",
@@ -167,7 +167,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/bad-emotes.json
+++ b/tests/snapshots/IrcMessageHandler/bad-emotes.json
@@ -34,7 +34,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/bad-emotes2.json
+++ b/tests/snapshots/IrcMessageHandler/bad-emotes2.json
@@ -34,7 +34,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/bad-emotes3.json
+++ b/tests/snapshots/IrcMessageHandler/bad-emotes3.json
@@ -33,7 +33,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/bad-emotes4.json
+++ b/tests/snapshots/IrcMessageHandler/bad-emotes4.json
@@ -33,7 +33,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/badges-invalid.json
+++ b/tests/snapshots/IrcMessageHandler/badges-invalid.json
@@ -34,7 +34,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/badges.json
+++ b/tests/snapshots/IrcMessageHandler/badges.json
@@ -35,7 +35,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/bitsbadge.json
+++ b/tests/snapshots/IrcMessageHandler/bitsbadge.json
@@ -18,7 +18,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/cheer1.json
+++ b/tests/snapshots/IrcMessageHandler/cheer1.json
@@ -34,7 +34,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/cheer2.json
+++ b/tests/snapshots/IrcMessageHandler/cheer2.json
@@ -34,7 +34,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/cheer3.json
+++ b/tests/snapshots/IrcMessageHandler/cheer3.json
@@ -34,7 +34,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/cheer4.json
+++ b/tests/snapshots/IrcMessageHandler/cheer4.json
@@ -34,7 +34,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/clearchat-stack-always.json
+++ b/tests/snapshots/IrcMessageHandler/clearchat-stack-always.json
@@ -18,7 +18,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",
@@ -108,7 +108,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/clearchat-stack-never.json
+++ b/tests/snapshots/IrcMessageHandler/clearchat-stack-never.json
@@ -18,7 +18,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/clearchat-stack-no-user.json
+++ b/tests/snapshots/IrcMessageHandler/clearchat-stack-no-user.json
@@ -18,7 +18,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/clearchat.json
+++ b/tests/snapshots/IrcMessageHandler/clearchat.json
@@ -18,7 +18,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/custom-mod.json
+++ b/tests/snapshots/IrcMessageHandler/custom-mod.json
@@ -36,7 +36,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/custom-vip.json
+++ b/tests/snapshots/IrcMessageHandler/custom-vip.json
@@ -36,7 +36,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/emote-emoji.json
+++ b/tests/snapshots/IrcMessageHandler/emote-emoji.json
@@ -37,7 +37,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/emote.json
+++ b/tests/snapshots/IrcMessageHandler/emote.json
@@ -34,7 +34,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/emoteonly-on.json
+++ b/tests/snapshots/IrcMessageHandler/emoteonly-on.json
@@ -18,7 +18,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/emotes.json
+++ b/tests/snapshots/IrcMessageHandler/emotes.json
@@ -34,7 +34,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/emotes2.json
+++ b/tests/snapshots/IrcMessageHandler/emotes2.json
@@ -35,7 +35,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/emotes3.json
+++ b/tests/snapshots/IrcMessageHandler/emotes3.json
@@ -35,7 +35,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/emotes4.json
+++ b/tests/snapshots/IrcMessageHandler/emotes4.json
@@ -33,7 +33,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/emotes5.json
+++ b/tests/snapshots/IrcMessageHandler/emotes5.json
@@ -33,7 +33,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/first-msg.json
+++ b/tests/snapshots/IrcMessageHandler/first-msg.json
@@ -36,7 +36,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/highlight1.json
+++ b/tests/snapshots/IrcMessageHandler/highlight1.json
@@ -33,7 +33,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/highlight2.json
+++ b/tests/snapshots/IrcMessageHandler/highlight2.json
@@ -35,7 +35,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/highlight3.json
+++ b/tests/snapshots/IrcMessageHandler/highlight3.json
@@ -35,7 +35,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/hype-chat-invalid.json
+++ b/tests/snapshots/IrcMessageHandler/hype-chat-invalid.json
@@ -36,7 +36,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/hype-chat0.json
+++ b/tests/snapshots/IrcMessageHandler/hype-chat0.json
@@ -36,7 +36,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",
@@ -176,7 +176,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/hype-chat1.json
+++ b/tests/snapshots/IrcMessageHandler/hype-chat1.json
@@ -38,7 +38,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",
@@ -185,7 +185,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/hype-chat2.json
+++ b/tests/snapshots/IrcMessageHandler/hype-chat2.json
@@ -36,7 +36,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",
@@ -182,7 +182,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/ignore-block1.json
+++ b/tests/snapshots/IrcMessageHandler/ignore-block1.json
@@ -35,7 +35,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/ignore-infinite.json
+++ b/tests/snapshots/IrcMessageHandler/ignore-infinite.json
@@ -35,7 +35,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/ignore-replace.json
+++ b/tests/snapshots/IrcMessageHandler/ignore-replace.json
@@ -35,7 +35,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/justinfan.json
+++ b/tests/snapshots/IrcMessageHandler/justinfan.json
@@ -35,7 +35,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/links.json
+++ b/tests/snapshots/IrcMessageHandler/links.json
@@ -35,7 +35,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/mentions.json
+++ b/tests/snapshots/IrcMessageHandler/mentions.json
@@ -35,7 +35,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/mod.json
+++ b/tests/snapshots/IrcMessageHandler/mod.json
@@ -36,7 +36,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/nickname.json
+++ b/tests/snapshots/IrcMessageHandler/nickname.json
@@ -35,7 +35,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/no-nick.json
+++ b/tests/snapshots/IrcMessageHandler/no-nick.json
@@ -35,7 +35,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/no-tags.json
+++ b/tests/snapshots/IrcMessageHandler/no-tags.json
@@ -33,7 +33,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/raid.json
+++ b/tests/snapshots/IrcMessageHandler/raid.json
@@ -18,7 +18,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/redeemed-highlight.json
+++ b/tests/snapshots/IrcMessageHandler/redeemed-highlight.json
@@ -35,7 +35,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/reply-action.json
+++ b/tests/snapshots/IrcMessageHandler/reply-action.json
@@ -91,7 +91,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/reply-block.json
+++ b/tests/snapshots/IrcMessageHandler/reply-block.json
@@ -91,7 +91,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/reply-blocked-user.json
+++ b/tests/snapshots/IrcMessageHandler/reply-blocked-user.json
@@ -77,7 +77,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/reply-child.json
+++ b/tests/snapshots/IrcMessageHandler/reply-child.json
@@ -91,7 +91,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/reply-ignore.json
+++ b/tests/snapshots/IrcMessageHandler/reply-ignore.json
@@ -91,7 +91,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/reply-no-prev.json
+++ b/tests/snapshots/IrcMessageHandler/reply-no-prev.json
@@ -91,7 +91,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/reply-root.json
+++ b/tests/snapshots/IrcMessageHandler/reply-root.json
@@ -91,7 +91,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/reply-single.json
+++ b/tests/snapshots/IrcMessageHandler/reply-single.json
@@ -95,7 +95,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/reward-bits.json
+++ b/tests/snapshots/IrcMessageHandler/reward-bits.json
@@ -20,7 +20,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",
@@ -183,7 +183,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/reward-empty.json
+++ b/tests/snapshots/IrcMessageHandler/reward-empty.json
@@ -20,7 +20,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",
@@ -133,7 +133,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/reward-known.json
+++ b/tests/snapshots/IrcMessageHandler/reward-known.json
@@ -20,7 +20,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",
@@ -129,7 +129,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/reward-unknown.json
+++ b/tests/snapshots/IrcMessageHandler/reward-unknown.json
@@ -35,7 +35,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/rm-deleted.json
+++ b/tests/snapshots/IrcMessageHandler/rm-deleted.json
@@ -35,7 +35,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/shared-chat-announcement.json
+++ b/tests/snapshots/IrcMessageHandler/shared-chat-announcement.json
@@ -35,7 +35,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",
@@ -200,7 +200,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/shared-chat-emotes.json
+++ b/tests/snapshots/IrcMessageHandler/shared-chat-emotes.json
@@ -35,7 +35,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/shared-chat-known.json
+++ b/tests/snapshots/IrcMessageHandler/shared-chat-known.json
@@ -35,7 +35,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/shared-chat-same-channel.json
+++ b/tests/snapshots/IrcMessageHandler/shared-chat-same-channel.json
@@ -35,7 +35,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/shared-chat-unknown.json
+++ b/tests/snapshots/IrcMessageHandler/shared-chat-unknown.json
@@ -35,7 +35,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/simple.json
+++ b/tests/snapshots/IrcMessageHandler/simple.json
@@ -36,7 +36,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/sub-first-gift.json
+++ b/tests/snapshots/IrcMessageHandler/sub-first-gift.json
@@ -18,7 +18,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/sub-first-time.json
+++ b/tests/snapshots/IrcMessageHandler/sub-first-time.json
@@ -18,7 +18,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/sub-gift.json
+++ b/tests/snapshots/IrcMessageHandler/sub-gift.json
@@ -18,7 +18,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/sub-message.json
+++ b/tests/snapshots/IrcMessageHandler/sub-message.json
@@ -36,7 +36,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",
@@ -201,7 +201,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/sub-multi-month-anon-gift.json
+++ b/tests/snapshots/IrcMessageHandler/sub-multi-month-anon-gift.json
@@ -18,7 +18,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/sub-multi-month-gift-count.json
+++ b/tests/snapshots/IrcMessageHandler/sub-multi-month-gift-count.json
@@ -18,7 +18,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/sub-multi-month-gift.json
+++ b/tests/snapshots/IrcMessageHandler/sub-multi-month-gift.json
@@ -18,7 +18,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/sub-multi-month-resub.json
+++ b/tests/snapshots/IrcMessageHandler/sub-multi-month-resub.json
@@ -18,7 +18,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/sub-multi-month.json
+++ b/tests/snapshots/IrcMessageHandler/sub-multi-month.json
@@ -18,7 +18,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/sub-no-message.json
+++ b/tests/snapshots/IrcMessageHandler/sub-no-message.json
@@ -18,7 +18,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/timeout-stack-always.json
+++ b/tests/snapshots/IrcMessageHandler/timeout-stack-always.json
@@ -18,7 +18,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",
@@ -118,7 +118,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/timeout-stack-never.json
+++ b/tests/snapshots/IrcMessageHandler/timeout-stack-never.json
@@ -18,7 +18,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",
@@ -118,7 +118,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/timeout-stack-no-user.json
+++ b/tests/snapshots/IrcMessageHandler/timeout-stack-no-user.json
@@ -18,7 +18,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",
@@ -116,7 +116,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",
@@ -217,7 +217,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/timeout.json
+++ b/tests/snapshots/IrcMessageHandler/timeout.json
@@ -18,7 +18,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/username-localized.json
+++ b/tests/snapshots/IrcMessageHandler/username-localized.json
@@ -35,7 +35,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/username-localized2.json
+++ b/tests/snapshots/IrcMessageHandler/username-localized2.json
@@ -35,7 +35,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/username.json
+++ b/tests/snapshots/IrcMessageHandler/username.json
@@ -35,7 +35,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",

--- a/tests/snapshots/IrcMessageHandler/vip.json
+++ b/tests/snapshots/IrcMessageHandler/vip.json
@@ -36,7 +36,7 @@
                             "type": "None",
                             "value": ""
                         },
-                        "style": "ChatMedium",
+                        "style": "TimestampMedium",
                         "tooltip": "",
                         "trailingSpace": true,
                         "type": "TextElement",


### PR DESCRIPTION
this will make timestamps a bit wider for some people but will make them always take up the same amount of space, regardless of what time it is

Without this PR:
![without](https://github.com/user-attachments/assets/270594db-4de8-4c41-a9aa-849185517515)

With this PR:
![with](https://github.com/user-attachments/assets/74dd4e67-d9c0-4940-8309-3232e8974589)


Commands used for testing:
```
/fakemsg @tmi-sent-ts=1741687871000;subscriber=1;id=9491503c-6d66-4b68-bd26-19f2e73ff8a7;room-id=11148817;user-id=11148817;display-name=pajlada;badges=broadcaster/1,subscriber/3072,partner/1;badge-info=subscriber/110;color=#CC44FF;flags=;user-type=;emotes=301544922:16-23 :pajlada!pajlada@pajlada.tmi.twitch.tv PRIVMSG #pajlada :hello hello
/fakemsg @tmi-sent-ts=1741690800000;subscriber=1;id=9491503c-6d66-4b68-bd26-19f2e73ff8a7;room-id=11148817;user-id=11148817;display-name=pajlada;badges=broadcaster/1,subscriber/3072,partner/1;badge-info=subscriber/110;color=#CC44FF;flags=;user-type=;emotes=301544922:16-23 :pajlada!pajlada@pajlada.tmi.twitch.tv PRIVMSG #pajlada :hello hello
```