### PR TITLE
refactor: fix some spelling mistakes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Bugfix: Fixed some Twitch commands not getting tab-completed correctly. (#6143)
 - Bugfix: Fixed shared chat badges displaying pixelated when Chatterino is scaled too much. (#6146)
 - Bugfix: Fixed a crash that could occur when eventsub was enabled and Chatterino was attached to a conhost on Windows that was later gone. (#6161)
+- Bugfix: Fixed some minor typos. (#6196)
 - Dev: Mini refactor of Split. (#6148)
 - Dev: Conan will no longer generate a `CMakeUserPresets.json` file. (#6117)
 - Dev: Pass `--force-openssl` when installing from CMake in Qt 6.8+. (#6129)

--- a/src/widgets/AccountSwitchPopup.cpp
+++ b/src/widgets/AccountSwitchPopup.cpp
@@ -45,7 +45,7 @@ AccountSwitchPopup::AccountSwitchPopup(QWidget *parent)
 
     this->getLayoutContainer()->setLayout(vbox);
 
-    this->setScaleIndependantSize(200, 200);
+    this->setScaleIndependentSize(200, 200);
     this->themeChangedEvent();
 }
 

--- a/src/widgets/BaseWidget.cpp
+++ b/src/widgets/BaseWidget.cpp
@@ -124,7 +124,7 @@ void BaseWidget::setScaleIndependentWidth(int value)
         QSize(value, this->scaleIndependantSize_.height()));
 }
 
-void BaseWidget::setScaleIndependantHeight(int value)
+void BaseWidget::setScaleIndependentHeight(int value)
 {
     this->setScaleIndependentSize(
         QSize(this->scaleIndependantSize_.width(), value));

--- a/src/widgets/BaseWidget.cpp
+++ b/src/widgets/BaseWidget.cpp
@@ -118,7 +118,7 @@ void BaseWidget::setScaleIndependentSize(QSize size)
     }
 }
 
-void BaseWidget::setScaleIndependantWidth(int value)
+void BaseWidget::setScaleIndependentWidth(int value)
 {
     this->setScaleIndependentSize(
         QSize(value, this->scaleIndependantSize_.height()));

--- a/src/widgets/BaseWidget.cpp
+++ b/src/widgets/BaseWidget.cpp
@@ -70,7 +70,7 @@ void BaseWidget::setScale(float value)
     this->scaleChangedEvent(this->scale());
     this->scaleChanged.invoke(this->scale());
 
-    this->setScaleIndependantSize(this->scaleIndependantSize());
+    this->setScaleIndependantSize(this->scaleIndependentSize());
 }
 
 void BaseWidget::setOverrideScale(std::optional<float> value)
@@ -84,7 +84,7 @@ std::optional<float> BaseWidget::overrideScale() const
     return this->overrideScale_;
 }
 
-QSize BaseWidget::scaleIndependantSize() const
+QSize BaseWidget::scaleIndependentSize() const
 {
     return this->scaleIndependantSize_;
 }

--- a/src/widgets/BaseWidget.cpp
+++ b/src/widgets/BaseWidget.cpp
@@ -89,12 +89,12 @@ QSize BaseWidget::scaleIndependentSize() const
     return this->scaleIndependantSize_;
 }
 
-int BaseWidget::scaleIndependantWidth() const
+int BaseWidget::scaleIndependentWidth() const
 {
     return this->scaleIndependantSize_.width();
 }
 
-int BaseWidget::scaleIndependantHeight() const
+int BaseWidget::scaleIndependentHeight() const
 {
     return this->scaleIndependantSize_.height();
 }

--- a/src/widgets/BaseWidget.cpp
+++ b/src/widgets/BaseWidget.cpp
@@ -86,17 +86,17 @@ std::optional<float> BaseWidget::overrideScale() const
 
 QSize BaseWidget::scaleIndependentSize() const
 {
-    return this->scaleIndependantSize_;
+    return this->scaleIndependentSize_;
 }
 
 int BaseWidget::scaleIndependentWidth() const
 {
-    return this->scaleIndependantSize_.width();
+    return this->scaleIndependentSize_.width();
 }
 
 int BaseWidget::scaleIndependentHeight() const
 {
-    return this->scaleIndependantSize_.height();
+    return this->scaleIndependentSize_.height();
 }
 
 void BaseWidget::setScaleIndependentSize(int width, int height)
@@ -106,7 +106,7 @@ void BaseWidget::setScaleIndependentSize(int width, int height)
 
 void BaseWidget::setScaleIndependentSize(QSize size)
 {
-    this->scaleIndependantSize_ = size;
+    this->scaleIndependentSize_ = size;
 
     if (size.width() > 0)
     {
@@ -121,13 +121,13 @@ void BaseWidget::setScaleIndependentSize(QSize size)
 void BaseWidget::setScaleIndependentWidth(int value)
 {
     this->setScaleIndependentSize(
-        QSize(value, this->scaleIndependantSize_.height()));
+        QSize(value, this->scaleIndependentSize_.height()));
 }
 
 void BaseWidget::setScaleIndependentHeight(int value)
 {
     this->setScaleIndependentSize(
-        QSize(this->scaleIndependantSize_.width(), value));
+        QSize(this->scaleIndependentSize_.width(), value));
 }
 
 void BaseWidget::childEvent(QChildEvent *event)

--- a/src/widgets/BaseWidget.cpp
+++ b/src/widgets/BaseWidget.cpp
@@ -70,7 +70,7 @@ void BaseWidget::setScale(float value)
     this->scaleChangedEvent(this->scale());
     this->scaleChanged.invoke(this->scale());
 
-    this->setScaleIndependantSize(this->scaleIndependentSize());
+    this->setScaleIndependentSize(this->scaleIndependentSize());
 }
 
 void BaseWidget::setOverrideScale(std::optional<float> value)
