### PR TITLE
Channel-specific highlights

### DIFF
--- a/src/controllers/highlights/HighlightCheck.hpp
+++ b/src/controllers/highlights/HighlightCheck.hpp
@@ -25,9 +25,9 @@ using MessageFlags = FlagsEnum<MessageFlag>;
 struct HighlightCheck {
     using Checker = std::function<std::optional<HighlightResult>(
         const MessageParseArgs &args,
-        const std::vector<TwitchBadge> &twitchBadges, const QString &senderName,
-        const QString &originalMessage, const MessageFlags &messageFlags,
-        bool self)>;
+        const std::vector<TwitchBadge> &twitchBadges,
+        const QString &senderName, const QString &originalMessage,
+        const MessageFlags &messageFlags, bool self)>;
     Checker cb;
 };
 

--- a/src/controllers/highlights/HighlightController.cpp
+++ b/src/controllers/highlights/HighlightController.cpp
@@ -205,7 +205,8 @@ void rebuildMessageHighlights(Settings &settings,
             settings.enableSelfHighlightTaskbar,
             settings.enableSelfHighlightSound, false, false,
             settings.selfHighlightSoundUrl.getValue(),
-            ColorProvider::instance().color(ColorType::SelfHighlight));
+            ColorProvider::instance().color(ColorType::SelfHighlight),
+            settings.selfHighlightChannelNames.getValue());
 
         checks.emplace_back(highlightPhraseCheck(highlight));
     }
