### PR TITLE
fix(button): use DPR for cached pixmap scale

### DIFF
--- a/src/widgets/buttons/Button.cpp
+++ b/src/widgets/buttons/Button.cpp
@@ -306,9 +306,11 @@ void Button::paintButton(QPainter &painter)
 
     if (this->cachePixmap_)
     {
-        if (this->cachedPixmap_.size() != this->size())
+        if (this->cachedPixmap_.size() / this->devicePixelRatio() !=
+            this->size())
         {
-            this->cachedPixmap_ = QPixmap(this->size());
+            this->cachedPixmap_ =
+                QPixmap(this->size() * this->devicePixelRatio());
             this->cachedPixmap_.setDevicePixelRatio(this->devicePixelRatio());
             this->pixmapValid_ = false;
         }


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
I confused the pixmap size with its layout size in #6102. The size passed to the pixmap is the size in pixels, but the layout size (in device independent pixels - what Qt uses for coordinates) is `size() / DPR`.