### PR TITLE
fix(plugins): explicitly use draft-07 schema

### DIFF
--- a/docs/plugin-info.schema.json
+++ b/docs/plugin-info.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "https://json-schema.org/draft-07/schema",
   "$id": "https://raw.githubusercontent.com/Chatterino/chatterino2/master/docs/plugin-info.schema.json",
   "title": "Plugin info",
   "description": "Describes a Chatterino2 plugin (draft)",


### PR DESCRIPTION
Before, the schema would use the latest schema. 
We should specify that we only need the draft-07 schema like the Chatterino themes. The newer drafts aren't well-supported. For example, Visual Studio only recently added support for the 2019 and 2020 drafts (not even sure if that's released yet).

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
