### PR TITLE
Forward declare some things to speed up compile

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -20,6 +20,7 @@
 #include "providers/twitch/eventsub/Controller.hpp"
 #include "providers/twitch/TwitchBadges.hpp"
 #include "singletons/ImageUploader.hpp"
+#include "singletons/NativeMessaging.hpp"
 #ifdef CHATTERINO_HAVE_PLUGINS
 #    include "controllers/plugins/PluginController.hpp"
 #endif
@@ -197,6 +198,7 @@ Application::Application(Settings &_settings, const Paths &paths,
 #ifdef CHATTERINO_HAVE_PLUGINS
     , plugins(new PluginController(paths))
 #endif
+    , nmServer(new NativeMessagingServer())
     , updates(_updates)
 {
 }
@@ -655,7 +657,7 @@ void Application::initNm(const Paths &paths)
 
 #if defined QT_NO_DEBUG || defined CHATTERINO_DEBUG_NM
     registerNmHost(paths);
-    this->nmServer.start();
+    this->nmServer->start();
 #endif
 }
 

--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "singletons/NativeMessaging.hpp"
-
 #include <cassert>
 #include <memory>
 
@@ -54,6 +52,7 @@ class SeventvEventAPI;
 class ILinkResolver;
 class IStreamerMode;
 class ITwitchUsers;
+class NativeMessagingServer;
 namespace pronouns {
     class Pronouns;
 }  // namespace pronouns
@@ -236,7 +235,7 @@ public:
 private:
     void initNm(const Paths &paths);
 
-    NativeMessagingServer nmServer;
+    std::unique_ptr<NativeMessagingServer> nmServer;
     Updates &updates;
 
     bool initialized{false};

--- a/src/controllers/completion/sources/CommandSource.cpp
+++ b/src/controllers/completion/sources/CommandSource.cpp
@@ -5,6 +5,7 @@
 #include "controllers/commands/CommandController.hpp"
 #include "controllers/completion/sources/Helpers.hpp"
 #include "providers/twitch/TwitchCommon.hpp"
