### PR TITLE
fix: allow messages of just dots

### DIFF
--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -66,7 +66,8 @@ namespace detail {
 bool isUnknownCommand(const QString &text)
 {
     static QRegularExpression isUnknownCommand(
-        R"(^(?:\.|\/)(?!me\s|\s))", QRegularExpression::CaseInsensitiveOption);
+        R"(^(?:\.(?!\.|$)|\/)(?!me\s|\s))",
+        QRegularExpression::CaseInsensitiveOption);
 
     auto match = isUnknownCommand.match(text);
 

--- a/tests/src/TwitchChannel.cpp
+++ b/tests/src/TwitchChannel.cpp
@@ -20,6 +20,27 @@ TEST(TwitchChannelDetail_isUnknownCommand, good)
         ". .hello",
         "/ .hello",
         ". /hello",
+        ".", // this results in an empty message but not in an error (twitchdev/issues#1019)
+        "/me",
+        ".me",
+        "..",
+        "...",
+        "....",
+        "",
+        "foo",
+        "a",
+        "!",
+        ". .",
+        ". ..",
+        ".. ..",
+        ".. .",
+        "/ /",
+        "/ .",
+        ". /",
+        ". ./",
+        ".. /",
+        ".. me",
+        ". me",
     };
     // clang-format on
 
@@ -40,6 +61,14 @@ TEST(TwitchChannelDetail_isUnknownCommand, bad)
         ".badcommand hello",
         "/@badcommand hello",
         ".@badcommand hello",
+        "//",
+        "./",
+        "./me",
+        "./w",
+        "/.",
+        "/.me",
+        "/.w",
+        "/,me",
     };
     // clang-format on
 


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
`..` is fine and `...` too, so allow it.

It also adds a few more test messages.