### PR TITLE
feat: show text if emote failed to load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - Bugfix: Fixed eventsub message delete notifications not being affected by "Show deletions of single messages". (#6233)
 - Bugfix: Don't add reply buttons to messages that are invalid reply targets. (#6119)
 - Bugfix: Fixed invalid commands from being forwarded to Helix, making it possible for information to leak (e.g. if you typed `/bann username ban reason` it would be seen by others in chat as `username ban reason`). (#6272, #6330)
+- Bugfix: Emotes that failed to load their images now show as text. (#6355)
 - Dev: Mini refactor of Split. (#6148)
 - Dev: Conan will no longer generate a `CMakeUserPresets.json` file. (#6117)
 - Dev: Pass `--force-openssl` when installing from CMake in Qt 6.8+. (#6129)

--- a/src/messages/MessageElement.hpp
+++ b/src/messages/MessageElement.hpp
@@ -397,7 +397,12 @@ protected:
                                                          QSizeF size);
 
 private:
+    void ensureText(bool asFallback);
+
     std::unique_ptr<TextElement> textElement_;
+    MessageColor textColor_;
+    bool usingFallbackColor_ = false;
+
     EmotePtr emote_;
 };
 

--- a/tests/snapshots/IrcMessageHandler/action.json
+++ b/tests/snapshots/IrcMessageHandler/action.json
@@ -144,21 +144,6 @@
                         "type": "None",
                         "value": ""
                     },
-                    "text": {
-                        "color": "#ffcc44ff",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "Kappa"
-                        ]
-                    },
                     "tooltip": "Kappa<br>Twitch Emote",
                     "trailingSpace": true,
                     "type": "EmoteElement"

--- a/tests/snapshots/IrcMessageHandler/bad-emotes.json
+++ b/tests/snapshots/IrcMessageHandler/bad-emotes.json
@@ -112,21 +112,6 @@
                         "type": "None",
                         "value": ""
                     },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "Kappa"
-                        ]
-                    },
                     "tooltip": "Kappa Tooltip",
                     "trailingSpace": true,
                     "type": "EmoteElement"

--- a/tests/snapshots/IrcMessageHandler/bad-emotes2.json
+++ b/tests/snapshots/IrcMessageHandler/bad-emotes2.json
@@ -112,21 +112,6 @@
                         "type": "None",
                         "value": ""
                     },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "Kappa"
-                        ]
-                    },
                     "tooltip": "Kappa Tooltip",
                     "trailingSpace": true,
                     "type": "EmoteElement"

--- a/tests/snapshots/IrcMessageHandler/cheer1.json
+++ b/tests/snapshots/IrcMessageHandler/cheer1.json
@@ -113,22 +113,6 @@
                         "type": "None",
                         "value": ""
                     },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "cheer",
-                            "emote"
-                        ]
-                    },
                     "tooltip": "Cheer1<br>Twitch Cheer Emote",
                     "trailingSpace": true,
                     "type": "EmoteElement"
@@ -147,22 +131,6 @@
                     "link": {
                         "type": "None",
                         "value": ""
-                    },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "cheer",
-                            "emote"
-                        ]
                     },
                     "tooltip": "Cheer1<br>Twitch Cheer Emote",
                     "trailingSpace": true,
@@ -213,22 +181,6 @@
                         "type": "None",
                         "value": ""
                     },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "cheer",
-                            "emote"
-                        ]
-                    },
                     "tooltip": "Cheer1<br>Twitch Cheer Emote",
                     "trailingSpace": true,
                     "type": "EmoteElement"
@@ -247,22 +199,6 @@
                     "link": {
                         "type": "None",
                         "value": ""
-                    },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "cheer",
-                            "emote"
-                        ]
                     },
                     "tooltip": "Cheer1<br>Twitch Cheer Emote",
                     "trailingSpace": true,
@@ -298,22 +234,6 @@
                         "type": "None",
                         "value": ""
                     },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "cheer",
