### PR TITLE
fix: Twitch dropping `MAGIC_MESSAGE_SUFFIX`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Minor: The follow and sub dates now show the duration in a tooltip. (#6384)
 - Minor: Usercards now show a live indicator if the user is currently streaming. (#6383)
 - Minor: Consolidate twitch.tv URLs to start with www (#6407)
+- Bugfix: Fixed duplicate message sending for single-worded messages. (#6417)
 - Bugfix: Commands are no longer tab-completable in the middle of messages. (#6273)
 - Bugfix: Automatic streamer mode detection now works from Flatpak. (#6250)
 - Bugfix: Don't create native messaging manifest file if browser directory doesn't exist. (#6116)

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -80,9 +80,9 @@ using detail::isUnknownCommand;
 
 namespace {
 #if QT_VERSION < QT_VERSION_CHECK(6, 1, 0)
-const QString MAGIC_MESSAGE_SUFFIX = QString((const char *)u8" \U000E0000");
+const QString MAGIC_MESSAGE_SUFFIX = QString((const char *)u8" \u034f");
 #else
-const QString MAGIC_MESSAGE_SUFFIX = QString::fromUtf8(u8" \U000E0000");
+const QString MAGIC_MESSAGE_SUFFIX = QString::fromUtf8(u8" \u034f");
 #endif
 constexpr int CLIP_CREATION_COOLDOWN = 5000;
 const QString CLIPS_LINK("https://clips.twitch.tv/%1");

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -82,7 +82,7 @@ namespace {
 #if QT_VERSION < QT_VERSION_CHECK(6, 1, 0)
 const QString MAGIC_MESSAGE_SUFFIX = QString((const char *)u8" \u034f");
 #else
-const QString MAGIC_MESSAGE_SUFFIX = QString::fromUtf8(u8" \u034f");
+const QString MAGIC_MESSAGE_SUFFIX = u" \u034f"_s;
 #endif
 constexpr int CLIP_CREATION_COOLDOWN = 5000;
 const QString CLIPS_LINK("https://clips.twitch.tv/%1");

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -79,11 +79,7 @@ bool isUnknownCommand(const QString &text)
 using detail::isUnknownCommand;
 
 namespace {
-#if QT_VERSION < QT_VERSION_CHECK(6, 1, 0)
-const QString MAGIC_MESSAGE_SUFFIX = QString((const char *)u8" \u034f");
-#else
 const QString MAGIC_MESSAGE_SUFFIX = u" \u034f"_s;
-#endif
 constexpr int CLIP_CREATION_COOLDOWN = 5000;
 const QString CLIPS_LINK("https://clips.twitch.tv/%1");
 const QString CLIPS_FAILURE_CLIPS_UNAVAILABLE_TEXT(


### PR DESCRIPTION
The invisible Unicode block that `\u{e0000}`'s a part of, can't be sent to TMI any longer, it just gets dropped. `\u{34f}` shouldn't ever be dropped by TMI, it's future-proof, because emojis rely on this character to join. Chatterino currently only appends these characters when the duplicate message doesn't contain any spaces, so make sure to note when testing.