### PR TITLE
chore: add some channel view layout commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
 - Dev: Bumped clang-format requirement to 19. (#6236)
 - Dev: Factored out AUMID to `Version`. (#6321)
 - Dev: Silenced some warnings when compiling with clang-cl. (#6331)
+- Dev: Added some commands for forcing a relayout (and related things) in channel views. (#6342)
 
 ## 2.5.3
 

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -462,6 +462,15 @@ CommandController::CommandController(const Paths &paths)
     this->registerCommand("/debug-force-image-unload",
                           &commands::forceImageUnload);
 
+    this->registerCommand("/debug-force-layout-channel-views",
+                          &commands::forceLayoutChannelViews);
+
+    this->registerCommand("/debug-increment-image-generation",
+                          &commands::incrementImageGeneration);
+
+    this->registerCommand("/debug-invalidate-buffers",
+                          &commands::invalidateBuffers);
+
     this->registerCommand("/debug-test", &commands::debugTest);
 
     this->registerCommand("/shield", &commands::shieldModeOn);

--- a/src/controllers/commands/builtin/chatterino/Debugging.cpp
+++ b/src/controllers/commands/builtin/chatterino/Debugging.cpp
@@ -140,7 +140,7 @@ QString forceImageUnload(const CommandContext &ctx)
     return "";
 }
 
-QString forceLayoutChannelViews(const CommandContext &ctx)
+QString forceLayoutChannelViews(const CommandContext & /*ctx*/)
 {
     getApp()->getWindows()->forceLayoutChannelViews();
     return {};

--- a/src/controllers/commands/builtin/chatterino/Debugging.cpp
+++ b/src/controllers/commands/builtin/chatterino/Debugging.cpp
@@ -146,7 +146,7 @@ QString forceLayoutChannelViews(const CommandContext & /*ctx*/)
     return {};
 }
 
-QString incrementImageGeneration(const CommandContext &ctx)
+QString incrementImageGeneration(const CommandContext & /*ctx*/)
 {
     getApp()->getWindows()->incGeneration();
     return {};

--- a/src/controllers/commands/builtin/chatterino/Debugging.cpp
+++ b/src/controllers/commands/builtin/chatterino/Debugging.cpp
@@ -14,6 +14,7 @@
 #include "providers/twitch/TwitchIrcServer.hpp"
 #include "singletons/Theme.hpp"
 #include "singletons/Toasts.hpp"
+#include "singletons/WindowManager.hpp"
 #include "util/PostToThread.hpp"
 
 #include <QApplication>
@@ -137,6 +138,24 @@ QString forceImageUnload(const CommandContext &ctx)
         iep.freeAll();
     });
     return "";
+}
+
+QString forceLayoutChannelViews(const CommandContext &ctx)
+{
+    getApp()->getWindows()->forceLayoutChannelViews();
+    return {};
+}
+
+QString incrementImageGeneration(const CommandContext &ctx)
+{
+    getApp()->getWindows()->incGeneration();
+    return {};
+}
+
+QString invalidateBuffers(const CommandContext &ctx)
+{
+    getApp()->getWindows()->invalidateChannelViewBuffers();
+    return {};
 }
 
 QString debugTest(const CommandContext &ctx)

--- a/src/controllers/commands/builtin/chatterino/Debugging.cpp
+++ b/src/controllers/commands/builtin/chatterino/Debugging.cpp
@@ -152,7 +152,7 @@ QString incrementImageGeneration(const CommandContext & /*ctx*/)
     return {};
 }
 
-QString invalidateBuffers(const CommandContext &ctx)
+QString invalidateBuffers(const CommandContext & /*ctx*/)
 {
     getApp()->getWindows()->invalidateChannelViewBuffers();
     return {};

--- a/src/controllers/commands/builtin/chatterino/Debugging.hpp
+++ b/src/controllers/commands/builtin/chatterino/Debugging.hpp
@@ -22,6 +22,12 @@ QString forceImageGarbageCollection(const CommandContext &ctx);
 
 QString forceImageUnload(const CommandContext &ctx);
 
+QString forceLayoutChannelViews(const CommandContext &ctx);
+
+QString incrementImageGeneration(const CommandContext &ctx);
+
+QString invalidateBuffers(const CommandContext &ctx);
+
 QString debugTest(const CommandContext &ctx);
 
 }  // namespace chatterino::commands

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -735,8 +735,8 @@ void ChannelView::layoutVisibleMessages(
 
             y += message->getHeight();
         }
+        this->bufferInvalidationQueued_ = false;
     }
-    this->bufferInvalidationQueued_ = false;
 
     if (redrawRequired)
     {


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

There is a bug where images won't show in some occasions and I don't know why (resizing won't show them - only when some image is loaded (I think) they're shown). To aid debugging, I added some commands to trigger relayouts/buffer invalidations. I couldn't reproduce this yet.

I also noticed that the buffer invalidation is reset outside the `if` in `ChannelView::layoutVisibleMessages` but it's only used inside the `if`. This was moved inside, but I don't expect this to make a significant difference.