### PR TITLE
fix: update lineedit if setting changed externally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Bugfix: Fixed an on-shutdown-crash that could occur when we didn't wait long enough for 7TV/BetterTTV live update connections to close. (#6197)
 - Bugfix: Fixed a small typo in the settings page. (#6134)
 - Bugfix: Fixed blocked users showing up in "Users joined:" and "Users parted:" messages. (#6181)
+- Bugfix: Fixed an issue where text boxes in the settings dialog could be stuck with an old value. (#6286)
 - Bugfix: Fixed an issue where Splits could get lost by dragging it onto your Recycle Bin. (#6147)
 - Bugfix: Fixed some Twitch commands not getting tab-completed correctly. (#6143)
 - Bugfix: Fixed shared chat badges displaying pixelated when Chatterino is scaled too much. (#6146)

--- a/src/widgets/settingspages/SettingWidget.cpp
+++ b/src/widgets/settingspages/SettingWidget.cpp
@@ -202,7 +202,6 @@ SettingWidget *SettingWidget::lineEdit(const QString &label,
                                        QStringSetting &setting,
                                        const QString &placeholderText)
 {
-    QColor color(setting.getValue());
     auto *widget = new SettingWidget(label);
 
     auto *lbl = new QLabel(label + ":");
@@ -215,7 +214,6 @@ SettingWidget *SettingWidget::lineEdit(const QString &label,
     }
 
     widget->hLayout->addWidget(lbl);
-    // widget->hLayout->addStretch(1);
     widget->hLayout->addWidget(edit);
 
     // Update the setting when the widget changes.

--- a/src/widgets/settingspages/SettingWidget.cpp
+++ b/src/widgets/settingspages/SettingWidget.cpp
@@ -218,11 +218,23 @@ SettingWidget *SettingWidget::lineEdit(const QString &label,
     // widget->hLayout->addStretch(1);
     widget->hLayout->addWidget(edit);
 
-    // update when setting changes
+    // Update the setting when the widget changes.
     QObject::connect(edit, &QLineEdit::textChanged,
                      [&setting](const QString &newValue) {
                          setting = newValue;
                      });
+
+    // Update the widget to reflect the new setting value if the setting changes
+    // This _will_ fire every time the widget changes, so we are being conservative
+    // with the `setText` call to ensure the user doesn't get their cursor bounced around.
+    setting.connect(
+        [edit](const QString &value) {
+            if (edit->text() != value)
+            {
+                edit->setText(value);
+            }
+        },
+        widget->managedConnections, false);
 
     widget->actionWidget = edit;
     widget->label = lbl;


### PR DESCRIPTION
This does not fix every single "text box" setting in the settings dialog, only the ones that use `SettingWidget::lineEdit`

I'm OK with that, since that's where I want our development to move anyway.
