### PR TITLE
feat: add markdown support for user notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+- Minor: Added Markdown support to user notes. (#)
+
 ## 2.5.4
 
 - Bugfix: Fixed crashes that could occur when Lua functions errored with values other than strings. (#6441)

--- a/src/widgets/Label.cpp
+++ b/src/widgets/Label.cpp
@@ -242,11 +242,9 @@ void Label::updateSize()
     if (this->markdownEnabled_ && this->markdownDocument_ &&
         !this->text_.isEmpty())
     {
-        // Size based on Markdown document
         this->markdownDocument_->setDefaultFont(
             getApp()->getFonts()->getFont(this->getFontStyle(), this->scale()));
 
-        // Ensure markdown content is set
         this->markdownDocument_->setMarkdown(this->text_);
 
         // Use word wrap width if enabled, otherwise use a reasonable default
@@ -265,7 +263,6 @@ void Label::updateSize()
     }
     else
     {
-        // Original sizing logic
         auto height = metrics.height() + yPadding;
         if (this->shouldElide_)
         {

--- a/src/widgets/Label.hpp
+++ b/src/widgets/Label.hpp
@@ -5,7 +5,10 @@
 
 #include <pajlada/signals/signalholder.hpp>
 
+#include <memory>
+
 class QFontMetricsF;
+class QTextDocument;
 
 namespace chatterino {
 
@@ -34,6 +37,9 @@ public:
     /// Sets whether the text should elide if there's not enough room to
     /// render the current text.
     void setShouldElide(bool shouldElide);
+
+    bool getMarkdownEnabled() const;
+    void setMarkdownEnabled(bool enabled);
 
 protected:
     void scaleChangedEvent(float scale_) override;
@@ -68,10 +74,13 @@ private:
     bool centered_ = false;
     bool wordWrap_ = false;
     bool shouldElide_ = false;
+    bool markdownEnabled_ = false;
     /// The text, but elided. Only set if shouldElide_ is true
     QString elidedText_;
 
     pajlada::Signals::SignalHolder connections_;
+
+    mutable std::unique_ptr<QTextDocument> markdownDocument_;
 };
 
 }  // namespace chatterino

--- a/src/widgets/dialogs/EditUserNotesDialog.hpp
+++ b/src/widgets/dialogs/EditUserNotesDialog.hpp
@@ -3,9 +3,13 @@
 #include "pajlada/signals/signal.hpp"
 #include "widgets/BasePopup.hpp"
 
+class QCheckBox;
+class QSplitter;
 class QTextEdit;
 
 namespace chatterino {
+
+class Label;
 
 class EditUserNotesDialog : public BasePopup
 {
@@ -24,7 +28,12 @@ protected:
     void themeChangedEvent() override;
 
 private:
+    void updatePreview();
+
     QTextEdit *textEdit_{};
+    QCheckBox *previewCheckBox_{};
+    QSplitter *splitter_{};
+    Label *previewLabel_{};
 };
 
 }  // namespace chatterino

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -501,6 +501,7 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically, Split *split)
     auto notesPreview = layout.emplace<Label>().assign(&ui_.notesPreview);
     notesPreview->setVisible(false);
     notesPreview->setShouldElide(true);
+    notesPreview->setMarkdownEnabled(true);
 
     auto lineMod = layout.emplace<Line>(false);
 
@@ -1188,11 +1189,7 @@ void UserInfoPopup::updateNotes()
         return;
     }
 
-    static QRegularExpression spaceRegex{"\\s+"};
-
-    auto previewText = "Notes: " + userData->notes.replace(spaceRegex, " ");
-
-    this->ui_.notesPreview->setText(previewText);
+    this->ui_.notesPreview->setText(userData->notes);
     this->ui_.notesPreview->setVisible(true);
 }
 


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

fixes #6319

extends the `Label` widget to render markdown for user notes, and adds a toggle for a live markdown preview to the `EditUserNotesDialog`

<img width="363" height="231" alt="image" src="https://github.com/user-attachments/assets/bd7e5c3a-a04d-4a91-920a-219f4dfb4506" />

https://github.com/user-attachments/assets/817a31b5-591f-4750-a455-b65f03ac5ce2