### PR TITLE
fix: handle `aboutToQuit()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Dev: Conan will no longer generate a `CMakeUserPresets.json` file. (#6117)
 - Dev: Pass `--force-openssl` when installing from CMake in Qt 6.8+. (#6129)
 - Dev: Fixed `<build-tool> clean` not working correctly with generated sources. (#6154)
+- Dev: Save settings in `aboutToQuit`. (#6159)
 
 ## 2.5.3
 

--- a/src/RunGui.cpp
+++ b/src/RunGui.cpp
@@ -280,12 +280,20 @@ void runGui(QApplication &a, const Paths &paths, Settings &settings,
     chatterino::NetworkManager::init();
     updates.checkForUpdates();
 
+    QObject::connect(qApp, &QApplication::aboutToQuit, [] {
+        auto *app = dynamic_cast<Application *>(tryGetApp());
+        if (app)
+        {
+            app->save();
+        }
+
+        getSettings()->requestSave();
+        getSettings()->disableSave();
+    });
+
     Application app(settings, paths, args, updates);
     app.initialize(settings, paths);
     app.run();
-    app.save();
-
-    settings.requestSave();
 
     chatterino::NetworkManager::deinit();
 

--- a/src/singletons/Settings.cpp
+++ b/src/singletons/Settings.cpp
@@ -278,6 +278,11 @@ void Settings::restoreSnapshot()
     }
 }
 
+void Settings::disableSave()
+{
+    this->disableSaving = true;
+}
+
 float Settings::getClampedUiScale() const
 {
     return std::clamp(this->uiScale.getValue(), 0.2F, 10.F);

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -104,7 +104,7 @@ class Settings
     static Settings *instance_;
     Settings *prevInstance_ = nullptr;
 
-    const bool disableSaving;
+    bool disableSaving;
 
 public:
     Settings(const Args &args, const QString &settingsDirectory);
@@ -119,6 +119,8 @@ public:
 
     void saveSnapshot();
     void restoreSnapshot();
+
+    void disableSave();
 
     FloatSetting uiScale = {"/appearance/uiScale2", 1};
     BoolSetting windowTopMost = {"/appearance/windowAlwaysOnTop", false};


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

In an attempt to solve https://github.com/Chatterino/chatterino2/issues/6157, I added a handler for [`aboutToQuit`](https://doc.qt.io/qt-6/qcoreapplication.html#aboutToQuit) - specifically because this is called when the application is shut down by Windows ([source](https://github.com/qt/qtbase/blob/53ff8897c5c8bc6175cf94ed24e2d2c5fa17365b/src/plugins/platforms/windows/qwindowscontext.cpp#L1312-L1315)).

If we do this, we shouldn't save afterward - `aboutToQuit` will be called (immediately) before `Application::run` returns. I added `disableSave` to try to avoid saving after we exit.