### PR TITLE
fix: add scrollbar highlight for uncategorized notifications

### DIFF
--- a/src/messages/Message.cpp
+++ b/src/messages/Message.cpp
@@ -109,6 +109,14 @@ ScrollbarHighlight Message::getScrollBarHighlight() const
         };
     }
 
+    if (this->flags.has(MessageFlag::UncategorizedNotification))
+    {
+        // TODO: Give this a better/its own color :-)
+        return {
+            ColorProvider::instance().color(ColorType::Subscription),
+        };
+    }
+
     return {};
 }
 


### PR DESCRIPTION
I just noticed that #7038 didn't add this.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: #7038
-->
