### PR TITLE
fix: correctly override user color in sub gifts

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -440,6 +440,8 @@ set(SOURCE_FILES
         providers/twitch/TwitchUser.hpp
         providers/twitch/TwitchUsers.cpp
         providers/twitch/TwitchUsers.hpp
+        providers/twitch/UserColor.cpp
+        providers/twitch/UserColor.hpp
 
         providers/twitch/eventsub/Connection.cpp
         providers/twitch/eventsub/Connection.hpp

--- a/src/common/ChannelChatters.cpp
+++ b/src/common/ChannelChatters.cpp
@@ -112,7 +112,7 @@ size_t ChannelChatters::colorsSize() const
     return size;
 }
 
-const QColor ChannelChatters::getUserColor(const QString &user)
+QColor ChannelChatters::getUserColor(const QString &user) const
 {
     const auto chatterColors = this->chatterColors_.access();
 

--- a/src/common/ChannelChatters.hpp
+++ b/src/common/ChannelChatters.hpp
@@ -24,7 +24,7 @@ public:
     void addRecentChatter(const QString &user);
     void addJoinedUser(const QString &user, bool isMod, bool isBroadcaster);
     void addPartedUser(const QString &user, bool isMod, bool isBroadcaster);
-    const QColor getUserColor(const QString &user);
+    QColor getUserColor(const QString &user) const;
     void setUserColor(const QString &user, const QColor &color);
     void updateOnlineChatters(const std::unordered_set<QString> &usernames);
 

--- a/src/messages/MessageBuilder.hpp
+++ b/src/messages/MessageBuilder.hpp
@@ -240,7 +240,8 @@ public:
 
     static MessagePtrMut makeSubgiftMessage(const QString &text,
                                             const QVariantMap &tags,
-                                            const QTime &time);
+                                            const QTime &time,
+                                            TwitchChannel *channel);
 
     static MessagePtrMut makeMissingScopesMessage(const QString &missingScopes);
 

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -777,7 +777,7 @@ void IrcMessageHandler::parseUserNoticeMessageInto(Communi::IrcMessage *message,
             // subgifts are special because they include two users
             auto msg = MessageBuilder::makeSubgiftMessage(
                 parseTagString(messageText), tags,
-                calculateMessageTime(message).time());
+                calculateMessageTime(message).time(), channel);
 
             msg->flags.set(MessageFlag::Subscription);
             if (mirrored)

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -667,6 +667,8 @@ void IrcMessageHandler::parseUserNoticeMessageInto(Communi::IrcMessage *message,
                                                    MessageSink &sink,
                                                    TwitchChannel *channel)
 {
+    assert(channel != nullptr);
+
     auto tags = message->tags();
     auto parameters = message->parameters();
 

--- a/src/providers/twitch/UserColor.cpp
+++ b/src/providers/twitch/UserColor.cpp
@@ -1,0 +1,48 @@
+#include "providers/twitch/UserColor.hpp"
+
+#include "common/ChannelChatters.hpp"
+#include "controllers/userdata/UserDataController.hpp"
+#include "messages/MessageColor.hpp"
+
+namespace chatterino::twitch {
+
+std::optional<MessageColor> getUserColor(const GetUserColorParams &params)
+{
+    if (params.userDataController != nullptr)
+    {
+        if (!params.userID.isEmpty())
+        {
+            if (const auto &oUser =
+                    params.userDataController->getUser(params.userID))
+            {
+                const auto &user = *oUser;
+                if (user.color && user.color->isValid())
+                {
+                    return {*user.color};
+                }
+            }
+        }
+    }
+
+    if (params.color.isValid())
+    {
+        return {params.color};
+    }
+
+    if (params.channelChatters != nullptr)
+    {
+        if (!params.userLogin.isEmpty())
+        {
+            if (auto color =
+                    params.channelChatters->getUserColor(params.userLogin);
+                color.isValid())
+            {
+                return {color};
+            }
+        }
+    }
+
+    return std::nullopt;
+}
+
+}  // namespace chatterino::twitch

--- a/src/providers/twitch/UserColor.hpp
+++ b/src/providers/twitch/UserColor.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "messages/MessageColor.hpp"
+
+#include <QString>
+
+#include <optional>
+
+class QColor;
+
+namespace chatterino {
+
+class IUserDataController;
+class ChannelChatters;
+
+namespace twitch {
+
+struct GetUserColorParams {
+    QString userLogin;
+    QString userID;
+
+    const IUserDataController *userDataController{};
+    const ChannelChatters *channelChatters{};
+
+    QColor color;
+};
+
+/// Attempt to get the color of the user based on the provided parameters.
+///
+/// If there's a valid color for the given user ID in the user data controller, return it.
+/// If there's a valid `color` parameter, return it.
+/// If there's a valid color for the given user login in the channel chatters set, return it.
+/// Otherwise, return nullopt.
+std::optional<MessageColor> getUserColor(const GetUserColorParams &params);
+
+}  // namespace twitch
+}  // namespace chatterino

--- a/src/util/SampleData.cpp
+++ b/src/util/SampleData.cpp
@@ -104,6 +104,9 @@ const QStringList &getSampleSubMessages()
 
         // resub without message
         R"(@badges=subscriber/12;color=#CC00C2;display-name=cspice;emotes=;id=6fc4c3e0-ca61-454a-84b8-5669dee69fc9;login=cspice;mod=0;msg-id=resub;msg-param-months=12;msg-param-sub-plan-name=Channel\sSubscription\s(forsenlol):\s$9.99\sSub;msg-param-sub-plan=2000;room-id=22484632;subscriber=1;system-msg=cspice\sjust\ssubscribed\swith\sa\sTier\s2\ssub.\scspice\ssubscribed\sfor\s12\smonths\sin\sa\srow!;tmi-sent-ts=1528192510808;turbo=0;user-id=47894662;user-type= :tmi.twitch.tv USERNOTICE #pajlada)",
+
+        // pajlada gifted a sub to rustafur
+        R"(@tmi-sent-ts=1751793597378;subscriber=1;id=ac51c358-0525-468f-9e0f-e9f2b7953c29;room-id=11148817;user-id=11148817;login=pajlada;display-name=pajlada;badges=broadcaster/1,subscriber/3072,partner/1;badge-info=subscriber/114;color=#CC44FF;flags=;user-type=;emotes=;msg-param-sub-plan-name=look\sat\sthose\sshitty\semotes,\srip\s$5\sLUL;msg-param-gift-months=1;system-msg=pajlada\sgifted\sa\sTier\s1\ssub\sto\srustafur!;msg-param-months=6;msg-param-origin-id=4645652708379472175;msg-param-recipient-id=27787997;msg-param-sub-plan=1000;msg-id=subgift;msg-param-recipient-display-name=rustafur;msg-param-recipient-user-name=rustafur;msg-param-community-gift-id=4645652708379472175;msg-param-sender-count=0 :tmi.twitch.tv USERNOTICE #pajlada)",
     };
     return list;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -57,6 +57,7 @@ set(test_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/src/NativeMessaging.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/ImageUploader.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/TwitchChannel.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/TwitchUserColor.cpp
 
     ${CMAKE_CURRENT_LIST_DIR}/src/lib/Snapshot.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/lib/Snapshot.hpp

--- a/tests/snapshots/IrcMessageHandler/sub-gift-02.json
+++ b/tests/snapshots/IrcMessageHandler/sub-gift-02.json
@@ -1,0 +1,131 @@
+{
+    "input": "@tmi-sent-ts=1751793597378;subscriber=1;id=ac51c358-0525-468f-9e0f-e9f2b7953c29;room-id=11148817;user-id=11148817;login=pajlada;display-name=pajlada;badges=broadcaster/1,subscriber/3072,partner/1;badge-info=subscriber/114;color=#CC44FF;flags=;user-type=;emotes=;msg-param-sub-plan-name=look\\sat\\sthose\\sshitty\\semotes,\\srip\\s$5\\sLUL;msg-param-gift-months=1;system-msg=pajlada\\sgifted\\sa\\sTier\\s1\\ssub\\sto\\srustafur!;msg-param-months=6;msg-param-origin-id=4645652708379472175;msg-param-recipient-id=27787997;msg-param-sub-plan=1000;msg-id=subgift;msg-param-recipient-display-name=rustafur;msg-param-recipient-user-name=rustafur;msg-param-community-gift-id=4645652708379472175;msg-param-sender-count=0 :tmi.twitch.tv USERNOTICE #pajlada",
+    "output": [
+        {
+            "badgeInfos": {
+            },
+            "badges": [
+            ],
+            "channelName": "",
+            "count": 1,
+            "displayName": "",
+            "elements": [
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "TimestampMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "9:19"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "09:19:57",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "MentionElement",
+                    "userColor": "#ffcc44ff",
+                    "userLoginName": "pajlada",
+                    "words": [
+                        "pajlada"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "gifted",
+                        "a",
+                        "Tier",
+                        "1",
+                        "sub",
+                        "to"
+                    ]
+                },
+                {
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": false,
+                    "type": "MentionElement",
+                    "userColor": "#ffff00ff",
+                    "userLoginName": "rustafur",
+                    "words": [
+                        "rustafur"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "!"
+                    ]
+                }
+            ],
+            "flags": "System|DoNotTriggerNotification|Subscription",
+            "id": "",
+            "localizedName": "",
+            "loginName": "",
+            "messageText": "pajlada gifted a Tier 1 sub to rustafur!",
+            "searchText": "pajlada gifted a Tier 1 sub to rustafur!",
+            "serverReceivedTime": "",
+            "timeoutUser": "",
+            "userID": "",
+            "usernameColor": "#ff000000"
+        }
+    ],
+    "params": {
+        "userData": {
+            "27787997": {
+                "color": "#FF00FF"
+            }
+        }
+    }
+}

