### PR TITLE
feat: support mod streaks

### DIFF
--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -53,6 +53,7 @@ const QSet<QString> SPECIAL_MESSAGE_TYPES{
     "ritual",           // new viewer ritual
     "announcement",     // new mod announcement thing
     "viewermilestone",  // watch streak, but other categories possible in future
+    "modiversary",      // Mod anniversary.
     "socialsharingbadge",  // social media badge from sharing clips
 };
 
@@ -791,6 +792,19 @@ void IrcMessageHandler::parseUserNoticeMessageInto(Communi::IrcMessage *message,
         // By default, we return value of system-msg tag
         QString messageText = it.value().toString();
 
+        auto displayName = [&] {
+            if (msgType == u"raid")
+            {
+                return tags.value("msg-param-displayName").toString();
+            }
+            return tags.value("display-name").toString();
+        }();
+        auto login = tags.value("login").toString();
+        if (displayName.isEmpty())
+        {
+            displayName = login;
+        }
+
         if (msgType == "bitsbadgetier")
         {
             messageText =
@@ -891,18 +905,15 @@ void IrcMessageHandler::parseUserNoticeMessageInto(Communi::IrcMessage *message,
                               .arg(tags.value("display-name").toString(),
                                    QString::number(level));
         }
-
-        auto displayName = [&] {
-            if (msgType == u"raid")
-            {
-                return tags.value("msg-param-displayName").toString();
-            }
-            return tags.value("display-name").toString();
-        }();
-        auto login = tags.value("login").toString();
-        if (displayName.isEmpty())
+        else if (msgType == "modiversary")
         {
-            displayName = login;
+            // The message text we get is "has been a moderator for ..." (without the name).
+            // This might be a bug on Twitch's side.
+            if (!messageText.startsWith(login) &&
+                !messageText.startsWith(displayName))
+            {
+                messageText = displayName % ' ' % messageText;
+            }
         }
 
         auto userID = tags.value("user-id").toString();
@@ -920,7 +931,7 @@ void IrcMessageHandler::parseUserNoticeMessageInto(Communi::IrcMessage *message,
             parseTagString(messageText), login, displayName, userColor,
             calculateMessageTime(message).time());
 
-        if (msgType == "viewermilestone")
+        if (msgType == "viewermilestone" || msgType == "modiversary")
         {
             msg->flags.set(MessageFlag::WatchStreak);
         }
@@ -1253,7 +1264,7 @@ void IrcMessageHandler::addMessage(Communi::IrcMessage *message,
     {
         if (isSub)
         {
-            if (msgType == "viewermilestone")
+            if (msgType == "viewermilestone" || msgType == "modiversary")
             {
                 msg->flags.set(MessageFlag::WatchStreak);
             }

--- a/tests/snapshots/IrcMessageHandler/mod-streak-no-msg.json
+++ b/tests/snapshots/IrcMessageHandler/mod-streak-no-msg.json
@@ -1,0 +1,95 @@
+{
+    "input": "@id=090939a1-18a5-4370-9066-b4f56512c320;badges=moderator/1,subscriber/12,glitchcon2020/1;tmi-sent-ts=1780134274460;color=#FF7F50;system-msg=has\\sbeen\\sa\\smoderator\\sfor\\s18\\smonths!;login=jcrouzer;rm-received-ts=1780134274566;user-id=44850681;msg-param-months=18;room-id=11148817;subscriber=1;display-name=JCRouzer;mod=1;flags=;msg-id=modiversary;user-type=mod;badge-info=subscriber/20;emotes=;historical=1;vip=0 :tmi.twitch.tv USERNOTICE #pajlada",
+    "output": [
+        {
+            "channelName": "",
+            "count": 1,
+            "displayName": "",
+            "elements": [
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "TimestampMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "9:44"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "09:44:34",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "MentionElement",
+                    "userColor": "#ffff7f50",
+                    "userLoginName": "jcrouzer",
+                    "words": [
+                        "JCRouzer"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "has",
+                        "been",
+                        "a",
+                        "moderator",
+                        "for",
+                        "18",
+                        "months!"
+                    ]
+                }
+            ],
+            "externalBadges": [
+            ],
+            "flags": "System|DoNotTriggerNotification|WatchStreak",
+            "frozen": false,
+            "id": "",
+            "localizedName": "",
+            "loginName": "",
+            "messageText": "JCRouzer has been a moderator for 18 months!",
+            "searchText": "JCRouzer has been a moderator for 18 months!",
+            "serverReceivedTime": "",
+            "timeoutUser": "",
+            "twitchBadgeInfos": {
+            },
+            "twitchBadges": [
+            ],
+            "userID": "",
+            "usernameColor": "#ff000000"
+        }
+    ]
+}

--- a/tests/snapshots/IrcMessageHandler/mod-streak.json
+++ b/tests/snapshots/IrcMessageHandler/mod-streak.json
@@ -1,0 +1,269 @@
+{
+    "input": "@id=090939a1-18a5-4370-9066-b4f56512c320;badges=moderator/1,subscriber/12,glitchcon2020/1;tmi-sent-ts=1780134274460;color=#FF7F50;system-msg=has\\sbeen\\sa\\smoderator\\sfor\\s18\\smonths!;login=jcrouzer;rm-received-ts=1780134274566;user-id=44850681;msg-param-months=18;room-id=11148817;subscriber=1;display-name=JCRouzer;mod=1;flags=;msg-id=modiversary;user-type=mod;badge-info=subscriber/20;emotes=;historical=1;vip=0 :tmi.twitch.tv USERNOTICE #pajlada :I don't know what this looks like but new thing to celebrate the indentured servitude! I'm celebrating my 18 month Mod Anniversary!",
+    "output": [
+        {
+            "channelName": "pajlada",
+            "count": 1,
+            "displayName": "JCRouzer",
+            "elements": [
+                {
+                    "color": "System",
+                    "flags": "ChannelName",
+                    "link": {
+                        "type": "JumpToChannel",
+                        "value": "pajlada"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "#pajlada"
+                    ]
+                },
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "TimestampMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "9:44"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "09:44:34",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "emote": {
+                        "images": {
+                            "1x": "https://static-cdn.jtvnw.net/badges/v1/3267646d-33f0-4b17-b3df-f923a41db1d0/1",
+                            "2x": "https://static-cdn.jtvnw.net/badges/v1/3267646d-33f0-4b17-b3df-f923a41db1d0/2",
+                            "3x": "https://static-cdn.jtvnw.net/badges/v1/3267646d-33f0-4b17-b3df-f923a41db1d0/3"
+                        },
+                        "name": "",
+                        "tooltip": "Moderator"
+                    },
+                    "flags": "BadgeChannelAuthority",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "tooltip": "Moderator",
+                    "trailingSpace": true,
+                    "type": "BadgeElement"
+                },
+                {
+                    "emote": {
+                        "homePage": "https://www.twitchcon.com/",
+                        "images": {
+                            "1x": "https://static-cdn.jtvnw.net/badges/v1/1d4b03b9-51ea-42c9-8f29-698e3c85be3d/1",
+                            "2x": "https://static-cdn.jtvnw.net/badges/v1/1d4b03b9-51ea-42c9-8f29-698e3c85be3d/2",
+                            "3x": "https://static-cdn.jtvnw.net/badges/v1/1d4b03b9-51ea-42c9-8f29-698e3c85be3d/3"
+                        },
+                        "name": "",
+                        "tooltip": "GlitchCon 2020"
+                    },
+                    "flags": "BadgeVanity",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "tooltip": "GlitchCon 2020",
+                    "trailingSpace": true,
+                    "type": "BadgeElement"
+                },
+                {
+                    "color": "#ffff7f50",
+                    "flags": "Username",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "JCRouzer"
+                    },
+                    "style": "ChatMediumBold",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "JCRouzer:"
+                    ]
+                },
+                {
+                    "color": "Text",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "I",
+                        "don't",
+                        "know",
+                        "what",
+                        "this",
+                        "looks",
+                        "like",
+                        "but",
+                        "new",
+                        "thing",
+                        "to",
+                        "celebrate",
+                        "the",
+                        "indentured",
+                        "servitude!",
+                        "I'm",
+                        "celebrating",
+                        "my",
+                        "18",
+                        "month",
+                        "Mod",
+                        "Anniversary!"
+                    ]
+                },
+                {
+                    "background": "#ffa0a0a4",
+                    "flags": "ReplyButton",
+                    "link": {
+                        "type": "ReplyToMessage",
+                        "value": "090939a1-18a5-4370-9066-b4f56512c320"
+                    },
+                    "padding": 2,
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "CircularImageElement",
+                    "url": ""
+                }
+            ],
+            "externalBadges": [
+            ],
+            "flags": "Collapsed|WatchStreak",
+            "frozen": false,
+            "highlightColor": "#64c466ff",
+            "id": "090939a1-18a5-4370-9066-b4f56512c320",
+            "localizedName": "",
+            "loginName": "jcrouzer",
+            "messageText": "I don't know what this looks like but new thing to celebrate the indentured servitude! I'm celebrating my 18 month Mod Anniversary!",
+            "searchText": "jcrouzer  jcrouzer: I don't know what this looks like but new thing to celebrate the indentured servitude! I'm celebrating my 18 month Mod Anniversary! ",
+            "serverReceivedTime": "2026-05-30T09:44:34Z",
+            "timeoutUser": "",
+            "twitchBadgeInfos": {
+                "subscriber": "20"
+            },
+            "twitchBadges": [
+                "moderator",
+                "subscriber",
+                "glitchcon2020"
+            ],
+            "userID": "44850681",
+            "usernameColor": "#ffff7f50"
+        },
+        {
+            "channelName": "",
+            "count": 1,
+            "displayName": "",
+            "elements": [
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "TimestampMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "9:44"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "09:44:34",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "MentionElement",
+                    "userColor": "#ffff7f50",
+                    "userLoginName": "jcrouzer",
+                    "words": [
+                        "JCRouzer"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "has",
+                        "been",
+                        "a",
+                        "moderator",
+                        "for",
+                        "18",
+                        "months!"
+                    ]
+                }
+            ],
+            "externalBadges": [
+            ],
+            "flags": "System|DoNotTriggerNotification|WatchStreak",
+            "frozen": false,
+            "id": "",
+            "localizedName": "",
+            "loginName": "",
+            "messageText": "JCRouzer has been a moderator for 18 months!",
+            "searchText": "JCRouzer has been a moderator for 18 months!",
+            "serverReceivedTime": "",
+            "timeoutUser": "",
+            "twitchBadgeInfos": {
+            },
+            "twitchBadges": [
+            ],
+            "userID": "",
+            "usernameColor": "#ff000000"
+        }
+    ]
+}

