### PR TITLE
feat(spellcheck): Download dictionaries

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -683,6 +683,8 @@ set(SOURCE_FILES
         widgets/dialogs/ChannelFilterEditorDialog.hpp
         widgets/dialogs/ColorPickerDialog.cpp
         widgets/dialogs/ColorPickerDialog.hpp
+        widgets/dialogs/DownloadDictionaryDialog.cpp
+        widgets/dialogs/DownloadDictionaryDialog.hpp
         widgets/dialogs/EditHotkeyDialog.cpp
         widgets/dialogs/EditHotkeyDialog.hpp
         widgets/dialogs/EditUserNotesDialog.cpp

--- a/src/controllers/spellcheck/SpellChecker.cpp
+++ b/src/controllers/spellcheck/SpellChecker.cpp
@@ -12,9 +12,13 @@
 #include "util/FilesystemHelpers.hpp"
 #include "util/XDGDirectory.hpp"
 
+#include <QLocale>
+
 #ifdef CHATTERINO_WITH_SPELLCHECK
 #    include <hunspell/hunspell.hxx>
 #endif
+
+using namespace Qt::Literals;
 
 namespace chatterino {
 
@@ -263,6 +267,89 @@ std::vector<DictionaryInfo> SpellChecker::getAvailableDictionaries() const
 #else
     return {};
 #endif
+}
+
+QString spellcheck::prettyLossyBcp47Description(const QString &bcp47Str)
+{
+    /// This is a subset of the possible bcp 47 codes. We only pretty print
+    /// codes that Qt can convert.
+    /// See https://datatracker.ietf.org/doc/html/rfc5646#section-2.1.
+    static QRegularExpression smallBcp47Re(
+        u"^"_s
+        "([a-z]{2,3})"                 // language
+        "(?:[-_]([A-Za-z]{4}))?"       // script
+        "(?:[-_]([A-Z]{2,3}))?"        // region
+        "(?:[-_]([a-zA-Z0-9]{5,8}))?"  // variant
+        "$");
+
+    auto match = smallBcp47Re.matchView(bcp47Str);
+    if (!match.hasMatch())
+    {
+        return bcp47Str;
+    }
+    auto langView = match.capturedView(1);
+    auto scriptView = match.capturedView(2);
+    auto regionView = match.capturedView(3);
+    auto variantView = match.capturedView(4);
+
+    QLocale::Language lang = QLocale::codeToLanguage(langView);
+    if (lang == QLocale::AnyLanguage)
+    {
+        return bcp47Str;
+    }
+    QString desc = QLocale::languageToString(lang);
+    bool needsBrace = true;
+    auto nextPart = [&] {
+        if (needsBrace)
+        {
+            desc.append(u" (");
+            needsBrace = false;
+        }
+        else
+        {
+            desc.append(u", ");
+        }
+    };
+
+    if (!scriptView.empty())
+    {
+        nextPart();
+
+        QLocale::Script script = QLocale::codeToScript(scriptView);
+        if (script == QLocale::AnyScript)
+        {
+            desc.append(scriptView);
+        }
+        else
+        {
+            desc.append(QLocale::scriptToString(script));
+        }
+    }
+    if (!regionView.empty())
+    {
+        nextPart();
+
+        QLocale::Territory territory = QLocale::codeToTerritory(regionView);
+        if (territory == QLocale::AnyTerritory)
+        {
+            desc.append(regionView);
+        }
+        else
+        {
+            desc.append(QLocale::territoryToString(territory));
+        }
+    }
+    if (!variantView.empty())
+    {
+        nextPart();
+        desc.append(variantView);
+    }
+
+    if (!needsBrace)
+    {
+        desc.append(')');
+    }
+    return desc;
 }
 
 }  // namespace chatterino

--- a/src/controllers/spellcheck/SpellChecker.hpp
+++ b/src/controllers/spellcheck/SpellChecker.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <pajlada/signals/signal.hpp>
 #include <QString>
 
 #include <memory>