@@ -99,12 +99,12 @@ int BaseWidget::scaleIndependentHeight() const
     return this->scaleIndependantSize_.height();
 }
 
-void BaseWidget::setScaleIndependantSize(int width, int height)
+void BaseWidget::setScaleIndependentSize(int width, int height)
 {
-    this->setScaleIndependantSize(QSize(width, height));
+    this->setScaleIndependentSize(QSize(width, height));
 }
 
-void BaseWidget::setScaleIndependantSize(QSize size)
+void BaseWidget::setScaleIndependentSize(QSize size)
 {
     this->scaleIndependantSize_ = size;
 
@@ -120,13 +120,13 @@ void BaseWidget::setScaleIndependantSize(QSize size)
 
 void BaseWidget::setScaleIndependantWidth(int value)
 {
-    this->setScaleIndependantSize(
+    this->setScaleIndependentSize(
         QSize(value, this->scaleIndependantSize_.height()));
 }
 
 void BaseWidget::setScaleIndependantHeight(int value)
 {
-    this->setScaleIndependantSize(
+    this->setScaleIndependentSize(
         QSize(this->scaleIndependantSize_.width(), value));
 }
 

--- a/src/widgets/BaseWidget.hpp
+++ b/src/widgets/BaseWidget.hpp
@@ -31,7 +31,7 @@ public:
     int scaleIndependentHeight() const;
     void setScaleIndependentSize(int width, int height);
     void setScaleIndependentSize(QSize);
-    void setScaleIndependantWidth(int value);
+    void setScaleIndependentWidth(int value);
     void setScaleIndependantHeight(int value);
 
 protected:

--- a/src/widgets/BaseWidget.hpp
+++ b/src/widgets/BaseWidget.hpp
@@ -56,7 +56,7 @@ protected:
 private:
     float scale_{1.f};
     std::optional<float> overrideScale_;
-    QSize scaleIndependantSize_;
+    QSize scaleIndependentSize_;
 
     std::vector<BaseWidget *> widgets_;
 

--- a/src/widgets/BaseWidget.hpp
+++ b/src/widgets/BaseWidget.hpp
@@ -26,7 +26,7 @@ public:
     std::optional<float> overrideScale() const;
     void setOverrideScale(std::optional<float>);
 
-    QSize scaleIndependantSize() const;
+    QSize scaleIndependentSize() const;
     int scaleIndependantWidth() const;
     int scaleIndependantHeight() const;
     void setScaleIndependantSize(int width, int height);

--- a/src/widgets/BaseWidget.hpp
+++ b/src/widgets/BaseWidget.hpp
@@ -29,8 +29,8 @@ public:
     QSize scaleIndependentSize() const;
     int scaleIndependentWidth() const;
     int scaleIndependentHeight() const;
-    void setScaleIndependantSize(int width, int height);
-    void setScaleIndependantSize(QSize);
+    void setScaleIndependentSize(int width, int height);
+    void setScaleIndependentSize(QSize);
     void setScaleIndependantWidth(int value);
     void setScaleIndependantHeight(int value);
 

--- a/src/widgets/BaseWidget.hpp
+++ b/src/widgets/BaseWidget.hpp
@@ -32,7 +32,7 @@ public:
     void setScaleIndependentSize(int width, int height);
     void setScaleIndependentSize(QSize);
     void setScaleIndependentWidth(int value);
-    void setScaleIndependantHeight(int value);
+    void setScaleIndependentHeight(int value);
 
 protected:
     void childEvent(QChildEvent *) override;

--- a/src/widgets/BaseWidget.hpp
+++ b/src/widgets/BaseWidget.hpp
@@ -27,8 +27,8 @@ public:
     void setOverrideScale(std::optional<float>);
 
     QSize scaleIndependentSize() const;
-    int scaleIndependantWidth() const;
-    int scaleIndependantHeight() const;
+    int scaleIndependentWidth() const;
+    int scaleIndependentHeight() const;
     void setScaleIndependantSize(int width, int height);
     void setScaleIndependantSize(QSize);
     void setScaleIndependantWidth(int value);

--- a/src/widgets/BaseWindow.cpp
+++ b/src/widgets/BaseWindow.cpp
@@ -676,7 +676,7 @@ TitleBarButton *BaseWindow::addTitleBarButton(const TitleBarButtonStyle &style,
                                               std::function<void()> onClicked)
 {
     TitleBarButton *button = new TitleBarButton;
-    button->setScaleIndependantSize(30, 30);
+    button->setScaleIndependentSize(30, 30);
 
     this->ui_.buttons.push_back(button);
     this->ui_.titlebarBox->insertWidget(1, button);

--- a/src/widgets/BaseWindow.cpp
+++ b/src/widgets/BaseWindow.cpp
@@ -692,7 +692,7 @@ TitleBarButton *BaseWindow::addTitleBarButton(const TitleBarButtonStyle &style,
 EffectLabel *BaseWindow::addTitleBarLabel(std::function<void()> onClicked)
 {
     EffectLabel *button = new EffectLabel;
-    button->setScaleIndependantHeight(30);
+    button->setScaleIndependentHeight(30);
 
     this->ui_.buttons.push_back(button);
     this->ui_.titlebarBox->insertWidget(1, button);

--- a/src/widgets/DraggablePopup.cpp
+++ b/src/widgets/DraggablePopup.cpp
@@ -121,7 +121,7 @@ Button *DraggablePopup::createPinButton()
 {
     this->pinButton_ = new Button(this);
     this->pinButton_->setPixmap(getTheme()->buttons.pin);
-    this->pinButton_->setScaleIndependantSize(18, 18);
+    this->pinButton_->setScaleIndependentSize(18, 18);
     this->pinButton_->setToolTip("Pin Window");
 
     QObject::connect(this->pinButton_, &Button::leftClicked, this,

--- a/src/widgets/dialogs/EditUserNotesDialog.cpp
+++ b/src/widgets/dialogs/EditUserNotesDialog.cpp
@@ -17,7 +17,7 @@ EditUserNotesDialog::EditUserNotesDialog(QWidget *parent)
           },
           parent)
 {
-    this->setScaleIndependantSize(500, 350);
+    this->setScaleIndependentSize(500, 350);
 
     auto layout = LayoutCreator<QWidget>(this->getLayoutContainer())
                       .setLayoutType<QVBoxLayout>();

--- a/src/widgets/dialogs/UpdateDialog.cpp
+++ b/src/widgets/dialogs/UpdateDialog.cpp
@@ -44,7 +44,7 @@ UpdateDialog::UpdateDialog()
                                           this->updateStatusChanged(status);
                                       });
 
-    this->setScaleIndependantHeight(150);
+    this->setScaleIndependentHeight(150);
     this->setScaleIndependentWidth(250);
 }
 

--- a/src/widgets/dialogs/UpdateDialog.cpp
+++ b/src/widgets/dialogs/UpdateDialog.cpp
@@ -45,7 +45,7 @@ UpdateDialog::UpdateDialog()
                                       });
 
     this->setScaleIndependantHeight(150);
-    this->setScaleIndependantWidth(250);
+    this->setScaleIndependentWidth(250);
 }
 
 void UpdateDialog::updateStatusChanged(Updates::Status status)

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -71,7 +71,7 @@ Label *addCopyableLabel(LayoutCreator<QHBoxLayout> box, const char *tooltip,
         button.assign(copyButton);
     }
     button->setPixmap(getApp()->getThemes()->buttons.copy);
-    button->setScaleIndependantSize(18, 18);
+    button->setScaleIndependentSize(18, 18);
     button->setDim(Button::Dim::Lots);
     button->setToolTip(tooltip);
     QObject::connect(
@@ -274,7 +274,7 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically, Split *split)
         // avatar
         auto avatar =
             head.emplace<Button>(nullptr).assign(&this->ui_.avatarButton);
-        avatar->setScaleIndependantSize(100, 100);
+        avatar->setScaleIndependentSize(100, 100);
         avatar->setDim(Button::Dim::None);
         QObject::connect(
             avatar.getElement(), &Button::clicked,
@@ -418,16 +418,16 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically, Split *split)
         usercard->getLabel().setText("Usercard");
         auto mod = user.emplace<Button>(this);
         mod->setPixmap(getResources().buttons.mod);
-        mod->setScaleIndependantSize(30, 30);
+        mod->setScaleIndependentSize(30, 30);
         auto unmod = user.emplace<Button>(this);
         unmod->setPixmap(getResources().buttons.unmod);
-        unmod->setScaleIndependantSize(30, 30);
+        unmod->setScaleIndependentSize(30, 30);
         auto vip = user.emplace<Button>(this);
         vip->setPixmap(getResources().buttons.vip);
-        vip->setScaleIndependantSize(30, 30);
+        vip->setScaleIndependentSize(30, 30);
         auto unvip = user.emplace<Button>(this);
         unvip->setPixmap(getResources().buttons.unvip);
-        unvip->setScaleIndependantSize(30, 30);
+        unvip->setScaleIndependentSize(30, 30);
 
         user->addStretch(1);
 
@@ -1188,7 +1188,7 @@ UserInfoPopup::TimeoutWidget::TimeoutWidget()
                                const QPixmap &pixmap) {
         auto button = addLayout(title).emplace<Button>(nullptr);
         button->setPixmap(pixmap);
-        button->setScaleIndependantSize(buttonHeight, buttonHeight);
+        button->setScaleIndependentSize(buttonHeight, buttonHeight);
         button->setBorderColor(QColor(255, 255, 255, 127));
 
         QObject::connect(
@@ -1205,7 +1205,7 @@ UserInfoPopup::TimeoutWidget::TimeoutWidget()
             auto a = hbox.emplace<EffectLabel2>();
             a->getLabel().setText(QString::number(item.second) + item.first);
 
-            a->setScaleIndependantSize(buttonWidth, buttonHeight);
+            a->setScaleIndependentSize(buttonWidth, buttonHeight);
             a->setBorderColor(borderColor);
 
             const auto pair =

--- a/src/widgets/helper/Line.hpp
+++ b/src/widgets/helper/Line.hpp
@@ -19,7 +19,7 @@ public:
         }
         else
         {
-            this->setScaleIndependantHeight(8);
+            this->setScaleIndependentHeight(8);
         }
     }
 

