### PR TITLE
feat: dynamically track mutability of messages

### DIFF
--- a/src/common/Channel.cpp
+++ b/src/common/Channel.cpp
@@ -79,6 +79,8 @@ LimitedQueueSnapshot<MessagePtr> Channel::getMessageSnapshot()
 void Channel::addMessage(MessagePtr message, MessageContext context,
                          std::optional<MessageFlags> overridingFlags)
 {
+    message->freeze();
+
     MessagePtr deleted;
 
     if (context == MessageContext::Original && this->getType() != Type::None)
@@ -157,6 +159,11 @@ void Channel::disableAllMessages()
 
 void Channel::addMessagesAtStart(const std::vector<MessagePtr> &_messages)
 {
+    for (const auto &msg : _messages)
+    {
+        msg->freeze();
+    }
+
     std::vector<MessagePtr> addedMessages =
         this->messages_.pushFront(_messages);
 
@@ -171,6 +178,10 @@ void Channel::fillInMissingMessages(const std::vector<MessagePtr> &messages)
     if (messages.empty())
     {
         return;
+    }
+    for (const auto &msg : messages)
+    {
+        msg->freeze();
     }
 
     auto snapshot = this->getMessageSnapshot();
@@ -256,6 +267,7 @@ void Channel::fillInMissingMessages(const std::vector<MessagePtr> &messages)
 void Channel::replaceMessage(const MessagePtr &message,
                              const MessagePtr &replacement)
 {
+    replacement->freeze();
     int index = this->messages_.replaceItem(message, replacement);
 
     if (index >= 0)
@@ -266,6 +278,8 @@ void Channel::replaceMessage(const MessagePtr &message,
 
 void Channel::replaceMessage(size_t index, const MessagePtr &replacement)
 {
+    replacement->freeze();
+
     MessagePtr prev;
     if (this->messages_.replaceItem(index, replacement, &prev))
     {
@@ -276,6 +290,8 @@ void Channel::replaceMessage(size_t index, const MessagePtr &replacement)
 void Channel::replaceMessage(size_t hint, const MessagePtr &message,
                              const MessagePtr &replacement)
 {
+    replacement->freeze();
+
     auto index = this->messages_.replaceItem(hint, message, replacement);
     if (index >= 0)
     {

--- a/src/messages/Message.cpp
+++ b/src/messages/Message.cpp
@@ -107,6 +107,7 @@ QJsonObject Message::toJson() const
         {"count"_L1, static_cast<qint64>(this->count)},
         {"serverReceivedTime"_L1,
          this->serverReceivedTime.toString(Qt::ISODate)},
+        {"frozen"_L1, this->frozen},
     };
 
     QJsonArray badges;

--- a/src/messages/Message.hpp
+++ b/src/messages/Message.hpp
@@ -86,6 +86,13 @@ struct Message {
     };
     ReplyStatus isReplyable() const;
     uint32_t count = 1;
+
+    /// Can this message be modified?
+    ///
+    /// This is only used for plugins right now. This value is only ever set to
+    /// true.
+    mutable bool frozen = false;
+
     std::vector<std::unique_ptr<MessageElement>> elements;
 
     ScrollbarHighlight getScrollBarHighlight() const;
@@ -93,6 +100,11 @@ struct Message {
     std::shared_ptr<ChannelPointReward> reward = nullptr;
 
     QJsonObject toJson() const;
+
+    void freeze() const
+    {
+        this->frozen = true;
+    }
 };
 
 }  // namespace chatterino

--- a/tests/snapshots/EventSub/automod-message-hold/automod-category.json
+++ b/tests/snapshots/EventSub/automod-message-hold/automod-category.json
@@ -137,6 +137,7 @@
                 }
             ],
             "flags": "PubSub|AutoMod|AutoModOffendingMessageHeader|EventSub|ModerationAction",
+            "frozen": true,
             "id": "automod_19d067ff-89b5-4790-a720-97599894eb6b",
             "localizedName": "",
             "loginName": "automod",
@@ -243,6 +244,7 @@
                 }
             ],
             "flags": "PubSub|AutoMod|AutoModOffendingMessage|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/automod-message-hold/blocked-term-enclosed.json
+++ b/tests/snapshots/EventSub/automod-message-hold/blocked-term-enclosed.json
@@ -149,6 +149,7 @@
                 }
             ],
             "flags": "PubSub|AutoMod|AutoModOffendingMessageHeader|AutoModBlockedTerm|EventSub|ModerationAction",
+            "frozen": true,
             "id": "automod_0cbb6e48-1606-46c6-b1ac-c97626e1c5cb",
             "localizedName": "",
             "loginName": "automod",
@@ -257,6 +258,7 @@
                 }
             ],
             "flags": "PubSub|AutoMod|AutoModOffendingMessage|AutoModBlockedTerm|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/automod-message-hold/blocked-term.json
+++ b/tests/snapshots/EventSub/automod-message-hold/blocked-term.json
@@ -143,6 +143,7 @@
                 }
             ],
             "flags": "PubSub|AutoMod|AutoModOffendingMessageHeader|AutoModBlockedTerm|EventSub|ModerationAction",
+            "frozen": true,
             "id": "automod_c0fac418-25a9-41b8-adf3-5bd637fca1e1",
             "localizedName": "",
             "loginName": "automod",
@@ -249,6 +250,7 @@
                 }
             ],
             "flags": "PubSub|AutoMod|AutoModOffendingMessage|AutoModBlockedTerm|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/automod-message-hold/blocked-terms-4.json
+++ b/tests/snapshots/EventSub/automod-message-hold/blocked-terms-4.json
@@ -195,6 +195,7 @@
                 }
             ],
             "flags": "PubSub|AutoMod|AutoModOffendingMessageHeader|AutoModBlockedTerm|EventSub|ModerationAction",
+            "frozen": true,
             "id": "automod_45a63ca1-1b0c-46ef-9075-d112f9a9f376",
             "localizedName": "",
             "loginName": "automod",
@@ -307,6 +308,7 @@
                 }
             ],
             "flags": "PubSub|AutoMod|AutoModOffendingMessage|AutoModBlockedTerm|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/automod-message-hold/localized-name.json
+++ b/tests/snapshots/EventSub/automod-message-hold/localized-name.json
@@ -137,6 +137,7 @@
                 }
             ],
             "flags": "PubSub|AutoMod|AutoModOffendingMessageHeader|EventSub|ModerationAction",
+            "frozen": true,
             "id": "automod_19d067ff-89b5-4790-a720-97599894eb6b",
             "localizedName": "",
             "loginName": "automod",
@@ -243,6 +244,7 @@
                 }
             ],
             "flags": "PubSub|AutoMod|AutoModOffendingMessage|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "testaccount_420",

--- a/tests/snapshots/EventSub/automod-message-update/approved.json
+++ b/tests/snapshots/EventSub/automod-message-update/approved.json
@@ -177,6 +177,7 @@
                 }
             ],
             "flags": "Disabled|PubSub|AutoMod|AutoModOffendingMessageHeader|EventSub|ModerationAction",
+            "frozen": true,
             "id": "automod_19d067ff-89b5-4790-a720-97599894eb6b",
             "localizedName": "",
             "loginName": "automod",
@@ -283,6 +284,7 @@
                 }
             ],
             "flags": "PubSub|AutoMod|AutoModOffendingMessage|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/automod-message-update/denied.json
+++ b/tests/snapshots/EventSub/automod-message-update/denied.json
@@ -177,6 +177,7 @@
                 }
             ],
             "flags": "Disabled|PubSub|AutoMod|AutoModOffendingMessageHeader|EventSub|ModerationAction",
+            "frozen": true,
             "id": "automod_19d067ff-89b5-4790-a720-97599894eb6b",
             "localizedName": "",
             "loginName": "automod",
@@ -283,6 +284,7 @@
                 }
             ],
             "flags": "PubSub|AutoMod|AutoModOffendingMessage|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/automod-message-update/expired.json
+++ b/tests/snapshots/EventSub/automod-message-update/expired.json
@@ -177,6 +177,7 @@
                 }
             ],
             "flags": "Disabled|PubSub|AutoMod|AutoModOffendingMessageHeader|EventSub|ModerationAction",
