### PR TITLE
fix: qt 6.4.3 stringbuilding shenanigans with scope check message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - Minor: The font weight of chat messages can now be changed. (#6037)
 - Minor: Messages from restricted users can now be hidden when in streamer mode. This is enabled by default. (#6042, #6049)
 - Minor: Added a tab style option allowing you to make your tabs more compact. (#5858)
-- Minor: Chatterino now warns about missing scopes when logging in. (#6072)
+- Minor: Chatterino now warns about missing scopes when logging in. (#6072, #6083)
 - Bugfix: Fixed a potential way to escape the Lua Plugin sandbox. (#5846)
 - Bugfix: Fixed a crash relating to Lua HTTP. (#5800)
 - Bugfix: Fixed a crash that could occur on Linux and macOS when clicking "Install" from the update prompt. (#5818)

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -2060,13 +2060,13 @@ MessagePtr MessageBuilder::makeLowTrustUpdateMessage(
 MessagePtrMut MessageBuilder::makeMissingScopesMessage(
     const QString &missingScopes)
 {
-    auto warnText = u"Your account is missing the following permission(s): " %
-                    missingScopes %
-                    u". Some features might not work correctly.";
+    QString warnText =
+        u"Your account is missing the following permission(s): " %
+        missingScopes % u". Some features might not work correctly.";
     auto linkText = u"Consider re-adding your account."_s;
 
     MessageBuilder builder;
-    auto text = warnText % ' ' % linkText;
+    QString text = warnText % ' ' % linkText;
     builder->messageText = text;
     builder->searchText = text;
     builder->flags.set(MessageFlag::System,


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/1fa0b33a-43d6-49b0-b5ce-ad009917c864)

I might've strung too many strings in this diff here but it works
