### PR TITLE
fix: missing iostream include in nativemessaging & main

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,6 +33,7 @@
 #    include <shobjidl_core.h>
 #endif
 
+#include <iostream>
 #include <memory>
 
 using namespace chatterino;

--- a/src/singletons/NativeMessaging.cpp
+++ b/src/singletons/NativeMessaging.cpp
@@ -26,6 +26,8 @@
 #include <QSettings>
 #include <QStringBuilder>
 
+#include <iostream>
+
 #ifdef Q_OS_WIN
 #    include "widgets/AttachedWindow.hpp"
 #endif


### PR DESCRIPTION
main.cpp and nativemessaging.cpp use stuff from iostream but don't include it

this will fail to compile when settings/signals/serialize stop including iostream in their header file

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