+            "frozen": true,
             "id": "automod_19d067ff-89b5-4790-a720-97599894eb6b",
             "localizedName": "",
             "loginName": "automod",
@@ -283,6 +284,7 @@
                 }
             ],
             "flags": "PubSub|AutoMod|AutoModOffendingMessage|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-chat-user-message-hold/message-held.json
+++ b/tests/snapshots/EventSub/channel-chat-user-message-hold/message-held.json
@@ -91,6 +91,7 @@
                 }
             ],
             "flags": "PubSub|AutoMod|EventSub",
+            "frozen": true,
             "id": "automod_e39e3c58-3d25-49fd-8c94-e776ef57a7f8",
             "localizedName": "",
             "loginName": "automod",

--- a/tests/snapshots/EventSub/channel-chat-user-message-update/message-approved.json
+++ b/tests/snapshots/EventSub/channel-chat-user-message-update/message-approved.json
@@ -84,6 +84,7 @@
                 }
             ],
             "flags": "PubSub|AutoMod|EventSub",
+            "frozen": true,
             "id": "automod_5686ec52-e02c-4042-ac21-1dfd8cab0f9f",
             "localizedName": "",
             "loginName": "automod",

--- a/tests/snapshots/EventSub/channel-chat-user-message-update/message-denied.json
+++ b/tests/snapshots/EventSub/channel-chat-user-message-update/message-denied.json
@@ -90,6 +90,7 @@
                 }
             ],
             "flags": "PubSub|AutoMod|EventSub",
+            "frozen": true,
             "id": "automod_fc90dc3b-0634-41c3-8365-f40719f076ab",
             "localizedName": "",
             "loginName": "automod",

--- a/tests/snapshots/EventSub/channel-moderate/add-blocked-term-three.json
+++ b/tests/snapshots/EventSub/channel-moderate/add-blocked-term-three.json
@@ -193,6 +193,7 @@
                 }
             ],
             "flags": "System|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/add-blocked-term.json
+++ b/tests/snapshots/EventSub/channel-moderate/add-blocked-term.json
@@ -203,6 +203,7 @@
                 }
             ],
             "flags": "System|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/add-permitted-term-two.json
+++ b/tests/snapshots/EventSub/channel-moderate/add-permitted-term-two.json
@@ -191,6 +191,7 @@
                 }
             ],
             "flags": "System|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/add-permitted-term.json
+++ b/tests/snapshots/EventSub/channel-moderate/add-permitted-term.json
@@ -203,6 +203,7 @@
                 }
             ],
             "flags": "System|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/ban-reason.json
+++ b/tests/snapshots/EventSub/channel-moderate/ban-reason.json
@@ -158,6 +158,7 @@
                 }
             ],
             "flags": "System|Timeout|PubSub|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/ban-stacking-reason.json
+++ b/tests/snapshots/EventSub/channel-moderate/ban-stacking-reason.json
@@ -221,6 +221,7 @@
                 }
             ],
             "flags": "System|Timeout|PubSub|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "",
@@ -351,6 +352,7 @@
                 }
             ],
             "flags": "System|Timeout|PubSub|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/ban-stacking.json
+++ b/tests/snapshots/EventSub/channel-moderate/ban-stacking.json
@@ -219,6 +219,7 @@
                 }
             ],
             "flags": "System|Timeout|PubSub|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "",
@@ -333,6 +334,7 @@
                 }
             ],
             "flags": "System|Timeout|PubSub|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/ban.json
+++ b/tests/snapshots/EventSub/channel-moderate/ban.json
@@ -142,6 +142,7 @@
                 }
             ],
             "flags": "System|Timeout|PubSub|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/clear.json
+++ b/tests/snapshots/EventSub/channel-moderate/clear.json
@@ -106,6 +106,7 @@
                 }
             ],
             "flags": "System|DoNotTriggerNotification|PubSub|ClearChat|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "",

--- a/tests/snapshots/EventSub/channel-moderate/delete-long.json
+++ b/tests/snapshots/EventSub/channel-moderate/delete-long.json
@@ -160,6 +160,7 @@
                 }
             ],
             "flags": "System|DoNotTriggerNotification|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "testaccount_420",

--- a/tests/snapshots/EventSub/channel-moderate/delete.json
+++ b/tests/snapshots/EventSub/channel-moderate/delete.json
@@ -160,6 +160,7 @@
                 }
             ],
             "flags": "System|DoNotTriggerNotification|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "testaccount_420",

--- a/tests/snapshots/EventSub/channel-moderate/emoteonly-off.json
+++ b/tests/snapshots/EventSub/channel-moderate/emoteonly-off.json
@@ -149,6 +149,7 @@
                 }
             ],
             "flags": "System|EventSub",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/emoteonly.json
+++ b/tests/snapshots/EventSub/channel-moderate/emoteonly.json
@@ -149,6 +149,7 @@
                 }
             ],
             "flags": "System|EventSub",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/followers-0s.json
+++ b/tests/snapshots/EventSub/channel-moderate/followers-0s.json
@@ -151,6 +151,7 @@
                 }
             ],
             "flags": "System|EventSub",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/followers-off.json
+++ b/tests/snapshots/EventSub/channel-moderate/followers-off.json
@@ -149,6 +149,7 @@
                 }
             ],
             "flags": "System|EventSub",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/followers.json
+++ b/tests/snapshots/EventSub/channel-moderate/followers.json
@@ -167,6 +167,7 @@
                 }
             ],
             "flags": "System|EventSub",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/mod.json
+++ b/tests/snapshots/EventSub/channel-moderate/mod.json
@@ -141,6 +141,7 @@
                 }
             ],
             "flags": "System|EventSub",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "uint128",

--- a/tests/snapshots/EventSub/channel-moderate/raid.json
+++ b/tests/snapshots/EventSub/channel-moderate/raid.json
@@ -145,6 +145,7 @@
                 }
             ],
             "flags": "System|EventSub",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "pajlada",

--- a/tests/snapshots/EventSub/channel-moderate/remove-blocked-term-four.json
+++ b/tests/snapshots/EventSub/channel-moderate/remove-blocked-term-four.json
@@ -195,6 +195,7 @@
                 }
             ],
             "flags": "System|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/remove-blocked-term.json
+++ b/tests/snapshots/EventSub/channel-moderate/remove-blocked-term.json
@@ -203,6 +203,7 @@
                 }
             ],
             "flags": "System|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/remove-permitted-term-from-automod.json
+++ b/tests/snapshots/EventSub/channel-moderate/remove-permitted-term-from-automod.json
@@ -203,6 +203,7 @@
                 }
             ],
             "flags": "System|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/remove-permitted-term.json
+++ b/tests/snapshots/EventSub/channel-moderate/remove-permitted-term.json
@@ -203,6 +203,7 @@
                 }
             ],
             "flags": "System|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/shared-ban-reason.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-ban-reason.json
@@ -192,6 +192,7 @@
                 }
             ],
             "flags": "System|Timeout|PubSub|SharedMessage|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/shared-ban-stacking-diff-sources.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-ban-stacking-diff-sources.json
@@ -249,6 +249,7 @@
                 }
             ],
             "flags": "System|Timeout|PubSub|SharedMessage|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "",
@@ -396,6 +397,7 @@
                 }
             ],
             "flags": "System|Timeout|PubSub|SharedMessage|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/shared-ban-stacking.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-ban-stacking.json
@@ -249,6 +249,7 @@
                 }
             ],
             "flags": "System|Timeout|PubSub|SharedMessage|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "",

--- a/tests/snapshots/EventSub/channel-moderate/shared-ban.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-ban.json
@@ -175,6 +175,7 @@
                 }
             ],
             "flags": "System|Timeout|PubSub|SharedMessage|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/shared-delete-long.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-delete-long.json
@@ -193,6 +193,7 @@
                 }
             ],
             "flags": "System|DoNotTriggerNotification|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "testaccount_420",

--- a/tests/snapshots/EventSub/channel-moderate/shared-delete.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-delete.json
@@ -193,6 +193,7 @@
                 }
             ],
             "flags": "System|DoNotTriggerNotification|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "testaccount_420",

