### PR TITLE
fix(plugins): TSTL `HTTPRequest.create` generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Dev: Updated GoogleTest to v1.17.0. (#6180)
 - Dev: Mini refactor of `TwitchAccount`. (#6182)
 - Dev: Simplified string literals to be a re-export of Qt functions. (#6175)
+- Dev: Fixed incorrect lua generation of `c2.HTTPRequest.create` for typescript plugins. (#6190)
 
 ## 2.5.3
 

--- a/docs/chatterino.d.ts
+++ b/docs/chatterino.d.ts
@@ -95,9 +95,10 @@ declare namespace c2 {
         set_header(name: string, value: string): void;
 
         execute(): void;
+    }
 
-        // might error
-        static create(method: HTTPMethod, url: string): HTTPRequest;
+    namespace HTTPRequest {
+        function create(method: HTTPMethod, url: string): HTTPRequest;
     }
 
     function log(level: LogLevel, ...data: any[]): void;


### PR DESCRIPTION
Currently, the use of `c2.HTTPRequest.create(...)` in typescript results in code that produces the following error after being compiled with TSTL:
```
Failed to evaluate command from plugin HTTP Error: stack index 1, expected number, received table: (bad argument into 'std::shared_ptr<chatterino::lua::api::HTTPRequest>(sol::this_state, enum chatterino::NetworkRequestType, QString)')
```

This is because the generated lua code for this function call is:
```lua
c2.HTTPRequest:create(...)
```
This PR updates the types file so that the generated lua code is:
```lua
c2.HTTPRequest.create(...)
``` 