### PR TITLE
fix: crash on older versions of Qt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unversioned
 
 - Minor: Added user notes to the user info dialog (when clicking a username). (#6122)
-- Minor: Added cached emotes fallback when fetching from a provider fails. (#6125)
+- Minor: Added cached emotes fallback when fetching from a provider fails. (#6125, #6229)
 - Minor: Add an option for the reduced opacity of message history. (#6121)
 - Minor: Make paused chat indicator more visible, and fix its zoom behavior. (#6123)
 - Minor: Added WebSocket API for plugins. (#6076, #6186)

--- a/src/util/Helpers.cpp
+++ b/src/util/Helpers.cpp
@@ -404,7 +404,7 @@ void writeProviderEmotesCache(const QString &id, const QString &provider,
     }
 
     threadPool->start([bytes, id, provider]() {
-        auto cacheKey = id % "." % provider;
+        QString cacheKey = id % "." % provider;
         QFile responseCache(getApp()->getPaths().cacheFilePath(cacheKey));
 
         if (responseCache.open(QIODevice::WriteOnly))
@@ -419,7 +419,7 @@ void writeProviderEmotesCache(const QString &id, const QString &provider,
 bool readProviderEmotesCache(const QString &id, const QString &provider,
                              const std::function<void(QJsonDocument)> &callback)
 {
-    auto cacheKey = id % "." % provider;
+    QString cacheKey = id % "." % provider;
     QFile responseCache(getApp()->getPaths().cacheFilePath(cacheKey));
 
     if (responseCache.open(QIODevice::ReadOnly))


### PR DESCRIPTION
QStringBuilder is a bit more finicky on older versions of Qt. This "builds" the builders fully into a QString before we attempt to use them.

This crash was not part of the latest stable release, as it was introduced in #6125 

Fixes #6228