--- a/tests/snapshots/EventSub/channel-moderate/shared-timeout-stacking-diff-sources.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-timeout-stacking-diff-sources.json
@@ -295,6 +295,7 @@
                 }
             ],
             "flags": "System|Timeout|PubSub|SharedMessage|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "",
@@ -434,6 +435,7 @@
                 }
             ],
             "flags": "System|Timeout|PubSub|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",
@@ -603,6 +605,7 @@
                 }
             ],
             "flags": "System|Timeout|PubSub|SharedMessage|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/shared-timeout-stacking-diff-sources2.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-timeout-stacking-diff-sources2.json
@@ -255,6 +255,7 @@
                 }
             ],
             "flags": "System|Timeout|PubSub|SharedMessage|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "",
@@ -424,6 +425,7 @@
                 }
             ],
             "flags": "System|Timeout|PubSub|SharedMessage|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/shared-timeout-stacking.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-timeout-stacking.json
@@ -255,6 +255,7 @@
                 }
             ],
             "flags": "System|Timeout|PubSub|SharedMessage|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "",
@@ -394,6 +395,7 @@
                 }
             ],
             "flags": "System|Timeout|PubSub|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/shared-timeout.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-timeout.json
@@ -199,6 +199,7 @@
                 }
             ],
             "flags": "System|Timeout|PubSub|SharedMessage|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/shared-unban.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-unban.json
@@ -174,6 +174,7 @@
                 }
             ],
             "flags": "System|Untimeout|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/shared-untimeout.json
+++ b/tests/snapshots/EventSub/channel-moderate/shared-untimeout.json
@@ -174,6 +174,7 @@
                 }
             ],
             "flags": "System|Untimeout|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/slow-off.json
+++ b/tests/snapshots/EventSub/channel-moderate/slow-off.json
@@ -149,6 +149,7 @@
                 }
             ],
             "flags": "System|EventSub",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/slow.json
+++ b/tests/snapshots/EventSub/channel-moderate/slow.json
@@ -167,6 +167,7 @@
                 }
             ],
             "flags": "System|EventSub",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/subscribers-off.json
+++ b/tests/snapshots/EventSub/channel-moderate/subscribers-off.json
@@ -149,6 +149,7 @@
                 }
             ],
             "flags": "System|EventSub",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/subscribers.json
+++ b/tests/snapshots/EventSub/channel-moderate/subscribers.json
@@ -149,6 +149,7 @@
                 }
             ],
             "flags": "System|EventSub",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/timeout-stacking-reason.json
+++ b/tests/snapshots/EventSub/channel-moderate/timeout-stacking-reason.json
@@ -225,6 +225,7 @@
                 }
             ],
             "flags": "System|Timeout|PubSub|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "",
@@ -379,6 +380,7 @@
                 }
             ],
             "flags": "System|Timeout|PubSub|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/timeout-stacking.json
+++ b/tests/snapshots/EventSub/channel-moderate/timeout-stacking.json
@@ -224,6 +224,7 @@
                 }
             ],
             "flags": "System|Timeout|PubSub|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "",
@@ -363,6 +364,7 @@
                 }
             ],
             "flags": "System|Timeout|PubSub|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/timeout.json
+++ b/tests/snapshots/EventSub/channel-moderate/timeout.json
@@ -184,6 +184,7 @@
                 }
             ],
             "flags": "System|Timeout|PubSub|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/unban-request-approve-message.json
+++ b/tests/snapshots/EventSub/channel-moderate/unban-request-approve-message.json
@@ -151,6 +151,7 @@
                 }
             ],
             "flags": "System|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/unban-request-approve.json
+++ b/tests/snapshots/EventSub/channel-moderate/unban-request-approve.json
@@ -147,6 +147,7 @@
                 }
             ],
             "flags": "System|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/unban-request-deny-message.json
+++ b/tests/snapshots/EventSub/channel-moderate/unban-request-deny-message.json
@@ -152,6 +152,7 @@
                 }
             ],
             "flags": "System|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/unban-request-deny.json
+++ b/tests/snapshots/EventSub/channel-moderate/unban-request-deny.json
@@ -147,6 +147,7 @@
                 }
             ],
             "flags": "System|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/unban.json
+++ b/tests/snapshots/EventSub/channel-moderate/unban.json
@@ -141,6 +141,7 @@
                 }
             ],
             "flags": "System|Untimeout|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/uniquechat-off.json
+++ b/tests/snapshots/EventSub/channel-moderate/uniquechat-off.json
@@ -149,6 +149,7 @@
                 }
             ],
             "flags": "System|EventSub",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/uniquechat.json
+++ b/tests/snapshots/EventSub/channel-moderate/uniquechat.json
@@ -149,6 +149,7 @@
                 }
             ],
             "flags": "System|EventSub",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/unmod.json
+++ b/tests/snapshots/EventSub/channel-moderate/unmod.json
@@ -141,6 +141,7 @@
                 }
             ],
             "flags": "System|EventSub",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "uint128",

--- a/tests/snapshots/EventSub/channel-moderate/unraid.json
+++ b/tests/snapshots/EventSub/channel-moderate/unraid.json
@@ -144,6 +144,7 @@
                 }
             ],
             "flags": "System|EventSub",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "pajlada",

--- a/tests/snapshots/EventSub/channel-moderate/untimeout.json
+++ b/tests/snapshots/EventSub/channel-moderate/untimeout.json
@@ -141,6 +141,7 @@
                 }
             ],
             "flags": "System|Untimeout|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-moderate/warn-shared.json
+++ b/tests/snapshots/EventSub/channel-moderate/warn-shared.json
@@ -160,6 +160,7 @@
                 }
             ],
             "flags": "System|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "quotrok",

--- a/tests/snapshots/EventSub/channel-moderate/warn.json
+++ b/tests/snapshots/EventSub/channel-moderate/warn.json
@@ -160,6 +160,7 @@
                 }
             ],
             "flags": "System|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "quotrok",

--- a/tests/snapshots/EventSub/channel-suspicious-user-message/restricted-bad-type.json
+++ b/tests/snapshots/EventSub/channel-suspicious-user-message/restricted-bad-type.json
@@ -86,6 +86,7 @@
                 }
             ],
             "flags": "LowTrustUsers|RestrictedMessage|EventSub",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "",
@@ -192,6 +193,7 @@
                 }
             ],
             "flags": "PubSub|LowTrustUsers|RestrictedMessage|EventSub",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-suspicious-user-message/restricted-ban-evader.json
+++ b/tests/snapshots/EventSub/channel-suspicious-user-message/restricted-ban-evader.json
@@ -91,6 +91,7 @@
                 }
             ],
             "flags": "LowTrustUsers|RestrictedMessage|EventSub",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "",
@@ -197,6 +198,7 @@
                 }
             ],
             "flags": "PubSub|LowTrustUsers|RestrictedMessage|EventSub",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-suspicious-user-message/restricted-emote.json
+++ b/tests/snapshots/EventSub/channel-suspicious-user-message/restricted-emote.json
@@ -89,6 +89,7 @@
                 }
             ],
             "flags": "LowTrustUsers|RestrictedMessage|EventSub",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "",
@@ -195,6 +196,7 @@
                 }
             ],
             "flags": "PubSub|LowTrustUsers|RestrictedMessage|EventSub",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-suspicious-user-message/restricted.json
+++ b/tests/snapshots/EventSub/channel-suspicious-user-message/restricted.json
@@ -86,6 +86,7 @@
                 }
             ],
             "flags": "LowTrustUsers|RestrictedMessage|EventSub",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "",
@@ -192,6 +193,7 @@
                 }
             ],
             "flags": "PubSub|LowTrustUsers|RestrictedMessage|EventSub",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/EventSub/channel-suspicious-user-update/monitored.json
+++ b/tests/snapshots/EventSub/channel-suspicious-user-update/monitored.json
@@ -120,6 +120,7 @@
                 }
             ],
             "flags": "System|DoNotTriggerNotification|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "uint128",

