### PR TITLE
feat: optionally parallelize `clang-format-all.sh`

### DIFF
--- a/scripts/clang-format-all.sh
+++ b/scripts/clang-format-all.sh
@@ -1,10 +1,30 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 read -p "Are you sure you want to run clang-format on all source files? (y/n) " -n 1 -r
 echo
 if [[ $REPLY =~ ^[Yy]$ ]]; then
-    find src/ \( -iname "*.hpp" -o -iname "*.cpp" \) -exec clang-format -i {} \;
-    find tests/src/ \( -iname "*.hpp" -o -iname "*.cpp" \) -exec clang-format -i {} \;
-    find benchmarks/src/ \( -iname "*.hpp" -o -iname "*.cpp" \) -exec clang-format -i {} \;
-    find mocks/include/ \( -iname "*.hpp" -o -iname "*.cpp" \) -exec clang-format -i {} \;
+    if [ "$FAST" = "1" ]; then
+        if ! command -v parallel >/dev/null 2>&1; then
+            echo "Missing parallel command"
+            exit 1
+        fi
+
+        NUM_FORMAT_JOBS=${NUM_FORMAT_JOBS:-$(nproc)}
+
+        echo "Running clang-format with ${NUM_FORMAT_JOBS} jobs"
+
+        find . \( \
+            -regex '\./src/.*\.\(hpp\|cpp\)' -o \
+            -regex '\./tests/src/.*\.\(hpp\|cpp\)' -o \
+            -regex '\./benchmarks/src/.*\.\(hpp\|cpp\)' -o \
+            -regex '\./mocks/include/.*\.\(hpp\|cpp\)' \
+            \) | parallel --verbose --jobs "$NUM_FORMAT_JOBS" clang-format -i
+    else
+        find . \( \
+            -regex '\./src/.*\.\(hpp\|cpp\)' -o \
+            -regex '\./tests/src/.*\.\(hpp\|cpp\)' -o \
+            -regex '\./benchmarks/src/.*\.\(hpp\|cpp\)' -o \
+            -regex '\./mocks/include/.*\.\(hpp\|cpp\)' \
+            \) -exec clang-format -i {} \;
+    fi
 fi


### PR DESCRIPTION
this can be enabled by setting the FAST environment variable to 1

<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
