### PR TITLE
test: Add snapshot tests for imageuploader import/export

### DIFF
--- a/tests/snapshots/ImageUploader/Export/basic.json
+++ b/tests/snapshots/ImageUploader/Export/basic.json
@@ -1,0 +1,22 @@
+{
+    "input": {
+        "deletionLink": "{more}",
+        "formField": "form",
+        "headers": "My-Header: Foo",
+        "link": "foo{bar}baz",
+        "url": "http://example.com"
+    },
+    "output": {
+        "Body": "MultipartFormData",
+        "DeletionURL": "{more}",
+        "FileFormName": "form",
+        "Headers": {
+            "My-Header": "Foo"
+        },
+        "Name": "Chatterino Image Uploader Settings",
+        "RequestMethod": "POST",
+        "RequestURL": "http://example.com",
+        "URL": "foo{bar}baz",
+        "Version": "1.0.0"
+    }
+}

--- a/tests/snapshots/ImageUploader/Export/headers.json
+++ b/tests/snapshots/ImageUploader/Export/headers.json
@@ -1,0 +1,23 @@
+{
+    "input": {
+        "deletionLink": "{more}",
+        "formField": "file",
+        "headers": "My-Header: Foo ; Bar : Baz ; KeyOnly\nX-My-Header:1",
+        "link": "foo{bar}baz",
+        "url": "https://example.com"
+    },
+    "output": {
+        "Body": "MultipartFormData",
+        "DeletionURL": "{more}",
+        "FileFormName": "file",
+        "Headers": {
+            "My-Header": "Foo ; Bar : Baz ; KeyOnly",
+            "X-My-Header": "1"
+        },
+        "Name": "Chatterino Image Uploader Settings",
+        "RequestMethod": "POST",
+        "RequestURL": "https://example.com",
+        "URL": "foo{bar}baz",
+        "Version": "1.0.0"
+    }
+}

--- a/tests/snapshots/ImageUploader/Export/i-fourtf.json
+++ b/tests/snapshots/ImageUploader/Export/i-fourtf.json
@@ -1,0 +1,22 @@
+{
+    "input": {
+        "deletionLink": "",
+        "formField": "file",
+        "headers": "Authorization: Basic XXXXXXXXXXXXXXX",
+        "link": "",
+        "url": "https://i.yourwebsite.com/upload"
+    },
+    "output": {
+        "Body": "MultipartFormData",
+        "DeletionURL": "",
+        "FileFormName": "file",
+        "Headers": {
+            "Authorization": "Basic XXXXXXXXXXXXXXX"
+        },
+        "Name": "Chatterino Image Uploader Settings",
+        "RequestMethod": "POST",
+        "RequestURL": "https://i.yourwebsite.com/upload",
+        "URL": "",
+        "Version": "1.0.0"
+    }
+}

--- a/tests/snapshots/ImageUploader/Export/i-nuuls.json
+++ b/tests/snapshots/ImageUploader/Export/i-nuuls.json
@@ -1,0 +1,19 @@
+{
+    "input": {
+        "deletionLink": "",
+        "formField": "attachment",
+        "headers": "",
+        "link": "",
+        "url": "https://i.nuuls.com/upload"
+    },
+    "output": {
+        "Body": "MultipartFormData",
+        "DeletionURL": "",
+        "FileFormName": "attachment",
+        "Name": "Chatterino Image Uploader Settings",
+        "RequestMethod": "POST",
+        "RequestURL": "https://i.nuuls.com/upload",
+        "URL": "",
+        "Version": "1.0.0"
+    }
+}

--- a/tests/snapshots/ImageUploader/Export/imgur.json
+++ b/tests/snapshots/ImageUploader/Export/imgur.json
@@ -1,0 +1,22 @@
+{
+    "input": {
+        "deletionLink": "https://imgur.com/delete/{data.deletehash}",
+        "formField": "image",
+        "headers": "Authorization: Client-ID c898c0bb848ca39",
+        "link": "{data.link}",
+        "url": "https://api.imgur.com/3/image"
+    },
+    "output": {
+        "Body": "MultipartFormData",
+        "DeletionURL": "https://imgur.com/delete/{data.deletehash}",
+        "FileFormName": "image",
+        "Headers": {
+            "Authorization": "Client-ID c898c0bb848ca39"
+        },
+        "Name": "Chatterino Image Uploader Settings",
+        "RequestMethod": "POST",
+        "RequestURL": "https://api.imgur.com/3/image",
+        "URL": "{data.link}",
+        "Version": "1.0.0"
+    }
+}

--- a/tests/snapshots/ImageUploader/Export/s-ul.json
+++ b/tests/snapshots/ImageUploader/Export/s-ul.json
@@ -1,0 +1,19 @@
+{
+    "input": {
+        "deletionLink": "https://s-ul.eu/delete.php?file={filename}&key=XXXXXXXXXXXXXXX",
+        "formField": "file",
+        "headers": "",
+        "link": "{url}",
+        "url": "https://s-ul.eu/api/v1/upload?wizard=true&key=XXXXXXXXXXXXXXX"
+    },
+    "output": {
+        "Body": "MultipartFormData",
+        "DeletionURL": "https://s-ul.eu/delete.php?file={filename}&key=XXXXXXXXXXXXXXX",
+        "FileFormName": "file",
+        "Name": "Chatterino Image Uploader Settings",
+        "RequestMethod": "POST",
+        "RequestURL": "https://s-ul.eu/api/v1/upload?wizard=true&key=XXXXXXXXXXXXXXX",
+        "URL": "{url}",
+        "Version": "1.0.0"
+    }
+}

