### PR TITLE
fix: usercard resizing improperly without recent messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unversioned
 
+- Minor: Fixed usercard resizing improperly without recent messages.
 - Dev: Make code sanitizers opt in with the `CHATTERINO_SANITIZER_SUPPORT` CMake option. After that's enabled, use the `SANITIZE_*` flag to enable individual sanitizers. (#6493)
 - Dev: Fix 32-bit compile in PluginRepl. (#6483)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unversioned
 
-- Minor: Fixed usercard resizing improperly without recent messages.
+- Minor: Fixed usercard resizing improperly without recent messages. (#6496)
 - Dev: Make code sanitizers opt in with the `CHATTERINO_SANITIZER_SUPPORT` CMake option. After that's enabled, use the `SANITIZE_*` flag to enable individual sanitizers. (#6493)
 - Dev: Fix 32-bit compile in PluginRepl. (#6483)
 

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -587,6 +587,8 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically, Split *split)
     {
         this->ui_.noMessagesLabel = new Label("No recent messages");
         this->ui_.noMessagesLabel->setVisible(false);
+        this->ui_.noMessagesLabel->setSizePolicy(QSizePolicy::Expanding,
+                                                 QSizePolicy::Expanding);
 
         this->ui_.latestMessages =
             new ChannelView(this, this->split_, ChannelView::Context::UserCard,


### PR DESCRIPTION
before:
<img width="200" alt="before" src="https://github.com/user-attachments/assets/239d0ba5-5121-40b1-9991-89f6a8cb2c5d"/>

after:
<img width="200" alt="after" src="https://github.com/user-attachments/assets/66c57779-8c29-4fd2-989c-969bd3bd9474"/>

very niche but easy fix so uh