### PR TITLE
Store EmoteId for all Emotes

### DIFF
--- a/src/providers/bttv/BttvEmotes.cpp
+++ b/src/providers/bttv/BttvEmotes.cpp
@@ -93,6 +93,7 @@ std::pair<Outcome, EmoteMap> parseGlobalEmotes(const QJsonArray &jsonEmotes,
             .tooltip = Tooltip{name.string + "<br>Global BetterTTV Emote"},
             .homePage = Url{EMOTE_LINK_FORMAT.arg(id.string)},
             .zeroWidth = ZERO_WIDTH_EMOTES.contains(name.string),
+            .id = id,
         });
 
         emotes[name] = cachedOrMakeEmotePtr(std::move(emote), currentEmotes);

--- a/src/providers/ffz/FfzEmotes.cpp
+++ b/src/providers/ffz/FfzEmotes.cpp
@@ -98,6 +98,7 @@ void parseEmoteSetInto(const QJsonObject &emoteSet, const QString &kind,
             Url{QString("https://www.frankerfacez.com/emoticon/%1-%2")
                     .arg(id.string)
                     .arg(name.string)};
+        emote.id = id;
 
         map[name] = cachedOrMake(std::move(emote), id);
     }

--- a/src/providers/ffz/FfzEmotes.cpp
+++ b/src/providers/ffz/FfzEmotes.cpp
@@ -78,11 +78,16 @@ void parseEmoteSetInto(const QJsonObject &emoteSet, const QString &kind,
         const auto emoteJson = emoteRef.toObject();
 
         // margins
-        auto id = EmoteId{QString::number(emoteJson["id"].toInt())};
-        if (id.string == "0")
+
+        EmoteId id;
+        // FFZ seems to be using both variants to store Emote Id
+        if (emoteJson["id"].isDouble())
         {
-            // FFZ seems to be using both variants to store Emote Id
-            id = EmoteId{emoteJson["id"].toString()};
+            id.string = QString::number(emoteJson["id"].toInt());
+        }
+        else
+        {
+            id.string = emoteJson["id"].toString();
         }
         auto name = EmoteName{emoteJson["name"].toString()};
         auto author =

--- a/src/providers/ffz/FfzEmotes.cpp
+++ b/src/providers/ffz/FfzEmotes.cpp
@@ -79,6 +79,11 @@ void parseEmoteSetInto(const QJsonObject &emoteSet, const QString &kind,
 
         // margins
         auto id = EmoteId{QString::number(emoteJson["id"].toInt())};
+        if (id.string == "0")
+        {
+            // FFZ seems to be using both variants to store Emote Id
+            id = EmoteId{emoteJson["id"].toString()};
+        }
         auto name = EmoteName{emoteJson["name"].toString()};
         auto author =
             EmoteAuthor{emoteJson["owner"]["display_name"].toString()};

--- a/src/providers/twitch/TwitchEmotes.cpp
+++ b/src/providers/twitch/TwitchEmotes.cpp
@@ -473,6 +473,7 @@ EmotePtr TwitchEmotes::getOrCreateEmote(const EmoteId &id,
                                    baseSize * (1.0 / emote3xScaleFactor)),
                 },
             .tooltip = Tooltip{name.toHtmlEscaped() + "<br>Twitch Emote"},
+            .id = EmoteId{id},
         });
     }
 

--- a/tests/snapshots/IrcMessageHandler/action.json
+++ b/tests/snapshots/IrcMessageHandler/action.json
@@ -129,7 +129,8 @@
                             "3x": "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/3.0"
                         },
                         "name": "Kappa",
-                        "tooltip": "Kappa<br>Twitch Emote"
+                        "tooltip": "Kappa<br>Twitch Emote",
+                        "id": "25"
                     },
                     "flags": "EmoteImage|EmoteText",
                     "link": {

--- a/tests/snapshots/IrcMessageHandler/emote-emoji.json
+++ b/tests/snapshots/IrcMessageHandler/emote-emoji.json
@@ -129,7 +129,8 @@
                             "3x": "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/3.0"
                         },
                         "name": "Kappa",
