### PR TITLE
feat: store user aliases by Twitch user ID

### DIFF
--- a/mocks/include/mocks/UserData.hpp
+++ b/mocks/include/mocks/UserData.hpp
@@ -11,29 +11,62 @@ class UserDataController : public IUserDataController
 public:
     UserDataController() = default;
 
-    // Get extra data about a user
-    // If the user does not have any extra data, return none
+    // Get extra data about a user.
+    // If the user does not have any extra data, return none.
     std::optional<UserData> getUser(const QString &userID) const override
     {
-        auto it = this->userMap.find(userID);
+        const auto it = this->userMap.find(userID);
         if (it != this->userMap.end())
         {
             return it->second;
         }
+
         return std::nullopt;
     }
 
-    // Update or insert extra data for the user's color override
+    // Update or insert extra data for the user's color override.
     void setUserColor(const QString &userID,
                       const QString &colorString) override
     {
+        if (userID.isEmpty())
+        {
+            return;
+        }
+
         this->userMap[userID].color = QColor(colorString);
         this->userDataUpdated_.invoke();
     }
 
     void setUserNotes(const QString &userID, const QString &notes) override
     {
+        if (userID.isEmpty())
+        {
+            return;
+        }
+
         this->userMap[userID].notes = notes;
+        this->userDataUpdated_.invoke();
+    }
+
+    void setUserAlias(const QString &userID, const QString &alias) override
+    {
+        if (userID.isEmpty())
+        {
+            return;
+        }
+
+        auto user = this->getUser(userID).value_or(UserData{});
+        user.alias = alias.trimmed();
+
+        if (user.isEmpty())
+        {
+            this->userMap.erase(userID);
+        }
+        else
+        {
+            this->userMap[userID] = user;
+        }
+
         this->userDataUpdated_.invoke();
     }
 

--- a/src/controllers/userdata/UserData.hpp
+++ b/src/controllers/userdata/UserData.hpp
@@ -21,11 +21,14 @@ namespace chatterino {
 // Replacement fields should be optional, where none denotes that the field should not be updated for the user
 struct UserData {
     std::optional<QColor> color{std::nullopt};
+
     QString notes;
+    QString alias;
 
     bool isEmpty() const
     {
-        return !this->color.has_value() && this->notes.isEmpty();
+        return !this->color.has_value() && this->notes.isEmpty() &&
+               this->alias.isEmpty();
     }
 };
 
@@ -40,17 +43,26 @@ struct Serialize<chatterino::UserData> {
     {
         rapidjson::Value obj;
         obj.SetObject();
+
         if (value.color)
         {
             const auto &color = *value.color;
             chatterino::rj::set(obj, "color",
                                 color.name().toUtf8().toStdString(), a);
         }
+
         if (!value.notes.isEmpty())
         {
             chatterino::rj::set(obj, "notes",
                                 value.notes.toUtf8().toStdString(), a);
         }
+
+        if (!value.alias.isEmpty())
+        {
+            chatterino::rj::set(obj, "alias",
+                                value.alias.toUtf8().toStdString(), a);
+        }
+
         return obj;
     }
 };
@@ -82,6 +94,12 @@ struct Deserialize<chatterino::UserData> {
         if (chatterino::rj::getSafe(value, "notes", notes))
         {
             user.notes = notes;
+        }
+
+        QString alias;
+        if (chatterino::rj::getSafe(value, "alias", alias))
+        {
+            user.alias = alias;
         }
 
         return user;

--- a/src/controllers/userdata/UserDataController.cpp
+++ b/src/controllers/userdata/UserDataController.cpp
@@ -133,6 +133,20 @@ void UserDataController::setUserNotes(const QString &userID,
     this->update(std::move(users), std::move(lock));
 }
 
+void UserDataController::setUserAlias(const QString &userID,
+                                      const QString &alias)
+{
+    if (userID.isEmpty())
+    {
+        return;
+    }
+
+    std::unique_lock lock(this->usersMutex);
+    auto users = this->users;
+    users[userID].alias = alias.trimmed();
+    this->update(std::move(users), std::move(lock));
+}
+
 pajlada::Signals::NoArgSignal &UserDataController::userDataUpdated()
 {
     return this->userDataUpdated_;

--- a/src/controllers/userdata/UserDataController.hpp
+++ b/src/controllers/userdata/UserDataController.hpp
@@ -34,6 +34,8 @@ public:
                               const QString &colorString) = 0;
     virtual void setUserNotes(const QString &userID, const QString &notes) = 0;
 
+    virtual void setUserAlias(const QString &userID, const QString &alias) = 0;
+
     virtual pajlada::Signals::NoArgSignal &userDataUpdated() = 0;
 };
 
@@ -52,6 +54,8 @@ public:
 
     // Update or insert extra data for the notes about a user
     void setUserNotes(const QString &userID, const QString &notes) override;
+
+    void setUserAlias(const QString &userID, const QString &alias) override;
 
     pajlada::Signals::NoArgSignal &userDataUpdated() override;
 

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -232,6 +232,17 @@ QString stylizeUsername(const QString &username, const Message &message)
         break;
     }
 
