### PR TITLE
fix: set the app user model id when starting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 - Dev: Emoji style / set is now stored lowercase (and matched case-insensitively). Changing emoji style from this point on and then running an old version might mean you will use the Twitter emoji style by default. (#6300)
 - Dev: `OnceFlag`'s internal flag is now atomic. (#6237)
 - Dev: Bumped clang-format requirement to 19. (#6236)
+- Dev: On Windows, the App User Model ID is now explicitly set on startup (#6320).
 
 ## 2.5.3
 

--- a/src/singletons/Toasts.cpp
+++ b/src/singletons/Toasts.cpp
@@ -142,6 +142,13 @@ using WinToastLib::WinToast;
 using WinToastLib::WinToastTemplate;
 #endif
 
+Toasts::Toasts()
+{
+#ifdef Q_OS_WIN
+    this->ensureInitialized();
+#endif
+}
+
 Toasts::~Toasts()
 {
 #ifdef Q_OS_WIN

--- a/src/singletons/Toasts.hpp
+++ b/src/singletons/Toasts.hpp
@@ -16,6 +16,7 @@ enum class ToastReaction {
 class Toasts final
 {
 public:
+    Toasts();
     ~Toasts();
 
     void sendChannelNotification(const QString &channelName,


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
Currently, Windows groups my Chatterino7 and debug builds of Chatterino together, even though they have a different AUMID.

Chatterino already knows which AUMID it should have. So it should set this when starting (this PR).