@@ -48,8 +49,16 @@ public:
     /// System-dictionary loading is currently only implemented on Linux.
     std::vector<DictionaryInfo> getAvailableDictionaries() const;
 
+    pajlada::Signals::NoArgSignal dictionariesUpdated;
+
 private:
     std::unique_ptr<SpellCheckerPrivate> private_;
 };
+
+namespace spellcheck {
+
+QString prettyLossyBcp47Description(const QString &bcp47Str);
+
+}  // namespace spellcheck
 
 }  // namespace chatterino

--- a/src/widgets/dialogs/DownloadDictionaryDialog.cpp
+++ b/src/widgets/dialogs/DownloadDictionaryDialog.cpp
@@ -1,0 +1,284 @@
+// SPDX-FileCopyrightText: 2026 Contributors to Chatterino <https://chatterino.com>
+//
+// SPDX-License-Identifier: MIT
+
+#include "widgets/dialogs/DownloadDictionaryDialog.hpp"
+
+#include "Application.hpp"
+#include "common/network/NetworkRequest.hpp"
+#include "common/network/NetworkResult.hpp"
+#include "controllers/spellcheck/SpellChecker.hpp"
+#include "singletons/Paths.hpp"
+#include "util/Expected.hpp"
+#include "util/FilesystemHelpers.hpp"
+
+#include <QComboBox>
+#include <QDesktopServices>
+#include <QDialogButtonBox>
+#include <QFile>
+#include <QFormLayout>
+#include <QHBoxLayout>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QLabel>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QSpacerItem>
+#include <QWidget>
+
+namespace {
+
+using namespace Qt::Literals;
+using namespace chatterino;
+
+const QString DICTIONARIES_BASE_URL = u"http://localhost:8080"_s;
+
+}  // namespace
+
+namespace chatterino {
+
+DownloadDictionaryDialog::DownloadDictionaryDialog(QWidget *parent)
+    : BasePopup(
+          {
+              BaseWindow::EnableCustomFrame,
+              BaseWindow::DisableLayoutSave,
+          },
+          parent)
+{
+    this->setWindowTitle("Download Dictionary — Chatterino");
+    this->setAttribute(Qt::WA_DeleteOnClose);
+
+    auto *layout = new QFormLayout(this->getLayoutContainer());
+    layout->setSpacing(5);
+
+    layout->addRow(new QLabel("Select a dictionary to download."));
+
+    this->ui.dictionaries = new QComboBox;
+    this->ui.dictionaries->setEnabled(false);
+    layout->addRow("Dictionary:", this->ui.dictionaries);
+
+    this->ui.status = new QLabel("Loading dictionaries…");
+    layout->addRow(this->ui.status);
+
+    auto *buttons = new QDialogButtonBox(QDialogButtonBox::Cancel);
+    QObject::connect(buttons, &QDialogButtonBox::rejected, this,
+                     &DownloadDictionaryDialog::close);
+
+    auto *showLicense = new QPushButton("Show License");
+    QObject::connect(showLicense, &QPushButton::clicked, this,
+                     &DownloadDictionaryDialog::showLicense);
+    layout->addRow(showLicense);
+
+    this->ui.downloadButton =
+        buttons->addButton("Download", QDialogButtonBox::AcceptRole);
+    this->ui.downloadButton->setEnabled(false);
+    QObject::connect(buttons, &QDialogButtonBox::accepted, this,
+                     &DownloadDictionaryDialog::doDownload);
+    // Add stretch
+    layout->addItem(new QSpacerItem(0, 10, QSizePolicy::Ignored,
+                                    QSizePolicy::MinimumExpanding));
+    layout->addRow(buttons);
+
+    NetworkRequest(QString(DICTIONARIES_BASE_URL % u"/index.json"))
+        .caller(this)
+        .onError([this](const NetworkResult &result) {
+            this->ui.status->setText("Failed to load dictionaries: " %
+                                     result.formatError());
+        })
+        .onSuccess([this](const NetworkResult &result) {
+            this->ui.downloadButton->setEnabled(true);
+            this->ui.status->hide();
+
+            QComboBox *dicts = this->ui.dictionaries;
+            dicts->setEnabled(true);
+
+            auto json = result.parseJsonArray();
+            for (const auto val : json)
+            {
+                auto parsed = RemoteDictionary::fromJson(val.toObject());
+                if (!parsed)
+                {
+                    continue;
+                }
+                this->dictionaries.emplace_back(*std::move(parsed));
+            }
+            std::ranges::sort(this->dictionaries,
+                              [](const auto &a, const auto &b) {
+                                  return a.prettyName < b.prettyName;
+                              });
+
+            for (const auto &item : this->dictionaries)
+            {
+                dicts->addItem(item.prettyName);
+            }
+        })
+        .execute();
+}
+
+void DownloadDictionaryDialog::doDownload()
+{
+    const auto *selected = this->selected();
+    if (!selected)
+    {
+        return;
+    }
+    auto rootDir = qStringToStdPath(getApp()->getPaths().dictionariesDirectory);
+    auto basePath = rootDir / qStringToStdPath(selected->bcp47);
+    auto dicPath = basePath;
+    auto affPath = basePath;
+    auto licPath = basePath;
+    dicPath += ".dic";
+    affPath += ".aff";
+    licPath += ".lic";
+
+    if (std::filesystem::exists(dicPath) || std::filesystem::exists(affPath) ||
+        std::filesystem::exists(licPath))
+    {
+        auto res = QMessageBox::warning(
+            this, "Dictionary Exists",
+            "The dictionary already exists. Do you want to overwrite it?",
+            QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
+        if (res != QMessageBox::Yes)
+        {
+            return;
+        }
+    }
+
+    struct Results {
+        QString errors;
+        size_t nDone = 0;
+    };
+    auto results = std::make_shared<Results>();
+    auto pushAndCheck = [this, results](const QString &err) {
+        if (!err.isEmpty())
+        {
+            if (!results->errors.isEmpty())
+            {
+                results->errors.append('\n');
+            }
+            results->errors.append(err);
+        }
+        ++results->nDone;
+
+        // We're the last, close the dialog
+        if (results->nDone == 3)
+        {
+            if (results->errors.isEmpty())
+            {
+                getApp()->getSpellChecker()->dictionariesUpdated.invoke();
+                this->close();
+            }
+            else
+            {
+                QMessageBox::warning(this, "Dictionary Download Failed",
+                                     results->errors);
+            }
+        }
+    };
+    auto saveTo = [&](const std::filesystem::path &path) {
+        return [pushAndCheck,
+                path = stdPathToQString(path)](const NetworkResult &res) {
+            QFile f(path);
+            if (!f.open(QFile::WriteOnly))
+            {
+                pushAndCheck("Failed to open " % path % ": " % f.errorString());
+                return;
+            }
+            f.write(res.getData());
+            pushAndCheck({});
+        };
+    };
+
+    NetworkRequest(QString(DICTIONARIES_BASE_URL % '/' % selected->dic))
+        .caller(this)
+        .onError([pushAndCheck](const NetworkResult &res) {
+            pushAndCheck("Failed to download *.dic file: " % res.formatError());
+        })
+        .onSuccess(saveTo(dicPath))
+        .execute();
+
+    NetworkRequest(QString(DICTIONARIES_BASE_URL % '/' % selected->aff))
+        .caller(this)
+        .onError([pushAndCheck](const NetworkResult &res) {
+            pushAndCheck("Failed to download *.aff file: " % res.formatError());
+        })
+        .onSuccess(saveTo(affPath))
+        .execute();
+
+    if (selected->licence.isEmpty())
+    {
+        // Already done with the license.
+        pushAndCheck({});
+    }
+    else
+    {
+        NetworkRequest(QString(DICTIONARIES_BASE_URL % '/' % selected->licence))
+            .caller(this)
+            .onError([pushAndCheck](const NetworkResult &res) {
+                pushAndCheck("Failed to download *.lic file: " %
+                             res.formatError());
+            })
+            .onSuccess(saveTo(licPath))
+            .execute();
+    }
+}
+
+void DownloadDictionaryDialog::showLicense()
+{
+    const auto *selected = this->selected();
+    if (selected)
+    {
+        selected->showLicense(this);
+    }
+}
+
+const DownloadDictionaryDialog::RemoteDictionary *
+    DownloadDictionaryDialog::selected() const
+{
+    auto idx = this->ui.dictionaries->currentIndex();
+    if (idx < 0 || idx >= static_cast<int>(this->dictionaries.size()))
+    {
+        return nullptr;
+    }
+    return &this->dictionaries[static_cast<size_t>(idx)];
+}
+
+std::optional<DownloadDictionaryDialog::RemoteDictionary>
+    DownloadDictionaryDialog::RemoteDictionary::fromJson(const QJsonObject &obj)
+{
+    std::optional<RemoteDictionary> ret{{
+        .prettyName = {},
+        .bcp47 = obj["bcp47"_L1].toString(),
+        .spdxLicenseID = obj["spdx_license_id"_L1].toString(),
+        .dic = obj["dic"_L1].toString(),
+        .aff = obj["aff"_L1].toString(),
+        .licence = obj["license"_L1].toString(),
+    }};
+    if (ret->bcp47.isEmpty() || ret->spdxLicenseID.isEmpty() ||
+        ret->dic.isEmpty() || ret->aff.isEmpty())
+    {
+        ret.reset();
+    }
+    else
+    {
+        ret->prettyName = spellcheck::prettyLossyBcp47Description(ret->bcp47);
+    }
+    return ret;
+}
+
+void DownloadDictionaryDialog::RemoteDictionary::showLicense(
+    QWidget *parent) const
+{
+    if (!this->licence.isEmpty())
+    {
+        QDesktopServices::openUrl(
+            QString(DICTIONARIES_BASE_URL % '/' % this->licence));
+        return;
+    }
+    QMessageBox::information(parent, "License",
+                             "This dictionary is licensed under " %
+                                 this->spdxLicenseID %
+                                 ". There is no full license text available.");
+}
+
+}  // namespace chatterino

--- a/src/widgets/dialogs/DownloadDictionaryDialog.cpp
+++ b/src/widgets/dialogs/DownloadDictionaryDialog.cpp
@@ -92,7 +92,7 @@ DownloadDictionaryDialog::DownloadDictionaryDialog(QWidget *parent)
             QComboBox *dicts = this->ui.dictionaries;
             dicts->setEnabled(true);
 
-            auto json = result.parseJsonArray();
+            const auto json = result.parseJsonArray();
             for (const auto val : json)
             {
                 auto parsed = RemoteDictionary::fromJson(val.toObject());

--- a/src/widgets/dialogs/DownloadDictionaryDialog.hpp
+++ b/src/widgets/dialogs/DownloadDictionaryDialog.hpp
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2026 Contributors to Chatterino <https://chatterino.com>
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "widgets/BasePopup.hpp"
+
+#include <QString>
+#include <QVBoxLayout>
+
+#include <optional>
+
+class QComboBox;
+class QJsonObject;
+class QLabel;
+class QPushButton;
+
+namespace chatterino {
+
+class DownloadDictionaryDialog : public BasePopup
+{
+public:
+    DownloadDictionaryDialog(QWidget *parent = nullptr);
+
+private:
+    struct RemoteDictionary {
+        QString prettyName;
+        QString bcp47;
+        QString spdxLicenseID;
+        QString dic;
+        QString aff;
+        QString licence;
+
+        static std::optional<RemoteDictionary> fromJson(const QJsonObject &obj);
+        void showLicense(QWidget *parent) const;
+    };
+
+    void doDownload();
+    void showLicense();
+
+    const RemoteDictionary *selected() const;
+
+    struct {
+        QComboBox *dictionaries = nullptr;
+        QLabel *status = nullptr;
+        QPushButton *downloadButton = nullptr;
+    } ui;
+    std::vector<RemoteDictionary> dictionaries;
+};
+
+}  // namespace chatterino

--- a/src/widgets/settingspages/ExternalToolsPage.cpp
+++ b/src/widgets/settingspages/ExternalToolsPage.cpp
@@ -11,6 +11,7 @@
 #include "util/Helpers.hpp"
 #include "util/ImageUploader.hpp"
 #include "util/StreamLink.hpp"
+#include "widgets/dialogs/DownloadDictionaryDialog.hpp"
 #include "widgets/settingspages/SettingWidget.hpp"
 
 #include <QFormLayout>
@@ -281,12 +282,39 @@ void ExternalToolsPage::initLayout(GeneralPageView &layout)
             getApp()->getSpellChecker()->getAvailableDictionaries(),
             std::back_inserter(dictList), toItem);
 
-        if (dictList.size() > 1)
-        {
+        auto *defaultDict =
             SettingWidget::dropdown("Default dictionary (requires restart)",
-                                    s.spellCheckingDefaultDictionary, dictList)
-                ->addTo(layout);
-        }
+                                    s.spellCheckingDefaultDictionary, dictList);
+        defaultDict->addTo(layout);
+
+        this->managedConnections_.managedConnect(
+            getApp()->getSpellChecker()->dictionariesUpdated, [defaultDict] {
+                auto *cb =
+                    qobject_cast<QComboBox *>(defaultDict->actionWidget());
+                if (!cb)
+                {
+                    return;
+                }
+                QString prevDict =
+                    getSettings()->spellCheckingDefaultDictionary;
+                cb->clear();
+                cb->addItem("None", "");
+                for (const DictionaryInfo &dict :
+                     getApp()->getSpellChecker()->getAvailableDictionaries())
+                {
+                    cb->addItem(dict.name, dict.path);
+                }
+                // Restore previous path. This might no longer be valid.
+                getSettings()->spellCheckingDefaultDictionary = prevDict;
+            });
+        auto *buttons = new QHBoxLayout;
+        auto *download = new QPushButton("Download Dictionary");
+        QObject::connect(download, &QPushButton::clicked, this, [this] {
+            (new DownloadDictionaryDialog(this))->show();
+        });
+        buttons->addWidget(download);
+        buttons->addStretch();
+        layout.addLayout(buttons);
     }
 #endif
 

