### PR TITLE
fix(clang-cl): reduce warnings in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 - Dev: Refactored `OnceFlag`. (#6237, #6316)
 - Dev: Bumped clang-format requirement to 19. (#6236)
 - Dev: Factored out AUMID to `Version`. (#6321)
+- Dev: Silenced some warnings when compiling with clang-cl. (#6331)
 
 ## 2.5.3
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -94,6 +94,17 @@ if(CHATTERINO_TEST_USE_PUBLIC_HTTPBIN)
     target_compile_definitions(${PROJECT_NAME} PRIVATE CHATTERINO_TEST_USE_PUBLIC_HTTPBIN)
 endif()
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
+    # The warnings are stateful, options from target_compile_options get placed
+    # before the cxx flags. /W4 enables the initializer warnings.
+    string(REGEX REPLACE "/W4\\b" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+    target_compile_options(${PROJECT_NAME} PRIVATE
+        /W4
+        -Wno-missing-designated-field-initializers
+        -Wno-missing-field-initializers
+    )
+endif()
+
 set_target_properties(${PROJECT_NAME}
     PROPERTIES
     AUTORCC ON

--- a/tests/src/ChatterSet.cpp
+++ b/tests/src/ChatterSet.cpp
@@ -38,7 +38,7 @@ TEST(ChatterSet, MaxSize)
     EXPECT_TRUE(set.contains("Pajlada"));
 
     // After adding CHATTER_LIMIT-1 additional chatters, pajlada should still be in the set
-    for (auto i = 0; i < ChatterSet::CHATTER_LIMIT - 1; ++i)
+    for (size_t i = 0; i < ChatterSet::CHATTER_LIMIT - 1; ++i)
     {
         set.addRecentChatter(QString("%1").arg(i));
     }
@@ -65,7 +65,7 @@ TEST(ChatterSet, MaxSizeLastUsed)
     EXPECT_TRUE(set.contains("Pajlada"));
 
     // After adding CHATTER_LIMIT-1 additional chatters, pajlada should still be in the set
-    for (auto i = 0; i < ChatterSet::CHATTER_LIMIT - 1; ++i)
+    for (size_t i = 0; i < ChatterSet::CHATTER_LIMIT - 1; ++i)
     {
         set.addRecentChatter(QString("%1").arg(i));
     }
@@ -77,7 +77,7 @@ TEST(ChatterSet, MaxSizeLastUsed)
     set.addRecentChatter("pajlada");
 
     // After another CHATTER_LIMIT-1 additional chatters, pajlada should still be there
-    for (auto i = 0; i < ChatterSet::CHATTER_LIMIT - 1; ++i)
+    for (size_t i = 0; i < ChatterSet::CHATTER_LIMIT - 1; ++i)
     {
         set.addRecentChatter(QString("new-%1").arg(i));
     }

--- a/tests/src/TwitchPubSubClient.cpp
+++ b/tests/src/TwitchPubSubClient.cpp
@@ -220,7 +220,7 @@ TEST(TwitchPubSubClient, ExceedTopicLimit)
     ASSERT_EQ(pubSub.diag.connectionsFailed, 0);
     ASSERT_EQ(pubSub.diag.messagesReceived, 0);
 
-    for (auto i = 0; i < PubSubClient::MAX_LISTENS; ++i)
+    for (size_t i = 0; i < PubSubClient::MAX_LISTENS; ++i)
     {
         pubSub.listenToChannelPointRewards(QString("1%1").arg(i));
     }
@@ -231,7 +231,7 @@ TEST(TwitchPubSubClient, ExceedTopicLimit)
     ASSERT_EQ(pubSub.diag.connectionsClosed, 0);
     ASSERT_EQ(pubSub.diag.connectionsFailed, 0);
 
-    for (auto i = 0; i < PubSubClient::MAX_LISTENS; ++i)
+    for (size_t i = 0; i < PubSubClient::MAX_LISTENS; ++i)
     {
         pubSub.listenToChannelPointRewards(QString("2%1").arg(i));
     }
@@ -261,7 +261,7 @@ TEST(TwitchPubSubClient, ExceedTopicLimitSingleStep)
     ASSERT_EQ(pubSub.diag.connectionsFailed, 0);
     ASSERT_EQ(pubSub.diag.messagesReceived, 0);
 
-    for (auto i = 0; i < PubSubClient::MAX_LISTENS * 2; ++i)
+    for (size_t i = 0; i < PubSubClient::MAX_LISTENS * 2; ++i)
     {
         pubSub.listenToChannelPointRewards("123456");
     }


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

clang-cl was quite vocal when compiling the tests. For Clang in GNU mode and GCC, these warnings are disabled project wide. I think we can eventually enable them (I'm probably one of the few people using clang-cl to compile Chatterino and I can live with that - just not for the tests).