+    // User ID aliases take precedence over username-based nicknames.
+    const auto *userDataController = getApp()->getUserData();
+    if (userDataController != nullptr && !message.userID.isEmpty())
+    {
+        const auto userData = userDataController->getUser(message.userID);
+        if (userData.has_value() && !userData->alias.isEmpty())
+        {
+            return userData->alias;
+        }
+    }
+
     if (auto nicknameText = getSettings()->matchNickname(usernameText))
     {
         usernameText = *nicknameText;

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -48,6 +48,8 @@
 
 #include <QCheckBox>
 #include <QDesktopServices>
+#include <QInputDialog>
+#include <QLineEdit>
 #include <QMessageBox>
 #include <QMetaEnum>
 #include <QNetworkAccessManager>
@@ -421,9 +423,11 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically, Split *split)
         user.emplace<QCheckBox>("Ignore highlights")
             .assign(&this->ui_.ignoreHighlights);
         // visibility of this is updated in setData
-
         user.emplace<LabelButton>("Add notes", this)
             .assign(&this->ui_.notesAdd);
+        user.emplace<LabelButton>("Set alias", this)
+            .assign(&this->ui_.aliasSet);
+
         auto usercard = user.emplace<LabelButton>("Usercard", this)
                             .assign(&this->ui_.usercardLabel);
         auto mod = user.emplace<PixmapButton>(this);
@@ -796,6 +800,38 @@ void UserInfoPopup::installEvents()
             this->editUserNotesDialog_->updateWindowTitle(this->userName_);
             this->editUserNotesDialog_->show();
         });
+    // user alias
+    QObject::connect(this->ui_.aliasSet, &LabelButton::clicked, [this]() {
+        const auto userID = this->userId_;
+        const auto userName = this->userName_;
+
+        if (userID.isEmpty())
+        {
+            QMessageBox::warning(
+                nullptr, "Set user alias",
+                "Cannot set an alias because this user's Twitch "
+                "user ID is not available yet.");
+            return;
+        }
+
+        const auto userData = getApp()->getUserData()->getUser(userID);
+        const auto currentAlias =
+            userData.has_value() ? userData->alias : QString();
+
+        bool ok = false;
+        const auto alias = QInputDialog::getText(
+            nullptr, "Set user alias",
+            QString("Alias for %1:")
+                .arg(userName.isEmpty() ? userID : userName),
+            QLineEdit::Normal, currentAlias, &ok);
+
+        if (!ok)
+        {
+            return;
+        }
+
+        getApp()->getUserData()->setUserAlias(userID, alias);
+    });
 
     // user data updated
     this->userDataUpdatedConnection_ =

--- a/src/widgets/dialogs/UserInfoPopup.hpp
+++ b/src/widgets/dialogs/UserInfoPopup.hpp
@@ -97,7 +97,7 @@ private:
         QCheckBox *ignoreHighlights = nullptr;
         MarkdownLabel *notesPreview = nullptr;
         LabelButton *notesAdd = nullptr;
-
+        LabelButton *aliasSet = nullptr;
         Label *noMessagesLabel = nullptr;
         ChannelView *latestMessages = nullptr;
 


### PR DESCRIPTION
Fixes #6345

## Summary

Adds user aliases backed by `UserData`, keyed by Twitch user ID instead of username.

Changes:
- Stores an optional `alias` field in `user-data.json`.
- Adds `UserDataController::setUserAlias`.
- Applies user ID aliases before username-based nicknames when rendering usernames.
- Adds a **Set alias** action to the user info popup.
- Updates the user data mock for tests.

## Testing

Tested locally on Linux.

1. Built Chatterino successfully.
2. Opened a Twitch channel.
3. Opened the user info popup for a chat user.
4. Clicked **Set alias**.
5. Entered a custom alias.
6. Confirmed new messages from that user render with the alias.
7. Restarted Chatterino.
8. Confirmed the alias persisted.
9. Cleared the alias.
10. Confirmed new messages fall back to the normal username behavior.

The settings-dialog management UI is intentionally not included because the initial implementation only requires editing aliases from the user info popup.

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -