### PR TITLE
fix: set Qt definitions `PUBLIC` in chatterino-lib/-version

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,9 +1,8 @@
 set(LIBRARY_PROJECT "${PROJECT_NAME}-lib")
 set(VERSION_PROJECT "${LIBRARY_PROJECT}-version")
 set(EXECUTABLE_PROJECT "${PROJECT_NAME}")
-add_compile_definitions(QT_DISABLE_DEPRECATED_BEFORE=0x060403)
-add_compile_definitions(QT_WARN_DEPRECATED_UP_TO=0x060403)
-add_compile_definitions(QT_NO_KEYWORDS)
+# used for QT_DISABLE_DEPRECATED_BEFORE/QT_WARN_DEPRECATED_UP_TO
+set(CHATTERINO_MIN_QT_VERSION 0x060403)
 
 # registers the native messageing host
 option(CHATTERINO_DEBUG_NATIVE_MESSAGES "Debug native messages" OFF)
@@ -1078,6 +1077,14 @@ target_compile_definitions(${LIBRARY_PROJECT} PUBLIC
     $<$<BOOL:${WIN32}>:_WIN32_WINNT=0x0A00> # Windows 10
     $<$<BOOL:${BUILD_TESTS}>:CHATTERINO_WITH_TESTS>
     )
+
+set(_c2_qt_defs
+    QT_DISABLE_DEPRECATED_BEFORE=${CHATTERINO_MIN_QT_VERSION}
+    QT_WARN_DEPRECATED_UP_TO=${CHATTERINO_MIN_QT_VERSION}
+    QT_NO_KEYWORDS
+)
+target_compile_definitions(${VERSION_PROJECT} PUBLIC ${_c2_qt_defs})
+target_compile_definitions(${LIBRARY_PROJECT} PUBLIC ${_c2_qt_defs})
 
 if (USE_SYSTEM_QTKEYCHAIN)
     target_compile_definitions(${LIBRARY_PROJECT} PUBLIC


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

Currently, the `-DQT_DISABLE_DEPRECATED_BEFORE=xxx -DQT_WARN_DEPRECATED_UP_TO=xxx -DQT_NO_KEYWORDS` definitions are only set for `chatterino-lib` and `chatterino-version`. However, they should also be set for `chatterino-test` and `chatterino-benchmark`, since these projects consume headers from Chatterino. Especially `QT_NO_KEYWORDS` should match.

This PR does that by using `target_compile_definitions(xxx PUBLIC flags...)`.