### PR TITLE
Add Lead Moderator support for managing moderators and VIPs

### DIFF
--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -396,6 +396,7 @@ void IrcMessageHandler::parsePrivMessageInto(
             auto parsedBadges = parseBadges(badgesTag.toString());
             channel->setMod(parsedBadges.contains("moderator") ||
                             parsedBadges.contains("lead_moderator"));
+            channel->setLeadModerator(parsedBadges.contains("lead_moderator"));
             channel->setVIP(parsedBadges.contains("vip"));
             channel->setStaff(parsedBadges.contains("staff"));
         }
@@ -595,6 +596,7 @@ void IrcMessageHandler::handleUserStateMessage(Communi::IrcMessage *message)
             auto parsedBadges = parseBadges(badgesTag.toString());
             tc->setVIP(parsedBadges.contains("vip"));
             tc->setStaff(parsedBadges.contains("staff"));
+            tc->setLeadModerator(parsedBadges.contains("lead_moderator"));
 
             hasModBadge = parsedBadges.contains("moderator") ||
                           parsedBadges.contains("lead_moderator");

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -897,6 +897,11 @@ bool TwitchChannel::isStaff() const
     return this->staff_;
 }
 
+bool TwitchChannel::isLeadModerator() const
+{
+    return this->leadModerator_;
+}
+
 void TwitchChannel::setMod(bool value)
 {
     if (this->mod_ != value)
@@ -927,12 +932,27 @@ void TwitchChannel::setStaff(bool value)
     }
 }
 
+void TwitchChannel::setLeadModerator(bool value)
+{
+    if (this->leadModerator_ != value)
+    {
+        this->leadModerator_ = value;
+
+        this->userStateChanged.invoke();
+    }
+}
+
 bool TwitchChannel::isBroadcaster() const
 {
     auto *app = getApp();
 
     return this->getName() ==
            app->getAccounts()->twitch.getCurrent()->getUserName();
+}
+
+bool TwitchChannel::canManageModerators() const
+{
+    return this->isBroadcaster() || this->isLeadModerator();
 }
 
 bool TwitchChannel::hasHighRateLimit() const

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -177,7 +177,9 @@ public:
     bool isMod() const override;
     bool isVip() const;
     bool isStaff() const;
+    bool isLeadModerator() const;
     bool isBroadcaster() const override;
+    bool canManageModerators() const;
     bool hasHighRateLimit() const override;
     bool canReconnect() const override;
     void reconnect() override;
@@ -396,6 +398,7 @@ private:
     void setMod(bool value);
     void setVIP(bool value);
     void setStaff(bool value);
+    void setLeadModerator(bool value);
     void setRoomId(const QString &id);
     void setRoomModes(const RoomModes &newRoomModes);
     void setDisplayName(const QString &name);
@@ -484,6 +487,7 @@ private:
     bool mod_ = false;
     bool vip_ = false;
     bool staff_ = false;
+    bool leadModerator_ = false;
     UniqueAccess<QString> roomID_;
 
     // --

--- a/src/widgets/ChatterListWidget.cpp
+++ b/src/widgets/ChatterListWidget.cpp
@@ -290,8 +290,8 @@ ChatterListWidget::ChatterListWidget(const TwitchChannel *twitchChannel,
     QObject::connect(searchBar, &QLineEdit::textEdited, this,
                      performListSearch);
 
-    // Only broadcaster can get vips, mods can get chatters
-    if (twitchChannel->isBroadcaster())
+    // Only broadcaster and lead moderator can get vips, mods can get chatters
+    if (twitchChannel->canManageModerators())
     {
         // Add moderators
         getHelix()->getModerators(

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -487,7 +487,7 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically, Split *split)
                                      this->userName_, Qt::CaseInsensitive) == 0;
 
                 visibilityModButtons =
-                    twitchChannel->isBroadcaster() && !isMyself;
+                    twitchChannel->canManageModerators() && !isMyself;
             }
             mod->setVisible(visibilityModButtons);
             unmod->setVisible(visibilityModButtons);


### PR DESCRIPTION
This PR adds support for Lead Moderators to manage moderators and VIPs in the same way as broadcasters.

Note: The client-side implementation is ready, but Twitch's API does not yet allow (as far as I know) Lead Moderators to add/remove moderators and VIPs. The UI will show the appropriate buttons and functionality, but API calls may fail until Twitch enables this on their backend. This prepares the client-side code for when Twitch enables the feature.