### PR TITLE
Use Wissididom/msvc-dev-cmd

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,7 +201,7 @@ jobs:
       # WINDOWS
       - name: Enable Developer Command Prompt (Windows)
         if: startsWith(matrix.os, 'windows')
-        uses: ilammy/msvc-dev-cmd@v1.13.0
+        uses: Wissididom/msvc-dev-cmd@v2.0.2
 
       - name: Setup sccache (Windows)
         # sccache v0.7.4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,7 +201,7 @@ jobs:
       # WINDOWS
       - name: Enable Developer Command Prompt (Windows)
         if: startsWith(matrix.os, 'windows')
-        uses: Wissididom/msvc-dev-cmd@v2.0.3
+        uses: Chatterino/msvc-dev-cmd@v2.0.4
 
       - name: Setup sccache (Windows)
         # sccache v0.7.4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,7 +201,7 @@ jobs:
       # WINDOWS
       - name: Enable Developer Command Prompt (Windows)
         if: startsWith(matrix.os, 'windows')
-        uses: Wissididom/msvc-dev-cmd@v2.0.2
+        uses: Wissididom/msvc-dev-cmd@v2.0.3
 
       - name: Setup sccache (Windows)
         # sccache v0.7.4

--- a/.github/workflows/create-installer.yml
+++ b/.github/workflows/create-installer.yml
@@ -43,7 +43,7 @@ jobs:
         run: echo "C:\Program Files (x86)\Inno Setup 6\" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Enable Developer Command Prompt
-        uses: Wissididom/msvc-dev-cmd@v2.0.3
+        uses: Chatterino/msvc-dev-cmd@v2.0.4
 
       - name: Build installer
         id: build-installer

--- a/.github/workflows/create-installer.yml
+++ b/.github/workflows/create-installer.yml
@@ -43,7 +43,7 @@ jobs:
         run: echo "C:\Program Files (x86)\Inno Setup 6\" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Enable Developer Command Prompt
-        uses: ilammy/msvc-dev-cmd@v1.13.0
+        uses: Wissididom/msvc-dev-cmd@v2.0.2
 
       - name: Build installer
         id: build-installer

--- a/.github/workflows/create-installer.yml
+++ b/.github/workflows/create-installer.yml
@@ -43,7 +43,7 @@ jobs:
         run: echo "C:\Program Files (x86)\Inno Setup 6\" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Enable Developer Command Prompt
-        uses: Wissididom/msvc-dev-cmd@v2.0.2
+        uses: Wissididom/msvc-dev-cmd@v2.0.3
 
       - name: Build installer
         id: build-installer

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -52,7 +52,7 @@ jobs:
           version: ${{ matrix.qt-version }}
 
       - name: Enable Developer Command Prompt
-        uses: Wissididom/msvc-dev-cmd@v2.0.2
+        uses: Wissididom/msvc-dev-cmd@v2.0.3
 
       - name: Setup sccache
         # sccache v0.7.4

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -52,7 +52,7 @@ jobs:
           version: ${{ matrix.qt-version }}
 
       - name: Enable Developer Command Prompt
-        uses: ilammy/msvc-dev-cmd@v1.13.0
+        uses: Wissididom/msvc-dev-cmd@v2.0.2
 
       - name: Setup sccache
         # sccache v0.7.4

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -52,7 +52,7 @@ jobs:
           version: ${{ matrix.qt-version }}
 
       - name: Enable Developer Command Prompt
-        uses: Wissididom/msvc-dev-cmd@v2.0.3
+        uses: Chatterino/msvc-dev-cmd@v2.0.4
 
       - name: Setup sccache
         # sccache v0.7.4


### PR DESCRIPTION
I updated the msvc-dev-cmd action to my fork because [the original](https://github.com/ilammy/msvc-dev-cmd) was last updated 2 years ago (Mar 30, 2024) and I also added support for Visual Studio 2026, moved over from CommonJS to ES modules and let Dependabot do its work (and removed node_modules from gitignore because else it didn't seem to work without me bringing in a bundler).

This can also be moved to the Chatterino org if need be because I currently don't think I'll have a use case for my own projects currently.

The main reason for me doing it was that GitHub plans to deprecate/remove Node 20 on the runners which the original still is configured to use. I made the versions start with v2 to hopefully not conflict with the original versioning.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
