### PR TITLE
feat: add tooltip for rename on double-click setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Minor: Popup overlay now only draws an outline when being interacted with. (#6140)
 - Minor: Made filters searchable in the Settings dialog search bar. (#5890)
 - Minor: Updated emojis to Unicode 16.0. (#6155)
-- Minor: Allow disabling of double-click tab renaming through setting. (#6163)
+- Minor: Allow disabling of double-click tab renaming through setting. (#6163, #6184)
 - Bugfix: Don't create native messaging manifest file if browser directory doesn't exist. (#6116)
 - Bugfix: Fixed scrolling now working on inputs in the settings. (#6128)
 - Bugfix: Make reply-cancel button less coarse-grained. (#6106)

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1369,8 +1369,11 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         "Enable experimental Twitch EventSub support (requires restart)",
         s.enableExperimentalEventSub);
 
-    layout.addCheckbox("Disable renaming of tabs on double-click",
-                       s.disableTabRenamingOnClick);
+    SettingWidget::checkbox("Disable renaming of tabs on double-click",
+                            s.disableTabRenamingOnClick)
+        ->setTooltip("Prevents the rename dialog from opening when a "
+                     "tab is double-clicked")
+        ->addTo(layout);
 
     layout.addStretch();
 


### PR DESCRIPTION
This PR aims to add a tooltip to the setting introduced in #6163. I wasn't aware there were tooltips until I was testing something else :) 

(this screenshot was taken before aligning the wording of "double-click")
![image](https://github.com/user-attachments/assets/d891a146-14f6-46b7-ad76-b0a3d626bc8e)