+#include "widgets/splits/InputCompletionItem.hpp"
 
 namespace chatterino::completion {
 

--- a/src/controllers/completion/sources/EmoteSource.cpp
+++ b/src/controllers/completion/sources/EmoteSource.cpp
@@ -11,6 +11,7 @@
 #include "providers/twitch/TwitchChannel.hpp"
 #include "providers/twitch/TwitchIrcServer.hpp"
 #include "singletons/Emotes.hpp"
+#include "widgets/splits/InputCompletionItem.hpp"
 
 namespace chatterino::completion {
 

--- a/src/controllers/completion/sources/Source.hpp
+++ b/src/controllers/completion/sources/Source.hpp
@@ -1,13 +1,10 @@
 #pragma once
 
-#include "widgets/listview/GenericListModel.hpp"
-#include "widgets/splits/InputCompletionItem.hpp"
-
 #include <QStringList>
 
-#include <memory>
-#include <utility>
-#include <vector>
+namespace chatterino {
+class GenericListModel;
+}  // namespace chatterino
 
 namespace chatterino::completion {
 

--- a/src/controllers/completion/sources/UnifiedSource.cpp
+++ b/src/controllers/completion/sources/UnifiedSource.cpp
@@ -1,5 +1,7 @@
 #include "controllers/completion/sources/UnifiedSource.hpp"
 
+#include "widgets/listview/GenericListModel.hpp"
+
 namespace chatterino::completion {
 
 UnifiedSource::UnifiedSource(std::vector<std::unique_ptr<Source>> sources)

--- a/src/controllers/completion/sources/UserSource.cpp
+++ b/src/controllers/completion/sources/UserSource.cpp
@@ -4,6 +4,7 @@
 #include "providers/twitch/TwitchChannel.hpp"
 #include "singletons/Settings.hpp"
 #include "util/Helpers.hpp"
+#include "widgets/splits/InputCompletionItem.hpp"
 
 namespace chatterino::completion {
 


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

All time figures mentioned are CPU time from clean in debug on my system as claimed by [ClangBuildAnalyzer](https://github.com/aras-p/ClangBuildAnalyzer)

Things done so far:
 - `TimeoutStackStyle` moved to separate file to avoid expensive `Channel.hpp` include in `Settings.hpp` to save about a minute in includes
 - Notebook related enums moved to separate file to avoid expensive `Notebook.hpp` include in `Settings.hpp` to save about a minute in includes
 - `Application.hpp` include removed in `Plugin.hpp`. I don't think this saves all that much.
 - Forward declare `NativeMessagingServer` in `Settings.hpp` and use a `unique_ptr` to save around two minutes in includes
 - Forward declare `GenericListModel` in `controllers/completion/sources/Source.hpp` to save around two minutes in includes

<!--
cmake -DCMAKE_BUILD_TYPE=Debug -DUSE_PRECOMPILED_HEADERS=OFF -DBUILD_WITH_QTKEYCHAIN=OFF -DCMAKE_EXPORT_COMPILE_COMMANDS=YES -DCHATTERINO_PLUGINS=YES -DSANITIZE_MEMORY=YES -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_FLAGS=-ftime-trace -DCMAKE_CXX_FLAGS=-ftime-trace ..
-->


<details>
<summary>time-trace Before</summary>

```
Analyzing build trace from '../capture_file'...
**** Time summary:
Compilation (432 times):
  Parsing (frontend):         3063.9 s
  Codegen & opts (backend):    146.3 s

**** Files that took longest to parse (compiler frontend):
 40741 ms: ./src/CMakeFiles/chatterino-lib.dir/common/websockets/detail/WebSocketConnectionImpl.cpp.o
 28301 ms: ./src/CMakeFiles/chatterino-lib.dir/providers/twitch/TwitchChannel.cpp.o
 26216 ms: ./src/CMakeFiles/chatterino-lib.dir/Application.cpp.o
 23446 ms: ./src/CMakeFiles/chatterino-lib.dir/providers/seventv/SeventvEventAPI.cpp.o
 21823 ms: ./src/CMakeFiles/chatterino-lib.dir/providers/twitch/eventsub/Connection.cpp.o
 20793 ms: ./src/CMakeFiles/chatterino-lib.dir/controllers/plugins/PluginController.cpp.o
 19853 ms: ./src/CMakeFiles/chatterino-lib.dir/providers/bttv/BttvLiveUpdates.cpp.o
 19166 ms: ./src/CMakeFiles/chatterino-lib.dir/providers/twitch/TwitchIrcServer.cpp.o
 19017 ms: ./src/CMakeFiles/chatterino-lib.dir/widgets/Window.cpp.o
 18541 ms: ./src/CMakeFiles/chatterino-lib.dir/controllers/sound/MiniaudioBackend.cpp.o

**** Files that took longest to codegen (compiler backend):
 16839 ms: ./src/CMakeFiles/chatterino-lib.dir/common/websockets/detail/WebSocketConnectionImpl.cpp.o
  4960 ms: ./src/CMakeFiles/chatterino-lib.dir/providers/seventv/SeventvEventAPI.cpp.o
  4901 ms: ./src/CMakeFiles/chatterino-lib.dir/providers/bttv/BttvLiveUpdates.cpp.o
  4462 ms: ./src/CMakeFiles/chatterino-lib.dir/providers/twitch/PubSubManager.cpp.o
  3758 ms: ./lib/twitch-eventsub-ws/src/CMakeFiles/twitch-eventsub-ws.dir/session.cpp.o
  3075 ms: ./src/CMakeFiles/chatterino-lib.dir/controllers/sound/MiniaudioBackend.cpp.o
  2990 ms: ./src/CMakeFiles/chatterino-lib.dir/providers/twitch/api/Helix.cpp.o
  2573 ms: ./src/CMakeFiles/chatterino-lib.dir/singletons/Settings.cpp.o
  2275 ms: ./src/CMakeFiles/chatterino-lib.dir/providers/twitch/TwitchChannel.cpp.o
  2167 ms: ./src/CMakeFiles/chatterino-lib.dir/controllers/plugins/PluginController.cpp.o

**** Templates that took longest to instantiate:
 76674 ms: std::vformat_to<std::__format::_Sink_iter<char>> (346 times, avg 221 ms)
 76577 ms: std::__format::__do_vformat_to<std::__format::_Sink_iter<char>, char... (344 times, avg 222 ms)
 65131 ms: std::vformat_to<std::__format::_Sink_iter<wchar_t>> (345 times, avg 188 ms)
 65031 ms: std::__format::__do_vformat_to<std::__format::_Sink_iter<wchar_t>, w... (344 times, avg 189 ms)
 18367 ms: std::formatter<bool>::format<std::__format::_Sink_iter<char>> (344 times, avg 53 ms)
 18312 ms: std::__format::__formatter_int<char>::format<std::__format::_Sink_it... (344 times, avg 53 ms)
 15664 ms: std::__format::__formatter_int<char>::format<unsigned char, std::__f... (344 times, avg 45 ms)
 14474 ms: std::__format::__formatter_int<char>::_M_format_int<std::__format::_... (344 times, avg 42 ms)
 14331 ms: std::chrono::hh_mm_ss<std::chrono::duration<long>>::hh_mm_ss (688 times, avg 20 ms)
 13153 ms: std::formatter<bool, wchar_t>::format<std::__format::_Sink_iter<wcha... (344 times, avg 38 ms)
 13099 ms: std::__format::__formatter_int<wchar_t>::format<std::__format::_Sink... (344 times, avg 38 ms)
 12138 ms: std::__format::__formatter_int<wchar_t>::_M_parse<char> (344 times, avg 35 ms)
 11843 ms: std::__format::__formatter_int<wchar_t>::_M_do_parse (344 times, avg 34 ms)
 10497 ms: std::__format::_Formatting_scanner<std::__format::_Sink_iter<char>, ... (344 times, avg 30 ms)
 10489 ms: std::__format::__formatter_int<wchar_t>::format<unsigned char, std::... (344 times, avg 30 ms)
 10034 ms: std::__format::_Formatting_scanner<std::__format::_Sink_iter<char>, ... (344 times, avg 29 ms)
  9964 ms: std::formatter<const wchar_t *, wchar_t>::format<std::__format::_Sin... (344 times, avg 28 ms)
  9888 ms: std::visit_format_arg<(lambda at /usr/bin/../lib64/gcc/x86_64-pc-lin... (344 times, avg 28 ms)
  9872 ms: std::__format::__formatter_str<wchar_t>::format<std::__format::_Sink... (344 times, avg 28 ms)
  9806 ms: std::basic_format_arg<std::basic_format_context<std::__format::_Sink... (344 times, avg 28 ms)
  9797 ms: std::formatter<const char *>::format<std::__format::_Sink_iter<char>> (344 times, avg 28 ms)
  9745 ms: std::__format::__formatter_str<char>::format<std::__format::_Sink_it... (344 times, avg 28 ms)
  9437 ms: std::__format::_Seq_sink<std::basic_string<char>>::_M_reserve (344 times, avg 27 ms)
  9277 ms: std::__format::_Seq_sink<std::basic_string<wchar_t>>::_M_reserve (344 times, avg 26 ms)
  9249 ms: std::__format::__formatter_int<wchar_t>::_M_format_int<std::__format... (344 times, avg 26 ms)
  8773 ms: std::__unicode::__truncate<wchar_t> (344 times, avg 25 ms)
  8768 ms: std::__unicode::__truncate<char> (344 times, avg 25 ms)
  8148 ms: std::__format::_Formatting_scanner<std::__format::_Sink_iter<wchar_t... (344 times, avg 23 ms)
  7946 ms: std::__format::_Iter_sink<char, std::__format::_Sink_iter<char>>::_I... (344 times, avg 23 ms)
  7915 ms: std::__format::_Iter_sink<wchar_t, std::__format::_Sink_iter<wchar_t... (344 times, avg 23 ms)

**** Template sets that took longest to instantiate:
141805 ms: std::vformat_to<$> (691 times, avg 205 ms)
141804 ms: std::unique_ptr<$> (9462 times, avg 14 ms)
141609 ms: std::__format::__do_vformat_to<$> (688 times, avg 205 ms)
117459 ms: std::__uniq_ptr_data<$> (9462 times, avg 12 ms)
115863 ms: std::__uniq_ptr_impl<$> (9462 times, avg 12 ms)
100977 ms: std::__and_<$> (85818 times, avg 1 ms)
 87932 ms: std::formatter<$>::format<$> (8580 times, avg 10 ms)
 70420 ms: std::tuple<$> (10151 times, avg 6 ms)
 52646 ms: qRegisterNormalizedMetaType<$> (3275 times, avg 16 ms)
 52466 ms: qRegisterNormalizedMetaTypeImplementation<$> (3274 times, avg 16 ms)
 45279 ms: std::__or_<$> (51942 times, avg 0 ms)
 42294 ms: std::__format::__formatter_int<$>::format<$> (4816 times, avg 8 ms)
 33316 ms: QtPrivate::TypeNameHelper::typenameHelper<$> (25029 times, avg 1 ms)
 29855 ms: std::reverse_iterator<$> (2551 times, avg 11 ms)
 27579 ms: std::vector<$> (8619 times, avg 3 ms)
 25389 ms: QtPrivate::QMetaTypeForType<$> (20103 times, avg 1 ms)
 25012 ms: boost::asio::async_initiate<$> (139 times, avg 179 ms)
 24988 ms: boost::asio::detail::completion_handler_async_result<$>::initiate<$> (139 times, avg 179 ms)
 24389 ms: std::optional<$> (3039 times, avg 8 ms)
 23724 ms: std::__format::__formatter_int<$>::_M_format_int<$> (688 times, avg 34 ms)
 23375 ms: std::__format::__formatter_fp<$>::format<$> (2064 times, avg 11 ms)
 23138 ms: std::_Tuple_impl<$> (10127 times, avg 2 ms)
 22744 ms: std::is_scalar<$> (23984 times, avg 0 ms)
 22094 ms: std::visit_format_arg<$> (1716 times, avg 12 ms)
 21883 ms: std::tuple<$>::__constructible<$> (19105 times, avg 1 ms)
 21680 ms: std::basic_format_arg<$>::_M_visit<$> (1709 times, avg 12 ms)
 21508 ms: std::common_reference<$> (21527 times, avg 0 ms)
 21398 ms: std::tuple<$>::__assignable<$> (18816 times, avg 1 ms)
 21055 ms: std::is_move_constructible<$> (17964 times, avg 1 ms)
 20793 ms: std::vector<$>::emplace_back<$> (1371 times, avg 15 ms)

**** Functions that took longest to compile:
   127 ms: chatterino::Settings::Settings(chatterino::Args const&, QString cons... (/home/maciek/git/ch2dev/src/singletons/Settings.cpp)
    77 ms: __cxx_global_var_init.10 (/home/maciek/git/ch2dev/src/controllers/hotkeys/HotkeyHelpers.cpp)
    77 ms: __cxx_global_var_init.10 (/home/maciek/git/ch2dev/src/widgets/dialogs/EditHotkeyDialog.cpp)
    76 ms: ma_dr_flac__decode_samples_with_residual__rice__scalar(ma_dr_flac_bs... (/home/maciek/git/ch2dev/src/controllers/sound/MiniaudioBackend.cpp)
    75 ms: __cxx_global_var_init.10 (/home/maciek/git/ch2dev/src/controllers/hotkeys/Hotkey.cpp)
    68 ms: chatterino::UserInfoPopup::UserInfoPopup(bool, chatterino::Split*) (/home/maciek/git/ch2dev/src/widgets/dialogs/UserInfoPopup.cpp)
    65 ms: chatterino::HotkeyController::addDefaults(std::set<QString, std::les... (/home/maciek/git/ch2dev/src/controllers/hotkeys/HotkeyController.cpp)
    52 ms: decltype(async_initiate<boost::beast::basic_stream<boost::asio::ip::... (/home/maciek/git/ch2dev/src/common/websockets/detail/WebSocketConnectionImpl.cpp)
    49 ms: websocketpp::connection<chatterino::BasicPubSubConfig>::write_frame() (/home/maciek/git/ch2dev/src/providers/seventv/eventapi/Client.cpp)
    46 ms: chatterino::IrcMessageHandler::parseUserNoticeMessageInto(Communi::I... (/home/maciek/git/ch2dev/src/providers/twitch/IrcMessageHandler.cpp)
    44 ms: (anonymous namespace)::getEmoteExpectedBaseSize(chatterino::EmoteId ... (/home/maciek/git/ch2dev/src/providers/twitch/TwitchEmotes.cpp)
    43 ms: chatterino::GeneralPage::initLayout(chatterino::GeneralPageView&) (/home/maciek/git/ch2dev/src/widgets/settingspages/GeneralPage.cpp)
    41 ms: void chatterino::postToThread<auto chatterino::eventsub::Connection:... (/home/maciek/git/ch2dev/src/providers/twitch/eventsub/Connection.cpp)
    41 ms: std::__invoke_result<chatterino::eventsub::Connection::onChannelMode... (/home/maciek/git/ch2dev/src/providers/twitch/eventsub/Connection.cpp)
    40 ms: boost::asio::detail::recycling_allocator<boost::asio::detail::execut... (/home/maciek/git/ch2dev/src/common/websockets/detail/WebSocketConnectionImpl.cpp)
    37 ms: std::_Bind_helper<__is_socketlike<void (websocketpp::connection<chat... (/home/maciek/git/ch2dev/src/providers/seventv/eventapi/Client.cpp)
    34 ms: boost::asio::error::detail::ssl_category::message[abi:cxx11](int) co... (/home/maciek/git/ch2dev/src/providers/twitch/PubSubManager.cpp)
    33 ms: ma_pcm_f32_to_s16 (/home/maciek/git/ch2dev/src/controllers/sound/MiniaudioBackend.cpp)
    32 ms: QTypedArrayData<QString>::allocate(long long, QArrayData::Allocation... (/home/maciek/git/ch2dev/src/widgets/settingspages/CommandPage.cpp)
    32 ms: boost::beast::websocket::stream<boost::beast::basic_stream<boost::as... (/home/maciek/git/ch2dev/src/common/websockets/detail/WebSocketConnectionImpl.cpp)
    31 ms: boost::beast::websocket::stream<boost::asio::ssl::stream<boost::beas... (/home/maciek/git/ch2dev/src/common/websockets/detail/WebSocketConnectionImpl.cpp)
    27 ms: luaV_execute(lua_State*, CallInfo*) (/home/maciek/git/ch2dev/lib/lua/src/lvm.c)
    26 ms: chatterino::IrcMessageHandler::addMessage(Communi::IrcMessage*, chat... (/home/maciek/git/ch2dev/src/providers/twitch/IrcMessageHandler.cpp)
    26 ms: std::basic_istream<char, std::char_traits<char> >& std::chrono::__de... (/home/maciek/git/ch2dev/lib/twitch-eventsub-ws/src/chrono.cpp)
    26 ms: boost::asio::detail::wrapped_handler<boost::asio::io_context::strand... (/home/maciek/git/ch2dev/src/providers/bttv/BttvLiveUpdates.cpp)
    25 ms: std::_Sp_counted_ptr_inplace<pajlada::Signals::detail::CallbackBody<... (/home/maciek/git/ch2dev/src/singletons/StreamerMode.cpp)
    24 ms: chatterino::Notebook::performLayout(bool) (/home/maciek/git/ch2dev/src/widgets/Notebook.cpp)
    24 ms: chatterino::HighlightModel::afterInit() (/home/maciek/git/ch2dev/src/controllers/highlights/HighlightModel.cpp)
    24 ms: boost::beast::websocket::stream<boost::beast::basic_stream<boost::as... (/home/maciek/git/ch2dev/src/common/websockets/detail/WebSocketConnectionImpl.cpp)
    23 ms: std::vector<std::shared_ptr<chatterino::EmojiData>, std::allocator<s... (/home/maciek/git/ch2dev/src/singletons/Emotes.cpp)

**** Function sets that took longest to compile / optimize:
   770 ms: void boost::asio::detail::executor_function::complete<$>(boost::asio... (581 times, avg 1 ms)
   510 ms: std::_Function_base::_Base_manager<$>::_M_manager(std::_Any_data&, s... (681 times, avg 0 ms)
   495 ms: std::vector<$>::~vector() (637 times, avg 0 ms)
   457 ms: std::_Function_handler<$>::_M_manager(std::_Any_data&, std::_Any_dat... (666 times, avg 0 ms)
   388 ms: std::vector<$>::_M_check_len(unsigned long, char const*) const (474 times, avg 0 ms)
   385 ms: std::_Vector_base<$>::~_Vector_base() (599 times, avg 0 ms)
   337 ms: boost::asio::detail::executor_function::impl<$>::ptr::allocate(std::... (578 times, avg 0 ms)
   336 ms: boost::asio::detail::executor_function::impl<$>::ptr::reset() (576 times, avg 0 ms)
   304 ms: bool QAtomicOps<$>::deref<$>(std::atomic<$>&) (317 times, avg 0 ms)
   300 ms: std::vector<$>::_S_max_size(std::allocator<$> const&) (464 times, avg 0 ms)
   255 ms: int QAtomicOps<$>::loadRelaxed<$>(std::atomic<$> const&) (312 times, avg 0 ms)
   253 ms: void boost::asio::execution::detail::any_executor_base::execute<$>(b... (177 times, avg 1 ms)
   252 ms: std::vector<$>::back() (374 times, avg 0 ms)
   240 ms: void boost::asio::execution::detail::any_executor_base::execute<$>(b... (168 times, avg 1 ms)
   238 ms: QArrayDataPointer<$>::QArrayDataPointer(QArrayDataPointer<$>&&) (320 times, avg 0 ms)
   221 ms: QArrayDataPointer<$>::reallocateAndGrow(QArrayData::GrowthPosition, ... (138 times, avg 1 ms)
   220 ms: std::_Sp_counted_ptr_inplace<$>::_M_destroy() (306 times, avg 0 ms)
   203 ms: void std::vector<$>::_M_realloc_append<$>(std::shared_ptr<$>&&) (135 times, avg 1 ms)
   200 ms: QtPrivate::QCallableObject<$>::impl(int, QtPrivate::QSlotObjectBase*... (250 times, avg 0 ms)
   199 ms: pajlada::Settings::Setting<$>::getValue() const (141 times, avg 1 ms)
   190 ms: bool QAtomicOps<$>::ref<$>(std::atomic<$>&) (220 times, avg 0 ms)
   190 ms: std::unique_ptr<$>::~unique_ptr() (282 times, avg 0 ms)
   188 ms: std::_Sp_counted_base<$>::_M_release() (198 times, avg 0 ms)
   187 ms: boost::asio::detail::wait_handler<$>::do_complete(void*, boost::asio... (124 times, avg 1 ms)
   181 ms: boost::asio::detail::executor_function::executor_function<$>(boost::... (175 times, avg 1 ms)
   178 ms: std::_Sp_counted_ptr_inplace<$>::_M_dispose() (295 times, avg 0 ms)
   175 ms: boost::asio::detail::executor_function::executor_function<$>(boost::... (166 times, avg 1 ms)
   171 ms: std::function<$>::function(std::function<$> const&) (222 times, avg 0 ms)
   168 ms: boost::asio::detail::completion_handler<$>::do_complete(void*, boost... (111 times, avg 1 ms)
   166 ms: std::vector<$>::end() (276 times, avg 0 ms)

**** Expensive headers:
219292 ms: /home/maciek/git/ch2dev/src/Application.hpp (included 144 times, avg 1522 ms), included via:
  136x: <direct include>
  2x: GeneralPageView.hpp 
  2x: PluginController.hpp Plugin.hpp 
  1x: ExternalToolsPage.hpp GeneralPageView.hpp 
  1x: Plugin.hpp 
  1x: SettingWidget.hpp GeneralPageView.hpp 
  ...

178013 ms: /home/maciek/git/ch2dev/src/common/Channel.hpp (included 144 times, avg 1236 ms), included via:
  55x: Settings.hpp 
  24x: TwitchChannel.hpp 
  23x: <direct include>
  13x: TwitchIrcServer.hpp 
  5x: Split.hpp 
  3x: OverlayWindow.hpp 
  ...

156514 ms: /home/maciek/git/ch2dev/src/widgets/BaseWidget.hpp (included 136 times, avg 1150 ms), included via:
  68x: Settings.hpp Notebook.hpp 
  8x: WindowManager.hpp SplitContainer.hpp 
  4x: HighlightController.hpp Settings.hpp Notebook.hpp 
  2x: Window.hpp BaseWindow.hpp 
  2x: Scrollbar.hpp 
  2x: LoginDialog.hpp 
  ...

154395 ms: /home/maciek/git/ch2dev/src/widgets/listview/GenericListItem.hpp (included 153 times, avg 1009 ms), included via:
  54x: Settings.hpp Channel.hpp TabCompletionModel.hpp Source.hpp GenericListModel.hpp 
  24x: TwitchChannel.hpp Channel.hpp TabCompletionModel.hpp Source.hpp GenericListModel.hpp 
  21x: Channel.hpp TabCompletionModel.hpp Source.hpp GenericListModel.hpp 
  11x: TwitchIrcServer.hpp Channel.hpp TabCompletionModel.hpp Source.hpp GenericListModel.hpp 
  4x: Split.hpp Channel.hpp TabCompletionModel.hpp Source.hpp GenericListModel.hpp 
  3x: OverlayWindow.hpp Channel.hpp TabCompletionModel.hpp Source.hpp GenericListModel.hpp 
  ...

149785 ms: /home/maciek/git/ch2dev/src/singletons/NativeMessaging.hpp (included 145 times, avg 1033 ms), included via:
  135x: Application.hpp 
  2x: <direct include>
  2x: GeneralPageView.hpp Application.hpp 
  2x: PluginController.hpp Plugin.hpp Application.hpp 
  1x: ExternalToolsPage.hpp GeneralPageView.hpp Application.hpp 
  1x: Plugin.hpp Application.hpp 
  ...

145716 ms: /home/maciek/git/ch2dev/src/singletons/Settings.hpp (included 97 times, avg 1502 ms), included via:
  87x: <direct include>
  4x: HighlightController.hpp 
  2x: SeventvEventAPI.hpp BasicPubSubClient.hpp 
  2x: BttvLiveUpdates.hpp BasicPubSubManager.hpp BasicPubSubClient.hpp 
  1x: Client.hpp BasicPubSubClient.hpp 
  1x: ChannelHelpers.hpp 
  ...

137695 ms: /home/maciek/git/ch2dev/src/widgets/listview/GenericListModel.hpp (included 150 times, avg 917 ms), included via:
  54x: Settings.hpp Channel.hpp TabCompletionModel.hpp Source.hpp 
  24x: TwitchChannel.hpp Channel.hpp TabCompletionModel.hpp Source.hpp 
  21x: Channel.hpp TabCompletionModel.hpp Source.hpp 
  13x: TwitchIrcServer.hpp Channel.hpp TabCompletionModel.hpp Source.hpp 
  5x: Split.hpp Channel.hpp TabCompletionModel.hpp Source.hpp 
  3x: OverlayWindow.hpp Channel.hpp TabCompletionModel.hpp Source.hpp 
  ...

120855 ms: /home/maciek/git/ch2dev/src/controllers/completion/sources/Source.hpp (included 147 times, avg 822 ms), included via:
  54x: Settings.hpp Channel.hpp TabCompletionModel.hpp 
  24x: TwitchChannel.hpp Channel.hpp TabCompletionModel.hpp 
  22x: Channel.hpp TabCompletionModel.hpp 
  13x: TwitchIrcServer.hpp Channel.hpp TabCompletionModel.hpp 
  5x: Split.hpp Channel.hpp TabCompletionModel.hpp 
  3x: OverlayWindow.hpp Channel.hpp TabCompletionModel.hpp 
  ...

115019 ms: /home/maciek/git/ch2dev/src/controllers/completion/TabCompletionModel.hpp (included 144 times, avg 798 ms), included via:
  54x: Settings.hpp Channel.hpp 
  24x: TwitchChannel.hpp Channel.hpp 
  22x: Channel.hpp 
  13x: TwitchIrcServer.hpp Channel.hpp 
  5x: Split.hpp Channel.hpp 
  3x: OverlayWindow.hpp Channel.hpp 
  ...

107829 ms: /usr/include/qt6/QtCore/QJsonObject (included 183 times, avg 589 ms), included via:
  31x: Message.hpp ChannelPointReward.hpp 
  27x: Helix.hpp 
  22x: Theme.hpp 
  16x: NetworkResult.hpp 
  13x: Args.hpp WindowDescriptors.hpp 
  13x: WindowManager.hpp SplitContainer.hpp WindowDescriptors.hpp 
  ...

  done in 0.8s.
```

</details>


<details>
<summary>time-trace after 5th commit: f26b2c4ac649259e6e2dfedeb53eca2c19e6a4e6</summary>

```
Analyzing build trace from '../capture_file-after-5-commits'...
**** Time summary:
Compilation (433 times):
  Parsing (frontend):         2848.9 s
  Codegen & opts (backend):    135.0 s

**** Files that took longest to parse (compiler frontend):
 39154 ms: ./src/CMakeFiles/chatterino-lib.dir/common/websockets/detail/WebSocketConnectionImpl.cpp.o
 26175 ms: ./src/CMakeFiles/chatterino-lib.dir/Application.cpp.o
 24871 ms: ./src/CMakeFiles/chatterino-lib.dir/providers/twitch/TwitchChannel.cpp.o
 22159 ms: ./src/CMakeFiles/chatterino-lib.dir/providers/twitch/TwitchIrcServer.cpp.o
 21271 ms: ./src/CMakeFiles/chatterino-lib.dir/providers/twitch/eventsub/Connection.cpp.o
 20698 ms: ./src/CMakeFiles/chatterino-lib.dir/controllers/plugins/PluginController.cpp.o
 19673 ms: ./src/CMakeFiles/chatterino-lib.dir/providers/seventv/SeventvEventAPI.cpp.o
 18090 ms: ./src/CMakeFiles/chatterino-lib.dir/widgets/Window.cpp.o
 17413 ms: ./src/CMakeFiles/chatterino-lib.dir/providers/twitch/eventsub/Controller.cpp.o
 15802 ms: ./src/CMakeFiles/chatterino-lib.dir/providers/bttv/BttvLiveUpdates.cpp.o

**** Files that took longest to codegen (compiler backend):
 14901 ms: ./src/CMakeFiles/chatterino-lib.dir/common/websockets/detail/WebSocketConnectionImpl.cpp.o
  4267 ms: ./src/CMakeFiles/chatterino-lib.dir/providers/twitch/PubSubManager.cpp.o
  4012 ms: ./src/CMakeFiles/chatterino-lib.dir/providers/seventv/SeventvEventAPI.cpp.o
  3960 ms: ./src/CMakeFiles/chatterino-lib.dir/providers/bttv/BttvLiveUpdates.cpp.o
  3672 ms: ./lib/twitch-eventsub-ws/src/CMakeFiles/twitch-eventsub-ws.dir/session.cpp.o
  3058 ms: ./src/CMakeFiles/chatterino-lib.dir/controllers/sound/MiniaudioBackend.cpp.o
  2229 ms: ./src/CMakeFiles/chatterino-lib.dir/providers/twitch/TwitchChannel.cpp.o
  2139 ms: ./src/CMakeFiles/chatterino-lib.dir/singletons/Settings.cpp.o
  2025 ms: ./src/CMakeFiles/chatterino-lib.dir/providers/twitch/PubSubClient.cpp.o
  1970 ms: ./src/CMakeFiles/chatterino-lib.dir/providers/twitch/api/Helix.cpp.o

**** Templates that took longest to instantiate:
 74341 ms: std::vformat_to<std::__format::_Sink_iter<char>> (345 times, avg 215 ms)
 74233 ms: std::__format::__do_vformat_to<std::__format::_Sink_iter<char>, char... (343 times, avg 216 ms)
 61863 ms: std::vformat_to<std::__format::_Sink_iter<wchar_t>> (344 times, avg 179 ms)
 61771 ms: std::__format::__do_vformat_to<std::__format::_Sink_iter<wchar_t>, w... (343 times, avg 180 ms)
 17879 ms: std::formatter<bool>::format<std::__format::_Sink_iter<char>> (343 times, avg 52 ms)
 17829 ms: std::__format::__formatter_int<char>::format<std::__format::_Sink_it... (343 times, avg 51 ms)
 15316 ms: std::__format::__formatter_int<char>::format<unsigned char, std::__f... (343 times, avg 44 ms)
 14157 ms: std::__format::__formatter_int<char>::_M_format_int<std::__format::_... (343 times, avg 41 ms)
 13241 ms: std::chrono::hh_mm_ss<std::chrono::duration<long>>::hh_mm_ss (686 times, avg 19 ms)
 12604 ms: std::formatter<bool, wchar_t>::format<std::__format::_Sink_iter<wcha... (343 times, avg 36 ms)
 12552 ms: std::__format::__formatter_int<wchar_t>::format<std::__format::_Sink... (343 times, avg 36 ms)
 11474 ms: std::__format::__formatter_int<wchar_t>::_M_parse<char> (343 times, avg 33 ms)
 11233 ms: std::__format::__formatter_int<wchar_t>::_M_do_parse (343 times, avg 32 ms)
 10068 ms: std::__format::_Formatting_scanner<std::__format::_Sink_iter<char>, ... (343 times, avg 29 ms)
 10051 ms: std::__format::__formatter_int<wchar_t>::format<unsigned char, std::... (343 times, avg 29 ms)
  9619 ms: std::__format::_Formatting_scanner<std::__format::_Sink_iter<char>, ... (343 times, avg 28 ms)
  9468 ms: std::visit_format_arg<(lambda at /usr/bin/../lib64/gcc/x86_64-pc-lin... (343 times, avg 27 ms)
  9432 ms: std::formatter<const wchar_t *, wchar_t>::format<std::__format::_Sin... (343 times, avg 27 ms)
  9397 ms: std::formatter<const char *>::format<std::__format::_Sink_iter<char>> (343 times, avg 27 ms)
  9391 ms: std::basic_format_arg<std::basic_format_context<std::__format::_Sink... (343 times, avg 27 ms)
  9351 ms: std::__format::__formatter_str<wchar_t>::format<std::__format::_Sink... (343 times, avg 27 ms)
  9346 ms: std::__format::__formatter_str<char>::format<std::__format::_Sink_it... (343 times, avg 27 ms)
  8985 ms: std::__format::_Seq_sink<std::basic_string<char>>::_M_reserve (343 times, avg 26 ms)
  8868 ms: std::__format::__formatter_int<wchar_t>::_M_format_int<std::__format... (343 times, avg 25 ms)
  8847 ms: std::__format::_Seq_sink<std::basic_string<wchar_t>>::_M_reserve (343 times, avg 25 ms)
  8434 ms: std::__unicode::__truncate<char> (343 times, avg 24 ms)
  8310 ms: std::__unicode::__truncate<wchar_t> (343 times, avg 24 ms)
  7826 ms: std::__format::_Iter_sink<char, std::__format::_Sink_iter<char>>::_I... (343 times, avg 22 ms)
  7810 ms: std::__format::_Formatting_scanner<std::__format::_Sink_iter<wchar_t... (343 times, avg 22 ms)
  7768 ms: std::__format::_Iter_sink<char, std::__format::_Sink_iter<char>>::_M... (343 times, avg 22 ms)

**** Template sets that took longest to instantiate:
136204 ms: std::vformat_to<$> (689 times, avg 197 ms)
136005 ms: std::__format::__do_vformat_to<$> (686 times, avg 198 ms)
129483 ms: std::unique_ptr<$> (9356 times, avg 13 ms)
107214 ms: std::__uniq_ptr_data<$> (9356 times, avg 11 ms)
105731 ms: std::__uniq_ptr_impl<$> (9356 times, avg 11 ms)
 90468 ms: std::__and_<$> (81036 times, avg 1 ms)
 84109 ms: std::formatter<$>::format<$> (8552 times, avg 9 ms)
 64333 ms: std::tuple<$> (10043 times, avg 6 ms)
 49229 ms: qRegisterNormalizedMetaType<$> (3136 times, avg 15 ms)
 49074 ms: qRegisterNormalizedMetaTypeImplementation<$> (3136 times, avg 15 ms)
 40771 ms: std::__format::__formatter_int<$>::format<$> (4802 times, avg 8 ms)
 40001 ms: std::__or_<$> (48743 times, avg 0 ms)
 31008 ms: QtPrivate::TypeNameHelper::typenameHelper<$> (24622 times, avg 1 ms)
 28300 ms: std::reverse_iterator<$> (2543 times, avg 11 ms)
 23856 ms: QtPrivate::QMetaTypeForType<$> (19900 times, avg 1 ms)
 23548 ms: std::vector<$> (7735 times, avg 3 ms)
 23026 ms: std::__format::__formatter_int<$>::_M_format_int<$> (686 times, avg 33 ms)
 22376 ms: boost::asio::async_initiate<$> (139 times, avg 160 ms)
 22356 ms: std::optional<$> (2965 times, avg 7 ms)
 22354 ms: boost::asio::detail::completion_handler_async_result<$>::initiate<$> (139 times, avg 160 ms)
 22212 ms: std::__format::__formatter_fp<$>::format<$> (2058 times, avg 10 ms)
 21185 ms: std::visit_format_arg<$> (1708 times, avg 12 ms)
 21101 ms: std::_Tuple_impl<$> (10010 times, avg 2 ms)
 20869 ms: std::is_scalar<$> (23093 times, avg 0 ms)
 20785 ms: std::basic_format_arg<$>::_M_visit<$> (1701 times, avg 12 ms)
 20187 ms: std::common_reference<$> (21391 times, avg 0 ms)
 20146 ms: std::tuple<$>::__constructible<$> (18848 times, avg 1 ms)
 19232 ms: std::is_move_constructible<$> (17648 times, avg 1 ms)
 19106 ms: std::tuple<$>::__assignable<$> (18629 times, avg 1 ms)
 18972 ms: std::vector<$>::emplace_back<$> (1371 times, avg 13 ms)

**** Functions that took longest to compile:
   121 ms: chatterino::HotkeyController::addDefaults(std::set<QString, std::les... (/home/maciek/git/ch2dev/src/controllers/hotkeys/HotkeyController.cpp)
    94 ms: __cxx_global_var_init.10 (/home/maciek/git/ch2dev/src/controllers/hotkeys/Hotkey.cpp)
    92 ms: chatterino::Settings::Settings(chatterino::Args const&, QString cons... (/home/maciek/git/ch2dev/src/singletons/Settings.cpp)
    91 ms: __cxx_global_var_init.10 (/home/maciek/git/ch2dev/src/widgets/dialogs/EditHotkeyDialog.cpp)
    76 ms: ma_dr_flac__decode_samples_with_residual__rice__scalar(ma_dr_flac_bs... (/home/maciek/git/ch2dev/src/controllers/sound/MiniaudioBackend.cpp)
    71 ms: __cxx_global_var_init.10 (/home/maciek/git/ch2dev/src/controllers/hotkeys/HotkeyHelpers.cpp)
    46 ms: chatterino::GeneralPage::initLayout(chatterino::GeneralPageView&) (/home/maciek/git/ch2dev/src/widgets/settingspages/GeneralPage.cpp)
    40 ms: luaV_execute(lua_State*, CallInfo*) (/home/maciek/git/ch2dev/lib/lua/src/lvm.c)
    37 ms: websocketpp::md5::md5_process(websocketpp::md5::md5_state_s*, unsign... (/home/maciek/git/ch2dev/src/providers/seventv/SeventvEventAPI.cpp)
    36 ms: void boost::asio::detail::initiate_post_with_executor<boost::asio::i... (/home/maciek/git/ch2dev/src/providers/twitch/PubSubManager.cpp)
    35 ms: (anonymous namespace)::getEmoteExpectedBaseSize(chatterino::EmoteId ... (/home/maciek/git/ch2dev/src/providers/twitch/TwitchEmotes.cpp)
    32 ms: ma_pcm_f32_to_s16 (/home/maciek/git/ch2dev/src/controllers/sound/MiniaudioBackend.cpp)
    31 ms: bool std::_Function_base::_Base_manager<chatterino::TwitchIrcServer:... (/home/maciek/git/ch2dev/src/providers/twitch/TwitchIrcServer.cpp)
    31 ms: std::basic_istream<char, std::char_traits<char> >& std::chrono::__de... (/home/maciek/git/ch2dev/lib/twitch-eventsub-ws/src/chrono.cpp)
    29 ms: boost::asio::detail::completion_handler<boost::asio::detail::binder2... (/home/maciek/git/ch2dev/src/providers/twitch/PubSubClient.cpp)
    28 ms: chatterino::UserInfoPopup::UserInfoPopup(bool, chatterino::Split*)::... (/home/maciek/git/ch2dev/src/widgets/dialogs/UserInfoPopup.cpp)
    28 ms: chatterino::CommandController::CommandController(chatterino::Paths c... (/home/maciek/git/ch2dev/src/controllers/commands/CommandController.cpp)
    27 ms: QtPrivate::QPodArrayOps<char>::destroyAll() (/home/maciek/git/ch2dev/src/singletons/NativeMessaging.cpp)
    26 ms: boost::beast::websocket::stream<boost::asio::ssl::stream<boost::beas... (/home/maciek/git/ch2dev/src/common/websockets/detail/WebSocketConnectionImpl.cpp)
    25 ms: boost::beast::websocket::stream<boost::beast::basic_stream<boost::as... (/home/maciek/git/ch2dev/src/common/websockets/detail/WebSocketConnectionImpl.cpp)
    23 ms: std::_Function_handler<void (), std::_Bind<void (websocketpp::connec... (/home/maciek/git/ch2dev/src/providers/twitch/PubSubClient.cpp)
    23 ms: std::vector<std::shared_ptr<chatterino::EmojiData>, std::allocator<s... (/home/maciek/git/ch2dev/src/widgets/dialogs/EmotePopup.cpp)
    23 ms: chatterino::HighlightModel::afterInit() (/home/maciek/git/ch2dev/src/controllers/highlights/HighlightModel.cpp)
    22 ms: std::_Head_base<1ul, std::function<void (std::error_code const&)>, f... (/home/maciek/git/ch2dev/src/providers/twitch/PubSubClient.cpp)
    22 ms: chatterino::UserInfoPopup::UserInfoPopup(bool, chatterino::Split*) (/home/maciek/git/ch2dev/src/widgets/dialogs/UserInfoPopup.cpp)
    21 ms: boost::beast::websocket::stream<boost::asio::ssl::stream<boost::beas... (/home/maciek/git/ch2dev/src/common/websockets/detail/WebSocketConnectionImpl.cpp)
    21 ms: Communi::IrcMessageComposer::composeMessage(Communi::IrcNumericMessa... (/home/maciek/git/ch2dev/lib/libcommuni/src/core/ircmessagecomposer.cpp)
    20 ms: chatterino::IrcMessageHandler::parseUserNoticeMessageInto(Communi::I... (/home/maciek/git/ch2dev/src/providers/twitch/IrcMessageHandler.cpp)
    19 ms: std::unique_ptr<pajlada::Signals::ScopedConnection, std::default_del... (/home/maciek/git/ch2dev/src/widgets/Label.cpp)
    19 ms: chatterino::filters::buildContextMap(std::shared_ptr<chatterino::Mes... (/home/maciek/git/ch2dev/src/controllers/filters/lang/Filter.cpp)

**** Function sets that took longest to compile / optimize:
   693 ms: void boost::asio::detail::executor_function::complete<$>(boost::asio... (579 times, avg 1 ms)
   458 ms: std::_Function_base::_Base_manager<$>::_M_manager(std::_Any_data&, s... (672 times, avg 0 ms)
   455 ms: std::vector<$>::~vector() (630 times, avg 0 ms)
   436 ms: std::_Function_handler<$>::_M_manager(std::_Any_data&, std::_Any_dat... (661 times, avg 0 ms)
   355 ms: std::_Vector_base<$>::~_Vector_base() (585 times, avg 0 ms)
   349 ms: std::vector<$>::_M_check_len(unsigned long, char const*) const (471 times, avg 0 ms)
   303 ms: boost::asio::detail::executor_function::impl<$>::ptr::allocate(std::... (536 times, avg 0 ms)
   286 ms: bool QAtomicOps<$>::deref<$>(std::atomic<$>&) (310 times, avg 0 ms)
   262 ms: std::vector<$>::_S_max_size(std::allocator<$> const&) (411 times, avg 0 ms)
   232 ms: QArrayDataPointer<$>::QArrayDataPointer(QArrayDataPointer<$>&&) (324 times, avg 0 ms)
   230 ms: int QAtomicOps<$>::loadRelaxed<$>(std::atomic<$> const&) (310 times, avg 0 ms)
   228 ms: boost::asio::detail::executor_function::impl<$>::ptr::reset() (403 times, avg 0 ms)
   223 ms: std::vector<$>::back() (368 times, avg 0 ms)
   221 ms: void boost::asio::execution::detail::any_executor_base::execute<$>(b... (175 times, avg 1 ms)
   214 ms: void boost::asio::execution::detail::any_executor_base::execute<$>(b... (167 times, avg 1 ms)
   209 ms: QArrayDataPointer<$>::reallocateAndGrow(QArrayData::GrowthPosition, ... (137 times, avg 1 ms)
   186 ms: pajlada::Settings::Setting<$>::getValue() const (139 times, avg 1 ms)
   186 ms: std::_Sp_counted_ptr_inplace<$>::_M_destroy() (301 times, avg 0 ms)
   181 ms: std::_Sp_counted_ptr_inplace<$>::_M_dispose() (295 times, avg 0 ms)
   179 ms: boost::asio::detail::completion_handler<$>::do_complete(void*, boost... (111 times, avg 1 ms)
   176 ms: QtPrivate::QCallableObject<$>::impl(int, QtPrivate::QSlotObjectBase*... (239 times, avg 0 ms)
   176 ms: void std::vector<$>::_M_realloc_append<$>(std::shared_ptr<$>&&) (125 times, avg 1 ms)
   174 ms: bool QAtomicOps<$>::ref<$>(std::atomic<$>&) (214 times, avg 0 ms)
   173 ms: std::_Sp_counted_base<$>::_M_release() (195 times, avg 0 ms)
   170 ms: boost::asio::detail::executor_function::executor_function<$>(boost::... (175 times, avg 0 ms)
   164 ms: pajlada::Signals::Signal<$>::getActiveBodies() (100 times, avg 1 ms)
   162 ms: boost::asio::detail::executor_function::executor_function<$>(boost::... (166 times, avg 0 ms)
   161 ms: boost::asio::detail::wait_handler<$>::do_complete(void*, boost::asio... (120 times, avg 1 ms)
   160 ms: std::_Sp_counted_ptr_inplace<$>::_Sp_counted_ptr_inplace<$>(std::all... (190 times, avg 0 ms)
   157 ms: std::function<$>::function(std::function<$> const&) (211 times, avg 0 ms)

**** Expensive headers:
147908 ms: /home/maciek/git/ch2dev/src/widgets/BaseWidget.hpp (included 79 times, avg 1872 ms), included via:
  26x: WindowManager.hpp SplitContainer.hpp 
  2x: AccountSwitchPopup.hpp BaseWindow.hpp 
  2x: Scrollbar.hpp 
  2x: BasePopup.hpp BaseWindow.hpp 
  2x: LoginDialog.hpp 
  2x: BaseWindow.hpp 
  ...

128991 ms: /home/maciek/git/ch2dev/src/debug/AssertInGuiThread.hpp (included 146 times, avg 883 ms), included via:
  43x: AccountController.hpp SignalVector.hpp 
  42x: Settings.hpp SignalVector.hpp 
  11x: <direct include>
  11x: HotkeyController.hpp SignalVector.hpp 
  8x: CommandController.hpp SignalVector.hpp 
  4x: NotificationController.hpp SignalVector.hpp 
  ...

122723 ms: /home/maciek/git/ch2dev/src/common/Channel.hpp (included 89 times, avg 1378 ms), included via:
  25x: TwitchChannel.hpp 
  24x: <direct include>
  13x: TwitchIrcServer.hpp 
  8x: Split.hpp 
  3x: OverlayWindow.hpp 
  3x: MessageBuilder.hpp TwitchChannel.hpp 
  ...

114833 ms: /usr/include/qt6/QtCore/QJsonObject (included 183 times, avg 627 ms), included via:
  31x: Message.hpp ChannelPointReward.hpp 
  27x: Helix.hpp 
  22x: Theme.hpp 
  16x: NetworkResult.hpp 
  13x: Args.hpp WindowDescriptors.hpp 
  13x: WindowManager.hpp SplitContainer.hpp WindowDescriptors.hpp 
  ...

111396 ms: /home/maciek/git/ch2dev/src/controllers/accounts/AccountController.hpp (included 45 times, avg 2475 ms), included via:
  45x: <direct include>

105522 ms: /usr/include/qt6/QtCore/QCoreApplication (included 127 times, avg 830 ms), included via:
  38x: AccountController.hpp SignalVector.hpp AssertInGuiThread.hpp 
  37x: Settings.hpp SignalVector.hpp AssertInGuiThread.hpp 
  8x: AssertInGuiThread.hpp 
  7x: HotkeyController.hpp SignalVector.hpp AssertInGuiThread.hpp 
  5x: CommandController.hpp SignalVector.hpp AssertInGuiThread.hpp 
  4x: NotificationController.hpp SignalVector.hpp AssertInGuiThread.hpp 
  ...

99139 ms: /home/maciek/git/ch2dev/src/singletons/Settings.hpp (included 96 times, avg 1032 ms), included via:
  86x: <direct include>
  4x: HighlightController.hpp 
  2x: SeventvEventAPI.hpp BasicPubSubClient.hpp 
  2x: BttvLiveUpdates.hpp BasicPubSubManager.hpp BasicPubSubClient.hpp 
  1x: ChannelHelpers.hpp 
  1x: Client.hpp BasicPubSubClient.hpp 
  ...

92633 ms: /home/maciek/git/ch2dev/src/widgets/BaseWindow.hpp (included 51 times, avg 1816 ms), included via:
  7x: Window.hpp 
  4x: NotebookTab.hpp ChannelView.hpp TooltipWidget.hpp 
  3x: AccountSwitchPopup.hpp 
  3x: <direct include>
  3x: ColorPickerDialog.hpp BasePopup.hpp 
  3x: SettingsDialog.hpp 
  ...

87419 ms: /home/maciek/git/ch2dev/src/controllers/completion/TabCompletionModel.hpp (included 90 times, avg 971 ms), included via:
  25x: TwitchChannel.hpp Channel.hpp 
  23x: Channel.hpp 
  13x: TwitchIrcServer.hpp Channel.hpp 
  8x: Split.hpp Channel.hpp 
  3x: OverlayWindow.hpp Channel.hpp 
  3x: MessageBuilder.hpp TwitchChannel.hpp Channel.hpp 
  ...

85284 ms: /home/maciek/git/ch2dev/src/Application.hpp (included 144 times, avg 592 ms), included via:
  140x: <direct include>
  2x: GeneralPageView.hpp 
  1x: ExternalToolsPage.hpp GeneralPageView.hpp 
  1x: SettingWidget.hpp GeneralPageView.hpp 

  done in 0.7s.

```

</details>