-                        "tooltip": "Kappa<br>Twitch Emote"
+                        "tooltip": "Kappa<br>Twitch Emote",
+                        "id": "25"
                     },
                     "flags": "EmoteImage|EmoteText",
                     "link": {
@@ -165,7 +166,8 @@
                             "3x": "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/3.0"
                         },
                         "name": "Kappa",
-                        "tooltip": "Kappa<br>Twitch Emote"
+                        "tooltip": "Kappa<br>Twitch Emote",
+                        "id": "25"
                     },
                     "flags": "EmoteImage|EmoteText",
                     "link": {

--- a/tests/snapshots/IrcMessageHandler/emote.json
+++ b/tests/snapshots/IrcMessageHandler/emote.json
@@ -100,7 +100,8 @@
                             "3x": "https://static-cdn.jtvnw.net/emoticons/v2/1902/default/dark/3.0"
                         },
                         "name": "Keepo",
-                        "tooltip": "Keepo<br>Twitch Emote"
+                        "tooltip": "Keepo<br>Twitch Emote",
+                        "id": "1902"
                     },
                     "flags": "EmoteImage|EmoteText",
                     "link": {

--- a/tests/snapshots/IrcMessageHandler/emotes.json
+++ b/tests/snapshots/IrcMessageHandler/emotes.json
@@ -100,7 +100,8 @@
                             "3x": "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/3.0"
                         },
                         "name": "Kappa",
-                        "tooltip": "Kappa<br>Twitch Emote"
+                        "tooltip": "Kappa<br>Twitch Emote",
+                        "id": "25"
                     },
                     "flags": "EmoteImage|EmoteText",
                     "link": {
@@ -119,7 +120,8 @@
                             "3x": "https://static-cdn.jtvnw.net/emoticons/v2/1902/default/dark/3.0"
                         },
                         "name": "Keepo",
-                        "tooltip": "Keepo<br>Twitch Emote"
+                        "tooltip": "Keepo<br>Twitch Emote",
+                        "id": "1902"
                     },
                     "flags": "EmoteImage|EmoteText",
                     "link": {
@@ -138,7 +140,8 @@
                             "3x": "https://static-cdn.jtvnw.net/emoticons/v2/305954156/default/dark/3.0"
                         },
                         "name": "PogChamp",
-                        "tooltip": "PogChamp<br>Twitch Emote"
+                        "tooltip": "PogChamp<br>Twitch Emote",
+                        "id": "305954156"
                     },
                     "flags": "EmoteImage|EmoteText",
                     "link": {

--- a/tests/snapshots/IrcMessageHandler/emotes2.json
+++ b/tests/snapshots/IrcMessageHandler/emotes2.json
@@ -100,7 +100,8 @@
                             "3x": "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/3.0"
                         },
                         "name": "Kappa",
-                        "tooltip": "Kappa<br>Twitch Emote"
+                        "tooltip": "Kappa<br>Twitch Emote",
+                        "id": "25"
                     },
                     "flags": "EmoteImage|EmoteText",
                     "link": {
@@ -228,7 +229,8 @@
                             "3x": "https://static-cdn.jtvnw.net/emoticons/v2/305954156/default/dark/3.0"
                         },
                         "name": "PogChamp",
-                        "tooltip": "PogChamp<br>Twitch Emote"
+                        "tooltip": "PogChamp<br>Twitch Emote",
+                        "id": "305954156"
                     },
                     "flags": "EmoteImage|EmoteText",
                     "link": {
@@ -267,7 +269,8 @@
                             "3x": "https://static-cdn.jtvnw.net/emoticons/v2/1902/default/dark/3.0"
                         },
                         "name": "Keepo",
-                        "tooltip": "Keepo<br>Twitch Emote"
+                        "tooltip": "Keepo<br>Twitch Emote",
+                        "id": "1902"
                     },
                     "flags": "EmoteImage|EmoteText",
                     "link": {

--- a/tests/snapshots/IrcMessageHandler/emotes3.json
+++ b/tests/snapshots/IrcMessageHandler/emotes3.json
@@ -98,7 +98,8 @@
                             "3x": "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/3.0"
                         },
                         "name": "Kappa",