--- a/tests/snapshots/IrcMessageHandler/watch-streak-no-msg.json
+++ b/tests/snapshots/IrcMessageHandler/watch-streak-no-msg.json
@@ -1,0 +1,97 @@
+{
+    "input": "@badges=subscriber/3,sub-gifter/5;mod=0;historical=1;subscriber=1;flags=;color=#BE0000;rm-received-ts=1780143568293;msg-id=viewermilestone;emotes=;msg-param-id=8f04affa-bab5-4d50-81b9-40f97bff86bb;badge-info=subscriber/3;system-msg=club_reg\\swatched\\s15\\sconsecutive\\sstreams\\sand\\ssparked\\sa\\swatch\\sstreak!;id=12265c31-d7c1-4344-9afd-894b3c290bc9;display-name=club_reg;vip=0;user-type=;msg-param-value=15;msg-param-category=watch-streak;msg-param-copoReward=450;login=club_reg;user-id=28392974;tmi-sent-ts=1780143566057;room-id=11148817 :tmi.twitch.tv USERNOTICE #pajlada",
+    "output": [
+        {
+            "channelName": "",
+            "count": 1,
+            "displayName": "",
+            "elements": [
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "TimestampMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "12:19"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "12:19:28",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "MentionElement",
+                    "userColor": "#ffbe0000",
+                    "userLoginName": "club_reg",
+                    "words": [
+                        "club_reg"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "watched",
+                        "15",
+                        "consecutive",
+                        "streams",
+                        "and",
+                        "sparked",
+                        "a",
+                        "watch",
+                        "streak!"
+                    ]
+                }
+            ],
+            "externalBadges": [
+            ],
+            "flags": "System|DoNotTriggerNotification|WatchStreak",
+            "frozen": false,
+            "id": "",
+            "localizedName": "",
+            "loginName": "",
+            "messageText": "club_reg watched 15 consecutive streams and sparked a watch streak!",
+            "searchText": "club_reg watched 15 consecutive streams and sparked a watch streak!",
+            "serverReceivedTime": "",
+            "timeoutUser": "",
+            "twitchBadgeInfos": {
+            },
+            "twitchBadges": [
+            ],
+            "userID": "",
+            "usernameColor": "#ff000000"
+        }
+    ]
+}

