### PR TITLE
fix: don't mark announcements as subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+- Bugfix: Fixed Twitch announcements appearing in search results when searching for subscriptions (`is:sub`/`is:subscription`). (#6925)
+
 ## 2.5.5
 
 - Minor: Update emoji data to Unicode 17.0. (#6471)

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -914,7 +914,7 @@ void IrcMessageHandler::parseUserNoticeMessageInto(Communi::IrcMessage *message,
         {
             msg->flags.set(MessageFlag::WatchStreak);
         }
-        else
+        else if (msgType != "announcement")
         {
             msg->flags.set(MessageFlag::Subscription);
         }
@@ -1235,15 +1235,16 @@ void IrcMessageHandler::addMessage(Communi::IrcMessage *message,
             {
                 msg->flags.set(MessageFlag::WatchStreak);
             }
-            else
+            else if (msgType != "announcement")
             {
                 msg->flags.set(MessageFlag::Subscription);
             }
 
-            if (tags.value("msg-id") != "announcement")
+            if (msgType != "announcement")
             {
-                // Announcements are currently tagged as subscriptions,
-                // but we want them to be able to show up in mentions
+                // Subscription events shouldn't trigger mention-style
+                // highlights. Announcements aren't subscriptions, so
+                // they keep their highlight.
                 msg->flags.unset(MessageFlag::Highlighted);
             }
         }

--- a/tests/snapshots/IrcMessageHandler/announcement.json
+++ b/tests/snapshots/IrcMessageHandler/announcement.json
@@ -132,7 +132,7 @@
             ],
             "externalBadges": [
             ],
-            "flags": "Highlighted|Collapsed|Subscription",
+            "flags": "Highlighted|Collapsed",
             "frozen": false,
             "highlightColor": "#64c466ff",
             "id": "8c26e1ab-b50c-4d9d-bc11-3fd57a941d90",
@@ -203,7 +203,7 @@
             ],
             "externalBadges": [
             ],
-            "flags": "System|DoNotTriggerNotification|Subscription",
+            "flags": "System|DoNotTriggerNotification",
             "frozen": false,
             "id": "",
             "localizedName": "",

--- a/tests/snapshots/IrcMessageHandler/shared-chat-announcement.json
+++ b/tests/snapshots/IrcMessageHandler/shared-chat-announcement.json
@@ -188,7 +188,7 @@
             ],
             "externalBadges": [
             ],
-            "flags": "Collapsed|Subscription|SharedMessage",
+            "flags": "Highlighted|Collapsed|SharedMessage",
             "frozen": false,
             "highlightColor": "#64c466ff",
             "id": "01cd601f-bc3f-49d5-ab4b-136fa9d6ec22",
@@ -257,7 +257,7 @@
             ],
             "externalBadges": [
             ],
-            "flags": "System|DoNotTriggerNotification|Subscription|SharedMessage",
+            "flags": "System|DoNotTriggerNotification|SharedMessage",
             "frozen": false,
             "id": "",
             "localizedName": "",


### PR DESCRIPTION
## Summary

Announcements sent via Twitch's `/announce` command arrive over IRC as `USERNOTICE` messages, which share the same code path as subscription events (`sub`, `resub`, `subgift`, etc.). As a result, the code was setting `MessageFlag::Subscription` on announcement messages, causing them to appear in search results for `is:sub` / `is:subscription`.

This PR makes two small changes in `IrcMessageHandler`:

1. **Skip setting `MessageFlag::Subscription` when the message type is `announcement`** in both the system-message and user-content paths of `parseUserNoticeMessageInto` / `addMessage`.

2. **Switch the existing announcement check to use the resolved `msgType` parameter** instead of the raw `tags.value("msg-id")` tag. For shared-chat announcements, `msg-id` is `"sharedchatnotice"` and the real type lives in `source-msg-id`, which is already resolved into `msgType` earlier in the pipeline. This fixes a secondary issue where shared-chat announcements were losing their `Highlighted` flag.

Fixes #4163.

## Steps to reproduce (before this PR)

1. In a channel, have a mod/broadcaster run `/announce <text>`
2. Open search (Ctrl+F) and search `is:sub`
3. The announcement incorrectly appears in the results

After this PR, announcements no longer match `is:sub` / `is:subscription`, but still appear under `is:highlighted` as expected.

## Verification

- `announcement.json` and `shared-chat-announcement.json` snapshots were regenerated via `UPDATE_SNAPSHOTS = true` and verified; the `Subscription` flag is removed, and the shared-chat snapshot's `Highlighted` flag is now correctly preserved.
- All 101 `IrcMessageHandler` snapshot tests pass locally.
- Verified all 6 consumers of `MessageFlag::Subscription` (highlight color, reply-ability, layout, search predicate, tab mentions, user info popup) — none require the flag on announcements.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->