### PR TITLE
fix note/description not filtering in/out when it should

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 - Bugfix: Fixed theme changes not instantly applying to messages. (#6373)
 - Bugfix: Fixed command triggers showing as '/...' when the value is longer than the column width. (#6369)
 - Bugfix: Fixed a crash that could occur when making HTTP requests from a timeout handler. (#6375)
+- Bugfix: Fixed a setting description not filtering correctly on search. (#6389)
 - Dev: Mini refactor of Split. (#6148)
 - Dev: Conan will no longer generate a `CMakeUserPresets.json` file. (#6117)
 - Dev: Pass `--force-openssl` when installing from CMake in Qt 6.8+. (#6129)

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -896,7 +896,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         ->addTo(layout);
 
     {
-        auto *note = new QLabel(
+        auto *note = layout.addDescription(
             "A semicolon-separated list of Chrome or Firefox extension IDs "
             "allowed to interact with Chatterino's browser integration "
             "(requires restart).\n"


### PR DESCRIPTION
a part of General Page -> Browser Integration was not properly integrated and had issues on search

## Whole group not appearing
<img height="150" alt="image" src="https://github.com/user-attachments/assets/0a36ae80-fec1-444b-afd6-8666234c3b0b" />

fixed to

<img height="150" alt="image" src="https://github.com/user-attachments/assets/2276edd3-1e8d-4822-bb43-e96a82df314a" />

---

## Appearing when it should not

<img height="150" alt="image" src="https://github.com/user-attachments/assets/89eec36d-3821-465d-849c-e8010e20ce94" />

fixed to 

<img height="150" alt="image" src="https://github.com/user-attachments/assets/6ef5a9bb-d1db-478b-8f3a-65656be5f4dc" />

---

## Appearing in unrelated searches

<img height="200" alt="image" src="https://github.com/user-attachments/assets/ab571f39-0f1c-4737-b353-0f5664436724" />

fixed to

<img height="200" alt="image" src="https://github.com/user-attachments/assets/5d28d5ba-0097-48ac-86d2-51c3a804aeae" />



