### PR TITLE
fix: correctly scale SelectChannelDialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - Bugfix: Fixed a crash that would occurr if the user tried to open the search popup in an uninitialized split. (#6057)
 - Bugfix: Fixed an issue where commands would sometimes reset if Chatterino was improperly shut down. (#6011)
 - Bugfix: Fixed a thick border on Windows 11. (#5836)
+- Bugfix: Fixed an issue where the Select Channel Dialog did not correctly scale when your window scale was too high. (#6081)
 - Bugfix: Fixed some windows not immediately closing. (#6054)
 - Bugfix: The emote button no longer looks crunchy. (#6080)
 - Dev: Subscriptions to PubSub channel points redemption topics now use no auth token, making it continue to work during PubSub shutdown. (#5947)

--- a/src/common/Channel.cpp
+++ b/src/common/Channel.cpp
@@ -440,16 +440,14 @@ pajlada::Signals::NoArgSignal &IndirectChannel::getChannelChanged()
     return this->data_->changed;
 }
 
-Channel::Type IndirectChannel::getType()
+Channel::Type IndirectChannel::getType() const
 {
     if (this->data_->type == Channel::Type::Direct)
     {
         return this->get()->getType();
     }
-    else
-    {
-        return this->data_->type;
-    }
+
+    return this->data_->type;
 }
 
 }  // namespace chatterino

--- a/src/common/Channel.hpp
+++ b/src/common/Channel.hpp
@@ -164,7 +164,7 @@ public:
     ChannelPtr get() const;
     void reset(ChannelPtr channel);
     pajlada::Signals::NoArgSignal &getChannelChanged();
-    Channel::Type getType();
+    Channel::Type getType() const;
 
 private:
     std::shared_ptr<Data> data_;

--- a/src/widgets/dialogs/SelectChannelDialog.cpp
+++ b/src/widgets/dialogs/SelectChannelDialog.cpp
@@ -46,7 +46,6 @@ SelectChannelDialog::SelectChannelDialog(QWidget *parent)
 
     ui.channelLabel = new QLabel("Join a Twitch channel by its channel name");
     ui.channelLabel->setVisible(false);
-    ui.channelLabel->setFocusPolicy(Qt::FocusPolicy::NoFocus);
     layout->addWidget(ui.channelLabel);
 
     ui.channelName = new QLineEdit();
@@ -76,7 +75,6 @@ SelectChannelDialog::SelectChannelDialog(QWidget *parent)
     ui.whispersLabel = new QLabel(
         "Shows the whispers that you receive\nwhile Chatterino is running");
     ui.whispersLabel->setVisible(false);
-    ui.whispersLabel->setFocusPolicy(Qt::FocusPolicy::NoFocus);
     layout->addWidget(ui.whispersLabel);
 
     QObject::connect(ui.whispers, &AutoCheckedRadioButton::toggled, this,
@@ -94,7 +92,6 @@ SelectChannelDialog::SelectChannelDialog(QWidget *parent)
     ui.mentionsLabel = new QLabel(
         "Shows all the messages that\nhighlight you from any channel");
     ui.mentionsLabel->setVisible(false);
-    ui.mentionsLabel->setFocusPolicy(Qt::FocusPolicy::NoFocus);
     layout->addWidget(ui.mentionsLabel);
 
     QObject::connect(ui.mentions, &AutoCheckedRadioButton::toggled, this,

--- a/src/widgets/dialogs/SelectChannelDialog.cpp
+++ b/src/widgets/dialogs/SelectChannelDialog.cpp
@@ -37,7 +37,7 @@ SelectChannelDialog::SelectChannelDialog(QWidget *parent)
 
     this->tabFilter_.dialog = this;
 
-    auto *layout = new QVBoxLayout;
+    auto *layout = new QVBoxLayout(this);
 
     auto &ui = this->ui_;
     // Channel
@@ -163,8 +163,6 @@ SelectChannelDialog::SelectChannelDialog(QWidget *parent)
     QObject::connect(buttonBox, &QDialogButtonBox::rejected, [this] {
         this->close();
     });
-
-    this->setLayout(layout);
 
     this->addShortcuts();
 

--- a/src/widgets/dialogs/SelectChannelDialog.cpp
+++ b/src/widgets/dialogs/SelectChannelDialog.cpp
@@ -53,7 +53,7 @@ SelectChannelDialog::SelectChannelDialog(QWidget *parent)
     layout->addWidget(ui.channelName);
 
     QObject::connect(ui.channel, &AutoCheckedRadioButton::toggled, this,
-                     [this](bool enabled) mutable {
+                     [this](bool enabled) {
                          auto &ui = this->ui_;
                          if (enabled)
                          {
@@ -78,7 +78,7 @@ SelectChannelDialog::SelectChannelDialog(QWidget *parent)
     layout->addWidget(ui.whispersLabel);
 
     QObject::connect(ui.whispers, &AutoCheckedRadioButton::toggled, this,
-                     [this](bool enabled) mutable {
+                     [this](bool enabled) {
                          auto &ui = this->ui_;
                          ui.whispersLabel->setVisible(enabled);
                      });
@@ -95,7 +95,7 @@ SelectChannelDialog::SelectChannelDialog(QWidget *parent)
     layout->addWidget(ui.mentionsLabel);
 
     QObject::connect(ui.mentions, &AutoCheckedRadioButton::toggled, this,
-                     [this](bool enabled) mutable {
+                     [this](bool enabled) {
                          auto &ui = this->ui_;
                          ui.mentionsLabel->setVisible(enabled);
                      });
@@ -111,7 +111,7 @@ SelectChannelDialog::SelectChannelDialog(QWidget *parent)
     layout->addWidget(ui.watchingLabel);
 
     QObject::connect(ui.watching, &AutoCheckedRadioButton::toggled, this,
-                     [this](bool enabled) mutable {
+                     [this](bool enabled) {
                          auto &ui = this->ui_;
                          ui.watchingLabel->setVisible(enabled);
                      });
@@ -127,7 +127,7 @@ SelectChannelDialog::SelectChannelDialog(QWidget *parent)
     layout->addWidget(ui.liveLabel);
 
     QObject::connect(ui.live, &AutoCheckedRadioButton::toggled, this,
-                     [this](bool enabled) mutable {
+                     [this](bool enabled) {
                          auto &ui = this->ui_;
                          ui.liveLabel->setVisible(enabled);
                      });
@@ -144,7 +144,7 @@ SelectChannelDialog::SelectChannelDialog(QWidget *parent)
     layout->addWidget(ui.automodLabel);
 
     QObject::connect(ui.automod, &AutoCheckedRadioButton::toggled, this,
-                     [this](bool enabled) mutable {
+                     [this](bool enabled) {
                          auto &ui = this->ui_;
                          ui.automodLabel->setVisible(enabled);
                      });

--- a/src/widgets/dialogs/SelectChannelDialog.cpp
+++ b/src/widgets/dialogs/SelectChannelDialog.cpp
@@ -73,8 +73,9 @@ SelectChannelDialog::SelectChannelDialog(QWidget *parent)
     layout->addWidget(ui.whispers);
 
     ui.whispersLabel = new QLabel(
-        "Shows the whispers that you receive\nwhile Chatterino is running");
+        "Shows the whispers that you receive while Chatterino is running");
     ui.whispersLabel->setVisible(false);
+    ui.whispersLabel->setWordWrap(true);
     layout->addWidget(ui.whispersLabel);
 
     QObject::connect(ui.whispers, &AutoCheckedRadioButton::toggled, this,
@@ -90,8 +91,9 @@ SelectChannelDialog::SelectChannelDialog(QWidget *parent)
     layout->addWidget(ui.mentions);
 
     ui.mentionsLabel = new QLabel(
-        "Shows all the messages that\nhighlight you from any channel");
+        "Shows all the messages that highlight you from any channel");
     ui.mentionsLabel->setVisible(false);
+    ui.mentionsLabel->setWordWrap(true);
     layout->addWidget(ui.mentionsLabel);
 
     QObject::connect(ui.mentions, &AutoCheckedRadioButton::toggled, this,
@@ -138,9 +140,10 @@ SelectChannelDialog::SelectChannelDialog(QWidget *parent)
     ui.automod = new AutoCheckedRadioButton("AutoMod");
     layout->addWidget(ui.automod);
 
-    ui.automodLabel = new QLabel("Shows when AutoMod catches a message\nin "
+    ui.automodLabel = new QLabel("Shows when AutoMod catches a message in "
                                  "any channel you moderate.");
     ui.automodLabel->setVisible(false);
+    ui.automodLabel->setWordWrap(true);
     layout->addWidget(ui.automodLabel);
 
     QObject::connect(ui.automod, &AutoCheckedRadioButton::toggled, this,

--- a/src/widgets/dialogs/SelectChannelDialog.cpp
+++ b/src/widgets/dialogs/SelectChannelDialog.cpp
@@ -110,13 +110,13 @@ SelectChannelDialog::SelectChannelDialog(QWidget *parent)
     ui.watchingLabel->setVisible(false);
     layout->addWidget(ui.watchingLabel);
 
-    ui.watching->installEventFilter(&this->tabFilter_);
-
     QObject::connect(ui.watching, &AutoCheckedRadioButton::toggled, this,
                      [this](bool enabled) mutable {
                          auto &ui = this->ui_;
                          ui.watchingLabel->setVisible(enabled);
                      });
+
+    ui.watching->installEventFilter(&this->tabFilter_);
 
     // Live
     ui.live = new AutoCheckedRadioButton("Live");
@@ -126,13 +126,13 @@ SelectChannelDialog::SelectChannelDialog(QWidget *parent)
     ui.liveLabel->setVisible(false);
     layout->addWidget(ui.liveLabel);
 
-    ui.live->installEventFilter(&this->tabFilter_);
-
     QObject::connect(ui.live, &AutoCheckedRadioButton::toggled, this,
                      [this](bool enabled) mutable {
                          auto &ui = this->ui_;
                          ui.liveLabel->setVisible(enabled);
                      });
+
+    ui.live->installEventFilter(&this->tabFilter_);
 
     // Automod
     ui.automod = new AutoCheckedRadioButton("AutoMod");
@@ -143,13 +143,13 @@ SelectChannelDialog::SelectChannelDialog(QWidget *parent)
     ui.automodLabel->setVisible(false);
     layout->addWidget(ui.automodLabel);
 
-    ui.automod->installEventFilter(&this->tabFilter_);
-
     QObject::connect(ui.automod, &AutoCheckedRadioButton::toggled, this,
                      [this](bool enabled) mutable {
                          auto &ui = this->ui_;
                          ui.automodLabel->setVisible(enabled);
                      });
+
+    ui.automod->installEventFilter(&this->tabFilter_);
 
     layout->addStretch(1);
 

--- a/src/widgets/dialogs/SelectChannelDialog.cpp
+++ b/src/widgets/dialogs/SelectChannelDialog.cpp
@@ -37,7 +37,7 @@ SelectChannelDialog::SelectChannelDialog(QWidget *parent)
 
     this->tabFilter_.dialog = this;
 
-    auto *layout = new QVBoxLayout(this);
+    auto *layout = new QVBoxLayout(this->getLayoutContainer());
 
     auto &ui = this->ui_;
     // Channel

--- a/src/widgets/dialogs/SelectChannelDialog.cpp
+++ b/src/widgets/dialogs/SelectChannelDialog.cpp
@@ -155,10 +155,6 @@ SelectChannelDialog::SelectChannelDialog(QWidget *parent)
 
     auto *buttonBox =
         new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
-    for (auto *button : buttonBox->buttons())
-    {
-        button->setFocusPolicy(Qt::ClickFocus);
-    }
     layout->addWidget(buttonBox);
 
     QObject::connect(buttonBox, &QDialogButtonBox::accepted, this, [this] {

--- a/src/widgets/dialogs/SelectChannelDialog.cpp
+++ b/src/widgets/dialogs/SelectChannelDialog.cpp
@@ -283,98 +283,81 @@ bool SelectChannelDialog::EventFilter::eventFilter(QObject *watched,
 
     auto &ui = this->dialog->ui_;
 
-    switch (event->type())
+    if (event->type() == QEvent::KeyPress)
     {
-        case QEvent::KeyPress: {
-            auto *keyEvent = dynamic_cast<QKeyEvent *>(event);
-            assert(keyEvent);
+        auto *keyEvent = dynamic_cast<QKeyEvent *>(event);
+        assert(keyEvent);
 
-            if ((keyEvent->key() == Qt::Key_Tab ||
-                 keyEvent->key() == Qt::Key_Down) &&
-                keyEvent->modifiers() == Qt::NoModifier)
+        if ((keyEvent->key() == Qt::Key_Tab ||
+             keyEvent->key() == Qt::Key_Down) &&
+            keyEvent->modifiers() == Qt::NoModifier)
+        {
+            // Tab has been pressed, focus next entry in list
+
+            if (widget == ui.channelName)
             {
-                // Tab has been pressed, focus next entry in list
-
-                if (widget == ui.channelName)
-                {
-                    // Special case for when current selection is the "Channel" entry's edit box since the Edit box actually has the focus
-                    ui.whispers->setFocus();
-                    return true;
-                }
-
-                if (widget == ui.automod)
-                {
-                    // Special case for when current selection is "AutoMod" (the last entry in the list), next wrap is Channel, but we need to select its edit box
-                    ui.channel->setFocus();
-                    return true;
-                }
-
-                auto *nextInFocusChain = widget->nextInFocusChain();
-                if (nextInFocusChain->focusPolicy() == Qt::FocusPolicy::NoFocus)
-                {
-                    // Make sure we're not selecting one of the labels
-                    nextInFocusChain = nextInFocusChain->nextInFocusChain();
-                }
-                nextInFocusChain->setFocus();
+                // Special case for when current selection is the "Channel" entry's edit box since the Edit box actually has the focus
+                ui.whispers->setFocus();
                 return true;
             }
 
-            if (((keyEvent->key() == Qt::Key_Tab ||
-                  keyEvent->key() == Qt::Key_Backtab) &&
-                 keyEvent->modifiers() == Qt::ShiftModifier) ||
-                ((keyEvent->key() == Qt::Key_Up) &&
-                 keyEvent->modifiers() == Qt::NoModifier))
+            if (widget == ui.automod)
             {
-                // Shift+Tab has been pressed, focus previous entry in list
-
-                if (widget == ui.channelName)
-                {
-                    // Special case for when current selection is the "Channel" entry's edit box since the Edit box actually has the focus
-                    ui.automod->setFocus();
-                    return true;
-                }
-
-                if (widget == ui.whispers)
-                {
-                    ui.channel->setFocus();
-                    return true;
-                }
-
-                auto *previousInFocusChain = widget->previousInFocusChain();
-                if (previousInFocusChain->focusPolicy() ==
-                    Qt::FocusPolicy::NoFocus)
-                {
-                    // Make sure we're not selecting one of the labels
-                    previousInFocusChain =
-                        previousInFocusChain->previousInFocusChain();
-                }
-                previousInFocusChain->setFocus();
+                // Special case for when current selection is "AutoMod" (the last entry in the list), next wrap is Channel, but we need to select its edit box
+                ui.channel->setFocus();
                 return true;
             }
 
-            if (keyEvent == QKeySequence::DeleteStartOfWord &&
-                ui.channelName->selectionLength() > 0)
+            auto *nextInFocusChain = widget->nextInFocusChain();
+            if (nextInFocusChain->focusPolicy() == Qt::FocusPolicy::NoFocus)
             {
-                ui.channelName->backspace();
-                return true;
+                // Make sure we're not selecting one of the labels
+                nextInFocusChain = nextInFocusChain->nextInFocusChain();
             }
-
-            return false;
+            nextInFocusChain->setFocus();
+            return true;
         }
-        break;
 
-        case QEvent::KeyRelease: {
-            auto *keyEvent = dynamic_cast<QKeyEvent *>(event);
-            assert(keyEvent);
+        if (((keyEvent->key() == Qt::Key_Tab ||
+              keyEvent->key() == Qt::Key_Backtab) &&
+             keyEvent->modifiers() == Qt::ShiftModifier) ||
+            ((keyEvent->key() == Qt::Key_Up) &&
+             keyEvent->modifiers() == Qt::NoModifier))
+        {
+            // Shift+Tab has been pressed, focus previous entry in list
 
-            if ((keyEvent->key() == Qt::Key_Backtab ||
-                 keyEvent->key() == Qt::Key_Down) &&
-                keyEvent->modifiers() == Qt::NoModifier)
+            if (widget == ui.channelName)
             {
+                // Special case for when current selection is the "Channel" entry's edit box since the Edit box actually has the focus
+                ui.automod->setFocus();
                 return true;
             }
+
+            if (widget == ui.whispers)
+            {
+                ui.channel->setFocus();
+                return true;
+            }
+
+            auto *previousInFocusChain = widget->previousInFocusChain();
+            if (previousInFocusChain->focusPolicy() == Qt::FocusPolicy::NoFocus)
+            {
+                // Make sure we're not selecting one of the labels
+                previousInFocusChain =
+                    previousInFocusChain->previousInFocusChain();
+            }
+            previousInFocusChain->setFocus();
+            return true;
         }
-        break;
+
+        if (keyEvent == QKeySequence::DeleteStartOfWord &&
+            ui.channelName->selectionLength() > 0)
+        {
+            ui.channelName->backspace();
+            return true;
+        }
+
+        return false;
     }
 
     return false;

--- a/src/widgets/dialogs/SelectChannelDialog.cpp
+++ b/src/widgets/dialogs/SelectChannelDialog.cpp
@@ -288,12 +288,12 @@ bool SelectChannelDialog::EventFilter::eventFilter(QObject *watched,
     switch (event->type())
     {
         case QEvent::KeyPress: {
-            auto *event_key = dynamic_cast<QKeyEvent *>(event);
-            assert(event_key);
+            auto *keyEvent = dynamic_cast<QKeyEvent *>(event);
+            assert(keyEvent);
 
-            if ((event_key->key() == Qt::Key_Tab ||
-                 event_key->key() == Qt::Key_Down) &&
-                event_key->modifiers() == Qt::NoModifier)
+            if ((keyEvent->key() == Qt::Key_Tab ||
+                 keyEvent->key() == Qt::Key_Down) &&
+                keyEvent->modifiers() == Qt::NoModifier)
             {
                 // Tab has been pressed, focus next entry in list
 
@@ -321,11 +321,11 @@ bool SelectChannelDialog::EventFilter::eventFilter(QObject *watched,
                 return true;
             }
 
-            if (((event_key->key() == Qt::Key_Tab ||
-                  event_key->key() == Qt::Key_Backtab) &&
-                 event_key->modifiers() == Qt::ShiftModifier) ||
-                ((event_key->key() == Qt::Key_Up) &&
-                 event_key->modifiers() == Qt::NoModifier))
+            if (((keyEvent->key() == Qt::Key_Tab ||
+                  keyEvent->key() == Qt::Key_Backtab) &&
+                 keyEvent->modifiers() == Qt::ShiftModifier) ||
+                ((keyEvent->key() == Qt::Key_Up) &&
+                 keyEvent->modifiers() == Qt::NoModifier))
             {
                 // Shift+Tab has been pressed, focus previous entry in list
 
@@ -354,7 +354,7 @@ bool SelectChannelDialog::EventFilter::eventFilter(QObject *watched,
                 return true;
             }
 
-            if (event_key == QKeySequence::DeleteStartOfWord &&
+            if (keyEvent == QKeySequence::DeleteStartOfWord &&
                 ui.channelName->selectionLength() > 0)
             {
                 ui.channelName->backspace();
@@ -366,12 +366,12 @@ bool SelectChannelDialog::EventFilter::eventFilter(QObject *watched,
         break;
 
         case QEvent::KeyRelease: {
-            auto *event_key = dynamic_cast<QKeyEvent *>(event);
-            assert(event_key);
+            auto *keyEvent = dynamic_cast<QKeyEvent *>(event);
+            assert(keyEvent);
 
-            if ((event_key->key() == Qt::Key_Backtab ||
-                 event_key->key() == Qt::Key_Down) &&
-                event_key->modifiers() == Qt::NoModifier)
+            if ((keyEvent->key() == Qt::Key_Backtab ||
+                 keyEvent->key() == Qt::Key_Down) &&
+                keyEvent->modifiers() == Qt::NoModifier)
             {
                 return true;
             }

--- a/src/widgets/dialogs/SelectChannelDialog.cpp
+++ b/src/widgets/dialogs/SelectChannelDialog.cpp
@@ -1,20 +1,17 @@
 #include "widgets/dialogs/SelectChannelDialog.hpp"
 
 #include "Application.hpp"
-#include "common/QLogging.hpp"
 #include "controllers/hotkeys/HotkeyController.hpp"
 #include "providers/twitch/TwitchIrcServer.hpp"
-#include "singletons/Settings.hpp"
+#include "singletons/Fonts.hpp"
 #include "singletons/Theme.hpp"
-#include "util/LayoutCreator.hpp"
-#include "widgets/helper/EditableModelView.hpp"
-#include "widgets/helper/NotebookTab.hpp"
-#include "widgets/Notebook.hpp"
 
 #include <QDialogButtonBox>
+#include <QEvent>
 #include <QFormLayout>
 #include <QGroupBox>
 #include <QHeaderView>
+#include <QKeyEvent>
 #include <QLabel>
 #include <QLineEdit>
 #include <QPushButton>
@@ -22,8 +19,6 @@
 #include <QVBoxLayout>
 
 namespace chatterino {
-
-constexpr int TAB_TWITCH = 0;
 
 SelectChannelDialog::SelectChannelDialog(QWidget *parent)
     : BaseWindow(
@@ -36,159 +31,147 @@ SelectChannelDialog::SelectChannelDialog(QWidget *parent)
           parent)
     , selectedChannel_(Channel::getEmpty())
 {
+    using AutoCheckedRadioButton = detail::AutoCheckedRadioButton;
+
     this->setWindowTitle("Select a channel to join");
 
     this->tabFilter_.dialog = this;
 
-    LayoutCreator<QWidget> layoutWidget(this->getLayoutContainer());
-    auto layout = layoutWidget.setLayoutType<QVBoxLayout>().withoutMargin();
-    auto notebook = layout.emplace<Notebook>(this).assign(&this->ui_.notebook);
+    auto *layout = new QVBoxLayout;
 
-    // twitch
+    auto &ui = this->ui_;
+    // Channel
+    ui.channel = new AutoCheckedRadioButton("Channel");
+    layout->addWidget(ui.channel);
+
+    ui.channelLabel = new QLabel("Join a Twitch channel by its channel name");
+    ui.channelLabel->setVisible(false);
+    ui.channelLabel->setFocusPolicy(Qt::FocusPolicy::NoFocus);
+    layout->addWidget(ui.channelLabel);
+
+    ui.channelName = new QLineEdit();
+    ui.channelName->setVisible(false);
+    layout->addWidget(ui.channelName);
+
+    QObject::connect(ui.channel, &AutoCheckedRadioButton::toggled, this,
+                     [this](bool enabled) mutable {
+                         auto &ui = this->ui_;
+                         if (enabled)
+                         {
+                             ui.channelName->setFocus();
+                             ui.channelName->selectAll();
+                         }
+
+                         ui.channelName->setVisible(enabled);
+                         ui.channelLabel->setVisible(enabled);
+                     });
+
+    ui.channel->installEventFilter(&this->tabFilter_);
+    ui.channelName->installEventFilter(&this->tabFilter_);
+
+    // Whispers
+    ui.whispers = new AutoCheckedRadioButton("Whispers");
+    layout->addWidget(ui.whispers);
+
+    ui.whispersLabel = new QLabel(
+        "Shows the whispers that you receive\nwhile Chatterino is running");
+    ui.whispersLabel->setVisible(false);
+    ui.whispersLabel->setFocusPolicy(Qt::FocusPolicy::NoFocus);
+    layout->addWidget(ui.whispersLabel);
+
+    QObject::connect(ui.whispers, &AutoCheckedRadioButton::toggled, this,
+                     [this](bool enabled) mutable {
+                         auto &ui = this->ui_;
+                         ui.whispersLabel->setVisible(enabled);
+                     });
+
+    ui.whispers->installEventFilter(&this->tabFilter_);
+
+    // Mentions
+    ui.mentions = new AutoCheckedRadioButton("Mentions");
+    layout->addWidget(ui.mentions);
+
+    ui.mentionsLabel = new QLabel(
+        "Shows all the messages that\nhighlight you from any channel");
+    ui.mentionsLabel->setVisible(false);
+    ui.mentionsLabel->setFocusPolicy(Qt::FocusPolicy::NoFocus);
+    layout->addWidget(ui.mentionsLabel);
+
+    QObject::connect(ui.mentions, &AutoCheckedRadioButton::toggled, this,
+                     [this](bool enabled) mutable {
+                         auto &ui = this->ui_;
+                         ui.mentionsLabel->setVisible(enabled);
+                     });
+
+    ui.mentions->installEventFilter(&this->tabFilter_);
+
+    // Watching
+    ui.watching = new AutoCheckedRadioButton("Watching");
+    layout->addWidget(ui.watching);
+
+    ui.watchingLabel = new QLabel("Requires the Chatterino browser extension");
+    ui.watchingLabel->setVisible(false);
+    layout->addWidget(ui.watchingLabel);
+
+    ui.watching->installEventFilter(&this->tabFilter_);
+
+    QObject::connect(ui.watching, &AutoCheckedRadioButton::toggled, this,
+                     [this](bool enabled) mutable {
+                         auto &ui = this->ui_;
+                         ui.watchingLabel->setVisible(enabled);
+                     });
+
+    // Live
+    ui.live = new AutoCheckedRadioButton("Live");
+    layout->addWidget(ui.live);
+
+    ui.liveLabel = new QLabel("Shows when channels go live");
+    ui.liveLabel->setVisible(false);
+    layout->addWidget(ui.liveLabel);
+
+    ui.live->installEventFilter(&this->tabFilter_);
+
+    QObject::connect(ui.live, &AutoCheckedRadioButton::toggled, this,
+                     [this](bool enabled) mutable {
+                         auto &ui = this->ui_;
+                         ui.liveLabel->setVisible(enabled);
+                     });
+
+    // Automod
+    ui.automod = new AutoCheckedRadioButton("AutoMod");
+    layout->addWidget(ui.automod);
+
+    ui.automodLabel = new QLabel("Shows when AutoMod catches a message\nin "
+                                 "any channel you moderate.");
+    ui.automodLabel->setVisible(false);
+    layout->addWidget(ui.automodLabel);
+
+    ui.automod->installEventFilter(&this->tabFilter_);
+
+    QObject::connect(ui.automod, &AutoCheckedRadioButton::toggled, this,
+                     [this](bool enabled) mutable {
+                         auto &ui = this->ui_;
+                         ui.automodLabel->setVisible(enabled);
+                     });
+
+    layout->addStretch(1);
+
+    auto *buttonBox =
+        new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
+    for (auto *button : buttonBox->buttons())
     {
-        LayoutCreator<QWidget> obj(new QWidget());
-        auto vbox = obj.setLayoutType<QVBoxLayout>();
-
-        // channel_btn
-        auto channel_btn = vbox.emplace<QRadioButton>("Channel").assign(
-            &this->ui_.twitch.channel);
-        auto channel_lbl =
-            vbox.emplace<QLabel>("Join a Twitch channel by its name.").hidden();
-        channel_lbl->setWordWrap(true);
-        auto channel_edit = vbox.emplace<QLineEdit>().hidden().assign(
-            &this->ui_.twitch.channelName);
-
-        QObject::connect(channel_btn.getElement(), &QRadioButton::toggled,
-                         [=](bool enabled) mutable {
-                             if (enabled)
-                             {
-                                 channel_edit->setFocus();
-                                 channel_edit->setSelection(
-                                     0, channel_edit->text().length());
-                             }
-
-                             channel_edit->setVisible(enabled);
-                             channel_lbl->setVisible(enabled);
-                         });
-
-        channel_btn->installEventFilter(&this->tabFilter_);
-        channel_edit->installEventFilter(&this->tabFilter_);
-
-        // whispers_btn
-        auto whispers_btn = vbox.emplace<QRadioButton>("Whispers")
-                                .assign(&this->ui_.twitch.whispers);
-        auto whispers_lbl =
-            vbox.emplace<QLabel>("Shows the whispers that you receive while "
-                                 "Chatterino is running.")
-                .hidden();
-
-        whispers_lbl->setWordWrap(true);
-        whispers_btn->installEventFilter(&this->tabFilter_);
-
-        QObject::connect(whispers_btn.getElement(), &QRadioButton::toggled,
-                         [=](bool enabled) mutable {
-                             whispers_lbl->setVisible(enabled);
-                         });
-
-        // mentions_btn
-        auto mentions_btn = vbox.emplace<QRadioButton>("Mentions")
-                                .assign(&this->ui_.twitch.mentions);
-        auto mentions_lbl =
-            vbox.emplace<QLabel>("Shows all the messages that highlight you "
-                                 "from any channel.")
-                .hidden();
-
-        mentions_lbl->setWordWrap(true);
-        mentions_btn->installEventFilter(&this->tabFilter_);
-
-        QObject::connect(mentions_btn.getElement(), &QRadioButton::toggled,
-                         [=](bool enabled) mutable {
-                             mentions_lbl->setVisible(enabled);
-                         });
-
-        // watching_btn
-        auto watching_btn = vbox.emplace<QRadioButton>("Watching")
-                                .assign(&this->ui_.twitch.watching);
-        auto watching_lbl =
-            vbox.emplace<QLabel>("Requires the Chatterino browser extension.")
-                .hidden();
-
-        watching_lbl->setWordWrap(true);
-        watching_btn->installEventFilter(&this->tabFilter_);
-
-        QObject::connect(watching_btn.getElement(), &QRadioButton::toggled,
-                         [=](bool enabled) mutable {
-                             watching_lbl->setVisible(enabled);
-                         });
-
-        // live_btn
-        auto live_btn =
-            vbox.emplace<QRadioButton>("Live").assign(&this->ui_.twitch.live);
-        auto live_lbl =
-            vbox.emplace<QLabel>("Shows when channels go live.").hidden();
-
-        live_lbl->setWordWrap(true);
-        live_btn->installEventFilter(&this->tabFilter_);
-
-        QObject::connect(live_btn.getElement(), &QRadioButton::toggled,
-                         [=](bool enabled) mutable {
-                             live_lbl->setVisible(enabled);
-                         });
-
-        // automod_btn
-        auto automod_btn = vbox.emplace<QRadioButton>("AutoMod").assign(
-            &this->ui_.twitch.automod);
-        auto automod_lbl =
-            vbox.emplace<QLabel>("Shows when AutoMod catches a message in any "
-                                 "channel you moderate.")
-                .hidden();
-
-        automod_lbl->setWordWrap(true);
-        automod_btn->installEventFilter(&this->tabFilter_);
-
-        QObject::connect(automod_btn.getElement(), &QRadioButton::toggled,
-                         [=](bool enabled) mutable {
-                             automod_lbl->setVisible(enabled);
-                         });
-
-        vbox->addStretch(1);
-
-        // tabbing order
-        QWidget::setTabOrder(automod_btn.getElement(),
-                             channel_btn.getElement());
-        QWidget::setTabOrder(channel_btn.getElement(),
-                             whispers_btn.getElement());
-        QWidget::setTabOrder(whispers_btn.getElement(),
-                             mentions_btn.getElement());
-        QWidget::setTabOrder(mentions_btn.getElement(),
-                             watching_btn.getElement());
-        QWidget::setTabOrder(watching_btn.getElement(), live_btn.getElement());
-        QWidget::setTabOrder(live_btn.getElement(), automod_btn.getElement());
-
-        // tab
-        auto *tab = notebook->addPage(obj.getElement());
-        tab->setCustomTitle("Twitch");
+        button->setFocusPolicy(Qt::ClickFocus);
     }
+    layout->addWidget(buttonBox);
 
-    layout->setStretchFactor(notebook.getElement(), 1);
+    QObject::connect(buttonBox, &QDialogButtonBox::accepted, this, [this] {
+        this->ok();
+    });
+    QObject::connect(buttonBox, &QDialogButtonBox::rejected, [this] {
+        this->close();
+    });
 
-    auto buttons =
-        layout.emplace<QHBoxLayout>().emplace<QDialogButtonBox>(this);
-    {
-        auto *button_ok = buttons->addButton(QDialogButtonBox::Ok);
-        QObject::connect(button_ok, &QPushButton::clicked, [this](bool) {
-            this->ok();
-        });
-        auto *button_cancel = buttons->addButton(QDialogButtonBox::Cancel);
-        QObject::connect(button_cancel, &QAbstractButton::clicked,
-                         [this](bool) {
-                             this->close();
-                         });
-    }
-
-    this->setMinimumSize(300, 310);
-    this->ui_.notebook->selectIndex(TAB_TWITCH);
-    this->ui_.twitch.channel->setFocus();
+    this->setLayout(layout);
 
     this->addShortcuts();
 
@@ -202,50 +185,53 @@ void SelectChannelDialog::ok()
     this->close();
 }
 
-void SelectChannelDialog::setSelectedChannel(IndirectChannel _channel)
+void SelectChannelDialog::setSelectedChannel(
+    std::optional<IndirectChannel> channel_)
 {
-    auto channel = _channel.get();
+    if (!channel_.has_value())
+    {
+        this->ui_.channel->setChecked(true);
+
+        this->hasSelectedChannel_ = false;
+        return;
+    }
+
+    const auto &indirectChannel = channel_.value();
+    const auto &channel = indirectChannel.get();
 
     assert(channel);
 
     this->selectedChannel_ = channel;
 
-    switch (_channel.getType())
+    switch (indirectChannel.getType())
     {
         case Channel::Type::Twitch: {
-            this->ui_.notebook->selectIndex(TAB_TWITCH);
-            this->ui_.twitch.channel->setFocus();
-            this->ui_.twitch.channelName->setText(channel->getName());
+            this->ui_.channelName->setText(channel->getName());
+            this->ui_.channel->setChecked(true);
         }
         break;
         case Channel::Type::TwitchWatching: {
-            this->ui_.notebook->selectIndex(TAB_TWITCH);
-            this->ui_.twitch.watching->setFocus();
+            this->ui_.watching->setFocus();
         }
         break;
         case Channel::Type::TwitchMentions: {
-            this->ui_.notebook->selectIndex(TAB_TWITCH);
-            this->ui_.twitch.mentions->setFocus();
+            this->ui_.mentions->setFocus();
         }
         break;
         case Channel::Type::TwitchWhispers: {
-            this->ui_.notebook->selectIndex(TAB_TWITCH);
-            this->ui_.twitch.whispers->setFocus();
+            this->ui_.whispers->setFocus();
         }
         break;
         case Channel::Type::TwitchLive: {
-            this->ui_.notebook->selectIndex(TAB_TWITCH);
-            this->ui_.twitch.live->setFocus();
+            this->ui_.live->setFocus();
         }
         break;
         case Channel::Type::TwitchAutomod: {
-            this->ui_.notebook->selectIndex(TAB_TWITCH);
-            this->ui_.twitch.automod->setFocus();
+            this->ui_.automod->setFocus();
         }
         break;
         default: {
-            this->ui_.notebook->selectIndex(TAB_TWITCH);
-            this->ui_.twitch.channel->setFocus();
+            this->ui_.channel->setChecked(true);
         }
     }
 
@@ -259,36 +245,35 @@ IndirectChannel SelectChannelDialog::getSelectedChannel() const
         return this->selectedChannel_;
     }
 
-    switch (this->ui_.notebook->getSelectedIndex())
+    if (this->ui_.channel->isChecked())
     {
-        case TAB_TWITCH: {
-            if (this->ui_.twitch.channel->isChecked())
-            {
-                return getApp()->getTwitch()->getOrAddChannel(
-                    this->ui_.twitch.channelName->text().trimmed());
-            }
-            else if (this->ui_.twitch.watching->isChecked())
-            {
-                return getApp()->getTwitch()->getWatchingChannel();
-            }
-            else if (this->ui_.twitch.mentions->isChecked())
-            {
-                return getApp()->getTwitch()->getMentionsChannel();
-            }
-            else if (this->ui_.twitch.whispers->isChecked())
-            {
-                return getApp()->getTwitch()->getWhispersChannel();
-            }
-            else if (this->ui_.twitch.live->isChecked())
-            {
-                return getApp()->getTwitch()->getLiveChannel();
-            }
-            else if (this->ui_.twitch.automod->isChecked())
-            {
-                return getApp()->getTwitch()->getAutomodChannel();
-            }
-        }
-        break;
+        return getApp()->getTwitch()->getOrAddChannel(
+            this->ui_.channelName->text().trimmed());
+    }
+
+    if (this->ui_.watching->isChecked())
+    {
+        return getApp()->getTwitch()->getWatchingChannel();
+    }
+
+    if (this->ui_.mentions->isChecked())
+    {
+        return getApp()->getTwitch()->getMentionsChannel();
+    }
+
+    if (this->ui_.whispers->isChecked())
+    {
+        return getApp()->getTwitch()->getWhispersChannel();
+    }
+
+    if (this->ui_.live->isChecked())
+    {
+        return getApp()->getTwitch()->getLiveChannel();
+    }
+
+    if (this->ui_.automod->isChecked())
+    {
+        return getApp()->getTwitch()->getAutomodChannel();
     }
 
     return this->selectedChannel_;
@@ -302,90 +287,109 @@ bool SelectChannelDialog::hasSeletedChannel() const
 bool SelectChannelDialog::EventFilter::eventFilter(QObject *watched,
                                                    QEvent *event)
 {
-    auto *widget = static_cast<QWidget *>(watched);
+    auto *widget = dynamic_cast<QWidget *>(watched);
+    assert(widget);
 
-    if (event->type() == QEvent::FocusIn)
+    auto &ui = this->dialog->ui_;
+
+    switch (event->type())
     {
-        auto *radio = dynamic_cast<QRadioButton *>(watched);
-        if (radio)
-        {
-            radio->setChecked(true);
-            return true;
-        }
-        else
-        {
+        case QEvent::KeyPress: {
+            auto *event_key = dynamic_cast<QKeyEvent *>(event);
+            assert(event_key);
+
+            if ((event_key->key() == Qt::Key_Tab ||
+                 event_key->key() == Qt::Key_Down) &&
+                event_key->modifiers() == Qt::NoModifier)
+            {
+                // Tab has been pressed, focus next entry in list
+
+                if (widget == ui.channelName)
+                {
+                    // Special case for when current selection is the "Channel" entry's edit box since the Edit box actually has the focus
+                    ui.whispers->setFocus();
+                    return true;
+                }
+
+                if (widget == ui.automod)
+                {
+                    // Special case for when current selection is "AutoMod" (the last entry in the list), next wrap is Channel, but we need to select its edit box
+                    ui.channel->setFocus();
+                    return true;
+                }
+
+                auto *nextInFocusChain = widget->nextInFocusChain();
+                if (nextInFocusChain->focusPolicy() == Qt::FocusPolicy::NoFocus)
+                {
+                    // Make sure we're not selecting one of the labels
+                    nextInFocusChain = nextInFocusChain->nextInFocusChain();
+                }
+                nextInFocusChain->setFocus();
+                return true;
+            }
+
+            if (((event_key->key() == Qt::Key_Tab ||
+                  event_key->key() == Qt::Key_Backtab) &&
+                 event_key->modifiers() == Qt::ShiftModifier) ||
+                ((event_key->key() == Qt::Key_Up) &&
+                 event_key->modifiers() == Qt::NoModifier))
+            {
+                // Shift+Tab has been pressed, focus previous entry in list
+
+                if (widget == ui.channelName)
+                {
+                    // Special case for when current selection is the "Channel" entry's edit box since the Edit box actually has the focus
+                    ui.automod->setFocus();
+                    return true;
+                }
+
+                if (widget == ui.whispers)
+                {
+                    ui.channel->setFocus();
+                    return true;
+                }
+
+                auto *previousInFocusChain = widget->previousInFocusChain();
+                if (previousInFocusChain->focusPolicy() ==
+                    Qt::FocusPolicy::NoFocus)
+                {
+                    // Make sure we're not selecting one of the labels
+                    previousInFocusChain =
+                        previousInFocusChain->previousInFocusChain();
+                }
+                previousInFocusChain->setFocus();
+                return true;
+            }
+
+            if (event_key == QKeySequence::DeleteStartOfWord &&
+                ui.channelName->selectionLength() > 0)
+            {
+                ui.channelName->backspace();
+                return true;
+            }
+
             return false;
         }
-    }
-    else if (event->type() == QEvent::KeyPress)
-    {
-        QKeyEvent *event_key = static_cast<QKeyEvent *>(event);
-        if ((event_key->key() == Qt::Key_Tab ||
-             event_key->key() == Qt::Key_Down) &&
-            event_key->modifiers() == Qt::NoModifier)
-        {
-            // Tab has been pressed, focus next entry in list
+        break;
 
-            if (widget == this->dialog->ui_.twitch.channelName)
+        case QEvent::KeyRelease: {
+            auto *event_key = dynamic_cast<QKeyEvent *>(event);
+            assert(event_key);
+
+            if ((event_key->key() == Qt::Key_Backtab ||
+                 event_key->key() == Qt::Key_Down) &&
+                event_key->modifiers() == Qt::NoModifier)
             {
-                // Special case for when current selection is the "Channel" entry's edit box since the Edit box actually has the focus
-                this->dialog->ui_.twitch.whispers->setFocus();
                 return true;
             }
-            else if (widget == this->dialog->ui_.twitch.automod)
-            {
-                // Special case for when current selection is "AutoMod" (the last entry in the list), next wrap is Channel, but we need to select its edit box
-                this->dialog->ui_.twitch.channel->setFocus();
-                return true;
-            }
-
-            widget->nextInFocusChain()->setFocus();
-            return true;
         }
-        else if (((event_key->key() == Qt::Key_Tab ||
-                   event_key->key() == Qt::Key_Backtab) &&
-                  event_key->modifiers() == Qt::ShiftModifier) ||
-                 ((event_key->key() == Qt::Key_Up) &&
-                  event_key->modifiers() == Qt::NoModifier))
-        {
-            // Shift+Tab has been pressed, focus previous entry in list
-
-            if (widget == this->dialog->ui_.twitch.channelName)
-            {
-                // Special case for when current selection is the "Channel" entry's edit box since the Edit box actually has the focus
-                this->dialog->ui_.twitch.automod->setFocus();
-                return true;
-            }
-
-            widget->previousInFocusChain()->setFocus();
-            return true;
-        }
-        else if (event_key == QKeySequence::DeleteStartOfWord &&
-                 this->dialog->ui_.twitch.channelName->selectionLength() > 0)
-        {
-            this->dialog->ui_.twitch.channelName->backspace();
-            return true;
-        }
-        else
-        {
-            return false;
-        }
-    }
-    else if (event->type() == QEvent::KeyRelease)
-    {
-        QKeyEvent *event_key = static_cast<QKeyEvent *>(event);
-        if ((event_key->key() == Qt::Key_Backtab ||
-             event_key->key() == Qt::Key_Down) &&
-            event_key->modifiers() == Qt::NoModifier)
-        {
-            return true;
-        }
+        break;
     }
 
     return false;
 }
 
-void SelectChannelDialog::closeEvent(QCloseEvent *)
+void SelectChannelDialog::closeEvent(QCloseEvent * /*event*/)
 {
     this->closed.invoke();
 }
@@ -394,23 +398,38 @@ void SelectChannelDialog::themeChangedEvent()
 {
     BaseWindow::themeChangedEvent();
 
+    auto &ui = this->ui_;
+
     // NOTE: This currently overrides the QLineEdit's font size.
     // If the dialog is open when the theme is changed, things will look a bit off.
     // This can be alleviated by us using a single application-wide style sheet for these things.
-    this->ui_.twitch.channelName->setStyleSheet(
-        this->theme->splits.input.styleSheet);
+    ui.channelName->setStyleSheet(this->theme->splits.input.styleSheet);
+}
+
+void SelectChannelDialog::scaleChangedEvent(float newScale)
+{
+    BaseWindow::scaleChangedEvent(newScale);
+
+    auto &ui = this->ui_;
+
+    // NOTE: Normally the font is automatically inherited from its parent, but since we override
+    // the style sheet to respect light/dark theme, we have to manually update the font here
+    auto uiFont =
+        getApp()->getFonts()->getFont(FontStyle::UiMedium, this->scale());
+
+    ui.channelName->setFont(uiFont);
 }
 
 void SelectChannelDialog::addShortcuts()
 {
     HotkeyController::HotkeyMap actions{
         {"accept",
-         [this](std::vector<QString>) -> QString {
+         [this](const std::vector<QString> &) -> QString {
              this->ok();
              return "";
          }},
         {"reject",
-         [this](std::vector<QString>) -> QString {
+         [this](const std::vector<QString> &) -> QString {
              this->close();
              return "";
          }},

--- a/src/widgets/dialogs/SelectChannelDialog.hpp
+++ b/src/widgets/dialogs/SelectChannelDialog.hpp
@@ -3,13 +3,35 @@
 #include "widgets/BaseWindow.hpp"
 
 #include <pajlada/signals/signal.hpp>
+#include <QFocusEvent>
 #include <QLabel>
 #include <QLineEdit>
 #include <QRadioButton>
 
+#include <optional>
+
+namespace chatterino::detail {
+
+/// a radio button that checks itself when it receives focus
+class AutoCheckedRadioButton : public QRadioButton
+{
+public:
+    AutoCheckedRadioButton(const QString &label)
+        : QRadioButton(label)
+    {
+    }
+
+protected:
+    void focusInEvent(QFocusEvent * /*event*/) override
+    {
+        this->setChecked(true);
+    }
+};
+
+}  // namespace chatterino::detail
+
 namespace chatterino {
 
-class Notebook;
 class EditableModelView;
 class IndirectChannel;
 class Channel;
@@ -20,15 +42,16 @@ class SelectChannelDialog final : public BaseWindow
 public:
     SelectChannelDialog(QWidget *parent = nullptr);
 
-    void setSelectedChannel(IndirectChannel selectedChannel_);
+    void setSelectedChannel(std::optional<IndirectChannel> channel_);
     IndirectChannel getSelectedChannel() const;
     bool hasSeletedChannel() const;
 
     pajlada::Signals::NoArgSignal closed;
 
 protected:
-    void closeEvent(QCloseEvent *) override;
+    void closeEvent(QCloseEvent *event) override;
     void themeChangedEvent() override;
+    void scaleChangedEvent(float newScale) override;
 
 private:
     class EventFilter : public QObject
@@ -41,17 +64,25 @@ private:
     };
 
     struct {
-        Notebook *notebook;
-        struct {
-            QRadioButton *channel;
-            QLineEdit *channelName;
-            QRadioButton *whispers;
-            QRadioButton *mentions;
-            QRadioButton *watching;
-            QRadioButton *live;
-            QRadioButton *automod;
-        } twitch;
-    } ui_;
+        detail::AutoCheckedRadioButton *channel;
+        QLabel *channelLabel;
+        QLineEdit *channelName;
+
+        detail::AutoCheckedRadioButton *whispers;
+        QLabel *whispersLabel;
+
+        detail::AutoCheckedRadioButton *mentions;
+        QLabel *mentionsLabel;
+
+        detail::AutoCheckedRadioButton *watching;
+        QLabel *watchingLabel;
+
+        detail::AutoCheckedRadioButton *live;
+        QLabel *liveLabel;
+
+        detail::AutoCheckedRadioButton *automod;
+        QLabel *automodLabel;
+    } ui_{};
 
     EventFilter tabFilter_;
 

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -1029,6 +1029,10 @@ void Split::showChangeChannelPopup(const char *dialogTitle, bool empty,
     {
         dialog->setSelectedChannel(this->getIndirectChannel());
     }
+    else
+    {
+        dialog->setSelectedChannel({});
+    }
     dialog->setAttribute(Qt::WA_DeleteOnClose);
     dialog->setWindowTitle(dialogTitle);
     dialog->show();


### PR DESCRIPTION
We no longer use a Notebook for this, this means the layout we have will autosize appropriately.
To make it autosize on slightly larger font sizes I've done manual word wrapping on the labels instead of letting them word wrap themselves.

If the user resizes the dialog after opening it, things might look a little bit more goofy than before, but the default size it opens as should be better.

Something with how I add labels now (not using the layout creator) I messed up the focus chain.
I've fixed this by checking 2 steps ahead in the nextInFocuschain and previousInFocusChain.

the way we want this to work, we cannot use Qt's own focus chain logic since the QTextEdit that belongs with the "Channel" radiobox will always be ignored since it's not visible
