### PR TITLE
fix(cmake): use `--force-openssl` on Qt 6.8+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bugfix: Don't create native messaging manifest file if browser directory doesn't exist. (#6116)
 - Dev: Conan will no longer generate a `CMakeUserPresets.json` file. (#6117)
+- Dev: Pass `--force-openssl` when installing from CMake in Qt 6.8+. (#6129)
 
 ## 2.5.3
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -929,7 +929,18 @@ if (BUILD_APP)
         get_filename_component(QT_BIN_DIR ${QT_CORE_LOC} DIRECTORY)
 
         # This assumes the installed CRT is up-to-date (see .CI/deploy-crt.ps1)
-        set(WINDEPLOYQT_COMMAND_ARGV "${WINDEPLOYQT_PATH}" "$<TARGET_FILE:${EXECUTABLE_PROJECT}>" ${WINDEPLOYQT_MODE} --no-compiler-runtime --no-translations --no-opengl-sw)
+        set(WINDEPLOYQT_COMMAND_ARGV
+            "${WINDEPLOYQT_PATH}"
+            "$<TARGET_FILE:${EXECUTABLE_PROJECT}>"
+            ${WINDEPLOYQT_MODE}
+            --no-compiler-runtime
+            --no-translations
+            --no-opengl-sw
+        )
+        if (Qt6_VERSION VERSION_GREATER_EQUAL "6.8.0")
+            # windeployqt expects to find openssl in '/bin' but we deploy it in '/'.
+            list(APPEND WINDEPLOYQT_COMMAND_ARGV --force-openssl)
+        endif()
         string(REPLACE ";" " " WINDEPLOYQT_COMMAND "${WINDEPLOYQT_COMMAND_ARGV}")
 
         install(TARGETS ${EXECUTABLE_PROJECT} 


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

`windeployqt` tries to find `libcrypto*` and `libssl*` when deploying and omits `qopensslbackend.dll` in Qt 6.8.0+ if they're not found. However, it will always look in `/bin` (relative to the output), even when specifying `--openssl-root`. Since we deploy OpenSSL to `/`, we need to pass `--force-openssl`. Since we don't have any CI builds with 6.8/6.9, this is only a CMake modification.