### PR TITLE
deps: remove dependency on Boost.Signals2

### DIFF
--- a/src/PrecompiledHeader.hpp
+++ b/src/PrecompiledHeader.hpp
@@ -4,7 +4,6 @@
 
 #ifdef __cplusplus
 #    include <boost/circular_buffer.hpp>
-#    include <boost/signals2.hpp>
 #    include <IrcCommand>
 #    include <IrcConnection>
 #    include <IrcMessage>

--- a/src/controllers/highlights/HighlightController.cpp
+++ b/src/controllers/highlights/HighlightController.cpp
@@ -434,12 +434,12 @@ HighlightController::HighlightController(Settings &settings,
             this->rebuildChecks(settings);
         });
 
-    this->bConnections.emplace_back(
-        accounts->twitch.currentUserChanged.connect([this, &settings] {
+    this->signalHolder_.managedConnect(
+        accounts->twitch.currentUserChanged, [this, &settings] {
             qCDebug(chatterinoHighlights)
                 << "Rebuild checks because user swapped accounts";
             this->rebuildChecks(settings);
-        }));
+        });
 
     this->signalHolder_.managedConnect(
         accounts->twitch.currentUserNameChanged, [this, &settings] {

--- a/src/controllers/highlights/HighlightController.hpp
+++ b/src/controllers/highlights/HighlightController.hpp
@@ -9,7 +9,6 @@
 #include "controllers/highlights/HighlightCheck.hpp"
 #include "singletons/Settings.hpp"
 
-#include <boost/signals2/connection.hpp>
 #include <pajlada/settings.hpp>
 #include <pajlada/settings/settinglistener.hpp>
 #include <pajlada/signals/signalholder.hpp>
@@ -53,7 +52,6 @@ private:
 
     pajlada::SettingListener rebuildListener_;
     pajlada::Signals::SignalHolder signalHolder_;
-    std::vector<boost::signals2::scoped_connection> bConnections;
 };
 
 }  // namespace chatterino

--- a/src/controllers/plugins/Plugin.cpp
+++ b/src/controllers/plugins/Plugin.cpp
@@ -56,7 +56,7 @@ lua::SignalCallback Plugin::createCallback(sol::main_protected_function pfn)
 
 Plugin::~Plugin()
 {
-    this->onUnloaded();
+    this->onUnloaded.invoke();
 
     for (auto *timer : this->activeTimeouts)
     {
@@ -155,7 +155,7 @@ void Plugin::log(lua_State *L, lua::api::LogLevel level, QDebug stream,
         lua_pop(L, 1);
     }
 
-    this->onLog(level, fullMessage);
+    this->onLog.invoke(level, fullMessage);
 }
 
 sol::state_view Plugin::state()

--- a/src/controllers/plugins/Plugin.hpp
+++ b/src/controllers/plugins/Plugin.hpp
@@ -11,7 +11,7 @@
 #    include "controllers/plugins/PluginMeta.hpp"
 #    include "controllers/plugins/PluginRef.hpp"
 
-#    include <boost/signals2/signal.hpp>
+#    include <pajlada/signals/signal.hpp>
 #    include <QDir>
 #    include <QString>
 #    include <QUrl>
@@ -128,8 +128,8 @@ public:
     // This is a lifetime hack to ensure they get deleted with the plugin. This relies on the Plugin getting deleted on reload!
     std::vector<std::shared_ptr<lua::api::HTTPRequest>> httpRequests;
 
-    boost::signals2::signal<void()> onUnloaded;
-    boost::signals2::signal<void(lua::api::LogLevel, const QString &)> onLog;
+    pajlada::Signals::NoArgSignal onUnloaded;
+    pajlada::Signals::Signal<lua::api::LogLevel, const QString &> onLog;
     lua::ConnectionManager connections;
 
 private:

--- a/src/controllers/plugins/PluginController.cpp
+++ b/src/controllers/plugins/PluginController.cpp
@@ -332,7 +332,7 @@ void PluginController::load(const QFileInfo &index, const QDir &pluginDir,
     temp->dataDirectory().mkpath(".");
 
     // make sure we capture log messages during load
-    this->onPluginLoaded(temp);
+    this->onPluginLoaded.invoke(temp);
     qCDebug(chatterinoLua) << "Running lua file:" << index;
     int err = luaL_dofile(l, index.absoluteFilePath().toStdString().c_str());
     if (err != 0)

--- a/src/controllers/plugins/PluginController.hpp
+++ b/src/controllers/plugins/PluginController.hpp
@@ -10,7 +10,7 @@
 #    include "controllers/commands/CommandContext.hpp"
 #    include "controllers/plugins/Plugin.hpp"
 
-#    include <boost/signals2/signal.hpp>
+#    include <pajlada/signals/signal.hpp>
 #    include <QDir>
 #    include <QFileInfo>
 #    include <QJsonArray>
@@ -68,7 +68,7 @@ public:
 
     WebSocketPool &webSocketPool();
 
-    boost::signals2::signal<void(Plugin *)> onPluginLoaded;
+    pajlada::Signals::Signal<Plugin *> onPluginLoaded;
 
 private:
     void loadPlugins();

--- a/src/controllers/plugins/SolTypes.cpp
+++ b/src/controllers/plugins/SolTypes.cpp
@@ -111,7 +111,7 @@ void logError(Plugin *plugin, QStringView context, const QString &msg)
     QString fullMessage = context % u" - " % msg;
     qCWarning(chatterinoLua).noquote()
         << "[" + plugin->id + ":" + plugin->meta.name + "]" << fullMessage;
-    plugin->onLog(api::LogLevel::Warning, fullMessage);
+    plugin->onLog.invoke(api::LogLevel::Warning, fullMessage);
 }
 
 }  // namespace chatterino::lua