-                            "emote"
-                        ]
-                    },
                     "tooltip": "Cheer1<br>Twitch Cheer Emote",
                     "trailingSpace": true,
                     "type": "EmoteElement"
@@ -332,22 +252,6 @@
                     "link": {
                         "type": "None",
                         "value": ""
-                    },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "cheer",
-                            "emote"
-                        ]
                     },
                     "tooltip": "Cheer1<br>Twitch Cheer Emote",
                     "trailingSpace": true,
@@ -383,22 +287,6 @@
                         "type": "None",
                         "value": ""
                     },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "cheer",
-                            "emote"
-                        ]
-                    },
                     "tooltip": "Cheer1<br>Twitch Cheer Emote",
                     "trailingSpace": true,
                     "type": "EmoteElement"
@@ -417,22 +305,6 @@
                     "link": {
                         "type": "None",
                         "value": ""
-                    },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "cheer",
-                            "emote"
-                        ]
                     },
                     "tooltip": "Cheer1<br>Twitch Cheer Emote",
                     "trailingSpace": true,
@@ -468,22 +340,6 @@
                         "type": "None",
                         "value": ""
                     },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "cheer",
-                            "emote"
-                        ]
-                    },
                     "tooltip": "Cheer1<br>Twitch Cheer Emote",
                     "trailingSpace": true,
                     "type": "EmoteElement"
@@ -502,22 +358,6 @@
                     "link": {
                         "type": "None",
                         "value": ""
-                    },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "cheer",
-                            "emote"
-                        ]
                     },
                     "tooltip": "Cheer1<br>Twitch Cheer Emote",
                     "trailingSpace": true,

--- a/tests/snapshots/IrcMessageHandler/cheer2.json
+++ b/tests/snapshots/IrcMessageHandler/cheer2.json
@@ -113,22 +113,6 @@
                         "type": "None",
                         "value": ""
                     },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "cheer",
-                            "emote"
-                        ]
-                    },
                     "tooltip": "Cheer1<br>Twitch Cheer Emote",
                     "trailingSpace": true,
                     "type": "EmoteElement"
@@ -147,22 +131,6 @@
                     "link": {
                         "type": "None",
                         "value": ""
-                    },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "cheer",
-                            "emote"
-                        ]
                     },
                     "tooltip": "Cheer1<br>Twitch Cheer Emote",
                     "trailingSpace": true,

--- a/tests/snapshots/IrcMessageHandler/cheer3.json
+++ b/tests/snapshots/IrcMessageHandler/cheer3.json
@@ -113,22 +113,6 @@
                         "type": "None",
                         "value": ""
                     },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "cheer",
-                            "emote"
-                        ]
-                    },
                     "tooltip": "Cheer1<br>Twitch Cheer Emote",
                     "trailingSpace": true,
                     "type": "EmoteElement"
@@ -147,22 +131,6 @@
                     "link": {
                         "type": "None",
                         "value": ""
-                    },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "cheer",
-                            "emote"
-                        ]
                     },
                     "tooltip": "Cheer1<br>Twitch Cheer Emote",
                     "trailingSpace": true,

--- a/tests/snapshots/IrcMessageHandler/emote-emoji.json
+++ b/tests/snapshots/IrcMessageHandler/emote-emoji.json
@@ -144,21 +144,6 @@
                         "type": "None",
                         "value": ""
                     },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "Kappa"
-                        ]
-                    },
                     "tooltip": "Kappa<br>Twitch Emote",
                     "trailingSpace": true,
                     "type": "EmoteElement"
@@ -175,21 +160,6 @@
                     "link": {
                         "type": "None",
                         "value": ""
-                    },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "😂"
-                        ]
                     },
                     "tooltip": ":joy:<br/>Emoji",
                     "trailingSpace": true,
