### PR TITLE
fix: notebook custom button resizing/layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Bugfix: Fixed crashes that could occur when Lua functions errored with values other than strings. (#6441)
 - Bugfix: Fixed zero-width global BTTV emotes not showing in the `:~` completions. (#6440)
-- Bugfix: Fixed an issue where the update button would be unclickable on macOS and Linux. (#6447)
+- Bugfix: Fixed an issue where the update button would be unclickable on macOS and Linux. (#6447, #6453)
 - Bugfix: Fixed flickering tooltips on Wayland when the mouse cursor is over them. (#6451)
 
 ## 2.5.4-beta.1

--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -1510,6 +1510,8 @@ void SplitNotebook::addCustomButtons()
     QObject::connect(getApp()->getStreamerMode(), &IStreamerMode::changed, this,
                      &SplitNotebook::updateStreamerModeIcon);
     this->updateStreamerModeIcon();
+
+    this->performLayout(false);
 }
 
 void SplitNotebook::updateStreamerModeIcon()

--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -801,7 +801,9 @@ void Notebook::performHorizontalLayout(const LayoutContext &ctx, bool animated)
     // set size of custom buttons (settings, user, ...)
     for (auto *btn : this->customButtons_)
     {
-        if (!btn->isVisible())
+        // We use isHidden here since the layout can happen when the button has
+        // been added but before it's shown
+        if (btn->isHidden())
         {
             continue;
         }
@@ -925,7 +927,7 @@ void Notebook::performVerticalLayout(const LayoutContext &ctx, bool animated)
              btnIt != this->customButtons_.rend(); ++btnIt)
         {
             auto *btn = *btnIt;
-            if (!btn->isVisible())
+            if (btn->isHidden())
             {
                 continue;
             }
@@ -945,7 +947,7 @@ void Notebook::performVerticalLayout(const LayoutContext &ctx, bool animated)
         // set size of custom buttons (settings, user, ...)
         for (auto *btn : this->customButtons_)
         {
-            if (!btn->isVisible())
+            if (btn->isHidden())
             {
                 continue;
             }
@@ -1203,7 +1205,7 @@ size_t Notebook::visibleButtonCount() const
     size_t i = 0;
     for (auto *btn : this->customButtons_)
     {
-        if (btn->isVisible())
+        if (!btn->isHidden())
         {
             ++i;
         }

--- a/src/widgets/Notebook.hpp
+++ b/src/widgets/Notebook.hpp
@@ -138,7 +138,6 @@ protected:
     {
         auto *btn = new T(std::forward<decltype(args)>(args)..., this);
         this->customButtons_.push_back(btn);
-        this->performLayout();
 
         return btn;
     }


### PR DESCRIPTION
The big change here is that we use `isHidden` instead of `!isVisible` for the custom button visibility test.
The former returns true if it _will_ be shown when the Notebook is shown, where the latter returns true only if the Notebook is currently shown.

Using `isHidden` means we can always perform the layout safely, regardless of the state of the Notebook.

As a bonus, I've removed the layout that happens whenever a custom button is added, and instead now perform a single un-animated layout when _all_ custom buttons have been added.

With these changes, I can no longer reproduce any of the custom buttons being hidden behind tabs. I have tested all tab layouts.