### PR TITLE
feat: change duplicate message sending to use more variants

### DIFF
--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -79,7 +79,7 @@ bool isUnknownCommand(const QString &text)
 using detail::isUnknownCommand;
 
 namespace {
-const QString MAGIC_MESSAGE_SUFFIX = u" \u034f"_s;
+constexpr uint64_t MAX_VARIANT_COUNT = 8;
 constexpr int CLIP_CREATION_COOLDOWN = 5000;
 const QString CLIPS_LINK("https://clips.twitch.tv/%1");
 const QString CLIPS_FAILURE_CLIPS_UNAVAILABLE_TEXT(
@@ -750,6 +750,51 @@ void TwitchChannel::roomIdChanged()
         std::dynamic_pointer_cast<TwitchChannel>(shared_from_this()));
 }
 
+QString TwitchChannel::getNextVariant(const QString &message) const
+{
+    using namespace helpers::duplicate_message;
+
+    QVector<int> spacePositions = getSpacePositions(message);
+    uint64_t numSpaces = spacePositions.size();
+    uint64_t fullCycle = 3 * (1ULL << numSpaces);
+
+    // limit number of variants to MAX_VARIANT_COUNT
+    uint64_t cappedCycle = std::min(fullCycle, MAX_VARIANT_COUNT);
+    if (this->variantIndex_ >= cappedCycle)
+    {
+        this->variantIndex_ = 0;
+        this->currentMask_ = 0ULL;
+    }
+
+    if (numSpaces == 0)
+    {
+        // message has no spaces, just cycle through magic char variants
+        this->currentMagic_ = this->variantIndex_ % 3;
+        this->variantIndex_++;
+        return buildVariant(message, spacePositions, 0, this->currentMagic_);
+    }
+
+    if (this->currentMask_ == 0)
+    {
+        // cycle has reset
+        this->currentMask_ = 1ULL;
+        this->variantIndex_ = 1;
+        // first variant is the original message
+        return message;
+    }
+
+    uint64_t spaceMask = this->currentMask_ & ((1ULL << numSpaces) - 1);
+    uint64_t magicGroup = (this->currentMask_ >> numSpaces) & 3;
+
+    QString result =
+        buildVariant(message, spacePositions, spaceMask, magicGroup);
+
+    this->currentMask_ = getNextMask(this->currentMask_, numSpaces);
+    this->variantIndex_++;
+
+    return result;
+}
+
 QString TwitchChannel::prepareMessage(const QString &message) const
 {
     auto *app = getApp();
@@ -763,35 +808,26 @@ QString TwitchChannel::prepareMessage(const QString &message) const
         return "";
     }
 
