### PR TITLE
fix: user cards and reply thread popups taking over the entire space

### DIFF
--- a/src/widgets/DraggablePopup.cpp
+++ b/src/widgets/DraggablePopup.cpp
@@ -16,12 +16,17 @@ namespace chatterino {
 namespace {
 
 constexpr FlagsEnum<BaseWindow::Flags> POPUP_FLAGS{
-#ifdef Q_OS_LINUX
+// On macOS, the Dialog flag maps the popup to a Qt::Dialog window so the
+// NSWindow gets NSWindowCollectionBehaviorFullScreenAuxiliary.
+#if defined(Q_OS_LINUX) || defined(Q_OS_MACOS)
     BaseWindow::Dialog,
 #endif
     BaseWindow::EnableCustomFrame,
 };
 constexpr FlagsEnum<BaseWindow::Flags> POPUP_FLAGS_CLOSE_AUTOMATICALLY{
+#ifdef Q_OS_MACOS
+    BaseWindow::Dialog,
+#endif
     BaseWindow::EnableCustomFrame,
     BaseWindow::Frameless,
     BaseWindow::FramelessDraggable,


### PR DESCRIPTION
This PR fixes #6936 by making BaseWindow use `Qt::Dialog` instead of `Qt::Window`. Now in full screen mode, pop ups like user cards and threads will be displayed as popups instead of full screen windows.

<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
