### PR TITLE
feat: implement display name specializations for enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - Dev: Added a `run-and-kill.sh` script to help debug crash-on-exit bugs. (#6188)
 - Dev: Refactored the `TimeoutStackStyle` enum into its own file. (#6216)
 - Dev: Refactored `Notebook`-related enums into their own file. (#6220)
+- Dev: Implemented customizable display names for enums. (#6238)
 - Dev: Refactored event API initialization away from Application and into TwitchIrcServer. (#6198)
 - Dev: Updated GoogleTest to v1.17.0. (#6180)
 - Dev: Mini refactor of `TwitchAccount`. (#6182)

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -98,6 +98,19 @@ enum class TabStyle : std::uint8_t {
     Compact,
 };
 
+constexpr chatterino::qmagicenum::customize_t qmagicenumDisplayName(
+    TabStyle value) noexcept
+{
+    switch (value)
+    {
+        case TabStyle::Normal:
+            return "Normal (default)";
+
+        default:
+            return {};
+    }
+}
+
 /// Settings which are available for reading and writing on the gui thread.
 // These settings are still accessed concurrently in the code but it is bad practice.
 class Settings
@@ -773,22 +786,5 @@ constexpr magic_enum::customize::customize_t
 
         default:
             return default_tag;
-    }
-}
-
-template <>
-constexpr chatterino::qmagicenum::customize::customize_t
-    chatterino::qmagicenum::customize::enumTaggedData<
-        chatterino::TabStyle, chatterino::qmagicenum::tag::DisplayName>(
-        chatterino::TabStyle value) noexcept
-{
-    using chatterino::TabStyle;
-    switch (value)
-    {
-        case TabStyle::Normal:
-            return "Normal (default)";
-
-        default:
-            return {};
     }
 }

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -294,8 +294,6 @@ public:
         "/behaviour/autoSubToParticipatedThreads",
         true,
     };
-    // BoolSetting twitchSeperateWriteConnection =
-    // {"/behaviour/twitchSeperateWriteConnection", false};
 
     // Auto-completion
     BoolSetting onlyFetchChattersForSmallerStreamers = {

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -98,7 +98,7 @@ enum class TabStyle : std::uint8_t {
     Compact,
 };
 
-/// Settings which are availlable for reading and writing on the gui thread.
+/// Settings which are available for reading and writing on the gui thread.
 // These settings are still accessed concurrently in the code but it is bad practice.
 class Settings
 {

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -15,7 +15,6 @@
 #include "controllers/nicknames/Nickname.hpp"
 #include "controllers/sound/ISoundController.hpp"
 #include "singletons/Toasts.hpp"
-#include "util/QMagicEnumTagged.hpp"
 #include "util/RapidJsonSerializeQString.hpp"  // IWYU pragma: keep
 #include "widgets/NotebookEnums.hpp"
 
@@ -97,19 +96,6 @@ enum class TabStyle : std::uint8_t {
     Normal,
     Compact,
 };
-
-constexpr chatterino::qmagicenum::customize_t qmagicenumDisplayName(
-    TabStyle value) noexcept
-{
-    switch (value)
-    {
-        case TabStyle::Normal:
-            return "Normal (default)";
-
-        default:
-            return {};
-    }
-}
 
 /// Settings which are available for reading and writing on the gui thread.
 // These settings are still accessed concurrently in the code but it is bad practice.

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -777,7 +777,7 @@ constexpr magic_enum::customize::customize_t
 }
 
 template <>
-constexpr magic_enum::customize::customize_t
+constexpr chatterino::qmagicenum::customize::customize_t
     chatterino::qmagicenum::customize::enumTaggedData<
         chatterino::TabStyle, chatterino::qmagicenum::tag::DisplayName>(
         chatterino::TabStyle value) noexcept
@@ -789,6 +789,6 @@ constexpr magic_enum::customize::customize_t
             return "Normal (default)";
 
         default:
-            return magic_enum::customize::default_tag;
+            return {};
     }
 }

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -15,6 +15,7 @@
 #include "controllers/nicknames/Nickname.hpp"
 #include "controllers/sound/ISoundController.hpp"
 #include "singletons/Toasts.hpp"
+#include "util/QMagicEnumTagged.hpp"
 #include "util/RapidJsonSerializeQString.hpp"  // IWYU pragma: keep
 #include "widgets/NotebookEnums.hpp"
 
@@ -772,5 +773,22 @@ constexpr magic_enum::customize::customize_t
 
         default:
             return default_tag;
+    }
+}
+
+template <>
+constexpr magic_enum::customize::customize_t
+    chatterino::qmagicenum::customize::enumTaggedData<
+        chatterino::TabStyle, chatterino::qmagicenum::tag::DisplayName>(
+        chatterino::TabStyle value) noexcept
+{
+    using chatterino::TabStyle;
+    switch (value)
+    {
+        case TabStyle::Normal:
+            return "Normal (default)";
+
+        default:
+            return magic_enum::customize::default_tag;
     }
 }

--- a/src/util/QMagicEnumTagged.hpp
+++ b/src/util/QMagicEnumTagged.hpp
@@ -147,7 +147,7 @@ template <detail::IsEnum E, typename Tag>
 /// If the enum type provides a qmagicenumDisplayName specialization, it is used. Otherwise, fall back to magic_enum's name.
 ///
 /// @tparam V Enum value
-/// @returns Display name as QStringView, or name as fallback, or an empty string if not available.
+/// @returns Display name as QStringView, or name as fallback.
 template <detail::IsEnum auto V>
 [[nodiscard]] consteval QStringView enumDisplayName() noexcept
 {

--- a/src/util/QMagicEnumTagged.hpp
+++ b/src/util/QMagicEnumTagged.hpp
@@ -83,12 +83,11 @@ template <typename E, typename Tag>
 inline constexpr auto TAGGED_DATA_STORAGE = taggedDataStorage<E, Tag>(
     std::make_index_sequence<magic_enum::enum_count<E>()>{});
 
-/// @brief Get the name of an enum value TODO
-///
-/// This version is much lighter on the compile times and is not restricted to the enum_range limitation.
+/// @brief Get the tagged data of an enum value
 ///
 /// @tparam V The enum value
-/// @returns The name as a string view
+/// @tparam Tag The tag (i.e. type) of data to return
+/// @returns The tagged data belonging to the enum value as a string view.
 template <detail::IsEnum auto V, typename Tag>
 [[nodiscard]] consteval QStringView enumTaggedData() noexcept
 {
@@ -100,10 +99,7 @@ template <detail::IsEnum auto V, typename Tag>
 ///
 /// @tparam Tag The tag (i.e. type) of data to return
 /// @param value The enum value
-/// @returns The tagged data as a string view.
-///          If @a value does not have a display name, its name will be returned.
-///          If @a value does not have a name, or if it's out of range, an empty
-///          string is returned.
+/// @returns The tagged data belonging to the enum value as a string view.
 template <detail::IsEnum E, typename Tag>
 [[nodiscard]] constexpr QStringView enumTaggedData(E value) noexcept
 {
@@ -118,9 +114,11 @@ template <detail::IsEnum E, typename Tag>
 
 }  // namespace detail
 
-/// @brief Get the display name of an enum value
+/// @brief Get the display name of an enum value as a string view
 ///
-/// This version is much lighter on the compile times and is not restricted to the enum_range limitation.
+/// The enum can override `qmagicenumDisplayName(TheEnum enumValue)`, or this
+/// function will return the basic `qmagicenum::enumName` value instead, which relies
+/// on base `magic_enum`
 ///
 /// @tparam V The enum value
 /// @returns The display name as a string view.
@@ -139,7 +137,11 @@ template <detail::IsEnum auto V>
     return enumName<V>();
 }
 
-/// @brief Get the display name of an enum value
+/// @brief Get the display name of an enum value as a string view
+///
+/// The enum can override `qmagicenumDisplayName(TheEnum enumValue)`, or this
+/// function will return the basic `qmagicenum::enumName` value instead, which relies
+/// on base `magic_enum`
 ///
 /// @param value The enum value
 /// @returns The display name as a string view.
@@ -160,10 +162,11 @@ template <detail::IsEnum E>
     return enumName(value);
 }
 
-/// @brief Get the name of an enum value
+/// @brief Get the display name of an enum value as a static string
 ///
-/// This version is much lighter on the compile times and is not restricted to
-/// the enum_range limitation.
+/// The enum can override `qmagicenumDisplayName(TheEnum enumValue)`, or this
+/// function will return the basic `qmagicenum::enumName` value instead, which relies
+/// on base `magic_enum`
 ///
 /// @tparam V The enum value
 /// @returns The name as a string. The returned string is static.
@@ -173,10 +176,11 @@ template <detail::IsEnum auto V>
     return detail::staticString(enumDisplayName<V>());
 }
 