-                        "tooltip": "Kappa<br>Twitch Emote"
+                        "tooltip": "Kappa<br>Twitch Emote",
+                        "id": "25"
                     },
                     "flags": "EmoteImage|EmoteText",
                     "link": {
@@ -149,7 +150,8 @@
                             "3x": "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/3.0"
                         },
                         "name": "Kappa",
-                        "tooltip": "Kappa<br>Twitch Emote"
+                        "tooltip": "Kappa<br>Twitch Emote",
+                        "id": "25"
                     },
                     "flags": "EmoteImage|EmoteText",
                     "link": {

--- a/tests/snapshots/IrcMessageHandler/emotes4.json
+++ b/tests/snapshots/IrcMessageHandler/emotes4.json
@@ -81,7 +81,8 @@
                             "3x": "https://static-cdn.jtvnw.net/emoticons/v2/84608/default/dark/3.0"
                         },
                         "name": "f",
-                        "tooltip": "f<br>Twitch Emote"
+                        "tooltip": "f<br>Twitch Emote",
+                        "id": "84608"
                     },
                     "flags": "EmoteImage|EmoteText",
                     "link": {

--- a/tests/snapshots/IrcMessageHandler/emotes5.json
+++ b/tests/snapshots/IrcMessageHandler/emotes5.json
@@ -81,7 +81,8 @@
                             "3x": "https://static-cdn.jtvnw.net/emoticons/v2/84609/default/dark/3.0"
                         },
                         "name": "fo",
-                        "tooltip": "fo<br>Twitch Emote"
+                        "tooltip": "fo<br>Twitch Emote",
+                        "id": "84609"
                     },
                     "flags": "EmoteImage|EmoteText",
                     "link": {

--- a/tests/snapshots/IrcMessageHandler/first-msg.json
+++ b/tests/snapshots/IrcMessageHandler/first-msg.json
@@ -100,7 +100,8 @@
                             "3x": "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/3.0"
                         },
                         "name": "Kappa",
-                        "tooltip": "Kappa<br>Twitch Emote"
+                        "tooltip": "Kappa<br>Twitch Emote",
+                        "id": "25"
                     },
                     "flags": "EmoteImage|EmoteText",
                     "link": {

--- a/tests/snapshots/IrcMessageHandler/ignore-replace.json
+++ b/tests/snapshots/IrcMessageHandler/ignore-replace.json
@@ -81,7 +81,8 @@
                             "3x": "https://static-cdn.jtvnw.net/emoticons/v2/305954156/default/dark/3.0"
                         },
                         "name": "PogChamp",
-                        "tooltip": "PogChamp<br>Twitch Emote"
+                        "tooltip": "PogChamp<br>Twitch Emote",
+                        "id": "305954156"
                     },
                     "flags": "EmoteImage|EmoteText",
                     "link": {
@@ -115,7 +116,8 @@
                             "3x": "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/3.0"
                         },
                         "name": "Kappa",
-                        "tooltip": "Kappa<br>Twitch Emote"
+                        "tooltip": "Kappa<br>Twitch Emote",
+                        "id": "25"
                     },
                     "flags": "EmoteImage|EmoteText",
                     "link": {
@@ -149,7 +151,8 @@
                             "3x": "https://static-cdn.jtvnw.net/emoticons/v2/1902/default/dark/3.0"
                         },
                         "name": "Keepo",
-                        "tooltip": "Keepo<br>Twitch Emote"
+                        "tooltip": "Keepo<br>Twitch Emote",
+                        "id": "1902"
                     },
                     "flags": "EmoteImage|EmoteText",
                     "link": {
@@ -189,7 +192,8 @@
                             "3x": "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/3.0"
                         },
                         "name": "Kappa",
-                        "tooltip": "Kappa<br>Twitch Emote"
+                        "tooltip": "Kappa<br>Twitch Emote",
+                        "id": "25"
                     },
                     "flags": "EmoteImage|EmoteText",
                     "link": {

--- a/tests/snapshots/IrcMessageHandler/mod.json
+++ b/tests/snapshots/IrcMessageHandler/mod.json
@@ -105,7 +105,8 @@
                             "3x": "https://static-cdn.jtvnw.net/emoticons/v2/41/default/dark/3.0"
                         },
                         "name": "Kreygasm",