--- a/src/messages/MessageThread.cpp
+++ b/src/messages/MessageThread.cpp
@@ -78,7 +78,7 @@ void MessageThread::markSubscribed()
     }
 
     this->subscription_ = Subscription::Subscribed;
-    this->subscriptionUpdated();
+    this->subscriptionUpdated.invoke();
 }
 
 void MessageThread::markUnsubscribed()
@@ -89,7 +89,7 @@ void MessageThread::markUnsubscribed()
     }
 
     this->subscription_ = Subscription::Unsubscribed;
-    this->subscriptionUpdated();
+    this->subscriptionUpdated.invoke();
 }
 
 QJsonObject MessageThread::toJson() const

--- a/src/messages/MessageThread.hpp
+++ b/src/messages/MessageThread.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <boost/signals2.hpp>
+#include <pajlada/signals/signal.hpp>
 #include <QString>
 
 #include <memory>
@@ -70,7 +70,7 @@ public:
 
     QJsonObject toJson() const;
 
-    boost::signals2::signal<void()> subscriptionUpdated;
+    pajlada::Signals::NoArgSignal subscriptionUpdated;
 
 private:
     const QString rootMessageId_;

--- a/src/providers/twitch/TwitchAccountManager.cpp
+++ b/src/providers/twitch/TwitchAccountManager.cpp
@@ -231,7 +231,8 @@ TwitchAccountManager::TwitchAccountManager()
     : accounts(SharedPtrElementLess<TwitchAccount>{})
     , anonymousUser_(new TwitchAccount(ANONYMOUS_USERNAME, "", "", ""))
 {
-    this->currentUserChanged.connect([this] {
+    // This is our own signal.
+    std::ignore = this->currentUserChanged.connect([this] {
         auto currentUser = this->getCurrent();
         currentUser->loadBlocks();
         currentUser->loadSeventvUserID();
@@ -345,7 +346,7 @@ void TwitchAccountManager::reloadUsers()
                     qCDebug(chatterinoTwitch)
                         << "It was the current user, so we need to "
                            "reconnect stuff!";
-                    this->currentUserChanged();
+                    this->currentUserChanged.invoke();
                 }
             }
             break;
@@ -390,7 +391,7 @@ void TwitchAccountManager::load()
             this->currentUser_ = this->anonymousUser_;
         }
 
-        this->currentUserChanged();
+        this->currentUserChanged.invoke();
         this->currentUser_->reloadEmotes();
     });
 }

