### PR TITLE
fix: elide user notes

### DIFF
--- a/src/widgets/Label.cpp
+++ b/src/widgets/Label.cpp
@@ -33,6 +33,11 @@ void Label::setText(const QString &text)
     if (this->text_ != text)
     {
         this->text_ = text;
+        if (this->shouldElide_)
+        {
+            this->updateElidedText(this->getFontMetrics(),
+                                   this->getWidthWithoutOffset());
+        }
         this->updateSize();
         this->update();
     }
@@ -76,33 +81,40 @@ void Label::setWordWrap(bool wrap)
     this->update();
 }
 
+void Label::setShouldElide(bool shouldElide)
+{
+    this->shouldElide_ = shouldElide;
+    this->updateSize();
+    this->update();
+}
+
 void Label::setFontStyle(FontStyle style)
 {
     this->fontStyle_ = style;
     this->updateSize();
 }
 
-void Label::scaleChangedEvent(float scale)
+void Label::scaleChangedEvent(float /*scale*/)
 {
     this->updateSize();
 }
 
 QSize Label::sizeHint() const
 {
-    return this->preferedSize_;
+    return this->sizeHint_;
 }
 
 QSize Label::minimumSizeHint() const
 {
-    return this->preferedSize_;
+    return this->minimumSizeHint_;
 }
 
-void Label::paintEvent(QPaintEvent *)
+void Label::paintEvent(QPaintEvent * /*event*/)
 {
     QPainter painter(this);
 
-    auto metrics = getApp()->getFonts()->getFontMetrics(this->getFontStyle(),
-                                                        this->scale());
+    auto metrics = this->getFontMetrics();
+
     painter.setFont(
         getApp()->getFonts()->getFont(this->getFontStyle(), this->scale()));
 
@@ -111,7 +123,16 @@ void Label::paintEvent(QPaintEvent *)
     // draw text
     QRect textRect(offset, 0, this->width() - offset - offset, this->height());
 
-    int width = static_cast<int>(metrics.horizontalAdvance(this->text_));
+    auto text = [this] {
+        if (this->shouldElide_)
+        {
+            return this->elidedText_;
+        }
+
+        return this->text_;
+    }();
+
+    int width = static_cast<int>(metrics.horizontalAdvance(text));
     Qt::Alignment alignment = !this->centered_ || width > textRect.width()
                                   ? Qt::AlignLeft | Qt::AlignVCenter
                                   : Qt::AlignCenter;
@@ -127,30 +148,85 @@ void Label::paintEvent(QPaintEvent *)
     {
         option.setWrapMode(QTextOption::NoWrap);
     }
-    painter.drawText(textRect, this->text_, option);
+    painter.drawText(textRect, text, option);
 
 #if 0
-    painter.setPen(QColor(255, 0, 0));
-    painter.drawRect(0, 0, this->width() - 1, this->height() - 1);
+        painter.setPen(QColor(255, 0, 0));
+        painter.drawRect(0, 0, this->width() - 1, this->height() - 1);
 #endif
+}
+
+void Label::resizeEvent(QResizeEvent *event)
+{
+    if (this->shouldElide_)
+    {
+        auto metrics = this->getFontMetrics();
+        if (this->updateElidedText(metrics, this->getWidthWithoutOffset()))
+        {
+            this->update();
+        }
+    }
+
+    BaseWidget::resizeEvent(event);
+}
+
+QFontMetricsF Label::getFontMetrics() const
+{
+    return getApp()->getFonts()->getFontMetrics(this->fontStyle_,
+                                                this->scale());
+}
+
+qreal Label::getWidthWithoutOffset() const
+{
+    if (this->hasOffset_)
+    {
+        return this->width() - this->getOffset() - this->getOffset();
+    }
+
+    return this->width();
 }
 
 void Label::updateSize()
 {
-    auto metrics =
-        getApp()->getFonts()->getFontMetrics(this->fontStyle_, this->scale());
+    auto metrics = this->getFontMetrics();
 
-    auto width =
-        metrics.horizontalAdvance(this->text_) + (2 * this->getOffset());
-    auto height = metrics.height();
-    this->preferedSize_ = QSizeF(width, height).toSize();
+    if (this->shouldElide_)
+    {
+        auto height = metrics.height();
+        this->updateElidedText(metrics, this->getWidthWithoutOffset());
+        this->sizeHint_ = QSizeF(-1, height).toSize();
+        this->minimumSizeHint_ = this->sizeHint_;
+    }
+    else
+    {
+        auto width =
+            metrics.horizontalAdvance(this->text_) + (2 * this->getOffset());
+        auto height = metrics.height();
+        this->sizeHint_ = QSizeF(width, height).toSize();
+        this->minimumSizeHint_ = this->sizeHint_;
+    }
 
     this->updateGeometry();
 }
 
