### PR TITLE
Do not hide WebSocket API when missing permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Minor: Added cached emotes fallback when fetching from a provider fails. (#6125)
 - Minor: Add an option for the reduced opacity of message history. (#6121)
 - Minor: Make paused chat indicator more visible, and fix its zoom behavior. (#6123)
-- Minor: Added WebSocket API for plugins. (#6076)
+- Minor: Added WebSocket API for plugins. (#6076, #6186)
 - Minor: Allow for themes to set transparent values for window background on Linux. (#6137)
 - Minor: Popup overlay now only draws an outline when being interacted with. (#6140)
 - Minor: Made filters searchable in the Settings dialog search bar. (#5890)

--- a/src/controllers/plugins/PluginController.cpp
+++ b/src/controllers/plugins/PluginController.cpp
@@ -221,15 +221,11 @@ void PluginController::initSol(sol::state_view &lua, Plugin *plugin)
     lua::api::ChannelRef::createUserType(c2);
     lua::api::HTTPResponse::createUserType(c2);
     lua::api::HTTPRequest::createUserType(c2);
+    lua::api::WebSocket::createUserType(c2, plugin);
     c2["ChannelType"] = lua::createEnumTable<Channel::Type>(lua);
     c2["HTTPMethod"] = lua::createEnumTable<NetworkRequestType>(lua);
     c2["EventType"] = lua::createEnumTable<lua::api::EventType>(lua);
     c2["LogLevel"] = lua::createEnumTable<lua::api::LogLevel>(lua);
-
-    if (plugin->hasNetworkPermission())
-    {
-        lua::api::WebSocket::createUserType(c2, plugin);
-    }
 
     sol::table io = g["io"];
     io.set_function(

--- a/src/controllers/plugins/api/WebSocket.cpp
+++ b/src/controllers/plugins/api/WebSocket.cpp
@@ -31,6 +31,11 @@ void WebSocket::createUserType(sol::table &c2, Plugin *plugin)
     c2.new_usertype<WebSocket>(
         "WebSocket",
         sol::factories([plugin](const QString &spec, sol::variadic_args args) {
+            if (!plugin->hasNetworkPermission())
+            {
+                throw std::runtime_error(
+                    "Plugin does not have permission to use websockets");
+            }
             QUrl url(spec);
             if (url.scheme() != "wss" && url.scheme() != "ws")
             {

--- a/tests/src/Plugins.cpp
+++ b/tests/src/Plugins.cpp
@@ -786,9 +786,14 @@ TEST_F(PluginTest, testWebSocketNoPerms)
     configure();
 
     bool res = lua->script(R"lua(
-        return c2["WebSocket"] == nil
+        return c2["WebSocket"] ~= nil
     )lua");
     ASSERT_TRUE(res);
+
+    const char *shouldThrow = R"lua(
+        return c2.WebSocket.new('wss://127.0.0.1:9050/echo')
+    )lua";
+    EXPECT_ANY_THROW(shouldThrow);
 }
 
 TEST_F(PluginTest, testWebSocketApi)

--- a/tests/src/Plugins.cpp
+++ b/tests/src/Plugins.cpp
@@ -793,7 +793,7 @@ TEST_F(PluginTest, testWebSocketNoPerms)
     const char *shouldThrow = R"lua(
         return c2.WebSocket.new('wss://127.0.0.1:9050/echo')
     )lua";
-    EXPECT_ANY_THROW(shouldThrow);
+    EXPECT_ANY_THROW(lua->script(shouldThrow));
 }
 
 TEST_F(PluginTest, testWebSocketApi)


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
To try use this code:
```lua
c2.WebSocket.new('ws://localhost', {on_close=function()end})
```
###### The `on_close` prevents a crash in destroying the WebSocket