### PR TITLE
fix: don't detach threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 - Dev: Implemented customizable display names for enums. (#6238)
 - Dev: Refactored event API initialization away from Application and into TwitchIrcServer. (#6198)
 - Dev: Updated GoogleTest to v1.17.0. (#6180)
+- Dev: Don't detach threads. (#6333)
 - Dev: Mini refactor of `TwitchAccount`. (#6182)
 - Dev: Refactored away some `getApp` usages in `WindowManager`. (#6194)
 - Dev: Simplified string literals to be a re-export of Qt functions. (#6175)

--- a/src/controllers/sound/MiniaudioBackend.cpp
+++ b/src/controllers/sound/MiniaudioBackend.cpp
@@ -235,7 +235,6 @@ MiniaudioBackend::~MiniaudioBackend()
 
         qCWarning(chatterinoSound)
             << "Audio thread did not stop within 1 second";
-        this->audioThread->detach();
     }
 }
 

--- a/src/providers/liveupdates/BasicPubSubManager.hpp
+++ b/src/providers/liveupdates/BasicPubSubManager.hpp
@@ -175,9 +175,7 @@ public:
         }
 
         qCWarning(chatterinoLiveupdates)
-            << "Thread didn't finish after stopping, discard it";
-        // detach the thread so the destructor doesn't attempt any joining
-        this->mainThread_->detach();
+            << "Thread didn't finish after stopping";
     }
 
 protected:

--- a/src/providers/twitch/PubSubManager.cpp
+++ b/src/providers/twitch/PubSubManager.cpp
@@ -143,10 +143,7 @@ void PubSub::stop()
         return;
     }
 
-    qCWarning(chatterinoLiveupdates)
-        << "Thread didn't finish after stopping, discard it";
-    // detach the thread so the destructor doesn't attempt any joining
-    this->thread->detach();
+    qCWarning(chatterinoLiveupdates) << "Thread didn't finish after stopping";
 }
 
 void PubSub::listenToChannelPointRewards(const QString &channelID)


### PR DESCRIPTION
Previously, we would detach threads that did not exit in a reasonable
time, meaning they'd continue running and potentially accessing data
that had been freed, causing us to crash.
With this change, we _dont_ detach the thread, and let the thread
destructor do as it pleases (which will be terminating).
Neither solution is clean - old solution would sometimes work, but this
should give us a better indicator of where we're doing things wrong.

CC @Nerixyz

<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
