### PR TITLE
fix: disable sortTabsAlphabetically when notebook layout locked (#6704)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## Unversioned
 
-- Bugfix: Disable "Sort Tabs Alphabetically" action when notebook layout is locked. (#6704)
 - Minor: Add a separate highlight option for watchstreak notifications. (#6571, #6581)
 - Minor: Badges now link to their home page like emotes in the context menu. (#6437)
 - Minor: Fixed usercard resizing improperly without recent messages. (#6496)
@@ -43,6 +42,7 @@
 - Bugfix: Added `desktop-entry` hint to Linux notifications. (#6615)
 - Bugfix: Fixed <kbd>CMD</kbd> + <kbd>DELETE</kbd> behavior in the user notes editing dialog for macOS. (#6676)
 - Bugfix: Fixed a potential crash when closing Chatterino with a slow network connection. (#6645)
+- Bugfix: Disable "Sort Tabs Alphabetically" action when notebook layout is locked. (#6710)
 - Dev: Update release documentation. (#6498)
 - Dev: Make code sanitizers opt in with the `CHATTERINO_SANITIZER_SUPPORT` CMake option. After that's enabled, use the `SANITIZE_*` flag to enable individual sanitizers. (#6493)
 - Dev: Remove unused QTextCodec includes. (#6487)

--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -1640,7 +1640,7 @@ void SplitNotebook::forEachSplit(const std::function<void(Split *)> &cb)
 
 void SplitNotebook::setLockNotebookLayout(bool value)
 {
-    this->Notebook::setLockNotebookLayout(value);
+    Notebook::setLockNotebookLayout(value);
     this->sortTabsAlphabeticallyAction_->setEnabled(!value);
 }
 

--- a/src/widgets/Notebook.hpp
+++ b/src/widgets/Notebook.hpp
@@ -122,8 +122,6 @@ public:
     // Update layout and tab visibility
     void refresh();
 
-    void sortTabsAlphabetically();
-
 protected:
     bool getShowTabs() const;
     void setShowTabs(bool value);
@@ -170,6 +168,8 @@ protected:
     bool shouldShowTab(const NotebookTab *tab) const;
 
     void performLayout(bool animate = false);
+
+    void sortTabsAlphabetically();
 
 private:
     struct LayoutContext {


### PR DESCRIPTION
Greys out the "Sort Tabs Alphabetically" option if the tabs are locked.
- the assert should help ensure not being locked as a precondition
- this handles disabling for the click event for locking layout as well as the first initialization of menu if it's locked already from settings

<img width="300" height="135" alt="image" src="https://github.com/user-attachments/assets/a1bc7591-031e-403e-a9f8-5a9233b4cb11" />

first pr FeelsStrongMan