### PR TITLE
fix: explicitly queue forced layouts

### DIFF
--- a/src/messages/Image.cpp
+++ b/src/messages/Image.cpp
@@ -250,14 +250,16 @@ void assignFrames(std::weak_ptr<Image> weak, QList<Frame> parsed)
         if (!isPushQueued)
         {
             isPushQueued = true;
-            postToThread([] {
+            // We don't use postToThread here, because that would run immediately.
+            // We explicitly want to queue a callback after the current ones.
+            QMetaObject::invokeMethod(qApp, [] {
                 isPushQueued = false;
                 auto *app = tryGetApp();
                 if (app != nullptr)
                 {
                     app->getWindows()->forceLayoutChannelViews();
                 }
-            });
+            }, Qt::QueuedConnection);
         }
     };
 


### PR DESCRIPTION
This was accidentally introduced in https://github.com/Chatterino/chatterino2/pull/6203. `QMetaObject::invokeMethod` defaults to `Qt::AutoConnection`. In this case, we're always in the GUI thread when we call `postToThread`, so the callback will run immediately. When loading emojis, this resulted in `#emojis` (> 1k) forced layouts. That's quite slow. The comment above already explains why we want the queued connection.

Fixes #6277.