-                        "tooltip": "Kreygasm<br>Twitch Emote"
+                        "tooltip": "Kreygasm<br>Twitch Emote",
+                        "id": "41"
                     },
                     "flags": "EmoteImage|EmoteText",
                     "link": {
@@ -139,7 +140,8 @@
                             "3x": "https://static-cdn.jtvnw.net/emoticons/v2/41/default/dark/3.0"
                         },
                         "name": "Kreygasm",
-                        "tooltip": "Kreygasm<br>Twitch Emote"
+                        "tooltip": "Kreygasm<br>Twitch Emote",
+                        "id": "41"
                     },
                     "flags": "EmoteImage|EmoteText",
                     "link": {

--- a/tests/snapshots/IrcMessageHandler/redeemed-highlight.json
+++ b/tests/snapshots/IrcMessageHandler/redeemed-highlight.json
@@ -115,7 +115,8 @@
                             "3x": "https://static-cdn.jtvnw.net/emoticons/v2/1/default/dark/3.0"
                         },
                         "name": ":)",
-                        "tooltip": ":)<br>Twitch Emote"
+                        "tooltip": ":)<br>Twitch Emote",
+                        "id": "1"
                     },
                     "flags": "EmoteImage|EmoteText",
                     "link": {

--- a/tests/snapshots/IrcMessageHandler/reply-single.json
+++ b/tests/snapshots/IrcMessageHandler/reply-single.json
@@ -156,7 +156,8 @@
                             "3x": "https://static-cdn.jtvnw.net/emoticons/v2/1902/default/dark/3.0"
                         },
                         "name": "Keepo",
-                        "tooltip": "Keepo<br>Twitch Emote"
+                        "tooltip": "Keepo<br>Twitch Emote",
+                        "id": "1902"
                     },
                     "flags": "EmoteImage|EmoteText",
                     "link": {

--- a/tests/snapshots/IrcMessageHandler/reward-bits.json
+++ b/tests/snapshots/IrcMessageHandler/reward-bits.json
@@ -71,7 +71,8 @@
                             "3x": "https://static-cdn.jtvnw.net/emoticons/v2/42/default/dark/3.0"
                         },
                         "name": "MyBitsEmote",
-                        "tooltip": "MyBitsEmote<br>Twitch Emote"
+                        "tooltip": "MyBitsEmote<br>Twitch Emote",
+                        "id": "42"
                     },
                     "flags": "ChannelPointReward",
                     "link": {

--- a/tests/snapshots/IrcMessageHandler/rm-deleted.json
+++ b/tests/snapshots/IrcMessageHandler/rm-deleted.json
@@ -101,7 +101,8 @@
                             "3x": "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/3.0"
                         },
                         "name": "Kappa",
-                        "tooltip": "Kappa<br>Twitch Emote"
+                        "tooltip": "Kappa<br>Twitch Emote",
+                        "id": "25"
                     },
                     "flags": "EmoteImage|EmoteText",
                     "link": {

--- a/tests/snapshots/IrcMessageHandler/shared-chat-emotes.json
+++ b/tests/snapshots/IrcMessageHandler/shared-chat-emotes.json
@@ -101,7 +101,8 @@
                             "3x": "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/3.0"
                         },
                         "name": "Kappa",
-                        "tooltip": "Kappa<br>Twitch Emote"
+                        "tooltip": "Kappa<br>Twitch Emote",
+                        "id": "25"
                     },
                     "flags": "EmoteImage|EmoteText",
                     "link": {

--- a/tests/snapshots/IrcMessageHandler/simple.json
+++ b/tests/snapshots/IrcMessageHandler/simple.json
@@ -100,7 +100,8 @@
                             "3x": "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/3.0"
                         },
                         "name": "Kappa",
-                        "tooltip": "Kappa<br>Twitch Emote"
+                        "tooltip": "Kappa<br>Twitch Emote",
+                        "id": "25"
                     },
                     "flags": "EmoteImage|EmoteText",
                     "link": {


### PR DESCRIPTION
Unless I'm missing something, this is probably just an oversight?

I noticed this while playing with favourite Emotes stored by Emote IDs.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
