### PR TITLE
Build/cmake configuration changes

### DIFF
--- a/.CI/full-ubuntu-build.sh
+++ b/.CI/full-ubuntu-build.sh
@@ -25,6 +25,6 @@ cmake \
     -DCHATTERINO_STATIC_QT_BUILD=On \
     -DCMAKE_CXX_FLAGS="-fno-sized-deallocation" \
     .
-cmake --build build
+cmake --build build -j$(nproc) # builds the project with all available cores
 
 # sh ./../.CI/CreateUbuntuDeb.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,11 +67,11 @@ include(dependencies)
 # Can stil be broken into smaller modules
 include(toolchain)
 
-if (WIN32)
+if(WIN32)
     add_subdirectory(lib/WinToast EXCLUDE_FROM_ALL)
-endif ()
+endif()
 
-if (BUILD_TESTS)
+if(BUILD_TESTS)
     include(GoogleTest)
     # For MSVC: Prevent overriding the parent project's compiler/linker settings
     # See https://github.com/google/googletest/blob/main/googletest/README.md#visual-studio-dynamic-vs-static-runtimes
@@ -80,43 +80,43 @@ if (BUILD_TESTS)
     add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/lib/googletest" "lib/googletest")
 
     mark_as_advanced(
-            BUILD_GMOCK BUILD_GTEST BUILD_SHARED_LIBS
-            gmock_build_tests gtest_build_samples gtest_build_tests
-            gtest_disable_pthreads gtest_force_shared_crt gtest_hide_internal_symbols
+        BUILD_GMOCK BUILD_GTEST BUILD_SHARED_LIBS
+        gmock_build_tests gtest_build_samples gtest_build_tests
+        gtest_disable_pthreads gtest_force_shared_crt gtest_hide_internal_symbols
     )
 
     set_target_properties(gtest PROPERTIES FOLDER lib)
     set_target_properties(gtest_main PROPERTIES FOLDER lib)
     set_target_properties(gmock PROPERTIES FOLDER lib)
     set_target_properties(gmock_main PROPERTIES FOLDER lib)
-endif ()
+endif()
 
 # Used to provide a date of build in the About page (for nightly builds). Getting the actual time of
 # compilation in CMake is a more involved, as documented in https://stackoverflow.com/q/24292898.
 # For CI runs, however, the date of build file generation should be consistent with the date of
 # compilation so this approximation is "good enough" for our purpose.
-if (DEFINED ENV{CHATTERINO_SKIP_DATE_GEN})
+if(DEFINED ENV{CHATTERINO_SKIP_DATE_GEN})
     set(cmake_gen_date "1970-01-01")
-else ()
+else()
     string(TIMESTAMP cmake_gen_date "%Y-%m-%d")
-endif ()
+endif()
 
 enable_testing()
 
 add_subdirectory(lib/twitch-eventsub-ws)
 add_subdirectory(src)
 
-if (BUILD_TESTS OR BUILD_BENCHMARKS)
+if(BUILD_TESTS OR BUILD_BENCHMARKS)
     add_subdirectory(mocks)
-endif ()
+endif()
 
-if (BUILD_TESTS)
+if(BUILD_TESTS)
     add_subdirectory(tests)
-endif ()
+endif()
 
 
-if (BUILD_BENCHMARKS)
+if(BUILD_BENCHMARKS)
     add_subdirectory(benchmarks)
