### PR TITLE
Release v2.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+## 2.5.3
+
 - Minor: Shared chat messages now use the source channel's profile picture to denote it's a shared chat message. (#5760)
 - Minor: Moved the "Delete message" menu option into a "Moderate" sub-menu. (#6100)
 - Bugfix: Fixed the channel name input not being focused when opening the select-channel dialog. (#6096)

--- a/docs/make-release.md
+++ b/docs/make-release.md
@@ -11,8 +11,8 @@
 - [ ] Updated version code in `.CI/chatterino-installer.iss`  
        This can only be "whole versions", so if you're releasing `2.4.0-beta` you'll need to condense it to `2.4.0`
 
-- [ ] Update the changelog `## Unreleased` section to the new version `CHANGELOG.md`  
-       Make sure to leave the `## Unreleased` line unchanged for easier merges
+- [ ] Update the changelog `## Unversioned` section to the new version `CHANGELOG.md`  
+       Make sure to leave the `## Unversioned` line unchanged for easier merges
 
 - [ ] Ensure all GitHub API credentials from the `chatterino-ci` user are still valid
 

--- a/docs/make-release.md
+++ b/docs/make-release.md
@@ -21,11 +21,11 @@
 - [ ] Tag the release
 - [ ] Manually run the [create-installer](https://github.com/Chatterino/chatterino2/actions/workflows/create-installer.yml) workflow.  
        This is only necessary if the tag was created after the CI in the main branch finished.
-- [ ] __Stable release only__ If the winget releaser action doesn't work as expected, you can run this manually using [Komac](https://github.com/russellbanks/Komac), replacing `v2.5.2` with the current release:  
+- [ ] **Stable release only** If the winget releaser action doesn't work as expected, you can run this manually using [Komac](https://github.com/russellbanks/Komac), replacing `v2.5.2` with the current release:  
        `komac update ChatterinoTeam.Chatterino --version 2.5.2 --urls https://github.com/Chatterino/chatterino2/releases/download/v2.5.2/Chatterino.Installer.exe`
 - [ ] Ensure changelog on website is up-to-date
 
 ## After the binaries have been uploaded to fourtf's bucket
 
-- [ ] __Stable release only__ Re-run the Publish Homebrew Cask on Release action
+- [ ] **Stable release only** Re-run the Publish Homebrew Cask on Release action
 - [ ] Update links in the Chatterino website to point to the new release

--- a/docs/make-release.md
+++ b/docs/make-release.md
@@ -21,10 +21,11 @@
 - [ ] Tag the release
 - [ ] Manually run the [create-installer](https://github.com/Chatterino/chatterino2/actions/workflows/create-installer.yml) workflow.  
        This is only necessary if the tag was created after the CI in the main branch finished.
-- [ ] If the winget releaser action doesn't work as expected, you can run this manually using [Komac](https://github.com/russellbanks/Komac), replacing `v2.5.2` with the current release:  
+- [ ] __Stable release only__ If the winget releaser action doesn't work as expected, you can run this manually using [Komac](https://github.com/russellbanks/Komac), replacing `v2.5.2` with the current release:  
        `komac update ChatterinoTeam.Chatterino --version 2.5.2 --urls https://github.com/Chatterino/chatterino2/releases/download/v2.5.2/Chatterino.Installer.exe`
+- [ ] Ensure changelog on website is up-to-date
 
 ## After the binaries have been uploaded to fourtf's bucket
 
-- [ ] Re-run the Publish Homebrew Cask on Release action
+- [ ] __Stable release only__ Re-run the Publish Homebrew Cask on Release action
 - [ ] Update links in the Chatterino website to point to the new release

--- a/resources/com.chatterino.chatterino.appdata.xml
+++ b/resources/com.chatterino.chatterino.appdata.xml
@@ -34,6 +34,9 @@
         <binary>chatterino</binary>
     </provides>
     <releases>
+        <release version="2.5.3" date="2025-03-23">
+            <url>https://github.com/Chatterino/chatterino2/releases/tag/v2.5.3</url>
+        </release>
         <release version="2.5.3~beta1" date="2025-03-17">
             <url>https://github.com/Chatterino/chatterino2/releases/tag/v2.5.3-beta.1</url>
         </release>

--- a/src/common/Version.hpp
+++ b/src/common/Version.hpp
@@ -25,7 +25,7 @@ namespace chatterino {
  *  - 2.4.0-alpha.2
  *  - 2.4.0-alpha
  **/
-inline const QString CHATTERINO_VERSION = QStringLiteral("2.5.3-beta.1");
+inline const QString CHATTERINO_VERSION = QStringLiteral("2.5.3");
 
 class Version
 {


### PR DESCRIPTION
# Checklist for making a release

## In the release PR

- [x] Updated version code in `src/common/Version.hpp`
- [x] Updated version code in `CMakeLists.txt`  
       This can only be "whole versions", so if you're releasing `2.4.0-beta` you'll need to condense it to `2.4.0`
- [x] Add a new release at the top of the `releases` key in `resources/com.chatterino.chatterino.appdata.xml`  
       This cannot use dash to denote a pre-release identifier, you have to use a tilde instead.

- [x] Updated version code in `.CI/chatterino-installer.iss`  
       This can only be "whole versions", so if you're releasing `2.4.0-beta` you'll need to condense it to `2.4.0`

- [x] Update the changelog `## Unreleased` section to the new version `CHANGELOG.md`  
       Make sure to leave the `## Unreleased` line unchanged for easier merges

- [x] Ensure all GitHub API credentials from the `chatterino-ci` user are still valid

## After the PR has been merged

- [ ] Tag the release
- [ ] Manually run the [create-installer](https://github.com/Chatterino/chatterino2/actions/workflows/create-installer.yml) workflow.  
       This is only necessary if the tag was created after the CI in the main branch finished.
- [ ] __Stable release only__ If the winget releaser action doesn't work as expected, you can run this manually using [Komac](https://github.com/russellbanks/Komac), replacing `v2.5.2` with the current release:  
       `komac update ChatterinoTeam.Chatterino --version 2.5.2 --urls https://github.com/Chatterino/chatterino2/releases/download/v2.5.2/Chatterino.Installer.exe`
- [ ] Ensure changelog on website is up-to-date

## After the binaries have been uploaded to fourtf's bucket

- [ ] __Stable release only__ Re-run the Publish Homebrew Cask on Release action
- [ ] Update links in the Chatterino website to point to the new release
