### PR TITLE
fix: mouse over tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Bugfix: Fixed crashes that could occur when Lua functions errored with values other than strings. (#6441)
 - Bugfix: Fixed zero-width global BTTV emotes not showing in the `:~` completions. (#6440)
 - Bugfix: Fixed an issue where the update button would be unclickable on macOS and Linux. (#6447)
+- Bugfix: Fixed flickering tooltips on Wayland when the mouse cursor is over them. (#6451)
 
 ## 2.5.4-beta.1
 

--- a/src/widgets/TooltipWidget.cpp
+++ b/src/widgets/TooltipWidget.cpp
@@ -59,6 +59,7 @@ TooltipWidget::TooltipWidget(BaseWidget *parent)
 
     this->setStyleSheet("color: #fff; background: rgba(11, 11, 11, 0.8)");
     this->setAttribute(Qt::WA_TranslucentBackground);
+    this->setAttribute(Qt::WA_TransparentForMouseEvents);
     this->setWindowFlag(Qt::WindowStaysOnTopHint, true);
 
     // Default to using vertical layout


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

On wayland, the tooltip sometimes gets positioned in a way where the mouse is over both the tooltip and the emote/link. This causes some buggy behaviour where the tooltip is only displayed momentarily.

Adding the `Qt::WA_TransparentForMouseEvents` attribute to the tooltip widget seems to fix this.

Before: 
https://github.com/user-attachments/assets/9eee03e5-abe9-4ec5-8d88-42183d638513

After:

https://github.com/user-attachments/assets/1508a937-010a-442d-88b7-08b098f2fd37



