### PR TITLE
fix: typos and consistency

### DIFF
--- a/src/common/Args.cpp
+++ b/src/common/Args.cpp
@@ -124,7 +124,7 @@ Args::Args(const QApplication &app, const Paths &paths)
     QCommandLineOption loginOption(
         "login",
         "Starts Chatterino logged in as the account matching the supplied "
-        "username. If the supplied username does not match any account "
+        "username. If the supplied username does not match any account, "
         "Chatterino starts logged in as anonymous.",
         "username");
 

--- a/src/controllers/commands/builtin/chatterino/Debugging.cpp
+++ b/src/controllers/commands/builtin/chatterino/Debugging.cpp
@@ -87,7 +87,7 @@ QString setLoggingRules(const CommandContext &ctx)
     {
         ctx.channel->addSystemMessage(
             "Usage: /c2-set-logging-rules <rules...>. To enable debug logging "
-            "for all categories from chatterino, use "
+            "for all categories from Chatterino, use "
             "'chatterino.*.debug=true'. For the format on the rules, see "
             "https://doc.qt.io/qt-6/"
             "qloggingcategory.html#configuring-categories");

--- a/src/widgets/settingspages/ExternalToolsPage.cpp
+++ b/src/widgets/settingspages/ExternalToolsPage.cpp
@@ -163,8 +163,8 @@ void ExternalToolsPage::initLayout(GeneralPageView &layout)
         layout.addTitle("Custom stream player");
         layout.addDescription(
             "You can open Twitch streams directly in any video player that has "
-            "built-in Twitch support and has own URI Scheme.\nE.g.: IINA for "
-            "macOS and Potplayer (with extension) for Windows.\n\nWith this "
+            "built-in Twitch support and its own URI Scheme.\nE.g.: IINA for "
+            "macOS and PotPlayer (with extension) for Windows.\n\nWith this "
             "value set, you will get the option to \"Open in custom player\" "
             "when right-clicking a channel header.");
 
@@ -263,7 +263,7 @@ void ExternalToolsPage::initLayout(GeneralPageView &layout)
                                     .max = std::numeric_limits<int>::max(),
                                 })
             ->setTooltip(
-                "When right clicking any word, show this many suggestions. If "
+                "When right-clicking any word, show this many suggestions. If "
                 "this is 0, no suggestions will be shown and if it's -1, no "
                 "limit is set.")
             ->addTo(layout);

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -507,7 +507,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
                             s.fadeMessageHistory)
         ->setTooltip(
             "Reduce opacity of messages that were posted before Chatterino "
-            "was started or while re-connection.")
+            "was started or while re-connecting.")
         ->addTo(layout);
 
     SettingWidget::checkbox("Hide deleted messages", s.hideModerated)
@@ -981,7 +981,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
 
     layout.addSubtitle("Application Data");
     layout.addDescription("All local files like settings and cache files are "
-                          "store in this directory.");
+                          "stored in this directory.");
     layout.addButton("Open AppData directory", [] {
 #ifdef Q_OS_DARWIN
         QDesktopServices::openUrl("file://" +
@@ -1394,7 +1394,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
 
     SettingWidget::checkbox("Mention users with a comma",
                             s.mentionUsersWithComma)
-        ->setTooltip("When using tab-completon, if the username is at the "
+        ->setTooltip("When using tab-completion, if the username is at the "
                      "start of the message, include a comma at the end of the "
                      "name.\ne.g. pajl -> pajlada,")
         ->addTo(layout);
@@ -1479,7 +1479,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
             },
             false,
             "Customizes how you see Asian Language names.\nUsing an option "
-            "that includes \"localized\" will display the username in it's "
+            "that includes \"localized\" will display the username in its "
             "respective Asian language.\ne.g. "
             "Username and localized: testaccount_420(테스트계정420)\n"
             "Username: testaccount_420\n"
@@ -1506,7 +1506,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         "Double click to open links and other elements in chat",
         s.linksDoubleClickOnly)
         ->setTooltip("When enabled, opening links/usercards requires "
-                     "double-clicking.\nUseful making sure you don't "
+                     "double-clicking.\nUseful for making sure you don't "
                      "accidentally click on suspicious links.")
         ->addTo(layout);
 
@@ -1620,7 +1620,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         ->addTo(layout);
 
     SettingWidget::dropdown("Chat send protocol", s.chatSendProtocol)
-        ->setTooltip("'Helix' will use Twitch's Helix API to send message. "
+        ->setTooltip("'Helix' will use Twitch's Helix API to send messages. "
                      "'IRC' will use IRC to send messages.")
         ->addTo(layout);
 

--- a/src/widgets/settingspages/HighlightingPage.cpp
+++ b/src/widgets/settingspages/HighlightingPage.cpp
@@ -170,7 +170,7 @@ HighlightingPage::HighlightingPage()
                 badgeHighlights.emplace<QLabel>(
                     "Play notification sounds and highlight messages based on "
                     "user badges.\n"
-                    "Badge highlights are prioritzed under user and message "
+                    "Badge highlights are prioritized under user and message "
                     "highlights.");
                 auto *view = badgeHighlights
                                  .emplace<EditableModelView>(


### PR DESCRIPTION
"Potplayer" is usually stylized as PotPlayer
https://en.wikipedia.org/wiki/PotPlayer

Changed instances of "right click" to "right-click" to be more consistent throughout Chatterino

Various other typos/missing words fixed

<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