--- a/tests/snapshots/IrcMessageHandler/watch-streak.json
+++ b/tests/snapshots/IrcMessageHandler/watch-streak.json
@@ -1,0 +1,261 @@
+{
+    "input": "@login=imrlazyi;tmi-sent-ts=1780141763360;msg-id=viewermilestone;id=5f360c15-db41-439a-83fd-2e2dbcdebada;msg-param-copoReward=450;emotes=;flags=;color=#FF4500;mod=0;historical=1;user-type=;display-name=IMrLazyI;system-msg=IMrLazyI\\swatched\\s10\\sconsecutive\\sstreams\\sand\\ssparked\\sa\\swatch\\sstreak!;badges=subscriber/3,hello_neighbor_1/1;room-id=11148817;badge-info=subscriber/5;user-id=55530653;subscriber=1;vip=0;msg-param-value=10;msg-param-id=c3b94206-f875-4153-9c1e-112d9e650d4e;msg-param-category=watch-streak;rm-received-ts=1780141768602 :tmi.twitch.tv USERNOTICE #pajlada 🫣",
+    "output": [
+        {
+            "channelName": "pajlada",
+            "count": 1,
+            "displayName": "IMrLazyI",
+            "elements": [
+                {
+                    "color": "System",
+                    "flags": "ChannelName",
+                    "link": {
+                        "type": "JumpToChannel",
+                        "value": "pajlada"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "#pajlada"
+                    ]
+                },
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "TimestampMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "11:49"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "11:49:28",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "flags": "ModeratorTools",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TwitchModerationElement"
+                },
+                {
+                    "emote": {
+                        "images": {
+                            "1x": "https://static-cdn.jtvnw.net/badges/v1/e8984705-d091-4e54-8241-e53b30a84b0e/1",
+                            "2x": "https://static-cdn.jtvnw.net/badges/v1/e8984705-d091-4e54-8241-e53b30a84b0e/2",
+                            "3x": "https://static-cdn.jtvnw.net/badges/v1/e8984705-d091-4e54-8241-e53b30a84b0e/3"
+                        },
+                        "name": "",
+                        "tooltip": "3-Month Subscriber"
+                    },
+                    "flags": "BadgeSubscription",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "tooltip": "3-Month Subscriber (5 months)",
+                    "trailingSpace": true,
+                    "type": "BadgeElement"
+                },
+                {
+                    "emote": {
+                        "homePage": "https://www.twitch.tv/directory/game/Hello%20Neighbor/details",
+                        "images": {
+                            "1x": "https://static-cdn.jtvnw.net/badges/v1/030cab2c-5d14-11e7-8d91-43a5a4306286/1",
+                            "2x": "https://static-cdn.jtvnw.net/badges/v1/030cab2c-5d14-11e7-8d91-43a5a4306286/2",
+                            "3x": "https://static-cdn.jtvnw.net/badges/v1/030cab2c-5d14-11e7-8d91-43a5a4306286/3"
+                        },
+                        "name": "",
+                        "tooltip": "Hello Neighbor"
+                    },
+                    "flags": "BadgeVanity",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "tooltip": "Hello Neighbor",
+                    "trailingSpace": true,
+                    "type": "BadgeElement"
+                },
+                {
+                    "color": "#ffff4500",
+                    "flags": "Username",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "IMrLazyI"
+                    },
+                    "style": "ChatMediumBold",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "IMrLazyI:"
+                    ]
+                },
+                {
+                    "emote": {
+                        "images": {
+                            "1x": "https://pajbot.com/static/emoji-v2/img/twitter/64/1fae3.png"
+                        },
+                        "name": "🫣",
+                        "tooltip": ":face_with_peeking_eye:<br/>Emoji"
+                    },
+                    "flags": "EmojiImage|EmojiText",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "tooltip": ":face_with_peeking_eye:<br/>Emoji",
+                    "trailingSpace": true,
+                    "type": "EmoteElement"
+                },
+                {
+                    "background": "#ffa0a0a4",
+                    "flags": "ReplyButton",
+                    "link": {
+                        "type": "ReplyToMessage",
+                        "value": "5f360c15-db41-439a-83fd-2e2dbcdebada"
+                    },
+                    "padding": 2,
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "CircularImageElement",
+                    "url": ""
+                }
+            ],
+            "externalBadges": [
+            ],
+            "flags": "Collapsed|WatchStreak",
+            "frozen": false,
+            "highlightColor": "#64c466ff",
+            "id": "5f360c15-db41-439a-83fd-2e2dbcdebada",
+            "localizedName": "",
+            "loginName": "imrlazyi",
+            "messageText": "🫣",
+            "searchText": "imrlazyi  imrlazyi: 🫣 ",
+            "serverReceivedTime": "2026-05-30T11:49:28Z",
+            "timeoutUser": "",
+            "twitchBadgeInfos": {
+                "subscriber": "5"
+            },
+            "twitchBadges": [
+                "subscriber",
+                "hello_neighbor_1"
+            ],
+            "userID": "55530653",
+            "usernameColor": "#ffff4500"
+        },
+        {
+            "channelName": "",
+            "count": 1,
+            "displayName": "",
+            "elements": [
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "TimestampMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "11:49"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "11:49:28",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "Text",
+                    "fallbackColor": "System",
+                    "flags": "Text|Mention",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "MentionElement",
+                    "userColor": "#ffff4500",
+                    "userLoginName": "imrlazyi",
+                    "words": [
+                        "IMrLazyI"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "watched",
+                        "10",
+                        "consecutive",
+                        "streams",
+                        "and",
+                        "sparked",
+                        "a",
+                        "watch",
+                        "streak!"
+                    ]
+                }
+            ],
+            "externalBadges": [
+            ],
+            "flags": "System|DoNotTriggerNotification|WatchStreak",
+            "frozen": false,
+            "id": "",
+            "localizedName": "",
+            "loginName": "",
+            "messageText": "IMrLazyI watched 10 consecutive streams and sparked a watch streak!",
+            "searchText": "IMrLazyI watched 10 consecutive streams and sparked a watch streak!",
+            "serverReceivedTime": "",
+            "timeoutUser": "",
+            "twitchBadgeInfos": {
+            },
+            "twitchBadges": [
+            ],
+            "userID": "",
+            "usernameColor": "#ff000000"
+        }
+    ]
+}


### PR DESCRIPTION
It would be too easy if they were identical to watch streaks. The system message we get doesn't contain the username like watch streaks. I asked about this on the Twitch Dev Discord, but didn't receive an answer. We manually prepend the name to the message for now. 

Mod streaks are handled like watch streaks. I don't see a good reason to separate them.

Since watch streaks didn't have tests, I added some for them as well.

Closes #7025.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
