### PR TITLE
feat(eventsub): handle multi enum constant keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@
 - Bugfix: Fixed a thick border on Windows 11. (#5836)
 - Bugfix: Fixed some windows not immediately closing. (#6054)
 - Dev: Subscriptions to PubSub channel points redemption topics now use no auth token, making it continue to work during PubSub shutdown. (#5947)
-- Dev: Add initial experimental EventSub support. (#5837, #5895, #5897, #5904, #5910, #5903, #5915, #5916, #5930, #5935, #5932, #5943, #5952, #5953, #5968, #5973, #5974, #5980, #5981, #5985, #5990, #5992, #5993, #5996, #5995, #6000, #6001, #6002, #6003, #6005, #6007, #6010, #6008, #6012, #6013, #6015, #6017, #6027, #6028, #6035, #6036, #6040, #6041, #6048, #6058, #6059)
+- Dev: Add initial experimental EventSub support. (#5837, #5895, #5897, #5904, #5910, #5903, #5915, #5916, #5930, #5935, #5932, #5943, #5952, #5953, #5968, #5973, #5974, #5980, #5981, #5985, #5990, #5992, #5993, #5996, #5995, #6000, #6001, #6002, #6003, #6005, #6007, #6010, #6008, #6012, #6013, #6015, #6017, #6027, #6028, #6035, #6036, #6040, #6041, #6048, #6058, #6059, #6078)
 - Dev: Remove unneeded platform specifier for toasts. (#5914)
 - Dev: Cleanly shutdown on `SIGINT`/`SIGTERM` on Linux & macOS. (#6053)
 - Dev: Highlight checks now use non-capturing groups for the boundaries. (#5784)

--- a/lib/twitch-eventsub-ws/ast/lib/comment_commands.py
+++ b/lib/twitch-eventsub-ws/ast/lib/comment_commands.py
@@ -16,6 +16,10 @@ class CommentCommands:
     # If set, `name_transform` will do nothing
     name_change: Optional[str] = None
 
+    # Whether the enum constant should look for additional keys
+    # `name_transform` is not applied to these
+    extra_enum_constant_names: list[str] = []
+
     # Don't fail when an optional object exists and its data is bad
     dont_fail_on_deserialization: bool = False
 
@@ -31,6 +35,7 @@ class CommentCommands:
         if parent is not None:
             self.name_transform = parent.name_transform
             self.name_change = parent.name_change
+            self.extra_enum_constant_names = parent.extra_enum_constant_names
             self.dont_fail_on_deserialization = parent.dont_fail_on_deserialization
             self.tag = parent.tag
             self.inner_root = parent.inner_root
@@ -52,6 +57,8 @@ class CommentCommands:
             match command:
                 case "json_rename":
                     self.name_change = value
+                case "json_extra_enum_constant_names":
+                    self.extra_enum_constant_names = [v.strip() for v in value.split(",")]
                 case "json_dont_fail_on_deserialization":
                     self.dont_fail_on_deserialization = bool(value.lower() == "true")
                 case "json_transform":

--- a/lib/twitch-eventsub-ws/ast/lib/enum_constant.py
+++ b/lib/twitch-eventsub-ws/ast/lib/enum_constant.py
@@ -18,12 +18,14 @@ class EnumConstant:
     ) -> None:
         self.name = name
         self.json_name = name
+        self.json_extra_enum_constant_names: list[str] = []
         self.tag: Optional[str] = None
 
         self.dont_fail_on_deserialization: bool = False
 
     def apply_comment_commands(self, comment_commands: CommentCommands) -> None:
         self.json_name = comment_commands.apply_name_transform(self.json_name)
+        self.json_extra_enum_constant_names = comment_commands.extra_enum_constant_names
         self.tag = comment_commands.tag
         self.dont_fail_on_deserialization = comment_commands.dont_fail_on_deserialization
 

--- a/lib/twitch-eventsub-ws/ast/lib/templates/enum-implementation.tmpl
+++ b/lib/twitch-eventsub-ws/ast/lib/templates/enum-implementation.tmpl
@@ -13,6 +13,11 @@ boost::json::result_for<{{enum.full_name}}, boost::json::value>::type tag_invoke
     if (eString == "{{constant.json_name}}"sv) {
         return {{enum.full_name}}::{{constant.name}};
     }
+{%- for extra_name in constant.json_extra_enum_constant_names -%}
+    if (eString == "{{extra_name}}"sv) {
+        return {{enum.full_name}}::{{constant.name}};
+    }
+{%- endfor -%}
 {%- endfor %}
 
 {%- if enum.default -%}

--- a/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/payloads/suspicious-users.hpp
+++ b/lib/twitch-eventsub-ws/include/twitch-eventsub-ws/payloads/suspicious-users.hpp
@@ -16,8 +16,12 @@ enum class Status : std::uint8_t {
 /// default=Unknown
 enum class Type : std::uint8_t {
     Unknown,
+    /// The user was marked as Low Trust by a moderator
+    /// json_extra_enum_constant_names=manually_added
     Manual,
+    /// The user was detected as a ban evader
     BanEvaderDetector,
+    /// The user is banned in a channel the channel shares bans with
     SharedChannelBan
 };
 

--- a/lib/twitch-eventsub-ws/src/generated/payloads/suspicious-users.cpp
+++ b/lib/twitch-eventsub-ws/src/generated/payloads/suspicious-users.cpp
@@ -53,6 +53,10 @@ boost::json::result_for<Type, boost::json::value>::type tag_invoke(
     {
         return Type::Manual;
     }
+    if (eString == "manually_added"sv)
+    {
+        return Type::Manual;
+    }
     if (eString == "ban_evader_detector"sv)
     {
         return Type::BanEvaderDetector;


### PR DESCRIPTION
enum constants can have `/// extra_enum_constant_names` applied to allow for different strings to match to the same types

this is useful if the documentation is wrong and we're unsure for which is actually correct :-)
