### PR TITLE
fix(OnceFlag): add `isSet` and check before waiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@
 - Dev: Refactored `Button` and friends. (#6102, #6255, #6266, #6302, #6268)
 - Dev: Made Settings & Account button on Linux/macOS SVGs. (#6267)
 - Dev: Emoji style / set is now stored lowercase (and matched case-insensitively). Changing emoji style from this point on and then running an old version might mean you will use the Twitter emoji style by default. (#6300)
-- Dev: `OnceFlag`'s internal flag is now atomic. (#6237)
+- Dev: Refactored `OnceFlag`. (#6237, #6316)
 - Dev: Bumped clang-format requirement to 19. (#6236)
 
 ## 2.5.3

--- a/src/util/OnceFlag.cpp
+++ b/src/util/OnceFlag.cpp
@@ -16,6 +16,10 @@ void OnceFlag::set()
 bool OnceFlag::waitFor(std::chrono::milliseconds ms)
 {
     std::unique_lock lock(this->mutex);
+    if (this->flag.load(std::memory_order::relaxed))
+    {
+        return true;
+    }
     return this->condvar.wait_for(lock, ms, [this] {
         return this->flag.load(std::memory_order::relaxed);
     });
@@ -24,9 +28,19 @@ bool OnceFlag::waitFor(std::chrono::milliseconds ms)
 void OnceFlag::wait()
 {
     std::unique_lock lock(this->mutex);
+    if (this->flag.load(std::memory_order::relaxed))
+    {
+        return;
+    }
     this->condvar.wait(lock, [this] {
         return this->flag.load(std::memory_order::relaxed);
     });
+}
+
+bool OnceFlag::isSet()
+{
+    std::unique_lock lock(this->mutex);
+    return this->flag.load(std::memory_order::relaxed);
 }
 
 }  // namespace chatterino

--- a/src/util/OnceFlag.hpp
+++ b/src/util/OnceFlag.hpp
@@ -31,6 +31,9 @@ public:
     /// The calling thread will be suspended during the wait.
     void wait();
 
+    /// Is the flag currently set?
+    bool isSet();
+
 private:
     std::mutex mutex;
     std::condition_variable condvar;

--- a/tests/src/OnceFlag.cpp
+++ b/tests/src/OnceFlag.cpp
@@ -79,10 +79,31 @@ TEST(OnceFlag, waitForTimeout)
     });
 
     startedFlag.wait();
+    ASSERT_TRUE(startedFlag.isSet());
     startedAckFlag.set();
+    ASSERT_TRUE(startedAckFlag.isSet());
 
     ASSERT_FALSE(stoppedFlag.waitFor(std::chrono::milliseconds{25}));
     stoppedFlag.wait();
+    ASSERT_TRUE(stoppedFlag.isSet());
 
     t.join();
+}
+
+TEST(OnceFlag, alreadySet)
+{
+    OnceFlag flag;
+    flag.set();
+    ASSERT_TRUE(flag.isSet());
+
+    auto start = std::chrono::system_clock::now();
+    flag.wait();
+    auto stop = std::chrono::system_clock::now();
+    ASSERT_LT(stop - start, std::chrono::milliseconds{10});
+
+    start = std::chrono::system_clock::now();
+    ASSERT_TRUE(flag.waitFor(std::chrono::milliseconds{0}));
+    stop = std::chrono::system_clock::now();
+
+    ASSERT_LT(stop - start, std::chrono::milliseconds{10});
 }


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

This does two things to `OnceFlag`:

- Adds checks to `wait`/`waitFor` to check if the flag is already set. The callback passed to the condition variable is only executed when the variable is (potentially spuriously) notified. We need to take the mutex before to avoid a lost-update (e.g. T1: check; T2: set & notify; T1: wait [missed wakeup]).
- Adds a convenience `isSet` method to check if the flag is set. This is equivalent to `wait(0ms)`.