### PR TITLE
Add setting to specify custom path for the native messaging manifest

### DIFF
--- a/src/singletons/NativeMessaging.cpp
+++ b/src/singletons/NativeMessaging.cpp
@@ -147,8 +147,8 @@ QJsonDocument getFirefoxManifest(const QStringList &extensionIDs)
 #ifndef Q_OS_WIN
 void writeManifestToCustomPath(const QJsonDocument &manifest)
 {
-    auto customPath =
-        parseCustomPath(getSettings()->customNativeMessagingManifestPath.getValue());
+    auto customPath = parseCustomPath(
+        getSettings()->customNativeMessagingManifestPath.getValue());
     if (!customPath.has_value())
     {
         return;

--- a/src/singletons/NativeMessaging.cpp
+++ b/src/singletons/NativeMessaging.cpp
@@ -94,7 +94,7 @@ void registerNmManifest([[maybe_unused]] const Paths &paths,
 #endif
 }
 
-QJsonObject getBaseDocument()
+QJsonObject buildBaseDocument()
 {
     return QJsonObject{
         {u"name"_s, "com.chatterino.chatterino"_L1},
@@ -104,9 +104,9 @@ QJsonObject getBaseDocument()
     };
 }
 
-QJsonDocument getChromeManifest(const QStringList &extensionIDs)
+QJsonDocument buildChromeManifest(const QStringList &extensionIDs)
 {
-    auto obj = getBaseDocument();
+    auto obj = buildBaseDocument();
     QJsonArray allowedOriginsArr = {
         u"chrome-extension://%1/"_s.arg(EXTENSION_ID)};
 
@@ -125,9 +125,9 @@ QJsonDocument getChromeManifest(const QStringList &extensionIDs)
     return QJsonDocument{obj};
 }
 
-QJsonDocument getFirefoxManifest(const QStringList &extensionIDs)
+QJsonDocument buildFirefoxManifest(const QStringList &extensionIDs)
 {
-    auto obj = getBaseDocument();
+    auto obj = buildBaseDocument();
     QJsonArray allowedExtensions = {"chatterino_native@chatterino.com"};
 
     for (const auto &id : extensionIDs)
@@ -249,8 +249,8 @@ void registerNmHost(const Paths &paths)
         getSettings()->additionalExtensionIDs.getValue().split(
             ';', Qt::SkipEmptyParts);
 
-    QJsonDocument chromeManifest = getChromeManifest(extensionIDs);
-    QJsonDocument firefoxManifest = getFirefoxManifest(extensionIDs);
+    QJsonDocument chromeManifest = buildChromeManifest(extensionIDs);
+    QJsonDocument firefoxManifest = buildFirefoxManifest(extensionIDs);
 
     registerNmManifest(paths, CHROME, chromeManifest);
     registerNmManifest(paths, FIREFOX, firefoxManifest);

--- a/src/singletons/NativeMessaging.cpp
+++ b/src/singletons/NativeMessaging.cpp
@@ -14,6 +14,7 @@
 #include "singletons/Settings.hpp"
 #include "util/IpcQueue.hpp"
 #include "util/PostToThread.hpp"
+#include "util/XDGDirectory.hpp"
 
 #include <QCoreApplication>
 #include <QDir>
@@ -93,6 +94,79 @@ void registerNmManifest([[maybe_unused]] const Paths &paths,
 #endif
 }
 
+QJsonObject getBaseDocument()
+{
+    return QJsonObject{
+        {u"name"_s, "com.chatterino.chatterino"_L1},
+        {u"description"_s, "Browser interaction with chatterino."_L1},
+        {u"path"_s, QCoreApplication::applicationFilePath()},
+        {u"type"_s, "stdio"_L1},
+    };
+}
+
+QJsonDocument getChromeManifest(const QStringList &extensionIDs)
+{
+    auto obj = getBaseDocument();
+    QJsonArray allowedOriginsArr = {
+        u"chrome-extension://%1/"_s.arg(EXTENSION_ID)};
+
+    for (const auto &id : extensionIDs)
+    {
+        QString trimmedID = id.trimmed();
+        if (!trimmedID.isEmpty())
+        {
+            allowedOriginsArr.append(
+                u"chrome-extension://%1/"_s.arg(trimmedID));
+        }
+    }
+
+    obj.insert("allowed_origins", allowedOriginsArr);
+
+    return QJsonDocument{obj};
+}
+
+QJsonDocument getFirefoxManifest(const QStringList &extensionIDs)
+{
+    auto obj = getBaseDocument();
+    QJsonArray allowedExtensions = {"chatterino_native@chatterino.com"};
+
+    for (const auto &id : extensionIDs)
+    {
+        QString trimmedID = id.trimmed();
+        if (!trimmedID.isEmpty())
+        {
+            allowedExtensions.append(trimmedID);
+        }
+    }
+
+    obj.insert("allowed_extensions", allowedExtensions);
+
+    return QJsonDocument{obj};
+}
+
+#ifndef Q_OS_WIN
+void writeManifestToCustomPath(const QJsonDocument &manifest)
+{
+    auto customPath =
+        parseCustomPath(getSettings()->customNativeMessagingManifestPath.getValue());
+    if (!customPath.has_value())
+    {
+        return;
+    }
+
+    QFile file(customPath.value());
+    if (!file.open(QFile::WriteOnly | QFile::Truncate))
+    {
+        qCWarning(chatterinoNativeMessage)
+            << "Failed to open" << customPath.value();
+    }
+    else
+    {
+        file.write(manifest.toJson());
+    }
+}
+#endif
+
 }  // namespace
 
 namespace chatterino::nm::detail {
@@ -128,6 +202,35 @@ Expected<void, WriteManifestError> writeManifestTo(QString directory,
     return {};
 }
 
+#ifndef Q_OS_WIN
+std::optional<QString> parseCustomPath(QString path)
+{
+    if (path.isEmpty())
+    {
+        return {};
+    }
+
+#    ifdef Q_OS_LINUX
+    path = path.replace("$XDG_CONFIG_HOME",
+                        getXDGUserDirectories(XDGDirectoryType::Config).at(0))
+               .replace("$XDG_DATA_HOME",
+                        getXDGUserDirectories(XDGDirectoryType::Data).at(0));
+#    endif
+
+    if (path.startsWith('~'))
+    {
+        path = QDir::homePath() % QStringView{path}.sliced(1);
+    }
+
+    if (!path.startsWith('/'))
+    {
+        return {};
+    }
+
+    return path;
+}
+#endif
+
 }  // namespace chatterino::nm::detail
 
 namespace chatterino {
@@ -142,58 +245,27 @@ void registerNmHost(const Paths &paths)
         return;
     }
 
-    auto getBaseDocument = [] {
-        return QJsonObject{
-            {u"name"_s, "com.chatterino.chatterino"_L1},
-            {u"description"_s, "Browser interaction with chatterino."_L1},
-            {u"path"_s, QCoreApplication::applicationFilePath()},
-            {u"type"_s, "stdio"_L1},
-        };
-    };
-
     QStringList extensionIDs =
         getSettings()->additionalExtensionIDs.getValue().split(
             ';', Qt::SkipEmptyParts);
 
-    // chrome
+    QJsonDocument chromeManifest = getChromeManifest(extensionIDs);
+    QJsonDocument firefoxManifest = getFirefoxManifest(extensionIDs);
+
+    registerNmManifest(paths, CHROME, chromeManifest);
+    registerNmManifest(paths, FIREFOX, firefoxManifest);
+
+#ifndef Q_OS_WIN
+    switch (getSettings()->customNativeMessagingManifestFormat.getEnum())
     {
-        auto obj = getBaseDocument();
-        QJsonArray allowedOriginsArr = {
-            u"chrome-extension://%1/"_s.arg(EXTENSION_ID)};
-
-        for (const auto &id : extensionIDs)
-        {
-            QString trimmedID = id.trimmed();
-            if (!trimmedID.isEmpty())
-            {
-                allowedOriginsArr.append(
-                    u"chrome-extension://%1/"_s.arg(trimmedID));
-            }
-        }
-
-        obj.insert("allowed_origins", allowedOriginsArr);
-
-        registerNmManifest(paths, CHROME, QJsonDocument{obj});
+        case BrowserManifestFormat::Chrome:
+            writeManifestToCustomPath(chromeManifest);
+            break;
+        case BrowserManifestFormat::Firefox:
+            writeManifestToCustomPath(firefoxManifest);
+            break;
     }
-
-    // firefox
-    {
-        auto obj = getBaseDocument();
-        QJsonArray allowedExtensions = {"chatterino_native@chatterino.com"};
-
-        for (const auto &id : extensionIDs)
-        {
-            QString trimmedID = id.trimmed();
-            if (!trimmedID.isEmpty())
-            {
-                allowedExtensions.append(trimmedID);
-            }
-        }
-
-        obj.insert("allowed_extensions", allowedExtensions);
-
-        registerNmManifest(paths, FIREFOX, QJsonDocument{obj});
-    }
+#endif
 }
 
 std::string &getNmQueueName(const Paths &paths)

--- a/src/singletons/NativeMessaging.hpp
+++ b/src/singletons/NativeMessaging.hpp
@@ -25,6 +25,10 @@ Expected<void, WriteManifestError> writeManifestTo(QString directory,
                                                    const QString &filename,
                                                    const QJsonDocument &json);
 
+#ifndef Q_OS_WIN
+std::optional<QString> parseCustomPath(QString path);
+#endif
+
 }  // namespace chatterino::nm::detail
 
 namespace chatterino {
@@ -85,6 +89,11 @@ private:
     std::vector<ChannelPtr> channelWarmer_;
 
     friend ReceiverThread;
+};
+
+enum class BrowserManifestFormat {
+    Chrome,
+    Firefox,
 };
 
 }  // namespace chatterino

