### PR TITLE
fix: don't include blocked users in join/part messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Bugfix: Fixed the emote popup erroneously logging messages to the `Other` directory. (#6165)
 - Bugfix: Handle <kbd>CMD</kbd> + <kbd>BACKSPACE</kbd> behavior explicitly in main chat dialog input for macOS. (#6111)
 - Bugfix: Fixed a small typo in the settings page. (#6134)
+- Bugfix: Fixed blocked users showing up in "Users joined:" and "Users parted:" messages. (#6181)
 - Bugfix: Fixed an issue where Splits could get lost by dragging it onto your Recycle Bin. (#6147)
 - Bugfix: Fixed some Twitch commands not getting tab-completed correctly. (#6143)
 - Bugfix: Fixed shared chat badges displaying pixelated when Chatterino is scaled too much. (#6146)

--- a/src/common/ChannelChatters.cpp
+++ b/src/common/ChannelChatters.cpp
@@ -1,10 +1,8 @@
 #include "common/ChannelChatters.hpp"
 
-#include "Application.hpp"
 #include "common/Channel.hpp"
-#include "controllers/accounts/AccountController.hpp"
+#include "controllers/ignores/IgnoreController.hpp"
 #include "debug/AssertInGuiThread.hpp"
-#include "messages/Message.hpp"
 #include "messages/MessageBuilder.hpp"
 #include "providers/twitch/TwitchAccount.hpp"
 
@@ -29,15 +27,16 @@ void ChannelChatters::addRecentChatter(const QString &user)
     chatters->addRecentChatter(user);
 }
 
-void ChannelChatters::addJoinedUser(const QString &user)
+void ChannelChatters::addJoinedUser(const QString &user, bool isMod,
+                                    bool isBroadcaster)
 {
     assertInGuiThread();
 
-    if (getApp()
-            ->getAccounts()
-            ->twitch.getCurrent()
-            ->blockedUserLogins()
-            .contains(user))
+    if (isIgnoredMessage(IgnoredMessageParameters{
+            .twitchUserLogin = user,
+            .isMod = isMod,
+            .isBroadcaster = isBroadcaster,
+        }))
     {
         return;
     }
@@ -64,15 +63,16 @@ void ChannelChatters::addJoinedUser(const QString &user)
     }
 }
 
-void ChannelChatters::addPartedUser(const QString &user)
+void ChannelChatters::addPartedUser(const QString &user, bool isMod,
+                                    bool isBroadcaster)
 {
     assertInGuiThread();
 
-    if (getApp()
-            ->getAccounts()
-            ->twitch.getCurrent()
-            ->blockedUserLogins()
-            .contains(user))
+    if (isIgnoredMessage(IgnoredMessageParameters{
+            .twitchUserLogin = user,
+            .isMod = isMod,
+            .isBroadcaster = isBroadcaster,
+        }))
     {
         return;
     }

--- a/src/common/ChannelChatters.cpp
+++ b/src/common/ChannelChatters.cpp
@@ -1,8 +1,12 @@
 #include "common/ChannelChatters.hpp"
 
+#include "Application.hpp"
 #include "common/Channel.hpp"
+#include "controllers/accounts/AccountController.hpp"
+#include "debug/AssertInGuiThread.hpp"
 #include "messages/Message.hpp"
 #include "messages/MessageBuilder.hpp"
+#include "providers/twitch/TwitchAccount.hpp"
 
 #include <QColor>
 
@@ -27,8 +31,18 @@ void ChannelChatters::addRecentChatter(const QString &user)
 
 void ChannelChatters::addJoinedUser(const QString &user)
 {
-    auto joinedUsers = this->joinedUsers_.access();
-    joinedUsers->append(user);
+    assertInGuiThread();
+
+    if (getApp()
+            ->getAccounts()
+            ->twitch.getCurrent()
+            ->blockedUserLogins()
+            .contains(user))
+    {
+        return;
+    }
+
+    this->joinedUsers_.access()->append(user);
 
     if (!this->joinedUsersMergeQueued_)
     {
@@ -52,8 +66,18 @@ void ChannelChatters::addJoinedUser(const QString &user)
 
 void ChannelChatters::addPartedUser(const QString &user)
 {
-    auto partedUsers = this->partedUsers_.access();
-    partedUsers->append(user);
+    assertInGuiThread();
+
+    if (getApp()
+            ->getAccounts()
+            ->twitch.getCurrent()
+            ->blockedUserLogins()
+            .contains(user))
+    {
+        return;
+    }
+
+    this->partedUsers_.access()->append(user);
 
     if (!this->partedUsersMergeQueued_)
     {

--- a/src/common/ChannelChatters.hpp
+++ b/src/common/ChannelChatters.hpp
@@ -22,8 +22,8 @@ public:
     SharedAccessGuard<const ChatterSet> accessChatters() const;
 
     void addRecentChatter(const QString &user);
-    void addJoinedUser(const QString &user);
-    void addPartedUser(const QString &user);
+    void addJoinedUser(const QString &user, bool isMod, bool isBroadcaster);
+    void addPartedUser(const QString &user, bool isMod, bool isBroadcaster);
     const QColor getUserColor(const QString &user);
     void setUserColor(const QString &user, const QColor &color);
     void updateOnlineChatters(const std::unordered_set<QString> &usernames);

--- a/src/controllers/commands/builtin/twitch/Block.cpp
+++ b/src/controllers/commands/builtin/twitch/Block.cpp
@@ -53,7 +53,7 @@ QString blockUser(const CommandContext &ctx)
         [currentUser, channel{ctx.channel},
          target](const HelixUser &targetUser) {
             getApp()->getAccounts()->twitch.getCurrent()->blockUser(
-                targetUser.id, nullptr,
+                targetUser.id, targetUser.login, nullptr,
                 [channel, target, targetUser] {
                     channel->addSystemMessage(
                         QString("You successfully blocked user %1")
@@ -125,7 +125,7 @@ QString unblockUser(const CommandContext &ctx)
         target,
         [currentUser, channel{ctx.channel}, target](const auto &targetUser) {
             getApp()->getAccounts()->twitch.getCurrent()->unblockUser(
-                targetUser.id, nullptr,
+                targetUser.id, targetUser.login, nullptr,
                 [channel, target, targetUser] {
                     channel->addSystemMessage(
                         QString("You successfully unblocked user %1")

--- a/src/controllers/ignores/IgnoreController.cpp
+++ b/src/controllers/ignores/IgnoreController.cpp
@@ -149,16 +149,27 @@ bool isIgnoredMessage(IgnoredMessageParameters &&params)
         }
     }
 
-    if (!params.twitchUserID.isEmpty() &&
-        getSettings()->enableTwitchBlockedUsers)
+    if (getSettings()->enableTwitchBlockedUsers)
     {
-        auto sourceUserID = params.twitchUserID;
+        bool isBlocked = false;
 
-        bool isBlocked = getApp()
-                             ->getAccounts()
-                             ->twitch.getCurrent()
-                             ->blockedUserIds()
-                             .contains(sourceUserID);
+        if (!params.twitchUserID.isEmpty())
+        {
+            isBlocked = getApp()
+                            ->getAccounts()
+                            ->twitch.getCurrent()
+                            ->blockedUserIds()
+                            .contains(params.twitchUserID);
+        }
+        else if (!params.twitchUserLogin.isEmpty())
+        {
+            isBlocked = getApp()
+                            ->getAccounts()
+                            ->twitch.getCurrent()
+                            ->blockedUserLogins()
+                            .contains(params.twitchUserLogin);
+        }
+
         if (isBlocked)
         {
             switch (static_cast<ShowIgnoredUsersMessages>(

--- a/src/controllers/ignores/IgnoreController.hpp
+++ b/src/controllers/ignores/IgnoreController.hpp
@@ -15,6 +15,7 @@ struct IgnoredMessageParameters {
     QString message;
 
     QString twitchUserID;
+    QString twitchUserLogin;
     bool isMod;
     bool isBroadcaster;
 };

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -934,7 +934,8 @@ void IrcMessageHandler::handleJoinMessage(Communi::IrcMessage *message)
     }
     else if (getSettings()->showJoins.getValue())
     {
-        twitchChannel->addJoinedUser(message->nick());
+        twitchChannel->addJoinedUser(message->nick(), twitchChannel->isMod(),
+                                     twitchChannel->isBroadcaster());
     }
 }
 
@@ -954,7 +955,8 @@ void IrcMessageHandler::handlePartMessage(Communi::IrcMessage *message)
     if (message->nick() != selfAccountName &&
         getSettings()->showParts.getValue())
     {
-        twitchChannel->addPartedUser(message->nick());
+        twitchChannel->addPartedUser(message->nick(), twitchChannel->isMod(),
+                                     twitchChannel->isBroadcaster());
     }
 
     if (message->nick() == selfAccountName)

--- a/src/providers/twitch/TwitchAccount.cpp
+++ b/src/providers/twitch/TwitchAccount.cpp
@@ -193,7 +193,7 @@ void TwitchAccount::blockUserLocally(const QString &userID,
     blockedUser.name = userLogin;
     this->ignores_.insert(blockedUser);
     this->ignoresUserIds_.insert(blockedUser.id);
-    this->ignoresUserIds_.insert(blockedUser.name);
+    this->ignoresUserLogins_.insert(blockedUser.name);
 }
 
 const std::unordered_set<TwitchUser> &TwitchAccount::blocks() const

--- a/src/providers/twitch/TwitchAccount.hpp
+++ b/src/providers/twitch/TwitchAccount.hpp
@@ -64,17 +64,18 @@ public:
     bool isAnon() const;
 
     void loadBlocks();
-    void blockUser(const QString &userId, const QObject *caller,
-                   std::function<void()> onSuccess,
+    void blockUser(const QString &userId, const QString &userLogin,
+                   const QObject *caller, std::function<void()> onSuccess,
                    std::function<void()> onFailure);
-    void unblockUser(const QString &userId, const QObject *caller,
-                     std::function<void()> onSuccess,
+    void unblockUser(const QString &userId, const QString &userLogin,
+                     const QObject *caller, std::function<void()> onSuccess,
                      std::function<void()> onFailure);
 
-    void blockUserLocally(const QString &userID);
+    void blockUserLocally(const QString &userID, const QString &userLogin);
 
     [[nodiscard]] const std::unordered_set<TwitchUser> &blocks() const;
     [[nodiscard]] const std::unordered_set<QString> &blockedUserIds() const;
+    [[nodiscard]] const std::unordered_set<QString> &blockedUserLogins() const;
 
     // Automod actions
     void autoModAllow(const QString msgID, ChannelPtr channel);
@@ -120,6 +121,7 @@ private:
     ScopedCancellationToken blockToken_;
     std::unordered_set<TwitchUser> ignores_;
     std::unordered_set<QString> ignoresUserIds_;
+    std::unordered_set<QString> ignoresUserLogins_;
 
     ScopedCancellationToken emoteToken_;
     UniqueAccess<std::shared_ptr<const TwitchEmoteSetMap>> emoteSets_;

--- a/src/providers/twitch/TwitchUser.hpp
+++ b/src/providers/twitch/TwitchUser.hpp
@@ -15,9 +15,15 @@ struct HelixBlock;
 struct HelixUser;
 
 struct TwitchUser {
+    /// The Twitch User ID (e.g. `117166826`)
     QString id;
+
+    /// The Twitch User Login (e.g. `testaccount_420`)
     mutable QString name;
+
+    // The Twitch User Display Name (e.g. `테스트계정420`)
     mutable QString displayName;
+
     mutable QString profilePictureUrl;
 
     void update(const TwitchUser &other) const

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -661,7 +661,7 @@ void UserInfoPopup::installEvents()
                 this->ui_.block->setEnabled(false);
 
                 getApp()->getAccounts()->twitch.getCurrent()->unblockUser(
-                    this->userId_, this,
+                    this->userId_, this->userName_, this,
                     [this, reenableBlockCheckbox, currentUser] {
                         this->channel_->addSystemMessage(
                             QString("You successfully unblocked user %1")
@@ -702,7 +702,7 @@ void UserInfoPopup::installEvents()
                 }
 
                 getApp()->getAccounts()->twitch.getCurrent()->blockUser(
-                    this->userId_, this,
+                    this->userId_, this->userName_, this,
                     [this, reenableBlockCheckbox, currentUser] {
                         this->channel_->addSystemMessage(
                             QString("You successfully blocked user %1")

--- a/tests/src/IrcMessageHandler.cpp
+++ b/tests/src/IrcMessageHandler.cpp
@@ -469,7 +469,7 @@ public:
 
         this->mockApplication->getAccounts()
             ->twitch.getCurrent()
-            ->blockUserLocally(u"12345"_s);
+            ->blockUserLocally(u"12345"_s, u"blocked"_s);
 
         auto makeBadge = [](QStringView platform) {
             return std::make_shared<Emote>(Emote{


### PR DESCRIPTION
Users who are blocked no longer show up in the "Users joined:" or "Users parted:" messages

Fixes #2505

The biggest chunk of code of this fix comes from adding user logins to the list of blocks. There are some container types that allow for use of multiple keys (basically keeping the same type of logic we use with multiple sets but internally instead), but that seemed a bit out of scope of this change.