--- a/tests/src/IrcMessageHandler.cpp
+++ b/tests/src/IrcMessageHandler.cpp
@@ -576,6 +576,17 @@ TEST_P(TestIrcMessageHandlerP, Run)
 
     VectorMessageSink sink;
 
+    const auto &userData = snapshot->param("userData").toObject();
+    for (auto it = userData.begin(); it != userData.end(); ++it)
+    {
+        const auto &userID = it.key();
+        const auto &data = it.value().toObject();
+        if (auto color = data.value("color").toString(); !color.isEmpty())
+        {
+            this->mockApplication->getUserData()->setUserColor(userID, color);
+        }
+    }
+
     for (auto prevInput : snapshot->param("prevMessages").toArray())
     {
         auto *ircMessage = Communi::IrcMessage::fromData(

--- a/tests/src/TwitchUserColor.cpp
+++ b/tests/src/TwitchUserColor.cpp
@@ -1,8 +1,8 @@
 #include "common/ChannelChatters.hpp"
-#include "controllers/userdata/UserDataController.hpp"
 #include "mocks/BaseApplication.hpp"
 #include "mocks/Channel.hpp"
 #include "mocks/Logging.hpp"
+#include "mocks/UserData.hpp"
 #include "providers/twitch/UserColor.hpp"
 #include "Test.hpp"
 
@@ -33,8 +33,7 @@ protected:
     void SetUp() override
     {
         this->app = std::make_unique<MockApplication>();
-        this->userDataController =
-            std::make_unique<UserDataController>(this->app->getPaths());
+        this->userDataController = std::make_unique<mock::UserDataController>();
         this->channel = std::make_unique<mock::MockChannel>("test");
         this->chatters = std::make_unique<ChannelChatters>(*this->channel);
     }
@@ -48,7 +47,7 @@ protected:
     }
 
     std::unique_ptr<MockApplication> app;
-    std::unique_ptr<UserDataController> userDataController;
+    std::unique_ptr<mock::UserDataController> userDataController;
     std::unique_ptr<mock::MockChannel> channel;
     std::unique_ptr<ChannelChatters> chatters;
 };
