### PR TITLE
docs: update BUILDING_ON_LINUX.md for Fedora

### DIFF
--- a/BUILDING_ON_LINUX.md
+++ b/BUILDING_ON_LINUX.md
@@ -42,12 +42,12 @@ sudo zypper install cmake pkgconf boost-devel libboost_json1_89_0-devel desktop-
 doas emerge dev-libs/openssl dev-qt/qt5compat dev-qt/qtbase dev-qt/qtsvg dev-qt/qtimageformats x11-libs/libnotify dev-libs/qtkeychain dev-libs/boost dev-build/cmake app-text/hunspell
 ```
 
-### Fedora 39 and above
+### Fedora 42 and above
 
 _Most likely works the same for other Red Hat-like distros. Substitute `dnf` with `yum`._
 
 ```sh
-sudo dnf install qt6-qtbase-devel qt6-qtimageformats qt6-qtsvg-devel g++ git openssl-devel boost-devel libnotify-devel cmake hunspell
+sudo dnf install qt6-qtbase-devel qt6-qtimageformats qt6-qtsvg-devel g++ git openssl-devel boost-devel libnotify-devel cmake hunspell-devel clang-tools-extra
 ```
 
 ### NixOS 18.09+

--- a/BUILDING_ON_LINUX.md
+++ b/BUILDING_ON_LINUX.md
@@ -47,7 +47,7 @@ doas emerge dev-libs/openssl dev-qt/qt5compat dev-qt/qtbase dev-qt/qtsvg dev-qt/
 _Most likely works the same for other Red Hat-like distros. Substitute `dnf` with `yum`._
 
 ```sh
-sudo dnf install qt6-qtbase-devel qt6-qtimageformats qt6-qtsvg-devel g++ git openssl-devel boost-devel libnotify-devel cmake hunspell-devel clang-tools-extra
+sudo dnf install qt6-qtbase-devel qt6-qtimageformats qt6-qtsvg-devel g++ git openssl-devel boost-devel libnotify-devel cmake hunspell-devel
 ```
 
 ### NixOS 18.09+

--- a/lib/twitch-eventsub-ws/ast/check-clang.py
+++ b/lib/twitch-eventsub-ws/ast/check-clang.py
@@ -1,6 +1,7 @@
 import clang.cindex
 import sys
 from pathlib import Path
+import subprocess
 
 from lib import init_clang_cindex, parse
 
@@ -18,3 +19,9 @@ if len(tu.diagnostics) > 0:
         print(diag.spelling)
         print(diag.option)
     assert False, "TU had warnings/errors when parsing"
+
+# Ensure clang-format is installed
+try:
+    subprocess.run(["clang-format", "--version"])
+except FileNotFoundError:
+    assert False, "clang-format not installed"


### PR DESCRIPTION
- Fedora current non-EoL version is 42;
- hunspell errors out at build preparation time, really requires the `-devel` version;
- `twitch-eventsub-ws/ast/lib/format.py` line 1039 requires `clang-tools-extra`;

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
