### PR TITLE
feat(plugins): Add bindings for emotes

### DIFF
--- a/docs/chatterino.d.ts
+++ b/docs/chatterino.d.ts
@@ -274,9 +274,15 @@ declare namespace c2 {
         | TwitchModerationElementInit
         | LinebreakElementInit
         | ReplyCurveElementInit
+        | EmoteElementInit
+        | LayeredEmoteElementInit
         | ImageElementInit
         | CircularImageElementInit
-        | ScalingImageElementInit;
+        | ScalingImageElementInit
+        | BadgeElementInit
+        | ModBadgeElementInit
+        | VipBadgeElementInit
+        | FfzBadgeElementInit;
 
     interface TextElement extends MessageElementBase {
         type: "text";
@@ -367,10 +373,28 @@ declare namespace c2 {
 
     interface EmoteElement extends MessageElementBase {
         type: "emote";
+        emote: Emote;
+        text_element_color: MessageColor;
+    }
+
+    interface EmoteElementInit extends MessageElementInitBase {
+        type: "emote";
+        emote: Emote;
+        text_element_color?: MessageColor;
+        flags: MessageElementFlag;
     }
 
     interface LayeredEmoteElement extends MessageElementBase {
         type: "layered-emote";
+        emotes: { emote: Emote; flags: MessageElementFlag }[];
+        text_element_color: MessageColor;
+    }
+
+    interface LayeredEmoteElementInit extends MessageElementInitBase {
+        type: "layered-emote";
+        emotes: { emote: Emote; flags: MessageElementFlag }[];
+        text_element_color?: MessageColor;
+        flags: MessageElementFlag;
     }
 
     interface ImageElement extends MessageElementBase {
@@ -412,18 +436,45 @@ declare namespace c2 {
 
     interface BadgeElement extends MessageElementBase {
         type: "badge";
+        emote: Emote;
+    }
+
+    interface BadgeElementInit extends MessageElementInitBase {
+        type: "badge";
+        emote: Emote;
+        flags: MessageElementFlag;
     }
 
     interface ModBadgeElement extends Omit<BadgeElement, "type"> {
         type: "mod-badge";
     }
 
+    interface ModBadgeElementInit extends MessageElementInitBase {
+        type: "mod-badge";
+        emote: Emote;
+        flags: MessageElementFlag;
+    }
+
     interface VipBadgeElement extends Omit<BadgeElement, "type"> {
-        type: "ffz-badge";
+        type: "vip-badge";
+    }
+
+    interface VipBadgeElementInit extends MessageElementInitBase {
+        type: "vip-badge";
+        emote: Emote;
+        flags: MessageElementFlag;
     }
 
     interface FfzBadgeElement extends Omit<BadgeElement, "type"> {
         type: "ffz-badge";
+        color: string;
+    }
+
+    interface FfzBadgeElementInit extends MessageElementInitBase {
+        type: "ffz-badge";
+        emote: Emote;
+        flags: MessageElementFlag;
+        color: string;
     }
 
     interface Link {
@@ -606,6 +657,34 @@ declare namespace c2 {
         ) => ImageSet;
     }
     var ImageSet: ImageSetConstructor;
+
+    interface Emote {
+        name: string;
+        images: ImageSet;
+        tooltip: string;
+        home_page: string;
+        zero_width: boolean;
+        id: string;
+        author: string;
+        base_name: string | null;
+    }
+
+    interface EmoteConstructor {
+        new_uncached: (
+            this: void,
+            tbl: {
+                name: string;
+                images: ImageSet;
+                tooltip: string;
+                home_page?: string;
+                zero_width?: boolean;
+                id?: string;
+                author?: string;
+                base_name?: string;
+            }
+        ) => Emote;
+    }
+    var Emote: EmoteConstructor;
 
     class Split implements IWeakResource {
         is_valid(): boolean;

--- a/docs/lua-meta/globals.lua
+++ b/docs/lua-meta/globals.lua
@@ -332,6 +332,26 @@ function c2.ConnectionHandle:is_connected() end
 
 -- End src/controllers/plugins/api/ConnectionHandle.hpp
 
+-- Begin src/controllers/plugins/api/Emotes.hpp
+
+
+
+---@class c2.Emote
+---@field name string
+---@field images c2.ImageSet
+---@field tooltip string
+---@field home_page string URL to the platform specific emote page.
+---@field zero_width boolean
+---@field id string Platform specific ID.
+---@field author string Username of the emote creator.
+---@field base_name string|nil If this emote is aliased, this contains the original (base) name of the emote.
+
+---Create a new emote. This emote is not cached anywhere.
+---@param tbl {name: string, images: c2.ImageSet, tooltip: string, home_page?: string, zero_width?: boolean, id?: string, author?: string, base_name?: string}
+---@return c2.Emote
+function c2.Emote.new_uncached(tbl) end
+-- End src/controllers/plugins/api/Emotes.hpp
+
 -- Begin src/controllers/plugins/api/HTTPResponse.hpp
 
 ---@class c2.HTTPResponse
@@ -563,9 +583,28 @@ function c2.MessageElementBase:add_flags(flags) end
 
 ---@class c2.EmoteElement : c2.MessageElementBase
 ---@field type "emote"
+---@field emote c2.Emote The displayed emote.
+---@field text_element_color MessageColor Color of the text element if this emote is not displayed.
 
+---A table to initialize a new emote element
+---@class EmoteElementInit : MessageElementInitBase
+---@field type "emote"
+---@field emote c2.Emote The displayed emote.
+---@field flags c2.MessageElementFlag Message element flags (see `c2.MessageElementFlags`). These should be non-zero.
+---@field text_element_color MessageColor? Color of the text element if this emote is not displayed.
+
+---An element showing multiple emotes stacked on top of each other. Used for zero-width emotes.
 ---@class c2.LayeredEmoteElement : c2.MessageElementBase
 ---@field type "layered-emote"
+---@field emotes {emote: c2.Emote, flags: c2.MessageElementFlag}[] Emotes stacked in this element.
+---@field text_element_color MessageColor Color of the text element if an emote is not displayed.
+
+---A table to initialize a new layered emote element
+---@class LayeredEmoteElementInit : MessageElementInitBase
+---@field type "layered-emote"
+---@field emotes {emote: c2.Emote, flags: c2.MessageElementFlag}[] Emotes stacked in this element.
+---@field flags c2.MessageElementFlag Message element flags (see `c2.MessageElementFlags`). These should be non-zero.
+---@field text_element_color MessageColor? Color of the text element if an emote is not displayed.
 
 ---An element showing a single image.
 ---@class c2.ImageElement : c2.MessageElementBase
@@ -604,20 +643,51 @@ function c2.MessageElementBase:add_flags(flags) end
 ---@field images c2.ImageSet The images to show.
 ---@field flags c2.MessageElementFlag Message element flags (see `c2.MessageElementFlags`). These should be non-zero.
 
+---An element that shows an emote as a badge. Internally, badges are emotes, hence this holds an emote.
 ---@class c2.BadgeElement : c2.MessageElementBase
 ---@field type "badge"
+---@field emote c2.Emote The emote to show as a badge.
 
+---A table to initialize a new badge element
+---@class BadgeElementInit : MessageElementInitBase
+---@field type "badge"
+---@field emote c2.Emote The emote to show as a badge.
+---@field flags c2.MessageElementFlag Message element flags (see `c2.MessageElementFlags`). These should be non-zero.
+
+---An element showing a mod badge with the background being filled green.
 ---@class c2.ModBadgeElement : c2.BadgeElement
 ---@field type "mod-badge"
 
+---A table to initialize a new mod element
+---@class ModBadgeElementInit : MessageElementInitBase
+---@field type "mod-badge"
+---@field emote c2.Emote The emote to show as a badge.
+---@field flags c2.MessageElementFlag Message element flags (see `c2.MessageElementFlags`). These should be non-zero.
+
+---An element showing a VIP badge.
 ---@class c2.VipBadgeElement : c2.BadgeElement
 ---@field type "vip-badge"
 
+---A table to initialize a new VIP element
+---@class VipBadgeElementInit : MessageElementInitBase
+---@field type "vip-badge"
+---@field emote c2.Emote The emote to show as a badge.
+---@field flags c2.MessageElementFlag Message element flags (see `c2.MessageElementFlags`). These should be non-zero.
+
+---An element showing a badge with a custom background color.
 ---@class c2.FfzBadgeElement : c2.BadgeElement
 ---@field type "ffz-badge"
+---@field color string The background color of this badge.
+
+---A table to initialize a new ffz badge element
+---@class FfzBadgeElementInit : MessageElementInitBase
+---@field type "ffz-badge"
+---@field emote c2.Emote The emote to show as a badge.
+---@field flags c2.MessageElementFlag Message element flags (see `c2.MessageElementFlags`). These should be non-zero.
+---@field color string The background color of this badge.
 
 ---@alias MessageElement c2.TextElement|c2.SingleLineTextElement|c2.MentionElement|c2.TimestampElement|c2.TwitchModerationElement|c2.LinebreakElement|c2.ReplyCurveElement|c2.LinkElement|c2.EmoteElement|c2.LayeredEmoteElement|c2.ImageElement|c2.CircularImageElement|c2.ScalingImageElement|c2.BadgeElement|c2.ModBadgeElement|c2.VipBadgeElement|c2.FfzBadgeElement
----@alias MessageElementInit TextElementInit|SingleLineTextElementInit|MentionElementInit|TimestampElementInit|TwitchModerationElementInit|LinebreakElementInit|ReplyCurveElementInit|ImageElementInit|CircularImageElementInit|ScalingImageElementInit
+---@alias MessageElementInit TextElementInit|SingleLineTextElementInit|MentionElementInit|TimestampElementInit|TwitchModerationElementInit|LinebreakElementInit|ReplyCurveElementInit|EmoteElementInit|LayeredEmoteElementInit|ImageElementInit|CircularImageElementInit|ScalingImageElementInit|BadgeElementInit|ModBadgeElementInit|VipBadgeElementInit|FfzBadgeElementInit
 
 ---A chat message
 ---@class c2.Message

--- a/docs/lua-meta/globals.lua
+++ b/docs/lua-meta/globals.lua
@@ -346,7 +346,10 @@ function c2.ConnectionHandle:is_connected() end
 ---@field author string Username of the emote creator.
 ---@field base_name string|nil If this emote is aliased, this contains the original (base) name of the emote.
 
----Create a new emote. This emote is not cached anywhere.
+---Create a new emote. This emote is not cached anywhere (unlike images).
+---Plugins should call this once for an emote and save the result (e.g. in a
+---global table from emote-name => emote). Most importantly, plugins do not call
+---this every time a message is created.
 ---@param tbl {name: string, images: c2.ImageSet, tooltip: string, home_page?: string, zero_width?: boolean, id?: string, author?: string, base_name?: string}
 ---@return c2.Emote
 function c2.Emote.new_uncached(tbl) end

--- a/docs/wip-plugins.md
+++ b/docs/wip-plugins.md
@@ -894,6 +894,26 @@ All arguments accept an [`Image`](#image) or a `string` (URL).
 
 Requires the [network permission](#permissions).
 
+#### `Emote`
+
+An emote has the following fields:
+
+- `name` (`string`)
+- `images` ([`ImageSet`](#imageset))
+- `tooltip` (`string`)
+- `home_page` (`string`) URL to the platform specific emote page.
+- `zero_width` (`boolean`)
+- `id` (`string`) Platform specific ID.
+- `author` (`string`) Username of the emote creator.
+- `base_name` (`string | nil`) If this emote is aliased, this contains the
+  original (base) name of the emote.
+
+##### `Emote.new_uncached(init)`
+
+Creates a new emote. As the name suggests, this emote is not deduplicated
+(unlike images). `init` is a table with the desired fields (see above). `names`,
+`images`, and `tooltip` are required.
+
 #### `Split`
 
 A split. See [Anatomy of a Chatterino window](https://wiki.chatterino.com/Glossary/#anatomy-of-a-chatterino-window).

--- a/docs/wip-plugins.md
+++ b/docs/wip-plugins.md
@@ -911,8 +911,14 @@ An emote has the following fields:
 ##### `Emote.new_uncached(init)`
 
 Creates a new emote. As the name suggests, this emote is not deduplicated
-(unlike images). `init` is a table with the desired fields (see above). `names`,
-`images`, and `tooltip` are required.
+(unlike images).
+
+Plugins should call this once for an emote and save the result
+(e.g. in a global table from emote-name => emote). Most importantly, do not call
+this every time a message is created.
+
+`init` is a table with the desired fields (see above). `names`, `images`, and
+`tooltip` are required.
 
 #### `Split`
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -264,6 +264,8 @@ set(SOURCE_FILES
         controllers/plugins/api/ConnectionHandle.hpp
         controllers/plugins/api/DebugLibrary.cpp
         controllers/plugins/api/DebugLibrary.hpp
+        controllers/plugins/api/Emotes.cpp
+        controllers/plugins/api/Emotes.hpp
         controllers/plugins/api/EventType.hpp
         controllers/plugins/api/HTTPRequest.cpp
         controllers/plugins/api/HTTPRequest.hpp

--- a/src/controllers/plugins/LuaAPI.hpp
+++ b/src/controllers/plugins/LuaAPI.hpp
@@ -95,6 +95,7 @@ sol::table toTable(lua_State *L, const CompletionEvent &ev);
  * @includefile controllers/plugins/api/Accounts.hpp
  * @includefile controllers/plugins/api/ChannelRef.hpp
  * @includefile controllers/plugins/api/ConnectionHandle.hpp
+ * @includefile controllers/plugins/api/Emotes.hpp
  * @includefile controllers/plugins/api/HTTPResponse.hpp
  * @includefile controllers/plugins/api/HTTPRequest.hpp
  * @includefile controllers/plugins/api/Images.hpp

--- a/src/controllers/plugins/PluginController.cpp
+++ b/src/controllers/plugins/PluginController.cpp
@@ -15,6 +15,7 @@
 #    include "controllers/plugins/api/ChannelRef.hpp"
 #    include "controllers/plugins/api/ConnectionHandle.hpp"
 #    include "controllers/plugins/api/DebugLibrary.hpp"
+#    include "controllers/plugins/api/Emotes.hpp"
 #    include "controllers/plugins/api/HTTPRequest.hpp"
 #    include "controllers/plugins/api/HTTPResponse.hpp"
 #    include "controllers/plugins/api/Images.hpp"
@@ -253,6 +254,7 @@ void PluginController::initSol(sol::state_view &lua, Plugin *plugin)
     lua::api::ConnectionHandle::createUserType(c2);
     lua::api::message::createUserType(c2);
     lua::api::images::createUserTypes(c2);
+    lua::api::emotes::createUserTypes(c2);
     lua::api::createAccounts(c2);
     lua::api::windowmanager::createUserTypes(c2);
     c2["ChannelType"] = lua::createEnumTable<Channel::Type>(lua);
@@ -261,7 +263,9 @@ void PluginController::initSol(sol::state_view &lua, Plugin *plugin)
     c2["LogLevel"] = lua::createEnumTable<lua::api::LogLevel>(lua);
     c2["MessageFlag"] =
         lua::createEnumTable<MessageFlag, MessageFlag::None>(lua);
-    c2["MessageElementFlag"] = lua::createEnumTable<MessageElementFlag>(lua);
+    c2["MessageElementFlag"] =
+        lua::createEnumTable<MessageElementFlag, MessageElementFlag::Emote>(
+            lua);
     c2["FontStyle"] = lua::createEnumTable<FontStyle>(lua);
     c2["MessageContext"] = lua::createEnumTable<MessageContext>(lua);
     c2["LinkType"] =

--- a/src/controllers/plugins/SolTypes.hpp
+++ b/src/controllers/plugins/SolTypes.hpp
@@ -177,6 +177,18 @@ void loggedVoidCall(const auto &fn, QStringView context, Plugin *plugin,
     hasValueOrLog(res, context, plugin);
 }
 
+template <typename T>
+T requiredGet(const sol::table &tbl, auto &&key)
+{
+    auto v = tbl.get<sol::optional<T>>(std::forward<decltype(key)>(key));
+    if (!v)
+    {
+        throw std::runtime_error(std::string{"Missing required property: "} +
+                                 key);
+    }
+    return *std::move(v);
+}
+
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #    define SOL_STACK_FUNCTIONS(TYPE)                                 \
         bool sol_lua_check(                                           \

--- a/src/controllers/plugins/api/Emotes.cpp
+++ b/src/controllers/plugins/api/Emotes.cpp
@@ -24,6 +24,12 @@ EmotePtr newUncached(const sol::table &tbl)
     {
         throw std::runtime_error("`home_page` must be an http(s) link");
     }
+    auto baseNameStr = tbl.get<std::optional<QString>>("base_name");
+    std::optional<EmoteName> baseName;
+    if (baseNameStr)
+    {
+        baseName.emplace(*std::move(baseNameStr));
+    }
 
     return std::make_shared<const Emote>(Emote{
         .name = {requiredGet<QString>(tbl, "name")},
@@ -33,10 +39,7 @@ EmotePtr newUncached(const sol::table &tbl)
         .zeroWidth = tbl.get_or("zero_width", false),
         .id = {tbl.get_or("id", QString{})},
         .author = {tbl.get_or("author", QString{})},
-        .baseName = tbl.get<std::optional<QString>>("base_name")
-                        .transform([](auto name) {
-                            return EmoteName{std::move(name)};
-                        }),
+        .baseName = std::move(baseName),
     });
 }
 
@@ -71,9 +74,11 @@ void createUserTypes(sol::table &c2)
             return emote.author.string;
         }),
         "base_name", sol::property([](const Emote &emote) {
-            return emote.baseName.transform([](const auto &it) {
-                return it.string;
-            });
+            if (emote.baseName)
+            {
+                return std::optional<QString>(emote.baseName->string);
+            }
+            return std::optional<QString>{};
         })  //
     );
 }

--- a/src/controllers/plugins/api/Emotes.cpp
+++ b/src/controllers/plugins/api/Emotes.cpp
@@ -28,7 +28,7 @@ EmotePtr newUncached(const sol::table &tbl)
     std::optional<EmoteName> baseName;
     if (baseNameStr)
     {
-        baseName.emplace(*std::move(baseNameStr));
+        baseName.emplace(EmoteName{*std::move(baseNameStr)});
     }
 
     return std::make_shared<const Emote>(Emote{

--- a/src/controllers/plugins/api/Emotes.cpp
+++ b/src/controllers/plugins/api/Emotes.cpp
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: 2026 Contributors to Chatterino <https://chatterino.com>
+//
+// SPDX-License-Identifier: MIT
+
+#ifdef CHATTERINO_HAVE_PLUGINS
+
+#    include "controllers/plugins/api/Emotes.hpp"
+
+#    include "controllers/plugins/SolTypes.hpp"
+#    include "messages/Emote.hpp"
+
+#    include <sol/sol.hpp>
+
+namespace {
+
+using namespace chatterino;
+using namespace chatterino::lua;
+
+EmotePtr newUncached(const sol::table &tbl)
+{
+    auto homePage = tbl.get_or("home_page", QString{});
+    if (!homePage.isEmpty() &&
+        !(homePage.startsWith(u"https://") || homePage.startsWith(u"http://")))
+    {
+        throw std::runtime_error("`home_page` must be an http(s) link");
+    }
+
+    return std::make_shared<const Emote>(Emote{
+        .name = {requiredGet<QString>(tbl, "name")},
+        .images = requiredGet<ImageSet>(tbl, "images"),
+        .tooltip = {requiredGet<QString>(tbl, "tooltip")},
+        .homePage = {std::move(homePage)},
+        .zeroWidth = tbl.get_or("zero_width", false),
+        .id = {tbl.get_or("id", QString{})},
+        .author = {tbl.get_or("author", QString{})},
+        .baseName = tbl.get<std::optional<QString>>("base_name")
+                        .transform([](auto name) {
+                            return EmoteName{std::move(name)};
+                        }),
+    });
+}
+
+}  // namespace
+
+namespace chatterino::lua::api::emotes {
+
+void createUserTypes(sol::table &c2)
+{
+    c2.new_usertype<Emote>(
+        "Emote", sol::no_constructor,  //
+        "new_uncached", &newUncached,  //
+        "name", sol::property([](const Emote &emote) {
+            return emote.name.string;
+        }),
+        "images", sol::property([](const Emote &emote) {
+            return emote.images;
+        }),
+        "tooltip", sol::property([](const Emote &emote) {
+            return emote.tooltip.string;
+        }),
+        "home_page", sol::property([](const Emote &emote) {
+            return emote.homePage.string;
+        }),
+        "zero_width", sol::property([](const Emote &emote) {
+            return emote.zeroWidth;
+        }),
+        "id", sol::property([](const Emote &emote) {
+            return emote.id.string;
+        }),
+        "author", sol::property([](const Emote &emote) {
+            return emote.author.string;
+        }),
+        "base_name", sol::property([](const Emote &emote) {
+            return emote.baseName.transform([](const auto &it) {
+                return it.string;
+            });
+        })  //
+    );
+}
+
+}  // namespace chatterino::lua::api::emotes
+
+#endif

--- a/src/controllers/plugins/api/Emotes.hpp
+++ b/src/controllers/plugins/api/Emotes.hpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2026 Contributors to Chatterino <https://chatterino.com>
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#ifdef CHATTERINO_HAVE_PLUGINS
+
+#    include <sol/forward.hpp>
+
+namespace chatterino::lua::api::emotes {
+
+/* @lua-fragment
+
+---@class c2.Emote
+---@field name string
+---@field images c2.ImageSet
+---@field tooltip string
+---@field home_page string URL to the platform specific emote page.
+---@field zero_width boolean
+---@field id string Platform specific ID.
+---@field author string Username of the emote creator.
+---@field base_name string|nil If this emote is aliased, this contains the original (base) name of the emote.
+
+---Create a new emote. This emote is not cached anywhere.
+---@param tbl {name: string, images: c2.ImageSet, tooltip: string, home_page?: string, zero_width?: boolean, id?: string, author?: string, base_name?: string}
+---@return c2.Emote
+function c2.Emote.new_uncached(tbl) end
+*/
+
+void createUserTypes(sol::table &c2);
+
+}  // namespace chatterino::lua::api::emotes
+
+#endif

--- a/src/controllers/plugins/api/Emotes.hpp
+++ b/src/controllers/plugins/api/Emotes.hpp
@@ -22,7 +22,10 @@ namespace chatterino::lua::api::emotes {
 ---@field author string Username of the emote creator.
 ---@field base_name string|nil If this emote is aliased, this contains the original (base) name of the emote.
 
----Create a new emote. This emote is not cached anywhere.
+---Create a new emote. This emote is not cached anywhere (unlike images).
+---Plugins should call this once for an emote and save the result (e.g. in a
+---global table from emote-name => emote). Most importantly, plugins do not call
+---this every time a message is created.
 ---@param tbl {name: string, images: c2.ImageSet, tooltip: string, home_page?: string, zero_width?: boolean, id?: string, author?: string, base_name?: string}
 ---@return c2.Emote
 function c2.Emote.new_uncached(tbl) end

--- a/src/controllers/plugins/api/Message.cpp
+++ b/src/controllers/plugins/api/Message.cpp
@@ -14,6 +14,8 @@
 
 #    include <sol/sol.hpp>
 
+#    include <span>
+
 namespace {
 
 using namespace chatterino;

--- a/src/controllers/plugins/api/Message.cpp
+++ b/src/controllers/plugins/api/Message.cpp
@@ -140,8 +140,10 @@ std::unique_ptr<LayeredEmoteElement> layeredEmoteElementFromTable(
         {
             throw std::runtime_error("Expected item in `emotes` to be a table");
         }
-        emotes.emplace_back(requiredGet<EmotePtr>(*tbl, "emote"),
-                            requiredGet<MessageElementFlag>(*tbl, "flags"));
+        emotes.emplace_back(LayeredEmoteElement::Emote{
+            .ptr = requiredGet<EmotePtr>(*tbl, "emote"),
+            .flags = requiredGet<MessageElementFlag>(*tbl, "flags"),
+        });
     }
     if (emotes.empty())
     {

--- a/src/controllers/plugins/api/Message.cpp
+++ b/src/controllers/plugins/api/Message.cpp
@@ -822,7 +822,7 @@ void createUserType(sol::table &c2)
                     return el.color().toLua();
                 },
                 [](const FfzBadgeElement &el) {
-                    return el.color().name(QColor::HexArgb);
+                    return el.getColor().name(QColor::HexArgb);
                 });
         }),
         "style", sol::property([](const ElementRef &el) {

--- a/src/controllers/plugins/api/Message.cpp
+++ b/src/controllers/plugins/api/Message.cpp
@@ -8,6 +8,7 @@
 #    include "Application.hpp"
 #    include "controllers/plugins/LuaUtilities.hpp"
 #    include "controllers/plugins/SolTypes.hpp"
+#    include "messages/Emote.hpp"
 #    include "messages/Message.hpp"
 #    include "messages/MessageElement.hpp"
 
@@ -16,6 +17,7 @@
 namespace {
 
 using namespace chatterino;
+using namespace chatterino::lua;
 
 QDateTime datetimeFromOffset(qint64 offset)
 {
@@ -29,18 +31,6 @@ QDateTime datetimeFromOffset(qint64 offset)
 #    endif
 
     return dt;
-}
-
-template <typename T>
-T requiredGet(const sol::table &tbl, auto &&key)
-{
-    auto v = tbl.get<sol::optional<T>>(std::forward<decltype(key)>(key));
-    if (!v)
-    {
-        throw std::runtime_error(std::string{"Missing required property: "} +
-                                 key);
-    }
-    return *std::move(v);
 }
 
 std::unique_ptr<TextElement> textElementFromTable(const sol::table &tbl)
@@ -128,6 +118,68 @@ std::unique_ptr<ScalingImageElement> scalingImageElementFromTable(
         requiredGet<MessageElementFlag>(tbl, "flags"));
 }
 
+std::unique_ptr<EmoteElement> emoteElementFromTable(const sol::table &tbl)
+{
+    return std::make_unique<EmoteElement>(
+        requiredGet<EmotePtr>(tbl, "emote"),
+        requiredGet<MessageElementFlag>(tbl, "flags"),
+        MessageColor::fromLua(tbl.get_or("text_element_color", QString{})));
+}
+
+std::unique_ptr<LayeredEmoteElement> layeredEmoteElementFromTable(
+    const sol::table &tbl)
+{
+    std::vector<LayeredEmoteElement::Emote> emotes;
+    auto emotesTbl = requiredGet<sol::table>(tbl, "emotes");
+    for (const auto &[k, v] : emotesTbl)
+    {
+        auto tbl = v.as<sol::optional<sol::table>>();
+        if (!tbl)
+        {
+            throw std::runtime_error("Expected item in `emotes` to be a table");
+        }
+        emotes.emplace_back(requiredGet<EmotePtr>(*tbl, "emote"),
+                            requiredGet<MessageElementFlag>(*tbl, "flags"));
+    }
+    if (emotes.empty())
+    {
+        throw std::runtime_error("At least one emote must be added");
+    }
+
+    return std::make_unique<LayeredEmoteElement>(
+        std::move(emotes), requiredGet<MessageElementFlag>(tbl, "flags"),
+        MessageColor::fromLua(tbl.get_or("text_element_color", QString{})));
+}
+
+std::unique_ptr<BadgeElement> badgeElementFromTable(const sol::table &tbl)
+{
+    return std::make_unique<BadgeElement>(
+        requiredGet<EmotePtr>(tbl, "emote"),
+        requiredGet<MessageElementFlag>(tbl, "flags"));
+}
+
+std::unique_ptr<ModBadgeElement> modBadgeElementFromTable(const sol::table &tbl)
+{
+    return std::make_unique<ModBadgeElement>(
+        requiredGet<EmotePtr>(tbl, "emote"),
+        requiredGet<MessageElementFlag>(tbl, "flags"));
+}
+
+std::unique_ptr<VipBadgeElement> vipBadgeElementFromTable(const sol::table &tbl)
+{
+    return std::make_unique<VipBadgeElement>(
+        requiredGet<EmotePtr>(tbl, "emote"),
+        requiredGet<MessageElementFlag>(tbl, "flags"));
+}
+
+std::unique_ptr<FfzBadgeElement> ffzBadgeElementFromTable(const sol::table &tbl)
+{
+    return std::make_unique<FfzBadgeElement>(
+        requiredGet<EmotePtr>(tbl, "emote"),
+        requiredGet<MessageElementFlag>(tbl, "flags"),
+        QColor::fromString(requiredGet<std::string>(tbl, "color")));
+}
+
 void setLinkOn(MessageElement *el, const Link &link)
 {
     el->setLink(link);
@@ -213,6 +265,30 @@ std::unique_ptr<MessageElement> elementFromTable(const sol::table &tbl)
     {
         el = scalingImageElementFromTable(tbl);
     }
+    else if (type == EmoteElement::TYPE)
+    {
+        el = emoteElementFromTable(tbl);
+    }
+    else if (type == LayeredEmoteElement::TYPE)
+    {
+        el = layeredEmoteElementFromTable(tbl);
+    }
+    else if (type == BadgeElement::TYPE)
+    {
+        el = badgeElementFromTable(tbl);
+    }
+    else if (type == ModBadgeElement::TYPE)
+    {
+        el = modBadgeElementFromTable(tbl);
+    }
+    else if (type == VipBadgeElement::TYPE)
+    {
+        el = vipBadgeElementFromTable(tbl);
+    }
+    else if (type == FfzBadgeElement::TYPE)
+    {
+        el = ffzBadgeElementFromTable(tbl);
+    }
     else
     {
         throw std::runtime_error("Invalid message type");
@@ -233,7 +309,11 @@ std::unique_ptr<MessageElement> elementFromTable(const sol::table &tbl)
     }
     else
     {
-        el->setTooltip(tbl.get_or("tooltip", QString{}));
+        auto tooltip = tbl.get<std::optional<QString>>("tooltip");
+        if (tooltip)
+        {
+            el->setTooltip(*tooltip);
+        }
     }
 
     return el;
@@ -731,12 +811,16 @@ void createUserType(sol::table &c2)
                 &TextElement::words, &SingleLineTextElement::words);
         }),
         "color", sol::property([](const ElementRef &el) {
-            return el.visit<const TextElement, const SingleLineTextElement>(
+            return el.visit<const TextElement, const SingleLineTextElement,
+                            const FfzBadgeElement>(
                 [](const TextElement &el) {
                     return el.color().toLua();
                 },
                 [](const SingleLineTextElement &el) {
                     return el.color().toLua();
+                },
+                [](const FfzBadgeElement &el) {
+                    return el.color().name(QColor::HexArgb);
                 });
         }),
         "style", sol::property([](const ElementRef &el) {
@@ -770,6 +854,36 @@ void createUserType(sol::table &c2)
                 [](const TimestampElement &el) {
                     return QDateTime(QDate::currentDate(), el.time())
                         .toMSecsSinceEpoch();
+                });
+        }),
+        "emote", sol::property([](const ElementRef &el) {
+            return el.visit<const EmoteElement, const BadgeElement>(
+                &EmoteElement::emote, &BadgeElement::emote);
+        }),
+        "emotes",
+        sol::property([](const ElementRef &el, sol::this_state state) {
+            return el.asConst<LayeredEmoteElement>().map(
+                [state](const LayeredEmoteElement &el) {
+                    std::span emotes = el.getEmotes();
+                    auto tbl = sol::table::create(
+                        state.L, static_cast<int>(emotes.size()), 0);
+                    for (size_t i = 0; i < emotes.size(); i++)
+                    {
+                        const auto &emote = emotes[i];
+                        tbl[static_cast<int>(i) + 1] = sol::table::create_with(
+                            state.L, "emote", emote.ptr, "flags",
+                            emote.flags.value());
+                    }
+                    return tbl;
+                });
+        }),
+        "text_element_color", sol::property([](const ElementRef &el) {
+            return el.visit<const EmoteElement, const LayeredEmoteElement>(
+                [](const EmoteElement &el) {
+                    return el.textElementColor().toLua();
+                },
+                [](const LayeredEmoteElement &el) {
+                    return el.textElementColor().toLua();
                 });
         }));
 

--- a/src/controllers/plugins/api/Message.hpp
+++ b/src/controllers/plugins/api/Message.hpp
@@ -112,9 +112,28 @@ function c2.MessageElementBase:add_flags(flags) end
 
 ---@class c2.EmoteElement : c2.MessageElementBase
 ---@field type "emote"
+---@field emote c2.Emote The displayed emote.
+---@field text_element_color MessageColor Color of the text element if this emote is not displayed.
 
+---A table to initialize a new emote element
+---@class EmoteElementInit : MessageElementInitBase
+---@field type "emote"
+---@field emote c2.Emote The displayed emote.
+---@field flags c2.MessageElementFlag Message element flags (see `c2.MessageElementFlags`). These should be non-zero.
+---@field text_element_color MessageColor? Color of the text element if this emote is not displayed.
+
+---An element showing multiple emotes stacked on top of each other. Used for zero-width emotes.
 ---@class c2.LayeredEmoteElement : c2.MessageElementBase
 ---@field type "layered-emote"
+---@field emotes {emote: c2.Emote, flags: c2.MessageElementFlag}[] Emotes stacked in this element.
+---@field text_element_color MessageColor Color of the text element if an emote is not displayed.
+
+---A table to initialize a new layered emote element
+---@class LayeredEmoteElementInit : MessageElementInitBase
+---@field type "layered-emote"
+---@field emotes {emote: c2.Emote, flags: c2.MessageElementFlag}[] Emotes stacked in this element.
+---@field flags c2.MessageElementFlag Message element flags (see `c2.MessageElementFlags`). These should be non-zero.
+---@field text_element_color MessageColor? Color of the text element if an emote is not displayed.
 
 ---An element showing a single image.
 ---@class c2.ImageElement : c2.MessageElementBase
@@ -153,20 +172,51 @@ function c2.MessageElementBase:add_flags(flags) end
 ---@field images c2.ImageSet The images to show.
 ---@field flags c2.MessageElementFlag Message element flags (see `c2.MessageElementFlags`). These should be non-zero.
 
+---An element that shows an emote as a badge. Internally, badges are emotes, hence this holds an emote.
 ---@class c2.BadgeElement : c2.MessageElementBase
 ---@field type "badge"
+---@field emote c2.Emote The emote to show as a badge.
 
+---A table to initialize a new badge element
+---@class BadgeElementInit : MessageElementInitBase
+---@field type "badge"
+---@field emote c2.Emote The emote to show as a badge.
+---@field flags c2.MessageElementFlag Message element flags (see `c2.MessageElementFlags`). These should be non-zero.
+
+---An element showing a mod badge with the background being filled green.
 ---@class c2.ModBadgeElement : c2.BadgeElement
 ---@field type "mod-badge"
 
+---A table to initialize a new mod element
+---@class ModBadgeElementInit : MessageElementInitBase
+---@field type "mod-badge"
+---@field emote c2.Emote The emote to show as a badge.
+---@field flags c2.MessageElementFlag Message element flags (see `c2.MessageElementFlags`). These should be non-zero.
+
+---An element showing a VIP badge.
 ---@class c2.VipBadgeElement : c2.BadgeElement
 ---@field type "vip-badge"
 
+---A table to initialize a new VIP element
+---@class VipBadgeElementInit : MessageElementInitBase
+---@field type "vip-badge"
+---@field emote c2.Emote The emote to show as a badge.
+---@field flags c2.MessageElementFlag Message element flags (see `c2.MessageElementFlags`). These should be non-zero.
+
+---An element showing a badge with a custom background color.
 ---@class c2.FfzBadgeElement : c2.BadgeElement
 ---@field type "ffz-badge"
+---@field color string The background color of this badge.
+
+---A table to initialize a new ffz badge element
+---@class FfzBadgeElementInit : MessageElementInitBase
+---@field type "ffz-badge"
+---@field emote c2.Emote The emote to show as a badge.
+---@field flags c2.MessageElementFlag Message element flags (see `c2.MessageElementFlags`). These should be non-zero.
+---@field color string The background color of this badge.
 
 ---@alias MessageElement c2.TextElement|c2.SingleLineTextElement|c2.MentionElement|c2.TimestampElement|c2.TwitchModerationElement|c2.LinebreakElement|c2.ReplyCurveElement|c2.LinkElement|c2.EmoteElement|c2.LayeredEmoteElement|c2.ImageElement|c2.CircularImageElement|c2.ScalingImageElement|c2.BadgeElement|c2.ModBadgeElement|c2.VipBadgeElement|c2.FfzBadgeElement
----@alias MessageElementInit TextElementInit|SingleLineTextElementInit|MentionElementInit|TimestampElementInit|TwitchModerationElementInit|LinebreakElementInit|ReplyCurveElementInit|ImageElementInit|CircularImageElementInit|ScalingImageElementInit
+---@alias MessageElementInit TextElementInit|SingleLineTextElementInit|MentionElementInit|TimestampElementInit|TwitchModerationElementInit|LinebreakElementInit|ReplyCurveElementInit|EmoteElementInit|LayeredEmoteElementInit|ImageElementInit|CircularImageElementInit|ScalingImageElementInit|BadgeElementInit|ModBadgeElementInit|VipBadgeElementInit|FfzBadgeElementInit
 
 ---A chat message
 ---@class c2.Message

--- a/src/messages/MessageElement.cpp
+++ b/src/messages/MessageElement.cpp
@@ -625,7 +625,7 @@ std::string_view VipBadgeElement::type() const
 FfzBadgeElement::FfzBadgeElement(const EmotePtr &data,
                                  MessageElementFlags flags_, QColor color_)
     : BadgeElement(data, flags_)
-    , color_(color_)
+    , color(color_)
 {
 }
 
@@ -633,7 +633,7 @@ MessageLayoutElement *FfzBadgeElement::makeImageLayoutElement(
     const ImagePtr &image, QSizeF size)
 {
     auto *element =
-        new ImageWithBackgroundLayoutElement(*this, image, size, this->color_);
+        new ImageWithBackgroundLayoutElement(*this, image, size, this->color);
 
     return element;
 }
@@ -642,7 +642,7 @@ QJsonObject FfzBadgeElement::toJson() const
 {
     auto base = BadgeElement::toJson();
     base["type"_L1] = u"FfzBadgeElement"_s;
-    base["color"_L1] = this->color_.name(QColor::HexArgb);
+    base["color"_L1] = this->color.name(QColor::HexArgb);
 
     return base;
 }
@@ -652,9 +652,9 @@ std::string_view FfzBadgeElement::type() const
     return std::remove_pointer_t<decltype(this)>::TYPE;
 }
 
-QColor FfzBadgeElement::color() const
+QColor FfzBadgeElement::getColor() const
 {
-    return this->color_;
+    return this->color;
 }
 
 // TEXT

--- a/src/messages/MessageElement.cpp
+++ b/src/messages/MessageElement.cpp
@@ -290,6 +290,16 @@ std::string_view EmoteElement::type() const
     return std::remove_pointer_t<decltype(this)>::TYPE;
 }
 
+EmotePtr EmoteElement::emote() const
+{
+    return this->emote_;
+}
+
+MessageColor EmoteElement::textElementColor() const
+{
+    return this->textColor_;
+}
+
 LayeredEmoteElement::LayeredEmoteElement(
     std::vector<LayeredEmoteElement::Emote> &&emotes, MessageElementFlags flags,
     const MessageColor &textElementColor)
@@ -490,6 +500,11 @@ std::string_view LayeredEmoteElement::type() const
     return std::remove_pointer_t<decltype(this)>::TYPE;
 }
 
+MessageColor LayeredEmoteElement::textElementColor() const
+{
+    return this->textElementColor_;
+}
+
 // BADGE
 BadgeElement::BadgeElement(const EmotePtr &emote, MessageElementFlags flags)
     : MessageElement(flags)
@@ -540,6 +555,11 @@ QJsonObject BadgeElement::toJson() const
 std::string_view BadgeElement::type() const
 {
     return std::remove_pointer_t<decltype(this)>::TYPE;
+}
+
+EmotePtr BadgeElement::emote() const
+{
+    return this->emote_;
 }
 
 // MOD BADGE
@@ -605,7 +625,7 @@ std::string_view VipBadgeElement::type() const
 FfzBadgeElement::FfzBadgeElement(const EmotePtr &data,
                                  MessageElementFlags flags_, QColor color_)
     : BadgeElement(data, flags_)
-    , color(std::move(color_))
+    , color_(color_)
 {
 }
 
@@ -613,7 +633,7 @@ MessageLayoutElement *FfzBadgeElement::makeImageLayoutElement(
     const ImagePtr &image, QSizeF size)
 {
     auto *element =
-        new ImageWithBackgroundLayoutElement(*this, image, size, this->color);
+        new ImageWithBackgroundLayoutElement(*this, image, size, this->color_);
 
     return element;
 }
@@ -622,7 +642,7 @@ QJsonObject FfzBadgeElement::toJson() const
 {
     auto base = BadgeElement::toJson();
     base["type"_L1] = u"FfzBadgeElement"_s;
-    base["color"_L1] = this->color.name(QColor::HexArgb);
+    base["color"_L1] = this->color_.name(QColor::HexArgb);
 
     return base;
 }
@@ -630,6 +650,11 @@ QJsonObject FfzBadgeElement::toJson() const
 std::string_view FfzBadgeElement::type() const
 {
     return std::remove_pointer_t<decltype(this)>::TYPE;
+}
+
+QColor FfzBadgeElement::color() const
+{
+    return this->color_;
 }
 
 // TEXT

--- a/src/messages/MessageElement.hpp
+++ b/src/messages/MessageElement.hpp
@@ -468,6 +468,9 @@ public:
     QJsonObject toJson() const override;
     std::string_view type() const override;
 
+    EmotePtr emote() const;
+    MessageColor textElementColor() const;
+
 protected:
     virtual MessageLayoutElement *makeImageLayoutElement(const ImagePtr &image,
                                                          QSizeF size);
@@ -513,6 +516,8 @@ public:
     QJsonObject toJson() const override;
     std::string_view type() const override;
 
+    MessageColor textElementColor() const;
+
 private:
     MessageLayoutElement *makeImageLayoutElement(
         const std::vector<ImagePtr> &image, const std::vector<QSizeF> &sizes,
@@ -543,6 +548,8 @@ public:
 
     QJsonObject toJson() const override;
     std::string_view type() const override;
+
+    EmotePtr emote() const;
 
 protected:
     virtual MessageLayoutElement *makeImageLayoutElement(const ImagePtr &image,
@@ -593,10 +600,12 @@ public:
     QJsonObject toJson() const override;
     std::string_view type() const override;
 
+    QColor color() const;
+
 protected:
     MessageLayoutElement *makeImageLayoutElement(const ImagePtr &image,
                                                  QSizeF size) override;
-    const QColor color;
+    const QColor color_;
 };
 
 // contains a text, formated depending on the preferences

--- a/src/messages/MessageElement.hpp
+++ b/src/messages/MessageElement.hpp
@@ -600,12 +600,12 @@ public:
     QJsonObject toJson() const override;
     std::string_view type() const override;
 
-    QColor color() const;
+    QColor getColor() const;
 
 protected:
     MessageLayoutElement *makeImageLayoutElement(const ImagePtr &image,
                                                  QSizeF size) override;
-    const QColor color_;
+    const QColor color;
 };
 
 // contains a text, formated depending on the preferences

--- a/tests/lua/message/emotes.lua
+++ b/tests/lua/message/emotes.lua
@@ -1,0 +1,198 @@
+-- SPDX-FileCopyrightText: 2026 Contributors to Chatterino <https://chatterino.com>
+--
+-- SPDX-License-Identifier: CC0-1.0
+
+local function make_emote(name)
+    return c2.Emote.new_uncached({
+        name = name,
+        images = c2.ImageSet.new("https://example.com"),
+        tooltip = "a tooltip",
+    })
+end
+
+local tests = {
+    emote_ctor = function()
+        local images = c2.ImageSet.new("https://example.com")
+        local emote = c2.Emote.new_uncached({
+            name = "minimal",
+            images = images,
+            tooltip = "a",
+        })
+        assert(emote.name == "minimal")
+        assert(emote.images == images)
+        assert(emote.tooltip == "a")
+        assert(emote.home_page == "")
+        assert(not emote.zero_width)
+        assert(emote.id == "")
+        assert(emote.base_name == nil)
+
+        emote = c2.Emote.new_uncached({
+            name = "full",
+            images = images,
+            tooltip = "a",
+            home_page = "https://example.com",
+            zero_width = true,
+            id = "1234",
+            base_name = "basename",
+        })
+        assert(emote.name == "full")
+        assert(emote.images == images)
+        assert(emote.tooltip == "a")
+        assert(emote.home_page == "https://example.com")
+        assert(emote.zero_width)
+        assert(emote.id == "1234")
+        assert(emote.base_name == "basename")
+
+        -- Missing items
+        local ok, err = pcall(function()
+            c2.Emote.new_uncached({ name = "foo" })
+        end)
+        assert(not ok)
+
+        ok = pcall(function()
+            c2.Emote.new_uncached({ name = "foo", images = images })
+        end)
+        assert(not ok)
+
+        ok = pcall(function()
+            c2.Emote.new_uncached({ name = "foo", tooltip = "foo" })
+        end)
+        assert(not ok)
+
+        ok = pcall(function()
+            c2.Emote.new_uncached({ images = images, tooltip = "foo" })
+        end)
+        assert(not ok)
+
+        -- Invalid home_page
+        ok, err = pcall(function()
+            c2.Emote.new_uncached({
+                name = "foo",
+                images = images,
+                tooltip = "foo",
+                home_page = "file:///usr/bin/shutdown",
+            })
+        end)
+        assert(not ok and err == "`home_page` must be an http(s) link")
+    end,
+    emote_equality = function()
+        local emote1 = make_emote("foo")
+        local emote2 = make_emote("bar")
+        assert(emote1 == emote1)
+        assert(emote2 == emote2)
+        assert(emote1 ~= emote2)
+        assert(emote1 == make_emote("foo"))
+        assert(emote2 == make_emote("bar"))
+
+        local is1 = c2.ImageSet.new("https://example.com")
+        local is2 = c2.ImageSet.new("https://example.com/2")
+        local emote3 = c2.Emote.new_uncached({
+            name = "foo",
+            images = is1,
+            tooltip = "tool",
+            home_page = "https://example.com",
+            zero_width = true,
+        })
+        -- Only name, images, tooltip, and home_page are checked.
+        assert(emote3 == c2.Emote.new_uncached({
+            name = "foo",
+            images = is1,
+            tooltip = "tool",
+            home_page = "https://example.com",
+            zero_width = false,
+            author = "author",
+            base_name = "base",
+            id = "1234",
+        }))
+        assert(emote3 ~= c2.Emote.new_uncached({
+            name = "foo2",
+            images = is1,
+            tooltip = "tool",
+            home_page = "https://example.com",
+        }))
+        assert(emote3 ~= c2.Emote.new_uncached({
+            name = "foo",
+            images = is2,
+            tooltip = "tool",
+            home_page = "https://example.com",
+        }))
+        assert(emote3 ~= c2.Emote.new_uncached({
+            name = "foo",
+            images = is1,
+            tooltip = "tool2",
+            home_page = "https://example.com",
+        }))
+        assert(emote3 ~= c2.Emote.new_uncached({
+            name = "foo",
+            images = is1,
+            tooltip = "tool",
+            home_page = "https://example.com/2",
+        }))
+    end,
+    emote_element = function()
+        local emote = make_emote("foo")
+        local msg = c2.Message.new({
+            elements = {
+                { type = "emote", emote = emote, flags = c2.MessageElementFlag.Emote },
+                { type = "emote", emote = emote, flags = c2.MessageElementFlag.Emote, text_element_color = "system" },
+            },
+        })
+        assert(msg:elements()[1].emote == emote)
+        assert(msg:elements()[1].flags == c2.MessageElementFlag.Emote)
+        assert(msg:elements()[1].text_element_color == "text")
+        assert(msg:elements()[2].emote == emote)
+        assert(msg:elements()[2].flags == c2.MessageElementFlag.Emote)
+        assert(msg:elements()[2].text_element_color == "system")
+    end,
+    layered_emote_element = function()
+        local emote1 = make_emote("foo")
+        local emote2 = make_emote("foo2")
+        local msg = c2.Message.new({
+            elements = {
+                {
+                    type = "layered-emote",
+                    emotes = {
+                        { emote = emote1, flags = c2.MessageElementFlag.Emote },
+                        { emote = emote2, flags = c2.MessageElementFlag.EmoteImage },
+                    },
+                    flags = c2.MessageElementFlag.Emote,
+                },
+                {
+                    type = "layered-emote",
+                    emotes = {
+                        { emote = emote1, flags = c2.MessageElementFlag.Emote },
+                    },
+                    flags = c2.MessageElementFlag.Emote,
+                    text_element_color = "link",
+                },
+            },
+        })
+        assert(#msg:elements()[1].emotes == 2)
+        assert(msg:elements()[1].emotes[1].emote == emote1)
+        assert(msg:elements()[1].emotes[1].flags == c2.MessageElementFlag.Emote)
+        assert(msg:elements()[1].emotes[2].emote == emote2)
+        assert(msg:elements()[1].emotes[2].flags == c2.MessageElementFlag.EmoteImage)
+        assert(msg:elements()[1].flags == c2.MessageElementFlag.Emote)
+        assert(msg:elements()[1].text_element_color == "text")
+
+        assert(#msg:elements()[2].emotes == 1)
+        assert(msg:elements()[2].emotes[1].emote == emote1)
+        assert(msg:elements()[2].emotes[1].flags == c2.MessageElementFlag.Emote)
+        assert(msg:elements()[2].flags == c2.MessageElementFlag.Emote)
+        assert(msg:elements()[2].text_element_color == "link")
+
+        local ok, err = pcall(c2.Message.new, {
+            elements = {
+                { type = "layered-emote", emotes = {}, flags = c2.MessageElementFlag.Emote },
+            },
+        })
+        assert(not ok and err == "At least one emote must be added")
+    end,
+}
+
+for name, fn in pairs(tests) do
+    local ok, res = xpcall(fn, debug.traceback)
+    if not ok then
+        error(name .. " failed: " .. res)
+    end
+end

--- a/tests/src/Plugins.cpp
+++ b/tests/src/Plugins.cpp
@@ -1640,7 +1640,7 @@ class PluginMessageTest : public PluginTest,
 };
 TEST_P(PluginMessageTest, Run)
 {
-    this->configure();
+    this->configure({PluginPermission({{"type", "network"}})});
     runLuaTest("message", GetParam(), *this->lua);
 }
 


### PR DESCRIPTION
This adds bindings to create emotes and to read emotes from messages. Notably, it doesn't add an `EmoteMap`. With this PR, plugins can build all elements except `LinkElement`.

Emotes can be created from a table with `c2.Emote.new_uncached`. When plugins can create emote providers, then we'd add a function to create cached emotes, as the cache lives in the provider and there's no global cache.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
