### PR TITLE
fix: relayout tabs when update button visibility changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bugfix: Fixed crashes that could occur when Lua functions errored with values other than strings. (#6441)
 - Bugfix: Fixed zero-width global BTTV emotes not showing in the `:~` completions. (#6440)
+- Bugfix: Fixed an issue where the update button would be unclickable on macOS and Linux. (#6447)
 
 ## 2.5.4-beta.1
 

--- a/src/controllers/commands/builtin/chatterino/Debugging.cpp
+++ b/src/controllers/commands/builtin/chatterino/Debugging.cpp
@@ -15,6 +15,7 @@
 #include "providers/twitch/TwitchIrcServer.hpp"
 #include "singletons/Theme.hpp"
 #include "singletons/Toasts.hpp"
+#include "singletons/Updates.hpp"
 #include "singletons/WindowManager.hpp"
 #include "util/PostToThread.hpp"
 
@@ -195,6 +196,11 @@ QString debugTest(const CommandContext &ctx)
             ctx.twitchChannel->getName(), title);
         ctx.channel->addSystemMessage(
             QString("debug-test sent desktop notification"));
+    }
+    else if (command == "update-check")
+    {
+        getApp()->getUpdates().checkForUpdates();
+        ctx.channel->addSystemMessage(QString("checking for updates"));
     }
     else
     {

--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -1492,7 +1492,12 @@ void SplitNotebook::addCustomButtons()
     // updates
     auto *updateBtn = this->addCustomButton<PixmapButton>();
 
-    initUpdateButton(*updateBtn, this->signalHolder_);
+    initUpdateButton(
+        *updateBtn,
+        [this] {
+            this->performLayout(false);
+        },
+        this->signalHolder_);
 
     // streamer mode
     this->streamerModeIcon_ = this->addCustomButton<PixmapButton>();

--- a/src/widgets/Notebook.hpp
+++ b/src/widgets/Notebook.hpp
@@ -17,10 +17,8 @@ namespace chatterino {
 
 class Button;
 class PixmapButton;
-class SvgButton;
 class Window;
 class DrawnButton;
-class UpdateDialog;
 class NotebookTab;
 class SplitContainer;
 class Split;

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -221,7 +221,7 @@ void Window::addCustomTitlebarButtons()
     // updates
     auto *update = this->addTitleBarButton<PixmapButton>([] {});
 
-    initUpdateButton(*update, this->signalHolder_);
+    initUpdateButton(*update, [] {}, this->signalHolder_);
 
     // account
     this->userLabel_ = this->addTitleBarLabel([this] {

--- a/src/widgets/buttons/InitUpdateButton.hpp
+++ b/src/widgets/buttons/InitUpdateButton.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional>
+
 namespace pajlada::Signals {
 class SignalHolder;
 }  // namespace pajlada::Signals
@@ -7,9 +9,12 @@ class SignalHolder;
 namespace chatterino {
 
 class PixmapButton;
-class UpdateDialog;
 
+/// Initializes the update button
+///
+/// The `relayout` function gets called whenever the button visibility changes
 void initUpdateButton(PixmapButton &button,
+                      const std::function<void()> &relayout,
                       pajlada::Signals::SignalHolder &signalHolder);
 
 }  // namespace chatterino


### PR DESCRIPTION
CC @Wissididom if you could try this out - this is what i added to ensure the client actually responded yes to if there are updates

You can use `/debug-test update-check` to manually check for updates

```patch
diff --git a/src/common/Version.hpp b/src/common/Version.hpp
index faac0110d..6e77e7cd6 100644
--- a/src/common/Version.hpp
+++ b/src/common/Version.hpp
@@ -29,7 +29,7 @@ namespace chatterino {
  *  - 2.4.0-alpha.2
  *  - 2.4.0-alpha
  **/
-inline const QString CHATTERINO_VERSION = QStringLiteral("2.5.4-beta.1");
+inline const QString CHATTERINO_VERSION = QStringLiteral("2.5.4-beta.0");
 
 class Version
 {
```