@@ -209,21 +179,6 @@
                     "link": {
                         "type": "None",
                         "value": ""
-                    },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "Kappa"
-                        ]
                     },
                     "tooltip": "Kappa<br>Twitch Emote",
                     "trailingSpace": true,

--- a/tests/snapshots/IrcMessageHandler/emote.json
+++ b/tests/snapshots/IrcMessageHandler/emote.json
@@ -112,21 +112,6 @@
                         "type": "None",
                         "value": ""
                     },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "Keepo"
-                        ]
-                    },
                     "tooltip": "Keepo<br>Twitch Emote",
                     "trailingSpace": true,
                     "type": "EmoteElement"

--- a/tests/snapshots/IrcMessageHandler/emotes.json
+++ b/tests/snapshots/IrcMessageHandler/emotes.json
@@ -112,21 +112,6 @@
                         "type": "None",
                         "value": ""
                     },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "Kappa"
-                        ]
-                    },
                     "tooltip": "Kappa<br>Twitch Emote",
                     "trailingSpace": true,
                     "type": "EmoteElement"
@@ -146,21 +131,6 @@
                         "type": "None",
                         "value": ""
                     },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "Keepo"
-                        ]
-                    },
                     "tooltip": "Keepo<br>Twitch Emote",
                     "trailingSpace": true,
                     "type": "EmoteElement"
@@ -179,21 +149,6 @@
                     "link": {
                         "type": "None",
                         "value": ""
-                    },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "PogChamp"
-                        ]
                     },
                     "tooltip": "PogChamp<br>Twitch Emote",
                     "trailingSpace": true,

--- a/tests/snapshots/IrcMessageHandler/emotes2.json
+++ b/tests/snapshots/IrcMessageHandler/emotes2.json
@@ -94,21 +94,6 @@
                         "type": "None",
                         "value": ""
                     },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "BTTVEmote"
-                        ]
-                    },
                     "tooltip": "BTTVEmote Tooltip",
                     "trailingSpace": true,
                     "type": "EmoteElement"
@@ -127,21 +112,6 @@
                     "link": {
                         "type": "None",
                         "value": ""
-                    },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "Kappa"
-                        ]
                     },
                     "tooltip": "Kappa<br>Twitch Emote",
                     "trailingSpace": true,
@@ -235,21 +205,6 @@
                         "type": "None",
                         "value": ""
                     },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "😂"
-                        ]
-                    },
                     "tooltip": ":joy:<br/>Emoji",
                     "trailingSpace": true,
                     "type": "EmoteElement"
@@ -266,21 +221,6 @@
                     "link": {
                         "type": "None",
                         "value": ""
-                    },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "😂"
-                        ]
                     },
                     "tooltip": ":joy:<br/>Emoji",
                     "trailingSpace": true,
@@ -300,21 +240,6 @@
                     "link": {
                         "type": "None",
                         "value": ""
-                    },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "PogChamp"
-                        ]
                     },
                     "tooltip": "PogChamp<br>Twitch Emote",
                     "trailingSpace": true,
@@ -336,21 +261,6 @@
                         "type": "None",
                         "value": ""
                     },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "7TVGlobal"
-                        ]
-                    },
                     "tooltip": "7TVGlobal Tooltip",
                     "trailingSpace": true,
                     "type": "EmoteElement"
@@ -369,21 +279,6 @@
                     "link": {
                         "type": "None",
                         "value": ""
-                    },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "Keepo"
-                        ]
                     },
                     "tooltip": "Keepo<br>Twitch Emote",
                     "trailingSpace": true,
@@ -404,21 +299,6 @@
                         "type": "None",
                         "value": ""
                     },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "FFZEmote"
-                        ]
-                    },
                     "tooltip": "FFZEmote Tooltip",
                     "trailingSpace": true,
                     "type": "EmoteElement"
@@ -437,21 +317,6 @@
                     "link": {
                         "type": "None",
                         "value": ""
-                    },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "FFZGlobal"
-                        ]
                     },
                     "tooltip": "FFZGlobal Tooltip",
                     "trailingSpace": true,

