### PR TITLE
chore: remove references to temporaries in for loops

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1376,6 +1376,13 @@ else ()
     endif()
 endif ()
 
+# Extra Clang warnings
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    target_compile_options(${LIBRARY_PROJECT} PUBLIC
+        -Wrange-loop-analysis
+    )
+endif()
+
 if(CHATTERINO_ENABLE_LTO)
     message(STATUS "Enabling LTO for ${LIBRARY_PROJECT}")
     set_property(TARGET ${LIBRARY_PROJECT}

--- a/src/common/WindowDescriptors.cpp
+++ b/src/common/WindowDescriptors.cpp
@@ -88,7 +88,7 @@ const QList<QUuid> loadFilters(QJsonValue val)
     {
         const auto array = val.toArray();
         filterIds.reserve(array.size());
-        for (const auto &id : array)
+        for (const auto id : array)
         {
             filterIds.append(QUuid::fromString(id.toString()));
         }
@@ -166,7 +166,7 @@ WindowLayout WindowLayout::loadFromFile(const QString &path)
     bool hasSetAMainWindow = false;
 
     // "deserialize"
-    for (const QJsonValue &windowVal : loadWindowArray(path))
+    for (const auto windowVal : loadWindowArray(path))
     {
         QJsonObject windowObj = windowVal.toObject();
 

--- a/src/controllers/plugins/Plugin.cpp
+++ b/src/controllers/plugins/Plugin.cpp
@@ -140,7 +140,7 @@ void Plugin::log(lua_State *L, lua::api::LogLevel level, QDebug stream,
     stream.noquote();
     stream << "[" + this->id + ":" + this->meta.name + "]";
     QString fullMessage;
-    for (const auto &arg : args)
+    for (const auto arg : args)
     {
         auto s = lua::toString(L, arg.stack_index());
         stream << s;

--- a/src/providers/ffz/FfzEmotes.cpp
+++ b/src/providers/ffz/FfzEmotes.cpp
@@ -189,7 +189,7 @@ FfzChannelBadgeMap ffz::detail::parseChannelBadges(const QJsonObject &badgeRoot)
     {
         const auto badgeID = it.key().toInt();
         const auto &jsonUserIDs = it.value().toArray();
-        for (const auto &jsonUserID : jsonUserIDs)
+        for (const auto jsonUserID : jsonUserIDs)
         {
             // NOTE: The Twitch User IDs come through as ints right now, the code below
             // tries to parse them as strings first since that's how we treat them anyway.

--- a/src/providers/recentmessages/Impl.cpp
+++ b/src/providers/recentmessages/Impl.cpp
@@ -28,7 +28,7 @@ std::vector<Communi::IrcMessage *> parseRecentMessages(
         return messages;
     }
 
-    for (const auto &jsonMessage : jsonMessages)
+    for (const auto jsonMessage : jsonMessages)
     {
         auto content = unescapeZeroWidthJoiner(jsonMessage.toString());
 

--- a/src/providers/seventv/SeventvEmotes.cpp
+++ b/src/providers/seventv/SeventvEmotes.cpp
@@ -164,7 +164,7 @@ EmoteMap seventv::detail::parseEmotes(const QJsonArray &emoteSetEmotes,
 {
     auto emotes = EmoteMap();
 
-    for (const auto &activeEmoteJson : emoteSetEmotes)
+    for (const auto activeEmoteJson : emoteSetEmotes)
     {
         auto activeEmote = activeEmoteJson.toObject();
         auto emoteData = activeEmote["data"].toObject();

--- a/src/providers/seventv/eventapi/Dispatch.cpp
+++ b/src/providers/seventv/eventapi/Dispatch.cpp
@@ -120,7 +120,7 @@ EntitlementCreateDeleteDispatch::EntitlementCreateDeleteDispatch(
                      .value_or(CosmeticKind::INVALID);
 
     const auto userConnections = obj["user"]["connections"].toArray();
-    for (const auto &connectionJson : userConnections)
+    for (const auto connectionJson : userConnections)
     {
         const auto connection = connectionJson.toObject();
         if (connection["platform"].toString() == "TWITCH")

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -39,7 +39,7 @@ HelixChatters::HelixChatters(const QJsonObject &jsonObject)
           jsonObject.value("pagination").toObject().value("cursor").toString())
 {
     const auto &data = jsonObject.value("data").toArray();
-    for (const auto &chatter : data)
+    for (const auto chatter : data)
     {
         auto userLogin = chatter.toObject().value("user_login").toString();
         this->chatters.insert(userLogin);
@@ -598,7 +598,7 @@ void Helix::loadBlocks(QString userId,
             std::vector<HelixBlock> ignores;
             ignores.reserve(data.count());
 
-            for (const auto &ignore : data)
+            for (const auto ignore : data)
             {
                 ignores.emplace_back(ignore.toObject());
             }
@@ -901,7 +901,7 @@ void Helix::getChannelEmotes(
 
             std::vector<HelixChannelEmote> channelEmotes;
 
-            for (const auto &jsonStream : data.toArray())
+            for (const auto jsonStream : data.toArray())
             {
                 channelEmotes.emplace_back(jsonStream.toObject());
             }
@@ -3227,7 +3227,7 @@ void Helix::getUserEmotes(
             std::vector<HelixChannelEmote> emotes;
             emotes.reserve(data.count());
 
-            for (const auto &emote : data)
+            for (const auto emote : data)
             {
                 emotes.emplace_back(emote.toObject());
             }

--- a/src/providers/twitch/api/Helix.hpp
+++ b/src/providers/twitch/api/Helix.hpp
@@ -110,7 +110,7 @@ struct HelixStream {
         , thumbnailUrl(jsonObject.value("thumbnail_url").toString())
     {
         const auto jsonTags = jsonObject.value("tags").toArray();
-        for (const auto &tag : jsonTags)
+        for (const auto tag : jsonTags)
         {
             this->tags.push_back(tag.toString());
         }
@@ -251,7 +251,7 @@ struct HelixCheermoteSet {
         : prefix(jsonObject.value("prefix").toString())
         , type(jsonObject.value("type").toString())
     {
-        for (const auto &tier : jsonObject.value("tiers").toArray())
+        for (const auto tier : jsonObject.value("tiers").toArray())
         {
             this->tiers.emplace_back(tier.toObject());
         }
@@ -359,7 +359,7 @@ struct HelixModerators {
                      .toString())
     {
         const auto &data = jsonObject.value("data").toArray();
-        for (const auto &mod : data)
+        for (const auto mod : data)
         {
             HelixModerator moderator(mod.toObject());
 
@@ -395,7 +395,7 @@ struct HelixBadgeSet {
         : setID(json.value("set_id").toString())
     {
         const auto jsonVersions = json.value("versions").toArray();
-        for (const auto &version : jsonVersions)
+        for (const auto version : jsonVersions)
         {
             this->versions.emplace_back(version.toObject());
         }
@@ -408,7 +408,7 @@ struct HelixGlobalBadges {
     explicit HelixGlobalBadges(const QJsonObject &jsonObject)
     {
         const auto &data = jsonObject.value("data").toArray();
-        for (const auto &set : data)
+        for (const auto set : data)
         {
             this->badgeSets.emplace_back(set.toObject());
         }
@@ -494,7 +494,7 @@ struct HelixPoll {
     {
         const auto &data = jsonObject.value("choices").toArray();
         this->choices.reserve(data.size());
-        for (const auto &c : data)
+        for (const auto c : data)
         {
             HelixPollChoice choice(c.toObject());
             this->choices.push_back(choice);
@@ -511,7 +511,7 @@ struct HelixPolls {
     {
         const auto &data = jsonObject.value("data").toArray();
         this->polls.reserve(data.size());
-        for (const auto &p : data)
+        for (const auto p : data)
         {
             HelixPoll poll(p.toObject());
             this->polls.push_back(poll);
@@ -549,7 +549,7 @@ struct HelixPrediction {
     {
         const auto &data = jsonObject.value("outcomes").toArray();
         this->outcomes.reserve(data.size());
-        for (const auto &o : data)
+        for (const auto o : data)
         {
             HelixPredictionOutcome outcome(o.toObject());
             this->outcomes.push_back(outcome);
@@ -566,7 +566,7 @@ struct HelixPredictions {
     {
         const auto &data = jsonObject.value("data").toArray();
         this->predictions.reserve(data.size());
-        for (const auto &p : data)
+        for (const auto p : data)
         {
             HelixPrediction prediction(p.toObject());
             this->predictions.push_back(prediction);

--- a/src/singletons/NativeMessaging.cpp
+++ b/src/singletons/NativeMessaging.cpp
@@ -413,7 +413,7 @@ void NativeMessagingServer::syncChannels(const QJsonArray &twitchChannels)
 
     std::vector<ChannelPtr> updated;
     updated.reserve(twitchChannels.size());
-    for (const auto &value : twitchChannels)
+    for (const auto value : twitchChannels)
     {
         auto name = value.toString();
         if (name.isEmpty())

--- a/tests/src/Filters.cpp
+++ b/tests/src/Filters.cpp
@@ -339,7 +339,7 @@ TEST(Filters, Evaluation)
 
 TEST(Filters, Identifier)
 {
-    for (const auto &[identifier, _] : VALID_IDENTIFIERS_MAP.asKeyValueRange())
+    for (const auto [identifier, _] : VALID_IDENTIFIERS_MAP.asKeyValueRange())
     {
         auto expr = createIdentifierExpression(identifier);
         ASSERT_TRUE(isWellTyped(expr->synthesizeType()))


### PR DESCRIPTION
Clang's [`-Wrange-loop-analysis`](https://clang.llvm.org/docs/DiagnosticsReference.html#id890) is useful to detect references in range for-loops. We have this quite a lot when iterating over a `QJsonObject` or `QJsonArray`. They yield `QJsonValue(Const)Ref`s. These are already a reference. 

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
