### PR TITLE
add Import/Export for Nicknames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unversioned
 
+- Minor: Added Import/Export Buttons for Nicknames. (#6160)
 - Minor: Badges now link to their home page like emotes in the context menu. (#6437)
 - Minor: Fixed usercard resizing improperly without recent messages. (#6496)
 - Minor: Added setting for character limit of deleted messages. (#6491)

--- a/src/widgets/settingspages/NicknamesPage.cpp
+++ b/src/widgets/settingspages/NicknamesPage.cpp
@@ -7,9 +7,13 @@
 #include "util/LayoutCreator.hpp"
 #include "widgets/helper/EditableModelView.hpp"
 
+#include <QFileDialog>
 #include <QHeaderView>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QMessageBox>
 #include <QTableView>
-
 namespace chatterino {
 
 NicknamesPage::NicknamesPage()
@@ -44,6 +48,18 @@ NicknamesPage::NicknamesPage()
             Nickname{"Username", "Nickname", false, false});
     });
 
+    // Add Import and Export buttons to the EditableModelView
+    auto *importButton = new QPushButton("Import");
+    auto *exportButton = new QPushButton("Export");
+
+    QObject::connect(importButton, &QPushButton::clicked, this,
+                     &NicknamesPage::importNicknames);
+    QObject::connect(exportButton, &QPushButton::clicked, this,
+                     &NicknamesPage::exportNicknames);
+
+    view->addCustomButton(importButton);
+    view->addCustomButton(exportButton);
+
     QTimer::singleShot(1, [view] {
         view->getTableView()->resizeColumnsToContents();
         view->getTableView()->setColumnWidth(0, 200);
@@ -55,6 +71,104 @@ bool NicknamesPage::filterElements(const QString &query)
     std::array fields{0, 1};
 
     return this->view_->filterSearchResults(query, fields);
+
+}
+
+void NicknamesPage::importNicknames()
+{
+    QString filePath = QFileDialog::getOpenFileName(
+        this, tr("Import Nicknames"), "", tr("JSON Files (*.json)"));
+
+    if (filePath.isEmpty())
+    {
+        return;
+    }
+
+    QFile file(filePath);
+    if (!file.open(QIODevice::ReadOnly))
+    {
+        QMessageBox::critical(this, tr("Error"),
+                              tr("Could not open file for reading."));
+        return;
+    }
+
+    QByteArray data = file.readAll();
+    QJsonDocument doc = QJsonDocument::fromJson(data);
+
+    if (doc.isNull() || !doc.isArray())
+    {
+        QMessageBox::critical(
+            this, tr("Error"),
+            tr("Invalid JSON format. Expected an array of nicknames."));
+        return;
+    }
+
+    QJsonArray array = doc.array();
+    for (const QJsonValueRef &value : array)
+    {
+        if (!value.isObject())
+        {
+            continue;
+        }
+
+        QJsonObject obj = value.toObject();
+        QString username = obj["username"].toString();
+        QString nickname = obj["nickname"].toString();
+        bool regex = obj["regex"].toBool(false);
+        bool caseSensitive = obj["caseSensitive"].toBool(false);
+
+        if (!username.isEmpty() && !nickname.isEmpty())
+        {
+            getSettings()->nicknames.append(
+                Nickname{username, nickname, regex, caseSensitive});
+        }
+    }
+}
+
+void NicknamesPage::exportNicknames()
+{
+    QString filePath = QFileDialog::getSaveFileName(
+        this, tr("Export Nicknames"), "", tr("JSON Files (*.json)"));
+
+    if (filePath.isEmpty())
+    {
+        return;
+    }
+
+    if (!filePath.endsWith(".json", Qt::CaseInsensitive))
+    {
+        filePath += ".json";
+    }
+
+    QJsonArray array;
+    const auto &nicknames = getSettings()->nicknames.raw();
+
+    for (const auto &nickname : nicknames)
+    {
+        QJsonObject obj;
+        obj["username"] = nickname.name();
+        obj["nickname"] = nickname.replace();
+        obj["regex"] = nickname.isRegex();
+        obj["caseSensitive"] = nickname.isCaseSensitive();
+        array.append(obj);
+    }
+
+    QJsonDocument doc(array);
+    QByteArray data = doc.toJson(QJsonDocument::Indented);
+
+    QFile file(filePath);
+    if (!file.open(QIODevice::WriteOnly))
+    {
+        QMessageBox::critical(this, tr("Error"),
+                              tr("Could not open file for writing."));
+        return;
+    }
+
+    if (file.write(data) == -1)
+    {
+        QMessageBox::critical(this, tr("Error"),
+                              tr("Failed to write to file."));
+    }
 }
 
 }  // namespace chatterino

--- a/src/widgets/settingspages/NicknamesPage.cpp
+++ b/src/widgets/settingspages/NicknamesPage.cpp
@@ -1,19 +1,19 @@
 #include "widgets/settingspages/NicknamesPage.hpp"
 
+#include "common/Version.hpp"
 #include "controllers/nicknames/Nickname.hpp"
 #include "controllers/nicknames/NicknamesModel.hpp"
 #include "singletons/Settings.hpp"
 #include "singletons/WindowManager.hpp"
 #include "util/LayoutCreator.hpp"
 #include "widgets/helper/EditableModelView.hpp"
-#include "common/Version.hpp"
 
+#include <QDateTime>
 #include <QFileDialog>
 #include <QHeaderView>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
-#include <QDateTime>
 #include <QMessageBox>
 #include <QTableView>
 namespace chatterino {
@@ -105,13 +105,11 @@ void NicknamesPage::importNicknames()
     }
 
     QJsonObject root = doc.object();
-    if (root["type"].toString() != "nickname_export" || 
-        root["version"].toString() != "1" || 
-        !root["data"].isArray())
+    if (root["type"].toString() != "nickname_export" ||
+        root["version"].toString() != "1" || !root["data"].isArray())
     {
-        QMessageBox::critical(
-            this, tr("Error"),
-            tr("Invalid nickname export format."));
+        QMessageBox::critical(this, tr("Error"),
+                              tr("Invalid nickname export format."));
         return;
     }
 
@@ -155,11 +153,10 @@ void NicknamesPage::exportNicknames()
     QJsonObject root;
     root["type"] = "nickname_export";
     root["version"] = "1";
-    
     QString currentTime = QDateTime::currentDateTime().toString(Qt::ISODate);
     root["comment"] = QString("Exported from %1 at %2")
-                         .arg(Version::instance().buildString())
-                         .arg(currentTime);
+                          .arg(Version::instance().buildString())
+                          .arg(currentTime);
 
     QJsonArray data;
     const auto &nicknames = getSettings()->nicknames.raw();

--- a/src/widgets/settingspages/NicknamesPage.cpp
+++ b/src/widgets/settingspages/NicknamesPage.cpp
@@ -71,7 +71,6 @@ bool NicknamesPage::filterElements(const QString &query)
     std::array fields{0, 1};
 
     return this->view_->filterSearchResults(query, fields);
-
 }
 
 void NicknamesPage::importNicknames()

--- a/src/widgets/settingspages/NicknamesPage.hpp
+++ b/src/widgets/settingspages/NicknamesPage.hpp
@@ -14,6 +14,8 @@ public:
 
 private:
     EditableModelView *view_;
+    void importNicknames();
+    void exportNicknames();
 };
 
 }  // namespace chatterino


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

Hey we wanted to exchange nicknames among friends, so we came up with the idea of ​​adding import and export buttons to the Nicknames view.
This is my first time with C++ code, so feedback is very welcome.

Tested on Ubuntu:
![image](https://github.com/user-attachments/assets/d35786fc-3368-49b0-a9af-cdced643b868)
![image](https://github.com/user-attachments/assets/6e5d046d-9815-4eb0-8d4e-70b54f54325b)
![image](https://github.com/user-attachments/assets/fd07e517-b3d3-4906-9cdd-99b092501a0d)
![image](https://github.com/user-attachments/assets/50509cd2-33ff-4268-83fc-0f14e1aaa096)
