### PR TITLE
tests: fix NativeMessaging linux env reading

### DIFF
--- a/tests/src/NativeMessaging.cpp
+++ b/tests/src/NativeMessaging.cpp
@@ -9,6 +9,7 @@
 
 #include <QDir>
 #include <QJsonDocument>
+#include <QStandardPaths>
 #include <QTemporaryDir>
 
 using namespace chatterino;
@@ -79,13 +80,17 @@ TEST(NativeMessaging, parseCustomPath)
     ASSERT_EQ(parseCustomPath("relative/path/to/manifest.json"), std::nullopt);
 
 #    ifdef Q_OS_LINUX
-    ASSERT_EQ(
-        parseCustomPath("$XDG_CONFIG_HOME/path/to/manifest.json"),
-        std::optional{QDir::homePath() % "/.config/path/to/manifest.json"});
+    ASSERT_EQ(parseCustomPath("$XDG_CONFIG_HOME/path/to/manifest.json"),
+              std::optional{QStandardPaths::standardLocations(
+                                QStandardPaths::GenericConfigLocation)
+                                .first() %
+                            "/path/to/manifest.json"});
 
     ASSERT_EQ(parseCustomPath("$XDG_DATA_HOME/path/to/manifest.json"),
-              std::optional{QDir::homePath() %
-                            "/.local/share/path/to/manifest.json"});
+              std::optional{QStandardPaths::standardLocations(
+                                QStandardPaths::GenericDataLocation)
+                                .first() %
+                            "/path/to/manifest.json"});
 #    endif
 }
 #endif


### PR DESCRIPTION
instead of rawreading homePath, we use QStandardPaths as the "expected" value

<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
