### PR TITLE
fix: apply same margin to svg buttons as to pixmap buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@
 - Bugfix: Fixed a thick border on Windows 11. (#5836)
 - Bugfix: Fixed an issue where the Select Channel Dialog did not correctly scale when your window scale was too high. (#6081)
 - Bugfix: Fixed some windows not immediately closing. (#6054)
-- Bugfix: The emote button no longer looks crunchy. (#6080)
+- Bugfix: The emote button no longer looks crunchy. (#6080, #6085)
 - Dev: Subscriptions to PubSub channel points redemption topics now use no auth token, making it continue to work during PubSub shutdown. (#5947)
 - Dev: Add initial experimental EventSub support. (#5837, #5895, #5897, #5904, #5910, #5903, #5915, #5916, #5930, #5935, #5932, #5943, #5952, #5953, #5968, #5973, #5974, #5980, #5981, #5985, #5990, #5992, #5993, #5996, #5995, #6000, #6001, #6002, #6003, #6005, #6007, #6010, #6008, #6012, #6013, #6015, #6017, #6027, #6028, #6035, #6036, #6040, #6041, #6048, #6058, #6059, #6078, #6079)
 - Dev: Remove unneeded platform specifier for toasts. (#5914)

--- a/src/widgets/helper/Button.cpp
+++ b/src/widgets/helper/Button.cpp
@@ -194,7 +194,18 @@ void Button::paintButton(QPainter &painter)
     {
         painter.setOpacity(this->getCurrentDimAmount());
 
-        this->svgRenderer->render(&painter);
+        auto rect = this->rect();
+
+        if (this->enableMargin_)
+        {
+            auto s = this->getMargin();
+            rect.moveLeft(s);
+            rect.setRight(rect.right() - s - s);
+            rect.moveTop(s);
+            rect.setBottom(rect.bottom() - s - s);
+        }
+
+        this->svgRenderer->render(&painter, rect);
     }
     else if (!this->pixmap_.isNull())
     {
@@ -205,14 +216,14 @@ void Button::paintButton(QPainter &painter)
         resizePixmap(this->resizedPixmap_, this->pixmap_, rect.size(),
                      this->devicePixelRatio());
 
-        int margin = this->height() < 22 * this->scale() ? 3 : 6;
-
-        int s = this->enableMargin_ ? int(margin * this->scale()) : 0;
-
-        rect.moveLeft(s);
-        rect.setRight(rect.right() - s - s);
-        rect.moveTop(s);
-        rect.setBottom(rect.bottom() - s - s);
+        if (this->enableMargin_)
+        {
+            auto s = this->getMargin();
+            rect.moveLeft(s);
+            rect.setRight(rect.right() - s - s);
+            rect.moveTop(s);
+            rect.setBottom(rect.bottom() - s - s);
+        }
 
         painter.drawPixmap(rect, this->resizedPixmap_);
 
@@ -441,6 +452,15 @@ void Button::showMenu()
 
     this->menu_->popup(point);
     this->menuVisible_ = true;
+}
+
+int Button::getMargin() const
+{
+    assert(this->enableMargin_);
+
+    int baseMargin = this->height() < 22 * this->scale() ? 3 : 6;
+
+    return static_cast<int>(baseMargin * this->scale());
 }
 
 }  // namespace chatterino

--- a/src/widgets/helper/Button.cpp
+++ b/src/widgets/helper/Button.cpp
@@ -199,10 +199,15 @@ void Button::paintButton(QPainter &painter)
         if (this->enableMargin_)
         {
             auto s = this->getMargin();
-            rect.moveLeft(s);
-            rect.setRight(rect.right() - s - s);
-            rect.moveTop(s);
-            rect.setBottom(rect.bottom() - s - s);
+            auto outSize = rect.size() - QSize{2 * s, 2 * s};
+            outSize = this->svgRenderer->defaultSize().scaled(
+                outSize, Qt::KeepAspectRatio);
+            auto margin = rect.size() - outSize;
+
+            rect = QRect{
+                QPoint{margin.width() / 2, margin.height() / 2},
+                outSize,
+            };
         }
 
         this->svgRenderer->render(&painter, rect);

--- a/src/widgets/helper/Button.hpp
+++ b/src/widgets/helper/Button.hpp
@@ -88,6 +88,8 @@ private:
     void onMouseEffectTimeout();
     void showMenu();
 
+    int getMargin() const;
+
     QColor borderColor_{};
     QPixmap pixmap_{};
     QSvgRenderer *svgRenderer{};

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -295,7 +295,8 @@ void SplitInput::updateEmoteButton()
     }
 
     this->ui_.emoteButton->setFixedHeight(int(18 * scale));
-    this->ui_.emoteButton->setFixedWidth(int(18 * scale));
+    // Make button slightly wider so it's easier to click
+    this->ui_.emoteButton->setFixedWidth(int(24 * scale));
 }
 
 void SplitInput::updateCancelReplyButton()


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/6a4a6c74-1702-4ea9-a503-2680dc4255c7)

top new, bottom "old"

should look closer (but better) than the non-svg pixmap emote button