-endif ()
+endif()
 
 feature_summary(WHAT ALL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,61 +1,28 @@
 cmake_minimum_required(VERSION 3.22..4.3.2)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+# cmake include modules are included early to ensure that all features are available before project() is called
+include(FeatureSummary)
+include(FetchContent)
+include(CMakeDependentOption)
+
+# cmake/options.cmake is doing a lot of heavy lifting, so it's best to include it early to ensure that all options are set before project() is called
+include(options)
+
 # CMake upgrade notes:
 #  - In CMake >= 3.29, we should deprecate USE_ALTERNATE_LINKER in favour of CMake's CMAKE_LINKER_TYPE
-set(CMAKE_EXPORT_NO_PACKAGE_REGISTRY On) # For rapidjson
+set(CMAKE_EXPORT_NO_PACKAGE_REGISTRY ON) # For rapidjson
 cmake_policy(SET CMP0087 NEW) # evaluates generator expressions in `install(CODE/SCRIPT)`
 cmake_policy(SET CMP0091 NEW) # select MSVC runtime library through `CMAKE_MSVC_RUNTIME_LIBRARY`
 if(POLICY CMP0207)
     cmake_policy(SET CMP0207 NEW) # file(GET_RUNTIME_DEPENDENCIES) normalizes paths before matching
 endif()
-include(FeatureSummary)
-include(FetchContent)
-include(CMakeDependentOption)
 
-list(APPEND CMAKE_MODULE_PATH
-    "${CMAKE_SOURCE_DIR}/cmake"
-    )
+# For legacy non-CMakePresets.json builds, set the C++ standard to 23
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-option(BUILD_APP "Build Chatterino" ON)
-option(BUILD_TESTS "Build the tests for Chatterino" OFF)
-option(BUILD_BENCHMARKS "Build the benchmarks for Chatterino" OFF)
-option(USE_SYSTEM_PAJLADA_SETTINGS "Use system pajlada settings library" OFF)
-option(USE_SYSTEM_LIBCOMMUNI "Use system communi library" OFF)
-option(USE_SYSTEM_MINIAUDIO "Build Chatterino with your system miniaudio" OFF)
-option(BUILD_WITH_CRASHPAD "Build chatterino with crashpad" OFF)
-option(USE_PRECOMPILED_HEADERS "Use precompiled headers (Temporarily not supported on macOS)" ON)
-option(BUILD_WITH_QT6 "Build with Qt6" On)
-option(BUILD_WITH_LIBNOTIFY "Build with libnotify" ON)
-option(CHATTERINO_GENERATE_COVERAGE "Generate coverage files" OFF)
-option(BUILD_SHARED_LIBS "" OFF)
-option(CHATTERINO_LTO "Enable LTO for all targets" OFF)
-# CMake doesn't detect LTO for some compilers (e.g. clang-cl: https://gitlab.kitware.com/cmake/cmake/-/issues/21635),
-# so this skips the check and assumes LTO works.
-cmake_dependent_option(CHATTERINO_FORCE_LTO "Skip check if LTO is supported" OFF CHATTERINO_LTO OFF)
-option(CHATTERINO_FORCE_LTO "Don't check if LTO is supported" OFF)
-option(CHATTERINO_PLUGINS "Enable ALPHA plugin support in Chatterino" ON)
-option(CHATTERINO_USE_GDI_FONTENGINE "Use the legacy GDI fontengine instead of the new DirectWrite one on Windows (Qt 6.8.0 and later)" ON)
-option(CHATTERINO_ALLOW_PRIVATE_QT_API "Allow uses of Qt's private API - when enabling this, Chatterino must use the EXACT Qt version it was compiled against" OFF)
-option(CHATTERINO_SPELLCHECK "Enable spellchecking in Chatterino (requires Hunspell)" OFF)
-option(CHATTERINO_NIGHTLY_BUILD "Specifies whether this is a nightly build." OFF)
-
-option(CHATTERINO_SANITIZER_SUPPORT "Attempt to enable Sanitizer support on the test and app targets. Actual sanitizers can then be enabled with the SANITIZE_* options." OFF)
-mark_as_advanced(CHATTERINO_SANITIZER_SUPPORT)
-add_feature_info("Chatterino code sanitizer support" CHATTERINO_SANITIZER_SUPPORT "")
-
-option(CHATTERINO_UPDATER "Enable update checks" ON)
-mark_as_advanced(CHATTERINO_UPDATER)
-
-set(CHATTERINO_EXTRA_BUILD_STRING "" CACHE STRING "Provide an extra string to show in the about page under the Chatterino version. This string allows the use of Qt's HTML subset.")
-
-set(USE_ALTERNATE_LINKER "" CACHE STRING "Use alternate linker. Leave empty for system default. CMake 3.29 users can use CMAKE_LINKER_TYPE instead.")
-
-if(CHATTERINO_SANITIZER_SUPPORT)
-    list(APPEND CMAKE_MODULE_PATH
-        "${CMAKE_SOURCE_DIR}/cmake/sanitizers-cmake/cmake"
-    )
-    find_package(Sanitizers REQUIRED)
-endif()
-
+# Necessary for vcpkg manifest mode
 if(BUILD_TESTS)
     list(APPEND VCPKG_MANIFEST_FEATURES "tests")
 endif()
@@ -69,128 +36,40 @@ project(chatterino
     HOMEPAGE_URL "https://chatterino.com/"
 )
 
-if(CHATTERINO_GENERATE_COVERAGE)
-    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-        add_compile_options(-fprofile-instr-generate -fcoverage-mapping)
-        add_link_options(-fprofile-instr-generate -fcoverage-mapping)
-    elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-        add_compile_options(-coverage)
-        add_link_options(-coverage)
+# Determine Qt version
+if(BUILD_WITH_QT6)
+    find_package(Qt6 QUIET COMPONENTS Core)
+    if(NOT Qt6_FOUND)
+        message(FATAL_ERROR "BUILD_WITH_QT6=ON but Qt6 was not found")
     endif()
-endif()
-
-if(CHATTERINO_LTO)
-    if (CHATTERINO_FORCE_LTO)
-        set(CHATTERINO_ENABLE_LTO ON)
-        message(STATUS "LTO: Enabled (Force)")
-    else()
-        include(CheckIPOSupported)
-        check_ipo_supported(RESULT CHATTERINO_ENABLE_LTO OUTPUT IPO_ERROR)
-        message(STATUS "LTO: Enabled (Supported: ${CHATTERINO_ENABLE_LTO} - ${IPO_ERROR})")
-    endif()
+    set(MAJOR_QT_VERSION 6)
 else()
-    message(STATUS "LTO: Disabled")
-endif()
-
-if (BUILD_WITH_QT6)
-    set(MAJOR_QT_VERSION "6")
-else()
-    message(WARNING "Qt5 is not supported, continue building at your own risk")
-    set(MAJOR_QT_VERSION "5")
-endif()
-
-find_program(CCACHE_PROGRAM ccache)
-find_program(SCCACHE_PROGRAM sccache)
-if (SCCACHE_PROGRAM)
-    set(_compiler_launcher ${SCCACHE_PROGRAM})
-elseif (CCACHE_PROGRAM)
-    set(_compiler_launcher ${CCACHE_PROGRAM})
-endif ()
-
-if(USE_ALTERNATE_LINKER)
-    find_program(LINKER_EXECUTABLE ld.${USE_ALTERNATE_LINKER} ${USE_ALTERNATE_LINKER})
-    if(LINKER_EXECUTABLE)
-        message(STATUS "Using alternate linker '${USE_ALTERNATE_LINKER}'")
-        add_link_options("-fuse-ld=${USE_ALTERNATE_LINKER}")
-    else()
-        message(FATAL_ERROR "Alternate linker ${USE_ALTERNATE_LINKER} could not be found under ld.${USE_ALTERNATIVE_LINKER} or ${USE_ALTERNATE_LINKER}")
+    find_package(Qt5 QUIET COMPONENTS Core)
+    if(NOT Qt5_FOUND)
+        message(FATAL_ERROR "BUILD_WITH_QT6=OFF but Qt5 was not found")
     endif()
+    set(MAJOR_QT_VERSION 5)
+    message(WARNING "Qt6 is not found or selected, defaulting to Qt5. WARNING: This may result in build errors or unexpected behavior. Continue building at your own risk")
 endif()
-
-if (_compiler_launcher)
-    set(CMAKE_CXX_COMPILER_LAUNCHER "${_compiler_launcher}" CACHE STRING "CXX compiler launcher")
-    message(STATUS "Using ${_compiler_launcher} for speeding up build")
-
-    if (MSVC)
-        # /Zi can't be used with (s)ccache
-        # Use /Z7 instead (debug info in object files)
-        if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-            string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
-        elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
-            string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
-        elseif(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
-            string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
-        endif()
-    endif()
-endif()
-
-include(${CMAKE_CURRENT_LIST_DIR}/cmake/GIT.cmake)
-
-find_package(Qt${MAJOR_QT_VERSION} REQUIRED
-    COMPONENTS
-    Core
-    Widgets
-    Gui
-    Network
-    Svg
-    SvgWidgets
-    Concurrent
-    )
-if(CHATTERINO_ALLOW_PRIVATE_QT_API)
-    # Only exists since 6.10 and prints a warning regarding private headers
-    find_package(Qt${MAJOR_QT_VERSION} COMPONENTS GuiPrivate)
-endif()
-
 message(STATUS "Qt version: ${Qt${MAJOR_QT_VERSION}_VERSION}")
+
+include(ccache)
+include(fetch_contents)
+include(GIT)
+include(resources/generate_resources) # Generate resource files
+include(vcpkg)
+
+# Locate and acquire all dependencies: core + feature-gated options
+# Design by contract: Requires MAJOR_QT_VERSION  and the vcpkg module for Boost
+include(dependencies)
+
+# Configure compiler, instrumentation, LTO, sanitizers
+# Can stil be broken into smaller modules
+include(toolchain)
 
 if (WIN32)
     add_subdirectory(lib/WinToast EXCLUDE_FROM_ALL)
 endif ()
-
-# Find boost on the system
-set(BOOST_REQUIRED_COMPONENTS "")
-if (VCPKG_TARGET_TRIPLET)
-    list(APPEND BOOST_REQUIRED_COMPONENTS json)
-endif ()
-find_package(Boost REQUIRED CONFIG COMPONENTS ${BOOST_REQUIRED_COMPONENTS} OPTIONAL_COMPONENTS headers)
-
-# Find OpenSSL on the system
-find_package(OpenSSL REQUIRED)
-
-find_package(Threads REQUIRED)
-
-if(CHATTERINO_SPELLCHECK)
-    # Find from package manager
-    find_package(hunspell QUIET CONFIG)
-    if(NOT hunspell_FOUND)
-        find_package(PkgConfig REQUIRED)
-        pkg_check_modules(hunspell REQUIRED IMPORTED_TARGET hunspell)
-        add_library(hunspell::hunspell ALIAS PkgConfig::hunspell)
-    endif()
-endif()
-
-find_library(LIBRT rt)
-
-if (USE_SYSTEM_LIBCOMMUNI)
-    find_package(LibCommuni REQUIRED)
-else()
-    set(LIBCOMMUNI_ROOT_LIB_FOLDER "${CMAKE_SOURCE_DIR}/lib/libcommuni")
-    if (NOT EXISTS "${LIBCOMMUNI_ROOT_LIB_FOLDER}/CMakeLists.txt")
-        message(FATAL_ERROR "Submodules probably not loaded, unable to find lib/libcommuni/CMakeLists.txt")
-    endif()
-
-    add_subdirectory("${LIBCOMMUNI_ROOT_LIB_FOLDER}" EXCLUDE_FROM_ALL)
-endif()
 
 if (BUILD_TESTS)
     include(GoogleTest)
@@ -212,59 +91,6 @@ if (BUILD_TESTS)
     set_target_properties(gmock_main PROPERTIES FOLDER lib)
 endif ()
 
-if (BUILD_BENCHMARKS)
-    # Include system benchmark (Google Benchmark)
-    find_package(benchmark REQUIRED)
-endif ()
-
-FetchContent_Declare(
-    RapidJSON
-    SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/lib/rapidjson
-    EXCLUDE_FROM_ALL
-    FIND_PACKAGE_ARGS
-)
-set(RAPIDJSON_BUILD_EXAMPLES Off CACHE INTERNAL "")
-set(RAPIDJSON_BUILD_TESTS Off CACHE INTERNAL "")
-
-FetchContent_Declare(
-    PajladaSignals
-    SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/lib/signals
-    EXCLUDE_FROM_ALL
-    FIND_PACKAGE_ARGS 0.1.3 CONFIG
-)
-FetchContent_Declare(
-    PajladaSerialize
-    SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/lib/serialize
-    EXCLUDE_FROM_ALL
-    FIND_PACKAGE_ARGS 0.3.0 CONFIG
-)
-FetchContent_Declare(
-    PajladaSettings
-    SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/lib/settings
-    EXCLUDE_FROM_ALL
-    FIND_PACKAGE_ARGS 0.5.1 CONFIG
-)
-
-FetchContent_MakeAvailable(RapidJSON PajladaSignals PajladaSerialize PajladaSettings)
-
-find_package(LRUCache REQUIRED)
-find_package(MagicEnum REQUIRED)
-find_package(Doxygen)
-find_package(BoostCertify REQUIRED)
-
-if (CHATTERINO_PLUGINS)
-    set(LUA_INCLUDE_DIRS "${CMAKE_SOURCE_DIR}/lib/lua/src")
-    add_subdirectory(lib/lua)
-
-    find_package(Sol2 REQUIRED)
-endif()
-
-if (BUILD_WITH_CRASHPAD)
-    add_subdirectory("${CMAKE_SOURCE_DIR}/tools/crash-handler")
-endif()
-
-add_subdirectory(lib/twitch-eventsub-ws)
-
 # Used to provide a date of build in the About page (for nightly builds). Getting the actual time of
 # compilation in CMake is a more involved, as documented in https://stackoverflow.com/q/24292898.
 # For CI runs, however, the date of build file generation should be consistent with the date of
@@ -275,12 +101,9 @@ else ()
     string(TIMESTAMP cmake_gen_date "%Y-%m-%d")
 endif ()
 
-set(CMAKE_CXX_STANDARD 23)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+enable_testing()
 
-# Generate resource files
-include(cmake/resources/generate_resources.cmake)
-
+add_subdirectory(lib/twitch-eventsub-ws)
 add_subdirectory(src)
 
 if (BUILD_TESTS OR BUILD_BENCHMARKS)
@@ -288,9 +111,9 @@ if (BUILD_TESTS OR BUILD_BENCHMARKS)
 endif ()
 
 if (BUILD_TESTS)
-    enable_testing()
     add_subdirectory(tests)
 endif ()
+
 
 if (BUILD_BENCHMARKS)
     add_subdirectory(benchmarks)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,8 +101,6 @@ else()
     string(TIMESTAMP cmake_gen_date "%Y-%m-%d")
 endif()
 
-enable_testing()
-
 add_subdirectory(lib/twitch-eventsub-ws)
 add_subdirectory(src)
 
@@ -111,6 +109,7 @@ if(BUILD_TESTS OR BUILD_BENCHMARKS)
 endif()
 
 if(BUILD_TESTS)
+    enable_testing()
     add_subdirectory(tests)
 endif()
 

--- a/cmake/ccache.cmake
+++ b/cmake/ccache.cmake
@@ -2,17 +2,17 @@ include_guard(GLOBAL)
 
 find_program(CCACHE_PROGRAM ccache)
 find_program(SCCACHE_PROGRAM sccache)
-if (SCCACHE_PROGRAM)
+if(SCCACHE_PROGRAM)
     set(CCACHE_COMPILER_LAUNCHER ${SCCACHE_PROGRAM})
-elseif (CCACHE_PROGRAM)
+elseif(CCACHE_PROGRAM)
     set(CCACHE_COMPILER_LAUNCHER ${CCACHE_PROGRAM})
 endif()
 
-if (CCACHE_COMPILER_LAUNCHER)
+if(CCACHE_COMPILER_LAUNCHER)
     message(STATUS "Overriding ${CMAKE_CXX_COMPILER_LAUNCHER} with ${CCACHE_COMPILER_LAUNCHER} for faster incremental builds")
     set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_COMPILER_LAUNCHER}" CACHE STRING "CXX compiler launcher")
 
-    if (MSVC)
+    if(MSVC)
         # /Zi can't be used with (s)ccache
         # Use /Z7 instead (debug info in object files)
         if(CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/cmake/ccache.cmake
+++ b/cmake/ccache.cmake
@@ -1,0 +1,28 @@
+include_guard(GLOBAL)
+
+find_program(CCACHE_PROGRAM ccache)
+find_program(SCCACHE_PROGRAM sccache)
+if (SCCACHE_PROGRAM)
+    set(CCACHE_COMPILER_LAUNCHER ${SCCACHE_PROGRAM})
+elseif (CCACHE_PROGRAM)
+    set(CCACHE_COMPILER_LAUNCHER ${CCACHE_PROGRAM})
+endif()
+
+if (CCACHE_COMPILER_LAUNCHER)
+    message(STATUS "Overriding ${CMAKE_CXX_COMPILER_LAUNCHER} with ${CCACHE_COMPILER_LAUNCHER} for faster incremental builds")
+    set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_COMPILER_LAUNCHER}" CACHE STRING "CXX compiler launcher")
+
+    if (MSVC)
+        # /Zi can't be used with (s)ccache
+        # Use /Z7 instead (debug info in object files)
+        if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+            string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+        elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
+            string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
+        elseif(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+            string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+        endif()
+    endif()
+else()
+    message(STATUS "ccache not found. For faster builds, install ccache or sccache.")
+endif()

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -1,0 +1,63 @@
+include_guard(GLOBAL)
+
+include(options) # ensure options are defined if this module is used standalone
+
+find_package(Qt${MAJOR_QT_VERSION} REQUIRED COMPONENTS
+    Core
+    Widgets
+    Gui
+    Network
+    Svg
+    SvgWidgets
+    Concurrent
+)
+find_package(OpenSSL REQUIRED)
+find_package(Threads REQUIRED)
+find_package(LRUCache REQUIRED)
+find_package(MagicEnum REQUIRED)
+find_package(Doxygen)
+find_package(BoostCertify REQUIRED)
+
+find_library(LIBRT rt)
+
+if(BUILD_BENCHMARKS)
+    # Google Benchmark
+    find_package(benchmark REQUIRED)
+endif()
+
+if(USE_SYSTEM_LIBCOMMUNI)
+    find_package(LibCommuni REQUIRED)
+else()
+    set(LIBCOMMUNI_ROOT_LIB_FOLDER "${PROJECT_SOURCE_DIR}/lib/libcommuni")
+    if(NOT EXISTS "${LIBCOMMUNI_ROOT_LIB_FOLDER}/CMakeLists.txt")
+        message(FATAL_ERROR "Failed to find libcommuni submodule in path \"${LIBCOMMUNI_ROOT_LIB_FOLDER}/CMakeLists.txt\". Be sure to run \"git submodule update --init --recursive\" to load the submodules.")
+    endif()
+
+    add_subdirectory("${LIBCOMMUNI_ROOT_LIB_FOLDER}" EXCLUDE_FROM_ALL)
+endif()
+
+if(CHATTERINO_ALLOW_PRIVATE_QT_API)
+    # Only exists since 6.10 and prints a warning regarding private headers
+    find_package(Qt${MAJOR_QT_VERSION} COMPONENTS GuiPrivate)
+endif()
+
+if(CHATTERINO_SPELLCHECK)
+    # Prefer the package-manager config, fall back to pkg-config
+    find_package(hunspell QUIET CONFIG)
+    if(NOT hunspell_FOUND)
+        find_package(PkgConfig REQUIRED)
+        pkg_check_modules(hunspell REQUIRED IMPORTED_TARGET hunspell)
+        add_library(hunspell::hunspell ALIAS PkgConfig::hunspell)
+    endif()
+endif()
+
+if(CHATTERINO_PLUGINS)
+    set(LUA_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/lib/lua/src")
+    add_subdirectory(lib/lua)
+
+    find_package(Sol2 REQUIRED)
+endif()
+
+if(BUILD_WITH_CRASHPAD)
+    add_subdirectory("${PROJECT_SOURCE_DIR}/tools/crash-handler")
+endif()

--- a/cmake/fetch_contents.cmake
+++ b/cmake/fetch_contents.cmake
@@ -1,0 +1,38 @@
+include_guard(GLOBAL)
+
+# rapidjson
+FetchContent_Declare(
+    RapidJSON
+    SOURCE_DIR ${PROJECT_SOURCE_DIR}/lib/rapidjson
+    EXCLUDE_FROM_ALL
+    FIND_PACKAGE_ARGS
+)
+set(RAPIDJSON_BUILD_EXAMPLES OFF CACHE INTERNAL "")
+set(RAPIDJSON_BUILD_TESTS OFF CACHE INTERNAL "")
+
+# pajlada/signals
+FetchContent_Declare(
+    PajladaSignals
+    SOURCE_DIR ${PROJECT_SOURCE_DIR}/lib/signals
+    EXCLUDE_FROM_ALL
+    FIND_PACKAGE_ARGS 0.1.3 CONFIG
+)
+
+# pajlada/serialize
+FetchContent_Declare(
+    PajladaSerialize
+    SOURCE_DIR ${PROJECT_SOURCE_DIR}/lib/serialize
+    EXCLUDE_FROM_ALL
+    FIND_PACKAGE_ARGS 0.3.0 CONFIG
+)
+
+# pajlada/settings
+FetchContent_Declare(
+    PajladaSettings
+    SOURCE_DIR ${PROJECT_SOURCE_DIR}/lib/settings
+    EXCLUDE_FROM_ALL
+    FIND_PACKAGE_ARGS 0.5.1 CONFIG
+)
+
+# Make available the fetched contents
+FetchContent_MakeAvailable(RapidJSON PajladaSignals PajladaSerialize PajladaSettings)

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -1,0 +1,37 @@
+include_guard(GLOBAL)
+
+# Build options
+option(BUILD_SHARED_LIBS "" OFF)
+option(BUILD_APP "Build Chatterino" ON)
+option(BUILD_TESTS "Build the tests for Chatterino" OFF)
+option(BUILD_BENCHMARKS "Build the benchmarks for Chatterino" OFF)
+option(BUILD_WITH_CRASHPAD "Build chatterino with crashpad" OFF)
+option(BUILD_WITH_QT6 "Build with Qt6" ON)
+option(BUILD_WITH_LIBNOTIFY "Build with libnotify" ON)
+
+# Use system libraries options
+option(USE_SYSTEM_PAJLADA_SETTINGS "Use system pajlada settings library" OFF)
+option(USE_SYSTEM_LIBCOMMUNI "Use system communi library" OFF)
+option(USE_SYSTEM_MINIAUDIO "Build Chatterino with your system miniaudio" OFF)
+option(USE_PRECOMPILED_HEADERS "Use precompiled headers (Temporarily not supported on macOS)" ON)
+
+# Chatterino options
+option(CHATTERINO_GENERATE_COVERAGE "Generate coverage files" OFF)
+option(CHATTERINO_LTO "Enable LTO for all targets" OFF)
+option(CHATTERINO_PLUGINS "Enable ALPHA plugin support in Chatterino" ON)
+option(CHATTERINO_USE_GDI_FONTENGINE "Use the legacy GDI fontengine instead of the new DirectWrite one on Windows (Qt 6.8.0 and later)" ON)
+option(CHATTERINO_ALLOW_PRIVATE_QT_API "Allow uses of Qt's private API - when enabling this, Chatterino must use the EXACT Qt version it was compiled against" OFF)
+option(CHATTERINO_SPELLCHECK "Enable spellchecking in Chatterino (requires Hunspell)" OFF)
+option(CHATTERINO_SANITIZER_SUPPORT "Attempt to enable Sanitizer support on the test and app targets. Actual sanitizers can then be enabled with the SANITIZE_* options." OFF)
+mark_as_advanced(CHATTERINO_SANITIZER_SUPPORT)
+add_feature_info("Chatterino code sanitizer support" CHATTERINO_SANITIZER_SUPPORT "")
+option(CHATTERINO_NIGHTLY_BUILD "Specifies whether this is a nightly build." OFF)
+set(CHATTERINO_EXTRA_BUILD_STRING "" CACHE STRING "Provide an extra string to show in the about page under the Chatterino version. This string allows the use of Qt's HTML subset.")
+
+# CMake doesn't detect LTO for some compilers (e.g. clang-cl: https://gitlab.kitware.com/cmake/cmake/-/issues/21635),
+# so this skips the check and assumes LTO works.
+cmake_dependent_option(CHATTERINO_FORCE_LTO "Skip check if LTO is supported" OFF CHATTERINO_LTO OFF)
+option(CHATTERINO_FORCE_LTO "Don't check if LTO is supported" OFF)
+
+option(CHATTERINO_UPDATER "Enable update checks" ON)
+mark_as_advanced(CHATTERINO_UPDATER)

--- a/cmake/toolchain.cmake
+++ b/cmake/toolchain.cmake
@@ -1,0 +1,47 @@
+include_guard(GLOBAL)
+
+include(options) # ensure options are defined if this module is used standalone
+
+# Code coverage
+if(CHATTERINO_GENERATE_COVERAGE)
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        add_compile_options(-fprofile-instr-generate -fcoverage-mapping)
+        add_link_options(-fprofile-instr-generate -fcoverage-mapping)
+    elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+        add_compile_options(-coverage)
+        add_link_options(-coverage)
+    endif()
+endif()
+
+# Link-time optimization
+if(CHATTERINO_LTO)
+    if(CHATTERINO_FORCE_LTO)
+        set(CHATTERINO_ENABLE_LTO ON)
+        message(STATUS "LTO: Enabled (Force)")
+    else()
+        include(CheckIPOSupported)
+        check_ipo_supported(RESULT CHATTERINO_ENABLE_LTO OUTPUT IPO_ERROR)
+        message(STATUS "LTO: Enabled (Supported: ${CHATTERINO_ENABLE_LTO} - ${IPO_ERROR})")
+    endif()
+else()
+    message(STATUS "LTO: Disabled")
+endif()
+
+# Sanitizers
+if(CHATTERINO_SANITIZER_SUPPORT)
+    list(APPEND CMAKE_MODULE_PATH
+        "${PROJECT_SOURCE_DIR}/cmake/sanitizers-cmake/cmake"
+    )
+    find_package(Sanitizers REQUIRED)
+endif()
+
+set(USE_ALTERNATE_LINKER "" CACHE STRING "Use alternate linker. Leave empty for system default. CMake 3.29 users can use CMAKE_LINKER_TYPE instead.")
+if(USE_ALTERNATE_LINKER)
+    find_program(LINKER_EXECUTABLE ld.${USE_ALTERNATE_LINKER} ${USE_ALTERNATE_LINKER})
+    if(LINKER_EXECUTABLE)
+        message(STATUS "Using alternate linker '${USE_ALTERNATE_LINKER}'")
+        add_link_options("-fuse-ld=${USE_ALTERNATE_LINKER}")
+    else()
+        message(FATAL_ERROR "Alternate linker ${USE_ALTERNATE_LINKER} could not be found under ld.${USE_ALTERNATE_LINKER} or ${USE_ALTERNATE_LINKER}")
+    endif()
+endif()

--- a/cmake/vcpkg.cmake
+++ b/cmake/vcpkg.cmake
@@ -1,0 +1,9 @@
+include_guard(GLOBAL)
+
+# Find special case json package for vcpkg
+set(BOOST_VCPKG_REQUIRED_COMPONENTS "")
+if(VCPKG_TARGET_TRIPLET)
+    list(APPEND BOOST_VCPKG_REQUIRED_COMPONENTS json)
+endif()
+
+find_package(Boost REQUIRED CONFIG COMPONENTS ${BOOST_VCPKG_REQUIRED_COMPONENTS} OPTIONAL_COMPONENTS headers)


### PR DESCRIPTION
<!--
    Make sure you read the contribution guidelines:
    https://github.com/Chatterino/chatterino2/blob/master/CONTRIBUTING.md

    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
# Title
Refactored and modularized CMake project level code for future maintainability and further modernization.

Description:
The goal of this PR is to de-couple the CMake code so that it can be built in the previous build configuration noted in the existing md text files, and also has the ability to utilize CMake presets down the line that can handle build configuration as a much more maintainable scale under the <project_level>/cmake directory. No changes made to `src/CMakeLists.txt` as of this PR.

# Items changed:
- Created `cmake/options.cmake` for all `option()`s and CMake cache variables
- Created `cmake/dependencies.cmake` for required and feature-gated dependency consumption
- Created `cmake/toolchain.cmake` for code-coverage, sanitizers
- Created `cmake/fetch_contents.cmake` for CMake FetchContent declarations
- Created `cmake/ccache.cmake` for ccache/sccache compiler launcher (aimed to minimized regression of changing build configuration behavior)
- Created `cmake/vcpkg.cmake` for Boost discovery for vcpkg manager
- Brought CMakeLists.txt from ~300 lines of code down to ~120 lines of code for easier understanding of CMake build configuration responsibilities

#AI Disclaimer
I used AI to provide feedback of my PR description, but reworded it to match my own words and understanding of what was changed in this PR

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
