### PR TITLE
fix(plugins): check websocket callbacks before calling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Minor: Add an option for the reduced opacity of message history. (#6121)
 - Minor: Make paused chat indicator more visible, and fix its zoom behavior. (#6123)
 - Minor: Added interactive REPL for plugins. (#6120)
-- Minor: Added WebSocket API for plugins. (#6076, #6186)
+- Minor: Added WebSocket API for plugins. (#6076, #6186, #6314)
 - Minor: Allow for themes to set transparent values for window background on Linux. (#6137)
 - Minor: Popup overlay now only draws an outline when being interacted with. (#6140)
 - Minor: Made filters searchable in the Settings dialog search bar. (#5890)

--- a/src/controllers/plugins/api/WebSocket.cpp
+++ b/src/controllers/plugins/api/WebSocket.cpp
@@ -144,7 +144,10 @@ void WebSocketListenerProxy::onClose(std::unique_ptr<WebSocketListener> self)
             auto cb = std::move(strong->onClose);
             strong->onText.reset();
             strong->onBinary.reset();
-            loggedVoidCall(cb, u"WebSocket.on_close", strong->plugin);
+            if (cb)
+            {
+                loggedVoidCall(cb, u"WebSocket.on_close", strong->plugin);
+            }
         }
     });
 }
@@ -154,7 +157,7 @@ void WebSocketListenerProxy::onTextMessage(QByteArray data)
     auto target = this->target;
     runInGuiThread([target, data{std::move(data)}] {
         auto strong = target.lock();
-        if (strong)
+        if (strong && strong->onText)
         {
             loggedVoidCall(strong->onText, u"WebSocket.on_text", strong->plugin,
                            data);
@@ -167,7 +170,7 @@ void WebSocketListenerProxy::onBinaryMessage(QByteArray data)
     auto target = this->target;
     runInGuiThread([target, data{std::move(data)}] {
         auto strong = target.lock();
-        if (strong)
+        if (strong && strong->onBinary)
         {
             loggedVoidCall(strong->onBinary, u"WebSocket.on_binary",
                            strong->plugin, data);

--- a/tests/src/Plugins.cpp
+++ b/tests/src/Plugins.cpp
@@ -816,4 +816,27 @@ TEST_F(PluginTest, testWebSocketApi)
     ASSERT_TRUE(ok);
 }
 
+TEST_F(PluginTest, testWebSocketUnsetFns)
+{
+    configure({PluginPermission{{{"type", "Network"}}}});
+
+    RequestWaiter waiter;
+    lua->set("done", [&] {
+        waiter.requestDone();
+    });
+
+    lua->script(R"lua(
+        local ws = c2.WebSocket.new("wss://127.0.0.1:9050/echo")
+        ws.on_close = function()
+            done()
+        end
+        ws:send_text("message1")
+        ws:send_text("message2")
+        ws:send_binary("message3")
+        ws:send_binary("/CLOSE")
+    )lua");
+
+    waiter.waitForRequest();
+}
+
 #endif


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
If the callbacks for WebSockets are unset, then they can't be called and Chatterino would segfault (I wonder why sol doesn't check for this). This adds a check that the callbacks are actually set before calling them. 