-int Label::getOffset()
+int Label::getOffset() const
 {
     return this->hasOffset_ ? int(8 * this->scale()) : 0;
+}
+
+bool Label::updateElidedText(const QFontMetricsF &fontMetrics, qreal width)
+{
+    assert(this->shouldElide_ == true);
+    auto elidedText = fontMetrics.elidedText(
+        this->text_, Qt::TextElideMode::ElideRight, width);
+
+    if (elidedText != this->elidedText_)
+    {
+        this->elidedText_ = elidedText;
+        return true;
+    }
+
+    return false;
 }
 
 }  // namespace chatterino

--- a/src/widgets/Label.hpp
+++ b/src/widgets/Label.hpp
@@ -5,6 +5,8 @@
 
 #include <pajlada/signals/signalholder.hpp>
 
+class QFontMetricsF;
+
 namespace chatterino {
 
 class Label : public BaseWidget
@@ -30,23 +32,45 @@ public:
     bool getWordWrap() const;
     void setWordWrap(bool wrap);
 
+    /// Sets whether the text should elide if there's not enough room to
+    /// render the current text.
+    ///
+    /// When using text eliding, you should most likely set the horizontal size policy to Minimum
+    void setShouldElide(bool shouldElide);
+
 protected:
     void scaleChangedEvent(float scale_) override;
     void paintEvent(QPaintEvent *) override;
+    void resizeEvent(QResizeEvent *event) override;
 
     QSize sizeHint() const override;
     QSize minimumSizeHint() const override;
 
 private:
     void updateSize();
-    int getOffset();
+    int getOffset() const;
+
+    /// Returns the current font style's font metric based on the current scale.
+    QFontMetricsF getFontMetrics() const;
+
+    /// Returns the width of this widget, with the offset calculated out if the offset is enabled.
+    qreal getWidthWithoutOffset() const;
+
+    /// Calculate the new elided text based on text_
+    ///
+    /// Return true if the elided text changed
+    bool updateElidedText(const QFontMetricsF &fontMetrics, qreal width);
 
     QString text_;
     FontStyle fontStyle_;
-    QSize preferedSize_;
+    QSize sizeHint_;
+    QSize minimumSizeHint_;
     bool centered_ = false;
     bool hasOffset_ = true;
     bool wordWrap_ = false;
+    bool shouldElide_ = false;
+    /// The text, but elided. Only set if shouldElide_ is true
+    QString elidedText_;
 
     pajlada::Signals::SignalHolder connections_;
 };

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -490,6 +490,8 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically, Split *split)
 
     auto notesPreview = layout.emplace<Label>().assign(&ui_.notesPreview);
     notesPreview->setVisible(false);
+    notesPreview->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
+    notesPreview->setShouldElide(true);
 
     auto lineMod = layout.emplace<Line>(false);
 
@@ -1143,10 +1145,6 @@ void UserInfoPopup::updateNotes()
     static QRegularExpression spaceRegex{"\\s+"};
 
     auto previewText = "Notes: " + userData->notes.replace(spaceRegex, " ");
-    if (previewText.length() > NOTES_PREVIEW_LENGTH)
-    {
-        previewText = previewText.left(NOTES_PREVIEW_LENGTH - 3) + "...";
-    }
 
     this->ui_.notesPreview->setText(previewText);
     this->ui_.notesPreview->setVisible(true);


### PR DESCRIPTION
This PR adds support for basic text elision in the Label class.

I have not tested many of the options combined with text elision, only the default setup + text elision on or off.

Unrelated changes:
 - Label: Renamed `preferedSize_` to `sizeHint_`.
 - Label: Added a `minimumSizeHint_` param - I didn't end up using this but I'd like to play with it more.
 - Label: Added a `getFontMetrics` private method that returns the font metrics for the current font style & scale
 - Label: Added a `getWidthWithoutOffset` private method that returns the width we have to deal with when it comes to text rendering. I just didn't want to type width - offset - offset again.