--- a/src/widgets/helper/Line.hpp
+++ b/src/widgets/helper/Line.hpp
@@ -15,7 +15,7 @@ public:
     {
         if (this->vertical_)
         {
-            this->setScaleIndependantWidth(8);
+            this->setScaleIndependentWidth(8);
         }
         else
         {

--- a/src/widgets/helper/OverlayInteraction.cpp
+++ b/src/widgets/helper/OverlayInteraction.cpp
@@ -18,7 +18,7 @@ OverlayInteraction::OverlayInteraction(OverlayWindow *parent)
     this->interactAnimation_.setEndValue(1.0);
 
     this->closeButton_.setButtonStyle(TitleBarButtonStyle::Close);
-    this->closeButton_.setScaleIndependantSize(46, 30);
+    this->closeButton_.setScaleIndependentSize(46, 30);
     this->closeButton_.hide();
     this->closeButton_.setCursor(Qt::PointingHandCursor);
 }

--- a/src/widgets/helper/TitlebarButtons.cpp
+++ b/src/widgets/helper/TitlebarButtons.cpp
@@ -82,16 +82,16 @@ void TitleBarButtons::updateMaxButton()
 
 void TitleBarButtons::setSmallSize()
 {
-    this->minButton_->setScaleIndependantSize(30, 30);
-    this->maxButton_->setScaleIndependantSize(30, 30);
-    this->closeButton_->setScaleIndependantSize(30, 30);
+    this->minButton_->setScaleIndependentSize(30, 30);
+    this->maxButton_->setScaleIndependentSize(30, 30);
+    this->closeButton_->setScaleIndependentSize(30, 30);
 }
 
 void TitleBarButtons::setRegularSize()
 {
-    this->minButton_->setScaleIndependantSize(46, 30);
-    this->maxButton_->setScaleIndependantSize(46, 30);
-    this->closeButton_->setScaleIndependantSize(46, 30);
+    this->minButton_->setScaleIndependentSize(46, 30);
+    this->maxButton_->setScaleIndependentSize(46, 30);
+    this->closeButton_->setScaleIndependentSize(46, 30);
 }
 
 TitleBarButton *TitleBarButtons::buttonForHt(size_t ht) const

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -610,7 +610,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     layout.addCheckbox("Remove spaces between emotes",
                        s.removeSpacesBetweenEmotes, false,
                        "When enabled, adjacent emotes will no longer have an "
-                       "added space seperating them.");
+                       "added space separating them.");
     SettingWidget::checkbox("Show unlisted 7TV emotes",
                             s.showUnlistedSevenTVEmotes)
         ->addKeywords({"seventv"})

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -545,7 +545,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         [](auto args) {
             return fuzzyToInt(args.value, 0);
         });