--- a/tests/snapshots/EventSub/channel-suspicious-user-update/no-treatment.json
+++ b/tests/snapshots/EventSub/channel-suspicious-user-update/no-treatment.json
@@ -120,6 +120,7 @@
                 }
             ],
             "flags": "System|DoNotTriggerNotification|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "uint128",

--- a/tests/snapshots/EventSub/channel-suspicious-user-update/restricted.json
+++ b/tests/snapshots/EventSub/channel-suspicious-user-update/restricted.json
@@ -120,6 +120,7 @@
                 }
             ],
             "flags": "System|DoNotTriggerNotification|EventSub|ModerationAction",
+            "frozen": true,
             "id": "",
             "localizedName": "",
             "loginName": "uint128",

--- a/tests/snapshots/IrcMessageHandler/action.json
+++ b/tests/snapshots/IrcMessageHandler/action.json
@@ -163,6 +163,7 @@
                 }
             ],
             "flags": "Collapsed|Action",
+            "frozen": false,
             "id": "90ef1e46-8baa-4bf2-9c54-272f39d6fa11",
             "localizedName": "",
             "loginName": "pajlada",

--- a/tests/snapshots/IrcMessageHandler/all-usernames.json
+++ b/tests/snapshots/IrcMessageHandler/all-usernames.json
@@ -281,6 +281,7 @@
                 }
             ],
             "flags": "Collapsed",
+            "frozen": false,
             "id": "438b85cc-fa67-4c03-bc38-c4ec2527822c",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/IrcMessageHandler/announcement.json
+++ b/tests/snapshots/IrcMessageHandler/announcement.json
@@ -139,6 +139,7 @@
                 }
             ],
             "flags": "Highlighted|Collapsed|Subscription",
+            "frozen": false,
             "highlightColor": "#64c466ff",
             "id": "8c26e1ab-b50c-4d9d-bc11-3fd57a941d90",
             "localizedName": "",
@@ -203,6 +204,7 @@
                 }
             ],
             "flags": "System|DoNotTriggerNotification|Subscription",
+            "frozen": false,
             "id": "",
             "localizedName": "",
             "loginName": "",

--- a/tests/snapshots/IrcMessageHandler/bad-emotes.json
+++ b/tests/snapshots/IrcMessageHandler/bad-emotes.json
@@ -131,6 +131,7 @@
                 }
             ],
             "flags": "Collapsed",
+            "frozen": false,
             "id": "7be87072-bf24-4fa3-b3df-0ea6fa5f1474",
             "localizedName": "",
             "loginName": "mm2pl",

--- a/tests/snapshots/IrcMessageHandler/bad-emotes2.json
+++ b/tests/snapshots/IrcMessageHandler/bad-emotes2.json
@@ -131,6 +131,7 @@
                 }
             ],
             "flags": "Collapsed",
+            "frozen": false,
             "id": "7be87072-bf24-4fa3-b3df-0ea6fa5f1474",
             "localizedName": "",
             "loginName": "mm2pl",

--- a/tests/snapshots/IrcMessageHandler/bad-emotes3.json
+++ b/tests/snapshots/IrcMessageHandler/bad-emotes3.json
@@ -108,6 +108,7 @@
                 }
             ],
             "flags": "Collapsed",
+            "frozen": false,
             "id": "",
             "localizedName": "",
             "loginName": "test",

--- a/tests/snapshots/IrcMessageHandler/bad-emotes4.json
+++ b/tests/snapshots/IrcMessageHandler/bad-emotes4.json
@@ -108,6 +108,7 @@
                 }
             ],
             "flags": "Collapsed",
+            "frozen": false,
             "id": "",
             "localizedName": "",
             "loginName": "test",

--- a/tests/snapshots/IrcMessageHandler/badges-invalid.json
+++ b/tests/snapshots/IrcMessageHandler/badges-invalid.json
@@ -215,6 +215,7 @@
                 }
             ],
             "flags": "Collapsed",
+            "frozen": false,
             "id": "546c42a6-21d0-4f3d-a6a0-c77f78d7b131",
             "localizedName": "",
             "loginName": "badgy",

--- a/tests/snapshots/IrcMessageHandler/badges.json
+++ b/tests/snapshots/IrcMessageHandler/badges.json
@@ -216,6 +216,7 @@
                 }
             ],
             "flags": "Collapsed",
+            "frozen": false,
             "id": "546c42a6-21d0-4f3d-a6a0-c77f78d7b131",
             "localizedName": "",
             "loginName": "badgy",

--- a/tests/snapshots/IrcMessageHandler/bitsbadge.json
+++ b/tests/snapshots/IrcMessageHandler/bitsbadge.json
@@ -78,6 +78,7 @@
                 }
             ],
             "flags": "System|DoNotTriggerNotification|Subscription",
+            "frozen": false,
             "id": "",
             "localizedName": "",
             "loginName": "",

--- a/tests/snapshots/IrcMessageHandler/cheer1.json
+++ b/tests/snapshots/IrcMessageHandler/cheer1.json
@@ -409,6 +409,7 @@
                 }
             ],
             "flags": "Collapsed|CheerMessage",
+            "frozen": false,
             "id": "fd6c5507-3a4e-4d24-8f6e-fadf07f520d3",
             "localizedName": "",
             "loginName": "slyckity",

--- a/tests/snapshots/IrcMessageHandler/cheer2.json
+++ b/tests/snapshots/IrcMessageHandler/cheer2.json
@@ -183,6 +183,7 @@
                 }
             ],
             "flags": "Collapsed|CheerMessage",
+            "frozen": false,
             "id": "fd6c5507-3a4e-4d24-8f6e-fadf07f520d3",
             "localizedName": "",
             "loginName": "slyckity",

--- a/tests/snapshots/IrcMessageHandler/cheer3.json
+++ b/tests/snapshots/IrcMessageHandler/cheer3.json
@@ -166,6 +166,7 @@
                 }
             ],
             "flags": "Collapsed|CheerMessage",
+            "frozen": false,
             "id": "fd6c5507-3a4e-4d24-8f6e-fadf07f520d3",
             "localizedName": "",
             "loginName": "slyckity",

--- a/tests/snapshots/IrcMessageHandler/cheer4.json
+++ b/tests/snapshots/IrcMessageHandler/cheer4.json
@@ -128,6 +128,7 @@
                 }
             ],
             "flags": "Collapsed|CheerMessage",
+            "frozen": false,
             "id": "60d8835b-23fa-418c-96ca-5874e5d5e8ba",
             "localizedName": "",
             "loginName": "exde_hun",

--- a/tests/snapshots/IrcMessageHandler/clearchat-stack-always.json
+++ b/tests/snapshots/IrcMessageHandler/clearchat-stack-always.json
@@ -62,6 +62,7 @@
                 }
             ],
             "flags": "System|DoNotTriggerNotification|ClearChat|ModerationAction",
+            "frozen": false,
             "id": "",
             "localizedName": "",
             "loginName": "",
@@ -230,6 +231,7 @@
                 }
             ],
             "flags": "Collapsed",
+            "frozen": false,
             "id": "b4f3ac1d-6335-4567-bb8d-e76dfd83f7e3",
             "localizedName": "",
             "loginName": "pajlada",

--- a/tests/snapshots/IrcMessageHandler/clearchat-stack-never.json
+++ b/tests/snapshots/IrcMessageHandler/clearchat-stack-never.json
@@ -60,6 +60,7 @@
                 }
             ],
             "flags": "System|DoNotTriggerNotification|ClearChat|ModerationAction",
+            "frozen": false,
             "id": "",
             "localizedName": "",
             "loginName": "",

--- a/tests/snapshots/IrcMessageHandler/clearchat-stack-no-user.json
+++ b/tests/snapshots/IrcMessageHandler/clearchat-stack-no-user.json
@@ -62,6 +62,7 @@
                 }
             ],
             "flags": "System|DoNotTriggerNotification|ClearChat|ModerationAction",
+            "frozen": false,
             "id": "",
             "localizedName": "",
             "loginName": "",

