### PR TITLE
fix: check for `isAppAboutToQuit` in more places

### DIFF
--- a/src/common/Channel.cpp
+++ b/src/common/Channel.cpp
@@ -58,7 +58,7 @@ Channel::Channel(const QString &name, Type type)
 Channel::~Channel()
 {
     auto *app = tryGetApp();
-    if (app && this->anythingLogged_)
+    if (app && !isAppAboutToQuit() && this->anythingLogged_)
     {
         app->getChatLogger()->closeChannel(this->name_, this->platform_);
     }

--- a/src/providers/twitch/eventsub/SubscriptionHandle.cpp
+++ b/src/providers/twitch/eventsub/SubscriptionHandle.cpp
@@ -18,7 +18,7 @@ RawSubscriptionHandle::RawSubscriptionHandle(SubscriptionRequest request_)
 RawSubscriptionHandle::~RawSubscriptionHandle()
 {
     auto *app = tryGetApp();
-    if (app == nullptr)
+    if (app == nullptr || isAppAboutToQuit())
     {
         // We're shutting down, assume the unsubscription has been taken care of
         return;


### PR DESCRIPTION
When closing Chatterino with a popup window open, we go through the procedure handing `QApplication::aboutToQuit` [here](https://github.com/Chatterino/chatterino2/blob/8573688f3c3b5198f86d16f154789506b767023e/src/RunGui.cpp#L281-L290). There, we call `app->stop()`, which clears all components. However, the app instance from `getApp` or `tryGetApp` is still valid.

This feels more like a band-aid fix - we might want to clear the `INSTANCE` variable in `Application.cpp` when calling `stop()` immediately.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
