### PR TITLE
fix: disable check-clang-tidy `nounset` check

### DIFF
--- a/scripts/check-clang-tidy.sh
+++ b/scripts/check-clang-tidy.sh
@@ -2,7 +2,7 @@
 
 # example usage: FAST=1 ./scripts/check-clang-tidy.sh --checks '-*,modernize-return-braced-init-list' --fix
 
-set -eu
+set -e
 
 clang-tidy --version
 


### PR DESCRIPTION
`FAST` is allowed to be an unbound variable, so we shouldn't use `set -u`