### PR TITLE
fix: receive bttv live updates again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Minor: Make paused chat indicator more visible, and fix its zoom behavior. (#6123)
 - Bugfix: Don't create native messaging manifest file if browser directory doesn't exist. (#6116)
 - Bugfix: Make reply-cancel button less coarse-grained. (#6106)
+- Bugfix: Fixed missing BetterTTV live updates of emotes. (#6132)
 - Dev: Conan will no longer generate a `CMakeUserPresets.json` file. (#6117)
 - Dev: Pass `--force-openssl` when installing from CMake in Qt 6.8+. (#6129)
 

--- a/src/providers/bttv/BttvLiveUpdates.cpp
+++ b/src/providers/bttv/BttvLiveUpdates.cpp
@@ -21,13 +21,13 @@ BttvLiveUpdates::~BttvLiveUpdates()
 }
 
 void BttvLiveUpdates::joinChannel(const QString &channelID,
-                                  const QString &userName)
+                                  const QString &userID)
 {
     if (this->joinedChannels_.insert(channelID).second)
     {
         this->subscribe({BttvLiveUpdateSubscriptionChannel{channelID}});
         this->subscribe({BttvLiveUpdateBroadcastMe{.twitchID = channelID,
-                                                   .userName = userName}});
+                                                   .userID = userID}});
     }
 }
 

--- a/src/providers/bttv/BttvLiveUpdates.hpp
+++ b/src/providers/bttv/BttvLiveUpdates.hpp
@@ -32,9 +32,9 @@ public:
      * if it's not already joined.
      *
      * @param channelID the Twitch channel-id of the broadcaster.
-     * @param userName the Twitch username of the current user.
+     * @param userID the Twitch user-id of the current user.
      */
-    void joinChannel(const QString &channelID, const QString &userName);
+    void joinChannel(const QString &channelID, const QString &userID);
 
     /**
      * Parts a twitch channel by its id (without any prefix like 'twitch:')

--- a/src/providers/bttv/liveupdates/BttvLiveUpdateSubscription.cpp
+++ b/src/providers/bttv/liveupdates/BttvLiveUpdateSubscription.cpp
@@ -79,7 +79,8 @@ QJsonObject BttvLiveUpdateBroadcastMe::encode(bool /*isSubscribe*/) const
     root["name"] = "broadcast_me";
 
     QJsonObject data;
-    data["name"] = this->userName;
+    data["provider"] = "twitch";
+    data["providerId"] = this->userID;
     data["channel"] = QString("twitch:%1").arg(this->twitchID);
 
     root["data"] = data;
