### PR TITLE
refactor: remove GeneralPageView.addCheckbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 - Dev: Refactored `Notebook`-related enums into their own file. (#6220)
 - Dev: Refactored `SettingWidget::dropdown` for string enums to the source file. (#6293)
 - Dev: Don't try to save emote popup bounds if we're quitting. (#6292)
+- Dev: Remove `ChannelPageView::addCheckbox`. (#6305)
 - Dev: Implemented customizable display names for enums. (#6238)
 - Dev: Refactored event API initialization away from Application and into TwitchIrcServer. (#6198)
 - Dev: Updated GoogleTest to v1.17.0. (#6180)

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1161,8 +1161,11 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         "Show parted users (< 1000 chatters)", s.showParts, false,
         "Show a Twitch system message stating what users have left the chat, "
         "only available when chat has less than 1000 users");
-    layout.addCheckbox("Automatically close user popup when it loses focus",
-                       s.autoCloseUserPopup);
+
+    SettingWidget::checkbox(
+        "Automatically close user popup when it loses focus",
+        s.autoCloseUserPopup)
+        ->addTo(layout);
 
     SettingWidget::checkbox(
         "Automatically close reply thread popup when it loses focus",

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -967,7 +967,10 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         "Hide similar messages to those previously seen. Toggle hidden "
         "messages by pressing " +
         toggleLocalr9kShortcut + ".");
-    layout.addCheckbox("Enable similarity checks", s.similarityEnabled);
+
+    SettingWidget::checkbox("Enable similarity checks", s.similarityEnabled)
+        ->addTo(layout);
+
     //layout.addCheckbox("Gray out matches", s.colorSimilarDisabled);
 
     SettingWidget::checkbox("Only if by the same user", s.hideSimilarBySameUser)

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -689,9 +689,12 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     layout.addCheckbox("Hide link thumbnails", s.streamerModeHideLinkThumbnails,
                        "Prevent potentially explicit thumbnails from showing "
                        "when hovering links.");
-    layout.addCheckbox(
+
+    SettingWidget::checkbox(
         "Hide viewer count and stream length while hovering over split header",
-        s.streamerModeHideViewerCountAndDuration);
+        s.streamerModeHideViewerCountAndDuration)
+        ->addTo(layout);
+
     layout.addCheckbox(
         "Hide moderation actions", s.streamerModeHideModActions,
         "Hide bans, timeouts, and automod messages from appearing in chat.");

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -564,8 +564,11 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         "cvMask and 7TV's RainTime, will appear as normal emotes.");
     layout.addCheckbox("Enable emote auto-completion by typing :",
                        s.emoteCompletionWithColon);
-    layout.addCheckbox("Use experimental smarter emote completion.",
-                       s.useSmartEmoteCompletion);
+
+    SettingWidget::checkbox("Use experimental smarter emote completion.",
+                            s.useSmartEmoteCompletion)
+        ->addTo(layout);
+
     layout.addDropdown<float>(
         "Size", {"0.5x", "0.75x", "Default", "1.25x", "1.5x", "2x"},
         s.emoteScale,

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1299,11 +1299,13 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         // update this tooltip if https://github.com/Chatterino/chatterino2/pull/1557 is ever merged
         "When disabled, the /mentions tab will not highlight in "
         "red when you are mentioned.");
-    layout.addCheckbox(
-        "Strip leading mention in replies", s.stripReplyMention, false,
-        "When disabled, messages sent in reply threads will include the "
-        "@mention for the related thread. If the reply context is hidden, "
-        "these mentions will never be stripped.");
+    SettingWidget::checkbox("Strip leading mention in replies",
+                            s.stripReplyMention)
+        ->setTooltip(
+            "When disabled, messages sent in reply threads will include the "
+            "@mention for the related thread. If the reply context is hidden, "
+            "these mentions will never be stripped.")
+        ->addTo(layout);
 
     SettingWidget::dropdown("Chat send protocol", s.chatSendProtocol)
         ->setTooltip("'Helix' will use Twitch's Helix API to send message. "

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1227,11 +1227,14 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         [](auto args) {
             return fuzzyToFloat(args.value, 63.f);
         });
-    layout.addCheckbox("Double click to open links and other elements in chat",
-                       s.linksDoubleClickOnly, false,
-                       "When enabled, opening links/usercards requires "
-                       "double-clicking.\nUseful making sure you don't "
-                       "accidentally click on suspicious links.");
+
+    SettingWidget::checkbox(
+        "Double click to open links and other elements in chat",
+        s.linksDoubleClickOnly)
+        ->setTooltip("When enabled, opening links/usercards requires "
+                     "double-clicking.\nUseful making sure you don't "
+                     "accidentally click on suspicious links.")
+        ->addTo(layout);
 
     SettingWidget::checkbox("Unshorten links", s.unshortLinks)
         ->setTooltip("When enabled, \"right-click + copy link\" will copy the "

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1291,9 +1291,11 @@ void GeneralPage::initLayout(GeneralPageView &layout)
             return args.index;
         },
         false, "Combine consecutive timeout messages into a single message.");
-    layout.addCheckbox("Combine multiple bit tips into one", s.stackBits, false,
-                       "Combine consecutive cheermotes (sent in a single "
-                       "message) into one cheermote.");
+
+    SettingWidget::checkbox("Combine multiple bit tips into one", s.stackBits)
+        ->setTooltip("Combine consecutive cheermotes (sent in a single "
+                     "message) into one cheermote.")
+        ->addTo(layout);
 
     // update this tooltip if https://github.com/Chatterino/chatterino2/pull/1557 is ever merged
     SettingWidget::checkbox("Messages in /mentions highlights tab",

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1110,8 +1110,9 @@ void GeneralPage::initLayout(GeneralPageView &layout)
 
     if (supportsIncognitoLinks())
     {
-        layout.addCheckbox("Open links in incognito/private mode",
-                           s.openLinksIncognito);
+        SettingWidget::checkbox("Open links in incognito/private mode",
+                                s.openLinksIncognito)
+            ->addTo(layout);
     }
 
     SettingWidget::customCheckbox(

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1,13 +1,10 @@
 #include "widgets/settingspages/GeneralPage.hpp"
 
 #include "Application.hpp"
-#include "common/Literals.hpp"
-#include "common/QLogging.hpp"
-#include "common/ThumbnailPreviewMode.hpp"
+#include "common/Literals.hpp"  // IWYU pragma: keep
 #include "common/Version.hpp"
 #include "controllers/hotkeys/HotkeyCategory.hpp"
 #include "controllers/hotkeys/HotkeyController.hpp"
-#include "controllers/sound/ISoundController.hpp"
 #include "providers/twitch/TwitchChannel.hpp"
 #include "providers/twitch/TwitchIrcServer.hpp"
 #include "singletons/CrashHandler.hpp"
@@ -23,19 +20,17 @@
 #include "widgets/settingspages/GeneralPageView.hpp"
 #include "widgets/settingspages/SettingWidget.hpp"
 
-#include <magic_enum/magic_enum.hpp>
 #include <QDesktopServices>
 #include <QFileDialog>
 #include <QFontDialog>
 #include <QFormLayout>
 #include <QLabel>
 #include <QMessageBox>
-#include <QScrollArea>
 
 namespace {
 
 using namespace chatterino;
-using namespace literals;
+using namespace chatterino::literals;
 
 const QString CHROME_EXTENSION_LINK =
     u"https://chrome.google.com/webstore/detail/chatterino-native-host/glknmaideaikkmemifbfkhnomoknepka"_s;

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1264,8 +1264,11 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         "participate in.\n"
         "This means reply threads you participate in will use your "
         "\"Subscribed Reply Threads\" highlight settings.");
-    layout.addCheckbox("Load message history on connect",
-                       s.loadTwitchMessageHistoryOnConnect);
+
+    SettingWidget::checkbox("Load message history on connect",
+                            s.loadTwitchMessageHistoryOnConnect)
+        ->addTo(layout);
+
     // TODO: Change phrasing to use better english once we can tag settings, right now it's kept as history instead of historical so that the setting shows up when the user searches for history
     layout.addIntInput("Max number of history messages to load on connect",
                        s.twitchMessageHistoryLimit, 10, 800, 10);

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1253,10 +1253,13 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     layout.addCheckbox("Show Twitch whispers inline", s.inlineWhispers, false,
                        "Show whispers as messages in all splits instead "
                        "of just /whispers.");
-    layout.addCheckbox(
-        "Highlight received inline whispers", s.highlightInlineWhispers, false,
-        "Highlight the whispers shown in all splits.\nIf \"Show Twitch "
-        "whispers inline\" is disabled, this setting will do nothing.");
+
+    SettingWidget::checkbox("Highlight received inline whispers",
+                            s.highlightInlineWhispers)
+        ->setTooltip(
+            "Highlight the whispers shown in all splits.\nIf \"Show Twitch "
+            "whispers inline\" is disabled, this setting will do nothing.")
+        ->addTo(layout);
 
     SettingWidget::checkbox(
         "Automatically subscribe to participated reply threads",

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1163,9 +1163,11 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         "only available when chat has less than 1000 users");
     layout.addCheckbox("Automatically close user popup when it loses focus",
                        s.autoCloseUserPopup);
-    layout.addCheckbox(
+
+    SettingWidget::checkbox(
         "Automatically close reply thread popup when it loses focus",
-        s.autoCloseThreadPopup);
+        s.autoCloseThreadPopup)
+        ->addTo(layout);
 
     SettingWidget::checkbox("Lowercase domains (anti-phishing)",
                             s.lowercaseDomains)

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1185,11 +1185,14 @@ void GeneralPage::initLayout(GeneralPageView &layout)
                        "Find mentions of users in chat without the @ prefix.");
     layout.addCheckbox("Show username autocompletion popup menu",
                        s.showUsernameCompletionMenu);
-    layout.addCheckbox(
-        "Always include broadcaster in user completions",
-        s.alwaysIncludeBroadcasterInUserCompletions, false,
-        "This will ensure a broadcaster is always easy to ping, even if they "
-        "don't have chat open or have typed recently.");
+
+    SettingWidget::checkbox("Always include broadcaster in user completions",
+                            s.alwaysIncludeBroadcasterInUserCompletions)
+        ->setTooltip(
+            "This will ensure a broadcaster is always easy to ping, even if "
+            "they don't have chat open or have typed recently.")
+        ->addTo(layout);
+
     const QStringList usernameDisplayModes = {"Username", "Localized name",
                                               "Username and localized name"};
 

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -973,7 +973,9 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         "Only if by the same user", s.hideSimilarBySameUser, false,
         "When checked, messages that are very similar to each other can still "
         "be shown as long as they're sent by different users.");
-    layout.addCheckbox("Hide my own messages", s.hideSimilarMyself);
+
+    SettingWidget::checkbox("Hide my own messages", s.hideSimilarMyself)
+        ->addTo(layout);
 
     SettingWidget::checkbox("Receive notification sounds from hidden messages",
                             s.shownSimilarTriggerHighlights)

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1126,9 +1126,10 @@ void GeneralPage::initLayout(GeneralPageView &layout)
 #if defined(Q_OS_LINUX) && !defined(NO_QTKEYCHAIN)
     if (!getApp()->getPaths().isPortable())
     {
-        layout.addCheckbox(
+        SettingWidget::checkbox(
             "Use libsecret/KWallet/Gnome keychain to secure passwords",
-            s.useKeyring);
+            s.useKeyring)
+            ->addTo(layout);
     }
 #endif
 

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -749,11 +749,10 @@ void GeneralPage::initLayout(GeneralPageView &layout)
 
     SettingWidget::checkbox("Hide blocked terms",
                             s.streamerModeHideBlockedTermText)
-        ->setTooltip("Hide blocked terms from showing up in places like "
-                     "AutoMod messages. "
-                     "This can be useful in case you have some blocked terms "
-                     "that you don't "
-                     "want to show on stream.")
+        ->setTooltip(
+            "Hide blocked terms from showing up in places like AutoMod "
+            "messages. This can be useful in case you have some blocked terms "
+            "that you don't want to show on stream.")
         ->addTo(layout);
 
     SettingWidget::checkbox("Mute mention sounds", s.streamerModeMuteMentions)

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1157,10 +1157,12 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         "Show joined users (< 1000 chatters)", s.showJoins, false,
         "Show a Twitch system message stating what users have joined the chat, "
         "only available when the chat has less than 1000 users");
-    layout.addCheckbox(
-        "Show parted users (< 1000 chatters)", s.showParts, false,
-        "Show a Twitch system message stating what users have left the chat, "
-        "only available when chat has less than 1000 users");
+
+    SettingWidget::checkbox("Show parted users (< 1000 chatters)", s.showParts)
+        ->setTooltip(
+            "Show a Twitch system message stating what users have left the "
+            "chat, only available when chat has less than 1000 users")
+        ->addTo(layout);
 
     SettingWidget::checkbox(
         "Automatically close user popup when it loses focus",

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -554,7 +554,8 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     SettingWidget::colorButton("Line color", s.lastMessageColor)->addTo(layout);
 
     layout.addTitle("Emotes");
-    layout.addCheckbox("Enable", s.enableEmoteImages);
+
+    SettingWidget::checkbox("Enable", s.enableEmoteImages)->addTo(layout);
 
     SettingWidget::checkbox("Animate", s.animateEmotes)->addTo(layout);
 

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -912,9 +912,9 @@ void GeneralPage::initLayout(GeneralPageView &layout)
                           "attaching to other windows by accident.");
     SettingWidget::checkbox("Attach to any browser (may cause issues)",
                             s.attachExtensionToAnyProcess)
-        ->setTooltip("Attempt to force the Chatterino Browser Extension to "
-                     "work in certain "
-                     "browsers that do not work automatically.\ne.g. Librewolf")
+        ->setTooltip(
+            "Attempt to force the Chatterino Browser Extension to work in "
+            "certain browsers that do not work automatically.\ne.g. Librewolf")
         ->addTo(layout);
 
     {

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -385,7 +385,9 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         [](auto args) {
             return fuzzyToFloat(args.value, 1.f);
         });
-    layout.addCheckbox("Smooth scrolling", s.enableSmoothScrolling);
+
+    SettingWidget::checkbox("Smooth scrolling", s.enableSmoothScrolling)
+        ->addTo(layout);
 
     SettingWidget::checkbox("Smooth scrolling on new messages",
                             s.enableSmoothScrollingNewMessages)

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -298,11 +298,11 @@ void GeneralPage::initLayout(GeneralPageView &layout)
             removeTabSeq.toString(QKeySequence::SequenceFormat::NativeText);
     }
     layout.addCheckbox(
-        "Show tab close button", s.showTabCloseButton, false,
+        "Show tab close button", s.showTabCloseButton,
         "When disabled, the x to close a tab will be hidden.\nTabs can still "
         "be closed by right-clicking or pressing " +
             removeTabShortcut + ".");
-    layout.addCheckbox("Always on top", s.windowTopMost, false,
+    layout.addCheckbox("Always on top", s.windowTopMost,
                        "Always keep Chatterino as the top window.");
 #ifdef USEWINSDK
     layout.addCheckbox("Start with Windows", s.autorun, false,
@@ -328,7 +328,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         SettingWidget::inverseCheckbox("Show user button", s.hideUserButton)
             ->addTo(layout);
     }
-    layout.addCheckbox("Mark tabs with live channels", s.showTabLive, false,
+    layout.addCheckbox("Mark tabs with live channels", s.showTabLive,
                        "Shows a red dot in the top right corner of a tab to "
                        "indicate one of the channels in the tab is live.");
 
@@ -388,15 +388,15 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     layout.addCheckbox("Smooth scrolling", s.enableSmoothScrolling);
     layout.addCheckbox("Smooth scrolling on new messages",
                        s.enableSmoothScrollingNewMessages);
-    layout.addCheckbox("Show input when it's empty", s.showEmptyInput, false,
+    layout.addCheckbox("Show input when it's empty", s.showEmptyInput,
                        "Show the chat box even when there is nothing typed.");
     layout.addCheckbox(
-        "Show message length while typing", s.showMessageLength, false,
+        "Show message length while typing", s.showMessageLength,
         "Show how many characters are currently in your input box.\n"
         "Useful for making sure you don't go past the 500 character Twitch "
         "limit, or a lower limit enforced by a moderation bot");
     layout.addCheckbox(
-        "Allow sending duplicate messages", s.allowDuplicateMessages, false,
+        "Allow sending duplicate messages", s.allowDuplicateMessages,
         "Allow a single message to be repeatedly sent without any changes.");
     layout.addDropdown<std::underlying_type_t<MessageOverflow>>(
         "Message overflow", {"Highlight", "Prevent", "Allow"},
@@ -545,7 +545,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     layout.addSeparator();
     layout.addCheckbox("Draw a line below the most recent message before "
                        "switching applications.",
-                       s.showLastMessageIndicator, false,
+                       s.showLastMessageIndicator,
                        "Adds an underline below the most recent message "
                        "sent before you tabbed out of Chatterino.");
 
@@ -559,7 +559,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     layout.addCheckbox("Animate only when Chatterino is focused",
                        s.animationsWhenFocused);
     layout.addCheckbox(
-        "Enable zero-width emotes", s.enableZeroWidthEmotes, false,
+        "Enable zero-width emotes", s.enableZeroWidthEmotes,
         "When disabled, emotes that overlap other emotes, such as BTTV's "
         "cvMask and 7TV's RainTime, will appear as normal emotes.");
     layout.addCheckbox("Enable emote auto-completion by typing :",
@@ -584,7 +584,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         });
 
     layout.addCheckbox("Remove spaces between emotes",
-                       s.removeSpacesBetweenEmotes, false,
+                       s.removeSpacesBetweenEmotes,
                        "When enabled, adjacent emotes will no longer have an "
                        "added space separating them.");
     SettingWidget::checkbox("Show unlisted 7TV emotes",
@@ -684,17 +684,16 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     dankDropdown->setMinimumWidth(dankDropdown->minimumSizeHint().width() + 30);
 
     layout.addCheckbox("Hide usercard avatars",
-                       s.streamerModeHideUsercardAvatars, false,
+                       s.streamerModeHideUsercardAvatars,
                        "Prevent potentially explicit avatars from showing.");
     layout.addCheckbox("Hide link thumbnails", s.streamerModeHideLinkThumbnails,
-                       false,
                        "Prevent potentially explicit thumbnails from showing "
                        "when hovering links.");
     layout.addCheckbox(
         "Hide viewer count and stream length while hovering over split header",
         s.streamerModeHideViewerCountAndDuration);
     layout.addCheckbox(
-        "Hide moderation actions", s.streamerModeHideModActions, false,
+        "Hide moderation actions", s.streamerModeHideModActions,
         "Hide bans, timeouts, and automod messages from appearing in chat.");
 
     SettingWidget::checkbox("Hide messages from restricted users",
@@ -704,17 +703,17 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         ->addTo(layout);
 
     layout.addCheckbox(
-        "Hide blocked terms", s.streamerModeHideBlockedTermText, false,
+        "Hide blocked terms", s.streamerModeHideBlockedTermText,
         "Hide blocked terms from showing up in places like AutoMod messages. "
         "This can be useful in case you have some blocked terms that you don't "
         "want to show on stream.");
-    layout.addCheckbox("Mute mention sounds", s.streamerModeMuteMentions, false,
+    layout.addCheckbox("Mute mention sounds", s.streamerModeMuteMentions,
                        "Mute your ping sound from playing.");
     layout.addCheckbox(
         "Suppress Live Notifications", s.streamerModeSuppressLiveNotifications,
-        false, "Hide Live notification popups from appearing. (Windows Only)");
+        "Hide Live notification popups from appearing. (Windows Only)");
     layout.addCheckbox("Suppress Inline Whispers",
-                       s.streamerModeSuppressInlineWhispers, false,
+                       s.streamerModeSuppressInlineWhispers,
                        "Hide whispers sent to you from appearing in chat.");
 
     layout.addTitle("Link Previews");
@@ -855,7 +854,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
                           "attaching to other windows by accident.");
     layout.addCheckbox(
         "Attach to any browser (may cause issues)",
-        s.attachExtensionToAnyProcess, false,
+        s.attachExtensionToAnyProcess,
         "Attempt to force the Chatterino Browser Extension to work in certain "
         "browsers that do not work automatically.\ne.g. Librewolf");
 
@@ -944,14 +943,13 @@ void GeneralPage::initLayout(GeneralPageView &layout)
 
     layout.addSubtitle("Chat title");
     layout.addDescription("In live channels show:");
-    layout.addCheckbox("Uptime", s.headerUptime, false,
+    layout.addCheckbox("Uptime", s.headerUptime,
                        "Show how long the channel has been live");
-    layout.addCheckbox("Viewer count", s.headerViewerCount, false,
+    layout.addCheckbox("Viewer count", s.headerViewerCount,
                        "Show how many users are watching");
-    layout.addCheckbox("Category", s.headerGame, false,
+    layout.addCheckbox("Category", s.headerGame,
                        "Show what Category the stream is listed under");
-    layout.addCheckbox("Title", s.headerStreamTitle, false,
-                       "Show the stream title");
+    layout.addCheckbox("Title", s.headerStreamTitle, "Show the stream title");
 
     layout.addSubtitle("R9K");
     auto toggleLocalr9kSeq = getApp()->getHotkeys()->getDisplaySequence(

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1238,12 +1238,12 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         "version of the link.\ne.g. https://bit.ly/mrfors -> "
         "https://forsen.tv/");
 
-    layout.addCheckbox(
+    SettingWidget::checkbox(
         "Only search for emote autocompletion at the start of emote names",
-        s.prefixOnlyEmoteCompletion, false,
-        "When disabled, emote tab-completion will complete based on any part "
-        "of the name."
-        "\ne.g. sheffy -> DatSheffy");
+        s.prefixOnlyEmoteCompletion)
+        ->setTooltip("When disabled, emote tab-completion will complete based "
+                     "on any part of the name.\ne.g. sheffy -> DatSheffy")
+        ->addTo(layout);
 
     SettingWidget::checkbox("Only search for username autocompletion with an @",
                             s.userCompletionOnlyWithAt)

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -562,8 +562,10 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         "Enable zero-width emotes", s.enableZeroWidthEmotes,
         "When disabled, emotes that overlap other emotes, such as BTTV's "
         "cvMask and 7TV's RainTime, will appear as normal emotes.");
-    layout.addCheckbox("Enable emote auto-completion by typing :",
-                       s.emoteCompletionWithColon);
+
+    SettingWidget::checkbox("Enable emote auto-completion by typing :",
+                            s.emoteCompletionWithColon)
+        ->addTo(layout);
 
     SettingWidget::checkbox("Use experimental smarter emote completion.",
                             s.useSmartEmoteCompletion)

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1250,9 +1250,10 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         "When enabled, username tab-completion will only complete when using @"
         "\ne.g. pajl -> pajl | @pajl -> @pajlada");
 
-    layout.addCheckbox("Show Twitch whispers inline", s.inlineWhispers, false,
-                       "Show whispers as messages in all splits instead "
-                       "of just /whispers.");
+    SettingWidget::checkbox("Show Twitch whispers inline", s.inlineWhispers)
+        ->setTooltip("Show whispers as messages in all splits instead of just "
+                     "/whispers.")
+        ->addTo(layout);
 
     SettingWidget::checkbox("Highlight received inline whispers",
                             s.highlightInlineWhispers)

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1232,11 +1232,12 @@ void GeneralPage::initLayout(GeneralPageView &layout)
                        "When enabled, opening links/usercards requires "
                        "double-clicking.\nUseful making sure you don't "
                        "accidentally click on suspicious links.");
-    layout.addCheckbox(
-        "Unshorten links", s.unshortLinks, false,
-        "When enabled, \"right-click + copy link\" will copy the unshortened "
-        "version of the link.\ne.g. https://bit.ly/mrfors -> "
-        "https://forsen.tv/");
+
+    SettingWidget::checkbox("Unshorten links", s.unshortLinks)
+        ->setTooltip("When enabled, \"right-click + copy link\" will copy the "
+                     "unshortened version of the link.\ne.g. "
+                     "https://bit.ly/mrfors -> https://forsen.tv/")
+        ->addTo(layout);
 
     SettingWidget::checkbox(
         "Only search for emote autocompletion at the start of emote names",

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1294,11 +1294,14 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     layout.addCheckbox("Combine multiple bit tips into one", s.stackBits, false,
                        "Combine consecutive cheermotes (sent in a single "
                        "message) into one cheermote.");
-    layout.addCheckbox(
-        "Messages in /mentions highlights tab", s.highlightMentions, false,
-        // update this tooltip if https://github.com/Chatterino/chatterino2/pull/1557 is ever merged
-        "When disabled, the /mentions tab will not highlight in "
-        "red when you are mentioned.");
+
+    // update this tooltip if https://github.com/Chatterino/chatterino2/pull/1557 is ever merged
+    SettingWidget::checkbox("Messages in /mentions highlights tab",
+                            s.highlightMentions)
+        ->setTooltip("When disabled, the /mentions tab will not highlight in "
+                     "red when you are mentioned.")
+        ->addTo(layout);
+
     SettingWidget::checkbox("Strip leading mention in replies",
                             s.stripReplyMention)
         ->setTooltip(

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1180,9 +1180,11 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     layout.addCheckbox("Color @usernames", s.colorUsernames, false,
                        "If Chatterino has seen a user, highlight @mention's of "
                        "them with their Twitch color.");
-    layout.addCheckbox("Try to find usernames without @ prefix",
-                       s.findAllUsernames, false,
-                       "Find mentions of users in chat without the @ prefix.");
+
+    SettingWidget::checkbox("Try to find usernames without @ prefix",
+                            s.findAllUsernames)
+        ->setTooltip("Find mentions of users in chat without the @ prefix.")
+        ->addTo(layout);
 
     SettingWidget::checkbox("Show username autocompletion popup menu",
                             s.showUsernameCompletionMenu)

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1025,8 +1025,11 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     layout.addCheckbox("Channel", s.showBadgesChannelAuthority, false,
                        "e.g. broadcaster, moderator");
     layout.addCheckbox("Subscriber ", s.showBadgesSubscription);
-    layout.addCheckbox("Vanity", s.showBadgesVanity, false,
-                       "e.g. prime, bits, sub gifter");
+
+    SettingWidget::checkbox("Vanity", s.showBadgesVanity)
+        ->setTooltip("e.g. prime, bits, sub gifter")
+        ->addTo(layout);
+
     SettingWidget::checkbox("Chatterino", s.showBadgesChatterino)
         ->setTooltip("e.g. Chatterino Supporter/Contributor/Developer")
         ->addTo(layout);

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1257,13 +1257,15 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         "Highlight received inline whispers", s.highlightInlineWhispers, false,
         "Highlight the whispers shown in all splits.\nIf \"Show Twitch "
         "whispers inline\" is disabled, this setting will do nothing.");
-    layout.addCheckbox(
+
+    SettingWidget::checkbox(
         "Automatically subscribe to participated reply threads",
-        s.autoSubToParticipatedThreads, false,
-        "When enabled, you will automatically subscribe to reply threads you "
-        "participate in.\n"
-        "This means reply threads you participate in will use your "
-        "\"Subscribed Reply Threads\" highlight settings.");
+        s.autoSubToParticipatedThreads)
+        ->setTooltip(
+            "When enabled, you will automatically subscribe to reply threads "
+            "you participate in.\nThis means reply threads you participate in "
+            "will use your \"Subscribed Reply Threads\" highlight settings.")
+        ->addTo(layout);
 
     SettingWidget::checkbox("Load message history on connect",
                             s.loadTwitchMessageHistoryOnConnect)

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -299,10 +299,10 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     }
 
     SettingWidget::checkbox("Show tab close button", s.showTabCloseButton)
-        ->setTooltip("When disabled, the x to close a tab will be "
-                     "hidden.\nTabs can still "
-                     "be closed by right-clicking or pressing " +
-                     removeTabShortcut + ".")
+        ->setTooltip(
+            "When disabled, the x to close a tab will be hidden.\nTabs can "
+            "still be closed by right-clicking or pressing " +
+            removeTabShortcut + ".")
         ->addTo(layout);
 
     SettingWidget::checkbox("Always on top", s.windowTopMost)

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -297,16 +297,22 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         removeTabShortcut =
             removeTabSeq.toString(QKeySequence::SequenceFormat::NativeText);
     }
-    layout.addCheckbox(
-        "Show tab close button", s.showTabCloseButton,
-        "When disabled, the x to close a tab will be hidden.\nTabs can still "
-        "be closed by right-clicking or pressing " +
-            removeTabShortcut + ".");
-    layout.addCheckbox("Always on top", s.windowTopMost,
-                       "Always keep Chatterino as the top window.");
+
+    SettingWidget::checkbox("Show tab close button", s.showTabCloseButton)
+        ->setTooltip("When disabled, the x to close a tab will be "
+                     "hidden.\nTabs can still "
+                     "be closed by right-clicking or pressing " +
+                     removeTabShortcut + ".")
+        ->addTo(layout);
+
+    SettingWidget::checkbox("Always on top", s.windowTopMost)
+        ->setTooltip("Always keep Chatterino as the top window.")
+        ->addTo(layout);
+
 #ifdef USEWINSDK
-    layout.addCheckbox("Start with Windows", s.autorun, false,
-                       "Start Chatterino when your computer starts.");
+    SettingWidget::checkbox("Start with Windows", s.autorun)
+        ->setTooltip("Start Chatterino when your computer starts.")
+        ->addTo(layout);
 #endif
     if (!BaseWindow::supportsCustomWindowFrame())
     {
@@ -328,9 +334,11 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         SettingWidget::inverseCheckbox("Show user button", s.hideUserButton)
             ->addTo(layout);
     }
-    layout.addCheckbox("Mark tabs with live channels", s.showTabLive,
-                       "Shows a red dot in the top right corner of a tab to "
-                       "indicate one of the channels in the tab is live.");
+
+    SettingWidget::checkbox("Mark tabs with live channels", s.showTabLive)
+        ->setTooltip("Shows a red dot in the top right corner of a tab to "
+                     "indicate one of the channels in the tab is live.")
+        ->addTo(layout);
 
     layout.addTitle("Chat");
 
@@ -393,16 +401,24 @@ void GeneralPage::initLayout(GeneralPageView &layout)
                             s.enableSmoothScrollingNewMessages)
         ->addTo(layout);
 
-    layout.addCheckbox("Show input when it's empty", s.showEmptyInput,
-                       "Show the chat box even when there is nothing typed.");
-    layout.addCheckbox(
-        "Show message length while typing", s.showMessageLength,
-        "Show how many characters are currently in your input box.\n"
-        "Useful for making sure you don't go past the 500 character Twitch "
-        "limit, or a lower limit enforced by a moderation bot");
-    layout.addCheckbox(
-        "Allow sending duplicate messages", s.allowDuplicateMessages,
-        "Allow a single message to be repeatedly sent without any changes.");
+    SettingWidget::checkbox("Show input when it's empty", s.showEmptyInput)
+        ->setTooltip("Show the chat box even when there is nothing typed.")
+        ->addTo(layout);
+
+    SettingWidget::checkbox("Show message length while typing",
+                            s.showMessageLength)
+        ->setTooltip(
+            "Show how many characters are currently in your input box.\n"
+            "Useful for making sure you don't go past the 500 character Twitch "
+            "limit, or a lower limit enforced by a moderation bot")
+        ->addTo(layout);
+
+    SettingWidget::checkbox("Allow sending duplicate messages",
+                            s.allowDuplicateMessages)
+        ->setTooltip(
+            "Allow a single message to be repeatedly sent without any changes.")
+        ->addTo(layout);
+
     layout.addDropdown<std::underlying_type_t<MessageOverflow>>(
         "Message overflow", {"Highlight", "Prevent", "Allow"},
         s.messageOverflow,
@@ -548,11 +564,13 @@ void GeneralPage::initLayout(GeneralPageView &layout)
             return fuzzyToInt(args.value, 0);
         });
     layout.addSeparator();
-    layout.addCheckbox("Draw a line below the most recent message before "
-                       "switching applications.",
-                       s.showLastMessageIndicator,
-                       "Adds an underline below the most recent message "
-                       "sent before you tabbed out of Chatterino.");
+
+    SettingWidget::checkbox("Draw a line below the most recent message before "
+                            "switching applications.",
+                            s.showLastMessageIndicator)
+        ->setTooltip("Adds an underline below the most recent message "
+                     "sent before you tabbed out of Chatterino.")
+        ->addTo(layout);
 
     SettingWidget::dropdown("Line style", s.lastMessagePattern)->addTo(layout);
 
@@ -568,10 +586,11 @@ void GeneralPage::initLayout(GeneralPageView &layout)
                             s.animationsWhenFocused)
         ->addTo(layout);
 
-    layout.addCheckbox(
-        "Enable zero-width emotes", s.enableZeroWidthEmotes,
-        "When disabled, emotes that overlap other emotes, such as BTTV's "
-        "cvMask and 7TV's RainTime, will appear as normal emotes.");
+    SettingWidget::checkbox("Enable zero-width emotes", s.enableZeroWidthEmotes)
+        ->setTooltip(
+            "When disabled, emotes that overlap other emotes, such as BTTV's "
+            "cvMask and 7TV's RainTime, will appear as normal emotes.")
+        ->addTo(layout);
 
     SettingWidget::checkbox("Enable emote auto-completion by typing :",
                             s.emoteCompletionWithColon)
@@ -598,10 +617,12 @@ void GeneralPage::initLayout(GeneralPageView &layout)
             return fuzzyToFloat(args.value, 1.f);
         });
 