--- a/src/providers/twitch/TwitchAccountManager.hpp
+++ b/src/providers/twitch/TwitchAccountManager.hpp
@@ -10,7 +10,7 @@
 #include "util/QStringHash.hpp"
 #include "util/RapidJsonSerializeQString.hpp"
 
-#include <boost/signals2.hpp>
+#include <pajlada/signals/signal.hpp>
 #include <QString>
 
 #include <memory>
@@ -68,7 +68,7 @@ public:
                              std::shared_ptr<TwitchAccount>>
         currentUserAboutToChange;
 
-    boost::signals2::signal<void()> currentUserChanged;
+    pajlada::Signals::NoArgSignal currentUserChanged;
     pajlada::Signals::NoArgSignal userListUpdated;
     pajlada::Signals::NoArgSignal currentUserNameChanged;
 

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -140,12 +140,12 @@ TwitchChannel::TwitchChannel(const QString &name)
             this->eventSubSuspiciousUserUpdateHandle.reset();
         });
 
-    this->bSignals_.emplace_back(
-        getApp()->getAccounts()->twitch.currentUserChanged.connect([this] {
+    this->signalHolder_.managedConnect(
+        getApp()->getAccounts()->twitch.currentUserChanged, [this] {
             this->setMod(false);
             this->refreshPubSub();
             this->refreshTwitchChannelEmotes(false);
-        }));
+        });
 
     this->refreshPubSub();
     // We can safely ignore this signal connection since it's a private signal, meaning

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -18,7 +18,6 @@
 #include "util/ThreadGuard.hpp"
 
 #include <boost/circular_buffer/space_optimized.hpp>
-#include <boost/signals2.hpp>
 #include <IrcMessage>
 #include <pajlada/signals/signalholder.hpp>
 #include <QColor>
@@ -592,7 +591,6 @@ private:
     std::vector<QString> lastLiveUpdateEmoteNames_;
 
     pajlada::Signals::SignalHolder signalHolder_;
