### PR TITLE
chore(conan): don't create `CMakeUserPresets.json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+- Dev: Conan will no longer generate a `CMakeUserPresets.json` file. (#6117)
+
 ## 2.5.3
 
 - Minor: Shared chat messages now use the source channel's profile picture to denote it's a shared chat message. (#5760)

--- a/conanfile.py
+++ b/conanfile.py
@@ -40,6 +40,7 @@ class Chatterino(ConanFile):
         tc.blocks.remove("user_toolchain")
         tc.blocks.remove("output_dirs")
         tc.blocks.remove("apple_system")
+        tc.user_presets_path = False
         tc.generate()
 
         def copy_bin(dep, selector, subdir):


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
I was building with VisualStudio recently and used CMakePresets, but it conflicted with conan, because conan would create `CMakeUserPresets.json` which confused VS. The file that conan generates isn't useful.

I should revise the documentation for builds on Windows and add at least a small section about VS and CMakePresets, because with [cmake-conan](https://github.com/conan-io/cmake-conan), they're nice to use and will result in a vcpkg-like experience in VS.