--- a/tests/snapshots/IrcMessageHandler/emotes3.json
+++ b/tests/snapshots/IrcMessageHandler/emotes3.json
@@ -92,21 +92,6 @@
                         "type": "None",
                         "value": ""
                     },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "😂"
-                        ]
-                    },
                     "tooltip": ":joy:<br/>Emoji",
                     "trailingSpace": true,
                     "type": "EmoteElement"
@@ -126,21 +111,6 @@
                         "type": "None",
                         "value": ""
                     },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "Kappa"
-                        ]
-                    },
                     "tooltip": "Kappa<br>Twitch Emote",
                     "trailingSpace": false,
                     "type": "EmoteElement"
@@ -157,21 +127,6 @@
                     "link": {
                         "type": "None",
                         "value": ""
-                    },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "😂"
-                        ]
                     },
                     "tooltip": ":joy:<br/>Emoji",
                     "trailingSpace": true,
@@ -206,21 +161,6 @@
                     "link": {
                         "type": "None",
                         "value": ""
-                    },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "Kappa"
-                        ]
                     },
                     "tooltip": "Kappa<br>Twitch Emote",
                     "trailingSpace": true,

--- a/tests/snapshots/IrcMessageHandler/emotes4.json
+++ b/tests/snapshots/IrcMessageHandler/emotes4.json
@@ -92,21 +92,6 @@
                         "type": "None",
                         "value": ""
                     },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "f"
-                        ]
-                    },
                     "tooltip": "f<br>Twitch Emote",
                     "trailingSpace": false,
                     "type": "EmoteElement"

--- a/tests/snapshots/IrcMessageHandler/emotes5.json
+++ b/tests/snapshots/IrcMessageHandler/emotes5.json
@@ -92,21 +92,6 @@
                         "type": "None",
                         "value": ""
                     },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "fo"
-                        ]
-                    },
                     "tooltip": "fo<br>Twitch Emote",
                     "trailingSpace": false,
                     "type": "EmoteElement"

--- a/tests/snapshots/IrcMessageHandler/first-msg.json
+++ b/tests/snapshots/IrcMessageHandler/first-msg.json
@@ -114,21 +114,6 @@
                         "type": "None",
                         "value": ""
                     },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "Kappa"
-                        ]
-                    },
                     "tooltip": "Kappa<br>Twitch Emote",
                     "trailingSpace": true,
                     "type": "EmoteElement"

--- a/tests/snapshots/IrcMessageHandler/ignore-replace.json
+++ b/tests/snapshots/IrcMessageHandler/ignore-replace.json
@@ -94,21 +94,6 @@
                         "type": "None",
                         "value": ""
                     },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "PogChamp"
-                        ]
-                    },
                     "tooltip": "PogChamp<br>Twitch Emote",
                     "trailingSpace": true,
                     "type": "EmoteElement"
@@ -143,21 +128,6 @@
                         "type": "None",
                         "value": ""
                     },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "Kappa"
-                        ]
-                    },
                     "tooltip": "Kappa<br>Twitch Emote",
                     "trailingSpace": true,
                     "type": "EmoteElement"
@@ -191,21 +161,6 @@
                     "link": {
                         "type": "None",
                         "value": ""
-                    },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "Keepo"
-                        ]
                     },
                     "tooltip": "Keepo<br>Twitch Emote",
                     "trailingSpace": true,
@@ -247,21 +202,6 @@
                         "type": "None",
                         "value": ""
                     },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "Kappa"
-                        ]
-                    },
                     "tooltip": "Kappa<br>Twitch Emote",
                     "trailingSpace": true,
                     "type": "EmoteElement"
@@ -297,21 +237,6 @@
                     "link": {
                         "type": "None",
                         "value": ""
-                    },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "MyCoolTwitchEmote"
-                        ]
                     },
                     "tooltip": "MyCoolTwitchEmote Tooltip",
                     "trailingSpace": true,

