### PR TITLE
fix: Get rid of warnings on clang-cl

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1234,6 +1234,14 @@ if (MSVC)
         # Enable updated '__cplusplus' macro - workaround for CMake#18837
         /Zc:__cplusplus
     )
+
+    # Warnings on clang-cl
+    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        target_compile_options(${LIBRARY_PROJECT} PUBLIC
+            -Wno-missing-designated-field-initializers
+        )
+    endif()
+
     # Disable min/max macros from Windows.h
     target_compile_definitions(${LIBRARY_PROJECT} PUBLIC NOMINMAX)
 else ()

--- a/src/RunGui.cpp
+++ b/src/RunGui.cpp
@@ -110,20 +110,7 @@ void showLastCrashDialog(const Args &args, const Paths &paths)
     dialog->exec();
 }
 
-void createRunningFile(const QString &path)
-{
-    QFile runningFile(path);
-
-    std::ignore = runningFile.open(QIODevice::WriteOnly | QIODevice::Truncate);
-    runningFile.flush();
-    runningFile.close();
-}
-
-void removeRunningFile(const QString &path)
-{
-    QFile::remove(path);
-}
-
+#if defined(NDEBUG) && !defined(CHATTERINO_WITH_CRASHPAD)
 std::chrono::steady_clock::time_point signalsInitTime;
 
 [[noreturn]] void handleSignal(int signum)
@@ -135,7 +122,7 @@ std::chrono::steady_clock::time_point signalsInitTime;
     {
         QProcess proc;
 
-#ifdef Q_OS_MAC
+#    ifdef Q_OS_MAC
         // On macOS, programs are bundled into ".app" Application bundles,
         // when restarting Chatterino that bundle should be opened with the "open"
         // terminal command instead of directly starting the underlying executable,
@@ -152,16 +139,17 @@ std::chrono::steady_clock::time_point signalsInitTime;
 
         CFRelease(appUrlRef);
         CFRelease(macPath);
-#else
+#    else
         proc.setProgram(QApplication::applicationFilePath());
         proc.setArguments({"--crash-recovery"});
-#endif
+#    endif
 
         proc.startDetached();
     }
 
     std::_Exit(signum);
 }
+#endif
 
 // We want to restart Chatterino when it crashes and the setting is set to
 // true.

--- a/src/common/Args.cpp
+++ b/src/common/Args.cpp
@@ -306,7 +306,10 @@ void Args::applyCustomChannelLayout(const QString &argValue, const Paths &paths)
 
             // Set first tab as selected
             tab.selected_ = window.tabs_.empty();
-            tab.rootNode_ = SplitNodeDescriptor{{"twitch", channelName}};
+            tab.rootNode_ = SplitNodeDescriptor{{
+                .type_ = "twitch",
+                .channelName_ = channelName,
+            }};
 
             window.tabs_.emplace_back(std::move(tab));
         }

