### PR TITLE
ci: drop Qt 6.4.3 support

### DIFF
--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-14]
-        qt-version: [6.4.3, 6.7.1]
+        qt-version: [6.7.1, 6.10.1]
       fail-fast: false
     env:
       QT_MODULES: qtimageformats


### PR DESCRIPTION
This PR removes Qt 6.4.3 support, and starts testing Qt 6.10.1 in our macOS test workflow