### PR TITLE
fix: compilation error with Clang 21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Minor: Fixed usercard resizing improperly without recent messages. (#6496)
 - Minor: Added setting for character limit of deleted messages. (#6491)
 - Minor: Added link support to plugin message API. (#6386)
+- Bugfix: Fixed compilation error with Clang 21. (#6519)
 - Dev: Update release documentation. (#6498)
 - Dev: Make code sanitizers opt in with the `CHATTERINO_SANITIZER_SUPPORT` CMake option. After that's enabled, use the `SANITIZE_*` flag to enable individual sanitizers. (#6493)
 - Dev: Remove unused QTextCodec includes. (#6487)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 - Minor: Fixed usercard resizing improperly without recent messages. (#6496)
 - Minor: Added setting for character limit of deleted messages. (#6491)
 - Minor: Added link support to plugin message API. (#6386)
-- Bugfix: Fixed compilation error with Clang 21. (#6519)
 - Dev: Update release documentation. (#6498)
 - Dev: Make code sanitizers opt in with the `CHATTERINO_SANITIZER_SUPPORT` CMake option. After that's enabled, use the `SANITIZE_*` flag to enable individual sanitizers. (#6493)
 - Dev: Remove unused QTextCodec includes. (#6487)
@@ -18,6 +17,7 @@
 - Dev: Merged emote element flags from different providers into two. (#6511)
 - Dev: Removed unused method in `Emojis`. (#6517)
 - Dev: Refactored `Emotes` into `EmoteController`. (#6516)
+- Def: Fixed compilation error in tests with Clang 21. (#6519)
 
 ## 2.5.4
 

--- a/tests/src/QMagicEnum.cpp
+++ b/tests/src/QMagicEnum.cpp
@@ -203,7 +203,7 @@ TEST(QMagicEnum, open)
     static_assert(checkConst(OpenOne, u"OpenOne"));
     static_assert(checkConst(OpenTwo, u"OpenTwo"));
     static_assert(checkConst(OpenThree, u"OpenThree"));
-    static_assert(eq(enumName(static_cast<MyOpen>(16)), u""));
+    static_assert(eq(enumName(static_cast<MyOpen>(10)), u""));
     static_assert(checkValues<MyOpen>({u"OpenOne", u"OpenTwo", u"OpenThree"}));
 }
 


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
The range of `MyOpen` is `[1, 15]` but we instantiated `16` - this is an error in Clang 21. The point of the test is to see what happens if the name of an unnamed variant is requested. This PR fixes that by using a value inside the allowed range.