### PR TITLE
ci: build coverage on Ubuntu 26.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,15 +21,13 @@ concurrency:
 
 jobs:
   test:
-    name: "Test ${{ matrix.os }}, Qt ${{ matrix.qt-version }}"
+    name: "Test Ubuntu"
     runs-on: ubuntu-latest
     container: ${{ matrix.container }}
     strategy:
       matrix:
         include:
-          - os: "ubuntu-22.04"
-            container: ghcr.io/chatterino/chatterino2-build-ubuntu-22.04:latest
-            qt-version: 6.7.1
+          - container: ghcr.io/chatterino/chatterino2-build-ubuntu-26.04:latest
       fail-fast: false
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,19 +16,14 @@ env:
   QT_QPA_PLATFORM: minimal
 
 concurrency:
-  group: test-${{ github.ref }}
+  group: test-ubuntu-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   test:
     name: "Test Ubuntu"
     runs-on: ubuntu-latest
-    container: ${{ matrix.container }}
-    strategy:
-      matrix:
-        include:
-          - container: ghcr.io/chatterino/chatterino2-build-ubuntu-26.04:latest
-      fail-fast: false
+    container: ghcr.io/chatterino/chatterino2-build-ubuntu-26.04:latest
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
current idea is: seems like code coverage generation broke in https://github.com/Chatterino/docker/pull/39

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
