### PR TITLE
fix: don't show moderation buttons on your own usercard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Bugfix: Fixed the channel name input not being focused when opening the select-channel dialog. (#6096)
 - Bugfix: Fixed inputs in dialogs not having a border around and padding in them. (#6098)
 - Bugfix: Don't set default binding for "Toggle local R9K" on macOS. Was <kbd>CTRL</kbd> + <kdb>H</kdb> before, which clashes with a system binding. (#5764)
+- Bugfix: Don't add moderation buttons to your own Usercard. (#6107)
 - Dev: Temporarily disable precompiled header support for macOS. (#6104)
 
 ## 2.5.3-beta.1

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -494,26 +494,26 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically, Split *split)
 
         // We can safely ignore this signal connection since this is a private signal, and
         // we only connect once
-        std::ignore = this->userStateChanged_.connect([this, lineMod,
-                                                       timeout]() mutable {
-            TwitchChannel *twitchChannel =
-                dynamic_cast<TwitchChannel *>(this->underlyingChannel_.get());
+        std::ignore =
+            this->userStateChanged_.connect([this, lineMod, timeout]() mutable {
+                TwitchChannel *twitchChannel = dynamic_cast<TwitchChannel *>(
+                    this->underlyingChannel_.get());
 
-            bool visible = false;
-            if (twitchChannel)
-            {
-                bool isMyself =
-                    QString::compare(getApp()
-                                         ->getAccounts()
-                                         ->twitch.getCurrent()
-                                         ->getUserName(),
-                                     this->userName_, Qt::CaseInsensitive) == 0;
-                bool hasModRights = twitchChannel->hasModRights();
-                visible = hasModRights && !isMyself;
-            }
-            lineMod->setVisible(visible);
-            timeout->setVisible(visible);
-        });
+                bool visible = false;
+                if (twitchChannel)
+                {
+                    bool isMyself =
+                        getApp()
+                            ->getAccounts()
+                            ->twitch.getCurrent()
+                            ->getUserName()
+                            .compare(this->userName_, Qt::CaseInsensitive) == 0;
+                    bool hasModRights = twitchChannel->hasModRights();
+                    visible = hasModRights && !isMyself;
+                }
+                lineMod->setVisible(visible);
+                timeout->setVisible(visible);
+            });
 
         // We can safely ignore this signal connection since we own the button, and
         // the button will always be destroyed before the UserInfoPopup
@@ -1052,8 +1052,7 @@ void UserInfoPopup::updateUserData()
     this->ui_.block->setEnabled(false);
     this->ui_.ignoreHighlights->setEnabled(false);
     bool isMyself =
-        QString::compare(
-            getApp()->getAccounts()->twitch.getCurrent()->getUserName(),
+        getApp()->getAccounts()->twitch.getCurrent()->getUserName().compare(
             this->userName_, Qt::CaseInsensitive) == 0;
     this->ui_.block->setVisible(!isMyself);
     this->ui_.ignoreHighlights->setVisible(!isMyself);

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -401,17 +401,11 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically, Split *split)
     auto user = layout.emplace<QHBoxLayout>().withoutMargin();
     {
         user->addStretch(1);
-        bool isMyself =
-            QString::compare(
-                getApp()->getAccounts()->twitch.getCurrent()->getUserName(),
-                this->userName_, Qt::CaseInsensitive) == 0;
-        if (isMyself)
-        {
-            user.emplace<QCheckBox>("Block").assign(&this->ui_.block);
-            user.emplace<QCheckBox>("Ignore highlights")
-                .assign(&this->ui_.ignoreHighlights);
-            // visibility of this is updated in setData
-        }
+
+        user.emplace<QCheckBox>("Block").assign(&this->ui_.block);
+        user.emplace<QCheckBox>("Ignore highlights")
+            .assign(&this->ui_.ignoreHighlights);
+        // visibility of this is updated in setData
 
         auto usercard =
             user.emplace<EffectLabel2>(this).assign(&this->ui_.usercardLabel);
@@ -508,13 +502,13 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically, Split *split)
             bool visible = false;
             if (twitchChannel)
             {
-                const bool isMyself =
+                bool isMyself =
                     QString::compare(getApp()
                                          ->getAccounts()
                                          ->twitch.getCurrent()
                                          ->getUserName(),
                                      this->userName_, Qt::CaseInsensitive) == 0;
-                const bool hasModRights = twitchChannel->hasModRights();
+                bool hasModRights = twitchChannel->hasModRights();
                 visible = hasModRights && !isMyself;
             }
             lineMod->setVisible(visible);
@@ -1057,6 +1051,12 @@ void UserInfoPopup::updateUserData()
 
     this->ui_.block->setEnabled(false);
     this->ui_.ignoreHighlights->setEnabled(false);
+    bool isMyself =
+        QString::compare(
+            getApp()->getAccounts()->twitch.getCurrent()->getUserName(),
+            this->userName_, Qt::CaseInsensitive) == 0;
+    this->ui_.block->setVisible(!isMyself);
+    this->ui_.ignoreHighlights->setVisible(!isMyself);
 }
 
 void UserInfoPopup::loadAvatar(const QUrl &url)


### PR DESCRIPTION
Fixes: #6064 

Before:
<img width="433" alt="Screenshot 2025-03-23 at 12 23 31 AM" src="https://github.com/user-attachments/assets/e55669f6-eea8-4206-a2e8-7818d016b559" />



After:
<img width="417" alt="Screenshot 2025-03-23 at 12 26 07 AM" src="https://github.com/user-attachments/assets/7da15f32-1ab7-4310-8ca7-0b29e361f118" />
