### PR TITLE
fix: update input fonts on fontChanged signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Bugfix: Fixed flickering tooltips on Wayland when the mouse cursor is over them. (#6451)
 - Bugfix: Fixed `c2.Channel` comparing `false` to the same channel. (#6456)
 - Bugfix: Fixed an issue where the moderation icon was missing from the Moderation tab. (#6457)
+- Bugfix: Update the message length font when updating your chat font. (#6462)
 - Dev: Added documentation for WebSockets to `wip-plugins.md`. (#6432)
 
 ## 2.5.4-beta.1

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -217,6 +217,8 @@ void SplitInput::initLayout()
         app->getFonts()->fontChanged, [=, this]() {
             this->ui_.textEdit->setFont(
                 app->getFonts()->getFont(FontStyle::ChatMedium, this->scale()));
+            this->ui_.textEditLength->setFont(
+                app->getFonts()->getFont(FontStyle::TimestampMedium, this->scale()));
             this->ui_.replyLabel->setFont(app->getFonts()->getFont(
                 FontStyle::ChatMediumBold, this->scale()));
         });
@@ -275,16 +277,13 @@ void SplitInput::scaleChangedEvent(float scale)
             this->ui_.vbox->setSpacing(this->marginForTheme());
         }
     }
-    // TODO: This font does _not_ get updated when you change your chat font
     this->ui_.textEdit->setFont(
         app->getFonts()->getFont(FontStyle::ChatMedium, scale));
 
-    // TODO: This font does _not_ get updated when you change your chat font
     // NOTE: We're using TimestampMedium here to get a font that uses the tnum font feature,
     // meaning numbers get equal width & don't bounce around while the user is typing.
     this->ui_.textEditLength->setFont(
         app->getFonts()->getFont(FontStyle::TimestampMedium, scale));
-    // TODO: This font does _not_ get updated when you change your chat font
     this->ui_.replyLabel->setFont(
         app->getFonts()->getFont(FontStyle::ChatMediumBold, scale));
 }

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -217,8 +217,8 @@ void SplitInput::initLayout()
         app->getFonts()->fontChanged, [=, this]() {
             this->ui_.textEdit->setFont(
                 app->getFonts()->getFont(FontStyle::ChatMedium, this->scale()));
-            this->ui_.textEditLength->setFont(
-                app->getFonts()->getFont(FontStyle::TimestampMedium, this->scale()));
+            this->ui_.textEditLength->setFont(app->getFonts()->getFont(
+                FontStyle::TimestampMedium, this->scale()));
             this->ui_.replyLabel->setFont(app->getFonts()->getFont(
                 FontStyle::ChatMediumBold, this->scale()));
         });


### PR DESCRIPTION
I saw [the TODO on message length counter font not updating](https://github.com/Chatterino/chatterino2/blob/c7dea40b6baa9f401cc5559723b103edfb75741e/src/widgets/splits/SplitInput.cpp#L278C1-L278C77) on font change and thought this would be a simple fix. Now the `fontChanged` signal is connected to update the `textEditLength` widget's font. I've also removed the TODO comments.