-    layout.addCheckbox("Remove spaces between emotes",
-                       s.removeSpacesBetweenEmotes,
-                       "When enabled, adjacent emotes will no longer have an "
-                       "added space separating them.");
+    SettingWidget::checkbox("Remove spaces between emotes",
+                            s.removeSpacesBetweenEmotes)
+        ->setTooltip("When enabled, adjacent emotes will no longer have an "
+                     "added space separating them.")
+        ->addTo(layout);
+
     SettingWidget::checkbox("Show unlisted 7TV emotes",
                             s.showUnlistedSevenTVEmotes)
         ->addKeywords({"seventv"})
@@ -698,21 +719,27 @@ void GeneralPage::initLayout(GeneralPageView &layout)
             false);
     dankDropdown->setMinimumWidth(dankDropdown->minimumSizeHint().width() + 30);
 
-    layout.addCheckbox("Hide usercard avatars",
-                       s.streamerModeHideUsercardAvatars,
-                       "Prevent potentially explicit avatars from showing.");
-    layout.addCheckbox("Hide link thumbnails", s.streamerModeHideLinkThumbnails,
-                       "Prevent potentially explicit thumbnails from showing "
-                       "when hovering links.");
+    SettingWidget::checkbox("Hide usercard avatars",
+                            s.streamerModeHideUsercardAvatars)
+        ->setTooltip("Prevent potentially explicit avatars from showing.")
+        ->addTo(layout);
+
+    SettingWidget::checkbox("Hide link thumbnails",
+                            s.streamerModeHideLinkThumbnails)
+        ->setTooltip("Prevent potentially explicit thumbnails from showing "
+                     "when hovering links.")
+        ->addTo(layout);
 
     SettingWidget::checkbox(
         "Hide viewer count and stream length while hovering over split header",
         s.streamerModeHideViewerCountAndDuration)
         ->addTo(layout);
 
