### PR TITLE
fix: middle & right click buttons not working on `Button` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@
 - Dev: Simplified string literals to be a re-export of Qt functions. (#6175)
 - Dev: Fixed incorrect lua generation of static methods for typescript plugins. (#6190, #6223)
 - Dev: Merged top/bottom and left/right notebook layouts. (#6215)
-- Dev: Refactored `Button` and friends. (#6102, #6255, #6266)
+- Dev: Refactored `Button` and friends. (#6102, #6255, #6266, #6302)
 - Dev: Made Settings & Account button on Linux/macOS SVGs. (#6267)
 - Dev: `OnceFlag`'s internal flag is now atomic. (#6237)
 - Dev: Bumped clang-format requirement to 19. (#6236)

--- a/src/widgets/buttons/Button.cpp
+++ b/src/widgets/buttons/Button.cpp
@@ -167,48 +167,84 @@ void Button::mousePressEvent(QMouseEvent *event)
         return;
     }
 
-    if (event->button() != Qt::LeftButton)
+    switch (event->button())
     {
-        return;
-    }
+        case Qt::MouseButton::LeftButton: {
+            this->leftMouseButtonDown_ = true;
 
-    this->addClickEffect(event->pos());
+            this->addClickEffect(event->pos());
 
-    this->leftMouseButtonDown_ = true;
+            this->leftMouseButtonDown_ = true;
 
-    this->leftMousePress();
+            this->leftMousePress();
 
-    if (this->menu_ && !this->menuVisible_)
-    {
-        QTimer::singleShot(80, this, [this] {
-            this->showMenu();
-        });
-        this->leftMouseButtonDown_ = false;
-        this->mouseOver_ = false;
+            if (this->menu_ && !this->menuVisible_)
+            {
+                QTimer::singleShot(80, this, [this] {
+                    this->showMenu();
+                });
+                this->leftMouseButtonDown_ = false;
+                this->mouseOver_ = false;
+            }
+        }
+        break;
+        case Qt::MouseButton::RightButton: {
+            this->rightMouseButtonDown_ = true;
+        }
+        break;
+        case Qt::MouseButton::MiddleButton: {
+            this->middleMouseButtonDown_ = true;
+        }
+        break;
+
+        default:
+            // Unsupported button
+            return;
     }
 }
 
 void Button::mouseReleaseEvent(QMouseEvent *event)
 {
-    if (!this->enabled_ || !this->leftMouseButtonDown_)
+    // Reset the "mouse button down" state of the released button and store
+    // whether the button was in the down state when this event fired
+    bool hadCorrectButtonPressed = false;
+    switch (event->button())
+    {
+        case Qt::MouseButton::LeftButton: {
+            hadCorrectButtonPressed = this->leftMouseButtonDown_;
+            this->leftMouseButtonDown_ = false;
+        }
+        break;
+        case Qt::MouseButton::RightButton: {
+            hadCorrectButtonPressed = this->rightMouseButtonDown_;
+            this->rightMouseButtonDown_ = false;
+        }
+        break;
+        case Qt::MouseButton::MiddleButton: {
+            hadCorrectButtonPressed = this->middleMouseButtonDown_;
+            this->middleMouseButtonDown_ = false;
+        }
+        break;
+
+        default:
+            // Unsupported button
+            return;
+    }
+
+    if (!this->enabled_)
     {
         return;
     }
 
     bool isInside = this->rect().contains(event->pos());
 
-    if (event->button() == Qt::LeftButton)
+    if (isInside && hadCorrectButtonPressed)
     {
-        this->leftMouseButtonDown_ = false;
-
-        if (isInside)
+        if (event->button() == Qt::LeftButton)
         {
             leftClicked();
         }
-    }
 
-    if (isInside)
-    {
         clicked(event->button());
     }
 }

--- a/src/widgets/buttons/Button.cpp
+++ b/src/widgets/buttons/Button.cpp
@@ -174,8 +174,6 @@ void Button::mousePressEvent(QMouseEvent *event)
 
             this->addClickEffect(event->pos());
 
-            this->leftMouseButtonDown_ = true;
-
             this->leftMousePress();
 
             if (this->menu_ && !this->menuVisible_)

--- a/src/widgets/buttons/Button.cpp
+++ b/src/widgets/buttons/Button.cpp
@@ -39,9 +39,9 @@ bool Button::mouseOver() const noexcept
     return this->mouseOver_;
 }
 
-bool Button::mouseDown() const noexcept
+bool Button::leftMouseButtonDown() const noexcept
 {
-    return this->mouseDown_;
+    return this->leftMouseButtonDown_;
 }
 
 bool Button::menuVisible() const noexcept
@@ -174,7 +174,7 @@ void Button::mousePressEvent(QMouseEvent *event)
 
     this->addClickEffect(event->pos());
 
-    this->mouseDown_ = true;
+    this->leftMouseButtonDown_ = true;
 
     this->leftMousePress();
 
@@ -183,14 +183,14 @@ void Button::mousePressEvent(QMouseEvent *event)
         QTimer::singleShot(80, this, [this] {
             this->showMenu();
         });
-        this->mouseDown_ = false;
+        this->leftMouseButtonDown_ = false;
         this->mouseOver_ = false;
     }
 }
 
 void Button::mouseReleaseEvent(QMouseEvent *event)
 {
-    if (!this->enabled_ || !this->mouseDown_)
+    if (!this->enabled_ || !this->leftMouseButtonDown_)
     {
         return;
     }
@@ -199,7 +199,7 @@ void Button::mouseReleaseEvent(QMouseEvent *event)
 
     if (event->button() == Qt::LeftButton)
     {
-        this->mouseDown_ = false;
+        this->leftMouseButtonDown_ = false;
 
         if (isInside)
         {
@@ -258,7 +258,7 @@ void Button::onMouseEffectTimeout()
         for (auto it = this->clickEffects_.begin();
              it != this->clickEffects_.end();)
         {
-            it->progress += mouseDown_ ? 0.02 : 0.07;
+            it->progress += this->leftMouseButtonDown_ ? 0.02 : 0.07;
 
             if (it->progress >= 1.0)
             {

--- a/src/widgets/buttons/Button.hpp
+++ b/src/widgets/buttons/Button.hpp
@@ -57,7 +57,7 @@ public:
     [[nodiscard]] bool mouseOver() const noexcept;
 
     /// Returns true if the left mouse button is held down
-    [[nodiscard]] bool mouseDown() const noexcept;
+    [[nodiscard]] bool leftMouseButtonDown() const noexcept;
 
     /// @brief Returns true if the menu is visible
     ///
@@ -202,7 +202,7 @@ private:
 
     bool enabled_ = true;
     bool mouseOver_ = false;
-    bool mouseDown_ = false;
+    bool leftMouseButtonDown_ = false;
     bool menuVisible_ = false;
 
     QPixmap cachedPixmap_;

--- a/src/widgets/buttons/Button.hpp
+++ b/src/widgets/buttons/Button.hpp
@@ -203,6 +203,8 @@ private:
     bool enabled_ = true;
     bool mouseOver_ = false;
     bool leftMouseButtonDown_ = false;
+    bool rightMouseButtonDown_ = false;
+    bool middleMouseButtonDown_ = false;
     bool menuVisible_ = false;
 
     QPixmap cachedPixmap_;

--- a/src/widgets/buttons/NotebookButton.cpp
+++ b/src/widgets/buttons/NotebookButton.cpp
@@ -40,7 +40,7 @@ void NotebookButton::paintContent(QPainter &painter)
     QColor background;
     QColor foreground;
 
-    if (this->mouseDown() || this->mouseOver())
+    if (this->leftMouseButtonDown() || this->mouseOver())
     {
         background = this->theme->tabs.regular.backgrounds.hover;
         foreground = this->theme->tabs.regular.text;


### PR DESCRIPTION
Fixes #6301 

I deliberately did not add getters for `rightMouseButtonDown` and `middleMouseButtonDown` because they would not be used anywhere right now