### PR TITLE
Fix: Don't create native messaging manifest file if browser directory doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+- Bugfix: Don't create native messaging manifest file if browser directory doesn't exist. (#6116)
+
 ## 2.5.3
 
 - Minor: Shared chat messages now use the source channel's profile picture to denote it's a shared chat message. (#5760)

--- a/src/singletons/NativeMessaging.cpp
+++ b/src/singletons/NativeMessaging.cpp
@@ -77,6 +77,15 @@ void writeManifestTo(QString directory, const QString &filename,
     }
 
     QDir dir(directory);
+
+    // check if the parent directory (i.e. the browsers directory) exists
+    // if it does not exist we abort because it means that the browser is not installed
+    QDir dirCpy = dir;
+    if (!dirCpy.cdUp())
+    {
+        return;
+    }
+
     if (!dir.mkpath(u"."_s))
     {
         qCWarning(chatterinoNativeMessage) << "Failed to create" << directory;

--- a/src/singletons/NativeMessaging.hpp
+++ b/src/singletons/NativeMessaging.hpp
@@ -1,12 +1,26 @@
 #pragma once
 
 #include "common/Atomic.hpp"
+#include "util/Expected.hpp"
 
 #include <QString>
 #include <QThread>
 
 #include <optional>
 #include <vector>
+
+namespace chatterino::nm::detail {
+
+enum class WriteManifestError : std::uint8_t {
+    FailedToCreateDirectory,
+    FailedToCreateFile,
+};
+
+nonstd::expected<void, WriteManifestError> writeManifestTo(
+    QString directory, const QString &nmDirectory, const QString &filename,
+    const QJsonDocument &json);
+
+}  // namespace chatterino::nm::detail
 
 namespace chatterino {
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -54,6 +54,7 @@ set(test_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/src/OnceFlag.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/IncognitoBrowser.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/EventSubMessages.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/NativeMessaging.cpp
 
     ${CMAKE_CURRENT_LIST_DIR}/src/lib/Snapshot.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/lib/Snapshot.hpp

--- a/tests/src/NativeMessaging.cpp
+++ b/tests/src/NativeMessaging.cpp
@@ -60,16 +60,3 @@ TEST_F(NativeMessagingFixture, writeManifestToWindowsCurrentDir)
 
     ASSERT_TRUE(QFile(combinePath(this->dir.path(), "test.json")).exists());
 }
-
-TEST_F(NativeMessagingFixture, writeManifestBadPermissions)
-{
-    // writeManifestTo should fail if the subdir is already created but with bad permissions
-    ASSERT_TRUE(this->dir.mkpath("."));
-    ASSERT_TRUE(
-        this->dir.mkdir("native-messaging-hosts", QFileDevice::ReadOwner));
-
-    ASSERT_EQ(writeManifestTo(this->dir.path(), "native-messaging-hosts",
-                              "test.json", QJsonDocument())
-                  .error(),
-              WriteManifestError::FailedToCreateFile);
-}

--- a/tests/src/NativeMessaging.cpp
+++ b/tests/src/NativeMessaging.cpp
@@ -1,0 +1,75 @@
+#include "singletons/NativeMessaging.hpp"
+
+#include "Test.hpp"
+#include "util/CombinePath.hpp"
+
+#include <QDir>
+#include <QJsonDocument>
+#include <QTemporaryDir>
+
+using namespace chatterino;
+
+using namespace chatterino::nm::detail;
+
+class NativeMessagingFixture : public ::testing::Test
+{
+    QTemporaryDir tempDir;
+
+protected:
+    NativeMessagingFixture()
+        : dir(combinePath(this->tempDir.path(), QString("native-messaging")))
+    {
+    }
+
+    QDir dir;
+};
+
+TEST_F(NativeMessagingFixture, writeManifestToSubDirCreated)
+{
+    // writeManifestTo should succeed if the subdir directory is created
+    ASSERT_TRUE(this->dir.mkpath("."));
+
+    ASSERT_TRUE(writeManifestTo(this->dir.path(), "native-messaging-hosts",
+                                "test.json", QJsonDocument())
+                    .has_value());
+
+    QDir nmDir = combinePath(this->dir.path(), "native-messaging-hosts");
+
+    ASSERT_TRUE(nmDir.exists());
+
+    ASSERT_TRUE(QFile(combinePath(nmDir.path(), "test.json")).exists());
+}
+
+TEST_F(NativeMessagingFixture, writeManifestToSubDirNotCreated)
+{
+    // writeManifestTo should fail if the subdir is not created
+    ASSERT_EQ(writeManifestTo(this->dir.path(), "native-messaging-hosts",
+                              "test.json", QJsonDocument())
+                  .error(),
+              WriteManifestError::FailedToCreateDirectory);
+}
+
+TEST_F(NativeMessagingFixture, writeManifestToWindowsCurrentDir)
+{
+    // writeManifestTo should succeed if the subdir is created and the path to create is "."
+    ASSERT_TRUE(this->dir.mkpath("."));
+
+    ASSERT_TRUE(
+        writeManifestTo(this->dir.path(), ".", "test.json", QJsonDocument())
+            .has_value());
+
+    ASSERT_TRUE(QFile(combinePath(this->dir.path(), "test.json")).exists());
+}
+
+TEST_F(NativeMessagingFixture, writeManifestBadPermissions)
+{
+    // writeManifestTo should fail if the subdir is already created but with bad permissions
+    ASSERT_TRUE(this->dir.mkpath("."));
+    ASSERT_TRUE(
+        this->dir.mkdir("native-messaging-hosts", QFileDevice::ReadOwner));
+
+    ASSERT_EQ(writeManifestTo(this->dir.path(), "native-messaging-hosts",
+                              "test.json", QJsonDocument())
+                  .error(),
+              WriteManifestError::FailedToCreateFile);
+}


### PR DESCRIPTION
Fixes #6115

I did not find a clean way of checking this without creating a new `QDir`(or similar) object since `dir.cdUp()` changes the dir if it succeeds and `dir.exists("..")` returns false if `dir` does not exist.