### PR TITLE
fix(eventsub): stack bans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@
 - Bugfix: Fixed some windows not immediately closing. (#6054)
 - Bugfix: The emote button no longer looks crunchy. (#6080, #6085)
 - Dev: Subscriptions to PubSub channel points redemption topics now use no auth token, making it continue to work during PubSub shutdown. (#5947)
-- Dev: Add initial experimental EventSub support. (#5837, #5895, #5897, #5904, #5910, #5903, #5915, #5916, #5930, #5935, #5932, #5943, #5952, #5953, #5968, #5973, #5974, #5980, #5981, #5985, #5990, #5992, #5993, #5996, #5995, #6000, #6001, #6002, #6003, #6005, #6007, #6010, #6008, #6012, #6013, #6015, #6017, #6027, #6028, #6035, #6036, #6040, #6041, #6048, #6058, #6059, #6078, #6079, #6086)
+- Dev: Add initial experimental EventSub support. (#5837, #5895, #5897, #5904, #5910, #5903, #5915, #5916, #5930, #5935, #5932, #5943, #5952, #5953, #5968, #5973, #5974, #5980, #5981, #5985, #5990, #5992, #5993, #5996, #5995, #6000, #6001, #6002, #6003, #6005, #6007, #6010, #6008, #6012, #6013, #6015, #6017, #6027, #6028, #6035, #6036, #6040, #6041, #6048, #6058, #6059, #6078, #6079, #6086, #6092)
 - Dev: Remove unneeded platform specifier for toasts. (#5914)
 - Dev: Cleanly shutdown on `SIGINT`/`SIGTERM` on Linux & macOS. (#6053)
 - Dev: Highlight checks now use non-capturing groups for the boundaries. (#5784)

--- a/src/providers/twitch/eventsub/MessageBuilder.cpp
+++ b/src/providers/twitch/eventsub/MessageBuilder.cpp
@@ -251,40 +251,6 @@ void makeModerateMessage(EventSubMessageBuilder &builder,
     builder.setMessageAndSearchText(text);
 }
 
-void makeModerateMessage(EventSubMessageBuilder &builder,
-                         const lib::payload::channel_moderate::v2::Event &event,
-                         const lib::payload::channel_moderate::v2::Ban &action)
-{
-    builder->flags.set(MessageFlag::ModerationAction, MessageFlag::Timeout);
-
-    QString text;
-    bool isShared = event.isFromSharedChat();
-
-    builder.appendUser(event.moderatorUserName, event.moderatorUserLogin, text);
-    builder.emplaceSystemTextAndUpdate("banned", text);
-    builder.appendUser(action.userName, action.userLogin, text, isShared);
-
-    if (isShared)
-    {
-        builder.emplaceSystemTextAndUpdate("in", text);
-        builder.appendUser(*event.sourceBroadcasterUserName,
-                           *event.sourceBroadcasterUserLogin, text, false);
-    }
-
-    if (action.reason.view().empty())
-    {
-        builder.emplaceSystemTextAndUpdate(".", text);
-    }
-    else
-    {
-        builder.emplaceSystemTextAndUpdate(":", text);
-        builder.emplaceSystemTextAndUpdate(action.reason.qt(), text);
-    }
-
-    builder.setMessageAndSearchText(text);
-    builder->timeoutUser = action.userLogin.qt();
-}
-
 void makeModerateMessage(
     EventSubMessageBuilder &builder,
     const lib::payload::channel_moderate::v2::Event &event,

--- a/src/providers/twitch/eventsub/MessageBuilder.hpp
+++ b/src/providers/twitch/eventsub/MessageBuilder.hpp
@@ -61,11 +61,6 @@ void makeModerateMessage(
     const lib::payload::channel_moderate::v2::Event &event,
     const lib::payload::channel_moderate::v2::Warn &action);
 
-/// <MODERATOR> banned <USER>[ in <CHANNEL>]: <REASON>
-void makeModerateMessage(EventSubMessageBuilder &builder,
-                         const lib::payload::channel_moderate::v2::Event &event,
-                         const lib::payload::channel_moderate::v2::Ban &action);
-
 /// <MODERATOR> unbanned <USER>[ in <CHANNEL>].
 void makeModerateMessage(
     EventSubMessageBuilder &builder,

--- a/src/providers/twitch/eventsub/MessageHandlers.hpp
+++ b/src/providers/twitch/eventsub/MessageHandlers.hpp
@@ -22,9 +22,16 @@ void handleModerateMessage(
     const lib::payload::channel_moderate::v2::Event &event,
     const lib::payload::channel_moderate::v2::Clear &action);
 
+/// <MODERATOR> timed out <USER> for <DURATION>[ in <CHANNEL>]: <REASON>
 void handleModerateMessage(
     TwitchChannel *chan, const QDateTime &time,
     const lib::payload::channel_moderate::v2::Event &event,
     const lib::payload::channel_moderate::v2::Timeout &action);
+
+/// <MODERATOR> banned <USER>[ in <CHANNEL>]: <REASON>
+void handleModerateMessage(
+    TwitchChannel *chan, const QDateTime &time,
+    const lib::payload::channel_moderate::v2::Event &event,
+    const lib::payload::channel_moderate::v2::Ban &action);
 
 }  // namespace chatterino::eventsub

--- a/tests/snapshots/EventSub/channel-moderate/ban-reason.json
+++ b/tests/snapshots/EventSub/channel-moderate/ban-reason.json
@@ -157,7 +157,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|EventSub|ModerationAction",
+            "flags": "System|Timeout|PubSub|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/ban-stacking-reason.json
+++ b/tests/snapshots/EventSub/channel-moderate/ban-stacking-reason.json
@@ -1,0 +1,365 @@
+{
+    "input": [
+        {
+            "__timestamp": "2025-02-22T17:53:49.800959069Z",
+            "action": "ban",
+            "automod_terms": null,
+            "ban": {
+                "reason": "my reason",
+                "user_id": "489584266",
+                "user_login": "uint128",
+                "user_name": "uint128"
+            },
+            "broadcaster_user_id": "11148817",
+            "broadcaster_user_login": "pajlada",
+            "broadcaster_user_name": "pajlada",
+            "delete": null,
+            "followers": null,
+            "mod": null,
+            "moderator_user_id": "129546453",
+            "moderator_user_login": "nerixyz",
+            "moderator_user_name": "nerixyz",
+            "raid": null,
+            "shared_chat_ban": null,
+            "shared_chat_delete": null,
+            "shared_chat_timeout": null,
+            "shared_chat_unban": null,
+            "shared_chat_untimeout": null,
+            "slow": null,
+            "source_broadcaster_user_id": null,
+            "source_broadcaster_user_login": null,
+            "source_broadcaster_user_name": null,
+            "timeout": null,
+            "unban": null,
+            "unban_request": null,
+            "unmod": null,
+            "unraid": null,
+            "untimeout": null,
+            "unvip": null,
+            "vip": null,
+            "warn": null
+        },
+        {
+            "__timestamp": "2025-02-22T17:53:50.800959069Z",
+            "action": "ban",
+            "automod_terms": null,
+            "ban": {
+                "reason": "my reason",
+                "user_id": "489584266",
+                "user_login": "uint128",
+                "user_name": "uint128"
+            },
+            "broadcaster_user_id": "11148817",
+            "broadcaster_user_login": "pajlada",
+            "broadcaster_user_name": "pajlada",
+            "delete": null,
+            "followers": null,
+            "mod": null,
+            "moderator_user_id": "129546453",
+            "moderator_user_login": "nerixyz",
+            "moderator_user_name": "nerixyz",
+            "raid": null,
+            "shared_chat_ban": null,
+            "shared_chat_delete": null,
+            "shared_chat_timeout": null,
+            "shared_chat_unban": null,
+            "shared_chat_untimeout": null,
+            "slow": null,
+            "source_broadcaster_user_id": null,
+            "source_broadcaster_user_login": null,
+            "source_broadcaster_user_name": null,
+            "timeout": null,
+            "unban": null,
+            "unban_request": null,
+            "unmod": null,
+            "unraid": null,
+            "untimeout": null,
+            "unvip": null,
+            "vip": null,
+            "warn": null
+        },
+        {
+            "__timestamp": "2025-02-22T17:54:50.800959069Z",
+            "action": "ban",
+            "automod_terms": null,
+            "ban": {
+                "reason": "my reason",
+                "user_id": "489584266",
+                "user_login": "uint128",
+                "user_name": "uint128"
+            },
+            "broadcaster_user_id": "11148817",
+            "broadcaster_user_login": "pajlada",
+            "broadcaster_user_name": "pajlada",
+            "delete": null,
+            "followers": null,
+            "mod": null,
+            "moderator_user_id": "129546453",
+            "moderator_user_login": "nerixyz",
+            "moderator_user_name": "nerixyz",
+            "raid": null,
+            "shared_chat_ban": null,
+            "shared_chat_delete": null,
+            "shared_chat_timeout": null,
+            "shared_chat_unban": null,
+            "shared_chat_untimeout": null,
+            "slow": null,
+            "source_broadcaster_user_id": null,
+            "source_broadcaster_user_login": null,
+            "source_broadcaster_user_name": null,
+            "timeout": null,
+            "unban": null,
+            "unban_request": null,
+            "unmod": null,
+            "unraid": null,
+            "untimeout": null,
+            "unvip": null,
+            "vip": null,
+            "warn": null
+        }
+    ],
+    "output": [
+        {
+            "badgeInfos": {
+            },
+            "badges": [
+            ],
+            "channelName": "",
+            "count": 2,
+            "displayName": "",
+            "elements": [
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "TimestampMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "17:53"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "17:53:50",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "nerixyz"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "nerixyz"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "banned"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "uint128"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": false,
+                    "type": "TextElement",
+                    "words": [
+                        "uint128"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        ":",
+                        "my",
+                        "reason",
+                        "(2",
+                        "times)"
+                    ]
+                }
+            ],
+            "flags": "System|Timeout|PubSub|EventSub|ModerationAction",
+            "id": "",
+            "localizedName": "",
+            "loginName": "",
+            "messageText": "nerixyz banned uint128: my reason (2 times) ",
+            "searchText": "nerixyz banned uint128: my reason (2 times) ",
+            "serverReceivedTime": "2025-02-22T17:53:50Z",
+            "timeoutUser": "uint128",
+            "userID": "",
+            "usernameColor": "#ff000000"
+        },
+        {
+            "badgeInfos": {
+            },
+            "badges": [
+            ],
+            "channelName": "",
+            "count": 1,
+            "displayName": "",
+            "elements": [
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "TimestampMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "17:54"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "17:54:50",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "MentionElement",
+                    "userColor": "System",
+                    "userLoginName": "nerixyz",
+                    "words": [
+                        "nerixyz"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "banned"
+                    ]
+                },
+                {
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": false,
+                    "type": "MentionElement",
+                    "userColor": "System",
+                    "userLoginName": "uint128",
+                    "words": [
+                        "uint128"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        ":"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "my",
+                        "reason"
+                    ]
+                }
+            ],
+            "flags": "System|Timeout|PubSub|EventSub|ModerationAction",
+            "id": "",
+            "localizedName": "",
+            "loginName": "nerixyz",
+            "messageText": "nerixyz banned uint128: my reason ",
+            "searchText": "nerixyz banned uint128: my reason ",
+            "serverReceivedTime": "2025-02-22T17:54:50Z",
+            "timeoutUser": "uint128",
+            "userID": "",
+            "usernameColor": "#ff000000"
+        }
+    ]
+}

--- a/tests/snapshots/EventSub/channel-moderate/ban-stacking.json
+++ b/tests/snapshots/EventSub/channel-moderate/ban-stacking.json
@@ -1,0 +1,347 @@
+{
+    "input": [
+        {
+            "__timestamp": "2025-02-22T17:53:49.800959069Z",
+            "action": "ban",
+            "automod_terms": null,
+            "ban": {
+                "reason": "",
+                "user_id": "489584266",
+                "user_login": "uint128",
+                "user_name": "uint128"
+            },
+            "broadcaster_user_id": "11148817",
+            "broadcaster_user_login": "pajlada",
+            "broadcaster_user_name": "pajlada",
+            "delete": null,
+            "followers": null,
+            "mod": null,
+            "moderator_user_id": "129546453",
+            "moderator_user_login": "nerixyz",
+            "moderator_user_name": "nerixyz",
+            "raid": null,
+            "shared_chat_ban": null,
+            "shared_chat_delete": null,
+            "shared_chat_timeout": null,
+            "shared_chat_unban": null,
+            "shared_chat_untimeout": null,
+            "slow": null,
+            "source_broadcaster_user_id": null,
+            "source_broadcaster_user_login": null,
+            "source_broadcaster_user_name": null,
+            "timeout": null,
+            "unban": null,
+            "unban_request": null,
+            "unmod": null,
+            "unraid": null,
+            "untimeout": null,
+            "unvip": null,
+            "vip": null,
+            "warn": null
+        },
+        {
+            "__timestamp": "2025-02-22T17:53:50.800959069Z",
+            "action": "ban",
+            "automod_terms": null,
+            "ban": {
+                "reason": "",
+                "user_id": "489584266",
+                "user_login": "uint128",
+                "user_name": "uint128"
+            },
+            "broadcaster_user_id": "11148817",
+            "broadcaster_user_login": "pajlada",
+            "broadcaster_user_name": "pajlada",
+            "delete": null,
+            "followers": null,
+            "mod": null,
+            "moderator_user_id": "129546453",
+            "moderator_user_login": "nerixyz",
+            "moderator_user_name": "nerixyz",
+            "raid": null,
+            "shared_chat_ban": null,
+            "shared_chat_delete": null,
+            "shared_chat_timeout": null,
+            "shared_chat_unban": null,
+            "shared_chat_untimeout": null,
+            "slow": null,
+            "source_broadcaster_user_id": null,
+            "source_broadcaster_user_login": null,
+            "source_broadcaster_user_name": null,
+            "timeout": null,
+            "unban": null,
+            "unban_request": null,
+            "unmod": null,
+            "unraid": null,
+            "untimeout": null,
+            "unvip": null,
+            "vip": null,
+            "warn": null
+        },
+        {
+            "__timestamp": "2025-02-22T17:54:50.800959069Z",
+            "action": "ban",
+            "automod_terms": null,
+            "ban": {
+                "reason": "",
+                "user_id": "489584266",
+                "user_login": "uint128",
+                "user_name": "uint128"
+            },
+            "broadcaster_user_id": "11148817",
+            "broadcaster_user_login": "pajlada",
+            "broadcaster_user_name": "pajlada",
+            "delete": null,
+            "followers": null,
+            "mod": null,
+            "moderator_user_id": "129546453",
+            "moderator_user_login": "nerixyz",
+            "moderator_user_name": "nerixyz",
+            "raid": null,
+            "shared_chat_ban": null,
+            "shared_chat_delete": null,
+            "shared_chat_timeout": null,
+            "shared_chat_unban": null,
+            "shared_chat_untimeout": null,
+            "slow": null,
+            "source_broadcaster_user_id": null,
+            "source_broadcaster_user_login": null,
+            "source_broadcaster_user_name": null,
+            "timeout": null,
+            "unban": null,
+            "unban_request": null,
+            "unmod": null,
+            "unraid": null,
+            "untimeout": null,
+            "unvip": null,
+            "vip": null,
+            "warn": null
+        }
+    ],
+    "output": [
+        {
+            "badgeInfos": {
+            },
+            "badges": [
+            ],
+            "channelName": "",
+            "count": 2,
+            "displayName": "",
+            "elements": [
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "TimestampMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "17:53"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "17:53:50",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "nerixyz"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "nerixyz"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "banned"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "uint128"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": false,
+                    "type": "TextElement",
+                    "words": [
+                        "uint128"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        ".",
+                        "(2",
+                        "times)"
+                    ]
+                }
+            ],
+            "flags": "System|Timeout|PubSub|EventSub|ModerationAction",
+            "id": "",
+            "localizedName": "",
+            "loginName": "",
+            "messageText": "nerixyz banned uint128. (2 times) ",
+            "searchText": "nerixyz banned uint128. (2 times) ",
+            "serverReceivedTime": "2025-02-22T17:53:50Z",
+            "timeoutUser": "uint128",
+            "userID": "",
+            "usernameColor": "#ff000000"
+        },
+        {
+            "badgeInfos": {
+            },
+            "badges": [
+            ],
+            "channelName": "",
+            "count": 1,
+            "displayName": "",
+            "elements": [
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "TimestampMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "17:54"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "17:54:50",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "MentionElement",
+                    "userColor": "System",
+                    "userLoginName": "nerixyz",
+                    "words": [
+                        "nerixyz"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "banned"
+                    ]
+                },
+                {
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": false,
+                    "type": "MentionElement",
+                    "userColor": "System",
+                    "userLoginName": "uint128",
+                    "words": [
+                        "uint128"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "."
+                    ]
+                }
+            ],
+            "flags": "System|Timeout|PubSub|EventSub|ModerationAction",
+            "id": "",
+            "localizedName": "",
+            "loginName": "nerixyz",
+            "messageText": "nerixyz banned uint128. ",
+            "searchText": "nerixyz banned uint128. ",
+            "serverReceivedTime": "2025-02-22T17:54:50Z",
+            "timeoutUser": "uint128",
+            "userID": "",
+            "usernameColor": "#ff000000"
+        }
+    ]
+}

--- a/tests/snapshots/EventSub/channel-moderate/ban.json
+++ b/tests/snapshots/EventSub/channel-moderate/ban.json
@@ -141,7 +141,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|EventSub|ModerationAction",
+            "flags": "System|Timeout|PubSub|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/shared-ban-reason.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-ban-reason.json
@@ -43,7 +43,7 @@
             },
             "badges": [
             ],
-            "channelName": "",
+            "channelName": "testaccount_420",
             "count": 1,
             "displayName": "",
             "elements": [
@@ -191,7 +191,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|EventSub|ModerationAction",
+            "flags": "System|Timeout|PubSub|SharedMessage|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/shared-ban-stacking-diff-sources.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-ban-stacking-diff-sources.json
@@ -1,0 +1,410 @@
+{
+    "input": [
+        {
+            "__timestamp": "2025-02-22T17:54:04.523432776Z",
+            "action": "shared_chat_ban",
+            "automod_terms": null,
+            "ban": null,
+            "broadcaster_user_id": "11148817",
+            "broadcaster_user_login": "pajlada",
+            "broadcaster_user_name": "pajlada",
+            "delete": null,
+            "followers": null,
+            "mod": null,
+            "moderator_user_id": "129546453",
+            "moderator_user_login": "nerixyz",
+            "moderator_user_name": "nerixyz",
+            "raid": null,
+            "shared_chat_ban": {
+                "reason": "",
+                "user_id": "141981764",
+                "user_login": "twitchdev",
+                "user_name": "TwitchDev"
+            },
+            "shared_chat_delete": null,
+            "shared_chat_timeout": null,
+            "shared_chat_unban": null,
+            "shared_chat_untimeout": null,
+            "slow": null,
+            "source_broadcaster_user_id": "117166826",
+            "source_broadcaster_user_login": "testaccount_420",
+            "source_broadcaster_user_name": "테스트계정420",
+            "timeout": null,
+            "unban": null,
+            "unban_request": null,
+            "unmod": null,
+            "unraid": null,
+            "untimeout": null,
+            "unvip": null,
+            "vip": null,
+            "warn": null
+        },
+        {
+            "__timestamp": "2025-02-22T17:54:05.523432776Z",
+            "action": "shared_chat_ban",
+            "automod_terms": null,
+            "ban": null,
+            "broadcaster_user_id": "11148817",
+            "broadcaster_user_login": "pajlada",
+            "broadcaster_user_name": "pajlada",
+            "delete": null,
+            "followers": null,
+            "mod": null,
+            "moderator_user_id": "129546453",
+            "moderator_user_login": "nerixyz",
+            "moderator_user_name": "nerixyz",
+            "raid": null,
+            "shared_chat_ban": {
+                "reason": "",
+                "user_id": "141981764",
+                "user_login": "twitchdev",
+                "user_name": "TwitchDev"
+            },
+            "shared_chat_delete": null,
+            "shared_chat_timeout": null,
+            "shared_chat_unban": null,
+            "shared_chat_untimeout": null,
+            "slow": null,
+            "source_broadcaster_user_id": "117166826",
+            "source_broadcaster_user_login": "testaccount_420",
+            "source_broadcaster_user_name": "테스트계정420",
+            "timeout": null,
+            "unban": null,
+            "unban_request": null,
+            "unmod": null,
+            "unraid": null,
+            "untimeout": null,
+            "unvip": null,
+            "vip": null,
+            "warn": null
+        },
+        {
+            "__timestamp": "2025-02-22T17:54:06.523432776Z",
+            "action": "shared_chat_ban",
+            "automod_terms": null,
+            "ban": null,
+            "broadcaster_user_id": "11148817",
+            "broadcaster_user_login": "pajlada",
+            "broadcaster_user_name": "pajlada",
+            "delete": null,
+            "followers": null,
+            "mod": null,
+            "moderator_user_id": "129546453",
+            "moderator_user_login": "nerixyz",
+            "moderator_user_name": "nerixyz",
+            "raid": null,
+            "shared_chat_ban": {
+                "reason": "",
+                "user_id": "141981764",
+                "user_login": "twitchdev",
+                "user_name": "TwitchDev"
+            },
+            "shared_chat_delete": null,
+            "shared_chat_timeout": null,
+            "shared_chat_unban": null,
+            "shared_chat_untimeout": null,
+            "slow": null,
+            "source_broadcaster_user_id": "22484632",
+            "source_broadcaster_user_login": "forsen",
+            "source_broadcaster_user_name": "forsen",
+            "timeout": null,
+            "unban": null,
+            "unban_request": null,
+            "unmod": null,
+            "unraid": null,
+            "untimeout": null,
+            "unvip": null,
+            "vip": null,
+            "warn": null
+        }
+    ],
+    "output": [
+        {
+            "badgeInfos": {
+            },
+            "badges": [
+            ],
+            "channelName": "testaccount_420",
+            "count": 2,
+            "displayName": "",
+            "elements": [
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "TimestampMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "17:54"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "17:54:05",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "nerixyz"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "nerixyz"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "banned"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "twitchdev"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "twitchdev"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "in"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "testaccount_420"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": false,
+                    "type": "TextElement",
+                    "words": [
+                        "testaccount_420"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        ".",
+                        "(2",
+                        "times)"
+                    ]
+                }
+            ],
+            "flags": "System|Timeout|PubSub|SharedMessage|EventSub|ModerationAction",
+            "id": "",
+            "localizedName": "",
+            "loginName": "",
+            "messageText": "nerixyz banned twitchdev in testaccount_420. (2 times) ",
+            "searchText": "nerixyz banned twitchdev in testaccount_420. (2 times) ",
+            "serverReceivedTime": "2025-02-22T17:54:05Z",
+            "timeoutUser": "twitchdev",
+            "userID": "",
+            "usernameColor": "#ff000000"
+        },
+        {
+            "badgeInfos": {
+            },
+            "badges": [
+            ],
+            "channelName": "forsen",
+            "count": 1,
+            "displayName": "",
+            "elements": [
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "TimestampMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "17:54"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "17:54:06",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "MentionElement",
+                    "userColor": "System",
+                    "userLoginName": "nerixyz",
+                    "words": [
+                        "nerixyz"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "banned"
+                    ]
+                },
+                {
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "MentionElement",
+                    "userColor": "System",
+                    "userLoginName": "twitchdev",
+                    "words": [
+                        "TwitchDev"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "in"
+                    ]
+                },
+                {
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": false,
+                    "type": "MentionElement",
+                    "userColor": "System",
+                    "userLoginName": "forsen",
+                    "words": [
+                        "forsen"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "."
+                    ]
+                }
+            ],
+            "flags": "System|Timeout|PubSub|SharedMessage|EventSub|ModerationAction",
+            "id": "",
+            "localizedName": "",
+            "loginName": "nerixyz",
+            "messageText": "nerixyz banned twitchdev in forsen. ",
+            "searchText": "nerixyz banned twitchdev in forsen. ",
+            "serverReceivedTime": "2025-02-22T17:54:06Z",
+            "timeoutUser": "twitchdev",
+            "userID": "",
+            "usernameColor": "#ff000000"
+        }
+    ]
+}

--- a/tests/snapshots/EventSub/channel-moderate/shared-ban-stacking.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-ban-stacking.json
@@ -1,0 +1,263 @@
+{
+    "input": [
+        {
+            "__timestamp": "2025-02-22T17:54:04.523432776Z",
+            "action": "shared_chat_ban",
+            "automod_terms": null,
+            "ban": null,
+            "broadcaster_user_id": "11148817",
+            "broadcaster_user_login": "pajlada",
+            "broadcaster_user_name": "pajlada",
+            "delete": null,
+            "followers": null,
+            "mod": null,
+            "moderator_user_id": "129546453",
+            "moderator_user_login": "nerixyz",
+            "moderator_user_name": "nerixyz",
+            "raid": null,
+            "shared_chat_ban": {
+                "reason": "",
+                "user_id": "141981764",
+                "user_login": "twitchdev",
+                "user_name": "TwitchDev"
+            },
+            "shared_chat_delete": null,
+            "shared_chat_timeout": null,
+            "shared_chat_unban": null,
+            "shared_chat_untimeout": null,
+            "slow": null,
+            "source_broadcaster_user_id": "117166826",
+            "source_broadcaster_user_login": "testaccount_420",
+            "source_broadcaster_user_name": "테스트계정420",
+            "timeout": null,
+            "unban": null,
+            "unban_request": null,
+            "unmod": null,
+            "unraid": null,
+            "untimeout": null,
+            "unvip": null,
+            "vip": null,
+            "warn": null
+        },
+        {
+            "__timestamp": "2025-02-22T17:54:05.523432776Z",
+            "action": "shared_chat_ban",
+            "automod_terms": null,
+            "ban": null,
+            "broadcaster_user_id": "11148817",
+            "broadcaster_user_login": "pajlada",
+            "broadcaster_user_name": "pajlada",
+            "delete": null,
+            "followers": null,
+            "mod": null,
+            "moderator_user_id": "129546453",
+            "moderator_user_login": "nerixyz",
+            "moderator_user_name": "nerixyz",
+            "raid": null,
+            "shared_chat_ban": {
+                "reason": "",
+                "user_id": "141981764",
+                "user_login": "twitchdev",
+                "user_name": "TwitchDev"
+            },
+            "shared_chat_delete": null,
+            "shared_chat_timeout": null,
+            "shared_chat_unban": null,
+            "shared_chat_untimeout": null,
+            "slow": null,
+            "source_broadcaster_user_id": "117166826",
+            "source_broadcaster_user_login": "testaccount_420",
+            "source_broadcaster_user_name": "테스트계정420",
+            "timeout": null,
+            "unban": null,
+            "unban_request": null,
+            "unmod": null,
+            "unraid": null,
+            "untimeout": null,
+            "unvip": null,
+            "vip": null,
+            "warn": null
+        },
+        {
+            "__timestamp": "2025-02-22T17:54:06.523432776Z",
+            "action": "shared_chat_ban",
+            "automod_terms": null,
+            "ban": null,
+            "broadcaster_user_id": "11148817",
+            "broadcaster_user_login": "pajlada",
+            "broadcaster_user_name": "pajlada",
+            "delete": null,
+            "followers": null,
+            "mod": null,
+            "moderator_user_id": "129546453",
+            "moderator_user_login": "nerixyz",
+            "moderator_user_name": "nerixyz",
+            "raid": null,
+            "shared_chat_ban": {
+                "reason": "",
+                "user_id": "141981764",
+                "user_login": "twitchdev",
+                "user_name": "TwitchDev"
+            },
+            "shared_chat_delete": null,
+            "shared_chat_timeout": null,
+            "shared_chat_unban": null,
+            "shared_chat_untimeout": null,
+            "slow": null,
+            "source_broadcaster_user_id": "117166826",
+            "source_broadcaster_user_login": "testaccount_420",
+            "source_broadcaster_user_name": "테스트계정420",
+            "timeout": null,
+            "unban": null,
+            "unban_request": null,
+            "unmod": null,
+            "unraid": null,
+            "untimeout": null,
+            "unvip": null,
+            "vip": null,
+            "warn": null
+        }
+    ],
+    "output": [
+        {
+            "badgeInfos": {
+            },
+            "badges": [
+            ],
+            "channelName": "testaccount_420",
+            "count": 3,
+            "displayName": "",
+            "elements": [
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "TimestampMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "17:54"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "17:54:06",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "nerixyz"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "nerixyz"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "banned"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "twitchdev"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "twitchdev"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "in"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "testaccount_420"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": false,
+                    "type": "TextElement",
+                    "words": [
+                        "testaccount_420"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        ".",
+                        "(3",
+                        "times)"
+                    ]
+                }
+            ],
+            "flags": "System|Timeout|PubSub|SharedMessage|EventSub|ModerationAction",
+            "id": "",
+            "localizedName": "",
+            "loginName": "",
+            "messageText": "nerixyz banned twitchdev in testaccount_420. (3 times) ",
+            "searchText": "nerixyz banned twitchdev in testaccount_420. (3 times) ",
+            "serverReceivedTime": "2025-02-22T17:54:06Z",
+            "timeoutUser": "twitchdev",
+            "userID": "",
+            "usernameColor": "#ff000000"
+        }
+    ]
+}

--- a/tests/snapshots/EventSub/channel-moderate/shared-ban.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-ban.json
@@ -43,7 +43,7 @@
             },
             "badges": [
             ],
-            "channelName": "",
+            "channelName": "testaccount_420",
             "count": 1,
             "displayName": "",
             "elements": [
@@ -174,7 +174,7 @@
                     ]
                 }
             ],
-            "flags": "System|Timeout|EventSub|ModerationAction",
+            "flags": "System|Timeout|PubSub|SharedMessage|EventSub|ModerationAction",
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

In PubSub and IRC, we stack bans. We should do the same with EventSub (In https://github.com/Chatterino/chatterino2/pull/5985 I didn't want to do this, but now I realized that I was wrong). For the message itself, all it takes is to set the `PubSub` flag.
We now set the shared message info correctly on these messages.

Towards #5908.