### PR TITLE
fix: crash that could occur when force-closing 7tv/bttv live updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Bugfix: Fixed message contents being cleared when using the close button for replies. (#6145)
 - Bugfix: Fixed the emote popup erroneously logging messages to the `Other` directory. (#6165)
 - Bugfix: Handle <kbd>CMD</kbd> + <kbd>BACKSPACE</kbd> behavior explicitly in main chat dialog input for macOS. (#6111)
+- Bugfix: Fixed an on-shutdown-crash that could occur when we didn't wait long enough for 7TV/BetterTTV live update connections to close. (#6197)
 - Bugfix: Fixed a small typo in the settings page. (#6134)
 - Bugfix: Fixed blocked users showing up in "Users joined:" and "Users parted:" messages. (#6181)
 - Bugfix: Fixed an issue where Splits could get lost by dragging it onto your Recycle Bin. (#6147)

--- a/src/providers/liveupdates/BasicPubSubManager.hpp
+++ b/src/providers/liveupdates/BasicPubSubManager.hpp
@@ -402,22 +402,22 @@ private:
         return false;
     }
 
+    std::vector<Subscription> pendingSubscriptions_;
+    std::atomic<bool> addingClient_{false};
+    ExponentialBackoff<5> connectBackoff_{std::chrono::milliseconds(1000)};
+
+    liveupdates::WebsocketClient websocketClient_;
+    std::unique_ptr<std::thread> mainThread_;
+    OnceFlag stoppedFlag_;
+
     std::map<liveupdates::WebsocketHandle,
              std::shared_ptr<BasicPubSubClient<Subscription>>,
              std::owner_less<liveupdates::WebsocketHandle>>
         clients_;
 
-    std::vector<Subscription> pendingSubscriptions_;
-    std::atomic<bool> addingClient_{false};
-    ExponentialBackoff<5> connectBackoff_{std::chrono::milliseconds(1000)};
-
     std::shared_ptr<boost::asio::executor_work_guard<
         boost::asio::io_context::executor_type>>
         work_{nullptr};
-
-    liveupdates::WebsocketClient websocketClient_;
-    std::unique_ptr<std::thread> mainThread_;
-    OnceFlag stoppedFlag_;
 
     const QString host_;
 


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