-    std::vector<boost::signals2::scoped_connection> bSignals_;
 
     eventsub::SubscriptionHandle eventSubChannelModerateHandle;
     eventsub::SubscriptionHandle eventSubAutomodMessageHoldHandle;

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -221,11 +221,12 @@ TwitchIrcServer::TwitchIrcServer()
 
 void TwitchIrcServer::initialize()
 {
-    getApp()->getAccounts()->twitch.currentUserChanged.connect([this]() {
-        postToThread([this] {
-            this->connect();
+    this->signalHolder.managedConnect(
+        getApp()->getAccounts()->twitch.currentUserChanged, [this]() {
+            postToThread([this] {
+                this->connect();
+            });
         });
-    });
 
     this->signalHolder.managedConnect(
         getApp()->getTwitchPubSub()->pointReward.redeemed, [this](auto &data) {

--- a/src/widgets/PluginRepl.cpp
+++ b/src/widgets/PluginRepl.cpp
@@ -683,8 +683,8 @@ void PluginRepl::setPlugin(Plugin *plugin)
 
     if (!plugin)
     {
-        this->pluginDestroyConn.release();
-        this->pluginLogConn.release();
+        this->pluginDestroyConn = pajlada::Signals::ScopedConnection{};
+        this->pluginLogConn = pajlada::Signals::ScopedConnection{};
         return;
     }
 

--- a/src/widgets/PluginRepl.hpp
+++ b/src/widgets/PluginRepl.hpp
@@ -8,7 +8,7 @@
 #    include "buttons/SvgButton.hpp"
 #    include "widgets/BaseWindow.hpp"
 
-#    include <boost/signals2/connection.hpp>
+#    include <pajlada/signals/scoped-connection.hpp>
 #    include <QString>
 #    include <QTextBlockFormat>
 #    include <QTextCharFormat>
@@ -57,9 +57,9 @@ private:
     QString id;
     Plugin *plugin = nullptr;
 
-    boost::signals2::scoped_connection pluginDestroyConn;
-    boost::signals2::scoped_connection pluginLogConn;
-    boost::signals2::scoped_connection pluginLoadedConn;
+    pajlada::Signals::ScopedConnection pluginDestroyConn;
+    pajlada::Signals::ScopedConnection pluginLogConn;
+    pajlada::Signals::ScopedConnection pluginLoadedConn;
 
     bool isPinned = false;
 

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -71,10 +71,10 @@ Window::Window(WindowType type, QWidget *parent)
     this->addMenuBar();
 #endif
 
-    this->bSignals_.emplace_back(
-        getApp()->getAccounts()->twitch.currentUserChanged.connect([this] {
+    this->signalHolder_.managedConnect(
+        getApp()->getAccounts()->twitch.currentUserChanged, [this] {
             this->onAccountSelected();
-        }));
+        });
     this->onAccountSelected();
 
     if (type == WindowType::Main)

--- a/src/widgets/Window.hpp
+++ b/src/widgets/Window.hpp
@@ -6,7 +6,6 @@
 
 #include "widgets/BaseWindow.hpp"
 
-#include <boost/signals2.hpp>
 #include <pajlada/settings/setting.hpp>
 #include <pajlada/signals/signal.hpp>
 #include <pajlada/signals/signalholder.hpp>
@@ -59,7 +58,6 @@ private:
     std::shared_ptr<UpdateDialog> updateDialogHandle_;
 
     pajlada::Signals::SignalHolder signalHolder_;
-    std::vector<boost::signals2::scoped_connection> bSignals_;
 
     // this is only used on Windows and only on the main window, for the one used otherwise, see SplitNotebook in Notebook.hpp
     PixmapButton *streamerModeTitlebarIcon_ = nullptr;

--- a/src/widgets/dialogs/ReplyThreadPopup.cpp
+++ b/src/widgets/dialogs/ReplyThreadPopup.cpp
@@ -101,10 +101,10 @@ ReplyThreadPopup::ReplyThreadPopup(bool closeAutomatically, Split *split)
     this->ui_.replyInput =
         new SplitInput(this, this->split_, this->ui_.threadView, false);
 
-    this->bSignals_.emplace_back(
+    this->currentUserConnection_ =
         getApp()->getAccounts()->twitch.currentUserChanged.connect([this] {
             this->updateInputUI();
-        }));
+        });
 
     // We can safely ignore this signal's connection since threadView will always be deleted before
     // the ReplyThreadPopup

--- a/src/widgets/dialogs/ReplyThreadPopup.cpp
+++ b/src/widgets/dialogs/ReplyThreadPopup.cpp
@@ -201,7 +201,7 @@ void ReplyThreadPopup::setThread(std::shared_ptr<MessageThread> thread)
 
     if (!this->thread_) [[unlikely]]
     {
-        this->replySubscriptionSignal_ = boost::signals2::scoped_connection{};
+        this->replySubscriptionSignal_ = pajlada::Signals::ScopedConnection{};
         return;
     }
 

--- a/src/widgets/dialogs/ReplyThreadPopup.hpp
+++ b/src/widgets/dialogs/ReplyThreadPopup.hpp
@@ -7,7 +7,6 @@
 #include "ForwardDecl.hpp"
 #include "widgets/DraggablePopup.hpp"
 
-#include <boost/signals2.hpp>
 #include <pajlada/signals/scoped-connection.hpp>
 #include <pajlada/signals/signal.hpp>
 
@@ -57,7 +56,7 @@ private:
 
     std::unique_ptr<pajlada::Signals::ScopedConnection> messageConnection_;
     std::vector<boost::signals2::scoped_connection> bSignals_;
-    boost::signals2::scoped_connection replySubscriptionSignal_;
+    pajlada::Signals::ScopedConnection replySubscriptionSignal_;
 };
 
 }  // namespace chatterino

--- a/src/widgets/dialogs/ReplyThreadPopup.hpp
+++ b/src/widgets/dialogs/ReplyThreadPopup.hpp
@@ -55,7 +55,7 @@ private:
     } ui_;
 
     std::unique_ptr<pajlada::Signals::ScopedConnection> messageConnection_;
