### PR TITLE
ci: remove invalid `strategy` and guard winget/homebrew to main repo

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -19,6 +19,7 @@ jobs:
   update_stable_homebrew_cask:
     name: "Update the stable homebrew cask"
     runs-on: "macos-latest"
+    if: github.repository_owner == 'Chatterino'
     steps:
       # Pulls out the version from the ref (e.g. refs/tags/v2.3.1 -> 2.3.1)
       - name: Execute brew bump-cask-pr with version

--- a/.github/workflows/test-arch-linux.yml
+++ b/.github/workflows/test-arch-linux.yml
@@ -24,8 +24,6 @@ jobs:
     name: "Test Arch Linux"
     runs-on: ubuntu-latest
     container: archlinux:base-devel
-    strategy:
-      fail-fast: false
 
     steps:
       - name: Install dependencies

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   publish:
     runs-on: windows-latest
-    if: ${{ startsWith(github.event.release.tag_name, 'v') }}
+    if: ${{ startsWith(github.event.release.tag_name, 'v') }} && github.repository_owner == 'Chatterino'
     steps:
       - uses: vedantmgoyal9/winget-releaser@main
         with:


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
I didn't want to open two PRs for such tiny changes:

- `strategy` is only valid if `matrix` is specified (the yaml schema complained).
- Similar to the codecov upload (#6391), the winget and homebrew updates should only run on the main repo.