### PR TITLE
fix(plugin-repl): add padding to pin button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,7 +102,7 @@
 - Dev: Made Settings & Account button on Linux/macOS SVGs. (#6267)
 - Dev: Made "Chatters" button an SVG. (#6397)
 - Dev: Made "Moderation" button an SVG. (#6398, #6412, #6414)
-- Dev: Made user card "pin" button SVGs. (#6399)
+- Dev: Made user card "pin" button SVGs. (#6399, #6426)
 - Dev: Some more setting widget refactors. (#6317)
 - Dev: Emoji style / set is now stored lowercase (and matched case-insensitively). Changing emoji style from this point on and then running an old version might mean you will use the Twitter emoji style by default. (#6300)
 - Dev: Refactored `OnceFlag`. (#6237, #6316)

--- a/src/widgets/PluginRepl.cpp
+++ b/src/widgets/PluginRepl.cpp
@@ -444,7 +444,7 @@ PluginRepl::PluginRepl(QString id, QWidget *parent)
             }
         });
 
-        this->ui.pin = new SvgButton(this->ui.pinDisabledSource_, this, {0, 0});
+        this->ui.pin = new SvgButton(this->ui.pinDisabledSource_, this, {3, 3});
         this->ui.pin->setScaleIndependentSize({18, 18});
         this->ui.pin->setToolTip(u"Pin Window"_s);
         QObject::connect(this->ui.pin, &Button::leftClicked, this, [this] {


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
The pin button was too big before. This uses the same padding as with the other SVG button.