### PR TITLE
Optionally allow a message when any filter matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Minor: Update emoji data to Unicode 17.0. (#6471)
 - Minor: Added a setting to disable sound device sleeping. This can help ensure highlight sounds play more reliably when using a wireless sound device. (#6859)
+- Minor: Added an option to match on any of a filter in a split rather than all selected filters. (#6861)
 - Bugfix: Make it possible to filter Watch Streak messages again. Previously, these messages were labeled `sub_messages`. This was fixed in #6571, but we didn't add a new filter to compensate. (#6741)
 - Bugfix: Improve nightly downgrade message. (#6842)
 - Bugfix: Improved blocked user loading on poor internet connections. (#6846)

--- a/src/common/WindowDescriptors.cpp
+++ b/src/common/WindowDescriptors.cpp
@@ -115,6 +115,7 @@ void SplitDescriptor::loadFromJSON(SplitDescriptor &descriptor,
         descriptor.channelName_ = data.value("name").toString();
     }
     descriptor.filters_ = loadFilters(root.value("filters"));
+    descriptor.filtersAnyOf_ = root.value("filtersAnyOf").toBool();
 
     auto spellOverride = root["checkSpelling"];
     if (spellOverride.isBool())

--- a/src/common/WindowDescriptors.hpp
+++ b/src/common/WindowDescriptors.hpp
@@ -51,6 +51,7 @@ struct SplitDescriptor {
     std::optional<bool> spellCheckOverride;
 
     QList<QUuid> filters_;
+    bool filtersAnyOf_;
 
     static void loadFromJSON(SplitDescriptor &descriptor,
                              const QJsonObject &root, const QJsonObject &data);

--- a/src/controllers/filters/FilterSet.cpp
+++ b/src/controllers/filters/FilterSet.cpp
@@ -17,7 +17,8 @@ FilterSet::FilterSet()
         });
 }
 
-FilterSet::FilterSet(const QList<QUuid> &filterIds)
+FilterSet::FilterSet(const QList<QUuid> &filterIds, bool anyOf)
+    : anyOf_(anyOf)
 {
     auto filters = getSettings()->filterRecords.readOnly();
     for (const auto &f : *filters)
@@ -47,15 +48,24 @@ bool FilterSet::filter(const MessagePtr &m, ChannelPtr channel) const
     }
 
     filters::ContextMap context = filters::buildContextMap(m, channel.get());
+    bool result = !this->anyOf_;
     for (const auto &f : this->filters_.values())
     {
-        if (!f->valid() || !f->filter(context))
+        if (!f->valid())
         {
             return false;
         }
+        if (this->anyOf_)
+        {
+            result = result || f->filter(context);
+        }
+        else
+        {
+            result = result && f->filter(context);
+        }
     }
 
-    return true;
+    return result;
 }
 
 const QList<QUuid> FilterSet::filterIds() const
@@ -82,6 +92,11 @@ void FilterSet::reloadFilters()
             this->filters_.remove(key);
         }
     }
+}
+
+bool FilterSet::getAnyOf() const
+{
+    return this->anyOf_;
 }
 
 }  // namespace chatterino

--- a/src/controllers/filters/FilterSet.hpp
+++ b/src/controllers/filters/FilterSet.hpp
@@ -24,16 +24,19 @@ class FilterSet
 {
 public:
     FilterSet();
-    FilterSet(const QList<QUuid> &filterIds);
+    FilterSet(const QList<QUuid> &filterIds, bool anyOf);
 
     ~FilterSet();
 
     bool filter(const MessagePtr &m, ChannelPtr channel) const;
     const QList<QUuid> filterIds() const;
+    bool getAnyOf() const;
 
 private:
     QMap<QUuid, FilterRecordPtr> filters_;
     pajlada::Signals::Connection listener_;
+
+    bool anyOf_{false};
 
     void reloadFilters();
 };

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -686,6 +686,7 @@ void WindowManager::encodeNodeRecursively(SplitNode *node, QJsonObject &obj)
             QJsonArray filters;
             WindowManager::encodeFilters(node->getSplit(), filters);
             obj.insert("filters", filters);
+            obj.insert("filtersAnyOf", node->getSplit()->getFiltersAnyOf());
 
             auto spellOverride = node->getSplit()->checkSpellingOverride();
             if (spellOverride)

