### PR TITLE
fix: also support magic_enum 0.9.5

### DIFF
--- a/src/util/QMagicEnum.hpp
+++ b/src/util/QMagicEnum.hpp
@@ -10,6 +10,15 @@
 
 #include <concepts>
 
+/// MAGIC_ENUM_VERSION_AT_LEAST(0, 9, 8) equivalent to magic enum version >= 0.9.8
+#define MAGIC_ENUM_VERSION_AT_LEAST(major, minor, patch) \
+    ((MAGIC_ENUM_VERSION_MAJOR > (major)) ||             \
+     (MAGIC_ENUM_VERSION_MAJOR == (major) &&             \
+      MAGIC_ENUM_VERSION_MINOR > (minor)) ||             \
+     (MAGIC_ENUM_VERSION_MAJOR == (major) &&             \
+      MAGIC_ENUM_VERSION_MINOR == (minor) &&             \
+      MAGIC_ENUM_VERSION_PATCH >= (patch)))
+
 namespace chatterino::qmagicenum::detail {
 
 template <typename T, typename U>
@@ -54,10 +63,14 @@ consteval bool isLatin1(std::string_view maybe)
 }
 
 template <typename BinaryPredicate>
-constexpr bool eq(
-    QStringView a, QStringView b,
-    [[maybe_unused]] BinaryPredicate &&
-        p) noexcept(magic_enum::detail::is_nothrow_invocable_v<BinaryPredicate>)
+constexpr bool
+    eq(QStringView a, QStringView b, [[maybe_unused]] BinaryPredicate &&p) noexcept(
+#if MAGIC_ENUM_VERSION_AT_LEAST(0, 9, 8)
+        magic_enum::detail::is_nothrow_invocable_v<BinaryPredicate>
+#else
+        magic_enum::detail::is_nothrow_invocable<BinaryPredicate>()
+#endif
+    )
 {
     // Note: QStringView::operator== isn't constexpr
     if (a.size() != b.size())

--- a/src/util/QMagicEnumTagged.hpp
+++ b/src/util/QMagicEnumTagged.hpp
@@ -71,8 +71,12 @@ inline constexpr auto TAGGED_DATA_STORAGE =
 template <typename C, typename E, typename Tag, E V>
 consteval auto enumTaggedDataStorage()
 {
+#if MAGIC_ENUM_VERSION_AT_LEAST(0, 9, 8)
     constexpr std::string_view utf8 =
         TAGGED_DATA_STORAGE<decltype(V), Tag, V>.str();
+#else
+    constexpr std::string_view utf8 = TAGGED_DATA_STORAGE<decltype(V), Tag, V>;
+#endif
 
     static_assert(isLatin1<utf8.size()>(utf8),
                   "Can't convert non-latin1 UTF8 to UTF16");


### PR DESCRIPTION
this is not a perfect version-check - there are version inbetween we
haven't actually tested, but magic_enum 0.9.5 and 0.9.8 both work as
expected

<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: 6980
-->