-    layout.addCheckbox(
-        "Hide moderation actions", s.streamerModeHideModActions,
-        "Hide bans, timeouts, and automod messages from appearing in chat.");
+    SettingWidget::checkbox("Hide moderation actions",
+                            s.streamerModeHideModActions)
+        ->setTooltip(
+            "Hide bans, timeouts, and automod messages from appearing in chat.")
+        ->addTo(layout);
 
     SettingWidget::checkbox("Hide messages from restricted users",
                             s.streamerModeHideRestrictedUsers)
@@ -720,19 +747,29 @@ void GeneralPage::initLayout(GeneralPageView &layout)
                      "or Twitch's AutoMod")
         ->addTo(layout);
 
-    layout.addCheckbox(
-        "Hide blocked terms", s.streamerModeHideBlockedTermText,
-        "Hide blocked terms from showing up in places like AutoMod messages. "
-        "This can be useful in case you have some blocked terms that you don't "
-        "want to show on stream.");
-    layout.addCheckbox("Mute mention sounds", s.streamerModeMuteMentions,
-                       "Mute your ping sound from playing.");
-    layout.addCheckbox(
-        "Suppress Live Notifications", s.streamerModeSuppressLiveNotifications,
-        "Hide Live notification popups from appearing. (Windows Only)");
-    layout.addCheckbox("Suppress Inline Whispers",
-                       s.streamerModeSuppressInlineWhispers,
-                       "Hide whispers sent to you from appearing in chat.");
+    SettingWidget::checkbox("Hide blocked terms",
+                            s.streamerModeHideBlockedTermText)
+        ->setTooltip("Hide blocked terms from showing up in places like "
+                     "AutoMod messages. "
+                     "This can be useful in case you have some blocked terms "
+                     "that you don't "
+                     "want to show on stream.")
+        ->addTo(layout);
+
+    SettingWidget::checkbox("Mute mention sounds", s.streamerModeMuteMentions)
+        ->setTooltip("Mute your ping sound from playing.")
+        ->addTo(layout);
+
+    SettingWidget::checkbox("Suppress Live Notifications",
+                            s.streamerModeSuppressLiveNotifications)
+        ->setTooltip(
+            "Hide Live notification popups from appearing. (Windows Only)")
+        ->addTo(layout);
+
+    SettingWidget::checkbox("Suppress Inline Whispers",
+                            s.streamerModeSuppressInlineWhispers)
+        ->setTooltip("Hide whispers sent to you from appearing in chat.")
+        ->addTo(layout);
 
     layout.addTitle("Link Previews");
     layout.addDescription(
@@ -874,11 +911,12 @@ void GeneralPage::initLayout(GeneralPageView &layout)
 
     layout.addDescription("Chatterino only attaches to known browsers to avoid "
                           "attaching to other windows by accident.");
-    layout.addCheckbox(
-        "Attach to any browser (may cause issues)",
-        s.attachExtensionToAnyProcess,
-        "Attempt to force the Chatterino Browser Extension to work in certain "
-        "browsers that do not work automatically.\ne.g. Librewolf");
+    SettingWidget::checkbox("Attach to any browser (may cause issues)",
+                            s.attachExtensionToAnyProcess)
+        ->setTooltip("Attempt to force the Chatterino Browser Extension to "
+                     "work in certain "
+                     "browsers that do not work automatically.\ne.g. Librewolf")
+        ->addTo(layout);
 
     {
         auto *note = new QLabel(
@@ -965,13 +1003,18 @@ void GeneralPage::initLayout(GeneralPageView &layout)
 
     layout.addSubtitle("Chat title");
     layout.addDescription("In live channels show:");
-    layout.addCheckbox("Uptime", s.headerUptime,
-                       "Show how long the channel has been live");
-    layout.addCheckbox("Viewer count", s.headerViewerCount,
-                       "Show how many users are watching");
-    layout.addCheckbox("Category", s.headerGame,
-                       "Show what Category the stream is listed under");
-    layout.addCheckbox("Title", s.headerStreamTitle, "Show the stream title");
+    SettingWidget::checkbox("Uptime", s.headerUptime)
+        ->setTooltip("Show how long the channel has been live")
+        ->addTo(layout);
+    SettingWidget::checkbox("Viewer count", s.headerViewerCount)
+        ->setTooltip("Show how many users are watching")
+        ->addTo(layout);
+    SettingWidget::checkbox("Category", s.headerGame)
+        ->setTooltip("Show what Category the stream is listed under")
+        ->addTo(layout);
+    SettingWidget::checkbox("Title", s.headerStreamTitle)
+        ->setTooltip("Show the stream title")
+        ->addTo(layout);
 
     layout.addSubtitle("R9K");
     auto toggleLocalr9kSeq = getApp()->getHotkeys()->getDisplaySequence(
@@ -991,7 +1034,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     SettingWidget::checkbox("Enable similarity checks", s.similarityEnabled)
         ->addTo(layout);
 
-    //layout.addCheckbox("Gray out matches", s.colorSimilarDisabled);
+    // SettingWidget::checkbox("Gray out matches", s.colorSimilarDisabled)->addTo(layout);
 
     SettingWidget::checkbox("Only if by the same user", s.hideSimilarBySameUser)
         ->setTooltip(

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -974,8 +974,11 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         "When checked, messages that are very similar to each other can still "
         "be shown as long as they're sent by different users.");
     layout.addCheckbox("Hide my own messages", s.hideSimilarMyself);
-    layout.addCheckbox("Receive notification sounds from hidden messages",
-                       s.shownSimilarTriggerHighlights);
+
+    SettingWidget::checkbox("Receive notification sounds from hidden messages",
+                            s.shownSimilarTriggerHighlights)
+        ->addTo(layout);
+
     s.hideSimilar.connect(
         []() {
             getApp()->getWindows()->forceLayoutChannelViews();

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1022,8 +1022,10 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     layout.addCheckbox("Authority", s.showBadgesGlobalAuthority, false,
                        "e.g. staff, admin");
     layout.addCheckbox("Predictions", s.showBadgesPredictions);
-    layout.addCheckbox("Channel", s.showBadgesChannelAuthority, false,
-                       "e.g. broadcaster, moderator");
+
+    SettingWidget::checkbox("Channel", s.showBadgesChannelAuthority)
+        ->setTooltip("e.g. broadcaster, moderator")
+        ->addTo(layout);
 
     SettingWidget::checkbox("Subscriber ", s.showBadgesSubscription)
         ->addTo(layout);

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1170,13 +1170,15 @@ void GeneralPage::initLayout(GeneralPageView &layout)
                        false,
                        "Make all clickable links lowercase to deter "
                        "phishing attempts.");
+
     SettingWidget::checkbox("Show user's pronouns in user card", s.showPronouns)
         ->setDescription(
             R"(Pronouns are retrieved from <a href="https://pr.alejo.io">pr.alejo.io</a> when a user card is opened.)")
         ->addTo(layout);
 
-    layout.addCheckbox("Bold @usernames", s.boldUsernames, false,
-                       "Bold @mentions to make them more noticeable.");
+    SettingWidget::checkbox("Bold @usernames", s.boldUsernames)
+        ->setTooltip("Bold @mentions to make them more noticeable.")
+        ->addTo(layout);
 
     SettingWidget::checkbox("Color @usernames", s.colorUsernames)
         ->setTooltip("If Chatterino has seen a user, highlight @mention's of "

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -969,10 +969,12 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         toggleLocalr9kShortcut + ".");
     layout.addCheckbox("Enable similarity checks", s.similarityEnabled);
     //layout.addCheckbox("Gray out matches", s.colorSimilarDisabled);
-    layout.addCheckbox(
-        "Only if by the same user", s.hideSimilarBySameUser, false,
-        "When checked, messages that are very similar to each other can still "
-        "be shown as long as they're sent by different users.");
+
+    SettingWidget::checkbox("Only if by the same user", s.hideSimilarBySameUser)
+        ->setTooltip(
+            "When checked, messages that are very similar to each other can "
+            "still be shown as long as they're sent by different users.")
+        ->addTo(layout);
 
     SettingWidget::checkbox("Hide my own messages", s.hideSimilarMyself)
         ->addTo(layout);

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1144,10 +1144,11 @@ void GeneralPage::initLayout(GeneralPageView &layout)
                      "from TreuKS was deleted: abc")
         ->addTo(layout);
 
-    layout.addCheckbox(
-        "Colorize users without color set (gray names)", s.colorizeNicknames,
-        false,
-        "Grant a random color to users who never set a color for themselves");
+    SettingWidget::checkbox("Colorize users without color set (gray names)",
+                            s.colorizeNicknames)
+        ->setTooltip("Grant a random color to users who never set a color for "
+                     "themselves")
+        ->addTo(layout);
 
     SettingWidget::checkbox("Mention users with a comma",
                             s.mentionUsersWithComma)

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1183,8 +1183,10 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     layout.addCheckbox("Try to find usernames without @ prefix",
                        s.findAllUsernames, false,
                        "Find mentions of users in chat without the @ prefix.");
-    layout.addCheckbox("Show username autocompletion popup menu",
-                       s.showUsernameCompletionMenu);
+
+    SettingWidget::checkbox("Show username autocompletion popup menu",
+                            s.showUsernameCompletionMenu)
+        ->addTo(layout);
 
     SettingWidget::checkbox("Always include broadcaster in user completions",
                             s.alwaysIncludeBroadcasterInUserCompletions)

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1153,10 +1153,12 @@ void GeneralPage::initLayout(GeneralPageView &layout)
                        "When using tab-completon, if the username is at the "
                        "start of the message, include a comma at the end of "
                        "the name.\ne.g. pajl -> pajlada,");
-    layout.addCheckbox(
-        "Show joined users (< 1000 chatters)", s.showJoins, false,
-        "Show a Twitch system message stating what users have joined the chat, "
-        "only available when the chat has less than 1000 users");
+
+    SettingWidget::checkbox("Show joined users (< 1000 chatters)", s.showJoins)
+        ->setTooltip(
+            "Show a Twitch system message stating what users have joined the "
+            "chat, only available when the chat has less than 1000 users")
+        ->addTo(layout);
 
     SettingWidget::checkbox("Show parted users (< 1000 chatters)", s.showParts)
         ->setTooltip(

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1026,10 +1026,9 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         toggleLocalr9kShortcut = toggleLocalr9kSeq.toString(
             QKeySequence::SequenceFormat::NativeText);
     }
-    layout.addDescription(
-        "Hide similar messages to those previously seen. Toggle hidden "
-        "messages by pressing " +
-        toggleLocalr9kShortcut + ".");
+    layout.addDescription("Hide similar messages to those previously seen. "
+                          "Toggle hidden messages by pressing " +
+                          toggleLocalr9kShortcut + ".");
 
     SettingWidget::checkbox("Enable similarity checks", s.similarityEnabled)
         ->addTo(layout);
@@ -1451,8 +1450,8 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         ->addTo(layout);
 
     SettingWidget::dropdown("Sound backend (requires restart)", s.soundBackend)
-        ->setTooltip("Change this only if you're noticing issues "
-                     "with sound playback on your system")
+        ->setTooltip("Change this only if you're noticing issues with sound "
+                     "playback on your system")
         ->addTo(layout);
 
     SettingWidget::checkbox(
@@ -1462,8 +1461,8 @@ void GeneralPage::initLayout(GeneralPageView &layout)
 
     SettingWidget::checkbox("Disable renaming of tabs on double-click",
                             s.disableTabRenamingOnClick)
-        ->setTooltip("Prevents the rename dialog from opening when a "
-                     "tab is double-clicked")
+        ->setTooltip("Prevents the rename dialog from opening when a tab is "
+                     "double-clicked")
         ->addTo(layout);
 
     layout.addStretch();

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -819,7 +819,9 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         layout.addDescription(
             "You can receive updates earlier by ticking the box below. Report "
             "issues <a href='https://chatterino.com/link/issues'>here</a>.");
-        layout.addCheckbox("Receive beta updates", s.betaUpdates);
+
+        SettingWidget::checkbox("Receive beta updates", s.betaUpdates)
+            ->addTo(layout);
     }
     else
     {

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -564,8 +564,10 @@ void GeneralPage::initLayout(GeneralPageView &layout)
 
     SettingWidget::checkbox("Animate", s.animateEmotes)->addTo(layout);
 
-    layout.addCheckbox("Animate only when Chatterino is focused",
-                       s.animationsWhenFocused);
+    SettingWidget::checkbox("Animate only when Chatterino is focused",
+                            s.animationsWhenFocused)
+        ->addTo(layout);
+
     layout.addCheckbox(
         "Enable zero-width emotes", s.enableZeroWidthEmotes,
         "When disabled, emotes that overlap other emotes, such as BTTV's "

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -555,7 +555,9 @@ void GeneralPage::initLayout(GeneralPageView &layout)
 
     layout.addTitle("Emotes");
     layout.addCheckbox("Enable", s.enableEmoteImages);
-    layout.addCheckbox("Animate", s.animateEmotes);
+
+    SettingWidget::checkbox("Animate", s.animateEmotes)->addTo(layout);
+
     layout.addCheckbox("Animate only when Chatterino is focused",
                        s.animationsWhenFocused);
     layout.addCheckbox(

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1148,11 +1148,13 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         "Colorize users without color set (gray names)", s.colorizeNicknames,
         false,
         "Grant a random color to users who never set a color for themselves");
-    layout.addCheckbox("Mention users with a comma", s.mentionUsersWithComma,
-                       false,
-                       "When using tab-completon, if the username is at the "
-                       "start of the message, include a comma at the end of "
-                       "the name.\ne.g. pajl -> pajlada,");
+
+    SettingWidget::checkbox("Mention users with a comma",
+                            s.mentionUsersWithComma)
+        ->setTooltip("When using tab-completon, if the username is at the "
+                     "start of the message, include a comma at the end of the "
+                     "name.\ne.g. pajl -> pajlada,")
+        ->addTo(layout);
 
     SettingWidget::checkbox("Show joined users (< 1000 chatters)", s.showJoins)
         ->setTooltip(

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1320,9 +1320,10 @@ void GeneralPage::initLayout(GeneralPageView &layout)
                      "with sound playback on your system")
         ->addTo(layout);
 
-    layout.addCheckbox(
+    SettingWidget::checkbox(
         "Enable experimental Twitch EventSub support (requires restart)",
-        s.enableExperimentalEventSub);
+        s.enableExperimentalEventSub)
+        ->addTo(layout);
 
     SettingWidget::checkbox("Disable renaming of tabs on double-click",
                             s.disableTabRenamingOnClick)

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1024,7 +1024,9 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     layout.addCheckbox("Predictions", s.showBadgesPredictions);
     layout.addCheckbox("Channel", s.showBadgesChannelAuthority, false,
                        "e.g. broadcaster, moderator");
-    layout.addCheckbox("Subscriber ", s.showBadgesSubscription);
+
+    SettingWidget::checkbox("Subscriber ", s.showBadgesSubscription)
+        ->addTo(layout);
 
     SettingWidget::checkbox("Vanity", s.showBadgesVanity)
         ->setTooltip("e.g. prime, bits, sub gifter")

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1019,8 +1019,9 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         "compared to only if they are new enough.");
 
     layout.addSubtitle("Visible badges");
-    layout.addCheckbox("Authority", s.showBadgesGlobalAuthority, false,
-                       "e.g. staff, admin");
+    SettingWidget::checkbox("Authority", s.showBadgesGlobalAuthority)
+        ->setTooltip("e.g. staff, admin")
+        ->addTo(layout);
 
     SettingWidget::checkbox("Predictions", s.showBadgesPredictions)
         ->addTo(layout);

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1166,10 +1166,12 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     layout.addCheckbox(
         "Automatically close reply thread popup when it loses focus",
         s.autoCloseThreadPopup);
-    layout.addCheckbox("Lowercase domains (anti-phishing)", s.lowercaseDomains,
-                       false,
-                       "Make all clickable links lowercase to deter "
-                       "phishing attempts.");
+
+    SettingWidget::checkbox("Lowercase domains (anti-phishing)",
+                            s.lowercaseDomains)
+        ->setTooltip(
+            "Make all clickable links lowercase to deter phishing attempts.")
+        ->addTo(layout);
 
     SettingWidget::checkbox("Show user's pronouns in user card", s.showPronouns)
         ->setDescription(

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1027,8 +1027,10 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     layout.addCheckbox("Subscriber ", s.showBadgesSubscription);
     layout.addCheckbox("Vanity", s.showBadgesVanity, false,
                        "e.g. prime, bits, sub gifter");
-    layout.addCheckbox("Chatterino", s.showBadgesChatterino, false,
-                       "e.g. Chatterino Supporter/Contributor/Developer");
+    SettingWidget::checkbox("Chatterino", s.showBadgesChatterino)
+        ->setTooltip("e.g. Chatterino Supporter/Contributor/Developer")
+        ->addTo(layout);
+
     SettingWidget::checkbox("FrankerFaceZ", s.showBadgesFfz)
         ->addKeywords({"ffz"})
         ->setTooltip("e.g. Bot, FrankerFaceZ supporter, FrankerFaceZ developer")

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1021,7 +1021,9 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     layout.addSubtitle("Visible badges");
     layout.addCheckbox("Authority", s.showBadgesGlobalAuthority, false,
                        "e.g. staff, admin");
-    layout.addCheckbox("Predictions", s.showBadgesPredictions);
+
+    SettingWidget::checkbox("Predictions", s.showBadgesPredictions)
+        ->addTo(layout);
 
     SettingWidget::checkbox("Channel", s.showBadgesChannelAuthority)
         ->setTooltip("e.g. broadcaster, moderator")

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1077,9 +1077,11 @@ void GeneralPage::initLayout(GeneralPageView &layout)
             "corresponds to a fully opaque background.")
         ->addTo(layout);
 
-    layout.addCheckbox("Enable Shadow", s.enableOverlayShadow, false,
-                       "Enables a drop shadow on the overlay. This will use "
-                       "more processing power.");
+    SettingWidget::checkbox("Enable Shadow", s.enableOverlayShadow)
+        ->setTooltip("Enables a drop shadow on the overlay. This will use more "
+                     "processing power.")
+        ->addTo(layout);
+
     layout.addIntInput("Shadow opacity (0-255)", s.overlayShadowOpacity, 0, 255,
                        1,
                        "Controls the opacity of the added drop shadow. 255 "

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1177,9 +1177,11 @@ void GeneralPage::initLayout(GeneralPageView &layout)
 
     layout.addCheckbox("Bold @usernames", s.boldUsernames, false,
                        "Bold @mentions to make them more noticeable.");
-    layout.addCheckbox("Color @usernames", s.colorUsernames, false,
-                       "If Chatterino has seen a user, highlight @mention's of "
-                       "them with their Twitch color.");
+
+    SettingWidget::checkbox("Color @usernames", s.colorUsernames)
+        ->setTooltip("If Chatterino has seen a user, highlight @mention's of "
+                     "them with their Twitch color.")
+        ->addTo(layout);
 
     SettingWidget::checkbox("Try to find usernames without @ prefix",
                             s.findAllUsernames)

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -386,8 +386,11 @@ void GeneralPage::initLayout(GeneralPageView &layout)
             return fuzzyToFloat(args.value, 1.f);
         });
     layout.addCheckbox("Smooth scrolling", s.enableSmoothScrolling);
-    layout.addCheckbox("Smooth scrolling on new messages",
-                       s.enableSmoothScrollingNewMessages);
+
+    SettingWidget::checkbox("Smooth scrolling on new messages",
+                            s.enableSmoothScrollingNewMessages)
+        ->addTo(layout);
+
     layout.addCheckbox("Show input when it's empty", s.showEmptyInput,
                        "Show the chat box even when there is nothing typed.");
     layout.addCheckbox(

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1244,11 +1244,12 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         "When disabled, emote tab-completion will complete based on any part "
         "of the name."
         "\ne.g. sheffy -> DatSheffy");
-    layout.addCheckbox(
-        "Only search for username autocompletion with an @",
-        s.userCompletionOnlyWithAt, false,
-        "When enabled, username tab-completion will only complete when using @"
-        "\ne.g. pajl -> pajl | @pajl -> @pajlada");
+
+    SettingWidget::checkbox("Only search for username autocompletion with an @",
+                            s.userCompletionOnlyWithAt)
+        ->setTooltip("When enabled, username tab-completion will only complete "
+                     "when using @\ne.g. pajl -> pajl | @pajl -> @pajlada")
+        ->addTo(layout);
 
     SettingWidget::checkbox("Show Twitch whispers inline", s.inlineWhispers)
         ->setTooltip("Show whispers as messages in all splits instead of just "

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -728,7 +728,9 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         "terms-of-service\">Terms of Services</a> and <a "
         "href=\"https://braize.pajlada.com/chatterino/legal/"
         "privacy-policy\">Privacy Policy</a>.");
-    layout.addCheckbox("Enable", s.linkInfoTooltip);
+
+    SettingWidget::checkbox("Enable", s.linkInfoTooltip)->addTo(layout);
+
     layout.addDropdown<int>(
         "Also show thumbnails if available",
         {"Off", "Small", "Medium", "Large"}, s.thumbnailSize,

--- a/src/widgets/settingspages/GeneralPageView.cpp
+++ b/src/widgets/settingspages/GeneralPageView.cpp
@@ -159,33 +159,6 @@ SubtitleLabel *GeneralPageView::addSubtitle(const QString &title)
     return label;
 }
 
-QCheckBox *GeneralPageView::addCheckbox(const QString &text,
-                                        BoolSetting &setting,
-                                        QString toolTipText)
-{
-    auto *check = new QCheckBox(text);
-    this->addToolTip(*check, toolTipText);
-
-    // update when setting changes
-    setting.connect(
-        [check](const bool &value, auto) {
-            check->setChecked(value);
-        },
-        this->managedConnections_);
-
-    // update setting on toggle
-    QObject::connect(check, &QCheckBox::toggled, this, [&setting](bool state) {
-        setting = state;
-    });
-
-    this->addWidget(check);
-
-    // groups
-    this->groups_.back().widgets.push_back({check, {text}});
-
-    return check;
-}
-
 ComboBox *GeneralPageView::addDropdown(const QString &text,
                                        const QStringList &list,
                                        QString toolTipText)

--- a/src/widgets/settingspages/GeneralPageView.cpp
+++ b/src/widgets/settingspages/GeneralPageView.cpp
@@ -160,30 +160,23 @@ SubtitleLabel *GeneralPageView::addSubtitle(const QString &title)
 }
 
 QCheckBox *GeneralPageView::addCheckbox(const QString &text,
-                                        BoolSetting &setting, bool inverse,
+                                        BoolSetting &setting,
                                         QString toolTipText)
 {
-    if (inverse)
-    {
-        qCWarning(chatterinoWidget)
-            << "use SettingWidget::inverseCheckbox instead";
-    }
-
     auto *check = new QCheckBox(text);
     this->addToolTip(*check, toolTipText);
 
     // update when setting changes
     setting.connect(
-        [inverse, check](const bool &value, auto) {
-            check->setChecked(inverse ^ value);
+        [check](const bool &value, auto) {
+            check->setChecked(value);
         },
         this->managedConnections_);
 
     // update setting on toggle
-    QObject::connect(check, &QCheckBox::toggled, this,
-                     [&setting, inverse](bool state) {
-                         setting = inverse ^ state;
-                     });
+    QObject::connect(check, &QCheckBox::toggled, this, [&setting](bool state) {
+        setting = state;
+    });
 
     this->addWidget(check);
 

--- a/src/widgets/settingspages/GeneralPageView.hpp
+++ b/src/widgets/settingspages/GeneralPageView.hpp
@@ -133,9 +133,6 @@ public:
     TitleLabel *addTitle(const QString &text);
     SubtitleLabel *addSubtitle(const QString &text);
 
-    QCheckBox *addCheckbox(const QString &text, BoolSetting &setting,
-                           QString toolTipText = {});
-
     ComboBox *addDropdown(const QString &text, const QStringList &items,
                           QString toolTipText = {});
     ComboBox *addDropdown(const QString &text, const QStringList &items,

--- a/src/widgets/settingspages/GeneralPageView.hpp
+++ b/src/widgets/settingspages/GeneralPageView.hpp
@@ -132,9 +132,9 @@ public:
 
     TitleLabel *addTitle(const QString &text);
     SubtitleLabel *addSubtitle(const QString &text);
-    /// @param inverse Inverses true to false and vice versa
+
     QCheckBox *addCheckbox(const QString &text, BoolSetting &setting,
-                           bool inverse = false, QString toolTipText = {});
+                           QString toolTipText = {});
 
     ComboBox *addDropdown(const QString &text, const QStringList &items,
                           QString toolTipText = {});

--- a/src/widgets/settingspages/SettingWidget.hpp
+++ b/src/widgets/settingspages/SettingWidget.hpp
@@ -42,44 +42,50 @@ public:
     SettingWidget(const SettingWidget &other) = delete;
     SettingWidget(SettingWidget &&other) = delete;
 
-    static SettingWidget *checkbox(const QString &label, BoolSetting &setting);
-    static SettingWidget *inverseCheckbox(const QString &label,
-                                          BoolSetting &setting);
-    static SettingWidget *customCheckbox(const QString &label,
-                                         bool initialValue,
-                                         const std::function<void(bool)> &save);
+    [[nodiscard("Must use created setting widget")]] static SettingWidget *
+        checkbox(const QString &label, BoolSetting &setting);
+    [[nodiscard("Must use created setting widget")]] static SettingWidget *
+        inverseCheckbox(const QString &label, BoolSetting &setting);
+    [[nodiscard("Must use created setting widget")]] static SettingWidget *
+        customCheckbox(const QString &label, bool initialValue,
+                       const std::function<void(bool)> &save);
 
-    static SettingWidget *intInput(const QString &label, IntSetting &setting,
-                                   IntInputParams params);
-
-    template <typename T>
-    static SettingWidget *dropdown(const QString &label,
-                                   EnumStringSetting<T> &setting);
+    [[nodiscard("Must use created setting widget")]] static SettingWidget *
+        intInput(const QString &label, IntSetting &setting,
+                 IntInputParams params);
 
     template <typename T>
-    static SettingWidget *dropdown(const QString &label,
-                                   EnumSetting<T> &setting);
+    [[nodiscard("Must use created setting widget")]] static SettingWidget *
+        dropdown(const QString &label, EnumStringSetting<T> &setting);
 
-    static SettingWidget *colorButton(const QString &label,
-                                      QStringSetting &setting);
-    static SettingWidget *lineEdit(const QString &label,
-                                   QStringSetting &setting,
-                                   const QString &placeholderText = {});
+    template <typename T>
+    [[nodiscard("Must use created setting widget")]] static SettingWidget *
+        dropdown(const QString &label, EnumSetting<T> &setting);
 
-    static SettingWidget *fontButton(const QString &label,
-                                     QStringSetting &familySetting,
-                                     std::function<QFont()> currentFont,
-                                     std::function<void(QFont)> onChange);
+    [[nodiscard("Must use created setting widget")]] static SettingWidget *
+        colorButton(const QString &label, QStringSetting &setting);
+    [[nodiscard("Must use created setting widget")]] static SettingWidget *
+        lineEdit(const QString &label, QStringSetting &setting,
+                 const QString &placeholderText = {});
 
-    SettingWidget *setTooltip(QString tooltip);
-    SettingWidget *setDescription(const QString &text);
+    [[nodiscard("Must use created setting widget")]] static SettingWidget *
+        fontButton(const QString &label, QStringSetting &familySetting,
+                   std::function<QFont()> currentFont,
+                   std::function<void(QFont)> onChange);
+
+    [[nodiscard("Must use created setting widget")]] SettingWidget *setTooltip(
+        QString tooltip);
+    [[nodiscard("Must use created setting widget")]] SettingWidget *
+        setDescription(const QString &text);
 
     /// Add extra keywords to the widget
     ///
     /// All text from the tooltip, description, and label are already keywords
-    SettingWidget *addKeywords(const QStringList &newKeywords);
+    [[nodiscard("Must use created setting widget")]] SettingWidget *addKeywords(
+        const QStringList &newKeywords);
 
-    SettingWidget *conditionallyEnabledBy(BoolSetting &setting);
+    [[nodiscard("Must use created setting widget")]] SettingWidget *
+        conditionallyEnabledBy(BoolSetting &setting);
 
     void addTo(GeneralPageView &view);
     void addTo(GeneralPageView &view, QFormLayout *formLayout);


### PR DESCRIPTION
this PR cleans up some includes, and converts all remaining addCheckbox usages to use SettingWidget.

Additionally, I've added `[[nodiscard]]` to all SettingWidget creators, meaning your IDE will scream at you if you don't use `addTo` at the end of the builder pattern