### PR TITLE
make paused chat indicator more apparent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Unversioned
 
+- Minor: Make paused chat indicator more visible. (#6123)
 - Bugfix: Don't create native messaging manifest file if browser directory doesn't exist. (#6116)
 - Dev: Conan will no longer generate a `CMakeUserPresets.json` file. (#6117)
-- Minor: Make paused chat indicator more visible. (#6123)
 
 ## 2.5.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unversioned
 
-- Minor: Make paused chat indicator more visible. (#6123)
+- Minor: Make paused chat indicator more visible, and fix its zoom behavior. (#6123)
 - Bugfix: Don't create native messaging manifest file if browser directory doesn't exist. (#6116)
 - Dev: Conan will no longer generate a `CMakeUserPresets.json` file. (#6117)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bugfix: Don't create native messaging manifest file if browser directory doesn't exist. (#6116)
 - Dev: Conan will no longer generate a `CMakeUserPresets.json` file. (#6117)
+- Minor: Make paused chat indicator more visible. (#6123)
 
 ## 2.5.3
 

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1549,42 +1549,27 @@ void ChannelView::paintEvent(QPaintEvent *event)
     if (this->paused())
     {
         auto a = this->scale() * 20;
-        auto color = QColor(127, 127, 127, 255);
+        auto color = QColor(180, 180, 180, 255);
         auto brush = QBrush(color);
 
-        const auto widgetHeight = this->height();
-        const auto pausedY = widgetHeight - a - 5;
-        auto pausedX = 5;
-
-        painter.setPen(Qt::black);
-        painter.fillRect(QRectF(pausedX, pausedY, a / 4, a), brush);
-        painter.drawRect(QRectF(pausedX, pausedY, a / 4, a));
-
-        pausedX *= 3;
-        painter.fillRect(QRectF(pausedX, pausedY, a / 4, a), brush);
-        painter.drawRect(QRectF(pausedX, pausedY, a / 4, a));
+        const auto pausedY = a / 4;
+        const auto pausedX = 5;
 
         QFont font = painter.font();
         font.setPixelSize(a);
         painter.setFont(font);
 
-        const QString text = "Chat Paused";
+        const QString text = "Paused";
         const QFontMetrics metrics(font);
         const auto textWidth = metrics.horizontalAdvance(text);
-        const auto textX = pausedX + 10;
+        const auto textX = pausedX * 3 + 10;
 
-        for (int dx = -1; dx <= 1; ++dx)
-        {
-            for (int dy = -1; dy <= 1; ++dy)
-            {
-                if (dx != 0 || dy != 0)
-                {
-                    painter.drawText(
-                        QRectF(textX + dx, pausedY + dy, textWidth, a),
-                        Qt::AlignLeft | Qt::AlignVCenter, text);
-                }
-            }
-        }
+        painter.fillRect(
+            QRectF(0, 0, pausedX + textX + textWidth, a / 2 + a),
+            QBrush(QColor(0, 0, 0, 200), Qt::SolidPattern));
+
+        painter.fillRect(QRectF(pausedX, pausedY, a / 4, a), brush);
+        painter.fillRect(QRectF(pausedX * 3, pausedY, a / 4, a), brush);
 
         painter.setPen(color);
         painter.drawText(QRectF(textX, pausedY, textWidth, a),

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1564,9 +1564,8 @@ void ChannelView::paintEvent(QPaintEvent *event)
         const auto textWidth = metrics.horizontalAdvance(text);
         const auto textX = pausedX * 3 + 10;
 
-        painter.fillRect(
-            QRectF(0, 0, pausedX + textX + textWidth, a / 2 + a),
-            QBrush(QColor(0, 0, 0, 200), Qt::SolidPattern));
+        painter.fillRect(QRectF(0, 0, pausedX + textX + textWidth, a / 2 + a),
+                         QBrush(QColor(0, 0, 0, 200), Qt::SolidPattern));
 
         painter.fillRect(QRectF(pausedX, pausedY, a / 4, a), brush);
         painter.fillRect(QRectF(pausedX * 3, pausedY, a / 4, a), brush);

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1548,30 +1548,32 @@ void ChannelView::paintEvent(QPaintEvent *event)
     // draw paused sign
     if (this->paused())
     {
-        auto a = this->scale() * 20;
+        auto baseSize = 20;
+        auto scale = this->scale();
+        auto indicatorSize = baseSize * scale;
         auto color = QColor(180, 180, 180, 255);
         auto brush = QBrush(color);
 
-        const auto pausedY = a / 4;
-        const auto pausedX = 5;
+        const auto pausedY = indicatorSize / 4;
+        const auto pausedX = 5 * scale;
 
         QFont font = painter.font();
-        font.setPixelSize(a);
+        font.setPixelSize(indicatorSize);
         painter.setFont(font);
 
         const QString text = "Paused";
         const QFontMetrics metrics(font);
         const auto textWidth = metrics.horizontalAdvance(text);
-        const auto textX = pausedX * 3 + 10;
+        const auto textX = pausedX * 3 + 10 * scale;
 
-        painter.fillRect(QRectF(0, 0, pausedX + textX + textWidth, a / 2 + a),
+        painter.fillRect(QRectF(0, 0, pausedX + textX + textWidth, indicatorSize / 2 + indicatorSize),
                          QBrush(QColor(0, 0, 0, 200), Qt::SolidPattern));
 
-        painter.fillRect(QRectF(pausedX, pausedY, a / 4, a), brush);
-        painter.fillRect(QRectF(pausedX * 3, pausedY, a / 4, a), brush);
+        painter.fillRect(QRectF(pausedX, pausedY, indicatorSize / 4, indicatorSize), brush);
+        painter.fillRect(QRectF(pausedX * 3, pausedY, indicatorSize / 4, indicatorSize), brush);
 
         painter.setPen(color);
-        painter.drawText(QRectF(textX, pausedY, textWidth, a),
+        painter.drawText(QRectF(textX, pausedY, textWidth, indicatorSize),
                          Qt::AlignLeft | Qt::AlignVCenter, text);
     }
 }

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1549,9 +1549,43 @@ void ChannelView::paintEvent(QPaintEvent *event)
     if (this->paused())
     {
         auto a = this->scale() * 20;
-        auto brush = QBrush(QColor(127, 127, 127, 255));
-        painter.fillRect(QRectF(5, a / 4, a / 4, a), brush);
-        painter.fillRect(QRectF(15, a / 4, a / 4, a), brush);
+        auto color = QColor(127, 127, 127, 255);
+        auto brush = QBrush(color);
+
+        const auto widgetHeight = this->height();
+        const auto pausedY = widgetHeight - a - 5;
+        auto pausedX = 5;
+
+        painter.setPen(Qt::black);
+        painter.fillRect(QRectF(pausedX, pausedY, a / 4, a), brush);
+        painter.drawRect(QRectF(pausedX, pausedY, a / 4, a));
+
+        pausedX *= 3;
+        painter.fillRect(QRectF(pausedX, pausedY, a / 4, a), brush);
+        painter.drawRect(QRectF(pausedX, pausedY, a / 4, a));
+
+        QFont font = painter.font();
+        font.setPixelSize(a);
+        painter.setFont(font);
+
+        const QString text = "Chat Paused";
+        const QFontMetrics metrics(font);
+        const auto textWidth = metrics.horizontalAdvance(text);
+        const auto textX = pausedX + 10;
+
+        for (int dx = -1; dx <= 1; ++dx)
+        {
+            for (int dy = -1; dy <= 1; ++dy)
+            {
+                if (dx != 0 || dy != 0)
+                {
+                    painter.drawText(QRectF(textX + dx, pausedY + dy, textWidth, a), Qt::AlignLeft | Qt::AlignVCenter, text);
+                }
+            }
+        }
+
+        painter.setPen(color);
+        painter.drawText(QRectF(textX, pausedY, textWidth, a), Qt::AlignLeft | Qt::AlignVCenter, text);
     }
 }
 

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1579,13 +1579,16 @@ void ChannelView::paintEvent(QPaintEvent *event)
             {
                 if (dx != 0 || dy != 0)
                 {
-                    painter.drawText(QRectF(textX + dx, pausedY + dy, textWidth, a), Qt::AlignLeft | Qt::AlignVCenter, text);
+                    painter.drawText(
+                        QRectF(textX + dx, pausedY + dy, textWidth, a),
+                        Qt::AlignLeft | Qt::AlignVCenter, text);
                 }
             }
         }
 
         painter.setPen(color);
-        painter.drawText(QRectF(textX, pausedY, textWidth, a), Qt::AlignLeft | Qt::AlignVCenter, text);
+        painter.drawText(QRectF(textX, pausedY, textWidth, a),
+                         Qt::AlignLeft | Qt::AlignVCenter, text);
     }
 }
 

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1566,11 +1566,15 @@ void ChannelView::paintEvent(QPaintEvent *event)
         const auto textWidth = metrics.horizontalAdvance(text);
         const auto textX = pausedX * 3 + 10 * scale;
 
-        painter.fillRect(QRectF(0, 0, pausedX + textX + textWidth, indicatorSize / 2 + indicatorSize),
+        painter.fillRect(QRectF(0, 0, pausedX + textX + textWidth,
+                                indicatorSize / 2 + indicatorSize),
                          QBrush(QColor(0, 0, 0, 200), Qt::SolidPattern));
 
-        painter.fillRect(QRectF(pausedX, pausedY, indicatorSize / 4, indicatorSize), brush);
-        painter.fillRect(QRectF(pausedX * 3, pausedY, indicatorSize / 4, indicatorSize), brush);
+        painter.fillRect(
+            QRectF(pausedX, pausedY, indicatorSize / 4, indicatorSize), brush);
+        painter.fillRect(
+            QRectF(pausedX * 3, pausedY, indicatorSize / 4, indicatorSize),
+            brush);
 
         painter.setPen(color);
         painter.drawText(QRectF(textX, pausedY, textWidth, indicatorSize),


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

fixes #2688

the paused chat indicator in its current form is a little bit difficult to see. I am suggesting:

- adding an outline so that the indicator stands out from other widget elements such as chat timestamps
- moving the indicator to the bottom of the widget since users' eyes are more likely to be focused on the bottom half of the widget than the top half of the widget
- adding "Chat Paused" text next to the symbol to make the indicator bigger and easier to notice

# screenshots

<details>
<summary>before</summary>
<IMG src="https://github.com/user-attachments/assets/428db078-e2ee-481a-9961-428cafb3338e"/>
</details>

<details>
<summary>after (dark theme)</summary>
<IMG src="https://github.com/user-attachments/assets/67aa6d89-8a07-402e-831b-3b64555b503b"/>
</details>

<details>
<summary>after (black theme)</summary>
<IMG src="https://github.com/user-attachments/assets/1eca6576-df61-4526-8a2a-983a3bea65ea"/>
</details>

<details>
<summary>after (light theme)</summary>
<IMG src="https://github.com/user-attachments/assets/8ca67d0b-e8b8-4177-93b2-7e3fd960d8cd"/>
</details>

<details>
<summary>after (white theme)</summary>
<IMG src="https://github.com/user-attachments/assets/4b8f38d6-eeac-484c-8eeb-2765506bece2"/>
</details>