### PR TITLE
ci(freebsd): skip imageformats install

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,7 +3,7 @@ freebsd_instance:
 
 task:
   install_script:
-    - pkg install -y boost-libs git libnotify qt6-base qt6-svg qt6-imageformats qtkeychain-qt6 cmake pkgconf
+    - pkg install -y boost-libs git libnotify qt6-base qt6-svg qtkeychain-qt6 cmake pkgconf
   script: |
     git submodule init
     git submodule update


### PR DESCRIPTION
it's not necessary for just building

<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
