### PR TITLE
chore: check if WEBP is supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 - Dev: Added snapshot tests for EventSub. (#5965)
 - Dev: Updated crashpad. (#6026)
 - Dev: Removed dead code and some MSVC warnings. (#6024)
+- Dev: Added check if WEBP is supported. (#6073)
 
 ## 2.5.2
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -539,6 +539,8 @@ set(SOURCE_FILES
         util/RenameThread.hpp
         util/SampleData.cpp
         util/SampleData.hpp
+        util/SelfCheck.cpp
+        util/SelfCheck.hpp
         util/SharedPtrElementLess.hpp
         util/SignalListener.hpp
         util/StreamLink.cpp

--- a/src/RunGui.cpp
+++ b/src/RunGui.cpp
@@ -11,6 +11,7 @@
 #include "singletons/Settings.hpp"
 #include "singletons/Updates.hpp"
 #include "util/CombinePath.hpp"
+#include "util/SelfCheck.hpp"
 #include "util/UnixSignalHandler.hpp"
 #include "widgets/dialogs/LastRunCrashDialog.hpp"
 
@@ -256,6 +257,8 @@ void runGui(QApplication &a, const Paths &paths, Settings &settings,
         showLastCrashDialog(args, paths);
     }
 #endif
+
+    selfcheck::checkWebp();
 
     updates.deleteOldFiles();
 

--- a/src/util/SelfCheck.cpp
+++ b/src/util/SelfCheck.cpp
@@ -6,6 +6,7 @@
 #include <QImageReader>
 #include <QMessageBox>
 #include <QMimeDatabase>
+#include <QStringBuilder>
 #include <QStringList>
 
 namespace {

--- a/src/util/SelfCheck.cpp
+++ b/src/util/SelfCheck.cpp
@@ -1,0 +1,69 @@
+#include "util/SelfCheck.hpp"
+
+#include "common/Literals.hpp"
+
+#include <QBuffer>
+#include <QImageReader>
+#include <QMessageBox>
+#include <QMimeDatabase>
+#include <QStringList>
+
+namespace {
+
+using namespace chatterino::literals;
+
+// lossy image from https://developers.google.com/speed/webp/faq#in_your_own_javascript
+const QByteArray WEBP_IMAGE =
+    "RIFF\x22\0\0\0WEBPVP8\x20\x16\0\0\0\x30\x01\0\x9d\x01\x2a\x01\0\x01\0\x0e\xc0\xfe\x25\xa4\0\x03p\0\0\0\0"_ba;
+
+}  // namespace
+
+namespace chatterino::selfcheck {
+
+void checkWebp()
+{
+    QStringList messages;
+    QMimeDatabase mimeDb;
+
+    auto mime = mimeDb.mimeTypeForData(WEBP_IMAGE);
+    if (!mime.inherits("image/webp"))
+    {
+        messages.emplace_back(u"Failed to determine MIME type for WEBP image - "
+                              u"detected MIME type: \"" %
+                              mime.name() % '"');
+    }
+
+    QBuffer buffer;
+    buffer.setData(WEBP_IMAGE);
+    QImageReader reader(&buffer);
+
+    if (reader.canRead())
+    {
+        if (reader.imageCount() != 1)
+        {
+            messages.emplace_back(u"Minimal WEBP image doesn't have one (1) "
+                                  u"expected image - got: " %
+                                  QString::number(reader.imageCount()) %
+                                  u" - error: " % reader.errorString());
+        }
+        reader.read();
+    }
+    else
+    {
+        messages.emplace_back(
+            u"Minimal WEBP image can't be read - QImageReader::canRead "
+            u"returned false - error: \"" %
+            reader.errorString() % '"');
+    }
+
+    if (!messages.empty())
+    {
+        QMessageBox::warning(
+            nullptr, u"Chatterino - Sanity Check"_s,
+            u"Your Chatterino instance is not able to load WEBP files.\nMake "
+            u"sure you have qtimageformats installed.\n\n" %
+                messages.join(u"\n\n"));
+    }
+}
+
+}  // namespace chatterino::selfcheck

--- a/src/util/SelfCheck.hpp
+++ b/src/util/SelfCheck.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace chatterino::selfcheck {
+
+/// Checks if WEBPs can be loaded
+void checkWebp();
+
+}  // namespace chatterino::selfcheck


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

All third party emote providers require WEBP. Some users forget to install qtimageformats. This results in missing images. This PR makes sure we are able to load WEBP images and shows a warning if we aren't.

In the future, we could move PNGs to lossless WEBPs. They're almost always smaller.