--- a/tests/snapshots/IrcMessageHandler/mod.json
+++ b/tests/snapshots/IrcMessageHandler/mod.json
@@ -119,21 +119,6 @@
                         "type": "None",
                         "value": ""
                     },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "Kreygasm"
-                        ]
-                    },
                     "tooltip": "Kreygasm<br>Twitch Emote",
                     "trailingSpace": false,
                     "type": "EmoteElement"
@@ -167,21 +152,6 @@
                     "link": {
                         "type": "None",
                         "value": ""
-                    },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "Kreygasm"
-                        ]
                     },
                     "tooltip": "Kreygasm<br>Twitch Emote",
                     "trailingSpace": true,

--- a/tests/snapshots/IrcMessageHandler/no-tags.json
+++ b/tests/snapshots/IrcMessageHandler/no-tags.json
@@ -92,21 +92,6 @@
                         "type": "None",
                         "value": ""
                     },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "Kappa"
-                        ]
-                    },
                     "tooltip": "Kappa Tooltip",
                     "trailingSpace": true,
                     "type": "EmoteElement"

--- a/tests/snapshots/IrcMessageHandler/redeemed-highlight.json
+++ b/tests/snapshots/IrcMessageHandler/redeemed-highlight.json
@@ -94,21 +94,6 @@
                         "type": "None",
                         "value": ""
                     },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "BTTVGlobal"
-                        ]
-                    },
                     "tooltip": "BTTVGlobal Tooltip",
                     "trailingSpace": true,
                     "type": "EmoteElement"
@@ -142,21 +127,6 @@
                     "link": {
                         "type": "None",
                         "value": ""
-                    },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            ":)"
-                        ]
                     },
                     "tooltip": ":)<br>Twitch Emote",
                     "trailingSpace": true,

--- a/tests/snapshots/IrcMessageHandler/reply-single.json
+++ b/tests/snapshots/IrcMessageHandler/reply-single.json
@@ -169,21 +169,6 @@
                         "type": "None",
                         "value": ""
                     },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "Keepo"
-                        ]
-                    },
                     "tooltip": "Keepo<br>Twitch Emote",
                     "trailingSpace": true,
                     "type": "EmoteElement"
@@ -203,21 +188,6 @@
                         "type": "None",
                         "value": ""
                     },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "FFZEmote"
-                        ]
-                    },
                     "tooltip": "FFZEmote Tooltip",
                     "trailingSpace": true,
                     "type": "EmoteElement"
@@ -234,21 +204,6 @@
                     "link": {
                         "type": "None",
                         "value": ""
-                    },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "😭"
-                        ]
                     },
                     "tooltip": ":sob:<br/>Emoji",
                     "trailingSpace": true,

--- a/tests/snapshots/IrcMessageHandler/reward-bits.json
+++ b/tests/snapshots/IrcMessageHandler/reward-bits.json
@@ -84,21 +84,6 @@
                         "type": "None",
                         "value": ""
                     },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "MyBitsEmote"
-                        ]
-                    },
                     "tooltip": "MyBitsEmote<br>Twitch Emote",
                     "trailingSpace": true,
                     "type": "EmoteElement"

--- a/tests/snapshots/IrcMessageHandler/rm-deleted.json
+++ b/tests/snapshots/IrcMessageHandler/rm-deleted.json
@@ -95,21 +95,6 @@
                         "type": "None",
                         "value": ""
                     },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "7TVEmote"
-                        ]
-                    },
                     "tooltip": "7TVEmote Tooltip",
                     "trailingSpace": true,
                     "type": "EmoteElement"
@@ -128,21 +113,6 @@
                     "link": {
                         "type": "None",
                         "value": ""
-                    },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "Kappa"
-                        ]
                     },
                     "tooltip": "Kappa<br>Twitch Emote",
                     "trailingSpace": true,
@@ -180,21 +150,6 @@
                         "type": "None",
                         "value": ""
                     },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "7TVEmote"
