### PR TITLE
deps: remove direct dependency on Boost.Variant

### DIFF
--- a/src/PrecompiledHeader.hpp
+++ b/src/PrecompiledHeader.hpp
@@ -4,8 +4,6 @@
 
 #ifdef __cplusplus
 #    include <boost/circular_buffer.hpp>
-#    include <boost/current_function.hpp>
-#    include <boost/foreach.hpp>
 #    include <boost/signals2.hpp>
 #    include <IrcCommand>
 #    include <IrcConnection>

--- a/src/messages/Image.hpp
+++ b/src/messages/Image.hpp
@@ -7,7 +7,6 @@
 #include "common/Aliases.hpp"
 #include "util/DebugCount.hpp"
 
-#include <boost/variant.hpp>
 #include <pajlada/signals/signal.hpp>
 #include <QList>
 #include <QPixmap>

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -53,7 +53,6 @@
 #include "util/Variant.hpp"
 #include "widgets/Window.hpp"
 
-#include <boost/variant.hpp>
 #include <QApplication>
 #include <QColor>
 #include <QDateTime>

--- a/src/providers/emoji/Emojis.cpp
+++ b/src/providers/emoji/Emojis.cpp
@@ -12,7 +12,6 @@
 #include "util/QMagicEnum.hpp"
 #include "util/RapidjsonHelpers.hpp"
 
-#include <boost/variant.hpp>
 #include <QFile>
 #include <rapidjson/error/en.h>
 #include <rapidjson/error/error.h>

