### PR TITLE
fix: Re-set SVG renderer aspect ratio after load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@
 - Dev: Simplified string literals to be a re-export of Qt functions. (#6175)
 - Dev: Fixed incorrect lua generation of static methods for typescript plugins. (#6190, #6223)
 - Dev: Merged top/bottom and left/right notebook layouts. (#6215)
-- Dev: Refactored `Button` and friends. (#6102, #6255, #6266, #6302, #6268)
+- Dev: Refactored `Button` and friends. (#6102, #6255, #6266, #6302, #6268, #6334)
 - Dev: Made Settings & Account button on Linux/macOS SVGs. (#6267)
 - Dev: Some more setting widget refactors. (#6317)
 - Dev: Emoji style / set is now stored lowercase (and matched case-insensitively). Changing emoji style from this point on and then running an old version might mean you will use the Twitter emoji style by default. (#6300)

--- a/src/widgets/buttons/SvgButton.cpp
+++ b/src/widgets/buttons/SvgButton.cpp
@@ -19,7 +19,7 @@ SvgButton::SvgButton(Src source, BaseWidget *parent, QSize padding)
 void SvgButton::setSource(Src source)
 {
     this->source_ = std::move(source);
-    this->svg_->load(this->currentSvgPath());
+    this->loadSource();
     this->invalidateContent();
 }
 
@@ -48,7 +48,7 @@ void SvgButton::themeChangedEvent()
     {
         return;
     }
-    this->svg_->load(this->currentSvgPath());
+    this->loadSource();
     this->invalidateContent();
 }
 
@@ -96,6 +96,12 @@ QString SvgButton::currentSvgPath() const
         return this->source_.light;
     }
     return this->source_.dark;
+}
+
+void SvgButton::loadSource()
+{
+    this->svg_->load(this->currentSvgPath());
+    this->svg_->setAspectRatioMode(Qt::KeepAspectRatio);
 }
 
 }  // namespace chatterino

--- a/src/widgets/buttons/SvgButton.hpp
+++ b/src/widgets/buttons/SvgButton.hpp
@@ -72,6 +72,8 @@ protected:
 private:
     [[nodiscard]] QString currentSvgPath() const;
 
+    void loadSource();
+
     Src source_;
     QSvgRenderer *svg_;
     QSize padding_;


### PR DESCRIPTION
The `QSvgRenderer::setAspectRatioMode` function only sets the aspect
ratio setting for the currently loaded SVG document.
https://github.com/qt/qtsvg/blob/29c3b512d9ca25941b18f7ee52ce8b80f003f3b4/src/svg/qsvgrenderer.cpp#L311-L320

When the theme changes, or we otherwise call load, this does not retain
our aspect ratio settings.
https://github.com/qt/qtsvg/blob/29c3b512d9ca25941b18f7ee52ce8b80f003f3b4/src/svg/qsvgrenderer.cpp#L412-L432

This means we need to ensure we re-set the SVG renderer's aspect ratio
after calling load.

<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
