### PR TITLE
set desktop-entry hint with libnotify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Bugfix: Fixed restore button not showing on Windows. (#6565)
 - Bugfix: Fixed popups and the overlay not being draggable on Wayland. (#6573)
 - Bugfix: Fixed middle-clicking usernames in a local channel opening an invalid viewercard. (#6577)
+- Bugfix: Added `desktop-entry` hint to Linux notifications. (#6615)
 - Dev: Update release documentation. (#6498)
 - Dev: Make code sanitizers opt in with the `CHATTERINO_SANITIZER_SUPPORT` CMake option. After that's enabled, use the `SANITIZE_*` flag to enable individual sanitizers. (#6493)
 - Dev: Remove unused QTextCodec includes. (#6487)

--- a/src/singletons/Toasts.cpp
+++ b/src/singletons/Toasts.cpp
@@ -346,7 +346,7 @@ void Toasts::ensureInitialized()
     {
         return;
     }
-    auto result = notify_init("chatterino2");
+    auto result = notify_init("Chatterino");
 
     if (result == 0)
     {

--- a/src/singletons/Toasts.cpp
+++ b/src/singletons/Toasts.cpp
@@ -367,6 +367,10 @@ void Toasts::sendLibnotify(const QString &channelName,
     NotifyNotification *notif = notify_notification_new(
         str.toUtf8().constData(), channelTitle.toUtf8().constData(), nullptr);
 
+    notify_notification_set_hint(
+        notif, "desktop-entry",
+        g_variant_new_string("com.chatterino.chatterino"));
+
     // this will be freed in onNotificationDestroyed
     auto *channelNameHeap = new QString(channelName);
 


### PR DESCRIPTION
Notifications previously had no application attached to them. With this change we get the chatterino icon to be used and persistence in the KDE notification centre should the popup be missed. Possibly more minor improvements on different environments as well.

If the user does not have the desktop file installed the notification will have the old behavior (possibly with a matching icon if installed), but this should maybe be tested on different environments, I have only tried on KDE.

Im bad at writing changelogs so I have left it out.