--- a/src/singletons/NativeMessaging.hpp
+++ b/src/singletons/NativeMessaging.hpp
@@ -26,6 +26,9 @@ Expected<void, WriteManifestError> writeManifestTo(QString directory,
                                                    const QJsonDocument &json);
 
 #ifndef Q_OS_WIN
+/// Parse `path` by replacing '~', '$XDG_CONFIG_HOME' and '$XDG_DATA_HOME'
+/// with their respective values.
+/// Returns nullopt if the path is empty or relative.
 std::optional<QString> parseCustomPath(QString path);
 #endif
 

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -814,10 +814,10 @@ public:
 
 #ifndef Q_OS_WIN
     QStringSetting customNativeMessagingManifestPath{
-        "/misc/customNativeMessagingManifestPath", ""};
+        "/misc/extension/customNativeMessagingManifestPath", ""};
     EnumStringSetting<BrowserManifestFormat>
         customNativeMessagingManifestFormat = {
-            "/misc/customNativeMessagingManifestFormat",
+            "/misc/extension/customNativeMessagingManifestFormat",
             BrowserManifestFormat::Chrome,
     };
 #endif

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -22,6 +22,7 @@
 #include "controllers/nicknames/Nickname.hpp"
 #include "controllers/sound/ISoundController.hpp"
 #include "providers/emoji/EmojiStyle.hpp"