-/// @brief Get the name of an enum value
+/// @brief Get the display name of an enum value as a static string
 ///
-/// This version is much lighter on the compile times and is not restricted to
-/// the enum_range limitation.
+/// The enum can override `qmagicenumDisplayName(TheEnum enumValue)`, or this
+/// function will return the basic `qmagicenum::enumName` value instead, which relies
+/// on base `magic_enum`
 ///
 /// @tparam V The enum value
 /// @returns The name as a string. If @a value does not have name or the

--- a/src/util/QMagicEnumTagged.hpp
+++ b/src/util/QMagicEnumTagged.hpp
@@ -1,0 +1,195 @@
+#pragma once
+
+#include "util/QMagicEnum.hpp"
+
+namespace chatterino::qmagicenum {
+
+namespace tag {
+
+struct DisplayName {
+};
+
+}  // namespace tag
+
+namespace customize {
+
+template <typename E, typename Tag>
+constexpr magic_enum::customize::customize_t enumTaggedData(E /*v*/) noexcept
+{
+    return magic_enum::customize::default_tag;
+}
+
+}  // namespace customize
+
+namespace detail {
+
+template <typename E, typename Tag, E V>
+constexpr auto enumTaggedDataValue() noexcept
+{
+    [[maybe_unused]] constexpr auto custom =
+        customize::enumTaggedData<E, Tag>(V);
+
+    static_assert(std::is_same_v<std::decay_t<decltype(custom)>,
+                                 magic_enum::customize::customize_t>,
+                  "qmagicenum::customize requires magic_enum::customize_t "
+                  "return value type.");
+
+    if constexpr (custom.first ==
+                  magic_enum::customize::detail::customize_tag::custom_tag)
+    {
+        constexpr auto name = custom.second;
+        static_assert(!name.empty(),
+                      "qmagicenum::customize must return a non-empty string.");
+        return magic_enum::detail::static_str<name.size()>{name};
+    }
+    else if constexpr (custom.first == magic_enum::customize::detail::
+                                           customize_tag::invalid_tag)
+    {
+        return magic_enum::detail::static_str<0>{};
+    }
+    else if constexpr (custom.first == magic_enum::customize::detail::
+                                           customize_tag::default_tag)
+    {
+        // Fallback to magic_enum::enum_name
+        return magic_enum::detail::enum_name_v<E, V>;
+    }
+    else
+    {
+        static_assert(magic_enum::detail::always_false_v<E>,
+                      "qmagicenum::customize implementation invalid.");
+    }
+}
+
+template <typename E, typename Tag, E V>
+inline constexpr auto TAGGED_DATA_V = enumTaggedDataValue<E, Tag, V>();
+
+template <typename C, typename E, typename Tag, E V>
+consteval auto enumTaggedDataStorage()
+{
+    constexpr std::string_view utf8 = TAGGED_DATA_V<decltype(V), Tag, V>;
+
+    static_assert(isLatin1<utf8.size()>(utf8),
+                  "Can't convert non-latin1 UTF8 to UTF16");
+
+    std::array<C, utf8.size() + 1> storage;
+    for (std::size_t i = 0; i < utf8.size(); i++)
+    {
+        storage[i] = static_cast<C>(utf8[i]);
+    }
+    storage[utf8.size()] = 0;
+    return storage;
+}
+
+/// This contains a std::array<char16_t> for each enum value + Tag
+template <typename E, typename Tag, E V>
+inline constexpr auto ENUM_TAGGED_DATA_STORAGE =
+    enumTaggedDataStorage<char16_t, E, Tag, V>();
+
+template <typename E, typename Tag, std::size_t... I>
+consteval auto taggedDataStorage(std::index_sequence<I...> /*unused*/)
+{
+    return std::array<QStringView, sizeof...(I)>{{detail::fromArray(
+        ENUM_TAGGED_DATA_STORAGE<E, Tag, magic_enum::enum_values<E>()[I]>)...}};
+}
+
+/// This contains a std::array<QStringView> for each enum + Tag
+template <typename E, typename Tag>
+inline constexpr auto TAGGED_DATA_STORAGE = taggedDataStorage<E, Tag>(
+    std::make_index_sequence<magic_enum::enum_count<E>()>{});
+
+/// @brief Get the name of an enum value TODO
+///
+/// This version is much lighter on the compile times and is not restricted to the enum_range limitation.
+///
+/// @tparam V The enum value
+/// @returns The name as a string view
+template <detail::IsEnum auto V, typename Tag>
+[[nodiscard]] consteval QStringView enumTaggedData() noexcept
+{
+    return QStringView{detail::fromArray(
+        detail::ENUM_TAGGED_DATA_STORAGE<decltype(V), Tag, V>)};
+}
+
+/// @brief Get the tagged data of an enum value
+///
+/// @tparam Tag The tag (i.e. type) of data to return
+/// @param value The enum value
+/// @returns The tagged data as a string view.
+///          If @a value does not have a display name, its name will be returned.
+///          If @a value does not have a name, or if it's out of range, an empty
+///          string is returned.
+template <detail::IsEnum E, typename Tag>
+[[nodiscard]] constexpr QStringView enumTaggedData(E value) noexcept
+{
+    using D = std::decay_t<E>;
+
+    if (const auto i = magic_enum::enum_index<D>(value))
+    {
+        return detail::TAGGED_DATA_STORAGE<D, Tag>[*i];
+    }
+    return {};
+}
+
+}  // namespace detail
+
+/// @brief Get the display name of an enum value
+///
+/// This version is much lighter on the compile times and is not restricted to the enum_range limitation.
+///
+/// @tparam V The enum value
+/// @returns The display name as a string view.
+///          If @a value does not have a display name, its name will be returned.
+///          If @a value does not have a name, or if it's out of range, an empty
+///          string is returned.
+template <detail::IsEnum auto V>
+[[nodiscard]] consteval QStringView enumDisplayName() noexcept
+{
+    return detail::enumTaggedData<V, tag::DisplayName>();
+}
+
+/// @brief Get the display name of an enum value
+///
+/// @param value The enum value
+/// @returns The display name as a string view.
+///          If @a value does not have a display name, its name will be returned.
+///          If @a value does not have a name, or if it's out of range, an empty
+///          string is returned.
+template <detail::IsEnum E>
+[[nodiscard]] constexpr QStringView enumDisplayName(E value) noexcept
+{
+    using D = std::decay_t<E>;
+
+    return detail::enumTaggedData<D, tag::DisplayName>(value);
+}
+
+/// @brief Get the name of an enum value
+///
+/// This version is much lighter on the compile times and is not restricted to
+/// the enum_range limitation.
+///
+/// @tparam V The enum value
+/// @returns The name as a string. The returned string is static.
+template <detail::IsEnum auto V>
+[[nodiscard]] inline QString enumDisplayNameString() noexcept
+{
+    return detail::staticString(enumDisplayName<V>());
+}
+
+/// @brief Get the name of an enum value
+///
+/// This version is much lighter on the compile times and is not restricted to
+/// the enum_range limitation.
+///
+/// @tparam V The enum value
+/// @returns The name as a string. If @a value does not have name or the
+///          value is out of range an empty string is returned.
+///          The returned string is static.
+template <detail::IsEnum E>
+[[nodiscard]] inline QString enumDisplayNameString(E value) noexcept
+{
+    using D = std::decay_t<E>;
+
+    return detail::staticString(enumDisplayName<D>(value));
+}
+
+}  // namespace chatterino::qmagicenum

