### PR TITLE
fix: allow scrolling by inputs in settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unversioned
 
 - Bugfix: Don't create native messaging manifest file if browser directory doesn't exist. (#6116)
+- Bugfix: Fixed scrolling now working on inputs in the settings. (#6128)
 - Dev: Conan will no longer generate a `CMakeUserPresets.json` file. (#6117)
 
 ## 2.5.3

--- a/src/widgets/settingspages/GeneralPageView.cpp
+++ b/src/widgets/settingspages/GeneralPageView.cpp
@@ -254,7 +254,7 @@ QSpinBox *GeneralPageView::addIntInput(const QString &text, IntSetting &setting,
     auto *label = new QLabel(text + ":");
     this->addToolTip(*label, toolTipText);
 
-    auto *input = new QSpinBox;
+    auto *input = new SpinBox;
     input->setMinimum(min);
     input->setMaximum(max);
 

--- a/src/widgets/settingspages/GeneralPageView.hpp
+++ b/src/widgets/settingspages/GeneralPageView.hpp
@@ -74,6 +74,8 @@ public:
 
 class ComboBox : public QComboBox
 {
+    Q_OBJECT
+
 protected:
     void wheelEvent(QWheelEvent *event) override
     {
@@ -83,6 +85,8 @@ protected:
 
 class SpinBox : public QSpinBox
 {
+    Q_OBJECT
+
 public:
     SpinBox(QWidget *parent = nullptr)
         : QSpinBox(parent)

--- a/src/widgets/settingspages/GeneralPageView.hpp
+++ b/src/widgets/settingspages/GeneralPageView.hpp
@@ -74,11 +74,27 @@ public:
 
 class ComboBox : public QComboBox
 {
-    Q_OBJECT
-
+protected:
     void wheelEvent(QWheelEvent *event) override
     {
-        (void)event;
+        event->ignore();
+    }
+};
+
+class SpinBox : public QSpinBox
+{
+public:
+    SpinBox(QWidget *parent = nullptr)
+        : QSpinBox(parent)
+    {
+        // QAbstractSpinBox defaults to Qt::WheelFocus
+        this->setFocusPolicy(Qt::StrongFocus);
+    }
+
+protected:
+    void wheelEvent(QWheelEvent *event) override
+    {
+        event->ignore();
     }
 };
 

--- a/src/widgets/settingspages/SettingWidget.cpp
+++ b/src/widgets/settingspages/SettingWidget.cpp
@@ -119,7 +119,7 @@ SettingWidget *SettingWidget::intInput(const QString &label,
 
     auto *lbl = new QLabel(label + ":");
 
-    auto *input = new QSpinBox;
+    auto *input = new SpinBox;
     if (params.min.has_value())
     {
         input->setMinimum(params.min.value());


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

- When scrolling on combo boxes, using the scroll wheel wouldn't do anything. Now it scrolls the parent container.
- When scrolling on spin boxes, the value would change. Now it scrolls the parent container.