--- a/tests/snapshots/IrcMessageHandler/clearchat.json
+++ b/tests/snapshots/IrcMessageHandler/clearchat.json
@@ -60,6 +60,7 @@
                 }
             ],
             "flags": "System|DoNotTriggerNotification|ClearChat|ModerationAction",
+            "frozen": false,
             "id": "",
             "localizedName": "",
             "loginName": "",

--- a/tests/snapshots/IrcMessageHandler/custom-mod.json
+++ b/tests/snapshots/IrcMessageHandler/custom-mod.json
@@ -117,6 +117,7 @@
                 }
             ],
             "flags": "Collapsed",
+            "frozen": false,
             "id": "97c28382-e8d2-45a0-bb5d-2305fc4ef139",
             "localizedName": "테스트계정420",
             "loginName": "testaccount_420",

--- a/tests/snapshots/IrcMessageHandler/custom-vip.json
+++ b/tests/snapshots/IrcMessageHandler/custom-vip.json
@@ -127,6 +127,7 @@
                 }
             ],
             "flags": "Collapsed",
+            "frozen": false,
             "id": "97bb0dfb-a35f-446d-8634-7522d8ef73ed",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/IrcMessageHandler/emote-emoji.json
+++ b/tests/snapshots/IrcMessageHandler/emote-emoji.json
@@ -199,6 +199,7 @@
                 }
             ],
             "flags": "Collapsed",
+            "frozen": false,
             "id": "44f85d39-b5fb-475d-8555-f4244f2f7e82",
             "localizedName": "",
             "loginName": "pajlada",

--- a/tests/snapshots/IrcMessageHandler/emote.json
+++ b/tests/snapshots/IrcMessageHandler/emote.json
@@ -131,6 +131,7 @@
                 }
             ],
             "flags": "Collapsed",
+            "frozen": false,
             "id": "9b1c3cb9-7817-47ea-add1-f9d4a9b4f846",
             "localizedName": "",
             "loginName": "mm2pl",

--- a/tests/snapshots/IrcMessageHandler/emoteonly-on.json
+++ b/tests/snapshots/IrcMessageHandler/emoteonly-on.json
@@ -60,6 +60,7 @@
                 }
             ],
             "flags": "System|DoNotTriggerNotification",
+            "frozen": false,
             "id": "",
             "localizedName": "",
             "loginName": "",

--- a/tests/snapshots/IrcMessageHandler/emotes.json
+++ b/tests/snapshots/IrcMessageHandler/emotes.json
@@ -169,6 +169,7 @@
                 }
             ],
             "flags": "Collapsed",
+            "frozen": false,
             "id": "7be87072-bf24-4fa3-b3df-0ea6fa5f1474",
             "localizedName": "",
             "loginName": "mm2pl",

--- a/tests/snapshots/IrcMessageHandler/emotes2.json
+++ b/tests/snapshots/IrcMessageHandler/emotes2.json
@@ -337,6 +337,7 @@
                 }
             ],
             "flags": "Collapsed",
+            "frozen": false,
             "id": "23c8b81c-7c73-44e4-84f1-7d37e99714e4",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/IrcMessageHandler/emotes3.json
+++ b/tests/snapshots/IrcMessageHandler/emotes3.json
@@ -197,6 +197,7 @@
                 }
             ],
             "flags": "Collapsed",
+            "frozen": false,
             "id": "aea562cc-1adf-47de-b656-0aaa245f1030",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/IrcMessageHandler/emotes4.json
+++ b/tests/snapshots/IrcMessageHandler/emotes4.json
@@ -127,6 +127,7 @@
                 }
             ],
             "flags": "Collapsed",
+            "frozen": false,
             "id": "",
             "localizedName": "",
             "loginName": "test",

--- a/tests/snapshots/IrcMessageHandler/emotes5.json
+++ b/tests/snapshots/IrcMessageHandler/emotes5.json
@@ -127,6 +127,7 @@
                 }
             ],
             "flags": "Collapsed",
+            "frozen": false,
             "id": "",
             "localizedName": "",
             "loginName": "test",

--- a/tests/snapshots/IrcMessageHandler/first-msg.json
+++ b/tests/snapshots/IrcMessageHandler/first-msg.json
@@ -133,6 +133,7 @@
                 }
             ],
             "flags": "Collapsed|FirstMessage",
+            "frozen": false,
             "id": "9c2dd916-5a6d-4c1f-9fe7-a081b62a9c6b",
             "localizedName": "",
             "loginName": "jammehcow",

--- a/tests/snapshots/IrcMessageHandler/highlight1.json
+++ b/tests/snapshots/IrcMessageHandler/highlight1.json
@@ -107,6 +107,7 @@
                 }
             ],
             "flags": "Collapsed",
+            "frozen": false,
             "id": "1bf2d49a-8b88-4116-81dd-5098f11726eb",
             "localizedName": "",
             "loginName": "ignoreduser",

--- a/tests/snapshots/IrcMessageHandler/highlight2.json
+++ b/tests/snapshots/IrcMessageHandler/highlight2.json
@@ -111,6 +111,7 @@
                 }
             ],
             "flags": "Highlighted|Collapsed|ShowInMentions",
+            "frozen": false,
             "highlightColor": "#7f7f3f49",
             "id": "7b5d2152-8eec-41ce-83eb-999ce5c21d28",
             "localizedName": "",

--- a/tests/snapshots/IrcMessageHandler/highlight3.json
+++ b/tests/snapshots/IrcMessageHandler/highlight3.json
@@ -110,6 +110,7 @@
                 }
             ],
             "flags": "Highlighted|Collapsed",
+            "frozen": false,
             "highlightColor": "#48ae812f",
             "id": "f72f5a7a-522d-407c-ac16-a0b413632fa9",
             "localizedName": "",

--- a/tests/snapshots/IrcMessageHandler/hype-chat-invalid.json
+++ b/tests/snapshots/IrcMessageHandler/hype-chat-invalid.json
@@ -149,6 +149,7 @@
                 }
             ],
             "flags": "Collapsed|ElevatedMessage",
+            "frozen": false,
             "id": "8779a9e5-cf1b-47b3-b9fe-67a5b1b605f6",
             "localizedName": "",
             "loginName": "snoopythebot",

--- a/tests/snapshots/IrcMessageHandler/hype-chat0.json
+++ b/tests/snapshots/IrcMessageHandler/hype-chat0.json
@@ -149,6 +149,7 @@
                 }
             ],
             "flags": "Collapsed|ElevatedMessage",
+            "frozen": false,
             "id": "8779a9e5-cf1b-47b3-b9fe-67a5b1b605f6",
             "localizedName": "",
             "loginName": "snoopythebot",
@@ -214,6 +215,7 @@
                 }
             ],
             "flags": "System|DoNotTriggerNotification|ElevatedMessage",
+            "frozen": false,
             "id": "",
             "localizedName": "",
             "loginName": "",

--- a/tests/snapshots/IrcMessageHandler/hype-chat1.json
+++ b/tests/snapshots/IrcMessageHandler/hype-chat1.json
@@ -158,6 +158,7 @@
                 }
             ],
             "flags": "Collapsed|ElevatedMessage",
+            "frozen": false,
             "id": "e6681ba0-cdc6-4482-93a3-515b74361e8b",
             "localizedName": "",
             "loginName": "matrhs",
@@ -226,6 +227,7 @@
                 }
             ],
             "flags": "System|DoNotTriggerNotification|ElevatedMessage",
+            "frozen": false,
             "id": "",
             "localizedName": "",
             "loginName": "",

--- a/tests/snapshots/IrcMessageHandler/hype-chat2.json
+++ b/tests/snapshots/IrcMessageHandler/hype-chat2.json
@@ -155,6 +155,7 @@
                 }
             ],
             "flags": "Collapsed|ElevatedMessage",
+            "frozen": false,
             "id": "39a80a3d-c16e-420f-9bbb-faba4976a3bb",
             "localizedName": "",
             "loginName": "rickharrisoncoc",
@@ -224,6 +225,7 @@
                 }
             ],
             "flags": "System|DoNotTriggerNotification|ElevatedMessage",
+            "frozen": false,
             "id": "",
             "localizedName": "",
             "loginName": "",