-    std::vector<boost::signals2::scoped_connection> bSignals_;
+    pajlada::Signals::ScopedConnection currentUserConnection_;
     pajlada::Signals::ScopedConnection replySubscriptionSignal_;
 };
 

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -109,10 +109,10 @@ Split::Split(QWidget *parent)
     this->input_->ui_.textEdit->installEventFilter(parent);
 
     // update placeholder text on Twitch account change and channel change
-    this->bSignals_.emplace_back(
-        getApp()->getAccounts()->twitch.currentUserChanged.connect([this] {
+    this->signalHolder_.managedConnect(
+        getApp()->getAccounts()->twitch.currentUserChanged, [this] {
             this->updateInputPlaceholder();
-        }));
+        });
     this->signalHolder_.managedConnect(this->channelChanged, [this] {
         this->updateInputPlaceholder();
     });

--- a/src/widgets/splits/Split.hpp
+++ b/src/widgets/splits/Split.hpp
@@ -9,7 +9,6 @@
 #include "widgets/BaseWidget.hpp"
 #include "widgets/splits/SplitCommon.hpp"
 
-#include <boost/signals2.hpp>
 #include <pajlada/signals/signalholder.hpp>
 #include <QFont>
 #include <QPointer>
@@ -182,7 +181,6 @@ private:
     pajlada::Signals::SignalHolder channelSignalHolder_;
 
     pajlada::Signals::SignalHolder signalHolder_;
-    std::vector<boost::signals2::scoped_connection> bSignals_;
 
 public Q_SLOTS:
     void addSibling();

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -260,10 +260,10 @@ SplitHeader::SplitHeader(Split *split)
         this->handleChannelChanged();
     });
 
-    this->bSignals_.emplace_back(
-        getApp()->getAccounts()->twitch.currentUserChanged.connect([this] {
+    this->managedConnections_.managedConnect(
+        getApp()->getAccounts()->twitch.currentUserChanged, [this] {
             this->updateIcons();
-        }));
+        });
 
     auto _ = [this](const auto &, const auto &) {
         this->updateChannelText();

--- a/src/widgets/splits/SplitHeader.hpp
+++ b/src/widgets/splits/SplitHeader.hpp
@@ -7,7 +7,6 @@
 #include "widgets/BaseWidget.hpp"
 #include "widgets/TooltipWidget.hpp"
 
-#include <boost/signals2.hpp>
 #include <pajlada/settings/setting.hpp>
 #include <pajlada/signals/connection.hpp>
 #include <pajlada/signals/signalholder.hpp>
@@ -100,7 +99,6 @@ private:
     // and don't change when the parent Split changes its underlying channel
     pajlada::Signals::SignalHolder managedConnections_;
     pajlada::Signals::SignalHolder channelConnections_;
-    std::vector<boost::signals2::scoped_connection> bSignals_;
 
 public Q_SLOTS:
     void reloadChannelEmotes();

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -10,7 +10,6 @@
     "boost-date-time",
     "boost-interprocess",
     "boost-json",
-    "boost-signals2",
     "hunspell",
     "pkgconf",
     {


### PR DESCRIPTION
We already depend on pajlada-signals. Places that used Boost.Signals2 would often have two connection managers (one for each library). There's no good benefit from using Signals2, so migrate them to pajlada-signals. We had three places that used Boost.Signals2 and they have been migrated in each commit:

1. Internal plugin signals
2. Message thread subscriptions
3. Current user change events in TwitchAccountManager

The third had the most uses.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
