### PR TITLE
Stop sending `JOIN`/`PART` commands for channels starting with `/`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 - Bugfix: Emotes that failed to load their images now show as text. (#6355)
 - Bugfix: Fixed a crash that occurs when searching for emotes in channel-less contexts. (#6357)
 - Bugfix: Fixed command triggers showing as '/...' when the value is longer than the column width. (#6369)
+- Bugfix: Fixed sending IRC `JOIN`/`PART` commands for channels starting with `/`. (#6376)
 - Dev: Mini refactor of Split. (#6148)
 - Dev: Conan will no longer generate a `CMakeUserPresets.json` file. (#6117)
 - Dev: Pass `--force-openssl` when installing from CMake in Qt 6.8+. (#6129)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,6 @@
 - Bugfix: Emotes that failed to load their images now show as text. (#6355)
 - Bugfix: Fixed a crash that occurs when searching for emotes in channel-less contexts. (#6357)
 - Bugfix: Fixed command triggers showing as '/...' when the value is longer than the column width. (#6369)
-- Bugfix: Fixed sending IRC `JOIN`/`PART` commands for channels starting with `/`. (#6376)
 - Dev: Mini refactor of Split. (#6148)
 - Dev: Conan will no longer generate a `CMakeUserPresets.json` file. (#6117)
 - Dev: Pass `--force-openssl` when installing from CMake in Qt 6.8+. (#6129)
@@ -97,6 +96,7 @@
 - Dev: Added some commands for forcing a relayout (and related things) in channel views. (#6342)
 - Dev: Update vcpkg baseline. (#6359)
 - Dev: Added an explicit `frozen` flag to `Message`. (#6367)
+- Dev: Stop sending `JOIN`/`PART` commands for channels starting with `/`. (#6376)
 
 ## 2.5.3
 

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -463,6 +463,10 @@ void TwitchIrcServer::onReadConnected(IrcConnection *connection)
     // join channels
     for (const auto &channel : activeChannels)
     {
+        if (channel->getName().startsWith("/"))
+        {
+            continue;
+        }
         this->joinBucket_->send(channel->getName());
     }
 
@@ -1164,7 +1168,7 @@ ChannelPtr TwitchIrcServer::getOrAddChannel(const QString &dirtyChannelName)
                                << "was destroyed";
         this->channels.remove(channelName);
 
-        if (this->readConnection_)
+        if (this->readConnection_ && !channelName.startsWith("/"))
         {
             this->readConnection_->sendRaw("PART #" + channelName);
         }
@@ -1174,12 +1178,10 @@ ChannelPtr TwitchIrcServer::getOrAddChannel(const QString &dirtyChannelName)
     {
         std::lock_guard<std::mutex> lock2(this->connectionMutex_);
 
-        if (this->readConnection_)
+        if (this->readConnection_ && this->readConnection_->isConnected() &&
+            !channelName.startsWith("/"))
         {
-            if (this->readConnection_->isConnected())
-            {
-                this->joinBucket_->send(channelName);
-            }
+            this->joinBucket_->send(channelName);
         }
     }
 


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
Plugins tend to use channels beginning with `/` as their own empty channels. We shouldn't send invalid JOIN commands for channels that are local. This is a simple hack, the fix for the root of the issue would be to give plugins a way to actually own channels, but that is going to take a lot of time to finalize.

We already do not send `JOIN`s for `/watching` and friends (with the exception of `/watching` for some reason)