### PR TITLE
fix: hide lines in search

### DIFF
--- a/src/widgets/settingspages/GeneralPageView.cpp
+++ b/src/widgets/settingspages/GeneralPageView.cpp
@@ -282,6 +282,12 @@ bool GeneralPageView::filterElements(const QString &query)
                     continue;
                 }
 
+                if (auto *x = dynamic_cast<Line *>(widget.element))
+                {
+                    // Hide lines in search when not searching for full categories
+                    x->hide();
+                }
+
                 for (auto &&keyword : widget.keywords)
                 {
                     if (keyword.contains(query, Qt::CaseInsensitive) ||


### PR DESCRIPTION
fixes #2845

this will hide lines that don't belong to a full group match