### PR TITLE
fix: Fix searching in emote popup if not in a twitch channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - Bugfix: Fixed eventsub message delete notifications not being affected by "Show deletions of single messages". (#6233)
 - Bugfix: Don't add reply buttons to messages that are invalid reply targets. (#6119)
 - Bugfix: Fixed invalid commands from being forwarded to Helix, making it possible for information to leak (e.g. if you typed `/bann username ban reason` it would be seen by others in chat as `username ban reason`). (#6272, #6330)
+- Bugfix: Fixed a crash that occurs when searching for emotes in channel-less contexts. (#6357)
 - Dev: Mini refactor of Split. (#6148)
 - Dev: Conan will no longer generate a `CMakeUserPresets.json` file. (#6117)
 - Dev: Pass `--force-openssl` when installing from CMake in Qt 6.8+. (#6129)

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -422,7 +422,6 @@ void EmotePopup::loadChannel(ChannelPtr channel)
 
     this->setWindowTitle("Emotes in #" + this->channel_->getName());
 
-
     this->globalEmotesView_->setChannel(
         std::make_shared<Channel>("", Channel::Type::None));
     this->subEmotesView_->setChannel(
@@ -458,17 +457,17 @@ void EmotePopup::reloadEmotes()
         if (Settings::instance().enableBTTVChannelEmotes)
         {
             addEmotes(*channelChannel, *this->twitchChannel_->bttvEmotes(),
-                    "BetterTTV", MessageElementFlag::BttvEmote);
+                      "BetterTTV", MessageElementFlag::BttvEmote);
         }
         if (Settings::instance().enableFFZChannelEmotes)
         {
             addEmotes(*channelChannel, *this->twitchChannel_->ffzEmotes(),
-                    "FrankerFaceZ", MessageElementFlag::FfzEmote);
+                      "FrankerFaceZ", MessageElementFlag::FfzEmote);
         }
         if (Settings::instance().enableSevenTVChannelEmotes)
         {
             addEmotes(*channelChannel, *this->twitchChannel_->seventvEmotes(),
-                    "7TV", MessageElementFlag::SevenTVEmote);
+                      "7TV", MessageElementFlag::SevenTVEmote);
         }
     }
     // global

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -422,10 +422,6 @@ void EmotePopup::loadChannel(ChannelPtr channel)
 
     this->setWindowTitle("Emotes in #" + this->channel_->getName());
 
-    if (this->twitchChannel_ == nullptr)
-    {
-        return;
-    }
 
     this->globalEmotesView_->setChannel(
         std::make_shared<Channel>("", Channel::Type::None));
@@ -441,11 +437,6 @@ void EmotePopup::loadChannel(ChannelPtr channel)
 
 void EmotePopup::reloadEmotes()
 {
-    if (this->twitchChannel_ == nullptr)
-    {
-        return;
-    }
-
     auto subChannel = this->subEmotesView_->underlyingChannel();
     auto globalChannel = this->globalEmotesView_->underlyingChannel();
     auto channelChannel = this->channelEmotesView_->underlyingChannel();
@@ -454,13 +445,32 @@ void EmotePopup::reloadEmotes()
     globalChannel->clearMessages();
     channelChannel->clearMessages();
 
-    // twitch
-    addTwitchEmoteSets(
-        twitchChannel_->localTwitchEmotes(),
-        *getApp()->getAccounts()->twitch.getCurrent()->accessEmoteSets(),
-        *globalChannel, *subChannel, twitchChannel_->roomId(),
-        twitchChannel_->getName());
+    if (this->twitchChannel_)
+    {
+        // twitch
+        addTwitchEmoteSets(
+            twitchChannel_->localTwitchEmotes(),
+            *getApp()->getAccounts()->twitch.getCurrent()->accessEmoteSets(),
+            *globalChannel, *subChannel, twitchChannel_->roomId(),
+            twitchChannel_->getName());
 
+        // channel
+        if (Settings::instance().enableBTTVChannelEmotes)
+        {
+            addEmotes(*channelChannel, *this->twitchChannel_->bttvEmotes(),
+                    "BetterTTV", MessageElementFlag::BttvEmote);
+        }
+        if (Settings::instance().enableFFZChannelEmotes)
+        {
+            addEmotes(*channelChannel, *this->twitchChannel_->ffzEmotes(),
+                    "FrankerFaceZ", MessageElementFlag::FfzEmote);
+        }
+        if (Settings::instance().enableSevenTVChannelEmotes)
+        {
+            addEmotes(*channelChannel, *this->twitchChannel_->seventvEmotes(),
+                    "7TV", MessageElementFlag::SevenTVEmote);
+        }
+    }
     // global
     if (Settings::instance().enableBTTVGlobalEmotes)
     {
@@ -475,23 +485,6 @@ void EmotePopup::reloadEmotes()
     if (Settings::instance().enableSevenTVGlobalEmotes)
     {
         addEmotes(*globalChannel, *getApp()->getSeventvEmotes()->globalEmotes(),
-                  "7TV", MessageElementFlag::SevenTVEmote);
-    }
-
-    // channel
-    if (Settings::instance().enableBTTVChannelEmotes)
-    {
-        addEmotes(*channelChannel, *this->twitchChannel_->bttvEmotes(),
-                  "BetterTTV", MessageElementFlag::BttvEmote);
-    }
-    if (Settings::instance().enableFFZChannelEmotes)
-    {
-        addEmotes(*channelChannel, *this->twitchChannel_->ffzEmotes(),
-                  "FrankerFaceZ", MessageElementFlag::FfzEmote);
-    }
-    if (Settings::instance().enableSevenTVChannelEmotes)
-    {
-        addEmotes(*channelChannel, *this->twitchChannel_->seventvEmotes(),
                   "7TV", MessageElementFlag::SevenTVEmote);
     }
 


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

Fixes the two issues mentioned in #6354:

When opening emote popup in a non-twitch channel (such as mentions)
- Global emotes are not showing up in the emote popup 
- Searching anything will crash Chatterino
<img width="305" height="505" alt="image" src="https://github.com/user-attachments/assets/3848317b-c416-4587-8255-432b7fcc3f15" /> 
<img width="300" height="498" alt="image" src="https://github.com/user-attachments/assets/e8f71642-92de-4226-8683-f79ac495b37f" />


