### PR TITLE
Update format-recent-changes.py to use git log

### DIFF
--- a/.CI/format-recent-changes.py
+++ b/.CI/format-recent-changes.py
@@ -36,7 +36,7 @@ def get_unreleased_commits():
     args = [
         "log",
         log_range,
-        "--pretty=format:%cI|%s",
+        "--pretty=format:%cI|%an|%s",
         "--no-merges",
     ]
     if limit:
@@ -46,7 +46,9 @@ def get_unreleased_commits():
     for line in log_output.splitlines():
         if not line.strip():
             continue
-        date_str, subject = line.split("|", 1)
+        date_str, author, subject = line.split("|", 2)
+        if author.lower() == "dependabot[bot]":
+            continue
         d = datetime.fromisoformat(date_str).astimezone(timezone.utc)
         content = f"- [{d.strftime('%Y-%m-%d')}] {subject}"
         unreleased.append((d, content))


### PR DESCRIPTION
This PR updates the python script so it takes the changes from git instead of the changelog file since the CHANGELOG file seems to not getting updates in the future (at least the last few PRs didn't add anything to it).

This at least makes the nightly-build not print out `No changes since last release.` anymore but the actual changes. Here is how it looks with the new script (should be the same, I think): https://github.com/Wissididom/chatterino2/releases/tag/nightly-build

I tested by making a dummy v2.5.5 release in my fork and disabling the if check for the create-release job for testing purposes, and I also tested it locally by running the script using `python .CI/format-recent-changes.py` inside zsh.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
