### PR TITLE
fix: don't include `.inc` in outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Dev: Mini refactor of Split. (#6148)
 - Dev: Conan will no longer generate a `CMakeUserPresets.json` file. (#6117)
 - Dev: Pass `--force-openssl` when installing from CMake in Qt 6.8+. (#6129)
+- Dev: Fixed `<build-tool> clean` not working correctly with generated sources. (#6154)
 
 ## 2.5.3
 

--- a/lib/twitch-eventsub-ws/cmake/GenerateJson.cmake
+++ b/lib/twitch-eventsub-ws/cmake/GenerateJson.cmake
@@ -172,20 +172,18 @@ function(generate_json_impls)
 
     foreach(_header ${arg_HEADERS})
         # keep in sync with generate.py
-        string(REGEX REPLACE \.hpp$ .inc _def_path "${_header}")
         string(REGEX REPLACE \.hpp$ .cpp _source_path "${_header}")
         string(REGEX REPLACE \.hpp$ .timestamp _timestamp_path "${_header}")
         string(REGEX REPLACE include[/\\]twitch-eventsub-ws[/\\] src/generated/ _source_path "${_source_path}")
 
         cmake_path(ABSOLUTE_PATH _timestamp_path BASE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/eventsub-deps")
         cmake_path(ABSOLUTE_PATH _header BASE_DIRECTORY "${arg_BASE_DIRECTORY}")
-        cmake_path(ABSOLUTE_PATH _def_path BASE_DIRECTORY "${arg_BASE_DIRECTORY}")
         cmake_path(ABSOLUTE_PATH _source_path BASE_DIRECTORY "${arg_BASE_DIRECTORY}")
         list(APPEND _all_sources "${_source_path}")
 
         if(_generation_supported)
             add_custom_command(
-                OUTPUT "${_timestamp_path}" "${_source_path}" "${_def_path}"
+                OUTPUT "${_timestamp_path}" "${_source_path}"
                 DEPENDS ${_gen_deps} "${_header}"
                 COMMENT "Generating implementation for ${_header}"
                 COMMAND "${_python3_path}" "${_gen_script}" "${_header}" --includes "${_inc_dirs}" --timestamp "${_timestamp_path}"


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
Compiling after a `ninja clean` caused the JSON generator to fail. This isn't a complete fix, the root of the problem is a bit deeper, because we'd actually need to split the task into two - one for generating the `.inc` file and one for generating the implementation, because clang will freak out if the `.inc` file doesn't exist and will refuse to resolve types like `std::chrono::system_clock`[^1].

Because we don't add new eventsub topics every day, it's fine having to recompile twice. Not being able to do clean the output is a bit worse, I think.

[^1]: Ok, actually, it's a bit more complicated. The two-step process would work because we generally don't need the type information to generate a forward declaration, but in theory, it still reads an incomplete header so if type information would alter the names of generated types, this would be wrong.