+#include "singletons/NativeMessaging.hpp"
 #include "singletons/Toasts.hpp"
 #include "util/RapidJsonSerializeQString.hpp"  // IWYU pragma: keep
 #include "widgets/NotebookEnums.hpp"
@@ -810,6 +811,16 @@ public:
     };
 
     QStringSetting additionalExtensionIDs{"/misc/additionalExtensionIDs", ""};
+
+#ifndef Q_OS_WIN
+    QStringSetting customNativeMessagingManifestPath{
+        "/misc/customNativeMessagingManifestPath", ""};
+    EnumStringSetting<BrowserManifestFormat>
+        customNativeMessagingManifestFormat = {
+            "/misc/customNativeMessagingManifestFormat",
+            BrowserManifestFormat::Chrome,
+    };
+#endif
 
 private:
     ChatterinoSetting<std::vector<HighlightPhrase>> highlightedMessagesSetting =

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -814,10 +814,12 @@ public:
 
 #ifndef Q_OS_WIN
     QStringSetting customNativeMessagingManifestPath{
-        "/misc/extension/customNativeMessagingManifestPath", ""};
+        "/misc/extension/customManifestPath",
+        "",
+    };
     EnumStringSetting<BrowserManifestFormat>
         customNativeMessagingManifestFormat = {
-            "/misc/extension/customNativeMessagingManifestFormat",
+            "/misc/extension/customManifestFormat",
             BrowserManifestFormat::Chrome,
     };
 #endif

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -958,12 +958,12 @@ void GeneralPage::initLayout(GeneralPageView &layout)
 
         auto *form = new QFormLayout();
         layout.addLayout(form);
-        SettingWidget::lineEdit("Custom Native Messaging Manifest Path",
+        SettingWidget::lineEdit("Custom manifest path",
                                 s.customNativeMessagingManifestPath,
                                 "/full/path/to/native/messaging/manifest.json")
             ->addTo(layout, form);
 
-        SettingWidget::dropdown("Custom Native Messaging Manifest Format",
+        SettingWidget::dropdown("Custom manifest format",
                                 s.customNativeMessagingManifestFormat)
             ->addTo(layout);
     }

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -942,6 +942,33 @@ void GeneralPage::initLayout(GeneralPageView &layout)
             ->addTo(layout, form);
     }
 
