### PR TITLE
Fix: 6133 drag and drop split loss

### DIFF
--- a/src/widgets/helper/NotebookButton.cpp
+++ b/src/widgets/helper/NotebookButton.cpp
@@ -199,6 +199,8 @@ void NotebookButton::dropEvent(QDropEvent *event)
         return;
     }
 
+    draggedSplit->markAsDropped();
+
     event->acceptProposedAction();
 
     auto *page = new SplitContainer(notebook);

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -1685,11 +1685,6 @@ void Split::drag()
     this->dragState_ = SplitDragState::Dragging;
 
     drag->exec(Qt::MoveAction);
-    qCWarning(chatterinoWidget)
-        << "DOGE: drag state after"
-        << static_cast<std::underlying_type_t<SplitDragState>>(
-               this->dragState_);
-    ;
 
     // drag->exec is a blocking action
     if (this->dragState_ != SplitDragState::Dropped)

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -1682,13 +1682,23 @@ void Split::drag()
     mimeData->setData("chatterino/split", "xD");
     drag->setMimeData(mimeData);
 
+    this->dragState_ = SplitDragState::Dragging;
+
+    drag->exec(Qt::MoveAction);
+    qCWarning(chatterinoWidget)
+        << "DOGE: drag state after"
+        << static_cast<std::underlying_type_t<SplitDragState>>(
+               this->dragState_);
+    ;
+
     // drag->exec is a blocking action
-    if (drag->exec(Qt::MoveAction) == Qt::IgnoreAction)
+    if (this->dragState_ != SplitDragState::Dropped)
     {
         // The split wasn't dropped in a valid spot, return it to its original position
         container->insertSplit(this, {.position = originalLocation});
     }
 
+    this->dragState_ = SplitDragState::NotDragging;
     stopDraggingSplit();
 }
 
@@ -1732,4 +1742,9 @@ QDebug operator<<(QDebug dbg, const chatterino::Split *split)
     dbg.nospace() << "Split(nullptr)";
 
     return dbg;
+}
+
+void Split::markAsDropped()
+{
+    this->dragState_ = SplitDragState::Dropped;
 }

--- a/src/widgets/splits/Split.hpp
+++ b/src/widgets/splits/Split.hpp
@@ -15,6 +15,14 @@
 
 namespace chatterino {
 
+enum class SplitDragState : int {
+    NotDragging = 0,
+    Dragging = 1,
+    Dropped = 2,
+
+    Default = NotDragging,
+};
+
 class ChannelView;
 class SplitHeader;
 class SplitInput;
@@ -77,6 +85,8 @@ public:
     void setContainer(SplitContainer *container);
 
     void setInputReply(const MessagePtr &reply);
+
+    void markAsDropped();
 
     // This is called on window focus lost
     void unpause();
@@ -160,6 +170,13 @@ private:
     ChannelView *const view_;
     SplitInput *const input_;
     SplitOverlay *const overlay_;
+
+    /* Store dragging state to accurately determine whether drop is successful
+     it's more reliable than just checking drag.exec() != Qt::IgnoreAction, for example
+
+     NOTE: the accepting site shall call markAsDropped() to notify that split is dropped
+    */
+    SplitDragState dragState_ = SplitDragState::Default;
 
     QPointer<OverlayWindow> overlayWindow_;
 

--- a/src/widgets/splits/SplitContainer.cpp
+++ b/src/widgets/splits/SplitContainer.cpp
@@ -1570,6 +1570,7 @@ void SplitContainer::DropOverlay::dropEvent(QDropEvent *event)
             << "Dropped something that wasn't a split onto a split container";
         return;
     }
+    draggedSplit->markAsDropped();
 
     this->parent_->insertSplit(draggedSplit, {.position = *position});
     event->acceptProposedAction();


### PR DESCRIPTION
This fixes #6133

Instead of checking drag->exec() which contains limited information and behave inconsistently on various platforms (e.g. broken on KDE, but works fine on sway).

I now added the state for explicitly checking whether split are dropped. 

Tested and seems working as intended now
- no more split lost when dragging into tab bar, desktop, dolphin
- existing cases that worked still working correctly.


[Screencast_20250408_175040.webm](https://github.com/user-attachments/assets/5153db07-2903-4a34-9e31-6f941c7db179)
