### PR TITLE
dep: update googletest to v1.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Dev: Removed authenticated PubSub implementation. (#6158)
 - Dev: Save settings in `aboutToQuit`. (#6159)
 - Dev: Bumped deprecation cutoff to Qt 6.4.3. (#6169)
+- Dev: Updated GoogleTest to v1.17.0. (#6180)
 - Dev: Simplified string literals to be a re-export of Qt functions. (#6175)
 
 ## 2.5.3


### PR DESCRIPTION
https://github.com/google/googletest/releases/tag/v1.17.0

C++17 required - no issues for us
