### PR TITLE
fix: make whisper usernames clickable

### DIFF
--- a/src/controllers/commands/builtin/twitch/SendWhisper.cpp
+++ b/src/controllers/commands/builtin/twitch/SendWhisper.cpp
@@ -101,13 +101,16 @@ bool appendWhisperMessageWordsLocally(const QStringList &words)
 
     b.emplace<TimestampElement>();
     b.emplace<TextElement>(
-        app->getAccounts()->twitch.getCurrent()->getUserName(),
-        MessageElementFlag::Text, MessageColor::Text,
-        FontStyle::ChatMediumBold);
+         app->getAccounts()->twitch.getCurrent()->getUserName(),
+         MessageElementFlag::Text, MessageColor::Text,
+         FontStyle::ChatMediumBold)
+        ->setLink({Link::UserWhisper,
+                   app->getAccounts()->twitch.getCurrent()->getUserName()});
     b.emplace<TextElement>("->", MessageElementFlag::Text,
                            getApp()->getThemes()->messages.textColors.system);
     b.emplace<TextElement>(words[1] + ":", MessageElementFlag::Text,
-                           MessageColor::Text, FontStyle::ChatMediumBold);
+                           MessageColor::Text, FontStyle::ChatMediumBold)
+        ->setLink({Link::UserWhisper, words[1]});
 
     const auto &acc = app->getAccounts()->twitch.getCurrent();
     const auto &accemotes = *acc->accessEmotes();

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -2247,7 +2247,8 @@ void MessageBuilder::appendUsername(const QVariantMap &tags,
         // Your own username
         this->emplace<TextElement>(currentUser->getUserName() + ":",
                                    MessageElementFlag::Username, selfMsgColor,
-                                   FontStyle::ChatMediumBold);
+                                   FontStyle::ChatMediumBold)
+            ->setLink({Link::UserWhisper, currentUser->getUserName()});
     }
     else
     {


### PR DESCRIPTION
When receiving a whisper, the receiver's username was not clickable. When sending a whisper, neither username was clickable.

This fix adds `UserWhisper` links to all three username elements, matching the pattern already used for the sender's username in received whispers.

I looked at using `MentionElement` as suggested in the issue, but found two problems with that approach:
- `MentionElement` explicitly forbids `setLink` via an assertion, and hardcodes `Link::UserInfo` instead of `Link::UserWhisper`
- `MentionElement` uses `MessageElementFlag::Text | MessageElementFlag::Mention` rather than `MessageElementFlag::Username`, which would break RTL reordering, "copy text only" mode, and `getFirstMessageCharacterIndex()`

Using `TextElement` with `->setLink({Link::UserWhisper, ...})` preserves all existing behavior while making the names clickable.

Fixes #6824.

## Testing

1. Send a whisper with `/w <username> <message>` and both your name and the recipient's name should be clickable and open the user info popup
2. Have someone whisper you — your username in the `sender -> you:` prefix should be clickable and open the user info popup

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: voiceofgrog
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
