### PR TITLE
refactor: use std::_Exit in rungui instead of _exit

### DIFF
--- a/src/RunGui.cpp
+++ b/src/RunGui.cpp
@@ -23,6 +23,7 @@
 #include <QtConcurrent>
 
 #include <csignal>
+#include <cstdlib>
 #include <tuple>
 
 #ifdef USEWINSDK
@@ -162,7 +163,7 @@ namespace {
             proc.startDetached();
         }
 
-        _exit(signum);
+        std::_Exit(signum);
     }
 
     // We want to restart Chatterino when it crashes and the setting is set to


### PR DESCRIPTION
i don't want to include stdlib.h

<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
