### PR TITLE
fix: make notebook add button 1dp smaller on all sides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,7 +97,7 @@
 - Dev: Simplified string literals to be a re-export of Qt functions. (#6175)
 - Dev: Fixed incorrect lua generation of static methods for typescript plugins. (#6190, #6223)
 - Dev: Merged top/bottom and left/right notebook layouts. (#6215)
-- Dev: Refactored `Button` and friends. (#6102, #6255, #6266, #6302, #6268, #6334, #6371, #6372)
+- Dev: Refactored `Button` and friends. (#6102, #6255, #6266, #6302, #6268, #6334, #6371, #6372, #6423)
 - Dev: Made "add split" button (part of the split header) a natively rendered button. (#6349, #6385)
 - Dev: Made Settings & Account button on Linux/macOS SVGs. (#6267)
 - Dev: Made "Chatters" button an SVG. (#6397)

--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -40,7 +40,7 @@ Notebook::Notebook(QWidget *parent)
     : BaseWidget(parent)
     , addButton_(new DrawnButton(DrawnButton::Symbol::Plus,
                                  {
-                                     .padding = 6,
+                                     .padding = 7,
                                      .thickness = 1,
                                  },
                                  this))


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
In #6371, the padding of the button was decreased by 1dp. This PR changes the padding back to 7dp (like before).