--- a/tests/snapshots/IrcMessageHandler/ignore-block1.json
+++ b/tests/snapshots/IrcMessageHandler/ignore-block1.json
@@ -109,6 +109,7 @@
                 }
             ],
             "flags": "Collapsed",
+            "frozen": false,
             "id": "c34a372b-d59e-4a36-9ad8-d964098526e4",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/IrcMessageHandler/ignore-infinite.json
+++ b/tests/snapshots/IrcMessageHandler/ignore-infinite.json
@@ -115,6 +115,7 @@
                 }
             ],
             "flags": "Collapsed",
+            "frozen": false,
             "id": "08e1573a-c09a-4052-8cf6-dd9fc5edf35b",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/IrcMessageHandler/ignore-replace.json
+++ b/tests/snapshots/IrcMessageHandler/ignore-replace.json
@@ -257,6 +257,7 @@
                 }
             ],
             "flags": "Collapsed",
+            "frozen": false,
             "id": "2199102c-31ae-49b1-9d2c-a33bb3a02021",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/IrcMessageHandler/justinfan.json
+++ b/tests/snapshots/IrcMessageHandler/justinfan.json
@@ -109,6 +109,7 @@
                 }
             ],
             "flags": "Collapsed",
+            "frozen": false,
             "id": "e5a690e7-74c8-41cb-977f-55b903f6be23",
             "localizedName": "",
             "loginName": "justinfan64537",

--- a/tests/snapshots/IrcMessageHandler/links.json
+++ b/tests/snapshots/IrcMessageHandler/links.json
@@ -226,6 +226,7 @@
                 }
             ],
             "flags": "Collapsed",
+            "frozen": false,
             "id": "84b6f44a-c8eb-4abe-8a78-cf736642f695",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/IrcMessageHandler/mentions.json
+++ b/tests/snapshots/IrcMessageHandler/mentions.json
@@ -160,6 +160,7 @@
                 }
             ],
             "flags": "Collapsed",
+            "frozen": false,
             "id": "49f33e31-101f-4b03-bfc4-4b8252d0c09c",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/IrcMessageHandler/mod.json
+++ b/tests/snapshots/IrcMessageHandler/mod.json
@@ -172,6 +172,7 @@
                 }
             ],
             "flags": "Collapsed",
+            "frozen": false,
             "id": "97c28382-e8d2-45a0-bb5d-2305fc4ef139",
             "localizedName": "테스트계정420",
             "loginName": "testaccount_420",

--- a/tests/snapshots/IrcMessageHandler/nickname.json
+++ b/tests/snapshots/IrcMessageHandler/nickname.json
@@ -109,6 +109,7 @@
                 }
             ],
             "flags": "Collapsed",
+            "frozen": false,
             "id": "a964d705-0b72-4867-aab7-bc9a14945742",
             "localizedName": "",
             "loginName": "nickname",

--- a/tests/snapshots/IrcMessageHandler/no-nick.json
+++ b/tests/snapshots/IrcMessageHandler/no-nick.json
@@ -109,6 +109,7 @@
                 }
             ],
             "flags": "Collapsed",
+            "frozen": false,
             "id": "1bf2d49a-8b88-4116-81dd-5098f11726eb",
             "localizedName": "nerixyz",
             "loginName": "",

--- a/tests/snapshots/IrcMessageHandler/no-tags.json
+++ b/tests/snapshots/IrcMessageHandler/no-tags.json
@@ -111,6 +111,7 @@
                 }
             ],
             "flags": "Collapsed",
+            "frozen": false,
             "id": "",
             "localizedName": "",
             "loginName": "jammehcow",

--- a/tests/snapshots/IrcMessageHandler/raid.json
+++ b/tests/snapshots/IrcMessageHandler/raid.json
@@ -90,6 +90,7 @@
                 }
             ],
             "flags": "System|DoNotTriggerNotification|Subscription",
+            "frozen": false,
             "id": "",
             "localizedName": "",
             "loginName": "",

--- a/tests/snapshots/IrcMessageHandler/redeemed-highlight.json
+++ b/tests/snapshots/IrcMessageHandler/redeemed-highlight.json
@@ -147,6 +147,7 @@
                 }
             ],
             "flags": "Collapsed|RedeemedHighlight",
+            "frozen": false,
             "id": "c5a927a2-1f68-41f7-9137-809a37e58e61",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/IrcMessageHandler/reply-action.json
+++ b/tests/snapshots/IrcMessageHandler/reply-action.json
@@ -165,6 +165,7 @@
                 }
             ],
             "flags": "Collapsed|ReplyMessage",
+            "frozen": false,
             "id": "9d74021f-375a-44f1-80e4-0dd58e64396a",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/IrcMessageHandler/reply-block.json
+++ b/tests/snapshots/IrcMessageHandler/reply-block.json
@@ -165,6 +165,7 @@
                 }
             ],
             "flags": "Collapsed",
+            "frozen": false,
             "id": "289ffa22-d29a-4300-88be-1734b0a33b2a",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/IrcMessageHandler/reply-blocked-user.json
+++ b/tests/snapshots/IrcMessageHandler/reply-blocked-user.json
@@ -169,6 +169,7 @@
                 }
             ],
             "flags": "Collapsed",
+            "frozen": false,
             "id": "e5b84adf-b62d-47ff-8534-2cc57e24a5fb",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/IrcMessageHandler/reply-child.json
+++ b/tests/snapshots/IrcMessageHandler/reply-child.json
@@ -165,6 +165,7 @@
                 }
             ],
             "flags": "Collapsed|ReplyMessage",
+            "frozen": false,
             "id": "997cb8fa-4d24-411b-a5cd-433e515a5b72",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/IrcMessageHandler/reply-ignore.json
+++ b/tests/snapshots/IrcMessageHandler/reply-ignore.json
@@ -165,6 +165,7 @@
                 }
             ],
             "flags": "Collapsed|ReplyMessage",
+            "frozen": false,
             "id": "89c8f200-ae37-4279-909d-5ff4f9ed10a0",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/IrcMessageHandler/reply-no-prev.json
+++ b/tests/snapshots/IrcMessageHandler/reply-no-prev.json
@@ -165,6 +165,7 @@
                 }
             ],
             "flags": "Collapsed",
+            "frozen": false,
             "id": "474f19ab-a1b0-410a-877a-5b0e2ae8be6d",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/IrcMessageHandler/reply-root.json
+++ b/tests/snapshots/IrcMessageHandler/reply-root.json
@@ -165,6 +165,7 @@
                 }
             ],
             "flags": "Collapsed|ReplyMessage",
+            "frozen": false,
             "id": "f0b45994-3e92-4c37-a35f-062072163d9d",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/IrcMessageHandler/reply-single.json
+++ b/tests/snapshots/IrcMessageHandler/reply-single.json
@@ -239,6 +239,7 @@
                 }
             ],
             "flags": "Collapsed|ReplyMessage",
+            "frozen": false,
             "id": "5e5f526a-5d60-4d81-800b-3b81b8a34c2c",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/IrcMessageHandler/reward-bits.json
+++ b/tests/snapshots/IrcMessageHandler/reward-bits.json
@@ -243,6 +243,7 @@
                 }
             ],
             "flags": "Collapsed|RedeemedChannelPointReward",
+            "frozen": false,
             "id": "87af876f-5591-4a63-924f-46f465ecd3c4",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/IrcMessageHandler/reward-empty.json
+++ b/tests/snapshots/IrcMessageHandler/reward-empty.json
@@ -207,6 +207,7 @@
                 }
             ],
             "flags": "Collapsed|RedeemedChannelPointReward",
+            "frozen": false,
             "id": "2932e250-1f49-4587-8783-7a13d9f99f6b",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/IrcMessageHandler/reward-known.json
+++ b/tests/snapshots/IrcMessageHandler/reward-known.json
@@ -204,6 +204,7 @@
                 }
             ],
             "flags": "Collapsed|RedeemedChannelPointReward",
+            "frozen": false,
             "id": "87af876f-5591-4a63-924f-46f465ecd3c4",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/IrcMessageHandler/reward-unknown.json
