### PR TITLE
fix(once-flag): make `flag` atomic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - Dev: Fixed incorrect lua generation of static methods for typescript plugins. (#6190, #6223)
 - Dev: Merged top/bottom and left/right notebook layouts. (#6215)
 - Dev: Refactored `Button` and friends. (#6102)
+- Dev: `OnceFlag`'s internal flag is now atomic. (#6237)
 
 ## 2.5.3
 

--- a/src/util/OnceFlag.cpp
+++ b/src/util/OnceFlag.cpp
@@ -3,13 +3,12 @@
 namespace chatterino {
 
 OnceFlag::OnceFlag() = default;
-OnceFlag::~OnceFlag() = default;
 
 void OnceFlag::set()
 {
     {
         std::unique_lock guard(this->mutex);
-        this->flag = true;
+        this->flag.store(true, std::memory_order::relaxed);
     }
     this->condvar.notify_all();
 }
@@ -18,7 +17,7 @@ bool OnceFlag::waitFor(std::chrono::milliseconds ms)
 {
     std::unique_lock lock(this->mutex);
     return this->condvar.wait_for(lock, ms, [this] {
-        return this->flag;
+        return this->flag.load(std::memory_order::relaxed);
     });
 }
 
@@ -26,7 +25,7 @@ void OnceFlag::wait()
 {
     std::unique_lock lock(this->mutex);
     this->condvar.wait(lock, [this] {
-        return this->flag;
+        return this->flag.load(std::memory_order::relaxed);
     });
 }
 

--- a/src/util/OnceFlag.hpp
+++ b/src/util/OnceFlag.hpp
@@ -14,7 +14,6 @@ class OnceFlag
 {
 public:
     OnceFlag();
-    ~OnceFlag();
 
     /// Set this flag and notify waiters
     void set();
@@ -35,7 +34,7 @@ public:
 private:
     std::mutex mutex;
     std::condition_variable condvar;
-    bool flag = false;
+    std::atomic<bool> flag = false;
 };
 
 }  // namespace chatterino


### PR DESCRIPTION
We don't need a strict memory ordering here, because there's no associated memory that we care about.

<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
As we only ever saw flaky tests on macOS runners which use ARM, the issue is probably that we aren't atomic enough. There's no real proof that this was the issue (only that it wasn't).