### PR TITLE
refactor: Move split deserialization to WindowDescriptors

### DIFF
--- a/src/common/WindowDescriptors.cpp
+++ b/src/common/WindowDescriptors.cpp
@@ -28,58 +28,6 @@ QJsonArray loadWindowArray(const QString &settingsPath)
     return windows_arr;
 }
 
-template <typename T>
-T loadNodes(const QJsonObject &obj)
-{
-    static_assert("loadNodes must be called with the SplitNodeDescriptor "
-                  "or ContainerNodeDescriptor type");
-}
-
-template <>
-SplitNodeDescriptor loadNodes(const QJsonObject &root)
-{
-    SplitNodeDescriptor descriptor;
-
-    descriptor.flexH_ = root.value("flexh").toDouble(1.0);
-    descriptor.flexV_ = root.value("flexv").toDouble(1.0);
-
-    auto data = root.value("data").toObject();
-
-    SplitDescriptor::loadFromJSON(descriptor, root, data);
-
-    return descriptor;
-}
-
-template <>
-ContainerNodeDescriptor loadNodes(const QJsonObject &root)
-{
-    ContainerNodeDescriptor descriptor;
-
-    descriptor.flexH_ = root.value("flexh").toDouble(1.0);
-    descriptor.flexV_ = root.value("flexv").toDouble(1.0);
-
-    descriptor.vertical_ = root.value("type").toString() == "vertical";
-
-    for (QJsonValue _val : root.value("items").toArray())
-    {
-        auto _obj = _val.toObject();
-
-        auto _type = _obj.value("type");
-        if (_type == "split")
-        {
-            descriptor.items_.emplace_back(
-                loadNodes<SplitNodeDescriptor>(_obj));
-        }
-        else
-        {
-            descriptor.items_.emplace_back(
-                loadNodes<ContainerNodeDescriptor>(_obj));
-        }
-    }
-
-    return descriptor;
-}
-
 const QList<QUuid> loadFilters(QJsonValue val)
 {
     QList<QUuid> filterIds;
@@ -123,6 +71,45 @@ void SplitDescriptor::loadFromJSON(SplitDescriptor &descriptor,
     }
 }
 
+SplitNodeDescriptor SplitNodeDescriptor::loadFromJSON(const QJsonObject &root)
+{
+    SplitNodeDescriptor descriptor;
+    SplitDescriptor::loadFromJSON(descriptor, root, root["data"].toObject());
+    descriptor.flexH_ = root["flexh"].toDouble(1.0);
+    descriptor.flexV_ = root["flexv"].toDouble(1.0);
+    return descriptor;
+}
+
+ContainerNodeDescriptor ContainerNodeDescriptor::loadFromJSON(
+    const QJsonObject &root)
+{
+    ContainerNodeDescriptor descriptor;
+
+    descriptor.flexH_ = root.value("flexh").toDouble(1.0);
+    descriptor.flexV_ = root.value("flexv").toDouble(1.0);
+
+    descriptor.vertical_ = root.value("type").toString() == "vertical";
+
+    const auto items = root.value("items").toArray();
+    for (const auto val : items)
+    {
+        const auto obj = val.toObject();
+        auto type = obj.value("type");
+        if (type.toString() == "split")
+        {
+            descriptor.items_.emplace_back(
+                SplitNodeDescriptor::loadFromJSON(obj));
+        }
+        else
+        {
+            descriptor.items_.emplace_back(
+                ContainerNodeDescriptor::loadFromJSON(obj));
+        }
+    }
+
+    return descriptor;
+}
+
 TabDescriptor TabDescriptor::loadFromJSON(const QJsonObject &tabObj)
 {
     TabDescriptor tab;
@@ -148,11 +135,11 @@ TabDescriptor TabDescriptor::loadFromJSON(const QJsonObject &tabObj)
         auto nodeType = splitRoot.value("type").toString();
         if (nodeType == "split")
         {
-            tab.rootNode_ = loadNodes<SplitNodeDescriptor>(splitRoot);
+            tab.rootNode_ = SplitNodeDescriptor::loadFromJSON(splitRoot);
         }
         else if (nodeType == "horizontal" || nodeType == "vertical")
         {
-            tab.rootNode_ = loadNodes<ContainerNodeDescriptor>(splitRoot);
+            tab.rootNode_ = ContainerNodeDescriptor::loadFromJSON(splitRoot);
         }
     }
 

--- a/src/common/WindowDescriptors.cpp
+++ b/src/common/WindowDescriptors.cpp
@@ -4,7 +4,10 @@
 
 #include "common/WindowDescriptors.hpp"
 
+#include "Application.hpp"
 #include "common/QLogging.hpp"
+#include "debug/AssertInGuiThread.hpp"
+#include "providers/twitch/TwitchIrcServer.hpp"
 #include "widgets/Window.hpp"
 
 #include <QFile>
@@ -69,6 +72,42 @@ void SplitDescriptor::loadFromJSON(SplitDescriptor &descriptor,
     {
         descriptor.spellCheckOverride = spellOverride.toBool();
     }
+}
+
+IndirectChannel SplitDescriptor::decodeChannel() const
+{
+    assertInGuiThread();
+
+    if (this->type_ == "twitch")
+    {
+        return getApp()->getTwitch()->getOrAddChannel(this->channelName_);
+    }
+    else if (this->type_ == "mentions")
+    {
+        return getApp()->getTwitch()->getMentionsChannel();
+    }
+    else if (this->type_ == "watching")
+    {
+        return getApp()->getTwitch()->getWatchingChannel();
+    }
+    else if (this->type_ == "whispers")
+    {
+        return getApp()->getTwitch()->getWhispersChannel();
+    }
+    else if (this->type_ == "live")
+    {
+        return getApp()->getTwitch()->getLiveChannel();
+    }
+    else if (this->type_ == "automod")
+    {
+        return getApp()->getTwitch()->getAutomodChannel();
+    }
+    else if (this->type_ == "misc")
+    {
+        return getApp()->getTwitch()->getChannelOrEmpty(this->channelName_);
+    }
+
+    return Channel::getEmpty();
 }
 
 SplitNodeDescriptor SplitNodeDescriptor::loadFromJSON(const QJsonObject &root)