+++ b/tests/snapshots/IrcMessageHandler/reward-unknown.json
@@ -110,6 +110,7 @@
                 }
             ],
             "flags": "Collapsed|RedeemedChannelPointReward",
+            "frozen": false,
             "id": "4d409401-f692-4dd1-9295-f21350f86860",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/IrcMessageHandler/rm-deleted.json
+++ b/tests/snapshots/IrcMessageHandler/rm-deleted.json
@@ -186,6 +186,7 @@
                 }
             ],
             "flags": "Disabled|Collapsed",
+            "frozen": false,
             "id": "3dc39240-0798-4103-8c3c-51e1a9a567a3",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/IrcMessageHandler/shared-chat-announcement.json
+++ b/tests/snapshots/IrcMessageHandler/shared-chat-announcement.json
@@ -172,6 +172,7 @@
                 }
             ],
             "flags": "Collapsed|Subscription|SharedMessage",
+            "frozen": false,
             "highlightColor": "#64c466ff",
             "id": "01cd601f-bc3f-49d5-ab4b-136fa9d6ec22",
             "localizedName": "",
@@ -236,6 +237,7 @@
                 }
             ],
             "flags": "System|DoNotTriggerNotification|Subscription|SharedMessage",
+            "frozen": false,
             "id": "",
             "localizedName": "",
             "loginName": "",

--- a/tests/snapshots/IrcMessageHandler/shared-chat-emotes.json
+++ b/tests/snapshots/IrcMessageHandler/shared-chat-emotes.json
@@ -292,6 +292,7 @@
                 }
             ],
             "flags": "DoNotTriggerNotification|Collapsed|SharedMessage",
+            "frozen": false,
             "id": "5b6f9721-80fd-4036-951e-1ced9c591b32",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/IrcMessageHandler/shared-chat-known.json
+++ b/tests/snapshots/IrcMessageHandler/shared-chat-known.json
@@ -166,6 +166,7 @@
                 }
             ],
             "flags": "DoNotTriggerNotification|Collapsed|SharedMessage",
+            "frozen": false,
             "id": "19ee1663-c14d-41cd-a4a2-30a4bb609c5a",
             "localizedName": "",
             "loginName": "creativewind",

--- a/tests/snapshots/IrcMessageHandler/shared-chat-same-channel.json
+++ b/tests/snapshots/IrcMessageHandler/shared-chat-same-channel.json
@@ -148,6 +148,7 @@
                 }
             ],
             "flags": "Collapsed",
+            "frozen": false,
             "id": "19ee1663-c14d-41cd-a4a2-30a4bb609c5a",
             "localizedName": "",
             "loginName": "creativewind",

--- a/tests/snapshots/IrcMessageHandler/shared-chat-unknown.json
+++ b/tests/snapshots/IrcMessageHandler/shared-chat-unknown.json
@@ -166,6 +166,7 @@
                 }
             ],
             "flags": "Collapsed|SharedMessage",
+            "frozen": false,
             "id": "19ee1663-c14d-41cd-a4a2-30a4bb609c5a",
             "localizedName": "",
             "loginName": "creativewind",

--- a/tests/snapshots/IrcMessageHandler/simple.json
+++ b/tests/snapshots/IrcMessageHandler/simple.json
@@ -133,6 +133,7 @@
                 }
             ],
             "flags": "Collapsed",
+            "frozen": false,
             "id": "9c2dd916-5a6d-4c1f-9fe7-a081b62a9c6b",
             "localizedName": "",
             "loginName": "jammehcow",

--- a/tests/snapshots/IrcMessageHandler/sub-first-gift.json
+++ b/tests/snapshots/IrcMessageHandler/sub-first-gift.json
@@ -119,6 +119,7 @@
                 }
             ],
             "flags": "System|DoNotTriggerNotification|Subscription",
+            "frozen": false,
             "id": "",
             "localizedName": "",
             "loginName": "",

--- a/tests/snapshots/IrcMessageHandler/sub-first-time.json
+++ b/tests/snapshots/IrcMessageHandler/sub-first-time.json
@@ -76,6 +76,7 @@
                 }
             ],
             "flags": "System|DoNotTriggerNotification|Subscription",
+            "frozen": false,
             "id": "",
             "localizedName": "",
             "loginName": "",

--- a/tests/snapshots/IrcMessageHandler/sub-gift-02.json
+++ b/tests/snapshots/IrcMessageHandler/sub-gift-02.json
@@ -110,6 +110,7 @@
                 }
             ],
             "flags": "System|DoNotTriggerNotification|Subscription",
+            "frozen": false,
             "id": "",
             "localizedName": "",
             "loginName": "",

--- a/tests/snapshots/IrcMessageHandler/sub-gift.json
+++ b/tests/snapshots/IrcMessageHandler/sub-gift.json
@@ -110,6 +110,7 @@
                 }
             ],
             "flags": "System|DoNotTriggerNotification|Subscription",
+            "frozen": false,
             "id": "",
             "localizedName": "",
             "loginName": "",

--- a/tests/snapshots/IrcMessageHandler/sub-message-user-color-override.json
+++ b/tests/snapshots/IrcMessageHandler/sub-message-user-color-override.json
@@ -173,6 +173,7 @@
                 }
             ],
             "flags": "Collapsed|Subscription",
+            "frozen": false,
             "highlightColor": "#64c466ff",
             "id": "db25007f-7a18-43eb-9379-80131e44d633",
             "localizedName": "",
@@ -259,6 +260,7 @@
                 }
             ],
             "flags": "System|DoNotTriggerNotification|Subscription",
+            "frozen": false,
             "id": "",
             "localizedName": "",
             "loginName": "",

--- a/tests/snapshots/IrcMessageHandler/sub-message.json
+++ b/tests/snapshots/IrcMessageHandler/sub-message.json
@@ -173,6 +173,7 @@
                 }
             ],
             "flags": "Collapsed|Subscription",
+            "frozen": false,
             "highlightColor": "#64c466ff",
             "id": "db25007f-7a18-43eb-9379-80131e44d633",
             "localizedName": "",
@@ -259,6 +260,7 @@
                 }
             ],
             "flags": "System|DoNotTriggerNotification|Subscription",
+            "frozen": false,
             "id": "",
             "localizedName": "",
             "loginName": "",

--- a/tests/snapshots/IrcMessageHandler/sub-multi-month-anon-gift.json
+++ b/tests/snapshots/IrcMessageHandler/sub-multi-month-anon-gift.json
@@ -98,6 +98,7 @@
                 }
             ],
             "flags": "System|DoNotTriggerNotification|Subscription",
+            "frozen": false,
             "id": "",
             "localizedName": "",
             "loginName": "",

--- a/tests/snapshots/IrcMessageHandler/sub-multi-month-gift-count.json
+++ b/tests/snapshots/IrcMessageHandler/sub-multi-month-gift-count.json
@@ -120,6 +120,7 @@
                 }
             ],
             "flags": "System|DoNotTriggerNotification|Subscription",
+            "frozen": false,
             "id": "",
             "localizedName": "",
             "loginName": "",

--- a/tests/snapshots/IrcMessageHandler/sub-multi-month-gift.json
+++ b/tests/snapshots/IrcMessageHandler/sub-multi-month-gift.json
@@ -113,6 +113,7 @@
                 }
             ],
             "flags": "System|DoNotTriggerNotification|Subscription",
+            "frozen": false,
             "id": "",
             "localizedName": "",
             "loginName": "",

--- a/tests/snapshots/IrcMessageHandler/sub-multi-month-resub.json
+++ b/tests/snapshots/IrcMessageHandler/sub-multi-month-resub.json
@@ -86,6 +86,7 @@
                 }
             ],
             "flags": "System|DoNotTriggerNotification|Subscription",
+            "frozen": false,
             "id": "",
             "localizedName": "",
             "loginName": "",

--- a/tests/snapshots/IrcMessageHandler/sub-multi-month.json
+++ b/tests/snapshots/IrcMessageHandler/sub-multi-month.json
@@ -80,6 +80,7 @@
                 }
             ],
             "flags": "System|DoNotTriggerNotification|Subscription",
+            "frozen": false,
             "id": "",
             "localizedName": "",
             "loginName": "",