+#ifndef Q_OS_WIN
+    {
+        auto *note = layout.addDescription(
+            "A path to write the native messaging manifest to. The manifest is "
+            "already automatically created for Firefox and Google Chrome if "
+            "they are installed."
+#    ifdef Q_OS_LINUX
+            "\nYou may use $XDG_CONFIG_HOME or $XDG_DATA_HOME in the path."
+#    endif
+        );
+        note->setWordWrap(true);
+        note->setStyleSheet("color: #bbb");
+        layout.addWidget(note);
+
+        auto *form = new QFormLayout();
+        layout.addLayout(form);
+        SettingWidget::lineEdit("Custom Native Messaging Manifest Path",
+                                s.customNativeMessagingManifestPath,
+                                "/full/path/to/native/messaging/manifest.json")
+            ->addTo(layout, form);
+
+        SettingWidget::dropdown("Custom Native Messaging Manifest Format",
+                                s.customNativeMessagingManifestFormat)
+            ->addTo(layout);
+    }
+#endif
+
     layout.addTitle("AppData & Cache");
 
     layout.addSubtitle("Application Data");

--- a/src/widgets/settingspages/SettingWidget.cpp
+++ b/src/widgets/settingspages/SettingWidget.cpp
@@ -5,6 +5,7 @@
 #include "widgets/settingspages/SettingWidget.hpp"
 
 #include "common/QLogging.hpp"
+#include "singletons/NativeMessaging.hpp"
 #include "singletons/Settings.hpp"  // IWYU pragma: keep
 #include "util/QMagicEnumTagged.hpp"
 #include "util/RapidJsonSerializeQString.hpp"  // IWYU pragma: keep
@@ -257,6 +258,8 @@ template SettingWidget *SettingWidget::dropdown<ShowModerationState>(
     const QString &label, EnumStringSetting<ShowModerationState> &setting);
 template SettingWidget *SettingWidget::dropdown<EmojiStyle>(
     const QString &label, EnumStringSetting<EmojiStyle> &setting);
+template SettingWidget *SettingWidget::dropdown<BrowserManifestFormat>(
+    const QString &label, EnumStringSetting<BrowserManifestFormat> &setting);
 
 template <typename T>
 SettingWidget *SettingWidget::dropdown(const QString &label,

--- a/tests/src/NativeMessaging.cpp
+++ b/tests/src/NativeMessaging.cpp
@@ -71,13 +71,12 @@ TEST(NativeMessaging, parseCustomPath)
     ASSERT_EQ(parseCustomPath("/my/custom/path/to/manifest.json"),
               std::optional{"/my/custom/path/to/manifest.json"});
 
-    ASSERT_EQ(parseCustomPath(""), std::optional<QString>{});
+    ASSERT_EQ(parseCustomPath(""), std::nullopt);
 
     ASSERT_EQ(parseCustomPath("~/path/to/manifest.json"),
               std::optional{QDir::homePath() % "/path/to/manifest.json"});
 
-    ASSERT_EQ(parseCustomPath("relative/path/to/manifest.json"),
-              std::optional<QString>{});
+    ASSERT_EQ(parseCustomPath("relative/path/to/manifest.json"), std::nullopt);
 
 #    ifdef Q_OS_LINUX
     ASSERT_EQ(

--- a/tests/src/NativeMessaging.cpp
+++ b/tests/src/NativeMessaging.cpp
@@ -64,3 +64,29 @@ TEST_F(NativeMessagingFixture, writeManifestToWindowsCurrentDir)
 
     ASSERT_TRUE(QFile(combinePath(this->dir.path(), "test.json")).exists());
 }
+
+#ifndef Q_OS_WIN
+TEST(NativeMessaging, parseCustomPath)
+{
+    ASSERT_EQ(parseCustomPath("/my/custom/path/to/manifest.json"),
+              std::optional{"/my/custom/path/to/manifest.json"});
+
+    ASSERT_EQ(parseCustomPath(""), std::optional<QString>{});
+
+    ASSERT_EQ(parseCustomPath("~/path/to/manifest.json"),
+              std::optional{QDir::homePath() % "/path/to/manifest.json"});
+
+    ASSERT_EQ(parseCustomPath("relative/path/to/manifest.json"),
+              std::optional<QString>{});
+
+#    ifdef Q_OS_LINUX
+    ASSERT_EQ(
+        parseCustomPath("$XDG_CONFIG_HOME/path/to/manifest.json"),
+        std::optional{QDir::homePath() % "/.config/path/to/manifest.json"});
+
+    ASSERT_EQ(parseCustomPath("$XDG_DATA_HOME/path/to/manifest.json"),
+              std::optional{QDir::homePath() %
+                            "/.local/share/path/to/manifest.json"});
+#    endif
+}
+#endif


### PR DESCRIPTION
Closes #6903 and #6758(?)

This setting is not added on Windows.

The current implementation only creates the file if the path already exists. No directories are created. This could be changed but would add complexity.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
