### PR TITLE
Add scrollbar marker for last message indicator

### DIFF
--- a/src/widgets/Scrollbar.cpp
+++ b/src/widgets/Scrollbar.cpp
@@ -14,6 +14,7 @@
 #include <QPainter>
 #include <QTimer>
 
+#include <algorithm>
 #include <cmath>
 
 namespace {
@@ -101,6 +102,20 @@ void Scrollbar::replaceHighlight(size_t index, ScrollbarHighlight replacement)
 void Scrollbar::clearHighlights()
 {
     this->highlights_.clear();
+}
+
+void Scrollbar::setLastMessageMarker(std::optional<qreal> position,
+                                     QColor color)
+{
+    if (this->lastMessageMarkerPosition_ == position &&
+        this->lastMessageMarkerColor_ == color)
+    {
+        return;
+    }
+
+    this->lastMessageMarkerPosition_ = position;
+    this->lastMessageMarkerColor_ = color;
+    this->update();
 }
 
 void Scrollbar::scrollToBottom(bool animate)
@@ -374,6 +389,28 @@ void Scrollbar::paintEvent(QPaintEvent * /*event*/)
 
                 case ScrollbarHighlight::None:;
             }
+        }
+    }
+
+    if (this->lastMessageMarkerPosition_.has_value() &&
+        this->lastMessageMarkerColor_.isValid())
+    {
+        const auto range = this->maximum_ - this->minimum_;
+
+        if (range > 0 && *this->lastMessageMarkerPosition_ >= this->minimum_ &&
+            *this->lastMessageMarkerPosition_ <= this->maximum_)
+        {
+            const auto relativePosition =
+                (*this->lastMessageMarkerPosition_ - this->minimum_) / range;
+
+            const auto y = std::clamp(static_cast<int>(std::lround(
+                                          relativePosition * this->height())),
+                                      0, std::max(0, this->height() - 1));
+
+            QColor color = this->lastMessageMarkerColor_;
+            color.setAlpha(255);
+
+            painter.fillRect(0, y, this->width(), 1, color);
         }
     }
 }

--- a/src/widgets/Scrollbar.hpp
+++ b/src/widgets/Scrollbar.hpp
@@ -10,8 +10,11 @@
 #include <boost/circular_buffer.hpp>
 #include <pajlada/signals/signal.hpp>
 #include <pajlada/signals/signalholder.hpp>
+#include <QColor>
 #include <QPropertyAnimation>
 #include <QWidget>
+
+#include <optional>
 
 namespace chatterino {
 
@@ -103,6 +106,8 @@ public:
 
     void clearHighlights();
 
+    void setLastMessageMarker(std::optional<qreal> position, QColor color = {});
+
     void scrollToBottom(bool animate = false);
     void scrollToTop(bool animate = false);
     bool isAtBottom() const;
@@ -187,6 +192,9 @@ private:
     QPropertyAnimation currentValueAnimation_;
 
     boost::circular_buffer<ScrollbarHighlight> highlights_;
+
+    std::optional<qreal> lastMessageMarkerPosition_;
+    QColor lastMessageMarkerColor_;
 
     bool atBottom_{true};
     /// This takes precedence over `settingHideThumb`

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -420,6 +420,7 @@ void ChannelView::initializeSignals()
 
     getSettings()->showLastMessageIndicator.connect(
         [this](auto, auto) {
+            this->updateScrollbarLastMessageMarker(this->getMessagesSnapshot());
             this->update();
         },
         this->signalHolder_);
@@ -685,6 +686,7 @@ void ChannelView::performLayout(bool causedByScrollbar, bool causedByShow)
 
     /// Update scrollbar
     this->updateScrollbar(messages, causedByScrollbar, causedByShow);
+    this->updateScrollbarLastMessageMarker(messages);
 
     this->goToBottom_->setVisible(this->enableScrollingToBottom_ &&
                                   this->scrollBar_->isVisible() &&
@@ -794,11 +796,50 @@ void ChannelView::updateScrollbar(const std::vector<MessageLayoutPtr> &messages,
     }
 }
 
+void ChannelView::updateScrollbarLastMessageMarker(
+    const std::vector<MessageLayoutPtr> &messages)
+{
+    if (!getSettings()->showLastMessageIndicator ||
+        !this->scrollBar_->isVisible() || !this->lastReadMessage_)
+    {
+        this->scrollBar_->setLastMessageMarker(std::nullopt);
+        return;
+    }
+
+    const auto it =
+        std::find(messages.begin(), messages.end(), this->lastReadMessage_);
+
+    if (it == messages.end())
+    {
+        this->scrollBar_->setLastMessageMarker(std::nullopt);
+        return;
+    }
+
+    const auto index = std::distance(messages.begin(), it);
+
+    QColor color;
+    if (this->messagePreferences_.lastMessageColor.isValid())
+    {
+        color = this->messagePreferences_.lastMessageColor;
+    }
+    else
+    {
+        color = this->window() == QApplication::activeWindow()
+                    ? this->messageColors_.focusedLastMessageLine
+                    : this->messageColors_.unfocusedLastMessageLine;
+    }
+
+    this->scrollBar_->setLastMessageMarker(
+        this->scrollBar_->getMinimum() + qreal(index + 1), color);
+}
+
 void ChannelView::clearMessages()
 {
     // Clear all stored messages in this chat widget
     this->messages_.clear();
+    this->lastReadMessage_.reset();
     this->scrollBar_->clearHighlights();
+    this->scrollBar_->setLastMessageMarker(std::nullopt);
     this->scrollBar_->resetBounds();
     this->scrollBar_->setMaximum(0);
     this->scrollBar_->setMinimum(0);
@@ -1354,6 +1395,7 @@ void ChannelView::updateLastReadMessage()
         this->lastReadMessage_ = *lastMessage;
     }
 
+    this->updateScrollbarLastMessageMarker(this->getMessagesSnapshot());
     this->update();
 }
 

--- a/src/widgets/helper/ChannelView.hpp
+++ b/src/widgets/helper/ChannelView.hpp
@@ -288,6 +288,8 @@ private:
     void layoutVisibleMessages(const std::vector<MessageLayoutPtr> &messages);
     void updateScrollbar(const std::vector<MessageLayoutPtr> &messages,
                          bool causedByScrollbar, bool causedByShow);
+    void updateScrollbarLastMessageMarker(
+        const std::vector<MessageLayoutPtr> &messages);
 
     void drawMessages(QPainter &painter, const QRect &area);
     void setSelection(const SelectionItem &start, const SelectionItem &end);


### PR DESCRIPTION
## Summary

Adds a scrollbar marker for the existing last-message indicator that is shown after returning to Chatterino.

The marker is derived from the same `lastReadMessage_` state used by the in-chat indicator, so both indicators stay in sync. It is intentionally stored separately from regular scrollbar highlights because it is persistent UI state, not a message highlight, and should not consume highlight-buffer capacity.

Fixes #6940.

## Testing

Built locally on CachyOS with CMake.

Manually verified that the scrollbar marker appears together with the existing last-message indicator after returning to Chatterino, and that it tracks the last-read position while new messages arrive.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->