--- a/src/widgets/OverlayWindow.cpp
+++ b/src/widgets/OverlayWindow.cpp
@@ -96,7 +96,7 @@ namespace chatterino {
 using namespace std::chrono_literals;
 
 OverlayWindow::OverlayWindow(IndirectChannel channel,
-                             const QList<QUuid> &filterIDs)
+                             const QList<QUuid> &filterIDs, bool filtersAnyOf)
     : BaseWindow({
           BaseWindow::Frameless,
           BaseWindow::TopMost,
@@ -130,7 +130,7 @@ OverlayWindow::OverlayWindow(IndirectChannel channel,
     });
 
     this->channelView_.installEventFilter(this);
-    this->channelView_.setFilters(filterIDs);
+    this->channelView_.setFilters(filterIDs, filtersAnyOf);
     this->channelView_.setChannel(this->channel_.get());
     this->channelView_.setIsOverlay(true);  // use overlay colors
     this->channelView_.setAttribute(Qt::WA_TranslucentBackground);

--- a/src/widgets/OverlayWindow.hpp
+++ b/src/widgets/OverlayWindow.hpp
@@ -26,7 +26,8 @@ class OverlayWindow : public BaseWindow
 {
     Q_OBJECT
 public:
-    OverlayWindow(IndirectChannel channel, const QList<QUuid> &filterIDs);
+    OverlayWindow(IndirectChannel channel, const QList<QUuid> &filterIDs,
+                  bool filtersAnyOf);
     ~OverlayWindow() override;
     OverlayWindow(const OverlayWindow &) = delete;
     OverlayWindow(OverlayWindow &&) = delete;

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -524,7 +524,7 @@ void Window::addShortcuts()
              Split *split = new Split(splitContainer);
              split->setChannel(
                  getApp()->getTwitch()->getOrAddChannel(si.channelName));
-             split->setFilters(si.filters);
+             split->setFilters(si.filters, si.filtersAnyOf);
              splitContainer->insertSplit(split);
              splitContainer->setSelected(split);
              this->notebook_->select(splitContainer);

--- a/src/widgets/dialogs/SelectChannelFiltersDialog.cpp
+++ b/src/widgets/dialogs/SelectChannelFiltersDialog.cpp
@@ -16,8 +16,9 @@
 namespace chatterino {
 
 SelectChannelFiltersDialog::SelectChannelFiltersDialog(
-    const QList<QUuid> &previousSelection, QWidget *parent)
+    const QList<QUuid> &previousSelection, bool previousAnyOf, QWidget *parent)
     : QDialog(parent)
+    , anyOf_(previousAnyOf)
 {
     auto *vbox = new QVBoxLayout(this);
     auto *itemVbox = new QVBoxLayout;
@@ -34,6 +35,23 @@ SelectChannelFiltersDialog::SelectChannelFiltersDialog(
     scrollArea->setWidget(scrollAreaContent);
 
     vbox->addWidget(scrollArea);
+
+    auto *anyOfCheckbox = new QCheckBox("Match if any filter applies", this);
+    anyOfCheckbox->setCheckState(previousAnyOf ? Qt::CheckState::Checked
+                                               : Qt::CheckState::Unchecked);
+    QObject::connect(anyOfCheckbox, &QCheckBox::stateChanged,
+                     [this](int state) {
+                         if (state == 0)
+                         {
+                             this->anyOf_ = false;
+                         }
+                         else
+                         {
+                             this->anyOf_ = true;
+                         }
+                     });
+    vbox->addWidget(anyOfCheckbox);
+
     vbox->addLayout(buttonBox);
 
     buttonBox->addStretch(1);
@@ -94,6 +112,11 @@ SelectChannelFiltersDialog::SelectChannelFiltersDialog(
 const QList<QUuid> &SelectChannelFiltersDialog::getSelection() const
 {
     return this->currentSelection_;
+}
+
+bool SelectChannelFiltersDialog::getAnyOf() const
+{
+    return this->anyOf_;
 }
 
 }  // namespace chatterino

--- a/src/widgets/dialogs/SelectChannelFiltersDialog.hpp
+++ b/src/widgets/dialogs/SelectChannelFiltersDialog.hpp
@@ -12,12 +12,14 @@ class SelectChannelFiltersDialog : public QDialog
 {
 public:
     SelectChannelFiltersDialog(const QList<QUuid> &previousSelection,
-                               QWidget *parent = nullptr);
+                               bool previousAnyOf, QWidget *parent = nullptr);
 
     const QList<QUuid> &getSelection() const;
+    bool getAnyOf() const;
 
 private:
     QList<QUuid> currentSelection_;
+    bool anyOf_;
 };
 
 }  // namespace chatterino

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1106,9 +1106,9 @@ void ChannelView::setChannel(const ChannelPtr &underlyingChannel)
     }
 }
 
-void ChannelView::setFilters(const QList<QUuid> &ids)
+void ChannelView::setFilters(const QList<QUuid> &ids, bool anyOf)
 {
-    this->channelFilters_ = std::make_shared<FilterSet>(ids);
+    this->channelFilters_ = std::make_shared<FilterSet>(ids, anyOf);
 
     this->updateID();
 }
@@ -1126,6 +1126,15 @@ QList<QUuid> ChannelView::getFilterIds() const
 FilterSetPtr ChannelView::getFilterSet() const
 {
     return this->channelFilters_;
+}
+
+bool ChannelView::getFilterSetAnyOf() const
+{
+    if (!this->channelFilters_)
+    {
+        return false;
+    }
+    return this->channelFilters_->getAnyOf();
 }
 
 bool ChannelView::shouldIncludeMessage(const MessagePtr &m) const

