### PR TITLE
Release v2.5.3-beta.1

### DIFF
--- a/.CI/chatterino-installer.iss
+++ b/.CI/chatterino-installer.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Chatterino"
-#define MyAppVersion "2.5.2"
+#define MyAppVersion "2.5.3"
 #define MyAppPublisher "Chatterino Team"
 #define MyAppURL "https://www.chatterino.com"
 #define MyAppExeName "chatterino.exe"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+## 2.5.3-beta.1
+
 - Minor: Added an option to allow multiple user-selected extensions to interact with Chatterino. (#5997)
 - Minor: Add `Set highlight sounds` and `Open subscription page` split hotkeys. (#5856, #6030)
 - Minor: `/clear` messages are now stacked like timeouts. (#5806)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ if(BUILD_BENCHMARKS)
 endif()
 
 project(chatterino
-    VERSION 2.5.2
+    VERSION 2.5.3
     DESCRIPTION "Chat client for twitch.tv"
     HOMEPAGE_URL "https://chatterino.com/"
 )

--- a/resources/com.chatterino.chatterino.appdata.xml
+++ b/resources/com.chatterino.chatterino.appdata.xml
@@ -34,6 +34,9 @@
         <binary>chatterino</binary>
     </provides>
     <releases>
+        <release version="2.5.3~beta1" date="2025-03-17">
+            <url>https://github.com/Chatterino/chatterino2/releases/tag/v2.5.3-beta.1</url>
+        </release>
         <release version="2.5.2" date="2025-01-05">
             <url>https://github.com/Chatterino/chatterino2/releases/tag/v2.5.2</url>
         </release>

--- a/src/common/Version.hpp
+++ b/src/common/Version.hpp
@@ -25,7 +25,7 @@ namespace chatterino {
  *  - 2.4.0-alpha.2
  *  - 2.4.0-alpha
  **/
-inline const QString CHATTERINO_VERSION = QStringLiteral("2.5.2");
+inline const QString CHATTERINO_VERSION = QStringLiteral("2.5.3-beta.1");
 
 class Version
 {


### PR DESCRIPTION
# Checklist for making a release

## In the release PR

- [x] Updated version code in `src/common/Version.hpp`
- [x] Updated version code in `CMakeLists.txt`  
       This can only be "whole versions", so if you're releasing `2.4.0-beta` you'll need to condense it to `2.4.0`
- [x] Add a new release at the top of the `releases` key in `resources/com.chatterino.chatterino.appdata.xml`  
       This cannot use dash to denote a pre-release identifier, you have to use a tilde instead.

- [x] Updated version code in `.CI/chatterino-installer.iss`  
       This can only be "whole versions", so if you're releasing `2.4.0-beta` you'll need to condense it to `2.4.0`

- [x] Update the changelog `## Unreleased` section to the new version `CHANGELOG.md`  
       Make sure to leave the `## Unreleased` line unchanged for easier merges

- [x] Ensure all GitHub API credentials from the `chatterino-ci` user are still valid

## After the PR has been merged

- [ ] Tag the release
- [ ] Manually run the [create-installer](https://github.com/Chatterino/chatterino2/actions/workflows/create-installer.yml) workflow.  
       This is only necessary if the tag was created after the CI in the main branch finished.
- [ ] __Stable release only__ If the winget releaser action doesn't work as expected, you can run this manually using [Komac](https://github.com/russellbanks/Komac), replacing `v2.5.2` with the current release:  
       `komac update ChatterinoTeam.Chatterino --version 2.5.2 --urls https://github.com/Chatterino/chatterino2/releases/download/v2.5.2/Chatterino.Installer.exe`
- [ ] Ensure changelog on website is up-to-date

## After the binaries have been uploaded to fourtf's bucket

- [ ] __Stable release only__ Re-run the Publish Homebrew Cask on Release action
- [ ] Update links in the Chatterino website to point to the new release
