### PR TITLE
fix: Fix a crash that would occur on exit if a ping sound played recently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@
 - Bugfix: Fixed a crash that could occur when eventsub was enabled and Chatterino was attached to a conhost on Windows that was later gone. (#6161)
 - Bugfix: Fixed a crash that could occur an eventsub connection's keepalive timer would run after the connection was dead, causing the keepalive timer to use-itself-after-free. (#6204)
 - Bugfix: Fixed a crash that could occur when an image started loading mid app shutdown. (#6213)
-- Bugfix: Fixed a crash that would occur on exit if a ping played less than 30 seconds prior. (#6332)
+- Bugfix: Fixed a crash that could occur on exit if a ping played less than 30 seconds prior. (#6332)
 - Bugfix: Fixed notebook buttons (settings, account switcher, streamer mode) not performing a relayout when their visibility changed, causing a gap until resize. Linux / macOS only. (#6328)
 - Bugfix: Fixed some minor typos. (#6196)
 - Bugfix: Fixed inconsistent spaces in messages when using fractional scaling. (#6231, #6254)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Bugfix: Fixed a crash that could occur when eventsub was enabled and Chatterino was attached to a conhost on Windows that was later gone. (#6161)
 - Bugfix: Fixed a crash that could occur an eventsub connection's keepalive timer would run after the connection was dead, causing the keepalive timer to use-itself-after-free. (#6204)
 - Bugfix: Fixed a crash that could occur when an image started loading mid app shutdown. (#6213)
+- Bugfix: Fixed a crash that could occur if a ping played within 30 seconds of the user shutting down Chatterino. (#6332)
 - Bugfix: Fixed notebook buttons (settings, account switcher, streamer mode) not performing a relayout when their visibility changed, causing a gap until resize. Linux / macOS only. (#6328)
 - Bugfix: Fixed some minor typos. (#6196)
 - Bugfix: Fixed inconsistent spaces in messages when using fractional scaling. (#6231, #6254)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@
 - Bugfix: Fixed a crash that could occur when eventsub was enabled and Chatterino was attached to a conhost on Windows that was later gone. (#6161)
 - Bugfix: Fixed a crash that could occur an eventsub connection's keepalive timer would run after the connection was dead, causing the keepalive timer to use-itself-after-free. (#6204)
 - Bugfix: Fixed a crash that could occur when an image started loading mid app shutdown. (#6213)
-- Bugfix: Fixed a crash that could occur if a ping played within 30 seconds of the user shutting down Chatterino. (#6332)
+- Bugfix: Fixed a crash that would occur on exit if a ping played less than 30 seconds prior. (#6332)
 - Bugfix: Fixed notebook buttons (settings, account switcher, streamer mode) not performing a relayout when their visibility changed, causing a gap until resize. Linux / macOS only. (#6328)
 - Bugfix: Fixed some minor typos. (#6196)
 - Bugfix: Fixed inconsistent spaces in messages when using fractional scaling. (#6231, #6254)

--- a/src/controllers/sound/MiniaudioBackend.hpp
+++ b/src/controllers/sound/MiniaudioBackend.hpp
@@ -4,12 +4,18 @@
 #include "util/OnceFlag.hpp"
 #include "util/ThreadGuard.hpp"
 
-#include <boost/asio.hpp>
+#include <boost/asio/executor_work_guard.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/steady_timer.hpp>
 #include <QByteArray>
 #include <QString>
 #include <QUrl>
 
+#include <atomic>
+#include <chrono>
+#include <cstdint>
 #include <memory>
+#include <thread>
 #include <vector>
 
 struct ma_engine;
@@ -26,6 +32,15 @@ namespace chatterino {
  **/
 class MiniaudioBackend : public ISoundController
 {
+    enum class State : std::uint8_t {
+        Uninitialized,
+        Initialized,
+        Failed,
+        Stopping,
+    };
+
+    std::atomic<State> state{State::Uninitialized};
+
 public:
     MiniaudioBackend();
     ~MiniaudioBackend() override;
@@ -62,8 +77,6 @@ private:
     std::unique_ptr<std::thread> audioThread;
     OnceFlag stoppedFlag;
     boost::asio::steady_timer sleepTimer;
-
-    bool initialized{false};
 
     friend class Application;
 };


### PR DESCRIPTION
Tested on:
 - Arch Linux (btw) with Pipewire
 - Windows 11 in a VM

Both no longer output "Audio thread did not stop within 1 second" on exit, which could crash things as we detached the thread.