### PR TITLE
Provide better feedback to the user when they toggle logging to file

### DIFF
--- a/src/controllers/commands/builtin/chatterino/Debugging.cpp
+++ b/src/controllers/commands/builtin/chatterino/Debugging.cpp
@@ -321,6 +321,8 @@ QString disableLogfile(const CommandContext &ctx)
 {
     FileLogger::instance().disable();
 
+    ctx.channel->addSystemMessage("Logging to file disabled");
+
     return {};
 }
 
@@ -341,13 +343,18 @@ QString enableLogfile(const CommandContext &ctx)
 
     QString logFilePath = ctx.words.mid(1).join(" ");
     auto result = FileLogger::instance().enable(logFilePath);
-    if (!result.has_value())
+    if (result.has_value())
+    {
+        ctx.channel->addSystemMessage("Logging to file enabled");
+    }
+    else
     {
         auto error = result.error();
 
         ctx.channel->addSystemMessage(
             QString("Unable to open log file '%1'. Error reported by "
-                    "the system was: %2")
+                    "the system was: %2 (Hint: Do not quote the file path "
+                    "even if it contains spaces)")
                 .arg(error.absFilePath, error.errorDesc));
     }
 

--- a/src/controllers/commands/builtin/chatterino/Debugging.cpp
+++ b/src/controllers/commands/builtin/chatterino/Debugging.cpp
@@ -351,11 +351,16 @@ QString enableLogfile(const CommandContext &ctx)
     {
         auto error = result.error();
 
-        ctx.channel->addSystemMessage(
+        MessageBuilder builder;
+        builder.emplace<TextElement>(
             QString("Unable to open log file '%1'. Error reported by "
                     "the system was: %2 (Hint: Do not quote the file path "
                     "even if it contains spaces)")
-                .arg(error.absFilePath, error.errorDesc));
+                .arg(error.absFilePath, error.errorDesc),
+            MessageElementFlags{MessageElementFlag::Text,
+                                MessageElementFlag::AlwaysShow},
+            MessageColor{QColor(230, 30, 30)});
+        ctx.channel->addMessage(builder.release(), MessageContext::Original);
     }
 
     return {};


### PR DESCRIPTION
This addresses some user convenience issues brought up by @8thony wrt  #6901

The error message displayed when logging to file fails to enable now specifically mentions that the path to the file should not be quoted. The error message is also displayed in red.

Fixes #6974 

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