--- a/src/widgets/settingspages/SettingWidget.hpp
+++ b/src/widgets/settingspages/SettingWidget.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "common/ChatterinoSetting.hpp"
+#include "common/QLogging.hpp"
 #include "util/QMagicEnum.hpp"
 #include "util/QMagicEnumTagged.hpp"
 #include "widgets/settingspages/GeneralPageView.hpp"
@@ -8,6 +9,7 @@
 #include <pajlada/signals/signalholder.hpp>
 #include <QBoxLayout>
 #include <QComboBox>
+#include <QDebug>
 #include <QLabel>
 #include <QObject>
 #include <QString>
@@ -93,12 +95,14 @@ public:
 
         QObject::connect(
             combo, &QComboBox::currentTextChanged,
-            [combo, &setting](const auto &newText) {
+            [label, combo, &setting](const auto &newText) {
                 bool ok = true;
                 auto enumValue = combo->currentData().toInt(&ok);
                 if (!ok)
                 {
-                    // TODO: log?
+                    qCWarning(chatterinoWidget)
+                        << "Combo" << label << " with value" << newText
+                        << "did not contain an intable UserRole data";
                     return;
                 }
 

--- a/src/widgets/settingspages/SettingWidget.hpp
+++ b/src/widgets/settingspages/SettingWidget.hpp
@@ -88,7 +88,6 @@ public:
 
                 auto i = magic_enum::enum_integer(enumValue);
 
-                // TODO: iterate over possible values & set based on user data instead?
                 combo->setCurrentIndex(i);
             },
             widget->managedConnections);

--- a/tests/src/QMagicEnum.cpp
+++ b/tests/src/QMagicEnum.cpp
@@ -244,7 +244,7 @@ TEST(QMagicEnumTagged, enumDisplayNameString)
     ASSERT_EQ(withSpecDN, u"First (Display Name)");
 
     auto withSpec = enumName<MyCustom::First>();
-    ASSERT_EQ(withSpec, u"first.*");
+    ASSERT_EQ(withSpec, u"myfirst");
 
     auto withoutSpecDN = enumDisplayNameString<MyFlag::Eight>();
     ASSERT_EQ(withoutSpecDN, u"Eight");

--- a/tests/src/QMagicEnum.cpp
+++ b/tests/src/QMagicEnum.cpp
@@ -107,7 +107,7 @@ constexpr magic_enum::customize::customize_t
 }
 
 template <>
