### PR TITLE
Fix plugin docs: HTTPRequest enum

### DIFF
--- a/docs/wip-plugins.md
+++ b/docs/wip-plugins.md
@@ -471,7 +471,7 @@ Sends the request. This function returns nothing.
 
 ```lua
 local url = "http://localhost:8080/thing"
-local request = c2.HTTPRequest.create("Post", url)
+local request = c2.HTTPRequest.create(c2.HTTPMethod.Post, url)
 request:set_timeout(1000)
 request:set_payload("TEST!")
 request:set_header("X-Test", "Testing!")


### PR DESCRIPTION
Using "Post" here causes type mismatch error

```
Failed to evaluate command from plugin Chatterino API: stack index 1,
expected number, received string: (bad argument into
'std::shared_ptr<chatterino::lua::api::HTTPRequest>(sol::this_state, enum
chatterino::NetworkRequestType, QString)')
```