--- a/src/common/ChannelChatters.cpp
+++ b/src/common/ChannelChatters.cpp
@@ -33,6 +33,8 @@ void ChannelChatters::addJoinedUser(const QString &user, bool isMod,
     assertInGuiThread();
 
     if (isIgnoredMessage(IgnoredMessageParameters{
+            .message = {},
+            .twitchUserID = {},
             .twitchUserLogin = user,
             .isMod = isMod,
             .isBroadcaster = isBroadcaster,
@@ -69,6 +71,8 @@ void ChannelChatters::addPartedUser(const QString &user, bool isMod,
     assertInGuiThread();
 
     if (isIgnoredMessage(IgnoredMessageParameters{
+            .message = {},
+            .twitchUserID = {},
             .twitchUserLogin = user,
             .isMod = isMod,
             .isBroadcaster = isBroadcaster,

--- a/src/controllers/commands/builtin/twitch/SendWhisper.cpp
+++ b/src/controllers/commands/builtin/twitch/SendWhisper.cpp
@@ -109,7 +109,6 @@ bool appendWhisperMessageWordsLocally(const QStringList &words)
     const auto &accemotes = *acc->accessEmotes();
     const auto *bttvemotes = app->getBttvEmotes();
     const auto *ffzemotes = app->getFfzEmotes();
-    auto flags = MessageElementFlags();
     auto emote = std::optional<EmotePtr>{};
     for (int i = 2; i < words.length(); i++)
     {

--- a/src/controllers/plugins/api/Message.cpp
+++ b/src/controllers/plugins/api/Message.cpp
@@ -203,6 +203,7 @@ std::unique_ptr<MessageElement> elementFromTable(const sol::table &tbl)
             case Link::AutoModDeny:
             case Link::InsertText:
             case Link::OpenAccountsPage:
+            case Link::ViewThread:
             case Link::Reconnect:
                 throw std::runtime_error(
                     "Invalid link type. How'd this happen?");

--- a/src/messages/layouts/MessageLayoutElement.cpp
+++ b/src/messages/layouts/MessageLayoutElement.cpp
@@ -480,7 +480,8 @@ int TextLayoutElement::getMouseOverIndex(QPointF abs) const
         // accept mouse to be at only 50%+ of character width to increase index
         if (x + (width * 0.5) > abs.x())
         {
-            if (text.size() > i + 1 && QChar::isLowSurrogate(text[i].unicode()))
+            if (text.size() > i + 1 &&
+                QChar::isLowSurrogate(static_cast<char32_t>(text[i].unicode())))
             {
                 i++;
             }

--- a/src/providers/bttv/BttvEmotes.cpp
+++ b/src/providers/bttv/BttvEmotes.cpp
@@ -110,22 +110,26 @@ CreateEmoteResult createChannelEmote(const QString &channelDisplayName,
     }
 
     auto emote = Emote({
-        name,
-        ImageSet{
-            Image::fromUrl(getEmoteLinkV3(id, "1x"), 1, EMOTE_BASE_SIZE),
-            Image::fromUrl(getEmoteLinkV3(id, "2x"), 0.5, EMOTE_BASE_SIZE * 2),
-            Image::fromUrl(getEmoteLinkV3(id, "3x"), 0.25, EMOTE_BASE_SIZE * 4),
-        },
-        Tooltip{
-            QString("%1<br>%2 BetterTTV Emote<br>By: %3")
-                .arg(name.string)
-                // when author is empty, it is a channel emote created by the broadcaster
-                .arg(author.string.isEmpty() ? "Channel" : "Shared")
-                .arg(author.string.isEmpty() ? channelDisplayName
-                                             : author.string)},
-        Url{EMOTE_LINK_FORMAT.arg(id.string)},
-        false,
-        id,
+        .name = name,
+        .images =
+            ImageSet{
+                Image::fromUrl(getEmoteLinkV3(id, "1x"), 1, EMOTE_BASE_SIZE),
+                Image::fromUrl(getEmoteLinkV3(id, "2x"), 0.5,
+                               EMOTE_BASE_SIZE * 2),
+                Image::fromUrl(getEmoteLinkV3(id, "3x"), 0.25,
+                               EMOTE_BASE_SIZE * 4),
+            },
+        .tooltip =
+            Tooltip{
+                QString("%1<br>%2 BetterTTV Emote<br>By: %3")
+                    .arg(name.string)
+                    // when author is empty, it is a channel emote created by the broadcaster
+                    .arg(author.string.isEmpty() ? "Channel" : "Shared")
+                    .arg(author.string.isEmpty() ? channelDisplayName
+                                                 : author.string)},
+        .homePage = Url{EMOTE_LINK_FORMAT.arg(id.string)},
+        .zeroWidth = false,
+        .id = id,
     });
 
     return {id, name, emote};

--- a/src/providers/emoji/Emojis.cpp
+++ b/src/providers/emoji/Emojis.cpp
@@ -297,9 +297,11 @@ void Emojis::loadEmojiSet()
             }
             QString url = urlPrefix + code + ".png";
             emoji->emote = std::make_shared<Emote>(Emote{
-                EmoteName{emoji->value},
-                ImageSet{Image::fromUrl({url}, 0.35, {64, 64})},
-                Tooltip{":" + emoji->shortCodes[0] + ":<br/>Emoji"}, Url{}});
+                .name = EmoteName{emoji->value},
+                .images = ImageSet{Image::fromUrl({url}, 0.35, {64, 64})},
+                .tooltip = Tooltip{":" + emoji->shortCodes[0] + ":<br/>Emoji"},
+                .homePage = Url{},
+            });
         }
     });
 }

--- a/src/providers/ffz/FfzBadges.cpp
+++ b/src/providers/ffz/FfzBadges.cpp
@@ -66,17 +66,21 @@ void FfzBadges::load()
                                jsonBadge["height"].toInt(18));
 
                 auto emote = Emote{
-                    EmoteName{},
-                    ImageSet{Image::fromUrl(
-                                 parseFfzUrl(jsonUrls.value("1").toString()),
-                                 1.0, baseSize),
-                             Image::fromUrl(
-                                 parseFfzUrl(jsonUrls.value("2").toString()),
-                                 0.5, baseSize * 2),
-                             Image::fromUrl(
-                                 parseFfzUrl(jsonUrls.value("4").toString()),
-                                 0.25, baseSize * 4)},
-                    Tooltip{jsonBadge.value("title").toString()}, Url{}};
+                    .name = EmoteName{},
+                    .images =
+                        ImageSet{
+                            Image::fromUrl(
+                                parseFfzUrl(jsonUrls.value("1").toString()),
+                                1.0, baseSize),
+                            Image::fromUrl(
+                                parseFfzUrl(jsonUrls.value("2").toString()),
+                                0.5, baseSize * 2),
+                            Image::fromUrl(
+                                parseFfzUrl(jsonUrls.value("4").toString()),
+                                0.25, baseSize * 4)},
+                    .tooltip = Tooltip{jsonBadge.value("title").toString()},
+                    .homePage = Url{},
+                };
 
                 Badge badge;
 

--- a/src/providers/seventv/SeventvAPI.hpp
+++ b/src/providers/seventv/SeventvAPI.hpp
@@ -24,18 +24,16 @@ public:
     SeventvAPI &operator=(const SeventvAPI &) = delete;
     SeventvAPI &operator=(SeventvAPI &&) = delete;
 
-    virtual void getUserByTwitchID(
-        const QString &twitchID,
-        SuccessCallback<const QJsonObject &> &&onSuccess,
-        ErrorCallback &&onError);
-    virtual void getEmoteSet(const QString &emoteSet,
-                             SuccessCallback<const QJsonObject &> &&onSuccess,
-                             ErrorCallback &&onError);
+    void getUserByTwitchID(const QString &twitchID,
+                           SuccessCallback<const QJsonObject &> &&onSuccess,
+                           ErrorCallback &&onError);
+    void getEmoteSet(const QString &emoteSet,
+                     SuccessCallback<const QJsonObject &> &&onSuccess,
+                     ErrorCallback &&onError);
 
-    virtual void updatePresence(const QString &twitchChannelID,
-                                const QString &seventvUserID,
-                                SuccessCallback<> &&onSuccess,
-                                ErrorCallback &&onError);
+    void updatePresence(const QString &twitchChannelID,
+                        const QString &seventvUserID,
+                        SuccessCallback<> &&onSuccess, ErrorCallback &&onError);
 };
 
 }  // namespace chatterino

