### PR TITLE
ci: bump conan to 2.28.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ env:
   C2_ENABLE_LTO: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/bugfix-release/') || startsWith(github.ref, 'refs/heads/release/') }}
   CHATTERINO_REQUIRE_CLEAN_GIT: On
   CHATTERINO_BUILD_TYPE: ${{ case(inputs.buildType != '', inputs.buildType, 'auto') }}
-  CONAN_VERSION: 2.11.0
+  CONAN_VERSION: 2.28.1
 
 jobs:
   build-ubuntu-docker:

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -10,7 +10,7 @@ env:
   TWITCH_PUBSUB_SERVER_TAG: v1.0.12
   HTTPBOX_TAG: v0.2.1
   QT_QPA_PLATFORM: minimal
-  CONAN_VERSION: 2.11.0
+  CONAN_VERSION: 2.28.1
 
 concurrency:
   group: test-windows-${{ github.ref }}


### PR DESCRIPTION
The GitHub runners will update to VS 2026, which wasn't supported by the old conan version.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
