### PR TITLE
chore: Update vcpkg baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@
 - Dev: Factored out AUMID to `Version`. (#6321)
 - Dev: Silenced some warnings when compiling with clang-cl. (#6331)
 - Dev: Added some commands for forcing a relayout (and related things) in channel views. (#6342)
+- Dev: Update vcpkg baseline. (#6359)
 
 ## 2.5.3
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "chatterino",
   "version": "2.0.0",
-  "builtin-baseline": "01f602195983451bc83e72f4214af2cbc495aa94",
+  "builtin-baseline": "dd3097e305afa53f7b4312371f62058d2e665320",
   "dependencies": [
     "boost-asio",
     "boost-beast",


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

As noted in https://github.com/Chatterino/chatterino2/issues/6354#issuecomment-3123448855, updating the vcpkg baseline fixes SHA512 mismatch issues that prevented vcpkg from installing several dependencies.