### PR TITLE
refactor: store settings args as a struct

### DIFF
--- a/mocks/include/mocks/BaseApplication.hpp
+++ b/mocks/include/mocks/BaseApplication.hpp
@@ -20,7 +20,10 @@ class BaseApplication : public EmptyApplication
 {
 public:
     BaseApplication()
-        : settings(this->args, this->settingsDir.path(), /*isTest=*/true)
+        : settings(this->args_, this->settingsDir.path(),
+                   {
+                       .isTest = true,
+                   })
         , updates(this->paths_, this->settings)
         , theme(this->paths_)
         , fonts(this->settings)
@@ -29,7 +32,10 @@ public:
 
     explicit BaseApplication(const QString &settingsData)
         : EmptyApplication(settingsData)
-        , settings(this->args, this->settingsDir.path(), /*isTest=*/true)
+        , settings(this->args_, this->settingsDir.path(),
+                   {
+                       .isTest = true,
+                   })
         , updates(this->paths_, this->settings)
         , theme(this->paths_)
         , fonts(this->settings)
@@ -71,7 +77,6 @@ public:
         return nullptr;
     }
 
-    Args args;
     Settings settings;
     Updates updates;
     DisabledStreamerMode streamerMode;

--- a/src/singletons/Settings.cpp
+++ b/src/singletons/Settings.cpp
@@ -151,7 +151,7 @@ bool Settings::toggleMutedChannel(const QString &channelName)
 Settings *Settings::instance_ = nullptr;
 
 Settings::Settings(const Args &args, const QString &settingsDirectory,
-                   bool isTest)
+                   const SettingsArgs &settingsArgs)
     : prevInstance_(Settings::instance_)
     , disableSaving(args.dontSaveSettings)
 {
@@ -160,7 +160,7 @@ Settings::Settings(const Args &args, const QString &settingsDirectory,
     // get global instance of the settings library
     auto settingsInstance = pajlada::Settings::SettingManager::getInstance();
 
-    if (isTest)
+    if (settingsArgs.isTest)
     {
         settingsInstance->load(qPrintable(settingsPath));
     }

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -118,6 +118,10 @@ constexpr std::optional<std::string_view> qmagicenumDisplayName(
     }
 }
 
+struct SettingsArgs {
+    bool isTest = false;
+};
+
 /// Settings which are available for reading and writing on the gui thread.
 // These settings are still accessed concurrently in the code but it is bad practice.
 class Settings
@@ -129,7 +133,7 @@ class Settings
 
 public:
     Settings(const Args &args, const QString &settingsDirectory,
-             bool isTest = false);
+             const SettingsArgs &settingsArgs = {});
     ~Settings();
 
     static Settings &instance();

--- a/tests/src/MessageLayout.cpp
+++ b/tests/src/MessageLayout.cpp
@@ -30,7 +30,7 @@ class MockApplication : public mock::BaseApplication
 {
 public:
     MockApplication()
-        : windowManager(this->args, this->paths_, this->settings, this->theme,
+        : windowManager(this->args_, this->paths_, this->settings, this->theme,
                         this->fonts)
     {
     }

--- a/tests/src/Plugins.cpp
+++ b/tests/src/Plugins.cpp
@@ -97,7 +97,7 @@ public:
         : mock::BaseApplication(TEST_SETTINGS)
         , plugins(this->paths_)
         , commands(this->paths_)
-        , windows(this->args, this->paths_, this->settings, this->theme,
+        , windows(this->args_, this->paths_, this->settings, this->theme,
                   this->fonts)
     {
     }

--- a/tests/src/Scrollbar.cpp
+++ b/tests/src/Scrollbar.cpp
@@ -25,7 +25,7 @@ class MockApplication : public mock::BaseApplication
 {
 public:
     MockApplication()
-        : windowManager(this->args, this->paths_, this->settings, this->theme,
+        : windowManager(this->args_, this->paths_, this->settings, this->theme,
                         this->fonts)
     {
     }

--- a/tests/src/SplitInput.cpp
+++ b/tests/src/SplitInput.cpp
@@ -32,7 +32,7 @@ class MockApplication : public mock::BaseApplication
 {
 public:
     MockApplication()
-        : windowManager(this->args, this->paths_, this->settings, this->theme,
+        : windowManager(this->args_, this->paths_, this->settings, this->theme,
                         this->fonts)
         , commands(this->paths_)
     {


### PR DESCRIPTION
this doesn't achieve anything now, but makes a future diff more readable

i also snuck out a duplicate `Args` decl

<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
