### PR TITLE
fix cmd+backspace behavior in main chat dialog input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Bugfix: Don't set default binding for "Toggle local R9K" on macOS. Was <kbd>CTRL</kbd> + <kdb>H</kdb> before, which clashes with a system binding. (#5764)
 - Bugfix: Don't add moderation buttons to your own Usercard. (#6107)
 - Dev: Temporarily disable precompiled header support for macOS. (#6104)
-- Bugfix: Fix <kbd>CMD</kbd> + <kbd>BACKSPACE</kbd> not clearing main chat dialog input. (#6111)
+- Bugfix: Handle <kbd>CMD</kbd> + <kbd>BACKSPACE</kbd> behavior explicitly in main chat dialog input for macOS. (#6111)
 
 ## 2.5.3-beta.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+- Bugfix: Handle <kbd>CMD</kbd> + <kbd>BACKSPACE</kbd> behavior explicitly in main chat dialog input for macOS. (#6111)
+
 ## 2.5.3
 
 - Minor: Shared chat messages now use the source channel's profile picture to denote it's a shared chat message. (#5760)
@@ -11,7 +13,6 @@
 - Bugfix: Don't set default binding for "Toggle local R9K" on macOS. Was <kbd>CTRL</kbd> + <kdb>H</kdb> before, which clashes with a system binding. (#5764)
 - Bugfix: Don't add moderation buttons to your own Usercard. (#6107)
 - Dev: Temporarily disable precompiled header support for macOS. (#6104)
-- Bugfix: Handle <kbd>CMD</kbd> + <kbd>BACKSPACE</kbd> behavior explicitly in main chat dialog input for macOS. (#6111)
 
 ## 2.5.3-beta.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Bugfix: Don't set default binding for "Toggle local R9K" on macOS. Was <kbd>CTRL</kbd> + <kdb>H</kdb> before, which clashes with a system binding. (#5764)
 - Bugfix: Don't add moderation buttons to your own Usercard. (#6107)
 - Dev: Temporarily disable precompiled header support for macOS. (#6104)
-- Bugfix: Fix <kbd>CMD</kbd> + <kbd>BACKSPACE</kbd> not clearing main chat dialog input. ()
+- Bugfix: Fix <kbd>CMD</kbd> + <kbd>BACKSPACE</kbd> not clearing main chat dialog input. (#6111)
 
 ## 2.5.3-beta.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Bugfix: Don't set default binding for "Toggle local R9K" on macOS. Was <kbd>CTRL</kbd> + <kdb>H</kdb> before, which clashes with a system binding. (#5764)
 - Bugfix: Don't add moderation buttons to your own Usercard. (#6107)
 - Dev: Temporarily disable precompiled header support for macOS. (#6104)
+- Bugfix: Fix <kbd>CMD</kbd> + <kbd>BACKSPACE</kbd> not clearing main chat dialog input. ()
 
 ## 2.5.3-beta.1
 

--- a/src/widgets/helper/ResizingTextEdit.cpp
+++ b/src/widgets/helper/ResizingTextEdit.cpp
@@ -131,12 +131,14 @@ bool ResizingTextEdit::eventFilter(QObject *obj, QEvent *event)
 }
 void ResizingTextEdit::keyPressEvent(QKeyEvent *event)
 {
+#ifdef Q_OS_MACOS
     if ((event->modifiers() == Qt::ControlModifier) &&
         (event->key() == Qt::Key_Backspace))
     {
         this->clear();
         return;
     }
+#endif
 
     event->ignore();
 

--- a/src/widgets/helper/ResizingTextEdit.cpp
+++ b/src/widgets/helper/ResizingTextEdit.cpp
@@ -135,7 +135,9 @@ void ResizingTextEdit::keyPressEvent(QKeyEvent *event)
     if ((event->modifiers() == Qt::ControlModifier) &&
         (event->key() == Qt::Key_Backspace))
     {
-        this->clear();
+        QTextCursor cursor = this->textCursor();
+        cursor.movePosition(QTextCursor::StartOfLine, QTextCursor::KeepAnchor);
+        cursor.removeSelectedText();
         return;
     }
 #endif

--- a/src/widgets/helper/ResizingTextEdit.cpp
+++ b/src/widgets/helper/ResizingTextEdit.cpp
@@ -131,6 +131,12 @@ bool ResizingTextEdit::eventFilter(QObject *obj, QEvent *event)
 }
 void ResizingTextEdit::keyPressEvent(QKeyEvent *event)
 {
+    if ((event->modifiers() == Qt::ControlModifier) && (event->key() == Qt::Key_Backspace))
+    {
+        this->clear();
+        return;
+    }
+
     event->ignore();
 
     this->keyPressed.invoke(event);

--- a/src/widgets/helper/ResizingTextEdit.cpp
+++ b/src/widgets/helper/ResizingTextEdit.cpp
@@ -131,7 +131,8 @@ bool ResizingTextEdit::eventFilter(QObject *obj, QEvent *event)
 }
 void ResizingTextEdit::keyPressEvent(QKeyEvent *event)
 {
-    if ((event->modifiers() == Qt::ControlModifier) && (event->key() == Qt::Key_Backspace))
+    if ((event->modifiers() == Qt::ControlModifier) &&
+        (event->key() == Qt::Key_Backspace))
     {
         this->clear();
         return;

--- a/src/widgets/helper/ResizingTextEdit.cpp
+++ b/src/widgets/helper/ResizingTextEdit.cpp
@@ -138,6 +138,7 @@ void ResizingTextEdit::keyPressEvent(QKeyEvent *event)
         QTextCursor cursor = this->textCursor();
         cursor.movePosition(QTextCursor::StartOfLine, QTextCursor::KeepAnchor);
         cursor.removeSelectedText();
+        this->setTextCursor(cursor);
         return;
     }
 #endif


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

fixes #4755 

it seems that [QTextEdit](https://doc.qt.io/qt-6/qtextedit.html#editing-key-bindings) does not handle this behavior on its own like [QLineEdit](https://doc.qt.io/qt-6/qlineedit.html#default-key-bindings) does. handling the behavior explicitly fixes the issue.