### PR TITLE
fix: use integers for message layout bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@
 - Bugfix: Fixed a crash that could occur an eventsub connection's keepalive timer would run after the connection was dead, causing the keepalive timer to use-itself-after-free. (#6204)
 - Bugfix: Fixed a crash that could occur when an image started loading mid app shutdown. (#6213)
 - Bugfix: Fixed some minor typos. (#6196)
-- Bugfix: Fixed inconsistent spaces in messages when using fractional scaling. (#6231)
+- Bugfix: Fixed inconsistent spaces in messages when using fractional scaling. (#6231, #6254)
 - Dev: Mini refactor of Split. (#6148)
 - Dev: Conan will no longer generate a `CMakeUserPresets.json` file. (#6117)
 - Dev: Pass `--force-openssl` when installing from CMake in Qt 6.8+. (#6129)

--- a/src/messages/layouts/MessageLayout.cpp
+++ b/src/messages/layouts/MessageLayout.cpp
@@ -56,14 +56,14 @@ const MessagePtr &MessageLayout::getMessagePtr() const
 }
 
 // Height
-qreal MessageLayout::getHeight() const
+int MessageLayout::getHeight() const
 {
-    return this->container_.getHeight();
+    return static_cast<int>(this->container_.getHeight());
 }
 
-qreal MessageLayout::getWidth() const
+int MessageLayout::getWidth() const
 {
-    return this->container_.getWidth();
+    return static_cast<int>(this->container_.getWidth());
 }
 
 // Layout
@@ -236,7 +236,7 @@ MessagePaintResult MessageLayout::paint(const MessagePaintContext &ctx)
     }
 
     // draw on buffer
-    ctx.painter.drawPixmap(QPointF{0, ctx.y}, *pixmap);
+    ctx.painter.drawPixmap(QPoint{0, ctx.y}, *pixmap);
 
     // draw gif emotes
     result.hasAnimatedElements =
@@ -246,11 +246,11 @@ MessagePaintResult MessageLayout::paint(const MessagePaintContext &ctx)
     if (this->message_->flags.has(MessageFlag::Disabled))
     {
         ctx.painter.fillRect(
-            QRectF{
+            QRect{
                 0,
                 ctx.y,
-                static_cast<qreal>(pixmap->width()),
-                static_cast<qreal>(pixmap->height()),
+                pixmap->width(),
+                pixmap->height(),
             },
             ctx.messageColors.disabled);
     }
@@ -259,11 +259,11 @@ MessagePaintResult MessageLayout::paint(const MessagePaintContext &ctx)
         ctx.preferences.fadeMessageHistory)
     {
         ctx.painter.fillRect(
-            QRectF{
+            QRect{
                 0,
                 ctx.y,
-                static_cast<qreal>(pixmap->width()),
-                static_cast<qreal>(pixmap->height()),
+                pixmap->width(),
+                pixmap->height(),
             },
             ctx.messageColors.disabled);
     }
@@ -274,11 +274,11 @@ MessagePaintResult MessageLayout::paint(const MessagePaintContext &ctx)
         ctx.preferences.enableRedeemedHighlight)
     {
         ctx.painter.fillRect(
-            QRectF{
+            QRect{
                 0,
                 ctx.y,
-                this->scale_ * 4,
-                static_cast<qreal>(pixmap->height()),
+                static_cast<int>(this->scale_ * 4),
+                pixmap->height(),
             },
             *ColorProvider::instance().color(ColorType::RedeemedHighlight));
     }

--- a/src/messages/layouts/MessageLayout.hpp
+++ b/src/messages/layouts/MessageLayout.hpp
@@ -52,8 +52,10 @@ public:
     const Message *getMessage();
     const MessagePtr &getMessagePtr() const;
 
-    qreal getHeight() const;
-    qreal getWidth() const;
+    /// In contrast to other metrics, the height and width are integers because
+    /// this is how the backing pixmap is measured - it needs whole integers.
+    int getHeight() const;
+    int getWidth() const;
 
     MessageLayoutFlags flags;
 

--- a/src/messages/layouts/MessageLayoutContext.hpp
+++ b/src/messages/layouts/MessageLayoutContext.hpp
@@ -76,7 +76,7 @@ struct MessagePaintContext {
     const bool isMentions{};
 
     // y coordinate we're currently painting at
-    qreal y{};
+    int y{};
 
     // Index of the message that is currently being painted
     // This index refers to the snapshot being used in the painting

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -764,7 +764,7 @@ void ChannelView::updateScrollbar(
         {
             this->scrollBar_->setPageSize(
                 static_cast<qreal>(messages.size() - i) +
-                (h / std::max(1.0, message->getHeight())));
+                (h / std::max(1, message->getHeight())));
 
             showScrollbar = true;
             break;
@@ -1608,8 +1608,9 @@ void ChannelView::drawMessages(QPainter &painter, const QRect &area)
         .isMentions = this->underlyingChannel_ ==
                       getApp()->getTwitch()->getMentionsChannel(),
 
-        .y = -(messagesSnapshot[start]->getHeight() *
-               (fmod(this->scrollBar_->getRelativeCurrentValue(), 1))),
+        .y = -static_cast<int>(
+            messagesSnapshot[start]->getHeight() *
+            (fmod(this->scrollBar_->getRelativeCurrentValue(), 1))),
         .messageIndex = start,
         .isLastReadMessage = false,
 
@@ -1646,25 +1647,23 @@ void ChannelView::drawMessages(QPainter &painter, const QRect &area)
                 {
                     animationArea = QRect{
                         0,
-                        static_cast<int>(ctx.y),
-                        static_cast<int>(layout->getWidth()),
-                        static_cast<int>(layout->getHeight()),
+                        ctx.y,
+                        layout->getWidth(),
+                        layout->getHeight(),
                     };
                 }
                 else
                 {
-                    animationArea.setBottom(
-                        static_cast<int>(ctx.y + layout->getHeight()));
+                    animationArea.setBottom((ctx.y + layout->getHeight()));
                     animationArea.setWidth(
-                        std::max(static_cast<int>(layout->getWidth()),
-                                 animationArea.width()));
+                        std::max(layout->getWidth(), animationArea.width()));
                 }
             }
 
             if (this->highlightedMessage_ == layout)
             {
                 painter.fillRect(
-                    QRectF{
+                    QRect{
                         0,
                         ctx.y,
                         layout->getWidth(),


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

Amends https://github.com/Chatterino/chatterino2/pull/6231.

We can't use floating points for the bounds of a message layout, because the backing pixmap will always use whole integers. `MessageLayout::get{Width,Height}` will now return an integer again to reflect this (the pixmap bounds were already rounded down). The layout inside the message still uses floating points to place elements.

Fixes #6253.