### PR TITLE
feat: add support for automatic streamer mode check from flatpak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Minor: The JSON selector in the upload response can now query arrays using their indices like `foo.0`. (#6193)
 - Minor: Made nicknames searchable in the Settings dialog search bar. (#5886)
 - Minor: Added hotkey Action for opening account selector. (#6192)
-- Minor: Automatic streamer mode detection now works from Flatpak. (#6249)
+- Minor: Automatic streamer mode detection now works from Flatpak. (#6250)
 - Bugfix: Don't create native messaging manifest file if browser directory doesn't exist. (#6116)
 - Bugfix: Fixed scrolling now working on inputs in the settings. (#6128)
 - Bugfix: Make reply-cancel button less coarse-grained. (#6106)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Minor: The JSON selector in the upload response can now query arrays using their indices like `foo.0`. (#6193)
 - Minor: Made nicknames searchable in the Settings dialog search bar. (#5886)
 - Minor: Added hotkey Action for opening account selector. (#6192)
-- Minor: Automatic streamer mode detection now works from Flatpak. (#6250)
+- Bugfix: Automatic streamer mode detection now works from Flatpak. (#6250)
 - Bugfix: Don't create native messaging manifest file if browser directory doesn't exist. (#6116)
 - Bugfix: Fixed scrolling now working on inputs in the settings. (#6128)
 - Bugfix: Make reply-cancel button less coarse-grained. (#6106)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Minor: The JSON selector in the upload response can now query arrays using their indices like `foo.0`. (#6193)
 - Minor: Made nicknames searchable in the Settings dialog search bar. (#5886)
 - Minor: Added hotkey Action for opening account selector. (#6192)
+- Minor: Automatic streamer mode detection now works from Flatpak. (#6249)
 - Bugfix: Don't create native messaging manifest file if browser directory doesn't exist. (#6116)
 - Bugfix: Fixed scrolling now working on inputs in the settings. (#6128)
 - Bugfix: Make reply-cancel button less coarse-grained. (#6106)

--- a/src/singletons/StreamerMode.cpp
+++ b/src/singletons/StreamerMode.cpp
@@ -3,6 +3,7 @@
 #include "Application.hpp"
 #include "common/Literals.hpp"
 #include "common/QLogging.hpp"
+#include "common/Version.hpp"
 #include "providers/twitch/TwitchIrcServer.hpp"
 #include "singletons/Settings.hpp"
 #include "util/PostToThread.hpp"
@@ -55,8 +56,17 @@ bool isBroadcasterSoftwareActive()
     static bool shouldShowWarning = true;
 
     QProcess p;
-    p.start("pgrep", {"-xi", broadcastingBinaries().join("|")},
-            QIODevice::NotOpen);
+    if (Version::instance().isFlatpak())
+    {
+        p.start("flatpak-spawn",
+                {"--host", "pgrep", "-xi", broadcastingBinaries().join("|")},
+                QIODevice::NotOpen);
+    }
+    else
+    {
+        p.start("pgrep", {"-xi", broadcastingBinaries().join("|")},
+                QIODevice::NotOpen);
+    }
 
     if (p.waitForFinished(1000) && p.exitStatus() == QProcess::NormalExit)
     {


### PR DESCRIPTION
Previously, the automatic streamer mode check did not work in flatpak builds, as `pgrep` was executed inside of the sandbox, which only has chatterino's processes and not anything else running on the system.

Now the command will be executed outside of the sandbox through `flatpak-spawn`, the same way as it's done for spawning streamlink. I've tested locally that this works and detects obs running correctly.