### PR TITLE
fix: use user ID in ban/timeout commands from user card when available

### DIFF
--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -201,17 +201,20 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically, Split *split)
                         "moderation action to execute, see description in the "
                         "editor";
              }
+             const QString userTarget = this->userId_.isEmpty()
+                                            ? this->userName_
+                                            : "id:" + this->userId_;
              auto target = arguments.at(0);
              QString msg;
 
              // these can't have /timeout/ buttons because they are not timeouts
              if (target == "ban")
              {
-                 msg = QString("/ban %1").arg(this->userName_);
+                 msg = QString("/ban %1").arg(userTarget);
              }
              else if (target == "unban")
              {
-                 msg = QString("/unban %1").arg(this->userName_);
+                 msg = QString("/unban %1").arg(userTarget);
              }
              else
              {
@@ -241,7 +244,7 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically, Split *split)
                  }
                  const auto &button = timeoutButtons.at(buttonNum - 1);
                  msg = QString("/timeout %1 %2")
-                           .arg(this->userName_)
+                           .arg(userTarget)
                            .arg(calculateTimeoutDuration(button));
              }
 
@@ -542,13 +545,15 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically, Split *split)
             TimeoutWidget::Action action;
             int arg;
             std::tie(action, arg) = item;
-
+            const QString userTarget = this->userId_.isEmpty()
+                                           ? this->userName_
+                                           : "id:" + this->userId_;
             switch (action)
             {
                 case TimeoutWidget::Ban: {
                     if (this->underlyingChannel_)
                     {
-                        QString value = "/ban " + this->userName_;
+                        QString value = "/ban " + userTarget;
                         value = getApp()->getCommands()->execCommand(
                             value, this->underlyingChannel_, false);
 
@@ -559,7 +564,7 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically, Split *split)
                 case TimeoutWidget::Unban: {
                     if (this->underlyingChannel_)
                     {
-                        QString value = "/unban " + this->userName_;
+                        QString value = "/unban " + userTarget;
                         value = getApp()->getCommands()->execCommand(
                             value, this->underlyingChannel_, false);
 
@@ -570,7 +575,7 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically, Split *split)
                 case TimeoutWidget::Timeout: {
                     if (this->underlyingChannel_)
                     {
-                        QString value = "/timeout " + this->userName_ + " " +
+                        QString value = "/timeout " + userTarget + " " +
                                         QString::number(arg);
 
                         value = getApp()->getCommands()->execCommand(


### PR DESCRIPTION
If a user is platform-banned, Twitch's API rejects ban/timeout commands
that use a username, returning "bad target name". This fix uses the
`id:` prefix syntax in the user card's ban/timeout buttons and the
`execModeratorAction` plugin handler when the user ID is available,
bypassing the username lookup entirely. Falls back to username if the
ID is not yet populated.

Fixes #6825

**Testing:**
- Verified normal timeout behavior is intact by testing on a live channel
- The platform-banned case is difficult to reproduce locally as it
  requires access to a suspended account

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
