### PR TITLE
Add native messaging manifest for Microsoft Edge

### DIFF
--- a/src/singletons/NativeMessaging.cpp
+++ b/src/singletons/NativeMessaging.cpp
@@ -77,6 +77,16 @@ const Config CHROME{
 #endif
 };
 
+// Edge is Chromium-based and uses the same native messaging manifest format
+// as Chrome. The registration path below is Windows-specific.
+#ifdef Q_OS_WIN
+const Config EDGE{
+    .fileName = u"native-messaging-manifest-edge.json"_s,
+    .registryKey =
+        u"HKCU\\Software\\Microsoft\\Edge\\NativeMessagingHosts\\com.chatterino.chatterino"_s,
+};
+#endif
+
 void registerNmManifest([[maybe_unused]] const Paths &paths,
                         const Config &config, const QJsonDocument &document)
 {
@@ -254,6 +264,10 @@ void registerNmHost(const Paths &paths)
 
     registerNmManifest(paths, CHROME, chromeManifest);
     registerNmManifest(paths, FIREFOX, firefoxManifest);
+
+#ifdef Q_OS_WIN
+    registerNmManifest(paths, EDGE, chromeManifest);
+#endif
 
 #ifndef Q_OS_WIN
     switch (getSettings()->customNativeMessagingManifestFormat.getEnum())


### PR DESCRIPTION
Fixes #6836

## Summary

Adds Microsoft Edge native messaging host registration on Windows.

Edge is Chromium-based and uses the same native messaging manifest format as Chrome, so this reuses the existing Chrome manifest generation and registers it under Edge's native messaging registry path:

`HKCU\Software\Microsoft\Edge\NativeMessagingHosts\com.chatterino.chatterino`

## Testing

- Not built locally
- Verified the Edge registration is guarded behind `Q_OS_WIN`
- Verified Edge reuses the existing Chromium native messaging manifest generation path

<!--
Leave this at the bottom

Co-authored-by: - 
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->