### PR TITLE
ci: Fix filename for create-installer workflow

### DIFF
--- a/.github/workflows/create-installer.yml
+++ b/.github/workflows/create-installer.yml
@@ -18,7 +18,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     strategy:
       matrix:
-        qt-version: ["6.11.1"]
+        qt-version: ["6.8.3"]
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
I guess that's something I overlooked when doing https://github.com/Chatterino/chatterino2/pull/7009.
I saw the error in https://github.com/Chatterino/chatterino2/actions/runs/27479154379/job/81223740085

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
