### PR TITLE
ci(macos): codesign with a hardened runtime

### DIFF
--- a/.CI/CreateDMG.sh
+++ b/.CI/CreateDMG.sh
@@ -23,7 +23,7 @@ fi
 
 if [ -n "$MACOS_CODESIGN_CERTIFICATE" ]; then
     echo "Codesigning force deep inside the app"
-    codesign -s "$MACOS_CODESIGN_CERTIFICATE" --deep --force chatterino.app
+    codesign -s "$MACOS_CODESIGN_CERTIFICATE" --deep --force --options=runtime chatterino.app
     echo "Done!"
 fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Bugfix: Fixed `c2.Channel` comparing `false` to the same channel. (#6456)
 - Bugfix: Fixed an issue where the moderation icon was missing from the Moderation tab. (#6457)
 - Dev: Added documentation for WebSockets to `wip-plugins.md`. (#6432)
+- Dev: Enable the hardened runtime on macOS. (#6467)
 
 ## 2.5.4-beta.1
 


### PR DESCRIPTION
https://developer.apple.com/documentation/security/resolving-common-notarization-issues#Enable-the-hardened-runtime