@@ -380,6 +381,7 @@ HighlightController::HighlightController(Settings &settings,
     this->rebuildListener_.addSetting(settings.enableSelfHighlightSound);
     this->rebuildListener_.addSetting(settings.enableSelfHighlightTaskbar);
     this->rebuildListener_.addSetting(settings.selfHighlightSoundUrl);
+    this->rebuildListener_.addSetting(settings.selfHighlightChannelNames);
     this->rebuildListener_.addSetting(settings.showSelfHighlightInMentions);
 
     this->rebuildListener_.addSetting(settings.enableWhisperHighlight);

--- a/src/controllers/highlights/HighlightController.cpp
+++ b/src/controllers/highlights/HighlightController.cpp
@@ -32,7 +32,8 @@ auto highlightPhraseCheck(const HighlightPhrase &highlight) -> HighlightCheck
             (void)twitchBadges;     // unused
             (void)senderName;       // unused
             (void)flags;        // unused
-
+            
+            if (self)
             {
                 // Phrase checks should ignore highlights from the user
                 return std::nullopt;

--- a/src/controllers/highlights/HighlightController.cpp
+++ b/src/controllers/highlights/HighlightController.cpp
@@ -25,18 +25,21 @@ using namespace chatterino;
 auto highlightPhraseCheck(const HighlightPhrase &highlight) -> HighlightCheck
 {
     return HighlightCheck{
-        [highlight](const auto &args, const auto &twitchBadges,
-                    const auto &senderName, const auto &originalMessage,
-                    const auto &flags,
+        [highlight](const auto &args,
+                    const auto &twitchBadges, const auto &senderName,
+                    const auto &originalMessage, const auto &flags,
                     const auto self) -> std::optional<HighlightResult> {
-            (void)args;          // unused
-            (void)twitchBadges;  // unused
-            (void)senderName;    // unused
-            (void)flags;         // unused
+            (void)twitchBadges;     // unused
+            (void)senderName;       // unused
+            (void)flags;        // unused
 
-            if (self)
             {
                 // Phrase checks should ignore highlights from the user
+                return std::nullopt;
+            }
+
+            if (!highlight.appliesToChannel(args.channelName))
+            {
                 return std::nullopt;
             }
 
@@ -76,9 +79,9 @@ void rebuildSubscriptionHighlights(Settings &settings,
         // The custom sub highlight color is handled in ColorProvider
 
         checks.emplace_back(HighlightCheck{
-            [=](const auto &args, const auto &twitchBadges,
-                const auto &senderName, const auto &originalMessage,
-                const auto &flags,
+        [=](const auto &args,
+                const auto &twitchBadges, const auto &senderName,
+                const auto &originalMessage, const auto &flags,
                 const auto self) -> std::optional<HighlightResult> {
                 (void)twitchBadges;     // unused
                 (void)senderName;       // unused
@@ -123,9 +126,9 @@ void rebuildWhisperHighlights(Settings &settings,
         // The custom whisper highlight color is handled in ColorProvider
 
         checks.emplace_back(HighlightCheck{
-            [=](const auto &args, const auto &twitchBadges,
-                const auto &senderName, const auto &originalMessage,
-                const auto &flags,
+            [=](const auto &args,
+                const auto &twitchBadges, const auto &senderName,
+                const auto &originalMessage, const auto &flags,
                 const auto self) -> std::optional<HighlightResult> {
                 (void)twitchBadges;     // unused
                 (void)senderName;       // unused
@@ -166,9 +169,9 @@ void rebuildReplyThreadHighlight(Settings &settings,
         auto highlightInMentions =
             settings.showThreadHighlightInMentions.getValue();
         checks.emplace_back(HighlightCheck{
-            [=](const auto & /*args*/, const auto & /*twitchBadges*/,
-                const auto & /*senderName*/, const auto & /*originalMessage*/,
-                const auto &flags,
+            [=](const auto & /*args*/,
+                const auto & /*twitchBadges*/, const auto & /*senderName*/,
+                const auto & /*originalMessage*/, const auto &flags,
                 const auto self) -> std::optional<HighlightResult> {
                 if (flags.has(MessageFlag::SubscribedThread) && !self)
                 {
@@ -224,9 +227,9 @@ void rebuildMessageHighlights(Settings &settings,
             ColorProvider::instance().color(ColorType::AutomodHighlight);
 
         checks.emplace_back(HighlightCheck{
-            [=](const auto & /*args*/, const auto & /*twitchBadges*/,
-                const auto & /*senderName*/, const auto & /*originalMessage*/,
-                const auto &flags,
+            [=](const auto & /*args*/,
+                const auto & /*twitchBadges*/, const auto & /*senderName*/,
+                const auto & /*originalMessage*/, const auto &flags,
                 const auto /*self*/) -> std::optional<HighlightResult> {
                 if (!flags.has(MessageFlag::AutoModOffendingMessage))
                 {
@@ -261,9 +264,9 @@ void rebuildUserHighlights(Settings &settings,
 
         checks.emplace_back(HighlightCheck{
             [showInMentions](
-                const auto &args, const auto &twitchBadges,
-                const auto &senderName, const auto &originalMessage,
-                const auto &flags,
+                const auto &args,
+                const auto &twitchBadges, const auto &senderName,
+                const auto &originalMessage, const auto &flags,
                 const auto self) -> std::optional<HighlightResult> {
                 (void)args;             //unused
                 (void)twitchBadges;     //unused
@@ -288,9 +291,9 @@ void rebuildUserHighlights(Settings &settings,
     for (const auto &highlight : *userHighlights)
     {
         checks.emplace_back(HighlightCheck{
-            [highlight](const auto &args, const auto &twitchBadges,
-                        const auto &senderName, const auto &originalMessage,
-                        const auto &flags,
+            [highlight](const auto &args,
+                        const auto &twitchBadges, const auto &senderName,
+                        const auto &originalMessage, const auto &flags,
                         const auto self) -> std::optional<HighlightResult> {
                 (void)args;             // unused
                 (void)twitchBadges;     // unused
@@ -328,9 +331,9 @@ void rebuildBadgeHighlights(Settings &settings,
     for (const auto &highlight : *badgeHighlights)
     {
         checks.emplace_back(HighlightCheck{
-            [highlight](const auto &args, const auto &twitchBadges,
-                        const auto &senderName, const auto &originalMessage,
-                        const auto &flags,
+            [highlight](const auto &args,
+                        const auto &twitchBadges, const auto &senderName,
+                        const auto &originalMessage, const auto &flags,
                         const auto self) -> std::optional<HighlightResult> {
                 (void)args;             // unused
                 (void)senderName;       // unused
@@ -473,7 +476,8 @@ void HighlightController::rebuildChecks(Settings &settings)
 }
 
 std::pair<bool, HighlightResult> HighlightController::check(
-    const MessageParseArgs &args, const std::vector<TwitchBadge> &twitchBadges,
+    const MessageParseArgs &args,
+    const std::vector<TwitchBadge> &twitchBadges,
     const QString &senderName, const QString &originalMessage,
     const MessageFlags &messageFlags) const
 {

--- a/src/controllers/highlights/HighlightController.hpp
+++ b/src/controllers/highlights/HighlightController.hpp
@@ -38,8 +38,9 @@ public:
      **/
     [[nodiscard]] std::pair<bool, HighlightResult> check(
         const MessageParseArgs &args,
-        const std::vector<TwitchBadge> &twitchBadges, const QString &senderName,
-        const QString &originalMessage, const MessageFlags &messageFlags) const;
+        const std::vector<TwitchBadge> &twitchBadges,
+        const QString &senderName, const QString &originalMessage,
+        const MessageFlags &messageFlags) const;
 
 private:
     /**

--- a/src/controllers/highlights/HighlightModel.cpp
+++ b/src/controllers/highlights/HighlightModel.cpp
@@ -38,7 +38,8 @@ HighlightPhrase HighlightModel::getItemFromRow(
         row[Column::UseRegex]->data(Qt::CheckStateRole).toBool(),
         row[Column::CaseSensitive]->data(Qt::CheckStateRole).toBool(),
         row[Column::SoundPath]->data(Qt::UserRole).toString(),
-        highlightColor};
+        highlightColor,
+        row[Column::Channel]->data(Qt::DisplayRole).toString()};
 }
 
 // turns a row in the model into a vector item
@@ -52,6 +53,7 @@ void HighlightModel::getRowFromItem(const HighlightPhrase &item,
     setBoolItem(row[Column::UseRegex], item.isRegex());
     setBoolItem(row[Column::CaseSensitive], item.isCaseSensitive());
     setFilePathItem(row[Column::SoundPath], item.getSoundUrl());
+    setStringItem(row[Column::Channel], item.getChannelNames());
     setColorItem(row[Column::Color], *item.getColor());
 }
 

--- a/src/controllers/highlights/HighlightModel.cpp
+++ b/src/controllers/highlights/HighlightModel.cpp
@@ -79,10 +79,11 @@ void HighlightModel::afterInit()
 
     QUrl selfSound = QUrl(getSettings()->selfHighlightSoundUrl.getValue());
     setFilePathItem(usernameRow[Column::SoundPath], selfSound, false);
+    setStringItem(usernameRow[Column::Channel],
+                  getSettings()->selfHighlightChannelNames.getValue());
 
     auto selfColor = ColorProvider::instance().color(ColorType::SelfHighlight);
     setColorItem(usernameRow[Column::Color], *selfColor, false);
-    setStringItem(usernameRow[Column::Channel], QString(), false, true);
 
     this->insertCustomRow(usernameRow, HighlightRowIndexes::SelfHighlightRow);
 
@@ -500,6 +501,15 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
                     getSettings()->automodHighlightSoundUrl.setValue(
                         value.toString());
                 }
+            }
+        }
+        break;
+        case Column::Channel: {
+            if (role == Qt::EditRole &&
+                rowIndex == HighlightRowIndexes::SelfHighlightRow)
+            {
+                getSettings()->selfHighlightChannelNames.setValue(
+                    value.toString());
             }
         }
         break;

--- a/src/controllers/highlights/HighlightModel.cpp
+++ b/src/controllers/highlights/HighlightModel.cpp
@@ -82,6 +82,7 @@ void HighlightModel::afterInit()
 
     auto selfColor = ColorProvider::instance().color(ColorType::SelfHighlight);
     setColorItem(usernameRow[Column::Color], *selfColor, false);
+    setStringItem(usernameRow[Column::Channel], QString(), false, true);
 
     this->insertCustomRow(usernameRow, HighlightRowIndexes::SelfHighlightRow);
 
@@ -106,6 +107,7 @@ void HighlightModel::afterInit()
 
     auto whisperColor = ColorProvider::instance().color(ColorType::Whisper);
     setColorItem(whisperRow[Column::Color], *whisperColor, false);
+    setStringItem(whisperRow[Column::Channel], QString(), false, true);
 
     this->insertCustomRow(whisperRow, HighlightRowIndexes::WhisperRow);
 
@@ -128,6 +130,7 @@ void HighlightModel::afterInit()
 
     auto subColor = ColorProvider::instance().color(ColorType::Subscription);
     setColorItem(subRow[Column::Color], *subColor, false);
+    setStringItem(subRow[Column::Channel], QString(), false, true);
 
     this->insertCustomRow(subRow, HighlightRowIndexes::SubRow);
 
@@ -153,6 +156,7 @@ void HighlightModel::afterInit()
     auto RedeemedColor =
         ColorProvider::instance().color(ColorType::RedeemedHighlight);
     setColorItem(redeemedRow[Column::Color], *RedeemedColor, false);
+    setStringItem(redeemedRow[Column::Channel], QString(), false, true);
 
     this->insertCustomRow(redeemedRow, HighlightRowIndexes::RedeemedRow);
 
@@ -179,6 +183,7 @@ void HighlightModel::afterInit()
     auto FirstMessageColor =
         ColorProvider::instance().color(ColorType::FirstMessageHighlight);
     setColorItem(firstMessageRow[Column::Color], *FirstMessageColor, false);
+    setStringItem(firstMessageRow[Column::Channel], QString(), false, true);
 
     this->insertCustomRow(firstMessageRow,
                           HighlightRowIndexes::FirstMessageRow);
@@ -206,6 +211,7 @@ void HighlightModel::afterInit()
         ColorProvider::instance().color(ColorType::ElevatedMessageHighlight);
     setColorItem(elevatedMessageRow[Column::Color], *elevatedMessageColor,
                  false);
+    setStringItem(elevatedMessageRow[Column::Channel], QString(), false, true);
 
     this->insertCustomRow(elevatedMessageRow,
                           HighlightRowIndexes::ElevatedMessageRow);
@@ -236,6 +242,7 @@ void HighlightModel::afterInit()
     auto threadMessageColor =
         ColorProvider::instance().color(ColorType::ThreadMessageHighlight);
     setColorItem(threadMessageRow[Column::Color], *threadMessageColor, false);
+    setStringItem(threadMessageRow[Column::Channel], QString(), false, true);
 
     this->insertCustomRow(threadMessageRow,
                           HighlightRowIndexes::ThreadMessageRow);
@@ -263,6 +270,7 @@ void HighlightModel::afterInit()
     auto automodColor =
         ColorProvider::instance().color(ColorType::AutomodHighlight);
     setColorItem(automodRow[Column::Color], *automodColor, false);
+    setStringItem(automodRow[Column::Channel], QString(), false, true);
 
     this->insertCustomRow(automodRow, HighlightRowIndexes::AutomodRow);
 
@@ -281,6 +289,7 @@ void HighlightModel::afterInit()
     auto watchStreakColor =
         ColorProvider::instance().color(ColorType::WatchStreak);
     setColorItem(watchStreakRow[Column::Color], *watchStreakColor, false);
+    setStringItem(watchStreakRow[Column::Channel], QString(), false, true);
 
     this->insertCustomRow(watchStreakRow, HighlightRowIndexes::WatchStreakRow);
 }

--- a/src/controllers/highlights/HighlightModel.hpp
+++ b/src/controllers/highlights/HighlightModel.hpp
@@ -26,7 +26,8 @@ public:
         CaseSensitive = 4,
         PlaySound = 5,
         SoundPath = 6,
-        Color = 7,
+        Channel = 7,
+        Color = 8,
         COUNT  // keep this as last member of enum
     };
 

--- a/src/controllers/highlights/HighlightPhrase.cpp
+++ b/src/controllers/highlights/HighlightPhrase.cpp
@@ -34,16 +34,16 @@ bool HighlightPhrase::operator==(const HighlightPhrase &other) const
 {
     return std::tie(this->pattern_, this->showInMentions_, this->hasSound_,
                     this->hasAlert_, this->isRegex_, this->isCaseSensitive_,
-                    this->soundUrl_, this->color_) ==
-           std::tie(other.pattern_, other.showInMentions_, other.hasSound_,
+                    this->soundUrl_, this->color_, this->channelName_) ==
+       std::tie(other.pattern_, other.showInMentions_, other.hasSound_,
                     other.hasAlert_, other.isRegex_, other.isCaseSensitive_,
-                    other.soundUrl_, other.color_);
+                    other.soundUrl_, other.color_, other.channelName_);
 }
 
 HighlightPhrase::HighlightPhrase(const QString &pattern, bool showInMentions,
                                  bool hasAlert, bool hasSound, bool isRegex,
                                  bool isCaseSensitive, const QString &soundUrl,
-                                 QColor color)
+                                 QColor color, const QString &channelName)
     : pattern_(pattern)
     , showInMentions_(showInMentions)
     , hasAlert_(hasAlert)
@@ -58,6 +58,7 @@ HighlightPhrase::HighlightPhrase(const QString &pattern, bool showInMentions,
              QRegularExpression::UseUnicodePropertiesOption |
                  (isCaseSensitive_ ? QRegularExpression::NoPatternOption
                                    : QRegularExpression::CaseInsensitiveOption))
+    , channelName_(channelName)
 {
     this->color_ = std::make_shared<QColor>(color);
 }
@@ -65,7 +66,8 @@ HighlightPhrase::HighlightPhrase(const QString &pattern, bool showInMentions,
 HighlightPhrase::HighlightPhrase(const QString &pattern, bool showInMentions,
                                  bool hasAlert, bool hasSound, bool isRegex,
                                  bool isCaseSensitive, const QString &soundUrl,
-                                 std::shared_ptr<QColor> color)
+                                 std::shared_ptr<QColor> color,
+                                 const QString &channelName)
     : pattern_(pattern)
     , showInMentions_(showInMentions)
     , hasAlert_(hasAlert)
@@ -81,6 +83,7 @@ HighlightPhrase::HighlightPhrase(const QString &pattern, bool showInMentions,
              QRegularExpression::UseUnicodePropertiesOption |
                  (isCaseSensitive_ ? QRegularExpression::NoPatternOption
                                    : QRegularExpression::CaseInsensitiveOption))
+    , channelName_(channelName)
 {
 }
 
@@ -127,6 +130,21 @@ bool HighlightPhrase::isMatch(const QString &subject) const
 bool HighlightPhrase::isCaseSensitive() const
 {
     return this->isCaseSensitive_;
+}
+
+bool HighlightPhrase::appliesToChannel(const QString &channelName) const
+{
+    if (this->channelName_.isEmpty())
+    {
+        return true;
+    }
+
+    return this->channelName_.compare(channelName, Qt::CaseInsensitive) == 0;
+}
+
+const QString &HighlightPhrase::getChannelName() const
+{
+    return this->channelName_;
 }
 
 const QUrl &HighlightPhrase::getSoundUrl() const

--- a/src/controllers/highlights/HighlightPhrase.cpp
+++ b/src/controllers/highlights/HighlightPhrase.cpp
@@ -34,16 +34,16 @@ bool HighlightPhrase::operator==(const HighlightPhrase &other) const
 {
     return std::tie(this->pattern_, this->showInMentions_, this->hasSound_,
                     this->hasAlert_, this->isRegex_, this->isCaseSensitive_,
-                    this->soundUrl_, this->color_, this->channelName_) ==
+                    this->soundUrl_, this->color_, this->channelNames_) ==
        std::tie(other.pattern_, other.showInMentions_, other.hasSound_,
                     other.hasAlert_, other.isRegex_, other.isCaseSensitive_,
-                    other.soundUrl_, other.color_, other.channelName_);
+                    other.soundUrl_, other.color_, other.channelNames_);
 }
 
 HighlightPhrase::HighlightPhrase(const QString &pattern, bool showInMentions,
                                  bool hasAlert, bool hasSound, bool isRegex,
                                  bool isCaseSensitive, const QString &soundUrl,
-                                 QColor color, const QString &channelName)
+                                 QColor color, const QString &channelNames)
     : pattern_(pattern)
     , showInMentions_(showInMentions)
     , hasAlert_(hasAlert)
@@ -58,7 +58,7 @@ HighlightPhrase::HighlightPhrase(const QString &pattern, bool showInMentions,
              QRegularExpression::UseUnicodePropertiesOption |
                  (isCaseSensitive_ ? QRegularExpression::NoPatternOption
                                    : QRegularExpression::CaseInsensitiveOption))
-    , channelName_(channelName)
+    , channelNames_(channelNames)
 {
     this->color_ = std::make_shared<QColor>(color);
 }
@@ -67,7 +67,7 @@ HighlightPhrase::HighlightPhrase(const QString &pattern, bool showInMentions,
                                  bool hasAlert, bool hasSound, bool isRegex,
                                  bool isCaseSensitive, const QString &soundUrl,
                                  std::shared_ptr<QColor> color,
-                                 const QString &channelName)
+                                 const QString &channelNames)
     : pattern_(pattern)
     , showInMentions_(showInMentions)
     , hasAlert_(hasAlert)
@@ -83,7 +83,7 @@ HighlightPhrase::HighlightPhrase(const QString &pattern, bool showInMentions,
              QRegularExpression::UseUnicodePropertiesOption |
                  (isCaseSensitive_ ? QRegularExpression::NoPatternOption
                                    : QRegularExpression::CaseInsensitiveOption))
-    , channelName_(channelName)
+    , channelNames_(channelNames)
 {
 }
 
@@ -134,17 +134,25 @@ bool HighlightPhrase::isCaseSensitive() const
 
 bool HighlightPhrase::appliesToChannel(const QString &channelName) const
 {
-    if (this->channelName_.isEmpty())
+    if (this->channelNames_.isEmpty())
     {
         return true;
     }
 
-    return this->channelName_.compare(channelName, Qt::CaseInsensitive) == 0;
+    for (auto channel : this->channelNames_.split(u';', Qt::SkipEmptyParts))
+    {
+        if (channel.trimmed().compare(channelName, Qt::CaseInsensitive) == 0)
+        {
+            return true;
+        }
+    }
+
+    return false;
 }
 
-const QString &HighlightPhrase::getChannelName() const
+const QString &HighlightPhrase::getChannelNames() const
 {
-    return this->channelName_;
+    return this->channelNames_;
 }
 
 const QUrl &HighlightPhrase::getSoundUrl() const

--- a/src/controllers/highlights/HighlightPhrase.hpp
+++ b/src/controllers/highlights/HighlightPhrase.hpp
@@ -29,7 +29,8 @@ public:
      */
     HighlightPhrase(const QString &pattern, bool showInMentions, bool hasAlert,
                     bool hasSound, bool isRegex, bool isCaseSensitive,
-                    const QString &soundUrl, QColor color);
+                    const QString &soundUrl, QColor color,
+                    const QString &channelName = QString());
 
     /**
      * @brief Create a new HighlightPhrase.
@@ -38,7 +39,8 @@ public:
      */
     HighlightPhrase(const QString &pattern, bool showInMentions, bool hasAlert,
                     bool hasSound, bool isRegex, bool isCaseSensitive,
-                    const QString &soundUrl, std::shared_ptr<QColor> color);
+                    const QString &soundUrl, std::shared_ptr<QColor> color,
+                    const QString &channelName = QString());
 
     const QString &getPattern() const;
     bool showInMentions() const;
@@ -51,7 +53,7 @@ public:
      * In distinction from `HighlightPhrase::hasCustomSound`, this method only
      * checks whether or not ANY sound should be played when the phrase is
      * triggered.
-     * 
+     *
      * To check whether a custom sound is set, use
      * `HighlightPhrase::hasCustomSound` instead.
      *
@@ -75,8 +77,11 @@ public:
     bool isValid() const;
     bool isMatch(const QString &subject) const;
     bool isCaseSensitive() const;
+    bool appliesToChannel(const QString &channelName) const;
+    const QString &getChannelName() const;
     const QUrl &getSoundUrl() const;
     const std::shared_ptr<QColor> getColor() const;
+
 
     /*
      * XXX: Use the constexpr constructor here once we are building with
@@ -103,6 +108,7 @@ private:
     QUrl soundUrl_;
     std::shared_ptr<QColor> color_;
     QRegularExpression regex_;
+    QString channelName_;
 };
 
 }  // namespace chatterino
@@ -131,6 +137,7 @@ struct Serialize<chatterino::HighlightPhrase> {
         chatterino::rj::set(ret, "regex", value.isRegex(), a);
         chatterino::rj::set(ret, "case", value.isCaseSensitive(), a);
         chatterino::rj::set(ret, "soundUrl", value.getSoundUrl().toString(), a);
+        chatterino::rj::set(ret, "channelName", value.getChannelName(), a);
         chatterino::rj::set(ret, "color",
                             value.getColor()->name(QColor::HexArgb), a);
 
@@ -157,6 +164,7 @@ struct Deserialize<chatterino::HighlightPhrase> {
         bool _isRegex = false;
         bool _isCaseSensitive = false;
         QString _soundUrl;
+        QString _channelName;
         QString encodedColor;
 
         chatterino::rj::getSafe(value, "pattern", _pattern);
@@ -166,6 +174,7 @@ struct Deserialize<chatterino::HighlightPhrase> {
         chatterino::rj::getSafe(value, "regex", _isRegex);
         chatterino::rj::getSafe(value, "case", _isCaseSensitive);
         chatterino::rj::getSafe(value, "soundUrl", _soundUrl);
+        chatterino::rj::getSafe(value, "channelName", _channelName);
         chatterino::rj::getSafe(value, "color", encodedColor);
 
         auto _color = QColor(encodedColor);
@@ -176,7 +185,8 @@ struct Deserialize<chatterino::HighlightPhrase> {
 
         return chatterino::HighlightPhrase(_pattern, _showInMentions, _hasAlert,
                                            _hasSound, _isRegex,
-                                           _isCaseSensitive, _soundUrl, _color);
+                                           _isCaseSensitive, _soundUrl, _color,
+                                           _channelName);
     }
 };
 

--- a/src/controllers/highlights/HighlightPhrase.hpp
+++ b/src/controllers/highlights/HighlightPhrase.hpp
@@ -164,7 +164,7 @@ struct Deserialize<chatterino::HighlightPhrase> {
         bool _isRegex = false;
         bool _isCaseSensitive = false;
         QString _soundUrl;
-        QString _channelName;
+        QString _channelNames;
         QString encodedColor;
 
         chatterino::rj::getSafe(value, "pattern", _pattern);
@@ -174,7 +174,7 @@ struct Deserialize<chatterino::HighlightPhrase> {
         chatterino::rj::getSafe(value, "regex", _isRegex);
         chatterino::rj::getSafe(value, "case", _isCaseSensitive);
         chatterino::rj::getSafe(value, "soundUrl", _soundUrl);
-        chatterino::rj::getSafe(value, "channelName", _channelName);
+        chatterino::rj::getSafe(value, "channelNames", _channelNames);
         chatterino::rj::getSafe(value, "color", encodedColor);
 
         auto _color = QColor(encodedColor);
@@ -186,7 +186,7 @@ struct Deserialize<chatterino::HighlightPhrase> {
         return chatterino::HighlightPhrase(_pattern, _showInMentions, _hasAlert,
                                            _hasSound, _isRegex,
                                            _isCaseSensitive, _soundUrl, _color,
-                                           _channelName);
+                                           _channelNames);
     }
 };
 

--- a/src/controllers/highlights/HighlightPhrase.hpp
+++ b/src/controllers/highlights/HighlightPhrase.hpp
@@ -30,7 +30,7 @@ public:
     HighlightPhrase(const QString &pattern, bool showInMentions, bool hasAlert,
                     bool hasSound, bool isRegex, bool isCaseSensitive,
                     const QString &soundUrl, QColor color,
-                    const QString &channelName = QString());
+                    const QString &channelNames = QString());
 
     /**
      * @brief Create a new HighlightPhrase.
@@ -40,7 +40,7 @@ public:
     HighlightPhrase(const QString &pattern, bool showInMentions, bool hasAlert,
                     bool hasSound, bool isRegex, bool isCaseSensitive,
                     const QString &soundUrl, std::shared_ptr<QColor> color,
-                    const QString &channelName = QString());
+                    const QString &channelNames = QString());
 
     const QString &getPattern() const;
     bool showInMentions() const;
@@ -78,7 +78,7 @@ public:
     bool isMatch(const QString &subject) const;
     bool isCaseSensitive() const;
     bool appliesToChannel(const QString &channelName) const;
-    const QString &getChannelName() const;
+    const QString &getChannelNames() const;
     const QUrl &getSoundUrl() const;
     const std::shared_ptr<QColor> getColor() const;
 
@@ -108,7 +108,7 @@ private:
     QUrl soundUrl_;
     std::shared_ptr<QColor> color_;
     QRegularExpression regex_;
-    QString channelName_;
+    QString channelNames_;
 };
 
 }  // namespace chatterino
@@ -137,7 +137,7 @@ struct Serialize<chatterino::HighlightPhrase> {
         chatterino::rj::set(ret, "regex", value.isRegex(), a);
         chatterino::rj::set(ret, "case", value.isCaseSensitive(), a);
         chatterino::rj::set(ret, "soundUrl", value.getSoundUrl().toString(), a);
-        chatterino::rj::set(ret, "channelName", value.getChannelName(), a);
+        chatterino::rj::set(ret, "channelNames", value.getChannelNames(), a);
         chatterino::rj::set(ret, "color",
                             value.getColor()->name(QColor::HexArgb), a);
 

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -1721,7 +1721,10 @@ std::pair<MessagePtrMut, HighlightAlert> MessageBuilder::makeIrcMessage(
                           builder->searchText;
 
     // highlights
-    HighlightAlert highlight = builder.parseHighlights(tags, content, args);
+    MessageParseArgs argsWithChannel = args;
+    argsWithChannel.channelName = channel->getName();
+    HighlightAlert highlight = builder.parseHighlights(tags, content,
+                                                       argsWithChannel);
     if (tags.contains("historical"))
     {
         highlight.playSound = false;

--- a/src/messages/MessageBuilder.hpp
+++ b/src/messages/MessageBuilder.hpp
@@ -82,6 +82,7 @@ struct MessageParseArgs {
     bool trimSubscriberUsername = false;
     bool isStaffOrBroadcaster = false;
     bool isSubscriptionMessage = false;
+    QString channelName = "";
     bool allowIgnore = true;
     bool isAction = false;
     QString channelPointRewardId = "";

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -509,6 +509,8 @@ public:
         "/highlighting/selfHighlightSoundUrl", ""};
     QStringSetting selfHighlightColor = {"/highlighting/selfHighlightColor",
                                          ""};
+    QStringSetting selfHighlightChannelNames = {
+        "/highlighting/selfHighlight/channelNames", ""};
 
     BoolSetting enableSelfMessageHighlight = {
         "/highlighting/selfMessageHighlight/enabled", false};

--- a/src/widgets/settingspages/HighlightingPage.cpp
+++ b/src/widgets/settingspages/HighlightingPage.cpp
@@ -80,7 +80,7 @@ HighlightingPage::HighlightingPage()
                 view->setTitles({"Pattern", "Show in\nMentions",
                                  "Flash\ntaskbar", "Enable\nregex",
                                  "Case-\nsensitive", "Play\nsound",
-                                 "Custom\nsound", "Color"});
+                                 "Custom\nsound", "Filter\nChannels", "Color"});
                 view->getTableView()->horizontalHeader()->setSectionResizeMode(
                     QHeaderView::Fixed);
                 view->getTableView()->horizontalHeader()->setSectionResizeMode(


### PR DESCRIPTION
Addresses #2401, #5219 

This PR introduces the ability to filter highlight phrases by channel, allowing users to define where specific highlights should apply.
There are many different ways this feature could be implemented. The way I did is by adding a `Filter Channels` column in the already existing highlights table:

<img width="762" height="583" alt="image" src="https://github.com/user-attachments/assets/3c3118be-fd30-43e4-a455-41693f765893" />

**Motivation**
Currently, highlight phrases are global - they trigger in every channel. This can be problematic for users who follow many channels and want the highlights to behave differently by channel.

This feature allows:
- Highlight/ping custom phrases only in specific channels;
- Reduce the amount of pings you get in unrelated channels;
- Create more flexible setups (e.g. ping in one channel, highlight-only in another);
- This can be especially useful for users that have common words in their names (e.g. username is fish123, but _only want to get pinged_ when "fish" is typed in some small channel);
- Leaving the field empty makes it global (same functionality as it is now);

**Implementation**
I tried to build this on the existing highlight system rather than introducing a new one:

- Added channel filtering to `HighlightPhrase` by introducing a new `QString channelNames_` field;
- Added `appliesToChannel(...) `helper that checks whether the current message’s channel matches (or allows everything if empty);
- Updated `highlightPhraseCheck(...) `to call `appliesToChannel(args.channelName)` before doing the actual match, so highlights are ignored early if they’re not meant for that channel;
- Extended `MessageParseArgs` with `QString channelName`;
- Passed the extra channel context to existing structures;
- Added a new “Filter channels” column in the UI;

Currently, this works for:
- Custom user-defined highlight phrases
- "**Your Username (automatic)"** built-in highlight

The "Filter Channels" column is  disabled for other built-in highlights (whispers, subscriptions, first messages, etc.)

If this approach doesn’t quite match the direction you’re aiming for, that’s totally fine. I still think channel-specific highlights/pings would be a really useful feature to have, so I wanted to share my take on it.


<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.". 
-->

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
