### PR TITLE
fix: hide more pubsub mod actions under streamer mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - Bugfix: Fixed an issue where commands would sometimes reset if Chatterino was improperly shut down. (#6011)
 - Bugfix: Fixed a thick border on Windows 11. (#5836)
 - Bugfix: Fixed some windows not immediately closing. (#6054)
+- Bugfix: Fixed certain types of moderation actions not being hidden in streamer mode. (#6067)
 - Dev: Subscriptions to PubSub channel points redemption topics now use no auth token, making it continue to work during PubSub shutdown. (#5947)
 - Dev: Add initial experimental EventSub support. (#5837, #5895, #5897, #5904, #5910, #5903, #5915, #5916, #5930, #5935, #5932, #5943, #5952, #5953, #5968, #5973, #5974, #5980, #5981, #5985, #5990, #5992, #5993, #5996, #5995, #6000, #6001, #6002, #6003, #6005, #6007, #6010, #6008, #6012, #6013, #6015, #6017, #6027, #6028, #6035, #6036, #6040, #6041, #6048, #6058, #6059)
 - Dev: Remove unneeded platform specifier for toasts. (#5914)

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -1985,6 +1985,7 @@ MessagePtr MessageBuilder::makeLowTrustUpdateMessage(
     builder.emplace<TimestampElement>();
     builder.message().flags.set(MessageFlag::System);
     builder.message().flags.set(MessageFlag::PubSub);
+    builder.message().flags.set(MessageFlag::ModerationAction);
     builder.message().flags.set(MessageFlag::DoNotTriggerNotification);
 
     builder

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -872,6 +872,9 @@ MessageBuilder::MessageBuilder(const WarnAction &action)
 {
     this->emplace<TimestampElement>();
     this->message().flags.set(MessageFlag::System);
+    this->message().flags.set(MessageFlag::PubSub);
+    this->message().flags.set(MessageFlag::ModerationAction);
+    this->message().flags.set(MessageFlag::DoNotTriggerNotification);
 
     QString text;
 

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -747,6 +747,7 @@ MessageBuilder::MessageBuilder(const BanAction &action, const QDateTime &time,
 
     this->emplace<TimestampElement>();
     this->message().flags.set(MessageFlag::System);
+    this->message().flags.set(MessageFlag::PubSub);
     this->message().flags.set(MessageFlag::Timeout);
     this->message().flags.set(MessageFlag::ModerationAction);
     this->message().timeoutUser = action.target.login;
@@ -848,6 +849,7 @@ MessageBuilder::MessageBuilder(const UnbanAction &action, const QDateTime &time)
 {
     this->emplace<TimestampElement>();
     this->message().flags.set(MessageFlag::System);
+    this->message().flags.set(MessageFlag::PubSub);
     this->message().flags.set(MessageFlag::Untimeout);
 
     this->message().timeoutUser = action.target.login;

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -934,6 +934,8 @@ MessageBuilder::MessageBuilder(const AutomodUserAction &action)
 {
     this->emplace<TimestampElement>();
     this->message().flags.set(MessageFlag::System);
+    this->message().flags.set(MessageFlag::PubSub);
+    this->message().flags.set(MessageFlag::ModerationAction);
 
     QString text;
     switch (action.type)


### PR DESCRIPTION
`/warn`, `/(un)monitor`, `/(un)restrict`, `/(add|remove)_(blocked|permitted)_term` were not hidden as moderation actions under streamer mode