--- a/tests/snapshots/IrcMessageHandler/sub-no-message.json
+++ b/tests/snapshots/IrcMessageHandler/sub-no-message.json
@@ -117,6 +117,7 @@
                 }
             ],
             "flags": "System|DoNotTriggerNotification|Subscription",
+            "frozen": false,
             "id": "",
             "localizedName": "",
             "loginName": "",

--- a/tests/snapshots/IrcMessageHandler/timeout-stack-always.json
+++ b/tests/snapshots/IrcMessageHandler/timeout-stack-always.json
@@ -76,6 +76,7 @@
                 }
             ],
             "flags": "System|Timeout|DoNotTriggerNotification|ModerationAction",
+            "frozen": false,
             "id": "",
             "localizedName": "",
             "loginName": "",
@@ -192,6 +193,7 @@
                 }
             ],
             "flags": "Collapsed",
+            "frozen": false,
             "id": "aa1baade-c9c7-4932-b518-07c6b0226914",
             "localizedName": "",
             "loginName": "twitchdev",

--- a/tests/snapshots/IrcMessageHandler/timeout-stack-never.json
+++ b/tests/snapshots/IrcMessageHandler/timeout-stack-never.json
@@ -76,6 +76,7 @@
                 }
             ],
             "flags": "System|Timeout|DoNotTriggerNotification|ModerationAction",
+            "frozen": false,
             "id": "",
             "localizedName": "",
             "loginName": "",
@@ -192,6 +193,7 @@
                 }
             ],
             "flags": "Collapsed",
+            "frozen": false,
             "id": "aa1baade-c9c7-4932-b518-07c6b0226914",
             "localizedName": "",
             "loginName": "twitchdev",

--- a/tests/snapshots/IrcMessageHandler/timeout-stack-no-user.json
+++ b/tests/snapshots/IrcMessageHandler/timeout-stack-no-user.json
@@ -74,6 +74,7 @@
                 }
             ],
             "flags": "System|Timeout|DoNotTriggerNotification|ModerationAction",
+            "frozen": false,
             "id": "",
             "localizedName": "",
             "loginName": "",
@@ -190,6 +191,7 @@
                 }
             ],
             "flags": "Collapsed",
+            "frozen": false,
             "id": "aa1baade-c9c7-4932-b518-07c6b0226914",
             "localizedName": "",
             "loginName": "twitchdev",
@@ -275,6 +277,7 @@
                 }
             ],
             "flags": "System|Timeout|DoNotTriggerNotification|ModerationAction",
+            "frozen": false,
             "id": "",
             "localizedName": "",
             "loginName": "",

--- a/tests/snapshots/IrcMessageHandler/timeout.json
+++ b/tests/snapshots/IrcMessageHandler/timeout.json
@@ -74,6 +74,7 @@
                 }
             ],
             "flags": "System|Timeout|DoNotTriggerNotification|ModerationAction",
+            "frozen": false,
             "id": "",
             "localizedName": "",
             "loginName": "",

--- a/tests/snapshots/IrcMessageHandler/username-localized.json
+++ b/tests/snapshots/IrcMessageHandler/username-localized.json
@@ -99,6 +99,7 @@
                 }
             ],
             "flags": "Collapsed",
+            "frozen": false,
             "id": "3ad26770-7299-4261-ab9b-24f410944517",
             "localizedName": "display-name=테스트계정420",
             "loginName": "testaccount_420",

--- a/tests/snapshots/IrcMessageHandler/username-localized2.json
+++ b/tests/snapshots/IrcMessageHandler/username-localized2.json
@@ -99,6 +99,7 @@
                 }
             ],
             "flags": "Collapsed",
+            "frozen": false,
             "id": "3ad26770-7299-4261-ab9b-24f410944517",
             "localizedName": "",
             "loginName": "testaccount_420",

--- a/tests/snapshots/IrcMessageHandler/username.json
+++ b/tests/snapshots/IrcMessageHandler/username.json
@@ -99,6 +99,7 @@
                 }
             ],
             "flags": "Collapsed",
+            "frozen": false,
             "id": "3ad26770-7299-4261-ab9b-24f410944517",
             "localizedName": "display-name=테스트계정420",
             "loginName": "testaccount_420",

--- a/tests/snapshots/IrcMessageHandler/vip.json
+++ b/tests/snapshots/IrcMessageHandler/vip.json
@@ -130,6 +130,7 @@
                 }
             ],
             "flags": "Collapsed",
+            "frozen": false,
             "id": "97bb0dfb-a35f-446d-8634-7522d8ef73ed",
             "localizedName": "",
             "loginName": "nerixyz",

--- a/tests/snapshots/PluginMessageCtor/empty.json
+++ b/tests/snapshots/PluginMessageCtor/empty.json
@@ -11,6 +11,7 @@
         "elements": [
         ],
         "flags": "",
+        "frozen": false,
         "id": "",
         "localizedName": "",
         "loginName": "",

--- a/tests/snapshots/PluginMessageCtor/linebreak-element.json
+++ b/tests/snapshots/PluginMessageCtor/linebreak-element.json
@@ -58,6 +58,7 @@
             }
         ],
         "flags": "",
+        "frozen": false,
         "id": "",
         "localizedName": "",
         "loginName": "",

--- a/tests/snapshots/PluginMessageCtor/mention-element.json
+++ b/tests/snapshots/PluginMessageCtor/mention-element.json
@@ -90,6 +90,7 @@
             }
         ],
         "flags": "",
+        "frozen": false,
         "id": "",
         "localizedName": "",
         "loginName": "",

--- a/tests/snapshots/PluginMessageCtor/properties.json
+++ b/tests/snapshots/PluginMessageCtor/properties.json
@@ -46,6 +46,7 @@
             }
         ],
         "flags": "System|Disabled",
+        "frozen": false,
         "highlightColor": "#12345678",
         "id": "foo-bar",
         "localizedName": "local",

--- a/tests/snapshots/PluginMessageCtor/reply-curve-element.json
+++ b/tests/snapshots/PluginMessageCtor/reply-curve-element.json
@@ -58,6 +58,7 @@
             }
         ],
         "flags": "",
+        "frozen": false,
         "id": "",
         "localizedName": "",
         "loginName": "",

--- a/tests/snapshots/PluginMessageCtor/single-line-text-element.json
+++ b/tests/snapshots/PluginMessageCtor/single-line-text-element.json
@@ -175,6 +175,7 @@
             }
         ],
         "flags": "",
+        "frozen": false,
         "id": "",
         "localizedName": "",
         "loginName": "",

--- a/tests/snapshots/PluginMessageCtor/text-element.json
+++ b/tests/snapshots/PluginMessageCtor/text-element.json
@@ -175,6 +175,7 @@
             }
         ],
         "flags": "",
+        "frozen": false,
         "id": "",
         "localizedName": "",
         "loginName": "",

--- a/tests/snapshots/PluginMessageCtor/timestamp-element.json
+++ b/tests/snapshots/PluginMessageCtor/timestamp-element.json
@@ -126,6 +126,7 @@
             }
         ],
         "flags": "",
+        "frozen": false,
         "id": "",
         "localizedName": "",
         "loginName": "",

--- a/tests/snapshots/PluginMessageCtor/twitch-moderation.json
+++ b/tests/snapshots/PluginMessageCtor/twitch-moderation.json
@@ -58,6 +58,7 @@
             }
         ],
         "flags": "",
+        "frozen": false,
         "id": "",
         "localizedName": "",
         "loginName": "",


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

This adds a flag to `Message` (`frozen`) that indicates that it shouldn't be modified anymore. This is set once it gets added to a channel.

**Why?**
Plugins (#6353). Consider the following:
- Create a message `msg`
- Add `msg` to some channel
- (some time later) add an element to `msg` or modify it in some other way
We don't allow this because we assume messages are immutable (except flags) once they're in a channel. Technically, this is also possible in C++. We can't enforce this statically - mutable messages are `std::shared_ptr<Message>` and immutable ones are `std::shared_ptr<const Message>`. There can be const and non-const pointers to the same message at the same time.
In Lua, we need to check this invariant.