### PR TITLE
feat: spellcheck input

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -232,6 +232,7 @@ jobs:
               -DBUILD_WITH_CRASHPAD="$Env:C2_ENABLE_CRASHPAD" `
               -DCHATTERINO_LTO="$Env:C2_ENABLE_LTO" `
               -DFORCE_JSON_GENERATION=On `
+              -DCHATTERINO_SPELLCHECK=On `
               ..
           set cl=/MP
           nmake /S /NOLOGO
@@ -285,8 +286,8 @@ jobs:
       - name: Install dependencies (MacOS)
         if: startsWith(matrix.os, 'macos')
         run: |
-          # brew install openssl rapidjson p7zip create-dmg cmake tree boost
-          brew install openssl rapidjson p7zip create-dmg tree boost
+          # brew install openssl rapidjson p7zip create-dmg cmake tree boost hunspell
+          brew install openssl rapidjson p7zip create-dmg tree boost hunspell
         shell: bash
 
       - name: Build (MacOS)
@@ -301,6 +302,7 @@ jobs:
               -DUSE_PRECOMPILED_HEADERS=OFF \
               -DCHATTERINO_LTO="$C2_ENABLE_LTO" \
               -DFORCE_JSON_GENERATION=Off \
+              -DCHATTERINO_SPELLCHECK=On \
               ..
           make -j"$(sysctl -n hw.logicalcpu)"
         shell: bash

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -45,8 +45,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          # brew install openssl rapidjson p7zip create-dmg cmake boost
-          brew install openssl rapidjson p7zip create-dmg boost
+          # brew install openssl rapidjson p7zip create-dmg cmake boost hunspell
+          brew install openssl rapidjson p7zip create-dmg boost hunspell
 
       - name: Install httpbox
         run: |
@@ -64,6 +64,7 @@ jobs:
               -DBUILD_TESTS=On \
               -DBUILD_APP=OFF \
               -DUSE_PRECOMPILED_HEADERS=OFF \
+              -DCHATTERINO_SPELLCHECK=On \
               ..
           make -j"$(sysctl -n hw.logicalcpu)"
 

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -115,6 +115,7 @@ jobs:
               -DCMAKE_TOOLCHAIN_FILE="conan_toolchain.cmake" `
               -DUSE_PRECOMPILED_HEADERS=On `
               -DBUILD_WITH_CRASHPAD="$Env:C2_ENABLE_CRASHPAD" `
+              -DCHATTERINO_SPELLCHECK=On `
               ..
           set cl=/MP
           nmake /S /NOLOGO

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ option(CHATTERINO_LTO "Enable LTO for all targets" OFF)
 option(CHATTERINO_PLUGINS "Enable ALPHA plugin support in Chatterino" ON)
 option(CHATTERINO_USE_GDI_FONTENGINE "Use the legacy GDI fontengine instead of the new DirectWrite one on Windows (Qt 6.8.0 and later)" ON)
 option(CHATTERINO_ALLOW_PRIVATE_QT_API "Allow uses of Qt's private API - when enabling this, Chatterino must use the EXACT Qt version it was compiled against" OFF)
+option(CHATTERINO_SPELLCHECK "Enable spellchecking in Chatterino (requires Hunspell)" OFF)
 
 option(CHATTERINO_UPDATER "Enable update checks" ON)
 mark_as_advanced(CHATTERINO_UPDATER)
@@ -146,6 +147,10 @@ find_package(Boost REQUIRED OPTIONAL_COMPONENTS headers)
 find_package(OpenSSL REQUIRED)
 
 find_package(Threads REQUIRED)
+
+if(CHATTERINO_SPELLCHECK)
+    find_package(hunspell REQUIRED)
+endif()
 
 find_library(LIBRT rt)
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -6,13 +6,14 @@ from os import path
 
 class Chatterino(ConanFile):
     name = "Chatterino"
-    requires = "boost/1.86.0"
+    requires = "boost/1.86.0", "hunspell/1.7.2"
     settings = "os", "compiler", "build_type", "arch"
     default_options = {
         "with_benchmark": False,
         "with_openssl3": True,
         "openssl*:shared": True,
         "boost*:header_only": True,
+        "hunspell*:shared": False,
     }
     options = {
         "with_benchmark": [True, False],

--- a/mocks/include/mocks/EmptyApplication.hpp
+++ b/mocks/include/mocks/EmptyApplication.hpp
@@ -199,6 +199,11 @@ public:
         return nullptr;
     }
 