--- a/src/providers/seventv/SeventvEmotes.cpp
+++ b/src/providers/seventv/SeventvEmotes.cpp
@@ -67,17 +67,6 @@ bool isZeroWidthActive(const QJsonObject &activeEmote)
     return flags.has(SeventvActiveEmoteFlag::ZeroWidth);
 }
 
-/**
-  * This is only an indicator if an emote should be added
-  * as zero-width or not. The user can still overwrite this.
-  */
-bool isZeroWidthRecommended(const QJsonObject &emoteData)
-{
-    auto flags =
-        SeventvEmoteFlags(SeventvEmoteFlag(emoteData.value("flags").toInt()));
-    return flags.has(SeventvEmoteFlag::ZeroWidth);
-}
-
 Tooltip createTooltip(const QString &name, const QString &author, bool isGlobal)
 {
     return Tooltip{QString("%1<br>%2 7TV Emote<br>By: %3")

--- a/src/providers/twitch/TwitchEmotes.cpp
+++ b/src/providers/twitch/TwitchEmotes.cpp
@@ -460,14 +460,15 @@ EmotePtr TwitchEmotes::getOrCreateEmote(const EmoteId &id,
         auto baseSize = getEmoteExpectedBaseSize(id);
         auto emote3xScaleFactor = getEmote3xScaleFactor(id);
         (*cache)[id] = shared = std::make_shared<Emote>(Emote{
-            EmoteName{name},
-            ImageSet{
-                Image::fromUrl(getEmoteLink(id, "1.0"), 1, baseSize),
-                Image::fromUrl(getEmoteLink(id, "2.0"), 0.5, baseSize * 2),
-                Image::fromUrl(getEmoteLink(id, "3.0"), emote3xScaleFactor,
-                               baseSize * (1.0 / emote3xScaleFactor)),
-            },
-            Tooltip{name.toHtmlEscaped() + "<br>Twitch Emote"},
+            .name = EmoteName{name},
+            .images =
+                ImageSet{
+                    Image::fromUrl(getEmoteLink(id, "1.0"), 1, baseSize),
+                    Image::fromUrl(getEmoteLink(id, "2.0"), 0.5, baseSize * 2),
+                    Image::fromUrl(getEmoteLink(id, "3.0"), emote3xScaleFactor,
+                                   baseSize * (1.0 / emote3xScaleFactor)),
+                },
+            .tooltip = Tooltip{name.toHtmlEscaped() + "<br>Twitch Emote"},
         });
     }
 

--- a/src/singletons/CrashHandler.cpp
+++ b/src/singletons/CrashHandler.cpp
@@ -36,12 +36,12 @@ const QString CRASHPAD_EXECUTABLE_NAME = QStringLiteral("crashpad-handler.exe");
 
 /// Converts a QString into the platform string representation.
 #if defined(Q_OS_UNIX)
-std::string nativeString(const QString &s)
+[[maybe_unused]] std::string nativeString(const QString &s)
 {
     return s.toStdString();
 }
 #elif defined(Q_OS_WINDOWS)
-std::wstring nativeString(const QString &s)
+[[maybe_unused]] std::wstring nativeString(const QString &s)
 {
     return s.toStdWString();
 }
@@ -82,7 +82,8 @@ std::optional<bool> readRecoverySettings(const Paths &paths)
     return shouldRecover.toBool();
 }
 
-bool canRestart(const Paths &paths, const Args &args)
+[[maybe_unused]] bool canRestart(const Paths &paths,
+                                 [[maybe_unused]] const Args &args)
 {
 #ifdef NDEBUG
     if (args.isFramelessEmbed || args.shouldRunBrowserExtensionHost)
@@ -108,7 +109,7 @@ bool canRestart(const Paths &paths, const Args &args)
 /// additional plus ('++' -> '+').
 ///
 /// The decoding happens in crash-handler/src/CommandLine.cpp
-std::string encodeArguments(const Args &appArgs)
+[[maybe_unused]] std::string encodeArguments(const Args &appArgs)
 {
     std::string args;
     for (auto arg : appArgs.currentArguments())

--- a/src/singletons/Fonts.cpp
+++ b/src/singletons/Fonts.cpp
@@ -251,6 +251,9 @@ Fonts::FontData Fonts::createFontData(FontStyle type, float scale)
 #endif
         }
         break;
+
+        default:
+            break;
     }
 
     return font;

--- a/src/singletons/NativeMessaging.cpp
+++ b/src/singletons/NativeMessaging.cpp
@@ -76,14 +76,16 @@ void registerNmManifest([[maybe_unused]] const Paths &paths,
                         const Config &config, const QJsonDocument &document)
 {
 #ifdef Q_OS_WIN
-    writeManifestTo(paths.miscDirectory, u"."_s, config.fileName, document);
+    std::ignore =
+        writeManifestTo(paths.miscDirectory, u"."_s, config.fileName, document);
 
     QSettings registry(config.registryKey, QSettings::NativeFormat);
     registry.setValue("Default",
                       QString(paths.miscDirectory % u'/' % config.fileName));
 #else
-    writeManifestTo(config.browserDirectory, config.nmDirectory,
-                    u"com.chatterino.chatterino.json"_s, document);
+    std::ignore =
+        writeManifestTo(config.browserDirectory, config.nmDirectory,
+                        u"com.chatterino.chatterino.json"_s, document);
 #endif
 }
 

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -314,6 +314,9 @@ Window &WindowManager::createWindow(WindowType type, bool show, QWidget *parent)
     assertInGuiThread();
 
     auto *const realParent = [this, type, parent]() -> QWidget * {
+        (void)this;
+        (void)type;
+
         if (parent)
         {
             // If a parent is explicitly specified, we use that immediately.
@@ -696,6 +699,9 @@ void WindowManager::encodeNodeRecursively(SplitNode *node, QJsonObject &obj)
             obj.insert("items", itemsArr);
         }
         break;
+
+        default:
+            break;
     }
 
     obj.insert("flexh", node->getHorizontalFlex());
@@ -737,6 +743,10 @@ void WindowManager::encodeChannel(IndirectChannel channel, QJsonObject &obj)
             obj.insert("type", "misc");
             obj.insert("name", channel.get()->getName());
         }
