### PR TITLE
chore: show settings directory in about page

### DIFF
--- a/src/widgets/settingspages/AboutPage.cpp
+++ b/src/widgets/settingspages/AboutPage.cpp
@@ -68,7 +68,8 @@ AboutPage::AboutPage()
                 string += "<br>" % version.extraString();
             }
 
-            string += "<br><br>The settings directory is located at <a href=\"";
+            string +=
+                "<br><br>Your settings directory is located at <a href=\"";
             string +=
                 QUrl::fromLocalFile(getApp()->getPaths().settingsDirectory)
                     .toString(QUrl::FullyEncoded);

--- a/src/widgets/settingspages/AboutPage.cpp
+++ b/src/widgets/settingspages/AboutPage.cpp
@@ -4,9 +4,11 @@
 
 #include "widgets/settingspages/AboutPage.hpp"
 
+#include "Application.hpp"
 #include "common/Common.hpp"
 #include "common/QLogging.hpp"
 #include "common/Version.hpp"
+#include "singletons/Paths.hpp"
 #include "util/Expected.hpp"  // IWYU pragma: keep - this is being used to see if we're using the expected_lite library
 #include "util/LayoutCreator.hpp"
 #include "util/RemoveScrollAreaBackground.hpp"
@@ -65,6 +67,14 @@ AboutPage::AboutPage()
             {
                 string += "<br>" % version.extraString();
             }
+
+            string += "<br><br>The settings directory is located at <a href=\"";
+            string +=
+                QUrl::fromLocalFile(getApp()->getPaths().settingsDirectory)
+                    .toString(QUrl::FullyEncoded);
+            string += "\">";
+            string += getApp()->getPaths().settingsDirectory.toHtmlEscaped();
+            string += "</a>.";
 
             auto label = vbox.emplace<QLabel>(string);
             label->setWordWrap(true);


### PR DESCRIPTION
We sometimes link users https://wiki.chatterino.com/Settings/. It would be great if Chatterino could tell the user where their settings are located, because it knows that better than anyone. The wiki page is still useful to know what the settings actually store.

The about page now reads (for example):

```
Chatterino 2.5.5 DEBUG (commit 90712f2e4 modified) built with Qt 6.11.0, MSVC 195035730
Running on Windows 11 Version 25H2, kernel: 10.0.26200

The settings directory is located at F:/Dev/chatterino2/build/bin/Settings.
```

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
