### PR TITLE
fix: notes behavior on users with no id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 - Bugfix: Fixed command triggers showing as '/...' when the value is longer than the column width. (#6369)
 - Bugfix: Fixed a crash that could occur when making HTTP requests from a timeout handler. (#6375)
 - Bugfix: Fixed a setting description not filtering correctly on search. (#6389)
+- Bugfix: Disable note creation on users without ID's. (#6409)
 - Dev: Mini refactor of Split. (#6148)
 - Dev: Conan will no longer generate a `CMakeUserPresets.json` file. (#6117)
 - Dev: Pass `--force-openssl` when installing from CMake in Qt 6.8+. (#6129)

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -1039,6 +1039,7 @@ void UserInfoPopup::updateUserData()
         this->ui_.block->setChecked(isIgnoring);
         this->ui_.block->setEnabled(true);
         this->ui_.ignoreHighlights->setChecked(isIgnoringHighlights);
+        this->ui_.notesAdd->setEnabled(true);
 
         auto type = this->underlyingChannel_->getType();
 
@@ -1141,6 +1142,8 @@ void UserInfoPopup::updateUserData()
 
     this->ui_.block->setEnabled(false);
     this->ui_.ignoreHighlights->setEnabled(false);
+    this->ui_.notesAdd->setEnabled(false);
+
     bool isMyself =
         getApp()->getAccounts()->twitch.getCurrent()->getUserName().compare(
             this->userName_, Qt::CaseInsensitive) == 0;


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
Toggle the 'Add notes' button the same way with the block and ignore highlights checkboxes #6409 