--- a/src/common/WindowDescriptors.hpp
+++ b/src/common/WindowDescriptors.hpp
@@ -18,6 +18,8 @@
 
 namespace chatterino {
 
+class IndirectChannel;
+
 /**
  * A WindowLayout contains one or more windows.
  * Only one of those windows can be the main window
@@ -54,6 +56,8 @@ struct SplitDescriptor {
 
     static void loadFromJSON(SplitDescriptor &descriptor,
                              const QJsonObject &root, const QJsonObject &data);
+
+    IndirectChannel decodeChannel() const;
 };
 
 struct SplitNodeDescriptor : SplitDescriptor {

--- a/src/common/WindowDescriptors.hpp
+++ b/src/common/WindowDescriptors.hpp
@@ -59,6 +59,8 @@ struct SplitDescriptor {
 struct SplitNodeDescriptor : SplitDescriptor {
     qreal flexH_ = 1;
     qreal flexV_ = 1;
+
+    static SplitNodeDescriptor loadFromJSON(const QJsonObject &root);
 };
 
 struct ContainerNodeDescriptor;
@@ -73,16 +75,18 @@ struct ContainerNodeDescriptor {
     bool vertical_ = false;
 
     std::vector<NodeDescriptor> items_;
+
+    static ContainerNodeDescriptor loadFromJSON(const QJsonObject &root);
 };
 
 struct TabDescriptor {
-    static TabDescriptor loadFromJSON(const QJsonObject &root);
-
     QString customTitle_;
     bool selected_{false};
     bool highlightsEnabled_{true};
 
     std::optional<NodeDescriptor> rootNode_;
+
+    static TabDescriptor loadFromJSON(const QJsonObject &tabObj);
 };
 
 struct WindowDescriptor {

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -782,43 +782,6 @@ void WindowManager::encodeFilters(Split *split, QJsonArray &arr)
     }
 }
 
-IndirectChannel WindowManager::decodeChannel(const SplitDescriptor &descriptor)
-{
-    assertInGuiThread();
-
-    if (descriptor.type_ == "twitch")
-    {
-        return getApp()->getTwitch()->getOrAddChannel(descriptor.channelName_);
-    }
-    else if (descriptor.type_ == "mentions")
-    {
-        return getApp()->getTwitch()->getMentionsChannel();
-    }
-    else if (descriptor.type_ == "watching")
-    {
-        return getApp()->getTwitch()->getWatchingChannel();
-    }
-    else if (descriptor.type_ == "whispers")
-    {
-        return getApp()->getTwitch()->getWhispersChannel();
-    }
-    else if (descriptor.type_ == "live")
-    {
-        return getApp()->getTwitch()->getLiveChannel();
-    }
-    else if (descriptor.type_ == "automod")
-    {
-        return getApp()->getTwitch()->getAutomodChannel();
-    }
-    else if (descriptor.type_ == "misc")
-    {
-        return getApp()->getTwitch()->getChannelOrEmpty(
-            descriptor.channelName_);
-    }
-
-    return Channel::getEmpty();
-}
-
 void WindowManager::closeAll()
 {
     assertInGuiThread();

--- a/src/singletons/WindowManager.hpp
+++ b/src/singletons/WindowManager.hpp
@@ -65,7 +65,6 @@ public:
                           QJsonObject &obj);
     static void encodeChannel(IndirectChannel channel, QJsonObject &obj);
     static void encodeFilters(Split *split, QJsonArray &arr);
-    static IndirectChannel decodeChannel(const SplitDescriptor &descriptor);
 
     void showSettingsDialog(
         QWidget *parent,

--- a/src/widgets/splits/SplitContainer.cpp
+++ b/src/widgets/splits/SplitContainer.cpp
@@ -909,7 +909,7 @@ void SplitContainer::applyFromDescriptorRecursively(
         const auto &splitNode = *n;
 
         auto *split = new Split(this);
-        split->setChannel(WindowManager::decodeChannel(splitNode));
+        split->setChannel(splitNode.decodeChannel());
         split->setModerationMode(splitNode.moderationMode_);
         split->setFilters(splitNode.filters_);
         split->setCheckSpellingOverride(splitNode.spellCheckOverride);
@@ -946,7 +946,7 @@ void SplitContainer::applyFromDescriptorRecursively(
                 const auto &splitNode = *inner;
                 auto *split = new Split(this);
                 split->setFilters(splitNode.filters_);
-                split->setChannel(WindowManager::decodeChannel(splitNode));
+                split->setChannel(splitNode.decodeChannel());
                 split->setModerationMode(splitNode.moderationMode_);
                 split->setCheckSpellingOverride(splitNode.spellCheckOverride);
 


### PR DESCRIPTION
This is split from #6906 to make it easier to review. The goal is to move all (de)serialization to WindowDescriptors to make it easier to change and interact with from the outside.

This removes the internal `loadNodes<T>` and uses `loadFromJSON` for containers like the other structs, and it moves `WindowManager::decodeChannel` to the descriptor. 

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