@@ -89,7 +90,7 @@ QJsonObject BttvLiveUpdateBroadcastMe::encode(bool /*isSubscribe*/) const
 bool BttvLiveUpdateBroadcastMe::operator==(
     const BttvLiveUpdateBroadcastMe &rhs) const
 {
-    return this->twitchID == rhs.twitchID && this->userName == rhs.userName;
+    return this->twitchID == rhs.twitchID && this->userID == rhs.userID;
 }
 
 bool BttvLiveUpdateBroadcastMe::operator!=(
@@ -101,7 +102,7 @@ bool BttvLiveUpdateBroadcastMe::operator!=(
 QDebug &operator<<(QDebug &dbg, const BttvLiveUpdateBroadcastMe &data)
 {
     dbg << "BttvLiveUpdateBroadcastMe{ twitchID:" << data.twitchID
-        << "userName:" << data.userName << '}';
+        << "userID:" << data.userID << '}';
     return dbg;
 }
 

--- a/src/providers/bttv/liveupdates/BttvLiveUpdateSubscription.hpp
+++ b/src/providers/bttv/liveupdates/BttvLiveUpdateSubscription.hpp
@@ -22,7 +22,7 @@ struct BttvLiveUpdateSubscriptionChannel {
 
 struct BttvLiveUpdateBroadcastMe {
     QString twitchID;
-    QString userName;
+    QString userID;
 
     QJsonObject encode(bool isSubscribe) const;
     bool operator==(const BttvLiveUpdateBroadcastMe &rhs) const;
@@ -72,7 +72,7 @@ struct hash<chatterino::BttvLiveUpdateBroadcastMe> {
     {
         size_t seed = 0;
         boost::hash_combine(seed, qHash(data.twitchID));
-        boost::hash_combine(seed, qHash(data.userName));
+        boost::hash_combine(seed, qHash(data.userID));
         return seed;
     }
 };

--- a/src/providers/liveupdates/BasicPubSubManager.hpp
+++ b/src/providers/liveupdates/BasicPubSubManager.hpp
@@ -337,7 +337,7 @@ private:
     WebsocketContextPtr onTLSInit(const websocketpp::connection_hdl & /*hdl*/)
     {
         WebsocketContextPtr ctx(
-            new boost::asio::ssl::context(boost::asio::ssl::context::tlsv13));
+            new boost::asio::ssl::context(boost::asio::ssl::context::tls_client));
 
         try
         {

--- a/src/providers/liveupdates/BasicPubSubManager.hpp
+++ b/src/providers/liveupdates/BasicPubSubManager.hpp
@@ -342,8 +342,6 @@ private:
         try
         {
             ctx->set_options(boost::asio::ssl::context::default_workarounds |
-                             boost::asio::ssl::context::no_sslv2 |
-                             boost::asio::ssl::context::no_sslv3 |
                              boost::asio::ssl::context::no_tlsv1 |
                              boost::asio::ssl::context::no_tlsv1_1 |
                              boost::asio::ssl::context::single_dh_use);

--- a/src/providers/liveupdates/BasicPubSubManager.hpp
+++ b/src/providers/liveupdates/BasicPubSubManager.hpp
@@ -336,8 +336,8 @@ private:
 
     WebsocketContextPtr onTLSInit(const websocketpp::connection_hdl & /*hdl*/)
     {
-        WebsocketContextPtr ctx(
-            new boost::asio::ssl::context(boost::asio::ssl::context::tls_client));
+        WebsocketContextPtr ctx(new boost::asio::ssl::context(
+            boost::asio::ssl::context::tls_client));
 
         try
         {

--- a/src/providers/liveupdates/BasicPubSubManager.hpp
+++ b/src/providers/liveupdates/BasicPubSubManager.hpp
@@ -337,12 +337,15 @@ private:
     WebsocketContextPtr onTLSInit(const websocketpp::connection_hdl & /*hdl*/)
     {
         WebsocketContextPtr ctx(
-            new boost::asio::ssl::context(boost::asio::ssl::context::tlsv12));
+            new boost::asio::ssl::context(boost::asio::ssl::context::tlsv13));
 
         try
         {
             ctx->set_options(boost::asio::ssl::context::default_workarounds |
                              boost::asio::ssl::context::no_sslv2 |
+                             boost::asio::ssl::context::no_sslv3 |
+                             boost::asio::ssl::context::no_tlsv1 |
+                             boost::asio::ssl::context::no_tlsv1_1 |
                              boost::asio::ssl::context::single_dh_use);
         }
         catch (const std::exception &e)

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -1021,12 +1021,12 @@ void TwitchChannel::joinBttvChannel() const
     {
         const auto currentAccount =
             getApp()->getAccounts()->twitch.getCurrent();
-        QString userName;
+        QString userID;
         if (currentAccount && !currentAccount->isAnon())
         {
-            userName = currentAccount->getUserName();
+            userID = currentAccount->getUserId();
         }
-        getApp()->getBttvLiveUpdates()->joinChannel(this->roomId(), userName);
+        getApp()->getBttvLiveUpdates()->joinChannel(this->roomId(), userID);
     }
 }
 


### PR DESCRIPTION
bttv socket server changed at some point to _only_ support TLS 1.3 but we previously maxed at TLS 1.2 so the bttv ws stopped connecting due to a tls handshake error

I've tested that 7tv ws (supports tls 1.0-1.3) still works with this change (out of paranoia I disabled tls 1.0 & 1.1, which are both deprecated)

also updates outdated `broadcast_me` payload: https://betterttv.com/developers/websocket#user-broadcast
