### PR TITLE
refactor: use `SettingWidget::dropdown` for emoji style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 - Dev: Merged top/bottom and left/right notebook layouts. (#6215)
 - Dev: Refactored `Button` and friends. (#6102, #6255, #6266)
 - Dev: Made Settings & Account button on Linux/macOS SVGs. (#6267)
+- Dev: Emoji style / set is now stored lowercase (and matched case-insensitively). Changing emoji style from this point on and then running an old version might mean you will use the Twitter emoji style by default. (#6300)
 - Dev: `OnceFlag`'s internal flag is now atomic. (#6237)
 - Dev: Bumped clang-format requirement to 19. (#6236)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -350,6 +350,7 @@ set(SOURCE_FILES
 
         providers/emoji/Emojis.cpp
         providers/emoji/Emojis.hpp
+        providers/emoji/EmojiStyle.hpp
 
         providers/ffz/FfzBadges.cpp
         providers/ffz/FfzBadges.hpp

--- a/src/providers/emoji/EmojiStyle.hpp
+++ b/src/providers/emoji/EmojiStyle.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <cstdint>
+
+namespace chatterino {
+
+/// The available emoji styles in Chatterino
+///
+/// Each enum value has a "bitset value" defined so it can be used in a FlagsEnum to figure out
+/// which emojis support which emoji style / set
+enum class EmojiStyle : std::uint8_t {
+    Twitter = 1 << 0,
+    Facebook = 1 << 1,
+    Apple = 1 << 2,
+    Google = 1 << 3,
+};
+
+}  // namespace chatterino

--- a/src/providers/emoji/Emojis.cpp
+++ b/src/providers/emoji/Emojis.cpp
@@ -4,6 +4,7 @@
 #include "messages/Emote.hpp"
 #include "messages/Image.hpp"
 #include "singletons/Settings.hpp"
+#include "util/QCompareTransparent.hpp"
 #include "util/QMagicEnum.hpp"
 #include "util/RapidjsonHelpers.hpp"
 
@@ -24,6 +25,24 @@ const std::map<QString, QString> TONE_NAMES{
     {"1F3FB", "tone1"}, {"1F3FC", "tone2"}, {"1F3FD", "tone3"},
     {"1F3FE", "tone4"}, {"1F3FF", "tone5"},
 };
+
+EmojiData::Capability emojiCapabilityFromEmojiStyle(EmojiStyle emojiStyle)
+{
+    switch (emojiStyle)
+    {
+        case EmojiStyle::Twitter:
+            return EmojiData::Capability::Twitter;
+
+        case EmojiStyle::Facebook:
+            return EmojiData::Capability::Facebook;
+
+        case EmojiStyle::Apple:
+            return EmojiData::Capability::Apple;
+
+        case EmojiStyle::Google:
+            return EmojiData::Capability::Google;
+    }
+}
 
 void parseEmoji(const std::shared_ptr<EmojiData> &emojiData,
                 const rapidjson::Value &unparsedEmoji,
@@ -245,15 +264,15 @@ void Emojis::sortEmojis()
 void Emojis::loadEmojiSet()
 {
     getSettings()->emojiSet.connect([this](const auto &emojiSet) {
-        EmojiData::Capability setCapability =
-            qmagicenum::enumCast<EmojiData::Capability>(emojiSet).value_or(
-                EmojiData::Capability::Google);
+        auto setCapability = qmagicenum::enumCast<EmojiData::Capability>(
+                                 emojiSet, qmagicenum::CASE_INSENSITIVE)
+                                 .value_or(EmojiData::Capability::Google);
 
         for (const auto &emoji : this->emojis)
         {
             QString emojiSetToUse = emojiSet;
             // clang-format off
-            static std::map<QString, QString> emojiSets = {
+            static std::map<QString, QString, QCompareCaseInsensitive> emojiSets = {
                 // JSDELIVR
                 // {"Twitter", "https://cdn.jsdelivr.net/npm/emoji-datasource-twitter@4.0.4/img/twitter/64/"},
                 // {"Facebook", "https://cdn.jsdelivr.net/npm/emoji-datasource-facebook@4.0.4/img/facebook/64/"},

--- a/src/providers/emoji/Emojis.hpp
+++ b/src/providers/emoji/Emojis.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "common/FlagsEnum.hpp"
+#include "providers/emoji/EmojiStyle.hpp"
 
 #include <boost/variant.hpp>
 #include <QMap>
@@ -30,12 +31,7 @@ struct EmojiData {
     // i.e. thinking
     std::vector<QString> shortCodes;
 
-    enum class Capability : uint8_t {
-        Apple = 1 << 0,
-        Google = 1 << 1,
-        Twitter = 1 << 2,
-        Facebook = 1 << 3,
-    };
+    using Capability = EmojiStyle;
     using Capabilities = FlagsEnum<Capability>;
 
     Capabilities capabilities;

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -14,6 +14,7 @@
 #include "controllers/moderationactions/ModerationAction.hpp"
 #include "controllers/nicknames/Nickname.hpp"
 #include "controllers/sound/ISoundController.hpp"
+#include "providers/emoji/EmojiStyle.hpp"
 #include "singletons/Toasts.hpp"
 #include "util/QMagicEnumTagged.hpp"
 #include "util/RapidJsonSerializeQString.hpp"  // IWYU pragma: keep
@@ -368,7 +369,10 @@ public:
     };
     BoolSetting showUnlistedSevenTVEmotes = {
         "/emotes/showUnlistedSevenTVEmotes", false};
-    QStringSetting emojiSet = {"/emotes/emojiSet", "Twitter"};
+    EnumStringSetting<EmojiStyle> emojiSet = {
+        "/emotes/emojiSet",
+        EmojiStyle::Twitter,
+    };
 
     BoolSetting stackBits = {"/emotes/stackBits", false};
     BoolSetting removeSpacesBetweenEmotes = {

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -661,14 +661,9 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     SettingWidget::dropdown("Emote & badge thumbnail size on hover",
                             s.emoteTooltipScale)
         ->addTo(layout);
-    layout.addDropdown("Emoji style",
-                       {
-                           "Twitter",
-                           "Facebook",
-                           "Apple",
-                           "Google",
-                       },
-                       s.emojiSet);
+
+    SettingWidget::dropdown("Emoji style", s.emojiSet)->addTo(layout);
+
     SettingWidget::checkbox("Show BetterTTV global emotes",
                             s.enableBTTVGlobalEmotes)
         ->addKeywords({"bttv"})

--- a/src/widgets/settingspages/SettingWidget.cpp
+++ b/src/widgets/settingspages/SettingWidget.cpp
@@ -227,6 +227,8 @@ template SettingWidget *SettingWidget::dropdown<TabStyle>(
     const QString &label, EnumStringSetting<TabStyle> &setting);
 template SettingWidget *SettingWidget::dropdown<ShowModerationState>(
     const QString &label, EnumStringSetting<ShowModerationState> &setting);
+template SettingWidget *SettingWidget::dropdown<EmojiStyle>(
+    const QString &label, EnumStringSetting<EmojiStyle> &setting);
 
 SettingWidget *SettingWidget::colorButton(const QString &label,
                                           QStringSetting &setting)


### PR DESCRIPTION
less repeating of supported emoji styles

This means we are now storing emoji styles in lowercase
(so "twitter" instead of "Twitter"). I've made the map lookup case
insensitive to compensate

<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