-    if (!this->hasHighRateLimit())
+    if (!this->hasHighRateLimit() && getSettings()->allowDuplicateMessages)
     {
-        if (getSettings()->allowDuplicateMessages)
-        {
-            if (parsedMessage == this->lastSentMessage_)
-            {
-                auto spaceIndex = parsedMessage.indexOf(' ');
-                // If the message starts with either '/' or '.' Twitch will treat it as a command, omitting
-                // first space and only rest of the arguments treated as actual message content
-                // In cases when user sends a message like ". .a b" first character and first space are omitted as well
-                bool ignoreFirstSpace =
-                    parsedMessage.at(0) == '/' || parsedMessage.at(0) == '.';
-                if (ignoreFirstSpace)
-                {
-                    spaceIndex = parsedMessage.indexOf(' ', spaceIndex + 1);
-                }
+        using namespace helpers::duplicate_message;
+        // Normalize messages for comparison by removing magic suffix and simplifying
+        // necessary because this->sendMessage() sets this->lastSentMessage_
+        // to the last non-normalized variant we generated, which won't match the user's input
+        QString normalizedParsedMessage = normalizeMessage(parsedMessage);
+        QString normalizedLastSentMessage =
+            normalizeMessage(this->lastSentMessage_);
 
-                if (spaceIndex == -1)
-                {
-                    // no spaces found, fall back to old magic character
-                    parsedMessage.append(MAGIC_MESSAGE_SUFFIX);
-                }
-                else
-                {
-                    // replace the space we found in spaceIndex with two spaces
-                    parsedMessage.replace(spaceIndex, 1, "  ");
-                }
-            }
+        if (normalizedParsedMessage == normalizedLastSentMessage)
+        {
+            return this->getNextVariant(parsedMessage);
         }
+
+        // Message changed, reset
+        // next round starts with the second variant because the first variant
+        // is the original and will have already been sent
+        this->currentMask_ = 1ULL;
+        this->variantIndex_ = 1;
     }
 
     return parsedMessage;

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -483,8 +483,34 @@ private:
     bool staff_ = false;
     UniqueAccess<QString> roomID_;
 
-    // --
+    // Duplicate messages
     QString lastSentMessage_;
+    mutable int variantIndex_{0};
+    mutable uint64_t currentMask_{0};
+    mutable uint64_t currentMagic_{0};
+    /**
+     * Generates a variant of a duplicate message
+     *
+     * This method works by determining all eligible space positions in the original message
+     * (ignoring the very first space if the message begins with a command character such as '/' or '.')
+     * and generating alternate variants by inserting an extra space at each eligible position.
+     * Additionally, a magic suffix is appended in one of two modes (either directly or prefixed by a space).
+     *
+     * The variants come in three groups:
+     *   - Group 0: Variants with only modified spacing.
+     *   - Group 1: Variants with the magic suffix appended without an extra space.
+     *   - Group 2: Variants with the magic suffix appended with a preceding space.
+     *
+     * In total there are 3 × (2^(# eligible space positions)) possible variants
+     * The number of variants we use is capped at MAX_VARIANT_COUNT
+     * When the cap is reached, we reset to the original message and repeat
+     *
+     * @param message The original user message.
+     * @return A modified message variant.
+     */
+    QString getNextVariant(const QString &message) const;
+
+    // --
     QObject lifetimeGuard_;
     QTimer chattersListTimer_;
     QTimer threadClearTimer_;

--- a/src/util/Helpers.cpp
+++ b/src/util/Helpers.cpp
@@ -476,10 +476,7 @@ std::pair<QStringView, QStringView> splitOnce(QStringView haystack,
 
 uint64_t gospersHack(uint64_t x)
 {
-#pragma warning(push)
-#pragma warning(disable : 4146)
-    uint64_t u = x & -x;
-#pragma warning(pop)
+    uint64_t u = x & (~x + 1ULL);
     uint64_t v = x + u;
     return v + (((v ^ x) / u) >> 2);
 }

--- a/src/util/Helpers.hpp
+++ b/src/util/Helpers.hpp
@@ -59,6 +59,59 @@ std::pair<uint64_t, bool> findUnitMultiplierToSec(QStringView view,
 
 }  // namespace helpers::detail
 
+namespace helpers::duplicate_message {
+
+    /**
+     * Normalize a message by removing magic suffix and simplifying.
+     *
+     * @param message The message to normalize.
+     * @return The normalized message.
+     */
+    QString normalizeMessage(const QString &message);
+
+    /**
+     * Returns the positions of spaces in a message, skipping the first space if it's a command.
+     *
+     * @param message The message to analyze.
+     * @return A vector of positions where spaces occur in the message.
+     */
+    QVector<int> getSpacePositions(const QString &message);
+
+    /**
+     * Builds a variant of a duplicate message using double spaces and magic characters.
+     *
+     * @param message Original message
+     * @param spacePositions Positions of spaces in the message
+     * @param spaceMask Mask of spaces to be inserted
+     * @param magicGroup Magic group to be appended (0, 1, or 2)
+     * @return A variant of the original message.
+     */
+    QString buildVariant(const QString &message,
+                         const QVector<int> &spacePositions, uint64_t spaceMask,
+                         uint64_t magicGroup);
+
+    // Computes the next bitmask for generating a duplicate message variant.
+    uint64_t getNextMask(uint64_t currentMask, uint64_t numSpaces);
+
+}  // namespace helpers::duplicate_message
+
+/**
+ * Returns the next combination with the same number of 1 bits.
+ * Used for efficiently generating the next variant within the same grade.
+ *
+ * @param x The current bit pattern
+ * @return The next bit pattern with the same number of 1 bits
+ */
+uint64_t gospersHack(uint64_t x);
+
+/**
+ * Counts the number of set bits in a 64-bit integer.
+ *
+ * @param x The integer to count the set bits in.
+ * @return The number of set bits in the integer.
+ */
+int popCount(uint64_t x);
+
 /**
  * @brief startsWithOrContains is a wrapper for checking
  * whether str1 starts with or contains str2 within itself


### PR DESCRIPTION
Implements permutation generation for duplicate messages.

In fast-moving chats, messages are often dropped. Since we currently generate only two message variations, we can easily trigger this error if any of our messages are dropped:

`Your message was not sent because it is identical to the previous one you sent, less than 30 seconds ago.`

Since we can't reliably detect if a message was delivered, we can instead increase the number of permutations to reduce the rate of identical messages delivered in sequence, even if some are dropped.

---

For a message with N usable spaces and using M magic characters, the total permutations are 2^(N + M).

The amount of permutations that we actually generate and use can be controlled by the constants `TARGET_PERMUTATION_COUNT` and `MAX_MAGIC_CHARACTERS` in `TwitchChannel.cpp`.

We generate the minimum number of variants needed to reach the target permutation count, in the following order:
  1. Original message: The base message, using single spaces only.
  2. Space-only Variations: All permutations created by selectively doubling usable spaces
     - For a message with N usable spaces, there are 2^N possible space-only variants (including the original message).
     - Computed in order from least edits to most edits of the original message.
  3. Magic Character Variants:
     - If space-only variants are not enough to reach the target permutation count, a magic suffix is appended to each previous variant.
     - Each magic append comes in two forms: one directly appended, and one with an extra space preceding the magic suffix.
     - This effectively doubles the count of variants per magic level.
     - The maximum number of magic characters can be specified in `TwitchChannel.cpp`.
       - In this case, we stop generating variants as soon as we reach either:
         - `TARGET_PERMUTATION_COUNT`, OR
         - `MAX_MAGIC_CHARACTERS`, whichever is reached first.

----

In these examples, the target permutation count is 4, and the max magic characters is 1.
The magic character is represented by ?
```
p0      NaM NaM NaM NaM NaM NaM NaM NaM
p1      NaM  NaM NaM NaM NaM NaM NaM NaM
p2      NaM NaM  NaM NaM NaM NaM NaM NaM
p3      NaM NaM NaM  NaM NaM NaM NaM NaM
p0      NaM NaM NaM NaM NaM NaM NaM NaM

p0      NaM NaM NaM
p1      NaM  NaM NaM
p2      NaM NaM  NaM
p3      NaM  NaM  NaM
p0      NaM NaM NaM

p0      NaM NaM
p1      NaM  NaM
p2      NaM NaM ?
p3      NaM  NaM ?
p0      NaM NaM

p0      NaM
p1      NaM ?
p2      NaM  ?
p0      NaM
NB: here we only reached 3 permutations because we hit the magic character limit (MAX_MAGIC_CHARACTERS) at 1
```

---


When messages are dropped, the chance of landing on a duplicate when delivery resumes is `1 / TARGET_PERMUTATION_COUNT`,  assuming that there are enough spaces available to reach the target permutation count. (This represents the worst case -- however, in practise the chance is lower than this unless you are spamming very fast during a period where delivery is failing).

The existing implementation has 2 permutations, so a 50% chance of landing on a duplicate.

This can inform how to tune `TARGET_PERMUTATION_COUNT` and `MAX_MAGIC_CHARACTERS`.
```
TARGET_PERMUTATION_COUNT = 3 -> duplicate chance = 33%
TARGET_PERMUTATION_COUNT = 4 -> duplicate chance = 25%
TARGET_PERMUTATION_COUNT = 5 -> duplicate chance = 20%
TARGET_PERMUTATION_COUNT = 6 -> duplicate chance = 16.66% (repeating of course)
```

In this PR, `MAX_MAGIC_CHARACTERS = 1` to limit obstructive variants, and `TARGET_PERMUTATION_COUNT = 4` as a conservative value—halving the denial rate compared to the existing implementation in the very worst case. However, a higher `TARGET_PERMUTATION_COUNT` would be fine, since `MAX_MAGIC_CHARACTERS` already prevents obstructive variants. I leave this decision to existing maintainers.

---

Duplicate of #6082 with improvements - I was being lazy and not creating an account, so @apa420 submitted for me.
Thank you @apa420 - #6082 can be closed.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->