+    SpellChecker *getSpellChecker() override
+    {
+        return nullptr;
+    }
+
 #ifdef CHATTERINO_HAVE_PLUGINS
     PluginController *getPlugins() override
     {

--- a/resources/licenses/hunspell.txt
+++ b/resources/licenses/hunspell.txt
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -11,6 +11,7 @@
 #include "controllers/ignores/IgnoreController.hpp"
 #include "controllers/notifications/NotificationController.hpp"
 #include "controllers/sound/ISoundController.hpp"
+#include "controllers/spellcheck/SpellChecker.hpp"
 #include "providers/bttv/BttvEmotes.hpp"
 #include "providers/ffz/FfzEmotes.hpp"
 #include "providers/links/LinkResolver.hpp"
@@ -195,6 +196,7 @@ Application::Application(Settings &_settings, const Paths &paths,
     , streamerMode(new StreamerMode)
     , twitchUsers(new TwitchUsers)
     , pronouns(new pronouns::Pronouns)
+    , spellChecker(new SpellChecker)
 #ifdef CHATTERINO_HAVE_PLUGINS
     , plugins(new PluginController(paths))
 #endif
@@ -597,6 +599,14 @@ eventsub::IController *Application::getEventSub()
     return this->eventSub.get();
 }
 
+SpellChecker *Application::getSpellChecker()
+{
+    assertInGuiThread();
+    assert(this->spellChecker);
+
+    return this->spellChecker.get();
+}
+
 void Application::aboutToQuit()
 {
     ABOUT_TO_QUIT.store(true);
@@ -649,6 +659,7 @@ void Application::stop()
     this->logging.reset();
     this->fonts.reset();
     this->themes.reset();
+    this->spellChecker.reset();
 
     STOPPED.store(true);
 }

--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -59,6 +59,7 @@ class Pronouns;
 namespace eventsub {
 class IController;
 }  // namespace eventsub
+class SpellChecker;
 
 class IApplication
 {
@@ -112,6 +113,7 @@ public:
     virtual ITwitchUsers *getTwitchUsers() = 0;
     virtual pronouns::Pronouns *getPronouns() = 0;
     virtual eventsub::IController *getEventSub() = 0;
+    virtual SpellChecker *getSpellChecker() = 0;
 };
 
 class Application : public IApplication
@@ -179,6 +181,7 @@ private:
     std::unique_ptr<IStreamerMode> streamerMode;
     std::unique_ptr<ITwitchUsers> twitchUsers;
     std::unique_ptr<pronouns::Pronouns> pronouns;
+    std::unique_ptr<SpellChecker> spellChecker;
 #ifdef CHATTERINO_HAVE_PLUGINS
     std::unique_ptr<PluginController> plugins;
 #endif
@@ -231,6 +234,7 @@ public:
     ILinkResolver *getLinkResolver() override;
     IStreamerMode *getStreamerMode() override;
     ITwitchUsers *getTwitchUsers() override;
+    SpellChecker *getSpellChecker() override;
 
 private:
     void initNm(const Paths &paths);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -273,6 +273,9 @@ set(SOURCE_FILES
         controllers/sound/NullBackend.cpp
         controllers/sound/NullBackend.hpp
 
+        controllers/spellcheck/SpellChecker.cpp
+        controllers/spellcheck/SpellChecker.hpp
+
         controllers/twitch/LiveController.cpp
         controllers/twitch/LiveController.hpp
 
@@ -879,6 +882,11 @@ target_link_libraries(${LIBRARY_PROJECT}
         )
 if (CHATTERINO_PLUGINS)
     target_link_libraries(${LIBRARY_PROJECT} PUBLIC lua sol2::sol2)
+endif()
+
+if (CHATTERINO_SPELLCHECK)
+    target_compile_definitions(${LIBRARY_PROJECT} PUBLIC CHATTERINO_WITH_SPELLCHECK)
+    target_link_libraries(${LIBRARY_PROJECT} PRIVATE hunspell::hunspell)
 endif()
 
 if (CHATTERINO_ALLOW_PRIVATE_QT_API)

--- a/src/common/QLogging.cpp
+++ b/src/common/QLogging.cpp
@@ -47,6 +47,7 @@ Q_LOGGING_CATEGORY(chatterinoSeventv, "chatterino.seventv", logThreshold);
 Q_LOGGING_CATEGORY(chatterinoSeventvEventAPI, "chatterino.seventv.eventapi",
                    logThreshold);
 Q_LOGGING_CATEGORY(chatterinoSound, "chatterino.sound", logThreshold);
+Q_LOGGING_CATEGORY(chatterinoSpellcheck, "chatterino.spellcheck", logThreshold);
 Q_LOGGING_CATEGORY(chatterinoStreamerMode, "chatterino.streamermode",
                    logThreshold);
 Q_LOGGING_CATEGORY(chatterinoStreamlink, "chatterino.streamlink", logThreshold);

--- a/src/common/QLogging.hpp
+++ b/src/common/QLogging.hpp
@@ -36,6 +36,7 @@ Q_DECLARE_LOGGING_CATEGORY(chatterinoSettings);
 Q_DECLARE_LOGGING_CATEGORY(chatterinoSeventv);
 Q_DECLARE_LOGGING_CATEGORY(chatterinoSeventvEventAPI);
 Q_DECLARE_LOGGING_CATEGORY(chatterinoSound);
+Q_DECLARE_LOGGING_CATEGORY(chatterinoSpellcheck);
 Q_DECLARE_LOGGING_CATEGORY(chatterinoStreamerMode);
 Q_DECLARE_LOGGING_CATEGORY(chatterinoStreamlink);
 Q_DECLARE_LOGGING_CATEGORY(chatterinoTheme);

--- a/src/common/WindowDescriptors.cpp
+++ b/src/common/WindowDescriptors.cpp
@@ -108,6 +108,12 @@ void SplitDescriptor::loadFromJSON(SplitDescriptor &descriptor,
         descriptor.channelName_ = data.value("name").toString();
     }
     descriptor.filters_ = loadFilters(root.value("filters"));
+
+    auto spellOverride = root["checkSpelling"];
+    if (spellOverride.isBool())
+    {
+        descriptor.spellCheckOverride = spellOverride.toBool();
+    }
 }
 
 TabDescriptor TabDescriptor::loadFromJSON(const QJsonObject &tabObj)

--- a/src/common/WindowDescriptors.hpp
+++ b/src/common/WindowDescriptors.hpp
@@ -44,6 +44,8 @@ struct SplitDescriptor {
     // Whether "Moderation Mode" (the sword icon) is enabled in this split or not
     bool moderationMode_{false};
 
+    std::optional<bool> spellCheckOverride;
+
     QList<QUuid> filters_;
 
     static void loadFromJSON(SplitDescriptor &descriptor,

--- a/src/controllers/spellcheck/SpellChecker.cpp
+++ b/src/controllers/spellcheck/SpellChecker.cpp
@@ -1,0 +1,209 @@
+#include "controllers/spellcheck/SpellChecker.hpp"
+
+#include "Application.hpp"
+#include "common/QLogging.hpp"
+#include "controllers/accounts/AccountController.hpp"
+#include "messages/Emote.hpp"
+#include "providers/bttv/BttvEmotes.hpp"
+#include "providers/seventv/SeventvEmotes.hpp"
+#include "providers/twitch/TwitchAccount.hpp"
+#include "providers/twitch/TwitchChannel.hpp"
+#include "singletons/Paths.hpp"
+#include "util/FilesystemHelpers.hpp"
+
+#include <QTextCharFormat>
+
+#ifdef CHATTERINO_WITH_SPELLCHECK
+#    include <hunspell/hunspell.hxx>
+#endif
+
+namespace {
+
+using namespace chatterino;
+
+bool shouldIgnore(TwitchChannel *twitch, const QString &word)
+{
+    EmoteName name(word);
+    if (twitch)
+    {
+        if (twitch->bttvEmote(name) || twitch->ffzEmote(name) ||
+            twitch->seventvEmote(name))
+        {
+            return true;
+        }
+        auto locals = twitch->localTwitchEmotes();
+        if (locals->contains(name))
+        {
+            return true;
+        }
+    }
+    if (getApp()->getBttvEmotes()->emote(name) ||
+        getApp()->getFfzEmotes()->emote(name) ||
+        getApp()->getSeventvEmotes()->globalEmote(name))
+    {
+        return true;
+    }
+
+    return getApp()
+        ->getAccounts()
+        ->twitch.getCurrent()
+        ->twitchEmote(name)
+        .has_value();
+}
+
+}  // namespace
+
+namespace chatterino {
+
+#ifdef CHATTERINO_WITH_SPELLCHECK
+class SpellCheckerPrivate
+{
+public:
+    static std::unique_ptr<SpellCheckerPrivate> tryLoad();
+
+    Hunspell hunspell;
+
+private:
+    SpellCheckerPrivate(const char *affpath, const char *dpath);
+};
+
+std::unique_ptr<SpellCheckerPrivate> SpellCheckerPrivate::tryLoad()
+{
+    auto stdPath = qStringToStdPath(getApp()->getPaths().dictionariesDirectory);
+    auto aff = stdPath / "index.aff";
+    auto dic = stdPath / "index.dic";
+    if (!std::filesystem::exists(aff) || !std::filesystem::exists(dic))
+    {
+        qCInfo(chatterinoSpellcheck)
+            << "Failed to find index.aff or index.dic in 'Dictionaries'";
+        return nullptr;
+    }
+    std::error_code ec;
+    auto affCanonical = std::filesystem::weakly_canonical(aff, ec);
+    if (ec)
+    {
+        qCInfo(chatterinoSpellcheck)
+            << "Failed to canonicalize" << stdPathToQString(aff)
+            << "error:" << ec.message();
+        return nullptr;
+    }
+    auto dicCanonical = std::filesystem::weakly_canonical(dic, ec);
+    if (ec)
+    {
+        qCInfo(chatterinoSpellcheck)
+            << "Failed to canonicalize" << stdPathToQString(dic)
+            << "error:" << ec.message();
+        return nullptr;
+    }
+
+    return std::unique_ptr<SpellCheckerPrivate>{new SpellCheckerPrivate(
+        affCanonical.string().c_str(), dicCanonical.string().c_str())};
+}
+
+SpellCheckerPrivate::SpellCheckerPrivate(const char *affpath, const char *dpath)
+    : hunspell(affpath, dpath)
+{
+}
+
+SpellChecker::SpellChecker()
+    : private_(SpellCheckerPrivate::tryLoad())
+{
+}
+#else
+class SpellCheckerPrivate
+{
+};
+SpellChecker::SpellChecker() = default;
+#endif
+
+SpellChecker::~SpellChecker() = default;
+
+bool SpellChecker::isLoaded() const
+{
+    return this->private_ != nullptr;
+}
+
+void SpellChecker::reload()
+{
+#ifdef CHATTERINO_WITH_SPELLCHECK
+    this->private_ = SpellCheckerPrivate::tryLoad();
+#endif
+}
+
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+bool SpellChecker::check(QStringView word)
+{
+#ifdef CHATTERINO_WITH_SPELLCHECK
+    if (!this->private_)
+    {
+        return true;
+    }
+
+    return this->private_->hunspell.spell(word.toUtf8().toStdString());
+#else
+    (void)word;
+    return true;
+#endif
+}
+
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+std::vector<std::string> SpellChecker::suggestions(const QString &word)
+{
+#ifdef CHATTERINO_WITH_SPELLCHECK
+    if (!this->private_)
+    {
+        return {};
+    }
+
+    auto stdWord = word.toStdString();
+    if (this->private_->hunspell.spell(stdWord))
+    {
+        return {};
+    }
+
+    return this->private_->hunspell.suggest(stdWord);
+#else
+    (void)word;
+    return {};
+#endif
+}
+
+SpellCheckHighlighter::SpellCheckHighlighter(QObject *parent)
+    : QSyntaxHighlighter(parent)
+    , wordRegex(R"(\p{L}+)",
+                QRegularExpression::PatternOption::UseUnicodePropertiesOption)
+{
+    this->spellFmt.setUnderlineStyle(QTextCharFormat::SpellCheckUnderline);
+    this->spellFmt.setUnderlineColor(Qt::red);
+}
+
+void SpellCheckHighlighter::setTwitchChannel(TwitchChannel *channel)
+{
+    this->channel = channel;
+    this->rehighlight();
+}
+
+void SpellCheckHighlighter::highlightBlock(const QString &text)
+{
+    auto *spellChecker = getApp()->getSpellChecker();
+    if (!spellChecker->isLoaded())
+    {
+        return;
+    }
+
+    QStringView textView = text;
+    auto it = this->wordRegex.globalMatchView(textView);
+    while (it.hasNext())
+    {
+        auto match = it.next();
+        auto text = match.capturedView();
+        if (!shouldIgnore(this->channel, text.toString()) &&
+            !spellChecker->check(text))
+        {
+            this->setFormat(static_cast<int>(text.data() - textView.data()),
+                            static_cast<int>(text.size()), this->spellFmt);
+        }
+    }
+}
+
+}  // namespace chatterino

--- a/src/controllers/spellcheck/SpellChecker.hpp
+++ b/src/controllers/spellcheck/SpellChecker.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <QRegularExpression>
+#include <QSyntaxHighlighter>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+class QTextDocument;
+
+namespace chatterino {
+
+class TwitchChannel;
+
+class SpellCheckerPrivate;
+class SpellChecker
+{
+public:
+    SpellChecker();
+    ~SpellChecker();
+
+    bool isLoaded() const;
+    void reload();
+
+    bool check(QStringView word);
+    std::vector<std::string> suggestions(const QString &word);
+
+private:
+    std::unique_ptr<SpellCheckerPrivate> private_;
+};
+
+class SpellCheckHighlighter : public QSyntaxHighlighter
+{
+public:
+    SpellCheckHighlighter(QObject *parent);
+
+    void setTwitchChannel(TwitchChannel *channel);
+
+protected:
+    void highlightBlock(const QString &text) override;
+
+private:
+    QRegularExpression wordRegex;
+    QTextCharFormat spellFmt;
+    TwitchChannel *channel = nullptr;
+};
+
+}  // namespace chatterino

--- a/src/singletons/Paths.cpp
+++ b/src/singletons/Paths.cpp
@@ -145,6 +145,7 @@ void Paths::initSubDirectories()
     this->pluginsDirectory = makePath("Plugins");
     this->themesDirectory = makePath("Themes");
     this->crashdumpDirectory = makePath("Crashes");
+    this->dictionariesDirectory = makePath("Dictionaries");
 #ifdef Q_OS_WIN
     this->ipcDirectory = makePath("IPC");
 #else

--- a/src/singletons/Paths.hpp
+++ b/src/singletons/Paths.hpp
@@ -39,6 +39,9 @@ public:
     // Custom themes live here. <appDataDirectory>/Themes
     QString themesDirectory;
 
+    // Spell checking dictionaries <appDataDirectory>/Dictionaries
+    QString dictionariesDirectory;
+
     // Directory for shared memory files.
     // <appDataDirectory>/IPC   on Windows
     // /tmp                     elsewhere

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -342,6 +342,8 @@ public:
         false,
     };
 
+    BoolSetting enableSpellChecking = {"/behaviour/spellChecking", false};
+
     FloatSetting pauseOnHoverDuration = {"/behaviour/pauseOnHoverDuration", 0};
     EnumSetting<Qt::KeyboardModifier> pauseChatModifier = {
         "/behaviour/pauseChatModifier", Qt::KeyboardModifier::NoModifier};

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -677,6 +677,12 @@ void WindowManager::encodeNodeRecursively(SplitNode *node, QJsonObject &obj)
             QJsonArray filters;
             WindowManager::encodeFilters(node->getSplit(), filters);
             obj.insert("filters", filters);
+
+            auto spellOverride = node->getSplit()->checkSpellingOverride();
+            if (spellOverride)
+            {
+                obj["checkSpelling"] = *spellOverride;
+            }
         }
         break;
         case SplitNode::Type::HorizontalContainer:

--- a/src/widgets/helper/ResizingTextEdit.cpp
+++ b/src/widgets/helper/ResizingTextEdit.cpp
@@ -5,6 +5,7 @@
 #include "controllers/completion/TabCompletionModel.hpp"
 #include "singletons/Settings.hpp"
 
+#include <QMenu>
 #include <QMimeData>
 #include <QMimeDatabase>
 #include <QObject>
@@ -346,6 +347,13 @@ void ResizingTextEdit::insertFromMimeData(const QMimeData *source)
     }
 
     insertPlainText(source->text());
