### PR TITLE
refactor: Remove operator!=

### DIFF
--- a/src/common/Aliases.hpp
+++ b/src/common/Aliases.hpp
@@ -20,10 +20,6 @@
         {                                                       \
             return this->string == other.string;                \
         }                                                       \
-        bool operator!=(const name &other) const                \
-        {                                                       \
-            return this->string != other.string;                \
-        }                                                       \
     };                                                          \
     } /* namespace chatterino */                                \
     namespace std {                                             \

--- a/src/common/ChatterinoSetting.hpp
+++ b/src/common/ChatterinoSetting.hpp
@@ -53,7 +53,6 @@ public:
     }
 
     using pajlada::Settings::Setting<Type>::operator==;
-    using pajlada::Settings::Setting<Type>::operator!=;
 
     using pajlada::Settings::Setting<Type>::operator Type;
 };
@@ -147,7 +146,6 @@ public:
     Enum defaultValue;
 
     using pajlada::Settings::Setting<QString>::operator==;
-    using pajlada::Settings::Setting<QString>::operator!=;
 
     using pajlada::Settings::Setting<QString>::operator QString;
 };

--- a/src/common/FlagsEnum.hpp
+++ b/src/common/FlagsEnum.hpp
@@ -28,27 +28,15 @@ public:
     {
         return lhs.value_ == rhs.value_;
     }
-    friend constexpr bool operator!=(FlagsEnum lhs, FlagsEnum rhs) noexcept
-    {
-        return lhs.value_ != rhs.value_;
-    }
 
     friend constexpr bool operator==(FlagsEnum lhs, T rhs) noexcept
     {
         return lhs.value_ == rhs;
     }
-    friend constexpr bool operator!=(FlagsEnum lhs, T rhs) noexcept
-    {
-        return lhs.value_ != rhs;
-    }
 
     friend constexpr bool operator==(T lhs, FlagsEnum rhs) noexcept
     {
         return lhs == rhs.value_;
-    }
-    friend constexpr bool operator!=(T lhs, FlagsEnum rhs) noexcept
-    {
-        return lhs != rhs.value_;
     }
 
     constexpr void set(std::convertible_to<T> auto... flags) noexcept

--- a/src/common/Outcome.hpp
+++ b/src/common/Outcome.hpp
@@ -43,11 +43,6 @@ public:
         return this->success_ == other.success_;
     }
 
-    bool operator!=(const Outcome &other) const
-    {
-        return !this->operator==(other);
-    }
-
 private:
     bool success_;
 };

--- a/src/controllers/filters/lang/Types.cpp
+++ b/src/controllers/filters/lang/Types.cpp
@@ -68,21 +68,6 @@ bool TypeClass::operator==(const IllTyped &t) const
     return false;
 }
 
