### PR TITLE
chore: slight restructuring of `check-clang-tidy.sh`

### DIFF
--- a/scripts/check-clang-tidy.sh
+++ b/scripts/check-clang-tidy.sh
@@ -1,12 +1,32 @@
 #!/usr/bin/env bash
 
+# example usage: FAST=1 ./scripts/check-clang-tidy.sh --checks '-*,modernize-return-braced-init-list' --fix
+
 set -eu
 
 clang-tidy --version
 
-find \
-    src/ \
-    tests/src/ \
-    benchmarks/src/ \
-    mocks/include/ \
-    -type f \( -name "*.hpp" -o -name "*.cpp" \) -print0 | parallel -0 -j16 -I {} clang-tidy --quiet "$@" "{}"
+if [ "$FAST" = "1" ]; then
+    if ! command -v parallel >/dev/null 2>&1; then
+        echo "Missing parallel command"
+        exit 1
+    fi
+
+    NUM_TIDY_JOBS=${NUM_TIDY_JOBS:-$(nproc)}
+
+    echo "Running clang-tidy with args '$*', with ${NUM_TIDY_JOBS} jobs"
+
+    find . \( \
+        -regex '\./src/.*\.\(hpp\|cpp\)' -o \
+        -regex '\./tests/src/.*\.\(hpp\|cpp\)' -o \
+        -regex '\./benchmarks/src/.*\.\(hpp\|cpp\)' -o \
+        -regex '\./mocks/include/.*\.\(hpp\|cpp\)' \
+        \) | parallel --jobs "$NUM_TIDY_JOBS" --verbose clang-tidy --quiet "$@"
+else
+    find . \( \
+        -regex '\./src/.*\.\(hpp\|cpp\)' -o \
+        -regex '\./tests/src/.*\.\(hpp\|cpp\)' -o \
+        -regex '\./benchmarks/src/.*\.\(hpp\|cpp\)' -o \
+        -regex '\./mocks/include/.*\.\(hpp\|cpp\)' \
+        \) -exec clang-tidy --quiet "$@" {} \;
+fi


### PR DESCRIPTION
default now single thread and not using parallel unless FAST=1 is
specified

<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