--- a/src/util/LayoutHelper.cpp
+++ b/src/util/LayoutHelper.cpp
@@ -20,15 +20,15 @@ QScrollArea *makeScrollArea(WidgetOrLayout item)
 {
     auto *area = new QScrollArea();
 
-    switch (item.which())
-    {
-        case 0:
-            area->setWidget(boost::get<QWidget *>(item));
-            break;
-        case 1:
-            area->setWidget(wrapLayout(boost::get<QLayout *>(item)));
-            break;
-    }
+    std::visit(variant::Overloaded{
+                   [&](QWidget *item) {
+                       area->setWidget(item);
+                   },
+                   [&](QLayout *item) {
+                       area->setWidget(wrapLayout(item));
+                   },
+               },
+               item);
 
     area->setWidgetResizable(true);
 

--- a/src/util/LayoutHelper.hpp
+++ b/src/util/LayoutHelper.hpp
@@ -4,16 +4,19 @@
 
 #pragma once
 
-#include <boost/variant.hpp>
+#include "util/Variant.hpp"
+
 #include <QLayout>
+
+#include <variant>
 
 class QWidget;
 class QScrollArea;
 
 namespace chatterino {
 
-using LayoutItem = boost::variant<QWidget *, QLayoutItem *>;
-using WidgetOrLayout = boost::variant<QWidget *, QLayout *>;
+using LayoutItem = std::variant<QWidget *, QLayoutItem *>;
+using WidgetOrLayout = std::variant<QWidget *, QLayout *>;
 
 QWidget *wrapLayout(QLayout *layout);
 QScrollArea *makeScrollArea(WidgetOrLayout item);
@@ -25,15 +28,15 @@ T *makeLayout(std::initializer_list<LayoutItem> items)
 
     for (const auto &item : items)
     {
-        switch (item.which())
-        {
-            case 0:
-                t->addItem(new QWidgetItem(boost::get<QWidget *>(item)));
-                break;
-            case 1:
-                t->addItem(boost::get<QLayoutItem *>(item));
-                break;
-        }
+        std::visit(variant::Overloaded{
+                       [&](QWidget *item) {
+                           t->addItem(new QWidgetItem(item));
+                       },
+                       [&](QLayoutItem *item) {
+                           t->addItem(item);
+                       },
+                   },
+                   item);
     }
 
     t->setContentsMargins(0, 0, 0, 0);

--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -25,7 +25,6 @@
 #include "widgets/splits/SplitContainer.hpp"
 #include "widgets/Window.hpp"
 
-#include <boost/foreach.hpp>
 #include <QActionGroup>
 #include <QDebug>
 #include <QFile>

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -394,7 +394,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     layout.addDropdown<std::underlying_type_t<MessageOverflow>>(
         "Message overflow", {"Highlight", "Prevent", "Allow"},
         s.messageOverflow,
-        [](auto index) {
+        [](auto index) -> std::variant<int, QString> {
             return index;
         },
         [](auto args) {

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -394,8 +394,8 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     layout.addDropdown<std::underlying_type_t<MessageOverflow>>(
         "Message overflow", {"Highlight", "Prevent", "Allow"},
         s.messageOverflow,
-        [](auto index) -> std::variant<int, QString> {
-            return index;
+        [](auto index) {
+            return static_cast<int>(index);
         },
         [](auto args) {
             return static_cast<MessageOverflow>(args.index);
@@ -412,7 +412,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         },
         s.usernameRightClickBehavior,
         [](auto index) {
-            return index;
+            return static_cast<int>(index);
         },
         [](auto args) {
             return static_cast<UsernameRightClickBehavior>(args.index);
@@ -429,7 +429,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         },
         s.usernameRightClickModifierBehavior,
         [](auto index) {
-            return index;
+            return static_cast<int>(index);
         },
         [](auto args) {
             return static_cast<UsernameRightClickBehavior>(args.index);

--- a/src/widgets/settingspages/GeneralPageView.hpp
+++ b/src/widgets/settingspages/GeneralPageView.hpp
@@ -7,9 +7,9 @@
 #include "Application.hpp"
 #include "common/ChatterinoSetting.hpp"
 #include "singletons/WindowManager.hpp"
+#include "util/Variant.hpp"
 #include "widgets/buttons/SignalLabel.hpp"
 
-#include <boost/variant.hpp>
 #include <pajlada/signals/signalholder.hpp>
 #include <QComboBox>
 #include <QDebug>
@@ -18,6 +18,7 @@
 #include <QVBoxLayout>
 
 #include <utility>
+#include <variant>
 
 class QScrollArea;
 
@@ -161,22 +162,22 @@ public:
     }
 
     template <typename T>
-    ComboBox *addDropdown(
-        const QString &text, const QStringList &items,
-        pajlada::Settings::Setting<T> &setting,
-        std::function<boost::variant<int, QString>(T)> getValue,
-        std::function<T(DropdownArgs)> setValue, bool editable = true,
-        QString toolTipText = {}, bool listenToActivated = false)
+    ComboBox *addDropdown(const QString &text, const QStringList &items,
+                          pajlada::Settings::Setting<T> &setting,
+                          std::function<std::variant<int, QString>(T)> getValue,
+                          std::function<T(DropdownArgs)> setValue,
+                          bool editable = true, QString toolTipText = {},
+                          bool listenToActivated = false)
     {
         auto items2 = items;
         auto selected = getValue(setting.getValue());
 
-        if (selected.which() == 1)
+        if (auto *str = std::get_if<QString>(&selected))
         {
             // QString
-            if (!editable && !items2.contains(boost::get<QString>(selected)))
+            if (!editable && !items2.contains(*str))
             {
-                items2.insert(0, boost::get<QString>(selected));
+                items2.insert(0, *str);
             }
         }
 
@@ -186,33 +187,31 @@ public:
             combo->setEditable(true);
         }
 
-        if (selected.which() == 0)
-        {
-            // int
-            auto value = boost::get<int>(selected);
-            if (value >= 0 && value < items2.size())
-            {
-                combo->setCurrentIndex(value);
-            }
-        }
-        else if (selected.which() == 1)
-        {
-            // QString
-            combo->setEditText(boost::get<QString>(selected));
-        }
+        std::visit(variant::Overloaded{
+                       [&](int value) {
+                           if (value >= 0 && value < items2.size())
+                           {
+                               combo->setCurrentIndex(value);
+                           }
+                       },
+                       [&](const QString &str) {
+                           combo->setEditText(str);
+                       },
+                   },
+                   selected);
 
         setting.connect(
             [getValue = std::move(getValue), combo](const T &value, auto) {
-                auto var = getValue(value);
-                if (var.which() == 0)
-                {
-                    combo->setCurrentIndex(boost::get<int>(var));
-                }
-                else
-                {
-                    combo->setCurrentText(boost::get<QString>(var));
-                    combo->setEditText(boost::get<QString>(var));
-                }
+                std::visit(variant::Overloaded{
+                               [&](int value) {
+                                   combo->setCurrentIndex(value);
+                               },
+                               [&](const QString &str) {
+                                   combo->setCurrentText(str);
+                                   combo->setEditText(str);
+                               },
+                           },
+                           getValue(value));
             },
             this->managedConnections_);
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -8,11 +8,9 @@
     "boost-beast",
     "boost-circular-buffer",
     "boost-date-time",
-    "boost-foreach",
     "boost-interprocess",
     "boost-json",
     "boost-signals2",
-    "boost-variant",
     "hunspell",
     "pkgconf",
     {


### PR DESCRIPTION
We compile with C++ 23 now and have compiled with 20 and 17 for a while. These standards support `std::variant` which we use in several places. A few older places still used `boost::variant`. `std::variant` supersedes `boost::variant`. It doesn't require an extra dependency and (usually) has built in support in debuggers.

I also removed includes for `boost/current_function` and `boost/foreach`. We didn't use them. We still depend on Boost.Variant through Boost.Signals2, though.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