-bool TypeClass::operator!=(Type t) const
-{
-    return !this->operator==(t);
-}
-
-bool TypeClass::operator!=(const TypeClass &t) const
-{
-    return !this->operator==(t);
-}
-
-bool TypeClass::operator!=(const IllTyped &t) const
-{
-    return true;
-}
-
 QString IllTyped::string() const
 {
     return "IllTyped";

--- a/src/controllers/filters/lang/Types.hpp
+++ b/src/controllers/filters/lang/Types.hpp
@@ -42,9 +42,6 @@ struct TypeClass {
     bool operator==(Type t) const;
     bool operator==(const TypeClass &t) const;
     bool operator==(const IllTyped &t) const;
-    bool operator!=(Type t) const;
-    bool operator!=(const TypeClass &t) const;
-    bool operator!=(const IllTyped &t) const;
 };
 
 struct IllTyped {

--- a/src/controllers/highlights/HighlightResult.cpp
+++ b/src/controllers/highlights/HighlightResult.cpp
@@ -56,6 +56,11 @@ bool HighlightResult::operator==(const HighlightResult &other) const
     return true;
 }
 
+bool HighlightResult::operator!=(const HighlightResult &other) const
+{
+    return !(*this == other);
+}
+
 bool HighlightResult::empty() const
 {
     return !this->alert && !this->playSound &&

--- a/src/controllers/highlights/HighlightResult.cpp
+++ b/src/controllers/highlights/HighlightResult.cpp
@@ -56,11 +56,6 @@ bool HighlightResult::operator==(const HighlightResult &other) const
     return true;
 }
 
-bool HighlightResult::operator!=(const HighlightResult &other) const
-{
-    return !(*this == other);
-}
-
 bool HighlightResult::empty() const
 {
     return !this->alert && !this->playSound &&

--- a/src/controllers/highlights/HighlightResult.hpp
+++ b/src/controllers/highlights/HighlightResult.hpp
@@ -51,6 +51,7 @@ struct HighlightResult {
     bool showInMentions{false};
 
     bool operator==(const HighlightResult &other) const;
+    bool operator!=(const HighlightResult &other) const;
 
     /**
      * @brief Returns true if no side-effect has been enabled

--- a/src/controllers/highlights/HighlightResult.hpp
+++ b/src/controllers/highlights/HighlightResult.hpp
@@ -51,7 +51,6 @@ struct HighlightResult {
     bool showInMentions{false};
 
     bool operator==(const HighlightResult &other) const;
-    bool operator!=(const HighlightResult &other) const;
 
     /**
      * @brief Returns true if no side-effect has been enabled

--- a/src/messages/Emote.cpp
+++ b/src/messages/Emote.cpp
@@ -20,11 +20,6 @@ bool operator==(const Emote &a, const Emote &b)
            std::tie(b.homePage, b.name, b.tooltip, b.images);
 }
 
-bool operator!=(const Emote &a, const Emote &b)
-{
-    return !(a == b);
-}
-
 QJsonObject Emote::toJson() const
 {
     QJsonObject obj{

--- a/src/messages/Emote.hpp
+++ b/src/messages/Emote.hpp
@@ -41,7 +41,6 @@ struct Emote {
 };
 
 bool operator==(const Emote &a, const Emote &b);
-bool operator!=(const Emote &a, const Emote &b);
 
 using EmotePtr = std::shared_ptr<const Emote>;
 

--- a/src/messages/Image.hpp
+++ b/src/messages/Image.hpp
@@ -107,7 +107,6 @@ public:
     bool animated() const;
 
     bool operator==(const Image &image) = delete;
-    bool operator!=(const Image &image) = delete;
 
 private:
     Image();

--- a/src/messages/ImageSet.cpp
+++ b/src/messages/ImageSet.cpp
@@ -136,11 +136,6 @@ bool ImageSet::operator==(const ImageSet &other) const
            std::tie(other.imageX1_, other.imageX2_, other.imageX3_);
 }
 
-bool ImageSet::operator!=(const ImageSet &other) const
-{
-    return !this->operator==(other);
-}
-
 QJsonObject ImageSet::toJson() const
 {
     QJsonObject obj;

--- a/src/messages/ImageSet.hpp
+++ b/src/messages/ImageSet.hpp
@@ -38,7 +38,6 @@ public:
     const ImagePtr &getImage(float scale) const;
 
     bool operator==(const ImageSet &other) const;
-    bool operator!=(const ImageSet &other) const;
 
     QJsonObject toJson() const;
 

--- a/src/messages/Selection.hpp
+++ b/src/messages/Selection.hpp
@@ -40,11 +40,6 @@ struct SelectionItem {
         return this->messageIndex == b.messageIndex &&
                this->charIndex == b.charIndex;
     }
-
-    bool operator!=(const SelectionItem &b) const
-    {
-        return !this->operator==(b);
-    }
 };
 
 struct Selection {
@@ -70,11 +65,6 @@ struct Selection {
     bool operator==(const Selection &b) const
     {
         return this->start == b.start && this->end == b.end;
-    }
-
-    bool operator!=(const Selection &b) const
-    {
-        return !this->operator==(b);
     }
 
     //union of both selections

--- a/src/providers/bttv/liveupdates/BttvLiveUpdateSubscription.cpp
+++ b/src/providers/bttv/liveupdates/BttvLiveUpdateSubscription.cpp
@@ -64,12 +64,6 @@ bool BttvLiveUpdateSubscriptionChannel::operator==(
     return this->twitchID == rhs.twitchID;
 }
 
-bool BttvLiveUpdateSubscriptionChannel::operator!=(
-    const BttvLiveUpdateSubscriptionChannel &rhs) const
-{
-    return !(*this == rhs);
-}
-
 QDebug &operator<<(QDebug &dbg, const BttvLiveUpdateSubscriptionChannel &data)
 {
     dbg << "BttvLiveUpdateSubscriptionChannel{ twitchID:" << data.twitchID
@@ -95,12 +89,6 @@ bool BttvLiveUpdateBroadcastMe::operator==(
     const BttvLiveUpdateBroadcastMe &rhs) const
 {
     return this->twitchID == rhs.twitchID && this->userID == rhs.userID;
-}
-
-bool BttvLiveUpdateBroadcastMe::operator!=(
-    const BttvLiveUpdateBroadcastMe &rhs) const
-{
-    return !(*this == rhs);
 }
 
 QDebug &operator<<(QDebug &dbg, const BttvLiveUpdateBroadcastMe &data)

--- a/src/providers/bttv/liveupdates/BttvLiveUpdateSubscription.hpp
+++ b/src/providers/bttv/liveupdates/BttvLiveUpdateSubscription.hpp
@@ -19,7 +19,6 @@ struct BttvLiveUpdateSubscriptionChannel {
 
     QJsonObject encode(bool isSubscribe) const;
     bool operator==(const BttvLiveUpdateSubscriptionChannel &rhs) const;
-    bool operator!=(const BttvLiveUpdateSubscriptionChannel &rhs) const;
     friend QDebug &operator<<(QDebug &dbg,
                               const BttvLiveUpdateSubscriptionChannel &data);
 };
@@ -30,7 +29,6 @@ struct BttvLiveUpdateBroadcastMe {
 
     QJsonObject encode(bool isSubscribe) const;
     bool operator==(const BttvLiveUpdateBroadcastMe &rhs) const;
-    bool operator!=(const BttvLiveUpdateBroadcastMe &rhs) const;
     friend QDebug &operator<<(QDebug &dbg,
                               const BttvLiveUpdateBroadcastMe &data);
 };
@@ -47,10 +45,6 @@ struct BttvLiveUpdateSubscription {
     bool operator==(const BttvLiveUpdateSubscription &rhs) const
     {
         return this->data == rhs.data;
-    }
-    bool operator!=(const BttvLiveUpdateSubscription &rhs) const
-    {
-        return !(*this == rhs);
     }
 
     friend QDebug &operator<<(QDebug &dbg,

--- a/src/providers/seventv/eventapi/Subscription.cpp
+++ b/src/providers/seventv/eventapi/Subscription.cpp
@@ -45,11 +45,6 @@ bool Subscription::operator==(const Subscription &rhs) const
            std::tie(rhs.condition, rhs.type);
 }
 
-bool Subscription::operator!=(const Subscription &rhs) const
-{
-    return !(rhs == *this);
-}
-
 QByteArray Subscription::encodeSubscribe() const
 {
     auto typeName = typeToString(this->type);
@@ -97,11 +92,6 @@ bool ObjectIDCondition::operator==(const ObjectIDCondition &rhs) const
     return this->objectID == rhs.objectID;
 }
 
-bool ObjectIDCondition::operator!=(const ObjectIDCondition &rhs) const
-{
-    return !(*this == rhs);
-}
-
 QDebug &operator<<(QDebug &dbg, const ObjectIDCondition &condition)
 {
     dbg << "{ objectID:" << condition.objectID << "}";
@@ -131,11 +121,6 @@ QDebug &operator<<(QDebug &dbg, const ChannelCondition &condition)
 bool ChannelCondition::operator==(const ChannelCondition &rhs) const
 {
     return this->twitchID == rhs.twitchID;
-}
-
-bool ChannelCondition::operator!=(const ChannelCondition &rhs) const
-{
-    return !(*this == rhs);
 }
 
 }  // namespace chatterino::seventv::eventapi

--- a/src/providers/seventv/eventapi/Subscription.hpp
+++ b/src/providers/seventv/eventapi/Subscription.hpp
@@ -61,7 +61,6 @@ struct ObjectIDCondition {
 
     friend QDebug &operator<<(QDebug &dbg, const ObjectIDCondition &condition);
     bool operator==(const ObjectIDCondition &rhs) const;
-    bool operator!=(const ObjectIDCondition &rhs) const;
 };
 
 struct ChannelCondition {
@@ -73,14 +72,12 @@ struct ChannelCondition {
 
     friend QDebug &operator<<(QDebug &dbg, const ChannelCondition &condition);
     bool operator==(const ChannelCondition &rhs) const;
-    bool operator!=(const ChannelCondition &rhs) const;
 };
 
 using Condition = std::variant<ObjectIDCondition, ChannelCondition>;
 
 struct Subscription {
     bool operator==(const Subscription &rhs) const;
-    bool operator!=(const Subscription &rhs) const;
     Condition condition;
     SubscriptionType type;
 

--- a/src/providers/twitch/TwitchUser.hpp
+++ b/src/providers/twitch/TwitchUser.hpp
@@ -52,11 +52,6 @@ struct TwitchUser {
     {
         return this->id == rhs.id;
     }
-
-    bool operator!=(const TwitchUser &rhs) const
-    {
-        return !(*this == rhs);
-    }
 };
 
 }  // namespace chatterino

--- a/src/providers/twitch/eventsub/SubscriptionRequest.cpp
+++ b/src/providers/twitch/eventsub/SubscriptionRequest.cpp
@@ -42,9 +42,4 @@ bool operator==(const SubscriptionRequest &lhs, const SubscriptionRequest &rhs)
                                                 rhs.conditions);
 }
 
-bool operator!=(const SubscriptionRequest &lhs, const SubscriptionRequest &rhs)
-{
-    return !(lhs == rhs);
-}
-
 }  // namespace chatterino::eventsub

--- a/src/providers/twitch/eventsub/SubscriptionRequest.hpp
+++ b/src/providers/twitch/eventsub/SubscriptionRequest.hpp
@@ -35,7 +35,6 @@ struct SubscriptionRequest {
 };
 
 bool operator==(const SubscriptionRequest &lhs, const SubscriptionRequest &rhs);
-bool operator!=(const SubscriptionRequest &lhs, const SubscriptionRequest &rhs);
 
 }  // namespace chatterino::eventsub
 

--- a/src/util/FunctionRef.hpp
+++ b/src/util/FunctionRef.hpp
@@ -63,8 +63,6 @@ public:
                this->callable == other.callable;
     }
 
-    bool operator!=(const FunctionRef &other) const = default;
-
 private:
     // same signature as callTrampoline
     using Callback = Ret(uintptr_t, Params...);

--- a/tests/src/BasicPubSub.cpp
+++ b/tests/src/BasicPubSub.cpp
@@ -31,10 +31,6 @@ struct DummySubscription {
         return std::tie(this->condition, this->type) ==
                std::tie(rhs.condition, rhs.type);
     }
-    bool operator!=(const DummySubscription &rhs) const
-    {
-        return !(rhs == *this);
-    }
 
     QByteArray encodeSubscribe() const
     {


### PR DESCRIPTION
Supersedes #5079 

Resolves #4895

The only place (except git submodules) with `operator!=` is now `lib/semver/include/semver/semver.hpp` but I didn't want to touch that.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
