### PR TITLE
fix: `reply-parent-display-name` escapes in `stripLeadingReplyMention`

### DIFF
--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -333,12 +333,8 @@ void appendBadges(MessageBuilder *builder,
             {
                 auto infoValue = badgeInfoIt->second;
                 auto predictionText =
-                    infoValue
-                        .replace(R"(\s)", " ")  // standard IRC escapes
-                        .replace(R"(\:)", ";")
-                        .replace(R"(\\)", R"(\)")
-                        .replace("⸝", ",");  // twitch's comma escape
-                // Careful, the first character is RIGHT LOW PARAPHRASE BRACKET or U+2E1D, which just looks like a comma
+                    parseTagString(infoValue).replace("⸝", ",");
+                // Twitch's comma escape. Careful, the first character is RIGHT LOW PARAPHRASE BRACKET or U+2E1D, which just looks like a comma
 
                 tooltip = QString("Predicted %1").arg(predictionText);
             }

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -106,7 +106,7 @@ int stripLeadingReplyMention(const QVariantMap &tags, QString &content)
     if (const auto it = tags.find("reply-parent-display-name");
         it != tags.end())
     {
-        auto displayName = it.value().toString();
+        auto displayName = parseTagString(it.value().toString());
 
         if (content.length() <= 1 + displayName.length())
         {
@@ -118,7 +118,8 @@ int stripLeadingReplyMention(const QVariantMap &tags, QString &content)
             content.at(1 + displayName.length()) == ' ' &&
             content.indexOf(displayName, 1) == 1)
         {
-            int messageOffset = 1 + displayName.length() + 1;
+            // Reply prefix's "@" + displayName + " "
+            qsizetype messageOffset = 1 + displayName.length() + 1;
             content.remove(0, messageOffset);
             return messageOffset;
         }

--- a/tests/snapshots/IrcMessageHandler/reply-unescape.json
+++ b/tests/snapshots/IrcMessageHandler/reply-unescape.json
@@ -1,0 +1,223 @@
+{
+    "input": "@tmi-sent-ts=1779592622071;subscriber=1;vip=1;id=dddbcb38-5c8e-4381-8050-d687ff9564ef;room-id=11148817;user-id=84180052;display-name=brian6932;badges=vip/1,subscriber/42,hornet/1;badge-info=subscriber/46;color=#0096CC;flags=;user-type=;emotes=;reply-parent-msg-body=LOL;reply-parent-user-id=27573656;reply-thread-parent-display-name=xgspidermonkey\\s;reply-thread-parent-msg-id=241c2a7e-be6e-4132-981b-fc76c5137e3a;reply-thread-parent-user-login=xgspidermonkey;reply-parent-display-name=xgspidermonkey\\s;reply-parent-user-login=xgspidermonkey;reply-thread-parent-user-id=27573656;reply-parent-msg-id=241c2a7e-be6e-4132-981b-fc76c5137e3a :brian6932!brian6932@brian6932.tmi.twitch.tv PRIVMSG #pajlada :@xgspidermonkey  b",
+    "output": [
+        {
+            "channelName": "pajlada",
+            "count": 1,
+            "displayName": "brian6932",
+            "elements": [
+                {
+                    "color": "System",
+                    "flags": "ChannelName",
+                    "link": {
+                        "type": "JumpToChannel",
+                        "value": "pajlada"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "#pajlada"
+                    ]
+                },
+                {
+                    "flags": "RepliedMessage",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "ReplyCurveElement"
+                },
+                {
+                    "color": "System",
+                    "flags": "RepliedMessage",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMediumSmall",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "Replying",
+                        "to"
+                    ]
+                },
+                {
+                    "color": "Text",
+                    "flags": "RepliedMessage",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "xgspidermonkey\\s"
+                    },
+                    "style": "ChatMediumSmall",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "@xgspidermonkey\\s:"
+                    ]
+                },
+                {
+                    "color": "Text",
+                    "flags": "Text|RepliedMessage",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMediumSmall",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "SingleLineTextElement",
+                    "words": [
+                        "LOL"
+                    ]
+                },
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "TimestampMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "3:17"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "03:17:02",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "flags": "ModeratorTools",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TwitchModerationElement"
+                },
+                {
+                    "emote": {
+                        "homePage": "https://help.twitch.tv/customer/en/portal/articles/659115-twitch-chat-badges-guide",
+                        "images": {
+                            "1x": "https://static-cdn.jtvnw.net/badges/v1/b817aba4-fad8-49e2-b88a-7cc744dfa6ec/1",
+                            "2x": "https://static-cdn.jtvnw.net/badges/v1/b817aba4-fad8-49e2-b88a-7cc744dfa6ec/2",
+                            "3x": "https://static-cdn.jtvnw.net/badges/v1/b817aba4-fad8-49e2-b88a-7cc744dfa6ec/3"
+                        },
+                        "name": "",
+                        "tooltip": "VIP"
+                    },
+                    "flags": "BadgeChannelAuthority",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "tooltip": "VIP",
+                    "trailingSpace": true,
+                    "type": "BadgeElement"
+                },
+                {
+                    "emote": {
+                        "images": {
+                            "1x": "https://static-cdn.jtvnw.net/badges/v1/4dc7b047-8c59-4522-97f2-24fb63147f56/1",
+                            "2x": "https://static-cdn.jtvnw.net/badges/v1/4dc7b047-8c59-4522-97f2-24fb63147f56/2",
+                            "3x": "https://static-cdn.jtvnw.net/badges/v1/4dc7b047-8c59-4522-97f2-24fb63147f56/3"
+                        },
+                        "name": "",
+                        "tooltip": "Hornet"
+                    },
+                    "flags": "BadgeVanity",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "tooltip": "Hornet",
+                    "trailingSpace": true,
+                    "type": "BadgeElement"
+                },
+                {
+                    "color": "#ff0096cc",
+                    "flags": "Username",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "brian6932"
+                    },
+                    "style": "ChatMediumBold",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "brian6932:"
+                    ]
+                },
+                {
+                    "color": "Text",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "b"
+                    ]
+                },
+                {
+                    "background": "#ffa0a0a4",
+                    "flags": "ReplyButton",
+                    "link": {
+                        "type": "ReplyToMessage",
+                        "value": "dddbcb38-5c8e-4381-8050-d687ff9564ef"
+                    },
+                    "padding": 2,
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "CircularImageElement",
+                    "url": ""
+                }
+            ],
+            "externalBadges": [
+            ],
+            "flags": "Collapsed",
+            "frozen": false,
+            "id": "dddbcb38-5c8e-4381-8050-d687ff9564ef",
+            "localizedName": "",
+            "loginName": "brian6932",
+            "messageText": "b",
+            "searchText": "brian6932  brian6932: b ",
+            "serverReceivedTime": "2026-05-24T03:17:02Z",
+            "timeoutUser": "",
+            "twitchBadgeInfos": {
+                "subscriber": "46"
+            },
+            "twitchBadges": [
+                "vip",
+                "subscriber",
+                "hornet"
+            ],
+            "userID": "84180052",
+            "usernameColor": "#ff0096cc"
+        }
+    ]
+}


### PR DESCRIPTION
fixes #7011

_Sorry for the spam, I was curious if I could remove the branch, but it seems like it's required for `[blocked user]` tests._

This is a monkey patch fix for now, I didn't want to touch the parser in such a PR in case of breakage, but ideally MessageBuilder.cpp should do unescaping of all tags first.

<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->


The following tags should be unescaped:
- [x] `badge-info`
- [x] `source-badge-info`
- [ ] `client-nonce`
- [ ] `msg-param-sub-plan-name`
- [x] `system-msg`
- [x] `reply-parent-msg-body`
- [ ] `reply-parent-display-name`
- [ ] `msg-param-origin-id`
- [ ] `msg-param-displayName`
- [x] `display-name`