### PR TITLE
docs: replace debian bookworm deps with trixie

### DIFF
--- a/BUILDING_ON_LINUX.md
+++ b/BUILDING_ON_LINUX.md
@@ -14,12 +14,6 @@ Use <https://github.com/Chatterino/docker/pkgs/container/chatterino2-build-ubunt
 
 The built binary should be exportable from the final image & able to run on your system assuming you perform a static build. See our [build.yml GitHub workflow file](.github/workflows/build.yml) for the CMake line used for Ubuntu builds.
 
-### Debian 12 (bookworm)
-
-```sh
-sudo apt install qt6-base-dev qt6-svg-dev qt6-image-formats-plugins libboost1.81-dev libnotify-dev libssl-dev cmake g++ git
-```
-
 ### Debian 13 (trixie) or later
 
 ```sh


### PR DESCRIPTION
Old dependency list does not work on trixie, this new list does and is not backwards compatible.