### PR TITLE
fix: use a palette for dialogs

### DIFF
--- a/src/singletons/Theme.cpp
+++ b/src/singletons/Theme.cpp
@@ -555,6 +555,29 @@ void Theme::parseFrom(const QJsonObject &root, bool isCustomTheme)
         this->buttons.copy = getResources().buttons.copyLight;
         this->buttons.pin = getResources().buttons.pinDisabledLight;
     }
+
+    // This assumes that we never update the application palette
+    auto palette = QApplication::palette();
+
+    if (this->isLightTheme())
+    {
+        palette.setColor(QPalette::Window, this->window.background);
+        palette.setColor(QPalette::Base, {0xe9, 0xe9, 0xe9});
+        palette.setColor(QPalette::AlternateBase, {0xe0, 0xe0, 0xe0});
+        palette.setColor(QPalette::Button, {0xd9, 0xd9, 0xd9});
+        palette.setColor(QPalette::Text, this->window.text);
+        palette.setColor(QPalette::WindowText, this->window.text);
+        palette.setColor(QPalette::ButtonText, this->window.text);
+        palette.setColor(QPalette::BrightText, Qt::red);
+        palette.setColor(QPalette::ToolTipBase, Qt::white);
+        palette.setColor(QPalette::ToolTipText, Qt::black);
+        palette.setColor(QPalette::Link, Qt::blue);
+        palette.setColor(QPalette::LinkVisited, Qt::magenta);
+        palette.setColor(QPalette::Highlight, {42, 130, 218});
+        palette.setColor(QPalette::HighlightedText, Qt::white);
+        palette.setColor(QPalette::PlaceholderText, {0x90, 0x90, 0x90});
+    }
+    this->palette = palette;
 }
 
 bool Theme::isAutoReloading() const

--- a/src/singletons/Theme.hpp
+++ b/src/singletons/Theme.hpp
@@ -155,6 +155,8 @@ public:
         QPixmap pin;
     } buttons;
 
+    QPalette palette;
+
     void normalizeColor(QColor &color) const;
     void update();
 

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -667,10 +667,7 @@ void EmotePopup::themeChangedEvent()
 {
     BasePopup::themeChangedEvent();
 
-    // NOTE: This currently overrides the QLineEdit's font size.
-    // If the dialog is open when the theme is changed, things will look a bit off.
-    // This can be alleviated by us using a single application-wide style sheet for these things.
-    this->search_->setStyleSheet(this->theme->splits.input.styleSheet);
+    this->setPalette(getTheme()->palette);
 }
 
 void EmotePopup::closeEvent(QCloseEvent *event)

--- a/src/widgets/dialogs/SelectChannelDialog.cpp
+++ b/src/widgets/dialogs/SelectChannelDialog.cpp
@@ -375,12 +375,7 @@ void SelectChannelDialog::themeChangedEvent()
 {
     BaseWindow::themeChangedEvent();
 
-    auto &ui = this->ui_;
-
-    // NOTE: This currently overrides the QLineEdit's font size.
-    // If the dialog is open when the theme is changed, things will look a bit off.
-    // This can be alleviated by us using a single application-wide style sheet for these things.
-    ui.channelName->setStyleSheet(this->theme->splits.input.styleSheet);
+    this->setPalette(getTheme()->palette);
 }
 
 void SelectChannelDialog::scaleChangedEvent(float newScale)

--- a/src/widgets/helper/SearchPopup.cpp
+++ b/src/widgets/helper/SearchPopup.cpp
@@ -219,10 +219,7 @@ void SearchPopup::themeChangedEvent()
 {
     BasePopup::themeChangedEvent();
 
-    // NOTE: This currently overrides the QLineEdit's font size.
-    // If the dialog is open when the theme is changed, things will look a bit off.
-    // This can be alleviated by us using a single application-wide style sheet for these things.
-    this->searchInput_->setStyleSheet(this->theme->splits.input.styleSheet);
+    this->setPalette(getTheme()->palette);
 }
 
 void SearchPopup::search()


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

The inputs changed in https://github.com/Chatterino/chatterino2/pull/6055 looked off, because they didn't have a border. https://github.com/Chatterino/chatterino2/issues/6022 didn't mention that buttons and other controls weren't themed properly. This PR fixes that.

| Theme | Before | After |
|---|---|---|
| White | ![](https://github.com/user-attachments/assets/370c0fee-87a8-46a9-a2e7-18eece8a565d) | ![](https://github.com/user-attachments/assets/61a07968-e3c7-476b-b566-801e263e5809) |
| Light | ![](https://github.com/user-attachments/assets/330b77f3-441f-40e0-b215-31f8a37c455b) | ![](https://github.com/user-attachments/assets/a26238d4-7504-4fcb-a8ed-c60537ad9002) |
| Dark | ![](https://github.com/user-attachments/assets/a44279c3-f85f-4497-a253-97246a56c069) | ![](https://github.com/user-attachments/assets/dc890ce1-d0a4-483d-a34e-5d4c985f0768) |
| Black | ![](https://github.com/user-attachments/assets/efd036fe-bc9d-4c1e-98d3-cacfb8b65529) | ![](https://github.com/user-attachments/assets/f51bb2c1-126c-4836-8b3d-174a966a992a) |