-constexpr magic_enum::customize::customize_t
+constexpr chatterino::qmagicenum::customize::customize_t
     chatterino::qmagicenum::customize::enumTaggedData<
         MyCustom, qmagicenum::tag::DisplayName>(MyCustom value) noexcept
 {
@@ -117,7 +117,7 @@ constexpr magic_enum::customize::customize_t
             return "First (Display Name)";
 
         default:
-            return magic_enum::customize::default_tag;
+            return {};
     }
 }
 

--- a/tests/src/QMagicEnum.cpp
+++ b/tests/src/QMagicEnum.cpp
@@ -41,6 +41,19 @@ enum class MyCustom {
     Second = 9,
 };
 
+constexpr chatterino::qmagicenum::customize_t qmagicenumDisplayName(
+    MyCustom value) noexcept
+{
+    switch (value)
+    {
+        case MyCustom::First:
+            return "First (Display Name)";
+
+        default:
+            return {};
+    }
+}
+
 enum MyOpen {
     OpenOne = 11,
     OpenTwo = 12,
@@ -103,21 +116,6 @@ constexpr magic_enum::customize::customize_t
 
         default:
             return default_tag;
-    }
-}
-
-template <>
-constexpr chatterino::qmagicenum::customize::customize_t
-    chatterino::qmagicenum::customize::enumTaggedData<
-        MyCustom, qmagicenum::tag::DisplayName>(MyCustom value) noexcept
-{
-    switch (value)
-    {
-        case MyCustom::First:
-            return "First (Display Name)";
-
-        default:
-            return {};
     }
 }
 