-                        ]
-                    },
                     "tooltip": "7TVEmote Tooltip",
                     "trailingSpace": true,
                     "type": "EmoteElement"
@@ -211,21 +166,6 @@
                     "link": {
                         "type": "None",
                         "value": ""
-                    },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "❤️"
-                        ]
                     },
                     "tooltip": ":heart:<br/>Emoji",
                     "trailingSpace": true,

--- a/tests/snapshots/IrcMessageHandler/shared-chat-emotes.json
+++ b/tests/snapshots/IrcMessageHandler/shared-chat-emotes.json
@@ -112,21 +112,6 @@
                         "type": "None",
                         "value": ""
                     },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "Kappa"
-                        ]
-                    },
                     "tooltip": "Kappa<br>Twitch Emote",
                     "trailingSpace": true,
                     "type": "EmoteElement"
@@ -160,21 +145,6 @@
                     "link": {
                         "type": "None",
                         "value": ""
-                    },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "BTTVGlobal"
-                        ]
                     },
                     "tooltip": "BTTVGlobal Tooltip",
                     "trailingSpace": true,
@@ -211,21 +181,6 @@
                         "type": "None",
                         "value": ""
                     },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "7TVGlobal"
-                        ]
-                    },
                     "tooltip": "7TVGlobal Tooltip",
                     "trailingSpace": true,
                     "type": "EmoteElement"
@@ -260,21 +215,6 @@
                         "type": "None",
                         "value": ""
                     },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "FFZGlobal"
-                        ]
-                    },
                     "tooltip": "FFZGlobal Tooltip",
                     "trailingSpace": true,
                     "type": "EmoteElement"
@@ -293,21 +233,6 @@
                     "link": {
                         "type": "None",
                         "value": ""
-                    },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "BTTVTwitchDev"
-                        ]
                     },
                     "tooltip": "BTTVTwitchDev Tooltip",
                     "trailingSpace": true,
@@ -329,21 +254,6 @@
                         "type": "None",
                         "value": ""
                     },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "7TVTwitchDev"
-                        ]
-                    },
                     "tooltip": "7TVTwitchDev Tooltip",
                     "trailingSpace": true,
                     "type": "EmoteElement"
@@ -362,21 +272,6 @@
                     "link": {
                         "type": "None",
                         "value": ""
-                    },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "FFZTwitchDev"
-                        ]
                     },
                     "tooltip": "FFZTwitchDev Tooltip",
                     "trailingSpace": true,

--- a/tests/snapshots/IrcMessageHandler/simple.json
+++ b/tests/snapshots/IrcMessageHandler/simple.json
@@ -114,21 +114,6 @@
                         "type": "None",
                         "value": ""
                     },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "Kappa"
-                        ]
-                    },
                     "tooltip": "Kappa<br>Twitch Emote",
                     "trailingSpace": true,
                     "type": "EmoteElement"


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
Before, if an emote failed to load, we didn't show anything. Copying the message through right-clicking wouldn't have any text. With this PR, emotes with empty (→ failed) images will now add themselves as system/gray text. I chose this color to indicate that Chatterino knows _something_ is wrong.

You can test this by randomly marking images as failed, like this:
```diff
diff --git a/src/messages/Image.cpp b/src/messages/Image.cpp
index ce636b5ab..8e26c1a27 100644
--- a/src/messages/Image.cpp
+++ b/src/messages/Image.cpp
@@ -19,6 +19,7 @@
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QNetworkRequest>
+#include <QRandomGenerator>
 #include <QTimer>
 
 #include <atomic>
@@ -530,7 +531,8 @@ void Image::actuallyLoad()
             }
 
             const auto size = reader.size();
-            if (size.isEmpty())
+            if (size.isEmpty() ||
+                QRandomGenerator::global()->generateDouble() > 0.9)
             {
                 shared->empty_ = true;
                 return;
```
