### PR TITLE
feat: Add `/(un)pin`

### DIFF
--- a/mocks/include/mocks/Helix.hpp
+++ b/mocks/include/mocks/Helix.hpp
@@ -513,6 +513,14 @@ public:
         (override));
 
     MOCK_METHOD(
+        void, updatePinnedChatMessage,
+        (const QString &broadcasterID, const QString &moderatorID,
+         const QString &messageID, std::optional<std::chrono::seconds> duration,
+         ResultCallback<> successCallback,
+         (FailureCallback<HelixPinMessageError, QString>)failureCallback),
+        (override));
+
+    MOCK_METHOD(
         void, getPinnedChatMessage,
         (const QString &broadcasterID, const QString &moderatorID,
          ResultCallback<std::optional<HelixPinnedChatMessage>> successCallback,

--- a/mocks/include/mocks/Helix.hpp
+++ b/mocks/include/mocks/Helix.hpp
@@ -504,6 +504,28 @@ public:
                  (FailureCallback<QString> failureCallback)),
                 (override));
 
+    MOCK_METHOD(
+        void, pinChatMessage,
+        (const QString &broadcasterID, const QString &moderatorID,
+         const QString &messageID, std::optional<std::chrono::seconds> duration,
+         ResultCallback<> successCallback,
+         (FailureCallback<HelixPinMessageError, QString>)failureCallback),
+        (override));
+
+    MOCK_METHOD(
+        void, getPinnedChatMessage,
+        (const QString &broadcasterID, const QString &moderatorID,
+         ResultCallback<std::optional<HelixPinnedChatMessage>> successCallback,
+         FailureCallback<QString> failureCallback),
+        (override));
+
+    MOCK_METHOD(
+        void, unpinChatMessage,
+        (const QString &broadcasterID, const QString &moderatorID,
+         const QString &messageID, ResultCallback<> successCallback,
+         (FailureCallback<HelixUnpinMessageError, QString>)failureCallback),
+        (override));
+
     MOCK_METHOD(void, update, (QString clientId, QString oauthToken),
                 (override));
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -103,6 +103,8 @@ set(SOURCE_FILES
         controllers/commands/builtin/twitch/GetVIPs.hpp
         controllers/commands/builtin/twitch/LowTrust.cpp
         controllers/commands/builtin/twitch/LowTrust.hpp
+        controllers/commands/builtin/twitch/Pin.cpp
+        controllers/commands/builtin/twitch/Pin.hpp
         controllers/commands/builtin/twitch/Poll.cpp
         controllers/commands/builtin/twitch/Poll.hpp
         controllers/commands/builtin/twitch/Prediction.cpp

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -20,6 +20,7 @@
 #include "controllers/commands/builtin/twitch/GetModerators.hpp"
 #include "controllers/commands/builtin/twitch/GetVIPs.hpp"
 #include "controllers/commands/builtin/twitch/LowTrust.hpp"
+#include "controllers/commands/builtin/twitch/Pin.hpp"
 #include "controllers/commands/builtin/twitch/Poll.hpp"
 #include "controllers/commands/builtin/twitch/Prediction.hpp"
 #include "controllers/commands/builtin/twitch/Raid.hpp"
@@ -511,6 +512,9 @@ CommandController::CommandController(const Paths &paths)
     this->registerCommand("/lockprediction", &commands::lockPrediction);
     this->registerCommand("/cancelprediction", &commands::cancelPrediction);
     this->registerCommand("/completeprediction", &commands::completePrediction);
+
+    this->registerCommand("/pin", &commands::pin);
+    this->registerCommand("/unpin", &commands::unpin);
 
     this->registerCommand("/c2-set-logging-rules", &commands::setLoggingRules);
     this->registerCommand("/c2-theme-autoreload", &commands::toggleThemeReload);

--- a/src/controllers/commands/builtin/twitch/Pin.cpp
+++ b/src/controllers/commands/builtin/twitch/Pin.cpp
@@ -1,0 +1,394 @@
+// SPDX-FileCopyrightText: 2026 Contributors to Chatterino <https://chatterino.com>
+//
+// SPDX-License-Identifier: MIT
+
+#include "Application.hpp"
+#include "common/Channel.hpp"
+#include "controllers/accounts/AccountController.hpp"
+#include "controllers/commands/CommandContext.hpp"
+#include "messages/Message.hpp"
+#include "messages/MessageBuilder.hpp"
+#include "messages/MessageElement.hpp"
+#include "providers/twitch/api/Helix.hpp"
+#include "providers/twitch/TwitchAccount.hpp"
+#include "providers/twitch/TwitchChannel.hpp"
+#include "util/Expected.hpp"
+#include "util/FormatTime.hpp"
+#include "util/Helpers.hpp"
+
+#include <controllers/commands/builtin/twitch/Pin.hpp>
+#include <QCommandLineParser>
+#include <QProcess>
+
+namespace {
+
+using namespace Qt::Literals;
+using namespace chatterino;
+
+struct SendPinnedAction {
+    QString text;
+
+    void run(const std::shared_ptr<TwitchChannel> &chan,
+             const TwitchAccount &moderator) const;
+};
+
+struct PinAction {
+    QString messageID;
+    std::optional<std::chrono::seconds> duration;
+
+    void run(const std::shared_ptr<TwitchChannel> &chan,
+             const TwitchAccount &moderator) const;
+};
+
+using Action = std::variant<SendPinnedAction, PinAction>;
+
+void SendPinnedAction::run(const std::shared_ptr<TwitchChannel> &chan,
+                           const TwitchAccount &moderator) const
+{
+    getHelix()->sendChatMessage(
+        {
+            .broadcasterID = chan->roomId(),
+            .senderID = moderator.getUserId(),
+            .message = this->text,
+            .pin = true,
+        },
+        [weak = std::weak_ptr(chan),
+         origText = this->text](const HelixSentMessage &res) {
+            auto chan = weak.lock();
+            if (!chan)
+            {
+                return;
+            }
+
+            if (res.isSent)
+            {
+                chan->addMessage(
+                    MessageBuilder::makePinSuccessMessage(origText, res.id),
+                    MessageContext::Original);
+                return;
+            }
+
+            if (res.dropReason)
+            {
+                chan->addSystemMessage(res.dropReason->message);
+            }
+            else
+            {
+                chan->addSystemMessage("Your message was not pinned.");
+            }
+        },
+        [weak = std::weak_ptr(chan)](auto error, auto message) {
+            auto chan = weak.lock();
+            if (!chan)
+            {
+                return;
+            }
+
+            if (message.isEmpty())
+            {
+                message = "(empty message)";
+            }
+
+            using Error = HelixSendMessageError;
+
+            auto errorMessage = [&]() -> QString {
+                switch (error)
+                {
+                    case Error::MissingText:
+                        return "You can't pin an empty message.";
+                    case Error::BadRequest:
+                        return "Failed to pin message: " + message;
+                    case Error::Forbidden:
+                        return "You are not allowed to pin messages in this "
+                               "channel.";
+                    case Error::MessageTooLarge:
+                        return "Your message was too long.";
+                    case Error::UserMissingScope:
+                        return "Missing required scope. Re-login with your "
+                               "account and try again.";
+                    case Error::Forwarded:
+                        return message;
+                    case Error::Unknown:
+                    default:
+                        return "Unknown error: " + message;
+                }
+            }();
+            chan->addSystemMessage(errorMessage);
+        });
+}
+
+void PinAction::run(const std::shared_ptr<TwitchChannel> &chan,
+                    const TwitchAccount &moderator) const
+{
+    chan->pinMessageAs(this->messageID, this->duration, moderator);
+}
+
+ExpectedStr<Action> parseAction(const CommandContext &ctx)
+{
+    QCommandLineParser parser;
+    parser.setSingleDashWordOptionMode(QCommandLineParser::ParseAsLongOptions);
+    parser.setOptionsAfterPositionalArgumentsMode(
+        QCommandLineParser::ParseAsOptions);
+    QCommandLineOption idOption(u"id"_s, {}, u"ID"_s);
+    QCommandLineOption durationOption(QStringList{u"d"_s, u"duration"_s}, {},
+                                      u"duration"_s);
+    parser.addOptions({idOption, durationOption});
+    parser.parse(QProcess::splitCommand(ctx.words.join(" ")));
+
+    std::optional<std::chrono::seconds> duration;
+    if (parser.isSet(durationOption))
+    {
+        const auto dur = parseDurationToSeconds(parser.value(durationOption));
+        if (dur <= 0)
+        {
+            return makeUnexpected(u"Duration must be positive."_s);
+        }
+        duration.emplace(dur);
+    }
+
+    std::optional<QString> id;
+    if (parser.isSet(idOption))
+    {
+        id.emplace(parser.value(idOption));
+    }
+
+    auto positionals = parser.positionalArguments();
+
+    if (id)
+    {
+        if (!positionals.empty())
+        {
+            return makeUnexpected(
+                u"No positional arguments can be specified when using --id."_s);
+        }
+
+        return PinAction{
+            .messageID = *std::move(id),
+            .duration = duration,
+        };
+    }
+
+    if (duration)
+    {
+        return makeUnexpected(
+            u"No duration can be specified when sending and pinning a message. "
+            "Send the message first, and pin it afterward."_s);
+    }
+
+    return SendPinnedAction{
+        .text = positionals.join(' '),
+    };
+}
+
+void showCurrentlyPinnedMessage(const std::shared_ptr<TwitchChannel> &chan,
+                                const TwitchAccount &moderator)
+{
+    getHelix()->getPinnedChatMessage(
+        chan->roomId(), moderator.getUserId(),
+        [weak = std::weak_ptr(chan)](
+            const std::optional<HelixPinnedChatMessage> &result) {
+            auto chan = weak.lock();
+            if (!chan)
+            {
+                return;
+            }
+
+            if (!result)
+            {
+                chan->addSystemMessage(u"There is no pinned message."_s);
+                return;
+            }
+
+            MessageBuilder builder;
+            builder->channelName = chan->getName();
+            builder.emplace<TimestampElement>();
+            builder->flags.set(MessageFlag::System,
+                               MessageFlag::DoNotTriggerNotification);
+
+            QString text = result->pinnedBy.login + ' ';
+            builder.emplace<MentionElement>(
+                result->pinnedBy.displayName, result->pinnedBy.login,
+                MessageColor::System,
+                chan->getUserColor(result->pinnedBy.login));
+            builder.emplaceSystemTextAndUpdate("pinned a message", text);
+
+            auto now = QDateTime::currentDateTimeUtc();
+            builder.appendOrEmplaceSystemTextAndUpdate(
+                formatTime(std::chrono::duration_cast<std::chrono::seconds>(
+                    now - result->startsAt)),
+                text);
+            builder.appendOrEmplaceSystemTextAndUpdate("ago", text);
+            if (result->endsAt)
+            {
+                auto remaining =
+                    std::chrono::duration_cast<std::chrono::seconds>(
+                        *result->endsAt - now);
+                builder.appendOrEmplaceSystemTextAndUpdate(
+                    '(' % formatTime(remaining) % " remaining)", text);
+            }
+            else
+            {
+                builder.appendOrEmplaceSystemTextAndUpdate(
+                    "until the stream ends", text);
+            }
+            builder.appendOrEmplaceSystemTextAndUpdate("from", text);
+            builder
+                .emplace<MentionElement>(
+                    result->sender.displayName, result->sender.login,
+                    MessageColor::System,
+                    chan->getUserColor(result->sender.login))
+                ->setTrailingSpace(false);
+            text += result->sender.login;
+            builder.appendOrEmplaceSystemTextAndUpdate(u":"_s, text);
+
+            auto pinMessageText = result->messageText;
+            if (pinMessageText.length() > 50)
+            {
+                pinMessageText = pinMessageText.left(50) + "…";
+            }
+
+            builder
+                .emplace<TextElement>(pinMessageText, MessageElementFlag::Text,
+                                      MessageColor::Text)
+                ->setLink({Link::JumpToMessage, result->messageID});
+            builder->messageText = pinMessageText;
+            builder->searchText = pinMessageText;
+            chan->addMessage(builder.release(), MessageContext::Original);
+        },
+        [weak = std::weak_ptr(chan)](const auto &result) {
+            auto chan = weak.lock();
+            if (!chan)
+            {
+                return;
+            }
+            chan->addSystemMessage("Failed to get pinned message: " % result);
+        });
+}
+
+}  // namespace
+
+namespace chatterino::commands {
+
+/// /pin
+QString pin(const CommandContext &ctx)
+{
+    if (!ctx.channel)
+    {
+        return {};
+    }
+    if (!ctx.twitchChannel)
+    {
+        ctx.channel->addSystemMessage(
+            u"The /pin command only works in Twitch channels"_s);
+        return {};
+    }
+
+    auto currentUser = getApp()->getAccounts()->twitch.getCurrent();
+    if (currentUser->isAnon())
+    {
+        ctx.channel->addSystemMessage("You must be logged in to pin messages!");
+        return "";
+    }
+
+    std::span<const QString> args = ctx.words;
+    if (args.empty())
+    {
+        assert(false && "should have /pin");
+        return {};
+    }
+    args = args.subspan(1);
+
+    if (args.size() == 1 && (args[0] == u"-h" || args[0] == u"--help"))
+    {
+        ctx.channel->addSystemMessage(
+            u"Pin a chat message or show the currently pinned one. Usage: /pin --duration <seconds> --id <id> [message]..."_s);
+        return {};
+    }
+
+    auto chan = std::static_pointer_cast<TwitchChannel>(
+        ctx.twitchChannel->shared_from_this());
+    if (args.empty())
+    {
+        showCurrentlyPinnedMessage(chan, *currentUser);
+        return {};
+    }
+
+    auto action = parseAction(ctx);
+    if (!action)
+    {
+        ctx.channel->addSystemMessage(action.error());
+        return {};
+    }
+
+    std::visit(
+        [&](const auto &action) {
+            action.run(chan, *currentUser);
+        },
+        *action);
+
+    return {};
+}
+
+/// /unpin
+QString unpin(const CommandContext &ctx)
+{
+    if (!ctx.channel)
+    {
+        return {};
+    }
+    if (!ctx.twitchChannel)
+    {
+        ctx.channel->addSystemMessage(
+            u"The /unpin command only works in Twitch channels"_s);
+        return {};
+    }
+
+    auto currentUser = getApp()->getAccounts()->twitch.getCurrent();
+    if (currentUser->isAnon())
+    {
+        ctx.channel->addSystemMessage("You must be logged in to pin messages!");
+        return "";
+    }
+
+    if (ctx.words.empty())
+    {
+        assert(false);
+        return {};
+    }
+
+    auto chan = std::static_pointer_cast<TwitchChannel>(
+        ctx.twitchChannel->shared_from_this());
+    if (ctx.words.size() == 1)
+    {
+        getHelix()->getPinnedChatMessage(
+            chan->roomId(), currentUser->getUserId(),
+            [weak = std::weak_ptr(chan), currentUser](const auto &result) {
+                auto chan = weak.lock();
+                if (!chan)
+                {
+                    return;
+                }
+                if (!result)
+                {
+                    chan->addSystemMessage(u"There is no pinned message"_s);
+                    return;
+                }
+                chan->unpinMessageAs(result->messageID, *currentUser);
+            },
+            [weak = std::weak_ptr(chan)](const auto &message) {
+                auto chan = weak.lock();
+                if (!chan)
+                {
+                    return;
+                }
+                chan->addSystemMessage(u"Failed to get pinned message: " %
+                                       message);
+            });
+        return {};
+    }
+
+    chan->unpinMessageAs(ctx.words.at(1), *currentUser);
+    return {};
+}
+
+}  // namespace chatterino::commands

--- a/src/controllers/commands/builtin/twitch/Pin.cpp
+++ b/src/controllers/commands/builtin/twitch/Pin.cpp
@@ -13,7 +13,6 @@
 #include "providers/twitch/TwitchAccount.hpp"
 #include "providers/twitch/TwitchChannel.hpp"
 #include "util/Expected.hpp"
-#include "util/FormatTime.hpp"
 #include "util/Helpers.hpp"
 
 #include <controllers/commands/builtin/twitch/Pin.hpp>
@@ -25,35 +24,29 @@ namespace {
 using namespace Qt::Literals;
 using namespace chatterino;
 
-struct SendPinnedAction {
+struct Action {
     QString text;
-
-    void run(const std::shared_ptr<TwitchChannel> &chan,
-             const TwitchAccount &moderator) const;
-};
-
-struct PinAction {
     QString messageID;
     std::optional<std::chrono::seconds> duration;
-
-    void run(const std::shared_ptr<TwitchChannel> &chan,
-             const TwitchAccount &moderator) const;
 };
 
-using Action = std::variant<SendPinnedAction, PinAction>;
+// Duration of pin when sending message with "Send Chat Message".
+// See https://dev.twitch.tv/docs/api/reference#send-chat-message.
+constexpr std::chrono::minutes SEND_CHAT_MESSAGE_PIN_DURATION(20);
 
-void SendPinnedAction::run(const std::shared_ptr<TwitchChannel> &chan,
-                           const TwitchAccount &moderator) const
+void sendPinnedMessageDefaultDuration(
+    const std::shared_ptr<TwitchChannel> &chan, const TwitchAccount &moderator,
+    const QString &text)
 {
     getHelix()->sendChatMessage(
         {
             .broadcasterID = chan->roomId(),
             .senderID = moderator.getUserId(),
-            .message = this->text,
+            .message = text,
             .pin = true,
         },
         [weak = std::weak_ptr(chan),
-         origText = this->text](const HelixSentMessage &res) {
+         origText = text](const HelixSentMessage &res) {
             auto chan = weak.lock();
             if (!chan)
             {
@@ -117,10 +110,35 @@ void SendPinnedAction::run(const std::shared_ptr<TwitchChannel> &chan,
         });
 }
 
-void PinAction::run(const std::shared_ptr<TwitchChannel> &chan,
-                    const TwitchAccount &moderator) const
+void sendAndPin(const std::shared_ptr<TwitchChannel> &chan,
+                const std::shared_ptr<TwitchAccount> &moderator,
+                const QString &text,
+                std::optional<std::chrono::seconds> duration)
 {
-    chan->pinMessageAs(this->messageID, this->duration, moderator);
+    getHelix()->sendChatMessage(
+        {
+            .broadcasterID = chan->roomId(),
+            .senderID = moderator->getUserId(),
+            .message = text,
+            .pin = false,  // we'll pin the message later
+        },
+        [weak = chan->weakFromThis(), moderator, duration,
+         text](const auto &result) {
+            auto chan = weak.lock();
+            if (!chan)
+            {
+                return;
+            }
+            chan->pinMessageAs(result.id, duration, *moderator, text);
+        },
+        [weak = chan->weakFromThis()](auto /* err */, const auto &message) {
+            auto chan = weak.lock();
+            if (!chan)
+            {
+                return;
+            }
+            chan->addSystemMessage("Failed to send message: " + message);
+        });
 }
 
 ExpectedStr<Action> parseAction(const CommandContext &ctx)
@@ -136,9 +154,12 @@ ExpectedStr<Action> parseAction(const CommandContext &ctx)
     parser.parse(QProcess::splitCommand(ctx.words.join(" ")));
 
     std::optional<std::chrono::seconds> duration;
-    if (parser.isSet(durationOption))
+    auto durationText = parser.value(durationOption);
+    bool isExplicitUntilEnd =
+        durationText == u"until-end" || durationText == u"none";
+    if (!durationText.isEmpty() && !isExplicitUntilEnd)
     {
-        const auto dur = parseDurationToSeconds(parser.value(durationOption));
+        const auto dur = parseDurationToSeconds(durationText);
         if (dur <= 0)
         {
             return makeUnexpected(u"Duration must be positive."_s);
@@ -152,31 +173,30 @@ ExpectedStr<Action> parseAction(const CommandContext &ctx)
         id.emplace(parser.value(idOption));
     }
 
-    auto positionals = parser.positionalArguments();
+    auto positionals = parser.positionalArguments().join(' ');
 
     if (id)
     {
-        if (!positionals.empty())
+        if (!positionals.isEmpty())
         {
             return makeUnexpected(
                 u"No positional arguments can be specified when using --id."_s);
         }
 
-        return PinAction{
+        return Action{
             .messageID = *std::move(id),
             .duration = duration,
         };
     }
 
-    if (duration)
+    if (!duration && !isExplicitUntilEnd)
     {
-        return makeUnexpected(
-            u"No duration can be specified when sending and pinning a message. "
-            "Send the message first, and pin it afterward."_s);
+        duration = SEND_CHAT_MESSAGE_PIN_DURATION;
     }
 
-    return SendPinnedAction{
-        .text = positionals.join(' '),
+    return Action{
+        .text = positionals,
+        .duration = duration,
     };
 }
 
@@ -199,61 +219,9 @@ void showCurrentlyPinnedMessage(const std::shared_ptr<TwitchChannel> &chan,
                 return;
             }
 
-            MessageBuilder builder;
-            builder->channelName = chan->getName();
-            builder.emplace<TimestampElement>();
-            builder->flags.set(MessageFlag::System,
-                               MessageFlag::DoNotTriggerNotification);
-
-            QString text = result->pinnedBy.login + ' ';
-            builder.emplace<MentionElement>(
-                result->pinnedBy.displayName, result->pinnedBy.login,
-                MessageColor::System,
-                chan->getUserColor(result->pinnedBy.login));
-            builder.emplaceSystemTextAndUpdate("pinned a message", text);
-
-            auto now = QDateTime::currentDateTimeUtc();
-            builder.appendOrEmplaceSystemTextAndUpdate(
-                formatTime(std::chrono::duration_cast<std::chrono::seconds>(
-                    now - result->startsAt)),
-                text);
-            builder.appendOrEmplaceSystemTextAndUpdate("ago", text);
-            if (result->endsAt)
-            {
-                auto remaining =
-                    std::chrono::duration_cast<std::chrono::seconds>(
-                        *result->endsAt - now);
-                builder.appendOrEmplaceSystemTextAndUpdate(
-                    '(' % formatTime(remaining) % " remaining)", text);
-            }
-            else
-            {
-                builder.appendOrEmplaceSystemTextAndUpdate(
-                    "until the stream ends", text);
-            }
-            builder.appendOrEmplaceSystemTextAndUpdate("from", text);
-            builder
-                .emplace<MentionElement>(
-                    result->sender.displayName, result->sender.login,
-                    MessageColor::System,
-                    chan->getUserColor(result->sender.login))
-                ->setTrailingSpace(false);
-            text += result->sender.login;
-            builder.appendOrEmplaceSystemTextAndUpdate(u":"_s, text);
-
-            auto pinMessageText = result->messageText;
-            if (pinMessageText.length() > 50)
-            {
-                pinMessageText = pinMessageText.left(50) + "…";
-            }
-
-            builder
-                .emplace<TextElement>(pinMessageText, MessageElementFlag::Text,
-                                      MessageColor::Text)
-                ->setLink({Link::JumpToMessage, result->messageID});
-            builder->messageText = pinMessageText;
-            builder->searchText = pinMessageText;
-            chan->addMessage(builder.release(), MessageContext::Original);
+            chan->addMessage(
+                MessageBuilder::makeCurrentPinnedMessage(*chan, *result),
+                MessageContext::Original);
         },
         [weak = std::weak_ptr(chan)](const auto &result) {
             auto chan = weak.lock();
@@ -300,7 +268,9 @@ QString pin(const CommandContext &ctx)
         (ctx.words.at(1) == u"-h" || ctx.words.at(1) == u"--help"))
     {
         ctx.channel->addSystemMessage(
-            u"Pin a chat message or show the currently pinned one. Usage: /pin --duration <seconds> --id <id> [message]..."_s);
+            u"Pin a chat message or show the currently pinned one."
+            "Usage: /pin --duration <seconds|until-end|none> [message]... OR "
+            "/pin --id <message-id> --duration <seconds|until-end|none>"_s);
         return {};
     }
 
@@ -319,12 +289,29 @@ QString pin(const CommandContext &ctx)
         return {};
     }
 
-    std::visit(
-        [&](const auto &action) {
-            action.run(chan, *currentUser);
-        },
-        *action);
+    if (!action->messageID.isEmpty())
+    {
+        chan->pinMessageAs(action->messageID, action->duration, *currentUser);
+        return {};
+    }
 
+    if (action->duration == SEND_CHAT_MESSAGE_PIN_DURATION)
+    {
+        sendPinnedMessageDefaultDuration(chan, *currentUser, action->text);
+        return {};
+    }
+
+    // Make sure we will be able to pin the message. Otherwise we'd send a
+    // message without pinning it. The "Send Chat Message" endpoint (used above)
+    // won't sent the message if the user can't pin.
+    if (!chan->hasModRights())
+    {
+        ctx.channel->addSystemMessage(
+            "You must be a moderator to pin messages.");
+        return {};
+    }
+
+    sendAndPin(chan, currentUser, action->text, action->duration);
     return {};
 }
 

--- a/src/controllers/commands/builtin/twitch/Pin.cpp
+++ b/src/controllers/commands/builtin/twitch/Pin.cpp
@@ -34,26 +34,41 @@ struct Action {
 // See https://dev.twitch.tv/docs/api/reference#send-chat-message.
 constexpr std::chrono::minutes SEND_CHAT_MESSAGE_PIN_DURATION(20);
 
-void sendPinnedMessageDefaultDuration(
-    const std::shared_ptr<TwitchChannel> &chan, const TwitchAccount &moderator,
-    const QString &text)
+void sendPinnedMessage(const std::shared_ptr<TwitchChannel> &chan,
+                       const std::shared_ptr<TwitchAccount> &moderator,
+                       const QString &text,
+                       std::optional<std::chrono::seconds> duration)
 {
     getHelix()->sendChatMessage(
         {
             .broadcasterID = chan->roomId(),
-            .senderID = moderator.getUserId(),
+            .senderID = moderator->getUserId(),
             .message = text,
             .pin = true,
         },
-        [weak = std::weak_ptr(chan),
-         origText = text](const HelixSentMessage &res) {
+        [weak = std::weak_ptr(chan), origText = text, duration,
+         moderator](const HelixSentMessage &res) {
             auto chan = weak.lock();
             if (!chan)
             {
                 return;
             }
 
-            if (res.isSent)
+            if (!res.isSent)
+            {
+                if (res.dropReason)
+                {
+                    chan->addSystemMessage(res.dropReason->message);
+                }
+                else
+                {
+                    chan->addSystemMessage("Your message was not pinned.");
+                }
+                return;
+            }
+
+            // Default duration, no need to update it once more.
+            if (duration == SEND_CHAT_MESSAGE_PIN_DURATION)
             {
                 chan->addMessage(
                     MessageBuilder::makePinSuccessMessage(origText, res.id),
@@ -61,14 +76,7 @@ void sendPinnedMessageDefaultDuration(
                 return;
             }
 
-            if (res.dropReason)
-            {
-                chan->addSystemMessage(res.dropReason->message);
-            }
-            else
-            {
-                chan->addSystemMessage("Your message was not pinned.");
-            }
+            chan->updatePinnedMessageAs(res.id, duration, *moderator, origText);
         },
         [weak = std::weak_ptr(chan)](auto error, auto message) {
             auto chan = weak.lock();
@@ -107,37 +115,6 @@ void sendPinnedMessageDefaultDuration(
                 }
             }();
             chan->addSystemMessage(errorMessage);
-        });
-}
-
-void sendAndPin(const std::shared_ptr<TwitchChannel> &chan,
-                const std::shared_ptr<TwitchAccount> &moderator,
-                const QString &text,
-                std::optional<std::chrono::seconds> duration)
-{
-    getHelix()->sendChatMessage(
-        {
-            .broadcasterID = chan->roomId(),
-            .senderID = moderator->getUserId(),
-            .message = text,
-            .pin = false,  // we'll pin the message later
-        },
-        [weak = chan->weakFromThis(), moderator, duration,
-         text](const auto &result) {
-            auto chan = weak.lock();
-            if (!chan)
-            {
-                return;
-            }
-            chan->pinMessageAs(result.id, duration, *moderator, text);
-        },
-        [weak = chan->weakFromThis()](auto /* err */, const auto &message) {
-            auto chan = weak.lock();
-            if (!chan)
-            {
-                return;
-            }
-            chan->addSystemMessage("Failed to send message: " + message);
         });
 }
 
@@ -295,23 +272,7 @@ QString pin(const CommandContext &ctx)
         return {};
     }
 
-    if (action->duration == SEND_CHAT_MESSAGE_PIN_DURATION)
-    {
-        sendPinnedMessageDefaultDuration(chan, *currentUser, action->text);
-        return {};
-    }
-
-    // Make sure we will be able to pin the message. Otherwise we'd send a
-    // message without pinning it. The "Send Chat Message" endpoint (used above)
-    // won't sent the message if the user can't pin.
-    if (!chan->hasModRights())
-    {
-        ctx.channel->addSystemMessage(
-            "You must be a moderator to pin messages.");
-        return {};
-    }
-
-    sendAndPin(chan, currentUser, action->text, action->duration);
+    sendPinnedMessage(chan, currentUser, action->text, action->duration);
     return {};
 }
 

--- a/src/controllers/commands/builtin/twitch/Pin.cpp
+++ b/src/controllers/commands/builtin/twitch/Pin.cpp
@@ -269,8 +269,8 @@ QString pin(const CommandContext &ctx)
     {
         ctx.channel->addSystemMessage(
             u"Pin a chat message or show the currently pinned one."
-            "Usage: /pin --duration <seconds|until-end|none> [message]... OR "
-            "/pin --id <message-id> --duration <seconds|until-end|none>"_s);
+            "Usage: /pin [--duration <seconds|until-end|none>] [message]... OR "
+            "/pin --id <message-id> [--duration <seconds|until-end|none>]"_s);
         return {};
     }
 

--- a/src/controllers/commands/builtin/twitch/Pin.cpp
+++ b/src/controllers/commands/builtin/twitch/Pin.cpp
@@ -231,8 +231,9 @@ QString pin(const CommandContext &ctx)
     auto currentUser = getApp()->getAccounts()->twitch.getCurrent();
     if (currentUser->isAnon())
     {
-        ctx.channel->addSystemMessage("You must be logged in to pin messages!");
-        return "";
+        ctx.channel->addSystemMessage(
+            u"You must be logged in to pin messages!"_s);
+        return {};
     }
 
     if (ctx.words.empty())
@@ -293,8 +294,9 @@ QString unpin(const CommandContext &ctx)
     auto currentUser = getApp()->getAccounts()->twitch.getCurrent();
     if (currentUser->isAnon())
     {
-        ctx.channel->addSystemMessage("You must be logged in to pin messages!");
-        return "";
+        ctx.channel->addSystemMessage(
+            u"You must be logged in to unpin messages!"_s);
+        return {};
     }
 
     if (ctx.words.empty())

--- a/src/controllers/commands/builtin/twitch/Pin.cpp
+++ b/src/controllers/commands/builtin/twitch/Pin.cpp
@@ -290,15 +290,14 @@ QString pin(const CommandContext &ctx)
         return "";
     }
 
-    std::span<const QString> args = ctx.words;
-    if (args.empty())
+    if (ctx.words.empty())
     {
         assert(false && "should have /pin");
         return {};
     }
-    args = args.subspan(1);
 
-    if (args.size() == 1 && (args[0] == u"-h" || args[0] == u"--help"))
+    if (ctx.words.size() == 2 &&
+        (ctx.words.at(1) == u"-h" || ctx.words.at(1) == u"--help"))
     {
         ctx.channel->addSystemMessage(
             u"Pin a chat message or show the currently pinned one. Usage: /pin --duration <seconds> --id <id> [message]..."_s);
@@ -307,7 +306,7 @@ QString pin(const CommandContext &ctx)
 
     auto chan = std::static_pointer_cast<TwitchChannel>(
         ctx.twitchChannel->shared_from_this());
-    if (args.empty())
+    if (ctx.words.size() == 1)
     {
         showCurrentlyPinnedMessage(chan, *currentUser);
         return {};

--- a/src/controllers/commands/builtin/twitch/Pin.hpp
+++ b/src/controllers/commands/builtin/twitch/Pin.hpp
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2026 Contributors to Chatterino <https://chatterino.com>
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+class QString;
+
+namespace chatterino {
+
+struct CommandContext;
+
+}  // namespace chatterino
+
+namespace chatterino::commands {
+
+/// /pin
+QString pin(const CommandContext &ctx);
+
+/// /unpin
+QString unpin(const CommandContext &ctx);
+
+}  // namespace chatterino::commands

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -1551,6 +1551,34 @@ MessagePtrMut MessageBuilder::makeClearChatMessage(const QDateTime &now,
     return builder.release();
 }
 
+MessagePtrMut MessageBuilder::makePinSuccessMessage(const QString &textOrID,
+                                                    const QString &id)
+{
+    MessageBuilder builder;
+    builder.emplace<TimestampElement>();
+    builder->flags.set(MessageFlag::System,
+                       MessageFlag::DoNotTriggerNotification,
+                       MessageFlag::ModerationAction);
+    builder.emplace<TextElement>("Pinned", MessageElementFlag::Text,
+                                 MessageColor::System);
+
+    auto text = textOrID;
+    if (text.length() > 50)
+    {
+        text = std::move(text).left(50) + "…";
+    }
+
+    builder
+        .emplace<TextElement>(text, MessageElementFlag::Text,
+                              MessageColor::Text)
+        ->setLink({Link::JumpToMessage, id});
+
+    auto searchText = u"Pinned "_s % text;
+    builder->messageText = searchText;
+    builder->searchText = searchText;
+    return builder.release();
+}
+
 std::pair<MessagePtrMut, HighlightAlert> MessageBuilder::makeIrcMessage(
     /* mutable */ Channel *channel, const Communi::IrcMessage *ircMessage,
     const MessageParseArgs &args, /* mutable */ QString content,

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -1573,9 +1573,66 @@ MessagePtrMut MessageBuilder::makePinSuccessMessage(const QString &textOrID,
                               MessageColor::Text)
         ->setLink({Link::JumpToMessage, id});
 
-    auto searchText = u"Pinned "_s % text;
+    QStringBuilder searchText = u"Pinned "_s % text;
     builder->messageText = searchText;
     builder->searchText = searchText;
+    return builder.release();
+}
+
+MessagePtrMut MessageBuilder::makeCurrentPinnedMessage(
+    const TwitchChannel &chan, const HelixPinnedChatMessage &pin)
+{
+    MessageBuilder builder;
+    builder->channelName = chan.getName();
+    builder.emplace<TimestampElement>();
+    builder->flags.set(MessageFlag::System,
+                       MessageFlag::DoNotTriggerNotification);
+
+    QString text = pin.pinnedBy.login + ' ';
+    builder.emplace<MentionElement>(pin.pinnedBy.displayName,
+                                    pin.pinnedBy.login, MessageColor::System,
+                                    chan.getUserColor(pin.pinnedBy.login));
+    builder.emplaceSystemTextAndUpdate("pinned a message", text);
+
+    auto now = QDateTime::currentDateTimeUtc();
+    builder.appendOrEmplaceSystemTextAndUpdate(
+        formatTime(std::chrono::duration_cast<std::chrono::seconds>(
+            now - pin.startsAt)),
+        text);
+    builder.appendOrEmplaceSystemTextAndUpdate("ago", text);
+    if (pin.endsAt)
+    {
+        auto remaining =
+            std::chrono::duration_cast<std::chrono::seconds>(*pin.endsAt - now);
+        builder.appendOrEmplaceSystemTextAndUpdate(
+            '(' % formatTime(remaining) % " remaining)", text);
+    }
+    else
+    {
+        builder.appendOrEmplaceSystemTextAndUpdate("until the stream ends",
+                                                   text);
+    }
+    builder.appendOrEmplaceSystemTextAndUpdate("from", text);
+    builder
+        .emplace<MentionElement>(pin.sender.displayName, pin.sender.login,
+                                 MessageColor::System,
+                                 chan.getUserColor(pin.sender.login))
+        ->setTrailingSpace(false);
+    text += pin.sender.login;
+    builder.appendOrEmplaceSystemTextAndUpdate(u":"_s, text);
+
+    auto pinMessageText = pin.messageText;
+    if (pinMessageText.length() > 50)
+    {
+        pinMessageText = pinMessageText.left(50) + "…";
+    }
+
+    builder
+        .emplace<TextElement>(pinMessageText, MessageElementFlag::Text,
+                              MessageColor::Text)
+        ->setLink({Link::JumpToMessage, pin.messageID});
+    builder->messageText = pinMessageText;
+    builder->searchText = pinMessageText;
     return builder.release();
 }
 

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -1551,7 +1551,7 @@ MessagePtrMut MessageBuilder::makeClearChatMessage(const QDateTime &now,
     return builder.release();
 }
 
-MessagePtrMut MessageBuilder::makePinSuccessMessage(const QString &textOrID,
+MessagePtrMut MessageBuilder::makePinSuccessMessage(QString text,
                                                     const QString &id)
 {
     MessageBuilder builder;
@@ -1562,7 +1562,6 @@ MessagePtrMut MessageBuilder::makePinSuccessMessage(const QString &textOrID,
     QString searchText;
     builder.emplaceSystemTextAndUpdate("Pinned", searchText);
 
-    auto text = textOrID;
     if (text.isEmpty())
     {
         text = id;

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -1559,21 +1559,27 @@ MessagePtrMut MessageBuilder::makePinSuccessMessage(const QString &textOrID,
     builder->flags.set(MessageFlag::System,
                        MessageFlag::DoNotTriggerNotification,
                        MessageFlag::ModerationAction);
-    builder.emplace<TextElement>("Pinned", MessageElementFlag::Text,
-                                 MessageColor::System);
+    QString searchText;
+    builder.emplaceSystemTextAndUpdate("Pinned", searchText);
 
     auto text = textOrID;
+    if (text.isEmpty())
+    {
+        text = id;
+        builder.emplaceSystemTextAndUpdate("message with ID", searchText);
+    }
+
     if (text.length() > 50)
     {
         text = std::move(text).left(50) + "…";
     }
+    searchText += text;
 
     builder
         .emplace<TextElement>(text, MessageElementFlag::Text,
                               MessageColor::Text)
         ->setLink({Link::JumpToMessage, id});
 
-    QStringBuilder searchText = u"Pinned "_s % text;
     builder->messageText = searchText;
     builder->searchText = searchText;
     return builder.release();

--- a/src/messages/MessageBuilder.hpp
+++ b/src/messages/MessageBuilder.hpp
@@ -258,8 +258,7 @@ public:
                                               const QString &actor,
                                               uint32_t count = 1);
 
-    static MessagePtrMut makePinSuccessMessage(const QString &textOrID,
-                                               const QString &id);
+    static MessagePtrMut makePinSuccessMessage(QString text, const QString &id);
 
     static MessagePtrMut makeCurrentPinnedMessage(
         const TwitchChannel &channel, const HelixPinnedChatMessage &pin);

--- a/src/messages/MessageBuilder.hpp
+++ b/src/messages/MessageBuilder.hpp
@@ -257,6 +257,9 @@ public:
                                               const QString &actor,
                                               uint32_t count = 1);
 
+    static MessagePtrMut makePinSuccessMessage(const QString &textOrID,
+                                               const QString &id);
+
 private:
     struct TextState {
         TwitchChannel *twitchChannel = nullptr;

--- a/src/messages/MessageBuilder.hpp
+++ b/src/messages/MessageBuilder.hpp
@@ -39,6 +39,7 @@ struct HelixVip;
 using HelixModerator = HelixVip;
 struct ChannelPointReward;
 struct TwitchEmoteOccurrence;
+struct HelixPinnedChatMessage;
 
 namespace linkparser {
 struct Parsed;
@@ -259,6 +260,9 @@ public:
 
     static MessagePtrMut makePinSuccessMessage(const QString &textOrID,
                                                const QString &id);
+
+    static MessagePtrMut makeCurrentPinnedMessage(
+        const TwitchChannel &channel, const HelixPinnedChatMessage &pin);
 
 private:
     struct TextState {

--- a/src/providers/twitch/TwitchAccountManager.cpp
+++ b/src/providers/twitch/TwitchAccountManager.cpp
@@ -165,7 +165,8 @@ const std::vector<QStringView> AUTH_SCOPES{
     u"moderator:manage:banned_users",  // for ban/unban/timeout/untimeout api & channel.moderate eventsub topic
 
     // https://dev.twitch.tv/docs/api/reference#delete-chat-messages
-    u"moderator:manage:chat_messages",  // for delete message api (/delete, /clear) & channel.moderate eventsub topic
+    // https://dev.twitch.tv/docs/api/reference#pin-chat-message
+    u"moderator:manage:chat_messages",  // for delete message api (/delete, /clear, /pin) & channel.moderate eventsub topic
 
     // https://dev.twitch.tv/docs/api/reference#update-user-chat-color
     u"user:manage:chat_color",  // for update user color api (/color coral)

--- a/src/providers/twitch/TwitchAccountManager.cpp
+++ b/src/providers/twitch/TwitchAccountManager.cpp
@@ -166,7 +166,7 @@ const std::vector<QStringView> AUTH_SCOPES{
 
     // https://dev.twitch.tv/docs/api/reference#delete-chat-messages
     // https://dev.twitch.tv/docs/api/reference#pin-chat-message
-    u"moderator:manage:chat_messages",  // for delete message api (/delete, /clear, /pin) & channel.moderate eventsub topic
+    u"moderator:manage:chat_messages",  // for message moderation api (/delete, /clear, /pin) & channel.moderate eventsub topic
 
     // https://dev.twitch.tv/docs/api/reference#update-user-chat-color
     u"user:manage:chat_color",  // for update user color api (/color coral)

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -251,6 +251,16 @@ TwitchChannel::~TwitchChannel()
     this->destroyed.invoke();
 }
 
+std::shared_ptr<TwitchChannel> TwitchChannel::sharedFromThis()
+{
+    return std::static_pointer_cast<TwitchChannel>(this->shared_from_this());
+}
+
+std::weak_ptr<TwitchChannel> TwitchChannel::weakFromThis()
+{
+    return this->sharedFromThis();
+}
+
 void TwitchChannel::initialize()
 {
     this->refreshChatters();
@@ -2175,6 +2185,117 @@ void TwitchChannel::deleteMessagesAs(const QString &messageID,
             }
 
             self->addSystemMessage(errorMessage);
+        });
+}
+
+void TwitchChannel::pinMessageAs(const QString &messageID,
+                                 std::optional<std::chrono::seconds> duration,
+                                 const TwitchAccount &moderator)
+{
+    getHelix()->pinChatMessage(
+        this->roomId(), moderator.getUserId(), messageID, duration,
+        [weak = this->weakFromThis(), id = messageID]() {
+            auto self = weak.lock();
+            if (!self)
+            {
+                return;
+            }
+
+            self->addMessage(MessageBuilder::makePinSuccessMessage(id, id),
+                             MessageContext::Original);
+        },
+        [weak = this->weakFromThis(), id = messageID](
+            HelixPinMessageError error, auto message) {
+            auto chan = weak.lock();
+            if (!chan)
+            {
+                return;
+            }
+
+            if (message.isEmpty())
+            {
+                message = "(empty message)";
+            }
+
+            using Error = HelixPinMessageError;
+
+            auto errorMessage = [&]() -> QString {
+                switch (error)
+                {
+                    case Error::InvalidParameter:
+                        return "Failed to pin message: " + message;
+                    case Error::MissingScope:
+                        return "Missing required scope. Re-login with your "
+                               "account and try again.";
+                    case Error::Forbidden:
+                        return "You are not allowed to pin messages in this "
+                               "channel.";
+                    case Error::NotFound:
+                        return "Failed to find message with id \"" % id % "\".";
+                    case Error::AlreadyPinned:
+                        return "The message is already pinned.";
+
+                    case Error::Forwarded:
+                        return message;
+                    case Error::Unknown:
+                    default:
+                        return "Unknown error: " + message;
+                }
+            }();
+            chan->addSystemMessage(errorMessage);
+        });
+}
+
+void TwitchChannel::unpinMessageAs(const QString &messageID,
+                                   const TwitchAccount &moderator)
+{
+    getHelix()->unpinChatMessage(
+        this->roomId(), moderator.getUserId(), messageID,
+        [weak = this->weakFromThis()] {
+            auto chan = weak.lock();
+            if (!chan)
+            {
+                return;
+            }
+
+            chan->addSystemMessage("Unpinned message.");
+        },
+        [weak = this->weakFromThis(), messageID](HelixUnpinMessageError error,
+                                                 auto message) {
+            auto chan = weak.lock();
+            if (!chan)
+            {
+                return;
+            }
+
+            if (message.isEmpty())
+            {
+                message = "(empty message)";
+            }
+
+            using Error = HelixUnpinMessageError;
+
+            auto errorMessage = [&]() -> QString {
+                switch (error)
+                {
+                    case Error::MissingScope:
+                        return "Missing required scope. Re-login with your "
+                               "account and try again.";
+                    case Error::Forbidden:
+                        return "You are not allowed to unpin messages in this "
+                               "channel.";
+                    case Error::NotFound:
+                        return "Failed to find message with id \"" % messageID %
+                               "\".";
+
+                    case Error::Forwarded:
+                        return message;
+                    case Error::Unknown:
+                    default:
+                        return "Unknown error: " + message;
+                }
+            }();
+            chan->addSystemMessage(errorMessage);
         });
 }
 

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -2203,13 +2203,9 @@ void TwitchChannel::pinMessageAs(const QString &messageID,
                 return;
             }
 
-            QString text = textHint;
-            if (text.isEmpty())
-            {
-                text = id;
-            }
-            self->addMessage(MessageBuilder::makePinSuccessMessage(text, id),
-                             MessageContext::Original);
+            self->addMessage(
+                MessageBuilder::makePinSuccessMessage(textHint, id),
+                MessageContext::Original);
         },
         [weak = this->weakFromThis(), id = messageID](
             HelixPinMessageError error, auto message) {

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -2190,18 +2190,25 @@ void TwitchChannel::deleteMessagesAs(const QString &messageID,
 
 void TwitchChannel::pinMessageAs(const QString &messageID,
                                  std::optional<std::chrono::seconds> duration,
-                                 const TwitchAccount &moderator)
+                                 const TwitchAccount &moderator,
+                                 QString textHint)
 {
     getHelix()->pinChatMessage(
         this->roomId(), moderator.getUserId(), messageID, duration,
-        [weak = this->weakFromThis(), id = messageID]() {
+        [weak = this->weakFromThis(), id = messageID,
+         textHint = std::move(textHint)]() {
             auto self = weak.lock();
             if (!self)
             {
                 return;
             }
 
-            self->addMessage(MessageBuilder::makePinSuccessMessage(id, id),
+            QString text = textHint;
+            if (text.isEmpty())
+            {
+                text = id;
+            }
+            self->addMessage(MessageBuilder::makePinSuccessMessage(text, id),
                              MessageContext::Original);
         },
         [weak = this->weakFromThis(), id = messageID](

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -2210,66 +2210,70 @@ void TwitchChannel::pinOrUpdateMessage(
     std::optional<std::chrono::seconds> duration,
     const TwitchAccount &moderator, QString textHint)
 {
-    auto fn = &IHelix::pinChatMessage;
+    auto onSuccess = [weak = this->weakFromThis(), id = messageID,
+                      textHint = std::move(textHint)]() {
+        auto self = weak.lock();
+        if (!self)
+        {
+            return;
+        }
+
+        self->addMessage(MessageBuilder::makePinSuccessMessage(textHint, id),
+                         MessageContext::Original);
+    };
+    auto onError = [weak = this->weakFromThis(), id = messageID](
+                       HelixPinMessageError error, auto message) {
+        auto chan = weak.lock();
+        if (!chan)
+        {
+            return;
+        }
+
+        if (message.isEmpty())
+        {
+            message = "(empty message)";
+        }
+
+        using Error = HelixPinMessageError;
+
+        auto errorMessage = [&]() -> QString {
+            switch (error)
+            {
+                case Error::InvalidParameter:
+                    return "Failed to pin message: " + message;
+                case Error::MissingScope:
+                    return "Missing required scope. Re-login with your "
+                           "account and try again.";
+                case Error::Forbidden:
+                    return "You are not allowed to pin messages in this "
+                           "channel.";
+                case Error::NotFound:
+                    return "Failed to find message with id \"" % id % "\".";
+                case Error::AlreadyPinned:
+                    return "The message is already pinned.";
+
+                case Error::Forwarded:
+                    return message;
+                case Error::Unknown:
+                default:
+                    return "Unknown error: " + message;
+            }
+        }();
+        chan->addSystemMessage(errorMessage);
+    };
+
     if (update)
     {
-        fn = &IHelix::updatePinnedChatMessage;
+        getHelix()->updatePinnedChatMessage(
+            this->roomId(), moderator.getUserId(), messageID, duration,
+            std::move(onSuccess), std::move(onError));
     }
-
-    (getHelix()->*fn)(
-        this->roomId(), moderator.getUserId(), messageID, duration,
-        [weak = this->weakFromThis(), id = messageID,
-         textHint = std::move(textHint)]() {
-            auto self = weak.lock();
-            if (!self)
-            {
-                return;
-            }
-
-            self->addMessage(
-                MessageBuilder::makePinSuccessMessage(textHint, id),
-                MessageContext::Original);
-        },
-        [weak = this->weakFromThis(), id = messageID](
-            HelixPinMessageError error, auto message) {
-            auto chan = weak.lock();
-            if (!chan)
-            {
-                return;
-            }
-
-            if (message.isEmpty())
-            {
-                message = "(empty message)";
-            }
-
-            using Error = HelixPinMessageError;
-
-            auto errorMessage = [&]() -> QString {
-                switch (error)
-                {
-                    case Error::InvalidParameter:
-                        return "Failed to pin message: " + message;
-                    case Error::MissingScope:
-                        return "Missing required scope. Re-login with your "
-                               "account and try again.";
-                    case Error::Forbidden:
-                        return "You are not allowed to pin messages in this "
-                               "channel.";
-                    case Error::NotFound:
-                        return "Failed to find message with id \"" % id % "\".";
-                    case Error::AlreadyPinned:
-                        return "The message is already pinned.";
-
-                    case Error::Forwarded:
-                        return message;
-                    case Error::Unknown:
-                    default:
-                        return "Unknown error: " + message;
-                }
-            }();
-            chan->addSystemMessage(errorMessage);
-        });
+    else
+    {
+        getHelix()->pinChatMessage(this->roomId(), moderator.getUserId(),
+                                   messageID, duration, std::move(onSuccess),
+                                   std::move(onError));
+    }
 }
 
 void TwitchChannel::unpinMessageAs(const QString &messageID,

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -2193,7 +2193,30 @@ void TwitchChannel::pinMessageAs(const QString &messageID,
                                  const TwitchAccount &moderator,
                                  QString textHint)
 {
-    getHelix()->pinChatMessage(
+    this->pinOrUpdateMessage(false, messageID, duration, moderator,
+                             std::move(textHint));
+}
+
+void TwitchChannel::updatePinnedMessageAs(
+    const QString &messageID, std::optional<std::chrono::seconds> duration,
+    const TwitchAccount &moderator, QString textHint)
+{
+    this->pinOrUpdateMessage(true, messageID, duration, moderator,
+                             std::move(textHint));
+}
+
+void TwitchChannel::pinOrUpdateMessage(
+    bool update, const QString &messageID,
+    std::optional<std::chrono::seconds> duration,
+    const TwitchAccount &moderator, QString textHint)
+{
+    auto fn = &IHelix::pinChatMessage;
+    if (update)
+    {
+        fn = &IHelix::updatePinnedChatMessage;
+    }
+
+    (getHelix()->*fn)(
         this->roomId(), moderator.getUserId(), messageID, duration,
         [weak = this->weakFromThis(), id = messageID,
          textHint = std::move(textHint)]() {

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -171,6 +171,9 @@ public:
     TwitchChannel &operator=(const TwitchChannel &) = delete;
     TwitchChannel &operator=(TwitchChannel &&) = delete;
 
+    std::shared_ptr<TwitchChannel> sharedFromThis();
+    std::weak_ptr<TwitchChannel> weakFromThis();
+
     void initialize();
 
     // Channel methods
@@ -193,6 +196,13 @@ public:
     /// If the ID is empty, all messages will be deleted, effectively clearing
     /// the chat.
     void deleteMessagesAs(const QString &messageID, TwitchAccount *moderator);
+
+    void pinMessageAs(const QString &messageID,
+                      std::optional<std::chrono::seconds> duration,
+                      const TwitchAccount &moderator);
+
+    void unpinMessageAs(const QString &messageID,
+                        const TwitchAccount &moderator);
 
     // Data
     const QString &subscriptionUrl();

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -199,7 +199,7 @@ public:
 
     void pinMessageAs(const QString &messageID,
                       std::optional<std::chrono::seconds> duration,
-                      const TwitchAccount &moderator);
+                      const TwitchAccount &moderator, QString textHint = {});
 
     void unpinMessageAs(const QString &messageID,
                         const TwitchAccount &moderator);

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -201,6 +201,11 @@ public:
                       std::optional<std::chrono::seconds> duration,
                       const TwitchAccount &moderator, QString textHint = {});
 
+    void updatePinnedMessageAs(const QString &messageID,
+                               std::optional<std::chrono::seconds> duration,
+                               const TwitchAccount &moderator,
+                               QString textHint = {});
+
     void unpinMessageAs(const QString &messageID,
                         const TwitchAccount &moderator);
 
@@ -498,6 +503,10 @@ private:
                                              const QString &platform,
                                              const QString &actor,
                                              const QString &emoteName);
+
+    void pinOrUpdateMessage(bool update, const QString &messageID,
+                            std::optional<std::chrono::seconds> duration,
+                            const TwitchAccount &moderator, QString textHint);
 
     // Data
     const QString subscriptionUrl_;

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -3130,6 +3130,10 @@ void Helix::sendChatMessage(
     {
         json["reply_parent_message_id"] = args.replyParentMessageID;
     }
+    if (args.pin)
+    {
+        json["pin"_L1] = args.pin;
+    }
 
     this->makePost("chat/messages", {})
         .json(json)
@@ -3801,6 +3805,163 @@ void Helix::deleteEventSubSubscription(const QString &subscriptionID,
             else
             {
                 failureCallback(message);
+            }
+        })
+        .execute();
+}
+
+void Helix::pinChatMessage(
+    const QString &broadcasterID, const QString &moderatorID,
+    const QString &messageID, std::optional<std::chrono::seconds> duration,
+    ResultCallback<> successCallback,
+    FailureCallback<HelixPinMessageError, QString> failureCallback)
+{
+    QJsonObject payload{
+        {"broadcaster_id"_L1, broadcasterID},
+        {"moderator_id"_L1, moderatorID},
+        {"message_id"_L1, messageID},
+    };
+    if (duration)
+    {
+        payload.insert("duration_seconds"_L1, duration->count());
+    }
+
+    this->makePut("chat/pins", {})
+        .json(payload)
+        .onSuccess([successCallback](const NetworkResult & /*result*/) {
+            successCallback();
+        })
+        .onError([failureCallback](const NetworkResult &result) -> void {
+            using Error = HelixPinMessageError;
+
+            auto status = result.status();
+            if (!status)
+            {
+                failureCallback(Error::Unknown, result.formatError());
+                return;
+            }
+
+            Error errorForStatus = [&] {
+                switch (*status)
+                {
+                    case 400:
+                        return Error::InvalidParameter;
+                    case 401:
+                        return Error::MissingScope;
+                    case 403:
+                        return Error::Forbidden;
+                    case 404:
+                        return Error::NotFound;
+                    case 409:
+                        return Error::AlreadyPinned;
+                    default:
+                        return Error::Forwarded;
+                }
+            }();
+
+            const auto message = result.parseJson().value("message").toString();
+            if (!message.isEmpty())
+            {
+                failureCallback(errorForStatus, message);
+            }
+            else
+            {
+                failureCallback(errorForStatus, result.formatError());
+            }
+        })
+        .execute();
+}
+
+void Helix::getPinnedChatMessage(
+    const QString &broadcasterID, const QString &moderatorID,
+    ResultCallback<std::optional<HelixPinnedChatMessage>> successCallback,
+    FailureCallback<QString> failureCallback)
+{
+    QUrlQuery query{
+        {u"broadcaster_id"_s, broadcasterID},
+        {u"moderator_id"_s, moderatorID},
+    };
+
+    this->makeGet("chat/pins", query)
+        .onSuccess([successCallback](const NetworkResult &result) {
+            const auto json = result.parseJson();
+            const auto data = json["data"_L1].toArray();
+            if (data.empty())
+            {
+                successCallback(std::nullopt);
+            }
+            else
+            {
+                successCallback(HelixPinnedChatMessage(data[0].toObject()));
+            }
+        })
+        .onError([failureCallback](const NetworkResult &result) -> void {
+            if (!result.status())
+            {
+                failureCallback(result.formatError());
+                return;
+            }
+
+            const auto message = result.parseJson().value("message").toString();
+            if (!message.isEmpty())
+            {
+                failureCallback(message);
+            }
+            else
+            {
+                failureCallback(result.formatError());
+            }
+        })
+        .execute();
+}
+
+void Helix::unpinChatMessage(
+    const QString &broadcasterID, const QString &moderatorID,
+    const QString &messageID, ResultCallback<> successCallback,
+    FailureCallback<HelixUnpinMessageError, QString> failureCallback)
+{
+    QUrlQuery query{
+        {"broadcaster_id"_L1, broadcasterID},
+        {"moderator_id"_L1, moderatorID},
+        {"message_id"_L1, messageID},
+    };
+
+    this->makeDelete("chat/pins", query)
+        .onSuccess([successCallback](const NetworkResult & /*result*/) {
+            successCallback();
+        })
+        .onError([failureCallback](const NetworkResult &result) -> void {
+            using Error = HelixUnpinMessageError;
+
+            auto status = result.status();
+            if (!status)
+            {
+                failureCallback(Error::Unknown, result.formatError());
+                return;
+            }
+
+            Error errorForStatus = [&] {
+                switch (*status)
+                {
+                    case 401:
+                        return Error::MissingScope;
+                    case 403:
+                        return Error::Forbidden;
+                    case 404:
+                        return Error::NotFound;
+                    default:
+                        return Error::Forwarded;
+                }
+            }();
+
+            const auto message = result.parseJson().value("message").toString();
+            if (!message.isEmpty())
+            {
+                failureCallback(errorForStatus, message);
+            }
+            else
+            {
+                failureCallback(errorForStatus, result.formatError());
             }
         })
         .execute();

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -3873,6 +3873,68 @@ void Helix::pinChatMessage(
         .execute();
 }
 
+void Helix::updatePinnedChatMessage(
+    const QString &broadcasterID, const QString &moderatorID,
+    const QString &messageID, std::optional<std::chrono::seconds> duration,
+    ResultCallback<> successCallback,
+    FailureCallback<HelixPinMessageError, QString> failureCallback)
+{
+    QJsonObject payload{
+        {"broadcaster_id"_L1, broadcasterID},
+        {"moderator_id"_L1, moderatorID},
+        {"message_id"_L1, messageID},
+    };
+    if (duration)
+    {
+        payload.insert("duration_seconds"_L1,
+                       static_cast<qint64>(duration->count()));
+    }
+
+    this->makePatch("chat/pins", {})
+        .json(payload)
+        .onSuccess([successCallback](const NetworkResult & /*result*/) {
+            successCallback();
+        })
+        .onError([failureCallback](const NetworkResult &result) -> void {
+            using Error = HelixPinMessageError;
+
+            auto status = result.status();
+            if (!status)
+            {
+                failureCallback(Error::Unknown, result.formatError());
+                return;
+            }
+
+            Error errorForStatus = [&] {
+                switch (*status)
+                {
+                    case 400:
+                        return Error::InvalidParameter;
+                    case 401:
+                        return Error::MissingScope;
+                    case 403:
+                        return Error::Forbidden;
+                    case 404:
+                        return Error::NotFound;
+                    // No "409: AlreadyPinned" here, but reusing the same error.
+                    default:
+                        return Error::Forwarded;
+                }
+            }();
+
+            const auto message = result.parseJson().value("message").toString();
+            if (!message.isEmpty())
+            {
+                failureCallback(errorForStatus, message);
+            }
+            else
+            {
+                failureCallback(errorForStatus, result.formatError());
+            }
+        })
+        .execute();
+}
+
 void Helix::getPinnedChatMessage(
     const QString &broadcasterID, const QString &moderatorID,
     ResultCallback<std::optional<HelixPinnedChatMessage>> successCallback,

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -3823,7 +3823,8 @@ void Helix::pinChatMessage(
     };
     if (duration)
     {
-        payload.insert("duration_seconds"_L1, duration->count());
+        payload.insert("duration_seconds"_L1,
+                       static_cast<qint64>(duration->count()));
     }
 
     this->makePut("chat/pins", {})

--- a/src/providers/twitch/api/Helix.hpp
+++ b/src/providers/twitch/api/Helix.hpp
@@ -54,6 +54,12 @@ struct HelixUser {
     }
 };
 
+struct HelixMinimalUser {
+    QString id;
+    QString login;
+    QString displayName;
+};
+
 struct HelixGetChannelFollowersResponse {
     int total;
 
@@ -467,6 +473,7 @@ struct HelixSendMessageArgs {
     QString message;
     /// Optional
     QString replyParentMessageID;
+    bool pin = false;
 };
 
 struct HelixPollChoice {
@@ -684,6 +691,38 @@ struct HelixCreateEventSubSubscriptionResponse {
 
     friend QDebug &operator<<(
         QDebug &dbg, const HelixCreateEventSubSubscriptionResponse &data);
+};
+
+struct HelixPinnedChatMessage {
+    HelixMinimalUser sender;
+    HelixMinimalUser pinnedBy;
+    QString messageID;
+    QString messageText;
+    QDateTime startsAt;
+    std::optional<QDateTime> endsAt;
+
+    explicit HelixPinnedChatMessage(const QJsonObject &data)
+        : sender({
+              .id = data["sender_user_id"].toString(),
+              .login = data["sender_user_login"].toString(),
+              .displayName = data["sender_user_name"].toString(),
+          })
+        , pinnedBy({
+              .id = data["pinned_by_user_id"].toString(),
+              .login = data["pinned_by_user_login"].toString(),
+              .displayName = data["pinned_by_user_name"].toString(),
+          })
+        , messageID(data["message_id"].toString())
+        , messageText(data["message"].toObject().value("text").toString())
+        , startsAt(
+              QDateTime::fromString(data["starts_at"].toString(), Qt::ISODate))
+    {
+        auto endsAt = data["ends_at"].toString();
+        if (!endsAt.isEmpty())
+        {
+            this->endsAt = QDateTime::fromString(endsAt, Qt::ISODate);
+        }
+    }
 };
 
 class IHelix
@@ -1091,6 +1130,23 @@ public:
         const QString &subscriptionID, ResultCallback<> successCallback,
         FailureCallback<QString> failureCallback) = 0;
 
+    // https://dev.twitch.tv/docs/api/reference#pin-chat-message
+    virtual void pinChatMessage(
+        const QString &broadcasterID, const QString &moderatorID,
+        const QString &messageID, std::optional<std::chrono::seconds> duration,
+        ResultCallback<> successCallback,
+        FailureCallback<HelixPinMessageError, QString> failureCallback) = 0;
+
+    virtual void getPinnedChatMessage(
+        const QString &broadcasterID, const QString &moderatorID,
+        ResultCallback<std::optional<HelixPinnedChatMessage>> successCallback,
+        FailureCallback<QString> failureCallback) = 0;
+
+    virtual void unpinChatMessage(
+        const QString &broadcasterID, const QString &moderatorID,
+        const QString &messageID, ResultCallback<> successCallback,
+        FailureCallback<HelixUnpinMessageError, QString> failureCallback) = 0;
+
     virtual void update(QString clientId, QString oauthToken) = 0;
 
 protected:
@@ -1493,6 +1549,22 @@ public:
     void deleteEventSubSubscription(
         const QString &subscriptionID, ResultCallback<> successCallback,
         FailureCallback<QString> failureCallback) final;
+
+    void pinChatMessage(
+        const QString &broadcasterID, const QString &moderatorID,
+        const QString &messageID, std::optional<std::chrono::seconds> duration,
+        ResultCallback<> successCallback,
+        FailureCallback<HelixPinMessageError, QString> failureCallback) final;
+
+    void getPinnedChatMessage(
+        const QString &broadcasterID, const QString &moderatorID,
+        ResultCallback<std::optional<HelixPinnedChatMessage>> successCallback,
+        FailureCallback<QString> failureCallback) final;
+
+    void unpinChatMessage(
+        const QString &broadcasterID, const QString &moderatorID,
+        const QString &messageID, ResultCallback<> successCallback,
+        FailureCallback<HelixUnpinMessageError, QString> failureCallback) final;
 
     void update(QString clientId, QString oauthToken) final;
 

--- a/src/providers/twitch/api/Helix.hpp
+++ b/src/providers/twitch/api/Helix.hpp
@@ -1137,11 +1137,20 @@ public:
         ResultCallback<> successCallback,
         FailureCallback<HelixPinMessageError, QString> failureCallback) = 0;
 
+    // https://dev.twitch.tv/docs/api/reference/#update-pinned-chat-message
+    virtual void updatePinnedChatMessage(
+        const QString &broadcasterID, const QString &moderatorID,
+        const QString &messageID, std::optional<std::chrono::seconds> duration,
+        ResultCallback<> successCallback,
+        FailureCallback<HelixPinMessageError, QString> failureCallback) = 0;
+
+    // https://dev.twitch.tv/docs/api/reference/#get-pinned-chat-message
     virtual void getPinnedChatMessage(
         const QString &broadcasterID, const QString &moderatorID,
         ResultCallback<std::optional<HelixPinnedChatMessage>> successCallback,
         FailureCallback<QString> failureCallback) = 0;
 
+    // https://dev.twitch.tv/docs/api/reference/#unpin-chat-message
     virtual void unpinChatMessage(
         const QString &broadcasterID, const QString &moderatorID,
         const QString &messageID, ResultCallback<> successCallback,
@@ -1550,17 +1559,27 @@ public:
         const QString &subscriptionID, ResultCallback<> successCallback,
         FailureCallback<QString> failureCallback) final;
 
+    // https://dev.twitch.tv/docs/api/reference/#pin-chat-message
     void pinChatMessage(
         const QString &broadcasterID, const QString &moderatorID,
         const QString &messageID, std::optional<std::chrono::seconds> duration,
         ResultCallback<> successCallback,
         FailureCallback<HelixPinMessageError, QString> failureCallback) final;
 
+    // https://dev.twitch.tv/docs/api/reference/#update-pinned-chat-message
+    void updatePinnedChatMessage(
+        const QString &broadcasterID, const QString &moderatorID,
+        const QString &messageID, std::optional<std::chrono::seconds> duration,
+        ResultCallback<> successCallback,
+        FailureCallback<HelixPinMessageError, QString> failureCallback) final;
+
+    // https://dev.twitch.tv/docs/api/reference/#get-pinned-chat-message
     void getPinnedChatMessage(
         const QString &broadcasterID, const QString &moderatorID,
         ResultCallback<std::optional<HelixPinnedChatMessage>> successCallback,
         FailureCallback<QString> failureCallback) final;
 
+    // https://dev.twitch.tv/docs/api/reference/#unpin-chat-message
     void unpinChatMessage(
         const QString &broadcasterID, const QString &moderatorID,
         const QString &messageID, ResultCallback<> successCallback,

--- a/src/providers/twitch/api/HelixEnums.hpp
+++ b/src/providers/twitch/api/HelixEnums.hpp
@@ -303,4 +303,28 @@ enum class HelixCreateEventSubSubscriptionError : std::uint8_t {
     Forwarded,
 };
 
+enum class HelixPinMessageError : std::uint8_t {
+    Unknown,
+
+    InvalidParameter,
+    MissingScope,
+    Forbidden,
+    NotFound,
+    AlreadyPinned,
+
+    // The error message is forwarded directly from the Twitch API
+    Forwarded,
+};
+
+enum class HelixUnpinMessageError : std::uint8_t {
+    Unknown,
+
+    MissingScope,
+    Forbidden,
+    NotFound,
+
+    // The error message is forwarded directly from the Twitch API
+    Forwarded,
+};
+
 }  // namespace chatterino

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -2761,18 +2761,22 @@ void ChannelView::addMessageContextMenuItems(QMenu *menu,
         auto *pinMenu = new QMenu(moderateMenu);
         pinAction->setMenu(pinMenu);
         auto pinFor = [&](std::optional<std::chrono::seconds> dur) {
-            return [twitchChannel, id = layout->getMessage()->id, dur] {
+            return [twitchChannel, id = layout->getMessage()->id, dur,
+                    text = layout->getMessage()->messageText] {
                 twitchChannel->pinMessageAs(
-                    id, dur, *getApp()->getAccounts()->twitch.getCurrent());
+                    id, dur, *getApp()->getAccounts()->twitch.getCurrent(),
+                    text);
             };
         };
-        pinMenu->addAction("&Until stream ends", pinFor(std::nullopt));
-        pinMenu->addAction("&1 minute", pinFor(std::chrono::minutes(1)));
-        pinMenu->addAction("10 minutes", pinFor(std::chrono::minutes(10)));
-        pinMenu->addAction("&30 minutes", pinFor(std::chrono::minutes(30)));
+        pinMenu->addAction("&Until stream ends", this, pinFor(std::nullopt));
+        pinMenu->addAction("&1 minute", this, pinFor(std::chrono::minutes(1)));
+        pinMenu->addAction("10 minutes", this,
+                           pinFor(std::chrono::minutes(10)));
+        pinMenu->addAction("&30 minutes", this,
+                           pinFor(std::chrono::minutes(30)));
 
         moderateMenu->addAction(
-            "&Unpin", [twitchChannel, id = layout->getMessage()->id] {
+            "&Unpin", this, [twitchChannel, id = layout->getMessage()->id] {
                 twitchChannel->unpinMessageAs(
                     id, *getApp()->getAccounts()->twitch.getCurrent());
             });

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -2756,6 +2756,26 @@ void ChannelView::addMessageContextMenuItems(QMenu *menu,
                 twitchChannel->deleteMessagesAs(
                     id, getApp()->getAccounts()->twitch.getCurrent().get());
             });
+
+        auto *pinAction = moderateMenu->addAction("&Pin");
+        auto *pinMenu = new QMenu(moderateMenu);
+        pinAction->setMenu(pinMenu);
+        auto pinFor = [&](std::optional<std::chrono::seconds> dur) {
+            return [twitchChannel, id = layout->getMessage()->id, dur] {
+                twitchChannel->pinMessageAs(
+                    id, dur, *getApp()->getAccounts()->twitch.getCurrent());
+            };
+        };
+        pinMenu->addAction("&Until stream ends", pinFor(std::nullopt));
+        pinMenu->addAction("&1 minute", pinFor(std::chrono::minutes(1)));
+        pinMenu->addAction("10 minutes", pinFor(std::chrono::minutes(10)));
+        pinMenu->addAction("&30 minutes", pinFor(std::chrono::minutes(30)));
+
+        moderateMenu->addAction(
+            "&Unpin", [twitchChannel, id = layout->getMessage()->id] {
+                twitchChannel->unpinMessageAs(
+                    id, *getApp()->getAccounts()->twitch.getCurrent());
+            });
     }
 
     bool isSearch = this->context_ == Context::Search;


### PR DESCRIPTION
This adds the `/pin` and `/unpin` commands as well as action in the context menu of messages.

The `/pin` command can do the following:
- `/pin`: Show the currently pinned message. Intended to be temporary until we have the PubSub/EventSub topic for this.
- `/pin some message here`: Send a message and pin it for 20 minutes.
- `/pin -d none some message here` (or `/pin -d until-end msg`): Send a message and pin it until the stream ends.
- `/pin --id abcd123 -d 15m`: Pin a message with ID `abcd123` for 15 min.
- `/pin -h` or `/pin --help`: Show usage.

`/unpin` either takes no arguments or the ID to unpin. When no arguments are specified, it unpins the currently pinned message.

Having three layers of submenus in the channel view seems a bit weird. But on the other hand, having multiple `Pin for x minutes` is also weird.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