--- a/src/widgets/settingspages/SettingWidget.cpp
+++ b/src/widgets/settingspages/SettingWidget.cpp
@@ -76,7 +76,7 @@ SettingWidget *SettingWidget::checkbox(const QString &label,
                          setting = state;
                      });
 
-    widget->actionWidget = check;
+    widget->actionWidget_ = check;
     widget->label = check;
 
     return widget;
@@ -106,7 +106,7 @@ SettingWidget *SettingWidget::inverseCheckbox(const QString &label,
                          setting = !state;
                      });
 
-    widget->actionWidget = check;
+    widget->actionWidget_ = check;
     widget->label = check;
 
     return widget;
@@ -128,7 +128,7 @@ SettingWidget *SettingWidget::customCheckbox(
 
     QObject::connect(check, &QCheckBox::toggled, widget, save);
 
-    widget->actionWidget = check;
+    widget->actionWidget_ = check;
     widget->label = check;
 
     return widget;
@@ -178,7 +178,7 @@ SettingWidget *SettingWidget::intInput(const QString &label,
                          setting = newValue;
                      });
 
-    widget->actionWidget = input;
+    widget->actionWidget_ = input;
     widget->label = lbl;
 
     return widget;
@@ -203,7 +203,7 @@ SettingWidget *SettingWidget::dropdown(const QString &label,
     // TODO: this can probably use some other size hint/size strategy
     combo->setMinimumWidth(combo->minimumSizeHint().width() + 30);
 
-    widget->actionWidget = combo;
+    widget->actionWidget_ = combo;
     widget->label = lbl;
 
     widget->hLayout->addWidget(lbl);
@@ -277,7 +277,7 @@ SettingWidget *SettingWidget::dropdown(const QString &label,
     // TODO: this can probably use some other size hint/size strategy
     combo->setMinimumWidth(combo->minimumSizeHint().width() + 30);
 
-    widget->actionWidget = combo;
+    widget->actionWidget_ = combo;
     widget->label = lbl;
 
     widget->hLayout->addWidget(lbl);
@@ -356,7 +356,7 @@ SettingWidget *SettingWidget::dropdown(
     // TODO: this can probably use some other size hint/size strategy
     combo->setMinimumWidth(combo->minimumSizeHint().width() + 30);
 
-    widget->actionWidget = combo;
+    widget->actionWidget_ = combo;
     widget->label = lbl;
 
     widget->hLayout->addWidget(lbl);
@@ -439,7 +439,7 @@ SettingWidget *SettingWidget::colorButton(const QString &label,
         dialog->show();
     });
 
-    widget->actionWidget = colorButton;
+    widget->actionWidget_ = colorButton;
     widget->label = lbl;
 
     return widget;
@@ -482,7 +482,7 @@ SettingWidget *SettingWidget::lineEdit(const QString &label,
         },
         widget->managedConnections, false);
 
-    widget->actionWidget = edit;
+    widget->actionWidget_ = edit;
     widget->label = lbl;
 
     return widget;
@@ -522,7 +522,7 @@ SettingWidget *SettingWidget::fontButton(const QString &label,
                          }
                      });
 