+}
+
+void ResizingTextEdit::contextMenuEvent(QContextMenuEvent *event)
+{
+    QObjectPtr<QMenu> menu{this->createStandardContextMenu(event->pos())};
+    this->contextMenuRequested.invoke(menu.get(), event->pos());
+    menu->exec(event->globalPos());
 }
 
 }  // namespace chatterino

--- a/src/widgets/helper/ResizingTextEdit.hpp
+++ b/src/widgets/helper/ResizingTextEdit.hpp
@@ -21,6 +21,7 @@ public:
     pajlada::Signals::NoArgSignal focused;
     pajlada::Signals::NoArgSignal focusLost;
     pajlada::Signals::Signal<const QMimeData *> imagePasted;
+    pajlada::Signals::Signal<QMenu *, QPoint> contextMenuRequested;
 
     void setCompleter(QCompleter *c);
     /**
@@ -38,6 +39,8 @@ protected:
 
     bool canInsertFromMimeData(const QMimeData *source) const override;
     void insertFromMimeData(const QMimeData *source) override;
+
+    void contextMenuEvent(QContextMenuEvent *event) override;
 
 private:
     // hadSpace is set to true in case the "textUnderCursor" word was after a

--- a/src/widgets/settingspages/AboutPage.cpp
+++ b/src/widgets/settingspages/AboutPage.cpp
@@ -135,6 +135,10 @@ AboutPage::AboutPage()
                        ":/licenses/howard-hinnant-date.txt");
             addLicense(form.getElement(), "{fmt}", "https://fmt.dev",
                        ":/licenses/fmtlib.txt");
+#ifdef CHATTERINO_WITH_SPELLCHECK
+            addLicense(form.getElement(), "Hunsppell",
+                       "https://hunspell.github.io", ":/licenses/hunspell.txt");
+#endif
         }
 
         // Attributions

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -504,6 +504,20 @@ void GeneralPage::initLayout(GeneralPageView &layout)
             "yours is successfully sent in the matching channel.")
         ->addTo(layout);
 
+#ifdef CHATTERINO_WITH_SPELLCHECK
+    SettingWidget::checkbox("Check spelling (experimental)",
+                            s.enableSpellChecking)
+        ->setTooltip(
+            u"Check the spelling of words in the input box. Chatterino does "
+            u"not "
+            "include dictionaries - they have to be downloaded or created "
+            "manually. Chatterino expects Hunspell dictionaries in '" %
+            getApp()->getPaths().dictionariesDirectory %
+            u"'. The file index.aff has to contain the affixes and index.dic "
+            u"must contain the dictionary (subject to change).")
+        ->addTo(layout);
+#endif
+
     layout.addTitle("Messages");
 
     SettingWidget::checkbox("Separate with lines", s.separateMessages)

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -894,6 +894,16 @@ bool Split::getModerationMode() const
     return this->moderationMode_;
 }
 
+std::optional<bool> Split::checkSpellingOverride() const
+{
+    return this->input_->checkSpellingOverride();
+}
+
+void Split::setCheckSpellingOverride(std::optional<bool> override)
+{
+    this->input_->setCheckSpellingOverride(override);
+}
+
 void Split::insertTextToInput(const QString &text)
 {
     this->input_->insertText(text);

--- a/src/widgets/splits/Split.hpp
+++ b/src/widgets/splits/Split.hpp
@@ -62,6 +62,9 @@ public:
     void setModerationMode(bool value);
     bool getModerationMode() const;
 
+    std::optional<bool> checkSpellingOverride() const;
+    void setCheckSpellingOverride(std::optional<bool> override);
+
     void insertTextToInput(const QString &text);
 
     void showChangeChannelPopup(const char *dialogTitle, bool empty,

--- a/src/widgets/splits/SplitContainer.cpp
+++ b/src/widgets/splits/SplitContainer.cpp
@@ -905,6 +905,7 @@ void SplitContainer::applyFromDescriptorRecursively(
         split->setChannel(WindowManager::decodeChannel(splitNode));
         split->setModerationMode(splitNode.moderationMode_);
         split->setFilters(splitNode.filters_);
+        split->setCheckSpellingOverride(splitNode.spellCheckOverride);
 
         this->insertSplit(split);
 
@@ -940,6 +941,7 @@ void SplitContainer::applyFromDescriptorRecursively(
                 split->setFilters(splitNode.filters_);
                 split->setChannel(WindowManager::decodeChannel(splitNode));
                 split->setModerationMode(splitNode.moderationMode_);
+                split->setCheckSpellingOverride(splitNode.spellCheckOverride);
 
                 auto *node = new Node();
                 node->parent_ = baseNode;

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -5,6 +5,7 @@
 #include "common/QLogging.hpp"
 #include "controllers/commands/CommandController.hpp"
 #include "controllers/hotkeys/HotkeyController.hpp"
+#include "controllers/spellcheck/SpellChecker.hpp"
 #include "messages/Link.hpp"
 #include "messages/Message.hpp"
 #include "providers/twitch/TwitchChannel.hpp"
@@ -72,14 +73,27 @@ SplitInput::SplitInput(QWidget *parent, Split *_chatWidget,
         new QCompleter(this->split_->getChannel()->completionModel);
     this->ui_.textEdit->setCompleter(completer);
 
+    // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
+    this->spellcheckHighlighter = new SpellCheckHighlighter(this);
+    this->spellcheckHighlighter->setTwitchChannel(
+        dynamic_cast<TwitchChannel *>(this->split_->getChannel().get()));
+
     this->signalHolder_.managedConnect(this->split_->channelChanged, [this] {
         auto channel = this->split_->getChannel();
         auto *completer = new QCompleter(channel->completionModel);
         this->ui_.textEdit->setCompleter(completer);
+        this->spellcheckHighlighter->setTwitchChannel(
+            dynamic_cast<TwitchChannel *>(this->split_->getChannel().get()));
     });
 
+    getSettings()->enableSpellChecking.connect(
+        [this] {
+            this->checkSpellingChanged();
+        },
+        this->signalHolder_);
+
     // misc
-    this->installKeyPressedEvent();
+    this->installTextEditEvents();
     this->addShortcuts();
     // The textEdit's signal will be destroyed before this SplitInput is
     // destroyed, so we can safely ignore this signal's connection.
@@ -731,7 +745,7 @@ bool SplitInput::eventFilter(QObject *obj, QEvent *event)
     return BaseWidget::eventFilter(obj, event);
 }
 
-void SplitInput::installKeyPressedEvent()
+void SplitInput::installTextEditEvents()
 {
     // We can safely ignore this signal's connection because SplitInput owns
     // the textEdit object, so it will always be deleted before SplitInput
@@ -763,10 +777,42 @@ void SplitInput::installKeyPressedEvent()
             }
         });
 
-#ifdef DEBUG
-    assert(this->keyPressedEventInstalled == false);
-    this->keyPressedEventInstalled = true;
+    std::ignore = this->ui_.textEdit->contextMenuRequested.connect(
+        [this](QMenu *menu, QPoint pos) {
+#ifdef CHATTERINO_WITH_SPELLCHECK
+            menu->addSeparator();
+            auto *spellcheckAction = new QAction("Check spelling", menu);
+            spellcheckAction->setCheckable(true);
+            spellcheckAction->setChecked(this->shouldCheckSpelling());
+            QObject::connect(spellcheckAction, &QAction::toggled, this,
+                             [this](bool enabled) {
+                                 this->checkSpellingOverride_ = enabled;
+                                 this->checkSpellingChanged();
+                             });
+            menu->addAction(spellcheckAction);
+
+            auto cursor = this->ui_.textEdit->cursorForPosition(pos);
+            cursor.select(QTextCursor::WordUnderCursor);
+            auto word = cursor.selectedText();
+            if (!word.isEmpty())
+            {
+                auto suggestions =
+                    getApp()->getSpellChecker()->suggestions(word);
+                for (const auto &sugg : suggestions)
+                {
+                    auto qSugg = QString::fromStdString(sugg);
+                    menu->addAction(qSugg, [this, qSugg, cursor]() mutable {
+                        cursor.insertText(qSugg);
+                        this->ui_.textEdit->setTextCursor(cursor);
+                    });
+                }
+            }
+#else
+            (void)menu;
+            (void)pos;
+            (void)this;
 #endif
+        });
 }
 
 void SplitInput::mousePressEvent(QMouseEvent *event)
@@ -1338,6 +1384,40 @@ void SplitInput::setBackgroundColor(QColor newColor)
     this->backgroundColor_ = newColor;
 
     this->updateTextEditPalette();
+}
+
+std::optional<bool> SplitInput::checkSpellingOverride() const
+{
+    return this->checkSpellingOverride_;
+}
+
+void SplitInput::setCheckSpellingOverride(std::optional<bool> override)
+{
+    this->checkSpellingOverride_ = override;
+    this->checkSpellingChanged();
+}
+
+bool SplitInput::shouldCheckSpelling() const
+{
+    if (this->checkSpellingOverride_)
+    {
+        return *this->checkSpellingOverride_;
+    }
+    return getSettings()->enableSpellChecking;
+}
+
+void SplitInput::checkSpellingChanged()
+{
+    QTextDocument *target = nullptr;
+    if (this->shouldCheckSpelling())
+    {
+        target = this->ui_.textEdit->document();
+    }
+
+    if (this->spellcheckHighlighter->document() != target)
+    {
+        this->spellcheckHighlighter->setDocument(target);
+    }
 }
 
 }  // namespace chatterino

--- a/src/widgets/splits/SplitInput.hpp
+++ b/src/widgets/splits/SplitInput.hpp
@@ -25,6 +25,7 @@ class LabelButton;
 class ResizingTextEdit;
 class ChannelView;
 class SvgButton;
+class SpellCheckHighlighter;
 enum class CompletionKind;
 
 class SplitInput : public BaseWidget
@@ -78,6 +79,9 @@ public:
 
     void triggerSelfMessageReceived();
 
+    std::optional<bool> checkSpellingOverride() const;
+    void setCheckSpellingOverride(std::optional<bool> override);
+
     pajlada::Signals::Signal<const QString &> textChanged;
     pajlada::Signals::NoArgSignal selectionChanged;
 
@@ -102,10 +106,7 @@ protected:
     void addShortcuts() override;
     void initLayout();
     bool eventFilter(QObject *obj, QEvent *event) override;
-#ifdef DEBUG
-    bool keyPressedEventInstalled{};
-#endif
-    void installKeyPressedEvent();
+    void installTextEditEvents();
     void onCursorPositionChanged();
     void onTextChanged();
     void updateEmoteButton();
@@ -187,6 +188,12 @@ protected:
     void setBackgroundColor(QColor newColor);
 
     QPropertyAnimation backgroundColorAnimation;
+
+    std::optional<bool> checkSpellingOverride_;
+    bool shouldCheckSpelling() const;
+    void checkSpellingChanged();
+
+    SpellCheckHighlighter *spellcheckHighlighter = nullptr;
 
 private Q_SLOTS:
     void editTextChanged();

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -13,6 +13,7 @@
     "boost-json",
     "boost-signals2",
     "boost-variant",
+    "hunspell",
     {
       "name": "qt5compat",
       "default-features": false,


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
Yesterday evening, I wanted to experiment how Hunspell would work in Chatterino. I discovered that it's not that much effort to get spell checking to work.

This is a minimal implementation of spell checking. Dictionaries must be saved as `index.aff` and `index.dic` in `Dictionaries/` (next to `Settings/`). You can find dictionaries [here](https://github.com/wooorm/dictionaries) (this collects some from various sources).

**Features**
- Toggle checking for all inputs in the settings
- Toggle checking for one input via context menu
- Apply suggestions via context menu (even when spellchecking is disabled)
- Works with undo/redo
- Emotes are ignored

**Missing Features** (might be cool to have this in the future)
- Currently, it's bring-your-own-dictionary. It would be cool if Chatterino could install dictionaries.
- You can't switch the language per split right now.
- Custom dictionaries would be great (and "Add to dictionary").
- The spellchecker should be able to reload.

One thing I dislike is that `QSyntaxHighlighter` is synchronous, meaning it reruns every time a character is typed. Technically, you could hack around that by ignoring its requests to highlight a block and manually call `rehighlight` (at some timer tick, for example).

Closes #16.