### PR TITLE
fix: split header "add split" button inconsistency

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -613,6 +613,8 @@ set(SOURCE_FILES
         widgets/buttons/Button.hpp
         widgets/buttons/DimButton.cpp
         widgets/buttons/DimButton.hpp
+        widgets/buttons/DrawnButton.cpp
+        widgets/buttons/DrawnButton.hpp
         widgets/buttons/InitUpdateButton.cpp
         widgets/buttons/InitUpdateButton.hpp
         widgets/buttons/LabelButton.cpp

--- a/src/widgets/buttons/Button.cpp
+++ b/src/widgets/buttons/Button.cpp
@@ -148,6 +148,7 @@ void Button::enterEvent(QEvent * /*event*/)
     {
         this->mouseOver_ = true;
         this->update();
+        this->mouseOverUpdated();
     }
 }
 
@@ -157,6 +158,7 @@ void Button::leaveEvent(QEvent * /*event*/)
     {
         this->mouseOver_ = false;
         this->update();
+        this->mouseOverUpdated();
     }
 }
 

--- a/src/widgets/buttons/Button.hpp
+++ b/src/widgets/buttons/Button.hpp
@@ -183,6 +183,12 @@ protected:
     /// Queue up the click animation at the given position
     void addClickEffect(QPoint position);
 
+protected:
+    /// This is fired when the mouse over state changes
+    virtual void mouseOverUpdated()
+    {
+    }
+
 private:
     void onMouseEffectTimeout();
     void showMenu();

--- a/src/widgets/buttons/DrawnButton.cpp
+++ b/src/widgets/buttons/DrawnButton.cpp
@@ -1,0 +1,108 @@
+#include "widgets/buttons/DrawnButton.hpp"
+
+#include "singletons/Theme.hpp"
+
+#include <QPainter>
+
+namespace chatterino {
+
+DrawnButton::DrawnButton(Type type_, Options options, BaseWidget *parent)
+    : Button(parent)
+    , foreground(this->theme->messages.textColors.system)
+    , foregroundHover(this->theme->messages.textColors.regular)
+    , basePadding(options.padding)
+    , baseThickness(options.thickness)
+    , type(type_)
+{
+    this->setContentCacheEnabled(true);
+}
+
+void DrawnButton::setBackground(QColor color)
+{
+    this->background = color;
+    this->invalidateContent();
+}
+
+void DrawnButton::setBackgroundHover(QColor color)
+{
+    this->backgroundHover = color;
+    this->invalidateContent();
+}
+
+void DrawnButton::setForeground(QColor color)
+{
+    this->foreground = color;
+    this->invalidateContent();
+}
+
+void DrawnButton::setForegroundHover(QColor color)
+{
+    this->foregroundHover = color;
+    this->invalidateContent();
+}
+
+void DrawnButton::mouseOverUpdated()
+{
+    this->invalidateContent();
+}
+
+void DrawnButton::paintContent(QPainter &painter)
+{
+    QColor fg;
+    QColor bg;
+
+    if (this->mouseOver())
+    {
+        bg = this->backgroundHover;
+        fg = this->foregroundHover;
+    }
+    else
+    {
+        bg = this->background;
+        fg = this->foreground;
+    }
+
+    if (bg.isValid())
+    {
+        painter.fillRect(this->rect(), bg);
+    }
+
+    switch (this->type)
+    {
+        case Type::Plus: {
+            QPen pen;
+            pen.setColor(fg);
+            int thickness = std::max(
+                1,
+                static_cast<int>(std::round(
+                    static_cast<double>(this->baseThickness) * this->scale())));
+            pen.setWidth(thickness);
+            painter.setPen(pen);
+
+            auto innerSize = this->rect().size();
+            innerSize.setHeight(innerSize.width());
+            QRect inner;
+            inner.setSize(innerSize);
+            inner.moveCenter(this->rect().center());
+
+            int padding = static_cast<int>(
+                static_cast<float>(this->basePadding) * this->scale());
+
+            auto top = inner.top();
+            auto bottom = inner.bottom();
+            auto center = inner.center();
+            auto left = inner.left();
+            auto right = inner.right();
+
+            QLine vertical(center.x(), top + padding, center.x(),
+                           bottom - padding);
+            painter.drawLine(vertical);
+            QLine horizontal(left + padding, center.y(), right - padding,
+                             center.y());
+            painter.drawLine(horizontal);
+        }
+        break;
+    }
+}
+
+}  // namespace chatterino

