### PR TITLE
chore: factor out AUMID creation

### DIFF
--- a/src/common/Version.cpp
+++ b/src/common/Version.cpp
@@ -36,6 +36,11 @@ Version::Version()
 
     this->generateBuildString();
     this->generateRunningString();
+
+#ifdef Q_OS_WIN
+    // keep in sync with .CI/chatterino-installer.iss
+    this->appUserModelID_ = L"ChatterinoTeam.Chatterino";
+#endif
 }
 
 const Version &Version::instance()
@@ -164,5 +169,12 @@ void Version::generateRunningString()
 
     this->runningString_ = s;
 }
+
+#ifdef Q_OS_WIN
+const std::wstring &Version::appUserModelID() const
+{
+    return this->appUserModelID_;
+}
+#endif
 
 }  // namespace chatterino

--- a/src/common/Version.hpp
+++ b/src/common/Version.hpp
@@ -2,6 +2,10 @@
 
 #include <QString>
 
+#ifdef Q_OS_WIN
+#    include <string>
+#endif
+
 namespace chatterino {
 
 /**
@@ -52,6 +56,13 @@ public:
     // Returns a string about the current running system
     const QString &runningString() const;
 
+#ifdef Q_OS_WIN
+    /// Chatterino's App ID on Windows
+    ///
+    /// See https://learn.microsoft.com/en-us/windows/win32/shell/appids
+    const std::wstring &appUserModelID() const;
+#endif
+
 private:
     Version();
 
@@ -69,6 +80,10 @@ private:
     QString runningString_;
     // Generate a running string (e.g. Running on Arch Linux, kernel 5.14.3) and store it in runningString_ for future use
     void generateRunningString();
+
+#ifdef Q_OS_WIN
+    std::wstring appUserModelID_;
+#endif
 };
 
 };  // namespace chatterino

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,7 +40,8 @@ int main(int argc, char **argv)
     QCoreApplication::setApplicationVersion(CHATTERINO_VERSION);
     QCoreApplication::setOrganizationDomain("chatterino.com");
 #ifdef Q_OS_WIN
-    SetCurrentProcessExplicitAppUserModelID(L"ChatterinoTeam.Chatterino");
+    SetCurrentProcessExplicitAppUserModelID(
+        Version::instance().appUserModelID().c_str());
 #endif
 
     std::unique_ptr<Paths> paths;

--- a/src/singletons/Toasts.cpp
+++ b/src/singletons/Toasts.cpp
@@ -285,8 +285,7 @@ void Toasts::ensureInitialized()
 
     auto *instance = WinToast::instance();
     instance->setAppName(L"Chatterino");
-    instance->setAppUserModelId(
-        WinToast::configureAUMI(L"ChatterinoTeam", L"Chatterino", L"", L""));
+    instance->setAppUserModelId(Version::instance().appUserModelID());
     if (!getSettings()->createShortcutForToasts)
     {
         instance->setShortcutPolicy(WinToast::SHORTCUT_POLICY_IGNORE);


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
From https://github.com/Chatterino/chatterino2/pull/6320#issuecomment-3041252899 - it's always bad to have the same string twice if you can avoid it.

This factors out the AUMID to be in `Version` instead of being created in `Toasts` as well as being spelled out in `main`.