--- a/tests/snapshots/ImageUploader/Import/basic.json
+++ b/tests/snapshots/ImageUploader/Import/basic.json
@@ -1,0 +1,22 @@
+{
+    "input": {
+        "Body": "MultipartFormData",
+        "DeletionURL": "{more}",
+        "FileFormName": "form",
+        "Headers": {
+            "My-Header": "Foo"
+        },
+        "Name": "Chatterino Image Uploader Settings",
+        "RequestMethod": "POST",
+        "RequestURL": "http://example.com",
+        "URL": "foo{bar}baz",
+        "Version": "1.0.0"
+    },
+    "output": {
+        "deletionLink": "{more}",
+        "formField": "form",
+        "headers": "My-Header: Foo",
+        "link": "foo{bar}baz",
+        "url": "http://example.com"
+    }
+}

--- a/tests/snapshots/ImageUploader/Import/headers.json
+++ b/tests/snapshots/ImageUploader/Import/headers.json
@@ -1,0 +1,24 @@
+{
+    "input": {
+        "Body": "MultipartFormData",
+        "DeletionURL": "{more}",
+        "FileFormName": "file",
+        "Headers": {
+            "Another": "header",
+            "My-Header": "Foo ; Bar : Baz ; KeyOnly",
+            "X-My-Header": "1"
+        },
+        "Name": "Chatterino Image Uploader Settings",
+        "RequestMethod": "POST",
+        "RequestURL": "https://example.com",
+        "URL": "foo{bar}baz",
+        "Version": "1.0.0"
+    },
+    "output": {
+        "deletionLink": "{more}",
+        "formField": "file",
+        "headers": "Another: header\nMy-Header: Foo ; Bar : Baz ; KeyOnly\nX-My-Header: 1",
+        "link": "foo{bar}baz",
+        "url": "https://example.com"
+    }
+}

--- a/tests/snapshots/ImageUploader/Import/i-fourtf.json
+++ b/tests/snapshots/ImageUploader/Import/i-fourtf.json
@@ -1,0 +1,22 @@
+{
+    "input": {
+        "Body": "MultipartFormData",
+        "DeletionURL": "",
+        "FileFormName": "file",
+        "Headers": {
+            "Authorization": "Basic XXXXXXXXXXXXXXX"
+        },
+        "Name": "Chatterino Image Uploader Settings",
+        "RequestMethod": "POST",
+        "RequestURL": "https://i.yourwebsite.com/upload",
+        "URL": "",
+        "Version": "1.0.0"
+    },
+    "output": {
+        "deletionLink": "",
+        "formField": "file",
+        "headers": "Authorization: Basic XXXXXXXXXXXXXXX",
+        "link": "",
+        "url": "https://i.yourwebsite.com/upload"
+    }
+}

--- a/tests/snapshots/ImageUploader/Import/i-nuuls.json
+++ b/tests/snapshots/ImageUploader/Import/i-nuuls.json
@@ -1,0 +1,19 @@
+{
+    "input": {
+        "Body": "MultipartFormData",
+        "DeletionURL": "",
+        "FileFormName": "attachment",
+        "Name": "Chatterino Image Uploader Settings",
+        "RequestMethod": "POST",
+        "RequestURL": "https://i.nuuls.com/upload",
+        "URL": "",
+        "Version": "1.0.0"
+    },
+    "output": {
+        "deletionLink": "",
+        "formField": "attachment",
+        "headers": "",
+        "link": "",
+        "url": "https://i.nuuls.com/upload"
+    }
+}

--- a/tests/snapshots/ImageUploader/Import/imgur.json
+++ b/tests/snapshots/ImageUploader/Import/imgur.json
@@ -1,0 +1,22 @@
+{
+    "input": {
+        "Body": "MultipartFormData",
+        "DeletionURL": "https://imgur.com/delete/{data.deletehash}",
+        "FileFormName": "image",
+        "Headers": {
+            "Authorization": "Client-ID c898c0bb848ca39"
+        },
+        "Name": "Chatterino Image Uploader Settings",
+        "RequestMethod": "POST",
+        "RequestURL": "https://api.imgur.com/3/image",
+        "URL": "{data.link}",
+        "Version": "1.0.0"
+    },
+    "output": {
+        "deletionLink": "https://imgur.com/delete/{data.deletehash}",
+        "formField": "image",
+        "headers": "Authorization: Client-ID c898c0bb848ca39",
+        "link": "{data.link}",
+        "url": "https://api.imgur.com/3/image"
+    }
+}

--- a/tests/snapshots/ImageUploader/Import/s-ul.json
+++ b/tests/snapshots/ImageUploader/Import/s-ul.json
@@ -1,0 +1,19 @@
+{
+    "input": {
+        "Body": "MultipartFormData",
+        "DeletionURL": "https://s-ul.eu/delete.php?file={filename}&key=XXXXXXXXXXXXXXX",
+        "FileFormName": "file",
+        "Name": "Chatterino Image Uploader Settings",
+        "RequestMethod": "POST",
+        "RequestURL": "https://s-ul.eu/api/v1/upload?wizard=true&key=XXXXXXXXXXXXXXX",
+        "URL": "{url}",
+        "Version": "1.0.0"
+    },
+    "output": {
+        "deletionLink": "https://s-ul.eu/delete.php?file={filename}&key=XXXXXXXXXXXXXXX",
+        "formField": "file",
+        "headers": "",
+        "link": "{url}",
+        "url": "https://s-ul.eu/api/v1/upload?wizard=true&key=XXXXXXXXXXXXXXX"
+    }
+}


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
Adds snapshot tests for #6284's import/export functionality. It uses the examples from [the wiki](https://wiki.chatterino.com/Image%20Uploader/) as well as a header sample. I found that multiple headers don't get converted correctly. We shouldn't use newlines but semicolons. Newlines won't work in the image uploader. But I'll wait for #6387 (or maybe it will be fixed there as well).