@@ -242,10 +240,21 @@ TEST(QMagicEnumTagged, displayName)
 
 TEST(QMagicEnumTagged, enumDisplayNameString)
 {
-    ASSERT_EQ(enumDisplayNameString<MyCustom::First>(),
-              u"First (Display Name)");
-    ASSERT_EQ(enumDisplayNameString<MyCustom::Second>(), u"mysecond.*");
+    auto withSpecDN = enumDisplayNameString<MyCustom::First>();
+    ASSERT_EQ(withSpecDN, u"First (Display Name)");
 
-    ASSERT_EQ(enumDisplayNameString(MyCustom::First), u"First (Display Name)");
-    ASSERT_EQ(enumDisplayNameString(MyCustom::Second), u"mysecond.*");
+    auto withSpec = enumName<MyCustom::First>();
+    ASSERT_EQ(withSpec, u"first.*");
+
+    auto withoutSpecDN = enumDisplayNameString<MyFlag::Eight>();
+    ASSERT_EQ(withoutSpecDN, u"Eight");
+
+    auto withoutSpec = enumName<MyFlag::Eight>();
+    ASSERT_EQ(withoutSpec, u"Eight");
+
+    auto secondWithSpecDN = enumDisplayNameString<MyCustom::Second>();
+    ASSERT_EQ(secondWithSpecDN, u"mysecond.*");
+
+    auto secondWithSpec = enumName<MyCustom::Second>();
+    ASSERT_EQ(secondWithSpec, u"mysecond.*");
 }


### PR DESCRIPTION
Currently not implemented anywhere, but I've tested implementing it for a setting and it works as expected.

Example implementation (put in same file/namespace as the enum itself)
```c++
constexpr chatterino::qmagicenum::customize_t qmagicenumDisplayName(
    TabStyle value) noexcept
{
    switch (value)
    {
        case TabStyle::Normal:
            return "Normal (default)";

        default:
            return {};
    }
}
```