+        break;
+
+        default:
+            break;
     }
 }
 
@@ -923,6 +933,9 @@ void WindowManager::applyWindowLayout(const WindowLayout &layout)
                 window.setWindowState(Qt::WindowMaximized);
             }
             break;
+
+            case WindowDescriptor::State::None:
+                break;
         }
     }
 }

--- a/src/widgets/AttachedWindow.cpp
+++ b/src/widgets/AttachedWindow.cpp
@@ -44,10 +44,9 @@ BOOL CALLBACK enumWindows(HWND hwnd, LPARAM)
 }
 #endif
 
-AttachedWindow::AttachedWindow(void *_target, int _yOffset)
+AttachedWindow::AttachedWindow(void *_target)
     : QWidget(nullptr, Qt::FramelessWindowHint | Qt::Window)
     , target_(_target)
-    , yOffset_(_yOffset)
 {
     QLayout *layout = new QVBoxLayout(this);
     layout->setContentsMargins(0, 0, 0, 0);
@@ -86,7 +85,7 @@ AttachedWindow *AttachedWindow::get(void *target, const GetArgs &args)
             }
         }
 
-        auto *window = new AttachedWindow(target, args.yOffset);
+        auto *window = new AttachedWindow(target);
         items.push_back(Item{target, window, args.winId});
         return window;
     }();

