### PR TITLE
fix(websockets): add query to URL

### DIFF
--- a/src/common/websockets/detail/WebSocketConnectionImpl.cpp
+++ b/src/common/websockets/detail/WebSocketConnectionImpl.cpp
@@ -167,13 +167,18 @@ void WebSocketConnectionHelper<Derived, Inner>::doWsHandshake()
 
     auto host = this->options.url.host(QUrl::FullyEncoded).toStdString() + ':' +
                 std::to_string(this->options.url.port(Derived::DEFAULT_PORT));
-    auto path = this->options.url.path(QUrl::FullyEncoded).toStdString();
-    if (path.empty())
+    auto path = this->options.url.path(QUrl::FullyEncoded);
+    if (path.isEmpty())
     {
         path = "/";
     }
+    if (this->options.url.hasQuery())
+    {
+        path += '?';
+        path += this->options.url.query(QUrl::FullyEncoded);
+    }
     this->stream.async_handshake(
-        host, path,
+        host, path.toStdString(),
         beast::bind_front_handler(&WebSocketConnectionHelper::onWsHandshake,
                                   this->shared_from_this()));
 }

--- a/tests/src/WebSocketPool.cpp
+++ b/tests/src/WebSocketPool.cpp
@@ -53,7 +53,7 @@ TEST(WebSocketPool, tcpEcho)
 
     auto handle = pool.createSocket(
         {
-            .url = QUrl("ws://127.0.0.1:9052/echo"),
+            .url = QUrl("ws://127.0.0.1:9052/echo?query=123&xd=wow"),
             .headers =
                 {
                     {"My-Header", "my-header-VALUE"},
@@ -76,11 +76,12 @@ TEST(WebSocketPool, tcpEcho)
     handle.sendText("/HEADER another-header");
     handle.sendText("/HEADER cookie");
     handle.sendText("/HEADER user-agent");
+    handle.sendText("/URL");
     handle.sendText("/CLOSE");
 
     ASSERT_TRUE(closeFlag.waitFor(1s));
 
-    ASSERT_EQ(messages.size(), 10);
+    ASSERT_EQ(messages.size(), 11);
     ASSERT_EQ(messages[0].first, false);
     ASSERT_EQ(messages[0].second, "message1");
     ASSERT_EQ(messages[1].first, false);
@@ -101,6 +102,8 @@ TEST(WebSocketPool, tcpEcho)
     ASSERT_EQ(messages[8].second, "xd");
     ASSERT_EQ(messages[9].first, true);
     ASSERT_EQ(messages[9].second, "MyUserAgent");
+    ASSERT_EQ(messages[10].first, true);
+    ASSERT_EQ(messages[10].second, "/echo?query=123&xd=wow");
 }
 
 TEST(WebSocketPool, tlsEcho)
@@ -135,11 +138,12 @@ TEST(WebSocketPool, tlsEcho)
     handle.sendText("/HEADER another-header");
     handle.sendText("/HEADER cookie");
     handle.sendText("/HEADER user-agent");
+    handle.sendText("/URL");
     handle.sendText("/CLOSE");
 
     ASSERT_TRUE(closeFlag.waitFor(1s));
 
-    ASSERT_EQ(messages.size(), 10);
+    ASSERT_EQ(messages.size(), 11);
     ASSERT_EQ(messages[0].first, false);
     ASSERT_EQ(messages[0].second, "message1");
     ASSERT_EQ(messages[1].first, false);
@@ -160,4 +164,6 @@ TEST(WebSocketPool, tlsEcho)
     ASSERT_EQ(messages[8].second, "xd");
     ASSERT_EQ(messages[9].first, true);
     ASSERT_TRUE(messages[9].second.startsWith("Chatterino"));
+    ASSERT_EQ(messages[10].first, true);
+    ASSERT_EQ(messages[10].second, "/echo");
 }


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

I missed this in #6076. If the URL has a query, we now append it.

Depends on https://github.com/Chatterino/twitch-pubsub-server-test/pull/126.