-    layout.addSeperator();
+    layout.addSeparator();
     layout.addCheckbox("Draw a line below the most recent message before "
                        "switching applications.",
                        s.showLastMessageIndicator, false,
@@ -1082,7 +1082,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         ->addKeywords({"seventv"})
         ->setTooltip("Badges for 7TV admins, developers, and supporters")
         ->addTo(layout);
-    layout.addSeperator();
+    layout.addSeparator();
     SettingWidget::checkbox("Use custom FrankerFaceZ moderator badges",
                             s.useCustomFfzModeratorBadges)
         ->addKeywords({"ffz"})

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -702,7 +702,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         ->addTo(layout);
     SettingWidget::checkbox("Send activity to 7TV", s.sendSevenTVActivity)
         ->setTooltip("When enabled, Chatterino will signal an activity to 7TV "
-                     "when you send a chat mesage. This is used for badges, "
+                     "when you send a chat message. This is used for badges, "
                      "paints, and personal emotes. When disabled, no activity "
                      "is sent and others won't see your cosmetics.")
         ->addKeywords({"seventv"})

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1379,7 +1379,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
 
     // invisible element for width
     auto *inv = new BaseWidget(this);
-    //    inv->setScaleIndependantWidth(600);
+    //    inv->setScaleIndependentWidth(600);
     layout.addWidget(inv);
 }
 

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1221,7 +1221,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         ->addTo(layout);
 
     layout.addCheckbox("Bold @usernames", s.boldUsernames, false,
-                       "Bold @mentions to make them more noticable.");
+                       "Bold @mentions to make them more noticeable.");
     layout.addCheckbox("Color @usernames", s.colorUsernames, false,
                        "If Chatterino has seen a user, highlight @mention's of "
                        "them with their Twitch color.");

