### PR TITLE
fix: remove QTextCodec include

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unversioned
 
 - Dev: Make code sanitizers opt in with the `CHATTERINO_SANITIZER_SUPPORT` CMake option. After that's enabled, use the `SANITIZE_*` flag to enable individual sanitizers. (#6493)
+- Dev: Remove unused QTextCodec includes. (#6487)
 - Dev: Fix 32-bit compile in PluginRepl. (#6483)
 
 ## 2.5.4

--- a/src/controllers/plugins/LuaAPI.cpp
+++ b/src/controllers/plugins/LuaAPI.cpp
@@ -13,7 +13,6 @@
 #    include <QFileInfo>
 #    include <QList>
 #    include <QLoggingCategory>
-#    include <QTextCodec>
 #    include <QUrl>
 #    include <sol/forward.hpp>
 #    include <sol/protected_function_result.hpp>

--- a/src/util/XDGHelper.cpp
+++ b/src/util/XDGHelper.cpp
@@ -11,7 +11,6 @@
 #include <QRegularExpression>
 #include <QSettings>
 #include <QStringLiteral>
-#include <QTextCodec>
 #include <QtGlobal>
 
 #include <unordered_set>


### PR DESCRIPTION
this is unused, and technically unavailable since we don't include the
Core5Compat Qt Component

<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
