### PR TITLE
Feat: Themes allow transparency on chat windows background

### DIFF
--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -71,6 +71,7 @@ Window::Window(WindowType type, QWidget *parent)
             this->onAccountSelected();
         }));
     this->onAccountSelected();
+    this->setAttribute(Qt::WA_TranslucentBackground);
 
     if (type == WindowType::Main)
     {

--- a/src/widgets/splits/SplitContainer.cpp
+++ b/src/widgets/splits/SplitContainer.cpp
@@ -643,14 +643,7 @@ void SplitContainer::paintEvent(QPaintEvent * /*event*/)
     }
     else
     {
-        if (getApp()->getThemes()->isLightTheme())
-        {
-            painter.fillRect(rect(), QColor("#999"));
-        }
-        else
-        {
-            painter.fillRect(rect(), QColor("#555"));
-        }
+        painter.fillRect(rect(), this->theme->splits.background);
     }
 
     for (DropRect &dropRect : this->dropRects_)


### PR DESCRIPTION
This allows you to create themes with different opacity settings. This only applies for the main window, popups and not any sub windows such as settings, accounts, emotes etc.

Example theme:
[Transparent.json](https://github.com/user-attachments/files/19638126/Transparent.json)
![image](https://github.com/user-attachments/assets/bab7a400-d381-47e5-9aa7-83d6f30e688e)