--- a/src/widgets/AttachedWindow.hpp
+++ b/src/widgets/AttachedWindow.hpp
@@ -15,7 +15,7 @@ using ChannelPtr = std::shared_ptr<Channel>;
 
 class AttachedWindow : public QWidget
 {
-    AttachedWindow(void *_target, int _yOffset);
+    AttachedWindow(void *_target);
 
 public:
     struct GetArgs {
@@ -60,8 +60,6 @@ private:
     void updateWindowRect(void *attached);
 
     void *target_;
-    int yOffset_;
-    int currentYOffset_{};
     double x_ = -1;
     double pixelRatio_ = -1;
     int width_ = 360;

--- a/src/widgets/layout/FlowLayout.hpp
+++ b/src/widgets/layout/FlowLayout.hpp
@@ -98,7 +98,6 @@ private:
     std::vector<QLayoutItem *> itemList_;
     int hSpace_ = -1;
     int vSpace_ = -1;
-    int lineSpacing_ = -1;
 };
 
 }  // namespace chatterino

--- a/src/widgets/settingspages/AccountsPage.hpp
+++ b/src/widgets/settingspages/AccountsPage.hpp
@@ -2,8 +2,6 @@
 
 #include "widgets/settingspages/SettingsPage.hpp"
 
-#include <QPushButton>
-
 namespace chatterino {
 
 class AccountSwitchWidget;
@@ -12,11 +10,6 @@ class AccountsPage : public SettingsPage
 {
 public:
     AccountsPage();
-
-private:
-    QPushButton *addButton_{};
-    QPushButton *removeButton_{};
-    AccountSwitchWidget *accountSwitchWidget_{};
 };
 
 }  // namespace chatterino

