### PR TITLE
fix(eventsub): retry if the WS session expired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@
 - Bugfix: Fixed some windows not immediately closing. (#6054)
 - Bugfix: The emote button no longer looks crunchy. (#6080, #6085)
 - Dev: Subscriptions to PubSub channel points redemption topics now use no auth token, making it continue to work during PubSub shutdown. (#5947)
-- Dev: Add initial experimental EventSub support. (#5837, #5895, #5897, #5904, #5910, #5903, #5915, #5916, #5930, #5935, #5932, #5943, #5952, #5953, #5968, #5973, #5974, #5980, #5981, #5985, #5990, #5992, #5993, #5996, #5995, #6000, #6001, #6002, #6003, #6005, #6007, #6010, #6008, #6012, #6013, #6015, #6017, #6027, #6028, #6035, #6036, #6040, #6041, #6048, #6058, #6059, #6078, #6079, #6086, #6092)
+- Dev: Add initial experimental EventSub support. (#5837, #5895, #5897, #5904, #5910, #5903, #5915, #5916, #5930, #5935, #5932, #5943, #5952, #5953, #5968, #5973, #5974, #5980, #5981, #5985, #5990, #5992, #5993, #5996, #5995, #6000, #6001, #6002, #6003, #6005, #6007, #6010, #6008, #6012, #6013, #6015, #6017, #6027, #6028, #6035, #6036, #6040, #6041, #6048, #6058, #6059, #6078, #6079, #6086, #6092, #6093)
 - Dev: Remove unneeded platform specifier for toasts. (#5914)
 - Dev: Cleanly shutdown on `SIGINT`/`SIGTERM` on Linux & macOS. (#6053)
 - Dev: Highlight checks now use non-capturing groups for the boundaries. (#5784)

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -3271,7 +3271,16 @@ void Helix::createEventSubSubscription(
             switch (*result.status())
             {
                 case 400: {
-                    failureCallback(Error::BadRequest, message);
+                    if (message.startsWith(
+                            "websocket transport session does not exist",
+                            Qt::CaseInsensitive))
+                    {
+                        failureCallback(Error::NoSession, message);
+                    }
+                    else
+                    {
+                        failureCallback(Error::BadRequest, message);
+                    }
                 }
                 break;
 

--- a/src/providers/twitch/api/Helix.hpp
+++ b/src/providers/twitch/api/Helix.hpp
@@ -864,6 +864,7 @@ enum class HelixCreateEventSubSubscriptionError : std::uint8_t {
     Forbidden,
     Conflict,
     Ratelimited,
+    NoSession,
 
     // The error message is forwarded directly from the Twitch API
     Forwarded,


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

When debugging and breaking at the right time (e.g. because of an exception), the WS session might time out. This will cause Twitch to return a 400. I have a feeling that this will happen more often. When retrying, we retry with the new session ID (if it exists).

Towards #5908.