--- a/src/widgets/settingspages/GeneralPageView.cpp
+++ b/src/widgets/settingspages/GeneralPageView.cpp
@@ -309,7 +309,7 @@ DescriptionLabel *GeneralPageView::addDescription(const QString &text)
     return label;
 }
 
-void GeneralPageView::addSeperator()
+void GeneralPageView::addSeparator()
 {
     this->addWidget(new Line(false));
 }

--- a/src/widgets/settingspages/GeneralPageView.hpp
+++ b/src/widgets/settingspages/GeneralPageView.hpp
@@ -309,7 +309,7 @@ public:
 
     DescriptionLabel *addDescription(const QString &text);
 
-    void addSeperator();
+    void addSeparator();
     bool filterElements(const QString &query);
 
 protected:

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -282,7 +282,7 @@ void SplitHeader::initializeLayout()
     auto *layout = makeLayout<QHBoxLayout>({
         // space
         makeWidget<BaseWidget>([](auto w) {
-            w->setScaleIndependantSize(8, 4);
+            w->setScaleIndependentSize(8, 4);
         }),
         // title
         this->titleLabel_ = makeWidget<Label>([](auto w) {
@@ -293,7 +293,7 @@ void SplitHeader::initializeLayout()
         }),
         // space
         makeWidget<BaseWidget>([](auto w) {
-            w->setScaleIndependantSize(8, 4);
+            w->setScaleIndependentSize(8, 4);
         }),
         // mode
         this->modeButton_ = makeWidget<EffectLabel>([&](auto w) {


### PR DESCRIPTION
- **addSeperator -> addSeparator**
- **seperating -> separating**
- **mesage -> message**
- **noticable -> noticeable**
- **BaseWidget::setScaleIndependantSize -> BaseWidget::scaleIndependentSize**
- **scaleIndependantSize -> scaleIndependentSize**
- **setScaleIndependantSize -> setScaleIndependentSize**
- **setScaleIndependantWidth -> setScaleIndependentWidth**
- **setScaleIndependantHeight -> setScaleIndependentHeight**
- **scaleIndependantSize_ -> scaleIndependentSize_**

<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
