### PR TITLE
feat(6156): disable tab renaming on double-click via setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Minor: Allow for themes to set transparent values for window background on Linux. (#6137)
 - Minor: Popup overlay now only draws an outline when being interacted with. (#6140)
 - Minor: Made filters searchable in the Settings dialog search bar. (#5890)
+- Minor: Allow disabling of double-click tab renaming through setting. (#6163)
 - Bugfix: Don't create native messaging manifest file if browser directory doesn't exist. (#6116)
 - Bugfix: Fixed scrolling now working on inputs in the settings. (#6128)
 - Bugfix: Make reply-cancel button less coarse-grained. (#6106)

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -326,6 +326,11 @@ public:
     BoolSetting mentionUsersWithComma = {"/behaviour/mentionUsersWithComma",
                                          true};
 
+    BoolSetting disableTabRenamingOnClick = {
+        "/behaviour/disableTabRenamingOnClick",
+        false,
+    };
+
     /// Emotes
     BoolSetting scaleEmotesByLineHeight = {"/emotes/scaleEmotesByLineHeight",
                                            false};

--- a/src/widgets/helper/NotebookTab.cpp
+++ b/src/widgets/helper/NotebookTab.cpp
@@ -958,9 +958,8 @@ void NotebookTab::mouseReleaseEvent(QMouseEvent *event)
 
 void NotebookTab::mouseDoubleClickEvent(QMouseEvent *event)
 {
-    const auto canRenameTab =
-        this->notebook_->getAllowUserTabManagement() &&
-        getSettings()->disableTabRenamingOnClick == false;
+    const auto canRenameTab = this->notebook_->getAllowUserTabManagement() &&
+                              getSettings()->disableTabRenamingOnClick == false;
 
     if (event->button() == Qt::LeftButton && canRenameTab)
     {

--- a/src/widgets/helper/NotebookTab.cpp
+++ b/src/widgets/helper/NotebookTab.cpp
@@ -958,8 +958,11 @@ void NotebookTab::mouseReleaseEvent(QMouseEvent *event)
 
 void NotebookTab::mouseDoubleClickEvent(QMouseEvent *event)
 {
-    if (event->button() == Qt::LeftButton &&
-        this->notebook_->getAllowUserTabManagement())
+    const auto canRenameTab =
+        this->notebook_->getAllowUserTabManagement() &&
+        getSettings()->disableTabRenamingOnClick == false;
+
+    if (event->button() == Qt::LeftButton && canRenameTab)
     {
         this->showRenameDialog();
     }

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1369,10 +1369,8 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         "Enable experimental Twitch EventSub support (requires restart)",
         s.enableExperimentalEventSub);
 
-    layout.addCheckbox(
-        "Disable renaming of tabs on double-click",
-        s.disableTabRenamingOnClick
-    );
+    layout.addCheckbox("Disable renaming of tabs on double-click",
+                       s.disableTabRenamingOnClick);
 
     layout.addStretch();
 

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1369,6 +1369,11 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         "Enable experimental Twitch EventSub support (requires restart)",
         s.enableExperimentalEventSub);
 
+    layout.addCheckbox(
+        "Disable renaming of tabs on double-click",
+        s.disableTabRenamingOnClick
+    );
+
     layout.addStretch();
 
     // invisible element for width


### PR DESCRIPTION
This PR aims to implement disabling of the "double-click to rename tab" feature through yet another setting, as discussed in #6156. I've stuffed the setting at the bottom of the advanced section, but I'm sure it would be better suited somewhere else. Do we still care given how much of a mess settings are?

Demo:
https://github.com/user-attachments/assets/6f6a3d56-9a4a-45a1-a9f3-52a5caf3597f