--- a/src/widgets/helper/ChannelView.hpp
+++ b/src/widgets/helper/ChannelView.hpp
@@ -164,9 +164,10 @@ public:
     /// @see #underlyingChannel()
     void setChannel(const ChannelPtr &underlyingChannel);
 
-    void setFilters(const QList<QUuid> &ids);
+    void setFilters(const QList<QUuid> &ids, bool anyOf);
     QList<QUuid> getFilterIds() const;
     FilterSetPtr getFilterSet() const;
+    bool getFilterSetAnyOf() const;
 
     /// @brief The channel this is derived from
     ///

--- a/src/widgets/splits/ClosedSplits.hpp
+++ b/src/widgets/splits/ClosedSplits.hpp
@@ -22,6 +22,7 @@ public:
     struct SplitInfo {
         QString channelName;
         QList<QUuid> filters;
+        bool filtersAnyOf;
         NotebookTab *tab;  // non owning ptr
     };
 

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -1095,7 +1095,7 @@ void Split::popup()
 
     split->setChannel(this->getIndirectChannel());
     split->setModerationMode(this->getModerationMode());
-    split->setFilters(this->getFilters());
+    split->setFilters(this->getFilters(), this->getFiltersAnyOf());
 
     window.getNotebook().getOrAddSelectedPage()->insertSplit(split);
     window.show();
@@ -1111,7 +1111,8 @@ void Split::showOverlayWindow()
     if (!this->overlayWindow_)
     {
         this->overlayWindow_ =
-            new OverlayWindow(this->getIndirectChannel(), this->getFilters());
+            new OverlayWindow(this->getIndirectChannel(), this->getFilters(),
+                              this->getFiltersAnyOf());
     }
     this->overlayWindow_->show();
 }
@@ -1216,24 +1217,30 @@ void Split::openSubPage()
 
 void Split::setFiltersDialog()
 {
-    SelectChannelFiltersDialog d(this->getFilters(), this);
+    SelectChannelFiltersDialog d(this->getFilters(), this->getFiltersAnyOf(),
+                                 this);
     d.setWindowTitle("Select filters");
 
     if (d.exec() == QDialog::Accepted)
     {
-        this->setFilters(d.getSelection());
+        this->setFilters(d.getSelection(), d.getAnyOf());
     }
 }
 
-void Split::setFilters(const QList<QUuid> ids)
+void Split::setFilters(const QList<QUuid> ids, bool anyOf)
 {
-    this->view_->setFilters(ids);
+    this->view_->setFilters(ids, anyOf);
     this->header_->updateChannelText();
 }
 
 QList<QUuid> Split::getFilters() const
 {
     return this->view_->getFilterIds();
+}
+
+bool Split::getFiltersAnyOf() const
+{
+    return this->view_->getFilterSetAnyOf();
 }
 
 void Split::showSearch(bool singleChannel)

--- a/src/widgets/splits/Split.hpp
+++ b/src/widgets/splits/Split.hpp
@@ -60,8 +60,9 @@ public:
     ChannelPtr getChannel() const;
     void setChannel(IndirectChannel newChannel);
 
-    void setFilters(const QList<QUuid> ids);
+    void setFilters(const QList<QUuid> ids, bool anyOf);
     QList<QUuid> getFilters() const;
+    bool getFiltersAnyOf() const;
 
     void setModerationMode(bool value);
     bool getModerationMode() const;

--- a/src/widgets/splits/SplitContainer.cpp
+++ b/src/widgets/splits/SplitContainer.cpp
@@ -879,6 +879,7 @@ NodeDescriptor SplitContainer::buildDescriptorRecursively(
         result.type_ = channelTypeToString(channelType);
         result.channelName_ = currentNode->split_->getChannel()->getName();
         result.filters_ = currentNode->split_->getFilters();
+        result.filtersAnyOf_ = currentNode->split_->getFiltersAnyOf();
         return result;
     }
 
@@ -911,7 +912,7 @@ void SplitContainer::applyFromDescriptorRecursively(
         auto *split = new Split(this);
         split->setChannel(WindowManager::decodeChannel(splitNode));
         split->setModerationMode(splitNode.moderationMode_);
-        split->setFilters(splitNode.filters_);
+        split->setFilters(splitNode.filters_, splitNode.filtersAnyOf_);
         split->setCheckSpellingOverride(splitNode.spellCheckOverride);
 
         this->insertSplit(split);
@@ -945,7 +946,7 @@ void SplitContainer::applyFromDescriptorRecursively(
                 }
                 const auto &splitNode = *inner;
                 auto *split = new Split(this);
-                split->setFilters(splitNode.filters_);
+                split->setFilters(splitNode.filters_, splitNode.filtersAnyOf_);
                 split->setChannel(WindowManager::decodeChannel(splitNode));
                 split->setModerationMode(splitNode.moderationMode_);
                 split->setCheckSpellingOverride(splitNode.spellCheckOverride);


### PR DESCRIPTION
It can be useful to allow a message if any of the filters match it, not just when all of them match. This PR adds a checkbox to the filter selection dialog which enables this behavior if the user wants to use it for that split.