### PR TITLE
fix: don't set split focus hotkeys by default on macOS

### DIFF
--- a/src/controllers/hotkeys/HotkeyController.cpp
+++ b/src/controllers/hotkeys/HotkeyController.cpp
@@ -378,6 +378,7 @@ void HotkeyController::addDefaults(std::set<QString> &addedHotkeys)
                             QKeySequence("Alt+x"), "createClip",
                             std::vector<QString>(), "create clip");
 
+#ifndef Q_OS_MACOS
         this->tryAddDefault(addedHotkeys, HotkeyCategory::Split,
                             QKeySequence("Alt+left"), "focus", {"left"},
                             "focus left");
@@ -390,6 +391,7 @@ void HotkeyController::addDefaults(std::set<QString> &addedHotkeys)
         this->tryAddDefault(addedHotkeys, HotkeyCategory::Split,
                             QKeySequence("Alt+right"), "focus", {"right"},
                             "focus right");
+#endif
 
         this->tryAddDefault(addedHotkeys, HotkeyCategory::Split,
                             QKeySequence("PgUp"), "scrollPage", {"up"},


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

fixes #5299
fixes #6166

macOS users being thrown off by this hotkey overlap is a reoccurring issue, so don't set these by default