### PR TITLE
fix(vcpkg): require pkgconf

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -14,6 +14,7 @@
     "boost-signals2",
     "boost-variant",
     "hunspell",
+    "pkgconf",
     {
       "name": "qtbase",
       "default-features": false,


### PR DESCRIPTION
vcpkg only provides a pkg-config component:

```
hunspell provides pkg-config modules:

  # Hunspell spellchecking library
  hunspell
```

But without `pkgconf`, CMake isn't able to find PkgConfig:

```
CMake Error at C:/Users/johannes/scoop/apps/cmake/current/share/cmake-4.3/Modules/FindPackageHandleStandardArgs.cmake:290 (message):
  Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)
Call Stack (most recent call first):
  C:/Users/johannes/scoop/apps/cmake/current/share/cmake-4.3/Modules/FindPackageHandleStandardArgs.cmake:654 (_FPHSA_FAILURE_MESSAGE)
  C:/Users/johannes/scoop/apps/cmake/current/share/cmake-4.3/Modules/FindPkgConfig.cmake:562 (find_package_handle_standard_args)
  F:/VisualStudio2026/VC/vcpkg/scripts/buildsystems/vcpkg.cmake:908 (_find_package)
  CMakeLists.txt:173 (find_package)
```

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
