### PR TITLE
feat: add setting for character limit of truncated deleted messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unversioned
 
 - Minor: Fixed usercard resizing improperly without recent messages. (#6496)
+- Minor: Added setting for character limit of deleted messages. (#6491)
 - Dev: Update release documentation. (#6498)
 - Dev: Make code sanitizers opt in with the `CHATTERINO_SANITIZER_SUPPORT` CMake option. After that's enabled, use the `SANITIZE_*` flag to enable individual sanitizers. (#6493)
 - Dev: Remove unused QTextCodec includes. (#6487)

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -1257,7 +1257,7 @@ MessagePtr MessageBuilder::makeDeletionMessageFromIRC(
                                  MessageColor::System);
 
     auto deletedMessageText = originalMessage->messageText;
-    auto limit = getSettings()->messageTruncationLimit;
+    auto limit = getSettings()->messageTruncationLimit.getValue();
     if (limit > 0 && deletedMessageText.length() > limit)
     {
         deletedMessageText = deletedMessageText.left(limit) + "…";

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -1257,7 +1257,7 @@ MessagePtr MessageBuilder::makeDeletionMessageFromIRC(
                                  MessageColor::System);
 
     auto deletedMessageText = originalMessage->messageText;
-    auto limit = getSettings()->messageTruncationLimit.getValue();
+    auto limit = getSettings()->deletedMessageLengthLimit.getValue();
     if (limit > 0 && deletedMessageText.length() > limit)
     {
         deletedMessageText = deletedMessageText.left(limit) + "…";

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -1257,9 +1257,10 @@ MessagePtr MessageBuilder::makeDeletionMessageFromIRC(
                                  MessageColor::System);
 
     auto deletedMessageText = originalMessage->messageText;
-    if (deletedMessageText.length() > 50)
+    auto limit = getSettings()->messageTruncationLimit;
+    if (limit > 0 && deletedMessageText.length() > limit)
     {
-        deletedMessageText = deletedMessageText.left(50) + "…";
+        deletedMessageText = deletedMessageText.left(limit) + "…";
     }
 
     builder

--- a/src/providers/twitch/eventsub/MessageBuilder.cpp
+++ b/src/providers/twitch/eventsub/MessageBuilder.cpp
@@ -331,14 +331,15 @@ void makeModerateMessage(
 
     builder.emplaceSystemTextAndUpdate("saying:", text);
 
-    if (action.messageBody.view().length() > 50)
+    auto limit = getSettings()->messageTruncationLimit;
+    if (limit > 0 && action.messageBody.view().length() > limit)
     {
         builder
-            .emplace<TextElement>(action.messageBody.qt().left(50) + "…",
+            .emplace<TextElement>(action.messageBody.qt().left(limit) + "…",
                                   MessageElementFlag::Text, MessageColor::Text)
             ->setLink({Link::JumpToMessage, action.messageID.qt()});
 
-        text.append(action.messageBody.qt().left(50) + "…");
+        text.append(action.messageBody.qt().left(limit) + "…");
     }
     else
     {

--- a/src/providers/twitch/eventsub/MessageBuilder.cpp
+++ b/src/providers/twitch/eventsub/MessageBuilder.cpp
@@ -331,7 +331,7 @@ void makeModerateMessage(
 
     builder.emplaceSystemTextAndUpdate("saying:", text);
 
-    auto limit = getSettings()->messageTruncationLimit.getValue();
+    auto limit = getSettings()->deletedMessageLengthLimit.getValue();
     if (limit > 0 && action.messageBody.view().length() > limit)
     {
         builder

--- a/src/providers/twitch/eventsub/MessageBuilder.cpp
+++ b/src/providers/twitch/eventsub/MessageBuilder.cpp
@@ -331,7 +331,7 @@ void makeModerateMessage(
 
     builder.emplaceSystemTextAndUpdate("saying:", text);
 
-    auto limit = getSettings()->messageTruncationLimit;
+    auto limit = getSettings()->messageTruncationLimit.getValue();
     if (limit > 0 && action.messageBody.view().length() > limit)
     {
         builder

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -322,7 +322,7 @@ public:
 
     IntSetting messageTruncationLimit = {
         "/behaviour/messageTruncationLimit",
-        50
+        50,
     };
 
     // Auto-completion

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -320,8 +320,10 @@ public:
         true,
     };
 
-    IntSetting messageTruncationLimit = {"/behaviour/messageTruncationLimit",
-                                         50};
+    IntSetting messageTruncationLimit = {
+        "/behaviour/messageTruncationLimit",
+        50
+    };
 
     // Auto-completion
     BoolSetting onlyFetchChattersForSmallerStreamers = {

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -321,7 +321,7 @@ public:
     };
 
     IntSetting messageTruncationLimit = {"/behaviour/messageTruncationLimit",
-                                        50};
+                                         50};
 
     // Auto-completion
     BoolSetting onlyFetchChattersForSmallerStreamers = {

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -320,8 +320,8 @@ public:
         true,
     };
 
-    IntSetting messageTruncationLimit = {
-        "/behaviour/messageTruncationLimit",
+    IntSetting deletedMessageLengthLimit = {
+        "/behaviour/deletedMessageLengthLimit",
         50,
     };
 

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -320,6 +320,9 @@ public:
         true,
     };
 
+    IntSetting messageTruncationLimit = {"/behaviour/messageTruncationLimit",
+                                        50};
+
     // Auto-completion
     BoolSetting onlyFetchChattersForSmallerStreamers = {
         "/behaviour/autocompletion/onlyFetchChattersForSmallerStreamers", true};

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -320,6 +320,8 @@ public:
         true,
     };
 
+    /// The maximum length the contents of a deleted message can be
+    /// before we truncate it in the chat
     IntSetting deletedMessageLengthLimit = {
         "/behaviour/deletedMessageLengthLimit",
         50,

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -546,7 +546,6 @@ void GeneralPage::initLayout(GeneralPageView &layout)
                                    : args.value;
         },
         true, "a = am/pm, zzz = milliseconds");
-
     layout.addDropdown<int>(
         "Limit message height",
         {"Never", "2 lines", "3 lines", "4 lines", "5 lines"},
@@ -557,7 +556,6 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         [](auto args) {
             return fuzzyToInt(args.value, 0);
         });
-
     layout.addDropdown<int>(
         "Limit truncation of deleted messages",
         {"No limit", "50 characters", "100 characters", "200 characters", "300 characters",

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -546,6 +546,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
                                    : args.value;
         },
         true, "a = am/pm, zzz = milliseconds");
+
     layout.addDropdown<int>(
         "Limit message height",
         {"Never", "2 lines", "3 lines", "4 lines", "5 lines"},
@@ -556,6 +557,19 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         [](auto args) {
             return fuzzyToInt(args.value, 0);
         });
+
+    layout.addDropdown<int>(
+        "Limit truncation of deleted messages",
+        {"No limit", "50 characters", "100 characters", "200 characters", "300 characters",
+         "400 characters"},
+        s.messageTruncationLimit,
+        [](auto val) {
+            return val ? QString::number(val) + " characters" : QString("No limit");
+        },
+        [](auto args) {
+            return fuzzyToInt(args.value, 0);
+        });
+
     layout.addSeparator();
 
     SettingWidget::checkbox("Draw a line below the most recent message before "

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -557,7 +557,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
             return fuzzyToInt(args.value, 0);
         });
     layout.addDropdown<int>(
-        "Limit truncation of deleted messages",
+        "Limit length of deleted messages",
         {"No limit", "50 characters", "100 characters", "200 characters",
          "300 characters", "400 characters"},
         s.messageTruncationLimit,
@@ -567,7 +567,10 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         },
         [](const auto &args) {
             return fuzzyToInt(args.value, 0);
-        });
+        },
+        true,
+        {"Limits the amount of characters displayed in deleted messages "
+         "when announced via system message."});
 
     layout.addSeparator();
 

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -565,7 +565,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
             return val ? QString::number(val) + " characters"
                        : QString("No limit");
         },
-        [](auto args) {
+        [](const auto &args) {
             return fuzzyToInt(args.value, 0);
         });
 

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -560,7 +560,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         "Limit length of deleted messages",
         {"No limit", "50 characters", "100 characters", "200 characters",
          "300 characters", "400 characters"},
-        s.messageTruncationLimit,
+        s.deletedMessageLengthLimit,
         [](auto val) {
             return val ? QString::number(val) + " characters"
                        : QString("No limit");

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -558,11 +558,12 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         });
     layout.addDropdown<int>(
         "Limit truncation of deleted messages",
-        {"No limit", "50 characters", "100 characters", "200 characters", "300 characters",
-         "400 characters"},
+        {"No limit", "50 characters", "100 characters", "200 characters",
+         "300 characters", "400 characters"},
         s.messageTruncationLimit,
         [](auto val) {
-            return val ? QString::number(val) + " characters" : QString("No limit");
+            return val ? QString::number(val) + " characters"
+                       : QString("No limit");
         },
         [](auto args) {
             return fuzzyToInt(args.value, 0);


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

fixes #6433

replaces hard-coded 50-character limit on system messages' reiteration of deleted messages