--- a/src/widgets/buttons/DrawnButton.hpp
+++ b/src/widgets/buttons/DrawnButton.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "widgets/buttons/Button.hpp"
+
+#include <QWidget>
+
+#include <optional>
+
+namespace chatterino {
+
+class DrawnButton : public Button
+{
+    Q_OBJECT
+
+public:
+    enum class Type : std::uint8_t {
+        Plus,
+    };
+
+    struct Options {
+        int padding = 2;
+        int thickness = 1;
+    };
+
+    DrawnButton(Type type_, Options options, BaseWidget *parent);
+
+    void setBackground(QColor color);
+    void setBackgroundHover(QColor color);
+    void setForeground(QColor color);
+    void setForegroundHover(QColor color);
+
+protected:
+    void mouseOverUpdated() override;
+
+    void paintContent(QPainter &painter) override;
+
+private:
+    QColor background;
+    QColor backgroundHover;
+    QColor foreground;
+    QColor foregroundHover;
+
+    const int basePadding;
+    const int baseThickness;
+    const Type type = Type::Plus;
+};
+
+}  // namespace chatterino

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -20,6 +20,7 @@
 #include "singletons/WindowManager.hpp"
 #include "util/Helpers.hpp"
 #include "util/LayoutHelper.hpp"
+#include "widgets/buttons/DrawnButton.hpp"
 #include "widgets/buttons/LabelButton.hpp"
 #include "widgets/buttons/PixmapButton.hpp"
 #include "widgets/dialogs/SettingsDialog.hpp"
@@ -280,6 +281,13 @@ void SplitHeader::initializeLayout()
 {
     assert(this->layout() == nullptr);
 
+    this->addButton_ = new DrawnButton(DrawnButton::Type::Plus,
+                                       {
+                                           .padding = 3,
+                                           .thickness = 1,
+                                       },
+                                       this);
+
     auto *layout = makeLayout<QHBoxLayout>({
         // space
         makeWidget<BaseWidget>([](auto w) {
@@ -353,14 +361,11 @@ void SplitHeader::initializeLayout()
             });
         }),
         // add split
-        this->addButton_ = makeWidget<PixmapButton>([&](auto w) {
-            w->setPixmap(getResources().buttons.addSplitDark);
-            w->setMarginEnabled(false);
+        this->addButton_,
+    });
 
-            QObject::connect(w, &Button::leftClicked, this, [this]() {
-                this->split_->addSibling();
-            });
-        }),
+    QObject::connect(this->addButton_, &Button::leftClicked, this, [this]() {
+        this->split_->addSibling();
     });
 
     getSettings()->customURIScheme.connect(
@@ -1061,18 +1066,20 @@ void SplitHeader::themeChangedEvent()
     }
     this->titleLabel_->setPalette(palette);
 
+    this->addButton_->setBackground(this->theme->messages.backgrounds.regular);
+    this->addButton_->setBackgroundHover(
+        this->theme->messages.backgrounds.regular);
+
     // --
     if (this->theme->isLightTheme())
     {
         this->chattersButton_->setPixmap(getResources().buttons.chattersDark);
         this->dropdownButton_->setPixmap(getResources().buttons.menuDark);
-        this->addButton_->setPixmap(getResources().buttons.addSplit);
     }
     else
     {
         this->chattersButton_->setPixmap(getResources().buttons.chattersLight);
         this->dropdownButton_->setPixmap(getResources().buttons.menuLight);
-        this->addButton_->setPixmap(getResources().buttons.addSplitDark);
     }
 
     this->update();

--- a/src/widgets/splits/SplitHeader.hpp
+++ b/src/widgets/splits/SplitHeader.hpp
@@ -16,6 +16,7 @@
 
 namespace chatterino {
 
+class DrawnButton;
 class PixmapButton;
 class LabelButton;
 class Label;
@@ -87,7 +88,7 @@ private:
 
     PixmapButton *moderationButton_{};
     PixmapButton *chattersButton_{};
-    PixmapButton *addButton_{};
+    DrawnButton *addButton_{};
 
     // states
     QPoint dragStart_{};


### PR DESCRIPTION
This button was previously a PNG with a background.

With this change, I have added a new type of Button which intends to draw primitive shapes using configured colors, line thicknessess, and padding.

For this change, I have only implemented the plus button (which is pretty similar to the NotebookButton plus painting).

Works towards solving the meta issue of https://github.com/Chatterino/chatterino2/issues/1574

Previously, I attempted to use an SVG for this but it did not end up good enough.