@@ -127,7 +126,7 @@ TEST_F(TwitchUserColor, UCD)
 
     chatters->setUserColor("pajlada", QColor("#FF0000"));
 
-    // userDataController->setUserColor("11148817", "#0000FF");
+    userDataController->setUserColor("11148817", "#0000FF");
 
     ASSERT_EQ(getUserColor({
                   .userLogin = "pajlada",

--- a/tests/src/TwitchUserColor.cpp
+++ b/tests/src/TwitchUserColor.cpp
@@ -1,0 +1,142 @@
+#include "common/ChannelChatters.hpp"
+#include "controllers/userdata/UserDataController.hpp"
+#include "mocks/BaseApplication.hpp"
+#include "mocks/Channel.hpp"
+#include "mocks/Logging.hpp"
+#include "providers/twitch/UserColor.hpp"
+#include "Test.hpp"
+
+#include <QString>
+
+namespace chatterino::twitch {
+
+namespace {
+
+class MockApplication : public mock::BaseApplication
+{
+public:
+    MockApplication() = default;
+
+    ILogging *getChatLogger() override
+    {
+        return &this->logging;
+    }
+
+    mock::EmptyLogging logging;
+};
+
+}  // namespace
+
+class TwitchUserColor : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        this->app = std::make_unique<MockApplication>();
+        this->userDataController =
+            std::make_unique<UserDataController>(this->app->getPaths());
+        this->channel = std::make_unique<mock::MockChannel>("test");
+        this->chatters = std::make_unique<ChannelChatters>(*this->channel);
+    }
+
+    void TearDown() override
+    {
+        this->chatters.reset();
+        this->channel.reset();
+        this->userDataController.reset();
+        this->app.reset();
+    }
+
+    std::unique_ptr<MockApplication> app;
+    std::unique_ptr<UserDataController> userDataController;
+    std::unique_ptr<mock::MockChannel> channel;
+    std::unique_ptr<ChannelChatters> chatters;
+};
+
+TEST_F(TwitchUserColor, NoDataForUser)
+{
+    ASSERT_EQ(getUserColor({
+                  .userLogin = "pajlada",
+                  .userID = "11148817",
+                  .userDataController = userDataController.get(),
+                  .channelChatters = chatters.get(),
+                  .color = {},
+              }),
+              std::nullopt);
+}
+
+TEST_F(TwitchUserColor, ChannelChattersData)
+{
+    // User exists in channel chatters.
+    // Their color should be fetched from there.
+
+    chatters->setUserColor("pajlada", QColor("#FF0000"));
+
+    ASSERT_EQ(getUserColor({
+                  .userLogin = "pajlada",
+                  .userID = "11148817",
+                  .userDataController = userDataController.get(),
+                  .channelChatters = chatters.get(),
+                  .color = {},
+              }),
+              QColor("#FF0000"));
+}
+
+TEST_F(TwitchUserColor, ChannelChattersDataButBaseColor)
+{
+    // User exists in channel chatters
+    // The base color is valid and should be used.
+
+    chatters->setUserColor("pajlada", QColor("#FF0000"));
+
+    ASSERT_EQ(getUserColor({
+                  .userLogin = "pajlada",
+                  .userID = "11148817",
+                  .userDataController = userDataController.get(),
+                  .channelChatters = chatters.get(),
+                  .color = QColor("#00FF00"),
+              }),
+              QColor("#00FF00"));
+}
+
+TEST_F(TwitchUserColor, ChannelChattersDataButBaseColorInvalid)
+{
+    // User exists in channel chatters
+    // A base color has been defined but it's invalid
+    // The channel chatter color should be used
+
+    ASSERT_EQ(0, chatters->colorsSize());
+    chatters->setUserColor("pajlada", QColor("#FF0000"));
+
+    ASSERT_EQ(getUserColor({
+                  .userLogin = "pajlada",
+                  .userID = "11148817",
+                  .userDataController = userDataController.get(),
+                  .channelChatters = chatters.get(),
+                  .color = QColor("this is an invalid color"),
+              }),
+              QColor("#FF0000"));
+}
+
+TEST_F(TwitchUserColor, UCD)
+{
+    // User exists in channel chatters
+    // A base color has been defined
+    // User exists in user data controller
+    // The user data controller color should be used
+
+    chatters->setUserColor("pajlada", QColor("#FF0000"));
+
+    // userDataController->setUserColor("11148817", "#0000FF");
+
+    ASSERT_EQ(getUserColor({
+                  .userLogin = "pajlada",
+                  .userID = "11148817",
+                  .userDataController = userDataController.get(),
+                  .channelChatters = chatters.get(),
+                  .color = QColor("#00FF00"),
+              }),
+              QColor("#0000FF"));
+}
+
+}  // namespace chatterino::twitch


### PR DESCRIPTION
This PR adds a helper function to figure out what color a user should have.

It reads from these sources, in order
1. UserDataController
2. A custom provided color
3. From ChannelChatters

I've also added some tests, including some IRCMessageHandler snapshot tests to support testing this a bit

Works towards fixing https://github.com/Chatterino/chatterino2/issues/6313 but doesn't actually fix it