-    widget->actionWidget = button;
+    widget->actionWidget_ = button;
     widget->label = lbl;
 
     return widget;
@@ -547,10 +547,10 @@ SettingWidget *SettingWidget::setTooltip(QString tooltip)
         sz = this->label->sizeHint().height();
     }
 
-    if (this->actionWidget != nullptr)
+    if (this->actionWidget_ != nullptr)
     {
-        this->actionWidget->setToolTip(tooltip);
-        sz = std::max(sz, this->actionWidget->sizeHint().height());
+        this->actionWidget_->setToolTip(tooltip);
+        sz = std::max(sz, this->actionWidget_->sizeHint().height());
     }
 
     this->tooltipIcon->setVisible(true);
@@ -594,7 +594,7 @@ SettingWidget *SettingWidget::conditionallyEnabledBy(BoolSetting &setting)
 {
     setting.connect(
         [this](const auto &value, const auto &) {
-            this->actionWidget->setEnabled(value);
+            this->actionWidget_->setEnabled(value);
         },
         this->managedConnections);
 
@@ -606,7 +606,7 @@ SettingWidget *SettingWidget::conditionallyEnabledBy(
 {
     setting.connect(
         [this, expectedValue](const auto &value, const auto &) {
-            this->actionWidget->setEnabled(value == expectedValue);
+            this->actionWidget_->setEnabled(value == expectedValue);
         },
         this->managedConnections);
 
@@ -624,14 +624,14 @@ void SettingWidget::addTo(GeneralPageView &view, QFormLayout *formLayout)
 {
     this->registerWidget(view);
 
-    formLayout->addRow(this->label, this->actionWidget);
+    formLayout->addRow(this->label, this->actionWidget_);
 }
 
 void SettingWidget::addToLayout(QLayout *layout)
 {
-    if (this->label == this->actionWidget)
+    if (this->label == this->actionWidget_)
     {
-        layout->addWidget(this->actionWidget);
+        layout->addWidget(this->actionWidget_);
         return;
     }
 
@@ -644,7 +644,7 @@ void SettingWidget::registerWidget(GeneralPageView &view)
     {
         view.registerWidget(this->label, this->keywords, this);
     }
-    view.registerWidget(this->actionWidget, this->keywords, this);
+    view.registerWidget(this->actionWidget_, this->keywords, this);
 }
 
 }  // namespace chatterino

--- a/src/widgets/settingspages/SettingWidget.hpp
+++ b/src/widgets/settingspages/SettingWidget.hpp
@@ -130,12 +130,17 @@ public:
     /// For settings pages without a page view
     void addToLayout(QLayout *layout);
 
+    QWidget *actionWidget()
+    {
+        return this->actionWidget_;
+    }
+
 private:
     /// Registers this widget & its optional label to the given page view
     void registerWidget(GeneralPageView &view);
 
     QWidget *label = nullptr;
-    QWidget *actionWidget = nullptr;
+    QWidget *actionWidget_ = nullptr;
     QSvgWidget *tooltipIcon;
 
     QVBoxLayout *vLayout;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -62,6 +62,7 @@ set(test_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/src/FunctionRef.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/InputHighlighter.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/BalancedResolverResults.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/SpellChecker.cpp
 
     ${CMAKE_CURRENT_LIST_DIR}/src/lib/Snapshot.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/lib/Snapshot.hpp

--- a/tests/src/SpellChecker.cpp
+++ b/tests/src/SpellChecker.cpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 Contributors to Chatterino <https://chatterino.com>
+//
+// SPDX-License-Identifier: MIT
+
+#include "controllers/spellcheck/SpellChecker.hpp"
+
+#include "Test.hpp"
+
+using namespace chatterino;
+using namespace chatterino::spellcheck;
+using namespace Qt::Literals;
+
+TEST(SpellChecker, prettyLossyBcp47Description)
+{
+    std::vector<std::pair<QString, QStringView>> cases{
+        {u""_s, u""},
+        {u"index"_s, u"index"},
+        {u"AF"_s, u"AF"},
+        {u"af"_s, u"Afrikaans"},
+        {u"ekk"_s, u"ekk"},
+        {u"el-polyton"_s, u"Greek (polyton)"},
+        {u"en-Latn-GB"_s, u"English (Latin, United Kingdom)"},
+        {
+            u"en-Latn-GB-variant"_s,
+            u"English (Latin, United Kingdom, variant)",
+        },
+        {u"pt"_s, u"Portuguese"},
+        {u"pt-PT"_s, u"Portuguese (Portugal)"},
+        {u"sr"_s, u"Serbian"},
+        {u"sr-Latn"_s, u"Serbian (Latin)"},
+        {u"sv-FI"_s, u"Swedish (Finland)"},
+        {u"tlh"_s, u"tlh"},
+        {u"tlh-Latn"_s, u"tlh-Latn"},
+        {u"tr"_s, u"Turkish"},
+    };
+
+    for (const auto &[bcp47, desc] : cases)
+    {
+        ASSERT_EQ(prettyLossyBcp47Description(bcp47), desc);
+    }
+}


### PR DESCRIPTION
One issue with the spell checker is that most users have to manually add dictionaries. To help users, this adds a downloader. We only need to host the static files somewhere (e.g. chatterino.com or wiki.chatterino.com).

The dictionaries are stored on some server (currently localhost). The following script collects all dictionaries from https://github.com/wooorm/dictionaries (cloned in a subfolder `dictionaries`):

<details><summary>generate.py</summary>

```py
# Generate and run file server: python generate.py --serve
import os
import shutil
import argparse
from dataclasses import dataclass
from pathlib import Path
import json


@dataclass
class Config:
    out_dir: Path
    dict_dir: Path
    serve: bool
    port: int


@dataclass
class LanguageDictionary:
    bcp47_name: str
    spdx_license_id: str
    license: Path | None
    dictionary: Path
    affixes: Path

    def dist_license(self) -> str:
        return f"{self.bcp47_name}.txt"

    def dist_dictionary(self) -> str:
        return f"{self.bcp47_name}.dic"

    def dist_affixes(self) -> str:
        return f"{self.bcp47_name}.aff"

    def to_json(self) -> dict[str, str]:
        base = {
            "bcp47": self.bcp47_name,
            "spdx_license_id": self.spdx_license_id,
            "dic": self.dist_dictionary(),
            "aff": self.dist_affixes(),
        }
        if self.license:
            base["license"] = self.dist_license()
        return base

    def export_to(self, dir: Path):
        if self.license is not None:
            shutil.copyfile(self.license, dir / self.dist_license())
        shutil.copyfile(self.dictionary, dir / self.dist_dictionary())
        shutil.copyfile(self.affixes, dir / self.dist_affixes())


def dictionary_from_dir(dir: Path, bcp47: str) -> LanguageDictionary:
    npm_package = dir / "package.json"
    aff = dir / "index.aff"
    dic = dir / "index.dic"
    license = dir / "license"
    if not npm_package.exists():
        raise ValueError(f"{npm_package} does not exist")
    if not aff.exists():
        raise ValueError(f"{aff} does not exist")
    if not dic.exists():
        raise ValueError(f"{dic} does not exist")
    if not license.exists():
        license = None

    package = json.loads(npm_package.read_text())
    spdx_license_id = package.get("license")
    if not spdx_license_id:
        raise ValueError(f"{npm_package} does not contain a 'license' field")
    return LanguageDictionary(
        bcp47_name=bcp47,
        spdx_license_id=spdx_license_id,
        license=license,
        dictionary=dic,
        affixes=aff,
    )


def main(config: Config):
    print(f"Output: {config.out_dir}")
    print(f"Source: {config.dict_dir}")

    print("Clearing output")
    shutil.rmtree(config.out_dir, ignore_errors=True)

    print("Enumerating dictionaries")
    dicts: list[LanguageDictionary] = []
    for bcp47 in os.listdir(config.dict_dir):
        print(f"  Found {bcp47}")
        try:
            dicts.append(dictionary_from_dir(config.dict_dir / bcp47, bcp47))
        except ValueError as e:
            print(f"{bcp47}: {e}")
            exit(1)

    print("Exporting")
    config.out_dir.mkdir()
    for dict in dicts:
        dict.export_to(config.out_dir)
    print("Creating index.json")
    with open(config.out_dir / "index.json", "w") as f:
        json.dump(list(map(lambda it: it.to_json(), dicts)), f)
    print("Done.")

    if config.serve:
        import http.server
        import socketserver
        import functools

        Handler = functools.partial(
            http.server.SimpleHTTPRequestHandler, directory=config.out_dir
        )
        with socketserver.TCPServer(("localhost", config.port), Handler) as httpd:
            print(f"Serving on http://localhost:{config.port}")
            httpd.serve_forever()


if __name__ == "__main__":
    parser = argparse.ArgumentParser()
    parser.add_argument("-o", "--out", type=Path, default="dist")
    parser.add_argument(
        "--dictionaries", type=Path, default="dictionaries/dictionaries"
    )
    parser.add_argument("--serve", action="store_true")
    parser.add_argument("--port", type=int, default=8080)
    args = parser.parse_args()
    config = Config(
        out_dir=args.out, dict_dir=args.dictionaries, serve=args.serve, port=args.port
    )
    main(config)
```
</details> 

Chatterino reads the `index.json` file to get a list of available dictionaries. After a dictionary is downloaded, the user can select the new one as the default.
Licenses, if available, are also downloaded.

The discovery of dictionaries is similar to how I'd imagine public plugins are discovered. This way, plugin repositories could build on GitHub Pages or similar.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
