### PR TITLE
Enable highlighting all Twitch global badges

### DIFF
--- a/src/providers/twitch/TwitchBadges.hpp
+++ b/src/providers/twitch/TwitchBadges.hpp
@@ -48,6 +48,8 @@ public:
     /// Loads the badges shipped with Chatterino (twitch-badges.json)
     void loadLocalBadges();
 
+    QList<DisplayBadge> getDisplayBadges() const;
+
 private:
     void loaded();
     void loadEmoteImage(const QString &name, const ImagePtr &image,

--- a/src/util/DisplayBadge.hpp
+++ b/src/util/DisplayBadge.hpp
@@ -12,6 +12,11 @@ public:
     QString displayName() const;
     QString badgeName() const;
 
+    bool operator<(const DisplayBadge& other) const
+    {
+        return displayName() < other.displayName();
+    }
+
 private:
     QString displayName_;
     QString badgeName_;

--- a/src/widgets/settingspages/HighlightingPage.cpp
+++ b/src/widgets/settingspages/HighlightingPage.cpp
@@ -9,6 +9,7 @@
 #include "controllers/highlights/HighlightPhrase.hpp"
 #include "controllers/highlights/UserHighlightModel.hpp"
 #include "providers/colors/ColorProvider.hpp"
+#include "providers/twitch/TwitchBadges.hpp"
 #include "singletons/Settings.hpp"
 #include "util/Helpers.hpp"
 #include "util/LayoutCreator.hpp"
@@ -25,23 +26,6 @@
 #include <QTabWidget>
 
 namespace chatterino {
-
-namespace {
-// Add additional badges for highlights here
-QList<DisplayBadge> availableBadges = {
-    {"Broadcaster", "broadcaster"},
-    {"Admin", "admin"},
-    {"Staff", "staff"},
-    {"Moderator", "moderator"},
-    {"Lead Moderator", "lead_moderator"},
-    {"Verified", "partner"},
-    {"VIP", "vip"},
-    {"Founder", "founder"},
-    {"Subscriber", "subscriber"},
-    {"Predicted Blue", "predictions/blue-1,predictions/blue-2"},
-    {"Predicted Pink", "predictions/pink-2,predictions/pink-1"},
-};
-}  // namespace
 
 HighlightingPage::HighlightingPage()
 {
@@ -191,10 +175,12 @@ HighlightingPage::HighlightingPage()
                     view->getTableView()->setColumnWidth(0, 200);
                 });
 
+                this->badges_ = getApp()->getTwitchBadges()->getDisplayBadges();
+
                 // We can safely ignore this signal connection since we own the view
                 std::ignore = view->addButtonPressed.connect([this] {
                     auto d = std::make_shared<BadgePickerDialog>(
-                        availableBadges, this);
+                        this->badges_, this);
 
                     d->setWindowTitle("Choose badge");
                     if (d->exec() == QDialog::Accepted)

--- a/src/widgets/settingspages/HighlightingPage.hpp
+++ b/src/widgets/settingspages/HighlightingPage.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "widgets/settingspages/SettingsPage.hpp"
+#include "util/DisplayBadge.hpp"
 
 #include <QAbstractTableModel>
 #include <QTimer>
@@ -19,6 +20,7 @@ public:
 
 private:
     enum HighlightTab { Messages = 0, Users = 1, Badges = 2, Blacklist = 3 };
+    QList<DisplayBadge> badges_;
 
     QTimer disabledUsersChangedTimer_;
 


### PR DESCRIPTION
Use the Twitch global badges that the application already knows to build the list of badges that can be highlighted. This allows new badges to be added to the highlights whenever Twitch adds a new badge without needing a software update.

This is somewhat similar to what FFZ allows for badge highlighting.

For simplicity, the badges displayed are only the first version of each badge, with the exception of 2 badges which don't use number versions. All versions of those badges will be listed.