### PR TITLE
ci(macos): use locally installed version of cmake

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -285,7 +285,8 @@ jobs:
       - name: Install dependencies (MacOS)
         if: startsWith(matrix.os, 'macos')
         run: |
-          brew install openssl rapidjson p7zip create-dmg cmake tree boost
+          # brew install openssl rapidjson p7zip create-dmg cmake tree boost
+          brew install openssl rapidjson p7zip create-dmg tree boost
         shell: bash
 
       - name: Build (MacOS)

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -45,7 +45,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          brew install openssl rapidjson p7zip create-dmg cmake boost
+          # brew install openssl rapidjson p7zip create-dmg cmake boost
+          brew install openssl rapidjson p7zip create-dmg boost
 
       - name: Install httpbox
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@
 - Dev: Added an explicit `frozen` flag to `Message`. (#6367)
 - Dev: Stop sending `JOIN`/`PART` commands for channels starting with `/`. (#6376)
 - Dev: Error handlers for Sol check functions now take a function reference over an owning type. (#6393)
+- Dev: Fix macOS CI build issues. (#6430)
 
 ## 2.5.3
 


### PR DESCRIPTION
This PR fixes some CI issues caused by the GitHub action runner suddenly pinning cmake.
See https://github.com/actions/runner-images/pull/12791 for more information