### PR TITLE
fix: don't add tests to autostart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
 - Dev: Mini feature refactor of BaseWindow. (#6074)
 - Dev: Removed dead code and some MSVC warnings. (#6024)
 - Dev: Added check if WEBP is supported. (#6073)
+- Dev: Tests won't add themselves to the autostart on Windows anymore. (#6084)
 
 ## 2.5.2
 

--- a/src/util/WindowsHelper.cpp
+++ b/src/util/WindowsHelper.cpp
@@ -1,5 +1,6 @@
 #include "util/WindowsHelper.hpp"
 
+#include "Application.hpp"
 #include "common/Literals.hpp"
 
 #include <QApplication>
@@ -64,6 +65,12 @@ bool isRegisteredForStartup()
 
 void setRegisteredForStartup(bool isRegistered)
 {
+    auto *app = tryGetApp();
+    if (app && app->isTest())
+    {
+        return;
+    }
+
     QSettings settings(RUN_KEY, QSettings::NativeFormat);
 
     if (isRegistered)


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

If you have added Chatterino to autostart and run tests, then those tests would overwrite the original entry. When starting, the tests would run instead of Chatterino.