### PR TITLE
Add undo/redo hotkeys

### DIFF
--- a/src/controllers/hotkeys/HotkeyController.cpp
+++ b/src/controllers/hotkeys/HotkeyController.cpp
@@ -481,6 +481,13 @@ void HotkeyController::addDefaults(std::set<QString> &addedHotkeys)
         this->tryAddDefault(addedHotkeys, HotkeyCategory::SplitInput,
                             QKeySequence("Down"), "nextMessage",
                             std::vector<QString>(), "next message");
+
+        this->tryAddDefault(addedHotkeys, HotkeyCategory::SplitInput,
+                            QKeySequence("Ctrl+Z"), "undo",
+                            std::vector<QString>(), "undo");
+        this->tryAddDefault(addedHotkeys, HotkeyCategory::SplitInput,
+                            QKeySequence("Ctrl+Shift+Z"), "redo",
+                            std::vector<QString>(), "redo");
     }
 
     // window

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -774,6 +774,16 @@ void SplitInput::installTextEditEvents()
                 }
             }
 
+            // Prevent QTextEdit default undo/redo
+            // undo/redo should only be handled by the assigned hotkeys
+            if (event->key() == Qt::Key_Z &&
+                (event->modifiers() == Qt::ControlModifier ||
+                event->modifiers() == (Qt::ControlModifier | Qt::ShiftModifier)))
+            {
+                event->accept();
+                return;
+            }
+
             // One of the last remaining of it's kind, the copy shortcut.
             // For some bizarre reason Qt doesn't want this key be rebound.
             // TODO(Mm2PL): Revisit in Qt6, maybe something changed?


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
Fixes #6817

Adds Undo and Redo to the Hotkeys menu, allowing users to rebind them according to their preferences.
<img width="686" height="363" alt="image" src="https://github.com/user-attachments/assets/2692ad60-7c18-4ab6-a8ef-be999dd3ea33" />

By default, `Ctrl+Z`and `Ctrl+Shift+Z` are handled by Qt. This means that even if these actions are rebound, the default shortcuts will still trigger undo/redo.

To fix this, the default Qt undo/redo shortcuts are disabled, ensuring that these actions are handled only through the configured hotkeys (A similar thing is already done for `Ctrl+C`)

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
