### PR TITLE
fix(plugin): handle non-string errors gracefully

### DIFF
--- a/src/controllers/plugins/SolTypes.cpp
+++ b/src/controllers/plugins/SolTypes.cpp
@@ -12,6 +12,8 @@
 
 namespace chatterino::lua {
 
+using namespace Qt::Literals;
+
 Plugin *ThisPluginState::plugin()
 {
     if (this->plugptr_ != nullptr)
@@ -25,6 +27,51 @@ Plugin *ThisPluginState::plugin()
     }
     this->plugptr_ = pl;
     return pl;
+}
+
+QString errorResultToString(const sol::protected_function_result &result)
+{
+    assert(!result.valid() &&
+           "This function must be called on invalid/error results");
+
+    auto optString = sol::stack::check_get<QString>(result.lua_state(), -1);
+    if (optString)
+    {
+        return *std::move(optString);
+    }
+
+    // If we get here, the stack didn't contain a string at the top. This is
+    // valid in Lua, but unconventional. Error handlers typically expect a
+    // string at the top of the stack.s
+    //
+    // There can be many reasons for this; here are three:
+    // - A C++ function was not wrapped in a trampoline (i.e. try{} catch{}).
+    //   sol usually does this for us, but there are some exceptions.
+    //   If that's the case, then Lua will catch our error in a catch(...).
+    //   It effectively swallows the error. This won't always cause us to end up
+    //   here. For example, a function that takes a string as an argument will
+    //   have this string at the top of the stack. When the error is swallowed,
+    //   we'd return that argument as the error. Unfortunately, we can't detect
+    //   this.
+    //   The workaround here is to use luaL_error() instead of C++ exceptions.
+    //   That function will eventually throw an error too, so the stack is
+    //   properly unwound (requires Lua being compiled as C++).
+    //
+    // - The error is popped _during unwinding_ (due to RAII).
+    //   If an error is thrown and a function in the C++ call stack has
+    //   variables with a destructor that pops a value from the Lua stack, this
+    //   might occur.
+    //   You can detect where the error is removed by setting a breakpoint
+    //   in lua_settop() (lapi.c) once the unwinding begins (most debuggers
+    //   allow breaking on C++ exceptions).
+    //
+    // - One can also raise an error from Lua by calling
+    //   `error(message[, level])`. The `message` is the "error object". As with
+    //   `lua_error()`, the object passed doesn't need to be a string, but it's
+    //   one by convention. If we get here because of this, that's not a bug.
+    return u"(no error message) "
+           "Unless an error without a message string was explicitly thrown, "
+           "this is a bug in Chatterino. Please report this."_s;
 }
 
 void logError(Plugin *plugin, QStringView context, const QString &msg)

--- a/src/controllers/plugins/SolTypes.hpp
+++ b/src/controllers/plugins/SolTypes.hpp
@@ -60,6 +60,8 @@ private:
     lua_State *state_;
 };
 
+QString errorResultToString(const sol::protected_function_result &result);
+
 /// @brief Attempts to call @a function with @a args
 ///
 /// @a T is expected to be returned.
@@ -79,9 +81,8 @@ inline nonstd::expected_lite::expected<T, QString> tryCall(const auto &function,
         function(std::forward<Args>(args)...);
     if (!result.valid())
     {
-        sol::error err = result;
         return nonstd::expected_lite::make_unexpected(
-            QString::fromUtf8(err.what()));
+            errorResultToString(result));
     }
 
     if constexpr (std::is_same_v<T, void>)

--- a/src/widgets/PluginRepl.cpp
+++ b/src/widgets/PluginRepl.cpp
@@ -596,8 +596,7 @@ void PluginRepl::logResult(const sol::protected_function_result &res,
 {
     if (!res.valid())
     {
-        sol::error err = res;
-        this->log(lua::api::LogLevel::Critical, err.what());
+        this->log(lua::api::LogLevel::Critical, lua::errorResultToString(res));
         return;
     }
     if (res.return_count() == 0)


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

I haven't encountered this in the current version of Chatterino, but there might be hidden cases where a failed function call won't have a string at the top of the stack. Currently, if that's the case, we'd crash, because we try to convert the error result to a `sol::error`. That type expects a string at the top of the stack (which would contain the error message). As explained in the comment, that's not always the case, and we shouldn't crash because of that.

Here's some example code that demonstrates the third and most unimportant case from the comment (but it's the easiest to reproduce):
```lua
ws = c2.WebSocket.new("wss://echo.websocket.org")
ws.on_text = function() error(42) end -- oopsie
ws:send_text("lol")
```

Fixes #6201.