### PR TITLE
ci: update to macOS 26 for the Qt 6.11 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,7 +147,7 @@ jobs:
       matrix:
         include:
           # macOS
-          - os: macos-15
+          - os: macos-26
             qt-version: 6.11.1
             force-lto: false
             skip-artifact: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,7 +147,7 @@ jobs:
       matrix:
         include:
           # macOS
-          - os: macos-14
+          - os: macos-15
             qt-version: 6.11.1
             force-lto: false
             skip-artifact: false

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-14]
+        os: [macos-15]
         qt-version: [6.8.3, 6.11.1]
       fail-fast: false
     env:

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -25,9 +25,9 @@ jobs:
       matrix:
         os: [macos-26]
         qt-version: [6.11.1]
-      include:
-        - os: macos-14
-          qt-version: 6.8.3
+        include:
+          - os: macos-14
+            qt-version: 6.8.3
       fail-fast: false
     env:
       QT_MODULES: qtimageformats

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -23,11 +23,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-26]
-        qt-version: [6.11.1]
         include:
           - os: macos-14
             qt-version: 6.8.3
+          - os: macos-26
+            qt-version: 6.11.1
       fail-fast: false
     env:
       QT_MODULES: qtimageformats

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -24,7 +24,10 @@ jobs:
     strategy:
       matrix:
         os: [macos-26]
-        qt-version: [6.8.3, 6.11.1]
+        qt-version: [6.11.1]
+      include:
+        - os: macos-14
+          qt-version: 6.8.3
       fail-fast: false
     env:
       QT_MODULES: qtimageformats

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-15]
+        os: [macos-26]
         qt-version: [6.8.3, 6.11.1]
       fail-fast: false
     env:


### PR DESCRIPTION
[macos-14 is deprecated since July 6th and will be removed Nov 2nd](https://redirect.github.com/actions/runner-images/issues/13518)

Using macos-26 might work too (haven't tested), but I'm sure there was a reason that we didn't use macos-latest before.

[The migration of the macos-latest label to use macos-26 GitHub plans to complete by July 15th](https://redirect.github.com/actions/runner-images/issues/14167)

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