--- a/src/widgets/settingspages/HighlightingPage.cpp
+++ b/src/widgets/settingspages/HighlightingPage.cpp
@@ -389,6 +389,9 @@ void HighlightingPage::tableCellClicked(const QModelIndex &clicked,
             }
         }
         break;
+
+        case HighlightTab::Blacklist:
+            break;
     }
 }
 

--- a/src/widgets/settingspages/SettingWidget.cpp
+++ b/src/widgets/settingspages/SettingWidget.cpp
@@ -371,8 +371,7 @@ SettingWidget *SettingWidget::dropdown(
         widget->managedConnections);
 
     QObject::connect(combo, &QComboBox::currentTextChanged,
-                     [label, combo, &setting](const auto &newText) {
-                         bool ok = true;
+                     [label, combo, &setting](const auto & /*newText*/) {
                          auto stringValue = combo->currentData().toString();
 
                          setting.setValue(stringValue);

--- a/src/widgets/splits/SplitContainer.cpp
+++ b/src/widgets/splits/SplitContainer.cpp
@@ -638,6 +638,8 @@ void SplitContainer::paintSplitBorder(Node *node, QPainter *painter)
             }
         }
         break;
+        case Node::Type::EmptyRoot:
+            break;
     }
 }
 
@@ -1481,6 +1483,8 @@ void SplitContainer::Node::layout(bool addSpacing, float _scale,
             }
         }
         break;
+        case Node::Type::EmptyRoot:
+            break;
     }
 }
 

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -353,7 +353,6 @@ void SplitHeader::initializeLayout()
     QObject::connect(
         this->moderationButton_, &Button::clicked, this,
         [this](Qt::MouseButton button) mutable {
-            auto *w = this->moderationButton_;
             switch (button)
             {
                 case Qt::LeftButton:
@@ -377,6 +376,9 @@ void SplitHeader::initializeLayout()
                 case Qt::MiddleButton:
                     getApp()->getWindows()->showSettingsDialog(
                         this, SettingsDialogPreference::ModerationActions);
+                    break;
+
+                default:
                     break;
             }
         });

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -258,7 +258,6 @@ void SplitInput::triggerSelfMessageReceived()
 
 void SplitInput::scaleChangedEvent(float scale)
 {
-    auto *app = getApp();
     // update the icon size of the buttons
     this->updateEmoteButton();
     this->updateCancelReplyButton();


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
Clang-cl has a few more warnings than MSVC. This fixes most of them. I silenced `missing-designated-field-initializers` because we often "miss" these fields when they're default constructed. 
Note that GCC and Clang with the GCC frontend don't have this warning enabled (under `-Wextra`).