### PR TITLE
fix: focus input after updating visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+- Bugfix: Fixed the channel name input not being focused when opening the select-channel dialog. (#6096)
+
 ## 2.5.3-beta.1
 
 - Minor: Added an option to allow multiple user-selected extensions to interact with Chatterino. (#5997)

--- a/src/widgets/dialogs/SelectChannelDialog.cpp
+++ b/src/widgets/dialogs/SelectChannelDialog.cpp
@@ -55,14 +55,14 @@ SelectChannelDialog::SelectChannelDialog(QWidget *parent)
     QObject::connect(ui.channel, &AutoCheckedRadioButton::toggled, this,
                      [this](bool enabled) {
                          auto &ui = this->ui_;
+                         ui.channelName->setVisible(enabled);
+                         ui.channelLabel->setVisible(enabled);
+
                          if (enabled)
                          {
                              ui.channelName->setFocus();
                              ui.channelName->selectAll();
                          }
-
-                         ui.channelName->setVisible(enabled);
-                         ui.channelLabel->setVisible(enabled);
                      });
 
     ui.channel->installEventFilter(&this->tabFilter_);


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

When opening the dialog for a regular Twitch channel, the input wasn't focused. With this change, the input is first shown and focused afterwards.