### PR TITLE
feat(plugins): Add remote plugins without UI

### DIFF
--- a/docs/plugin-info.schema.json
+++ b/docs/plugin-info.schema.json
@@ -8,7 +8,8 @@
   "properties": {
     "name": {
       "type": "string",
-      "description": "Plugin name shown to the user."
+      "description": "Plugin name shown to the user.",
+      "pattern": "[\\w +\\.\\-_':&]+$"
     },
     "description": {
       "type": "string",
@@ -55,6 +56,17 @@
           }
         }
       }
+    },
+    "files": {
+      "type": "array",
+      "description": "A list of files associated with this plugin. This is only used for metadata of remote plugins.",
+      "items": {
+        "type": "string",
+        "pattern": "^[\\w_\\-+\\./]+$"
+      }
+    },
+    "private": {
+      "description": "Private data of the plugin preserved when generating a metadata file."
     },
     "$schema": { "type": "string" }
   },

--- a/docs/plugin-info.schema.json
+++ b/docs/plugin-info.schema.json
@@ -9,7 +9,7 @@
     "name": {
       "type": "string",
       "description": "Plugin name shown to the user.",
-      "pattern": "[\\w +\\.\\-_':&]+$"
+      "pattern": "^[\\w +\\.\\-_':&]+$"
     },
     "description": {
       "type": "string",

--- a/docs/plugin-repo-meta.schema.json
+++ b/docs/plugin-repo-meta.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "title": "Chatterino Plugin Repo Metadata",
+  "description": "Metadata describing a plugin repository and its available plugins",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "metadata": {
+      "type": "object",
+      "additionalItems": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[\\w +\\.\\-_':&]+"
+        }
+      },
+      "required": ["name"]
+    },
+    "plugins": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalItems": false,
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[\\w+\\.\\-_@~]+$"
+          },
+          "download": {
+            "type": "string",
+            "$comment": "Path to the directory of the plugin - the file paths are appended to this. This can either be relative to the base URL or absolute (starting with a leading slash).",
+            "examples": ["plugins/plugin", "/static/plugins/plugin"]
+          },
+          "meta": {
+            "$ref": "https://github.com/Chatterino/chatterino2/raw/refs/heads/master/docs/plugin-info.schema.json#"
+          }
+        },
+        "required": ["id", "download", "meta"]
+      }
+    },
+    "$schema": { "type": "string" }
+  },
+  "required": ["metadata", "plugins"]
+}

--- a/docs/plugin-repo-meta.schema.json
+++ b/docs/plugin-repo-meta.schema.json
@@ -11,7 +11,7 @@
       "properties": {
         "name": {
           "type": "string",
-          "pattern": "^[\\w +\\.\\-_':&]+"
+          "pattern": "^[\\w +\\.\\-_':&]+$"
         }
       },
       "required": ["name"]
@@ -24,7 +24,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "pattern": "^[\\w+\\.\\-_@~]+$"
+            "pattern": "^[A-Za-z][\\w+\\.\\-_@~]+$"
           },
           "download": {
             "type": "string",

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -301,6 +301,10 @@ set(SOURCE_FILES
         controllers/plugins/PluginPermission.hpp
         controllers/plugins/PluginRef.cpp
         controllers/plugins/PluginRef.hpp
+        controllers/plugins/PluginRepository.cpp
+        controllers/plugins/PluginRepository.cpp
+        controllers/plugins/RemotePlugin.cpp
+        controllers/plugins/RemotePlugin.hpp
         controllers/plugins/SolTypes.cpp
         controllers/plugins/SolTypes.hpp
 

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -488,6 +488,9 @@ CommandController::CommandController(const Paths &paths)
     this->registerCommand("/debug-eventsub", &commands::eventsub);
 
     this->registerCommand("/debug-test", &commands::debugTest);
+#ifdef CHATTERINO_HAVE_PLUGINS
+    this->registerCommand("/debug-plugin", &commands::debugPlugin);
+#endif
 
 #ifdef Q_OS_WIN
     this->registerCommand("/debug-relaunch-with-console",

--- a/src/controllers/commands/builtin/chatterino/Debugging.cpp
+++ b/src/controllers/commands/builtin/chatterino/Debugging.cpp
@@ -9,6 +9,8 @@
 #include "common/Env.hpp"
 #include "controllers/commands/CommandContext.hpp"
 #include "controllers/notifications/NotificationController.hpp"
+#include "controllers/plugins/PluginController.hpp"
+#include "controllers/plugins/PluginRepository.hpp"
 #include "controllers/spellcheck/SpellChecker.hpp"
 #include "messages/Image.hpp"
 #include "messages/Message.hpp"
@@ -393,5 +395,153 @@ QString relaunchWithLogfile(const CommandContext &ctx)
 
     return {};
 }
+
+#ifdef CHATTERINO_HAVE_PLUGINS
+QString debugPlugin(const CommandContext &ctx)
+{
+    if (!ctx.channel)
+    {
+        return {};
+    }
+    auto weakChan = ctx.channel->weak_from_this();
+
+    // Send a message in the channel.
+    // Multiple lines will be sent as multiple messages (not spaces).
+    const auto reply = [weakChan](const QString &raw) {
+        auto chan = weakChan.lock();
+        QStringView text = QStringView(raw).trimmed();
+        if (!chan || text.isEmpty())
+        {
+            return;
+        }
+        for (auto line : text.tokenize(u'\n'))
+        {
+            chan->addSystemMessage(line.toString());
+        }
+    };
+
+    // Load the repository at `url` and invoke `cb` once loaded.
+    const auto loadRepository = [](const QString &url, auto &&cb) {
+        auto repo = std::make_shared<PluginRepository>(url);
+        // We're creating a cyclic reference here.
+        std::ignore = repo->onLoaded.connect([cb, repo] mutable {
+            cb(repo);
+            // Clear the repository reference after we're done.
+            // We need to wait until this signal callback is done, so do it in the next iteration.
+            QMetaObject::invokeMethod(qApp, [ref = std::move(repo)] mutable {
+                ref = {};
+            });
+        });
+        repo->load();
+    };
+
+    if (ctx.words.size() < 2)
+    {
+        reply("Missing subcommand");
+        return {};
+    }
+    auto subcommand = ctx.words.at(1);
+    if (subcommand == u"list")
+    {
+        for (const auto &url : getSettings()->remotePluginURLs.getValue())
+        {
+            loadRepository(
+                url, [reply](const std::shared_ptr<PluginRepository> &repo) {
+                    reply(repo->createSummary());
+                });
+        }
+    }
+    else if (subcommand == u"install" || subcommand == u"update")
+    {
+        if (ctx.words.size() < 3)
+        {
+            reply("Missing plugin ID");
+            return {};
+        }
+        auto id = ctx.words.at(2);
+
+        bool isUpdate = subcommand == u"update";
+        auto installIt = [reply, isUpdate](const RemotePluginPtr &plugin) {
+            getApp()->getPlugins()->download({
+                .remotePlugin = plugin,
+                .onExistingOverwrite =
+                    [&] {
+                        reply("Plugin is already installed - overwriting it.");
+                        return true;
+                    },
+                .onDone =
+                    [reply, isUpdate](const auto &result) {
+                        auto term = isUpdate ? u"update"_s : u"install"_s;
+                        if (result)
+                        {
+                            reply(u"Successfully " % term % u"ed plugin.");
+                        }
+                        else
+                        {
+                            reply(u"Failed to " % term % " plugin: " %
+                                  result.error());
+                        }
+                    },
+                .update = isUpdate,
+            });
+        };
+
+        std::shared_ptr<bool> foundID(new bool(false),
+                                      [reply](const bool *ptr) {
+                                          if (!*ptr)
+                                          {
+                                              reply("Failed to find plugin.");
+                                          }
+                                          delete ptr;
+                                      });
+        for (const auto &url : getSettings()->remotePluginURLs.getValue())
+        {
+            loadRepository(url,
+                           [id, foundID, installIt](
+                               const std::shared_ptr<PluginRepository> &repo) {
+                               if (*foundID)
+                               {
+                                   return;
+                               }
+                               for (const auto &plugin : repo->getPlugins())
+                               {
+                                   if (plugin->id == id)
+                                   {
+                                       *foundID = true;
+                                       installIt(plugin);
+                                       break;
+                                   }
+                               }
+                           });
+        }
+    }
+    else if (subcommand == u"uninstall" || subcommand == u"remove")
+    {
+        if (ctx.words.size() < 3)
+        {
+            reply("Missing plugin ID");
+            return {};
+        }
+        auto id = ctx.words.at(2);
+        auto res = getApp()->getPlugins()->removePlugin(
+            id, {
+                    .eraseData = ctx.words.contains(u"--erase-data"_s),
+                });
+        if (res)
+        {
+            reply("Removed " % id);
+        }
+        else
+        {
+            reply("Failed to remove plugin: " % res.error());
+        }
+    }
+    else
+    {
+        reply(u"Unknown subcommand: '" % subcommand % "'");
+    }
+    return {};
+}
+#endif
 
 }  // namespace chatterino::commands

--- a/src/controllers/commands/builtin/chatterino/Debugging.hpp
+++ b/src/controllers/commands/builtin/chatterino/Debugging.hpp
@@ -46,4 +46,9 @@ QString disableLogfile(const CommandContext &ctx);
 QString enableLogfile(const CommandContext &ctx);
 QString relaunchWithLogfile(const CommandContext &ctx);
 
+#ifdef CHATTERINO_HAVE_PLUGINS
+/// Temporary command until there's UI for remote plugins.
+QString debugPlugin(const CommandContext &ctx);
+#endif
+
 }  // namespace chatterino::commands

--- a/src/controllers/plugins/PluginController.cpp
+++ b/src/controllers/plugins/PluginController.cpp
@@ -32,6 +32,7 @@
 #    include "singletons/Settings.hpp"
 #    include "singletons/WindowManager.hpp"
 #    include "util/FilesystemHelpers.hpp"
+#    include "util/PostToThread.hpp"
 #    include "widgets/splits/SplitContainer.hpp"
 #    include "widgets/Window.hpp"
 
@@ -556,8 +557,9 @@ void PluginController::download(const DownloadArgs &args)
         .onDone = args.onDone,
     });
 
-    auto pushResult = [this, state](ExpectedStr<void> res) {
-        if (isAppAboutToQuit() || !tryGetApp())
+    auto pushResult = [this, lifetime = std::weak_ptr{this->lifetime},
+                       state](ExpectedStr<void> res) {
+        if (lifetime.expired())
         {
             return;
         }
@@ -586,6 +588,11 @@ void PluginController::download(const DownloadArgs &args)
 
         state->onDone(this->finishDownload(*state->plugin, state->pluginDir));
     };
+    auto pushOnGUI = [pushResult](ExpectedStr<void> res) {
+        runInGuiThread([pushResult, res = std::move(res)] mutable {
+            pushResult(std::move(res));
+        });
+    };
 
     auto fetchFile = args.fetchFile;
     if (!fetchFile)
@@ -595,6 +602,7 @@ void PluginController::download(const DownloadArgs &args)
                 const std::function<void(ExpectedStr<QByteArray>)> &cb) {
                 NetworkRequest(url)
                     .timeout(30'000)
+                    .concurrent()
                     .onSuccess([cb](const NetworkResult &res) {
                         cb(res.getData());
                     })
@@ -610,10 +618,10 @@ void PluginController::download(const DownloadArgs &args)
     // Send out the requests - rely on Qt to buffer requests.
     for (const auto &[url, path] : files)
     {
-        fetchFile(url, [pushResult, path](ExpectedStr<QByteArray> res) {
+        fetchFile(url, [pushOnGUI, path](ExpectedStr<QByteArray> res) mutable {
             if (!res)
             {
-                pushResult(makeUnexpected(std::move(res).error()));
+                pushOnGUI(makeUnexpected(std::move(res).error()));
                 return;
             }
 
@@ -621,14 +629,14 @@ void PluginController::download(const DownloadArgs &args)
                 QFile f(path);
                 if (!f.open(QFile::WriteOnly | QFile::Truncate))
                 {
-                    pushResult(makeUnexpected(u"Failed to open '" % path %
-                                              u"' for writing: " %
-                                              f.errorString()));
+                    pushOnGUI(makeUnexpected(u"Failed to open '" % path %
+                                             u"' for writing: " %
+                                             f.errorString()));
                     return;
                 }
                 f.write(*res);
             }
-            pushResult({});
+            pushOnGUI({});
         });
     }
 }

--- a/src/controllers/plugins/PluginController.cpp
+++ b/src/controllers/plugins/PluginController.cpp
@@ -31,6 +31,7 @@
 #    include "singletons/Paths.hpp"
 #    include "singletons/Settings.hpp"
 #    include "singletons/WindowManager.hpp"
+#    include "util/FilesystemHelpers.hpp"
 #    include "widgets/splits/SplitContainer.hpp"
 #    include "widgets/Window.hpp"
 
@@ -50,8 +51,11 @@
 
 namespace chatterino {
 
+using namespace Qt::Literals;
+
 PluginController::PluginController(const Paths &paths_)
     : paths(paths_)
+    , lifetime(std::make_shared<bool>(true))
 {
     this->loaders_.emplace_back("chatterino.json", &lua::api::loadJson);
 }
@@ -367,6 +371,290 @@ bool PluginController::reload(const QString &id)
     return true;
 }
 
+ExpectedStr<void> PluginController::removePlugin(const QString &id,
+                                                 RemovePluginArgs args)
+{
+    auto it = this->plugins_.find(id);
+    if (it == this->plugins_.end())
+    {
+        return makeUnexpected("Plugin not found");
+    }
+
+    QDir loadDirectory = it->second->loadDirectory();
+    this->plugins_.erase(it);
+    this->queueChangeNotification();
+
+    if (args.eraseData)
+    {
+        qCDebug(chatterinoLua)
+            << "Recursively removing" << loadDirectory.absolutePath();
+        if (!loadDirectory.removeRecursively())
+        {
+            return makeUnexpected(u"Failed to remove directory"_s);
+        }
+    }
+    else
+    {
+        const auto items = loadDirectory.entryInfoList(QDir::AllEntries |
+                                                       QDir::NoDotAndDotDot);
+        for (const auto &entry : items)
+        {
+            if (entry.fileName() == "data")
+            {
+                continue;
+            }
+
+            qCDebug(chatterinoLua) << "Removing" << entry.absoluteFilePath();
+
+            bool ok = false;
+            if (entry.isDir())
+            {
+                ok = QDir(entry.absoluteFilePath()).removeRecursively();
+            }
+            else
+            {
+                ok = loadDirectory.remove(entry.fileName());
+            }
+
+            if (!ok)
+            {
+                return makeUnexpected(u"Failed to remove '" % entry.fileName() %
+                                      "'");
+            }
+        }
+    }
+
+    if (args.disable)
+    {
+        auto vec = getSettings()->enabledPlugins.getValue();
+        vec.removeAll(id);
+        getSettings()->enabledPlugins.setValue(vec);
+    }
+
+    return {};
+}
+
+void PluginController::download(const DownloadArgs &args)
+{
+    auto id = args.remotePlugin->id;
+    auto existingIt = this->plugins_.find(id);
+    if (existingIt != this->plugins_.end())
+    {
+        if (args.update)
+        {
+            QString conflicts;
+            if (!existingIt->second->meta.isRelatedTo(args.remotePlugin->meta,
+                                                      &conflicts))
+            {
+                args.onDone(makeUnexpected(
+                    u"Plugin was installed from a different source: " %
+                    conflicts));
+                return;
+            }
+        }
+        else if (args.onExistingOverwrite)
+        {
+            if (!args.onExistingOverwrite())
+            {
+                // The user should know about it - don't show a new error or success.
+                return;
+            }
+        }
+        else
+        {
+            args.onDone(makeUnexpected(u"Plugin already exists"_s));
+            return;
+        }
+
+        auto err = this->removePlugin(id, {
+                                              .eraseData = false,
+                                              .disable = false,
+                                          });
+        if (!err)
+        {
+            args.onDone(err);
+            return;
+        }
+    }
+    else if (args.update)
+    {
+        args.onDone(makeUnexpected(u"Plugin does not exist."_s));
+        return;
+    }
+
+    auto pluginDir =
+        qStringToStdPath(this->paths.pluginsDirectory) / qStringToStdPath(id);
+    std::error_code ec;
+    std::filesystem::create_directories(pluginDir, ec);
+    if (ec)
+    {
+        args.onDone(makeUnexpected(u"Failed to create plugin directory: " %
+                                   QString::fromStdString(ec.message())));
+        return;
+    }
+
+    pluginDir = std::filesystem::canonical(pluginDir, ec);
+    if (ec)
+    {
+        args.onDone(makeUnexpected(u"Failed canonicalize plugin directory: " %
+                                   QString::fromStdString(ec.message())));
+        return;
+    }
+    auto infoJsonPath = pluginDir / "info.json";
+
+    QUrl baseUrl = args.remotePlugin->downloadURL;
+    std::vector<std::pair<QUrl, QString>> files;
+    for (const auto &path : args.remotePlugin->meta.files)
+    {
+        auto url = baseUrl;
+        url.setPath(url.path(QUrl::FullyEncoded) % '/' % path);
+        if (!baseUrl.isParentOf(url))
+        {
+            args.onDone(makeUnexpected(u"Plugin contains invalid file: '" %
+                                       url.toString() % "'"));
+            return;
+        }
+        auto localPath = pluginDir / qStringToStdPath(path);
+        if (localPath == infoJsonPath)
+        {
+            continue;  // We write this later.
+        }
+        auto parent = localPath.parent_path();
+        if (parent != localPath)
+        {
+            std::filesystem::create_directories(parent, ec);
+            if (ec)
+            {
+                args.onDone(makeUnexpected(
+                    u"Failed crete parent directories for '" % path % u"': " %
+                    QString::fromStdString(ec.message())));
+                return;
+            }
+        }
+        files.emplace_back(std::move(url), stdPathToQString(localPath));
+    }
+
+    if (files.empty())
+    {
+        args.onDone(makeUnexpected(u"No files to download"_s));
+        return;
+    }
+
+    struct State {
+        RemotePluginPtr plugin;
+        std::filesystem::path pluginDir;
+
+        size_t remainingRequests = 0;
+        QString errors;
+
+        std::function<void(ExpectedStr<void>)> onDone;
+    };
+    auto state = std::make_shared<State>(State{
+        .plugin = args.remotePlugin,
+        .pluginDir = pluginDir,
+        .remainingRequests = files.size(),
+        .onDone = args.onDone,
+    });
+
+    auto pushResult = [this, state](ExpectedStr<void> res) {
+        if (isAppAboutToQuit() || !tryGetApp())
+        {
+            return;
+        }
+
+        assertInGuiThread();
+        if (!res)
+        {
+            if (!state->errors.isEmpty())
+            {
+                state->errors += u"\n";
+            }
+            state->errors += res.error();
+        }
+        state->remainingRequests -= 1;
+        if (state->remainingRequests > 0)
+        {
+            return;
+        }
+
+        // We're the last result everyone was waiting for.
+        if (!state->errors.isEmpty())
+        {
+            state->onDone(makeUnexpected(state->errors));
+            return;
+        }
+
+        state->onDone(this->finishDownload(*state->plugin, state->pluginDir));
+    };
+
+    auto fetchFile = args.fetchFile;
+    if (!fetchFile)
+    {
+        fetchFile =
+            +[](const QUrl &url,
+                const std::function<void(ExpectedStr<QByteArray>)> &cb) {
+                NetworkRequest(url)
+                    .timeout(30'000)
+                    .followRedirects(true)
+                    .onSuccess([cb](const NetworkResult &res) {
+                        cb(res.getData());
+                    })
+                    .onError([cb, url](const NetworkResult &res) {
+                        cb(makeUnexpected(u"Failed to fetch '" %
+                                          url.toString() % u"': " %
+                                          res.formatError()));
+                    })
+                    .execute();
+            };
+    }
+
+    // Send out the requests - rely on Qt to buffer requests.
+    for (const auto &[url, path] : files)
+    {
+        fetchFile(url, [pushResult, path](ExpectedStr<QByteArray> res) {
+            if (!res)
+            {
+                pushResult(makeUnexpected(std::move(res).error()));
+                return;
+            }
+
+            {
+                QFile f(path);
+                if (!f.open(QFile::WriteOnly | QFile::Truncate))
+                {
+                    pushResult(makeUnexpected(u"Failed to open '" % path %
+                                              u"' for writing: " %
+                                              f.errorString()));
+                    return;
+                }
+                f.write(*res);
+            }
+            pushResult({});
+        });
+    }
+}
+
+ExpectedStr<void> PluginController::finishDownload(
+    const RemotePlugin &remote, const std::filesystem::path &pluginDir)
+{
+    {
+        QFile metaFile(stdPathToQString(pluginDir / "info.json"));
+        if (!metaFile.open(QFile::WriteOnly))
+        {
+            return makeUnexpected(u"Failed to open info.json for writing: " %
+                                  metaFile.errorString());
+        }
+        metaFile.write(QJsonDocument(remote.meta.toJson()).toJson());
+    }
+    bool ok = this->tryLoadFromDir(pluginDir);
+    if (!ok)
+    {
+        return makeUnexpected(u"Failed to load plugin from directory"_s);
+    }
+
+    return {};
+}
+
 QString PluginController::tryExecPluginCommand(const QString &commandName,
                                                const CommandContext &ctx)
 {
@@ -425,6 +713,16 @@ Plugin *PluginController::getPluginByStatePtr(lua_State *L)
         {
             return plugin.get();
         }
+    }
+    return nullptr;
+}
+
+Plugin *PluginController::getPluginByID(const QString &id)
+{
+    auto it = this->plugins_.find(id);
+    if (it != this->plugins_.end())
+    {
+        return it->second.get();
     }
     return nullptr;
 }
@@ -499,7 +797,11 @@ void PluginController::queueChangeNotification()
     this->changeNotificationQueued = true;
     QMetaObject::invokeMethod(
         qApp,
-        [this] {
+        [this, weak = std::weak_ptr(this->lifetime)] {
+            if (!weak.lock())
+            {
+                return;
+            }
             this->changeNotificationQueued = false;
             this->onPluginsUpdated.invoke();
         },

--- a/src/controllers/plugins/PluginController.cpp
+++ b/src/controllers/plugins/PluginController.cpp
@@ -595,7 +595,6 @@ void PluginController::download(const DownloadArgs &args)
                 const std::function<void(ExpectedStr<QByteArray>)> &cb) {
                 NetworkRequest(url)
                     .timeout(30'000)
-                    .followRedirects(true)
                     .onSuccess([cb](const NetworkResult &res) {
                         cb(res.getData());
                     })

--- a/src/controllers/plugins/PluginController.hpp
+++ b/src/controllers/plugins/PluginController.hpp
@@ -9,6 +9,9 @@
 #    include "common/websockets/WebSocketPool.hpp"
 #    include "controllers/commands/CommandContext.hpp"
 #    include "controllers/plugins/Plugin.hpp"
+#    include "controllers/plugins/RemotePlugin.hpp"
+#    include "util/Expected.hpp"
+#    include "util/FunctionRef.hpp"
 
 #    include <pajlada/signals/signal.hpp>
 #    include <QDir>
@@ -45,6 +48,8 @@ public:
     // This is required to be public because of c functions
     Plugin *getPluginByStatePtr(lua_State *L);
 
+    Plugin *getPluginByID(const QString &id);
+
     // TODO: make a function that iterates plugins that aren't errored/enabled
     const std::map<QString, std::unique_ptr<Plugin>> &plugins() const;
 
@@ -54,6 +59,37 @@ public:
      * @param id This is the unique identifier of the plugin, the name of the directory it is in
      */
     bool reload(const QString &id);
+
+    struct RemovePluginArgs {
+        bool eraseData = true;
+        bool disable = true;
+    };
+
+    ExpectedStr<void> removePlugin(const QString &id, RemovePluginArgs args);
+
+    struct DownloadArgs {
+        /// The plugin to install.
+        RemotePluginPtr remotePlugin;
+
+        /// Optional callback to ask the user about an existing, unrelated plugin.
+        ///
+        /// If this is not specified, unrelated plugins won't be updated.
+        FunctionRef<bool()> onExistingOverwrite;
+
+        /// Required completion callback.
+        std::function<void(ExpectedStr<void>)> onDone;
+
+        /// Optional callback to fetch files.
+        ///
+        /// By default `NetworkRequest` is used.
+        FunctionRef<void(QUrl, std::function<void(ExpectedStr<QByteArray>)>)>
+            fetchFile;
+
+        /// Update or (re-)install the plugin?
+        bool update = false;
+    };
+
+    void download(const DownloadArgs &args);
 
     /**
      * @brief Checks settings to tell if a plugin named by id is enabled.
@@ -86,6 +122,11 @@ private:
 
     void queueChangeNotification();
 
+    ExpectedStr<void> downloadImpl(const DownloadArgs &args);
+
+    ExpectedStr<void> finishDownload(const RemotePlugin &remote,
+                                     const std::filesystem::path &pluginDir);
+
     std::map<QString, std::unique_ptr<Plugin>> plugins_;
     WebSocketPool webSocketPool_;
 
@@ -94,6 +135,8 @@ private:
         loaders_;
 
     bool changeNotificationQueued = false;
+
+    std::shared_ptr<bool> lifetime;
 
     // This is for tests, pay no attention
     friend class PluginControllerAccess;

--- a/src/controllers/plugins/PluginMeta.cpp
+++ b/src/controllers/plugins/PluginMeta.cpp
@@ -5,11 +5,30 @@
 #ifdef CHATTERINO_HAVE_PLUGINS
 #    include "controllers/plugins/PluginMeta.hpp"
 
+#    include "util/Expected.hpp"
 #    include "util/QMagicEnum.hpp"
 
 #    include <QJsonArray>
 #    include <QJsonObject>
 #    include <QJsonValue>
+#    include <QRegularExpression>
+
+using namespace Qt::Literals;
+
+namespace {
+
+using namespace chatterino;
+
+bool validatePath(const QString &path)
+{
+    static const QRegularExpression regex(uR"(^[\w_\-+\./]+$)"_s);
+
+    return regex.matchView(path).hasMatch() && !path.contains(u"..") &&
+           !path.contains(u"//") && !path.startsWith('/') &&
+           !path.endsWith('/');
+}
+
+}  // namespace
 
 namespace chatterino {
 
@@ -180,8 +199,106 @@ PluginMeta::PluginMeta(const QJsonObject &obj)
             this->tags.push_back(t.toString());
         }
     }
+
+    auto remote = obj["remote"];
+    if (!remote.isUndefined())
+    {
+        if (remote.isString())
+        {
+            this->remoteBaseURL = remote.toString();
+        }
+        else
+        {
+            this->errors.emplace_back(
+                u"Remote URL is not a string (its type is %1)"_s.arg(
+                    qmagicenum::enumName(remote.type())));
+            return;
+        }
+    }
+
+    auto files = obj["files"];
+    if (!files.isUndefined())
+    {
+        if (!files.isArray())
+        {
+            this->errors.emplace_back(
+                u"\"files\" is not an array (its type is %1)"_s.arg(
+                    qmagicenum::enumName(files.type())));
+            return;
+        }
+        const auto arr = files.toArray();
+        for (qsizetype i = 0; i < arr.size(); ++i)
+        {
+            auto v = arr[i];
+            if (!v.isString())
+            {
+                this->errors.emplace_back(
+                    u"\"files\"[%1] is not a string (its type is %2)"_s.arg(
+                        QString::number(i), qmagicenum::enumName(v.type())));
+                continue;
+            }
+            QString str = v.toString();
+            if (!validatePath(str))
+            {
+                this->errors.emplace_back(
+                    u"\"files\"[%1] contains invalid characters"_s.arg(
+                        QString::number(i)));
+                continue;
+            }
+            this->files.emplace_back(str);
+        }
+    }
 }
 // NOLINTEND(clazy-reserve-candidates)
+
+bool PluginMeta::isRelatedTo(const PluginMeta &other, QString *conflicts) const
+{
+    if (other.remoteBaseURL != this->remoteBaseURL)
+    {
+        if (conflicts)
+        {
+            *conflicts =
+                u"Remote URLs differ (current: \"%1\", other: \"%2\")"_s.arg(
+                    this->remoteBaseURL, other.remoteBaseURL);
+        }
+        return false;
+    }
+
+    return true;
+}
+
+QJsonObject PluginMeta::toJson() const
+{
+    auto map = [](const auto &range, auto &&cb) {
+        QJsonArray arr;
+        for (const auto &it : range)
+        {
+            arr.append(std::invoke(cb, it));
+        }
+        return arr;
+    };
+    auto ifNotEmpty = [](auto &&value) -> QJsonValue {
+        if (!value.isEmpty())
+        {
+            return value;
+        }
+        return QJsonValue::Undefined;
+    };
+
+    return {
+        {"homepage"_L1, ifNotEmpty(this->homepage)},
+        {"name"_L1, this->name},
+        {"description"_L1, this->description},
+        {"authors"_L1, map(this->authors, std::identity{})},
+        {"license"_L1, this->license},
+        {"version"_L1, QString::fromStdString(this->version.to_string())},
+        {"permissions"_L1, map(this->permissions, &PluginPermission::toJson)},
+        {"tags"_L1, ifNotEmpty(map(this->tags, std::identity{}))},
+        {"private"_L1, ifNotEmpty(this->privateFields)},
+        {"remote"_L1, ifNotEmpty(this->remoteBaseURL)},
+        // Forget "files".
+    };
+}
 
 }  // namespace chatterino
 

--- a/src/controllers/plugins/PluginMeta.hpp
+++ b/src/controllers/plugins/PluginMeta.hpp
@@ -41,6 +41,30 @@ struct PluginMeta {
 
     std::vector<PluginPermission> permissions;
 
+    /// Extra fields ignored by Chatterino but preserved when re-exporting the
+    /// metadata.
+    ///
+    /// Key: "private"
+    QJsonObject privateFields;
+
+    /// The URL to the meta.json. For local plugins this is empty. If this URL
+    /// is added in the settings, the plugin can be updated through the UI.
+    ///
+    /// Plugins with the same ID but from different base URLs are considered
+    /// different (see #isRelatedTo()).
+    ///
+    /// Key: "remote"
+    QString remoteBaseURL;
+
+    /// Files that are included in this plugin.
+    ///
+    /// This is only used for downloading plugins. It's not used at runtime
+    /// to check the integrity or file accesses. When serializing to JSON, this
+    /// is discarded.
+    ///
+    /// Key: "files"
+    std::vector<QString> files;
+
     // errors that occurred while parsing info.json
     std::vector<QString> errors;
 
@@ -49,9 +73,18 @@ struct PluginMeta {
         return this->errors.empty();
     }
 
+    /// Is this meta from the same source as `remote`?
+    ///
+    /// Plugins are considered from the same source if they are installed from
+    /// the same base URL.
+    bool isRelatedTo(const PluginMeta &otherMeta,
+                     QString *conflicts = nullptr) const;
+
     explicit PluginMeta(const QJsonObject &obj);
     // This is for tests
     PluginMeta() = default;
+
+    QJsonObject toJson() const;
 };
 
 }  // namespace chatterino

--- a/src/controllers/plugins/PluginPermission.cpp
+++ b/src/controllers/plugins/PluginPermission.cpp
@@ -49,5 +49,12 @@ QString PluginPermission::toHtml() const
     }
 }
 
+QJsonObject PluginPermission::toJson() const
+{
+    return QJsonObject{
+        {"type", qmagicenum::enumNameString(this->type)},
+    };
+}
+
 }  // namespace chatterino
 #endif

--- a/src/controllers/plugins/PluginPermission.hpp
+++ b/src/controllers/plugins/PluginPermission.hpp
@@ -31,6 +31,8 @@ struct PluginPermission {
     }
 
     QString toHtml() const;
+
+    QJsonObject toJson() const;
 };
 
 }  // namespace chatterino

--- a/src/controllers/plugins/PluginRepository.cpp
+++ b/src/controllers/plugins/PluginRepository.cpp
@@ -1,0 +1,268 @@
+// SPDX-FileCopyrightText: 2026 Contributors to Chatterino <https://chatterino.com>
+//
+// SPDX-License-Identifier: MIT
+
+#ifdef CHATTERINO_HAVE_PLUGINS
+
+#    include "controllers/plugins/PluginRepository.hpp"
+
+#    include "Application.hpp"
+#    include "common/network/NetworkRequest.hpp"
+#    include "common/network/NetworkResult.hpp"
+#    include "controllers/plugins/PluginController.hpp"
+
+using namespace Qt::Literals;
+
+namespace chatterino {
+
+const QString DEFAULT_PLUGIN_REPOSITORY = u"http://localhost:8080/"_s;
+
+PluginRepository::PluginRepository(const QString &url)
+{
+    if (url == u"(default)")
+    {
+        this->baseURL = DEFAULT_PLUGIN_REPOSITORY;
+    }
+    else
+    {
+        this->baseURL = QUrl(url);
+    }
+}
+
+bool PluginRepository::hasErrorOrWarnings() const
+{
+    return !this->error.isEmpty() || !this->warnings.isEmpty();
+}
+
+QString PluginRepository::getName() const
+{
+    return this->name;
+}
+
+QUrl PluginRepository::getBaseURL() const
+{
+    return this->baseURL;
+}
+
+QString PluginRepository::getError() const
+{
+    return this->error;
+}
+
+QString PluginRepository::getWarnings() const
+{
+    return this->warnings;
+}
+
+std::span<const RemotePluginPtr> PluginRepository::getPlugins() const
+{
+    return this->plugins;
+}
+
+RemotePluginPtr PluginRepository::getPluginByID(QStringView id) const
+{
+    auto it = std::ranges::find_if(this->plugins, [&](const auto &plugin) {
+        return plugin->id == id;
+    });
+    if (it != this->plugins.end())
+    {
+        return *it;
+    }
+    return nullptr;
+}
+
+void PluginRepository::load()
+{
+    if (this->baseURL.scheme() != u"https" && this->baseURL.scheme() != u"http")
+    {
+        this->error = u"URL scheme must be http(s)"_s;
+        this->onLoaded.invoke();
+        return;
+    }
+
+    NetworkRequest(this->fileUrl(u"meta.json"_s))
+        .followRedirects(true)
+        .timeout(10 * 1000)
+        .onSuccess([weak = this->weak_from_this()](const NetworkResult &res) {
+            auto self = weak.lock();
+            if (!self)
+            {
+                return;
+            }
+
+            const auto json = res.parseJson();
+            auto loadRes = self->loadFromJson(json);
+            if (!loadRes)
+            {
+                assert(self->error.isEmpty());
+                self->error = std::move(loadRes).error();
+            }
+            self->onLoaded.invoke();
+        })
+        .onError([weak = this->weak_from_this()](const NetworkResult &res) {
+            auto self = weak.lock();
+            if (!self)
+            {
+                return;
+            }
+            self->error = u"Failed to fetch metadata: " % res.formatError();
+            self->onLoaded.invoke();
+        })
+        .execute();
+}
+
+QUrl PluginRepository::fileUrl(const QString &filename) const
+{
+    QUrl child(this->baseURL);
+    if (filename.startsWith('/'))
+    {
+        child.setPath(filename, QUrl::StrictMode);
+    }
+    else
+    {
+        QString path = child.path(QUrl::FullyEncoded);
+        if (!path.endsWith('/'))
+        {
+            path += '/';
+        }
+        path += filename;
+        child.setPath(path, QUrl::StrictMode);
+    }
+    return child;
+}
+
+ExpectedStr<void> PluginRepository::loadFromJson(const QJsonObject &root)
+{
+    static const QRegularExpression nameRegex(uR"(^[\w +\.\-_':&]+$)"_s);
+    static const QRegularExpression idRegex(uR"(^[\w+\.\-_@~]+$)"_s);
+
+    const auto meta = root["metadata"_L1].toObject();
+    if (meta.isEmpty())
+    {
+        return makeUnexpected(u"Invalid or missing 'metadata' object."_s);
+    }
+
+    this->name = meta["name"_L1].toString();
+    if (this->name.isEmpty())
+    {
+        return makeUnexpected(u"Empty or missing 'name'"_s);
+    }
+
+    if (!nameRegex.match(this->name).hasMatch())
+    {
+        return makeUnexpected(
+            u"Invalid name. Names must only contain alphanumeric characters, spaces, and selected special characters."_s);
+    }
+
+    auto pushWarning = [&](const auto &str) {
+        if (!this->warnings.isEmpty())
+        {
+            this->warnings += '\n';
+        }
+        this->warnings += str;
+    };
+
+    const auto plugins = root["plugins"_L1].toArray();
+    for (const auto jsonRef : plugins)
+    {
+        const auto pluginObj = jsonRef.toObject();
+        auto pluginPtr = std::make_shared<RemotePlugin>(pluginObj);
+        if (!idRegex.match(pluginPtr->id).hasMatch())
+        {
+            pushWarning("- ID '" % pluginPtr->id.toHtmlEscaped() %
+                        "' is invalid.");
+            continue;
+        }
+        if (!pluginPtr->meta.isValid())
+        {
+            QString warning = pluginPtr->id % u" contains invalid metadata: ";
+            bool first = true;
+            for (const auto &err : pluginPtr->meta.errors)
+            {
+                if (first)
+                {
+                    first = false;
+                }
+                else
+                {
+                    warning += u", ";
+                }
+                warning += err;
+            }
+            pushWarning(warning);
+            continue;
+        }
+        pluginPtr->meta.remoteBaseURL =
+            this->baseURL.toEncoded(QUrl::FullyEncoded);
+
+        if (pluginPtr->downloadPath.isEmpty())
+        {
+            pluginPtr->downloadPath = pluginPtr->id;
+        }
+        pluginPtr->downloadURL = this->fileUrl(pluginPtr->downloadPath);
+
+        this->plugins.emplace_back(std::move(pluginPtr));
+    }
+
+    return {};
+}
+
+QString PluginRepository::createSummary() const
+{
+    QString buf = u"Repository "_s;
+    buf += this->name;
+    buf += '\n';
+
+    QStringView separator = u"---------\n";
+
+    if (this->hasErrorOrWarnings())
+    {
+        buf += separator;
+    }
+    if (!this->error.isEmpty())
+    {
+        buf += u"Error: ";
+        buf += this->error;
+        buf += '\n';
+    }
+    if (!this->warnings.isEmpty())
+    {
+        buf += this->warnings;
+        buf += '\n';
+    }
+
+    buf += separator;
+    for (const auto &plugin : this->plugins)
+    {
+        buf += u"id=";
+        buf += plugin->id;
+        buf += u", version=";
+        buf += plugin->meta.version.to_string();
+
+        auto *existing = getApp()->getPlugins()->getPluginByID(plugin->id);
+        if (existing)
+        {
+            bool related = existing->meta.isRelatedTo(plugin->meta);
+            if (related)
+            {
+                buf += u", is-installed";
+                if (existing->meta.version < plugin->meta.version)
+                {
+                    buf += u", online-is-newer";
+                }
+            }
+            else
+            {
+                buf += u", installed-unrelated";
+            }
+        }
+
+        buf += '\n';
+    }
+    buf += separator;
+    return buf;
+}
+
+}  // namespace chatterino
+
+#endif

--- a/src/controllers/plugins/PluginRepository.cpp
+++ b/src/controllers/plugins/PluginRepository.cpp
@@ -81,7 +81,6 @@ void PluginRepository::load()
     }
 
     NetworkRequest(this->fileUrl(u"meta.json"_s))
-        .followRedirects(true)
         .timeout(10 * 1000)
         .onSuccess([weak = this->weak_from_this()](const NetworkResult &res) {
             auto self = weak.lock();

--- a/src/controllers/plugins/PluginRepository.cpp
+++ b/src/controllers/plugins/PluginRepository.cpp
@@ -134,7 +134,7 @@ QUrl PluginRepository::fileUrl(const QString &filename) const
 ExpectedStr<void> PluginRepository::loadFromJson(const QJsonObject &root)
 {
     static const QRegularExpression nameRegex(uR"(^[\w +\.\-_':&]+$)"_s);
-    static const QRegularExpression idRegex(uR"(^[\w+\.\-_@~]+$)"_s);
+    static const QRegularExpression idRegex(uR"(^[A-Za-z][\w+\.\-_@~]+$)"_s);
 
     const auto meta = root["metadata"_L1].toObject();
     if (meta.isEmpty())

--- a/src/controllers/plugins/PluginRepository.hpp
+++ b/src/controllers/plugins/PluginRepository.hpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2026 Contributors to Chatterino <https://chatterino.com>
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#ifdef CHATTERINO_HAVE_PLUGINS
+
+#    include "controllers/plugins/RemotePlugin.hpp"
+#    include "util/Expected.hpp"
+
+#    include <pajlada/signals/signal.hpp>
+#    include <QString>
+
+#    include <memory>
+#    include <span>
+#    include <vector>
+
+namespace chatterino {
+
+extern const QString DEFAULT_PLUGIN_REPOSITORY;
+
+class PluginRepository : public std::enable_shared_from_this<PluginRepository>
+{
+public:
+    PluginRepository(const QString &url);
+
+    pajlada::Signals::NoArgSignal onLoaded;
+
+    bool hasErrorOrWarnings() const;
+
+    QString getName() const;
+    QUrl getBaseURL() const;
+    QString getError() const;
+    QString getWarnings() const;
+
+    std::span<const RemotePluginPtr> getPlugins() const;
+    RemotePluginPtr getPluginByID(QStringView id) const;
+
+    void load();
+    ExpectedStr<void> loadFromJson(const QJsonObject &root);
+
+    QUrl fileUrl(const QString &filename) const;
+
+    /// Summary to be shown in chat (for /debug-plugin)
+    QString createSummary() const;
+
+private:
+    QString name;
+    QUrl baseURL;
+    QString error;
+    QString warnings;
+    std::vector<RemotePluginPtr> plugins;
+};
+
+}  // namespace chatterino
+
+#endif

--- a/src/controllers/plugins/RemotePlugin.cpp
+++ b/src/controllers/plugins/RemotePlugin.cpp
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2026 Contributors to Chatterino <https://chatterino.com>
+//
+// SPDX-License-Identifier: MIT
+
+#ifdef CHATTERINO_HAVE_PLUGINS
+
+#    include "controllers/plugins/RemotePlugin.hpp"
+
+using namespace Qt::Literals;
+
+namespace chatterino {
+
+RemotePlugin::RemotePlugin(const QJsonObject &root)
+    : id(root["id"_L1].toString())
+    , downloadPath(root["download"_L1].toString())
+    , meta(root["meta"_L1].toObject())
+{
+}
+
+}  // namespace chatterino
+
+#endif

--- a/src/controllers/plugins/RemotePlugin.hpp
+++ b/src/controllers/plugins/RemotePlugin.hpp
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2026 Contributors to Chatterino <https://chatterino.com>
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#ifdef CHATTERINO_HAVE_PLUGINS
+
+#    include "controllers/plugins/PluginMeta.hpp"
+
+#    include <QMetaType>
+
+namespace chatterino {
+
+class PluginRepository;
+
+struct RemotePlugin {
+    explicit RemotePlugin(const QJsonObject &root);
+
+    /// ID of this plugin.
+    ///
+    /// Key: "id"
+    QString id;
+
+    /// Path for this plugin relative to the repository's base URL.
+    ///
+    /// This may be empty. In that case, \ref id is used.
+    ///
+    /// Key: "download"
+    QString downloadPath;
+
+    /// Parsed metadata for this plugin.
+    ///
+    /// Key: "meta"
+    PluginMeta meta;
+
+    /// Root URL for this plugin to append the filenames from the metadata to.
+    ///
+    /// Not present in JSON. Computed afterward.
+    QUrl downloadURL;
+
+    std::weak_ptr<PluginRepository> repository;
+};
+
+using RemotePluginPtr = std::shared_ptr<const RemotePlugin>;
+
+}  // namespace chatterino
+
+// Allow use in QVariant
+Q_DECLARE_METATYPE(chatterino::RemotePluginPtr)
+
+#endif

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -820,6 +820,15 @@ public:
         "/plugins/enabledPlugins",
         {},
     };
+    ChatterinoSetting<QStringList> remotePluginURLs = {
+        "/plugins/remote/urls",
+        {
+            // Resolves to DEFAULT_PLUGIN_REPOSITORY.
+            // Using a placeholder here to allow changing the actual URL without
+            // requiring users to change their settings.
+            "(default)",
+        },
+    };
 
     // Sound
     EnumStringSetting<SoundBackend> soundBackend = {

--- a/tests/src/Plugins.cpp
+++ b/tests/src/Plugins.cpp
@@ -15,6 +15,7 @@
 #    include "controllers/plugins/Plugin.hpp"
 #    include "controllers/plugins/PluginController.hpp"
 #    include "controllers/plugins/PluginPermission.hpp"
+#    include "controllers/plugins/PluginRepository.hpp"
 #    include "controllers/plugins/SolTypes.hpp"  // IWYU pragma: keep
 #    include "lib/Snapshot.hpp"
 #    include "messages/Message.hpp"
@@ -40,6 +41,7 @@
 using namespace chatterino;
 using chatterino::mock::MockChannel;
 using namespace std::chrono_literals;
+using namespace Qt::Literals;
 
 namespace {
 
@@ -50,7 +52,9 @@ const QString TEST_SETTINGS = R"(
     "plugins": {
         "supportEnabled": true,
         "enabledPlugins": [
-            "test"
+            "test",
+            "first-plugin",
+            "second-plugin"
         ]
     },
     "accounts": {
@@ -199,6 +203,11 @@ public:
     static bool tryLoadFromDir(const QDir &pluginDir)
     {
         return getApp()->getPlugins()->tryLoadFromDir(pluginDir);
+    }
+
+    static void loadPlugins()
+    {
+        getApp()->getPlugins()->loadPlugins();
     }
 
     static void openLibrariesFor(Plugin *plugin)
@@ -1775,6 +1784,440 @@ TEST_F(PluginTest, debugTraceback)
     )lua")
                    .get<std::shared_ptr<Message>>();
     ASSERT_EQ(msg->id, "who would do this");
+}
+
+namespace {
+
+const QByteArrayView REMOTE_REPO_META(R"(
+{
+  "metadata": {
+    "name": "My Plugin Store"
+  },
+  "plugins": [
+    {
+      "id": "first-plugin",
+      "download": "my-plugin",
+      "meta": {
+        "name": "My Plugin",
+        "description": "",
+        "authors": [],
+        "version": "0.1.1",
+        "license": "MIT",
+        "permissions": [],
+        "files": ["init.lua"]
+      }
+    },
+    {
+      "id": "second-plugin",
+      "download": "second",
+      "meta": {
+        "name": "Second plugin",
+        "description": "",
+        "authors": [],
+        "version": "0.2.0",
+        "license": "MIT",
+        "permissions": [],
+        "files": [
+          "init.lua",
+          "info.json"
+        ]
+      }
+    }
+  ]
+}
+)");
+
+const QByteArrayView CONTENT_FIRST_INIT_LUA(R"(plugin_name = "first")");
+const QByteArrayView CONTENT_SECOND_INIT_LUA(R"(plugin_name = "second")");
+const QByteArrayView CONTENT_SECOND_INFO_JSON(R"({
+  "name": "DO NOT USE THIS",
+  "description": "",
+  "authors": ["User"],
+  "version": "1.0.0",
+  "license": "MIT",
+  "permissions": []
+})");
+
+const QByteArrayView CONTENT_FIRST_EXISTING_INIT_LUA(
+    R"(plugin_name = "ex-first")");
+const QByteArrayView CONTENT_FIRST_EXISTING_INFO_JSON(R"({
+  "name": "My Plugin",
+  "description": "",
+  "authors": ["User"],
+  "version": "0.1.0",
+  "license": "MIT",
+  "permissions": [],
+  "remote": "https://plugins.chatterino.com"
+})");
+// To fix clangd(?) -> "
+
+}  // namespace
+
+class RemotePluginTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        this->app = std::make_unique<MockApplication>();
+        this->app->paths_.pluginsDirectory = this->app->settingsDir.path();
+        this->remoteDir = std::make_unique<QTemporaryDir>();
+        this->initRemote();
+        this->initExisting();
+        PluginControllerAccess::loadPlugins();
+    }
+
+    void TearDown() override
+    {
+        this->remoteDir.reset();
+        this->app.reset();
+    }
+
+    void fetchCallback(const QUrl &url,
+                       const std::function<void(ExpectedStr<QByteArray>)> &cb)
+    {
+        auto path = url.path(QUrl::FullyEncoded);
+        path.removeFirst();  // first '/'
+        QFile f(this->remoteDir->filePath(path));
+        if (!f.open(QFile::ReadOnly))
+        {
+            cb(makeUnexpected(f.errorString()));
+            return;
+        }
+        cb(f.readAll());
+    }
+
+    std::string loadedPluginName(const QString &id) const
+    {
+        auto *plugin = this->app->getPlugins()->getPluginByID(id);
+        if (plugin)
+        {
+            return plugin->state().get_or("plugin_name",
+                                          std::string("NO-GLOBAL"));
+        }
+        return "NOT-FOUND";
+    }
+
+    std::unique_ptr<MockApplication> app;
+    std::unique_ptr<QTemporaryDir> remoteDir;
+
+private:
+    static void writeFile(const QString &path, QByteArrayView data)
+    {
+        QFile f(path);
+        if (!f.open(QFile::WriteOnly))
+        {
+            return;
+        }
+        f.write(data.data(), data.size());
+    }
+
+    void initRemote()
+    {
+        QDir dir(this->remoteDir->path());
+        dir.mkdir("my-plugin");
+        dir.mkdir("second");
+        writeFile(dir.filePath("my-plugin/init.lua"), CONTENT_FIRST_INIT_LUA);
+        writeFile(dir.filePath("second/init.lua"), CONTENT_SECOND_INIT_LUA);
+        writeFile(dir.filePath("second/info.json"), CONTENT_SECOND_INFO_JSON);
+    }
+
+    void initExisting()
+    {
+        QDir dir(this->app->getPaths().pluginsDirectory);
+        dir.mkdir("first-plugin");
+        dir.mkdir("first-plugin/data");
+        writeFile(dir.filePath("first-plugin/init.lua"),
+                  CONTENT_FIRST_EXISTING_INIT_LUA);
+        writeFile(dir.filePath("first-plugin/info.json"),
+                  CONTENT_FIRST_EXISTING_INFO_JSON);
+        writeFile(dir.filePath("first-plugin/data/file.txt"), "a file");
+    }
+};
+
+TEST_F(RemotePluginTest, install)
+{
+    ASSERT_EQ(this->loadedPluginName("second-plugin"), "NOT-FOUND");
+
+    PluginRepository repo("https://plugins.chatterino.com");
+    auto res = repo.loadFromJson(
+        QJsonDocument::fromJson(REMOTE_REPO_META.toByteArray()).object());
+    ASSERT_TRUE(res.has_value());
+
+    auto secondRemote = repo.getPluginByID(u"second-plugin");
+    ASSERT_NE(secondRemote, nullptr);
+
+    std::optional<ExpectedStr<void>> onDoneResult;
+    getApp()->getPlugins()->download({
+        .remotePlugin = secondRemote,
+        .onExistingOverwrite =
+            [] {
+                EXPECT_FALSE(true);
+                return false;
+            },
+        .onDone =
+            [&](auto res) {
+                onDoneResult = std::move(res);
+            },
+        .fetchFile =
+            [&](auto &&...args) {
+                return this->fetchCallback(
+                    std::forward<decltype(args)>(args)...);
+            },
+        .update = false,
+    });
+
+    ASSERT_EQ(onDoneResult, ExpectedStr<void>{});
+    ASSERT_EQ(this->loadedPluginName("second-plugin"), "second");
+    auto *second = getApp()->getPlugins()->getPluginByID("second-plugin");
+    ASSERT_NE(second, nullptr);
+    ASSERT_EQ(second->meta.name, "Second plugin");  // Not "DO NOT USE THIS".
+
+    // Even after reloading.
+    PluginControllerAccess::loadPlugins();
+    second = getApp()->getPlugins()->getPluginByID("second-plugin");
+    ASSERT_NE(second, nullptr);
+    ASSERT_EQ(second->meta.name, "Second plugin");
+}
+
+TEST_F(RemotePluginTest, reinstall)
+{
+    ASSERT_EQ(this->loadedPluginName("first-plugin"), "ex-first");
+
+    PluginRepository repo("https://plugins.chatterino.com");
+    auto res = repo.loadFromJson(
+        QJsonDocument::fromJson(REMOTE_REPO_META.toByteArray()).object());
+    ASSERT_TRUE(res.has_value());
+
+    auto firstRemote = repo.getPluginByID(u"first-plugin");
+    ASSERT_NE(firstRemote, nullptr);
+
+    bool overwriteCalled = false;
+    getApp()->getPlugins()->download({
+        .remotePlugin = firstRemote,
+        .onExistingOverwrite =
+            [&] {
+                overwriteCalled = true;
+                return false;  // Don't install it.
+            },
+        .onDone =
+            [&](auto &&...) {
+                EXPECT_FALSE(true);
+            },
+        .fetchFile =
+            [&](auto &&...) {
+                EXPECT_FALSE(true);
+            },
+        .update = false,
+    });
+    ASSERT_TRUE(overwriteCalled);
+    ASSERT_EQ(this->loadedPluginName("first-plugin"), "ex-first");
+
+    overwriteCalled = false;
+    std::optional<ExpectedStr<void>> onDoneResult;
+    getApp()->getPlugins()->download({
+        .remotePlugin = firstRemote,
+        .onExistingOverwrite =
+            [&] {
+                overwriteCalled = true;
+                return true;  // Yes, overwrite it.
+            },
+        .onDone =
+            [&](auto res) {
+                onDoneResult = std::move(res);
+            },
+        .fetchFile =
+            [&](auto &&...args) {
+                return this->fetchCallback(
+                    std::forward<decltype(args)>(args)...);
+            },
+        .update = false,
+    });
+
+    ASSERT_TRUE(overwriteCalled);
+    ASSERT_EQ(onDoneResult, ExpectedStr<void>{});
+    ASSERT_EQ(this->loadedPluginName("first-plugin"), "first");
+}
+
+TEST_F(RemotePluginTest, update)
+{
+    ASSERT_EQ(this->loadedPluginName("first-plugin"), "ex-first");
+
+    PluginRepository repo("https://plugins.chatterino.com");
+    auto res = repo.loadFromJson(
+        QJsonDocument::fromJson(REMOTE_REPO_META.toByteArray()).object());
+    ASSERT_TRUE(res.has_value());
+
+    auto firstRemote = repo.getPluginByID(u"first-plugin");
+    ASSERT_NE(firstRemote, nullptr);
+    auto secondRemote = repo.getPluginByID(u"second-plugin");
+    ASSERT_NE(secondRemote, nullptr);
+
+    std::optional<ExpectedStr<void>> onDoneResult;
+    getApp()->getPlugins()->download({
+        .remotePlugin = firstRemote,
+        .onExistingOverwrite =
+            [] {
+                EXPECT_FALSE(true);
+                return false;
+            },
+        .onDone =
+            [&](auto res) {
+                onDoneResult = std::move(res);
+            },
+        .fetchFile =
+            [&](auto &&...args) {
+                return this->fetchCallback(
+                    std::forward<decltype(args)>(args)...);
+            },
+        .update = true,
+    });
+
+    ASSERT_EQ(onDoneResult, ExpectedStr<void>{});
+    ASSERT_EQ(this->loadedPluginName("first-plugin"), "first");
+
+    // Now try updating the second plugin (not added locally).
+    ASSERT_EQ(this->loadedPluginName("second-plugin"), "NOT-FOUND");
+    onDoneResult.reset();
+    getApp()->getPlugins()->download({
+        .remotePlugin = secondRemote,
+        .onExistingOverwrite =
+            [] {
+                EXPECT_FALSE(true);
+                return false;
+            },
+        .onDone =
+            [&](auto res) {
+                onDoneResult = std::move(res);
+            },
+        .fetchFile =
+            [&](auto &&...) {
+                EXPECT_FALSE(true);
+            },
+        .update = true,
+    });
+
+    ASSERT_EQ(onDoneResult, makeUnexpected(u"Plugin does not exist."_s));
+    ASSERT_EQ(this->loadedPluginName("second-plugin"), "NOT-FOUND");
+}
+
+TEST_F(RemotePluginTest, updateUnrelated)
+{
+    ASSERT_EQ(this->loadedPluginName("first-plugin"), "ex-first");
+
+    // We're using a different URL here. Plugins with different URLs are unrelated.
+    PluginRepository repo("https://plugins2.chatterino.com");
+    auto res = repo.loadFromJson(
+        QJsonDocument::fromJson(REMOTE_REPO_META.toByteArray()).object());
+    ASSERT_TRUE(res.has_value());
+
+    auto firstRemote = repo.getPluginByID(u"first-plugin");
+    ASSERT_NE(firstRemote, nullptr);
+
+    std::optional<ExpectedStr<void>> onDoneResult;
+    getApp()->getPlugins()->download({
+        .remotePlugin = firstRemote,
+        .onExistingOverwrite =
+            [] {
+                EXPECT_FALSE(true);
+                return false;
+            },
+        .onDone =
+            [&](auto res) {
+                onDoneResult = std::move(res);
+            },
+        .fetchFile =
+            [&](auto &&...) {
+                EXPECT_FALSE(true);
+            },
+        .update = true,
+    });
+
+    ASSERT_TRUE(onDoneResult.has_value());
+    ASSERT_FALSE(onDoneResult->has_value());
+    ASSERT_TRUE(onDoneResult->error().startsWith(
+        u"Plugin was installed from a different source: "));
+    ASSERT_EQ(this->loadedPluginName("first-plugin"), "ex-first");
+}
+
+TEST_F(RemotePluginTest, removeKeepData)
+{
+    ASSERT_EQ(this->loadedPluginName("first-plugin"), "ex-first");
+    QDir dir(this->app->getPaths().pluginsDirectory);
+
+    ASSERT_TRUE(dir.exists("first-plugin"));
+    ASSERT_TRUE(dir.exists("first-plugin/init.lua"));
+    ASSERT_TRUE(dir.exists("first-plugin/info.json"));
+    ASSERT_TRUE(dir.exists("first-plugin/data/file.txt"));
+    ASSERT_TRUE(PluginController::isPluginEnabled("first-plugin"));
+
+    auto res = getApp()->getPlugins()->removePlugin("first-plugin",
+                                                    {
+                                                        .eraseData = false,
+                                                        .disable = false,
+                                                    });
+    ASSERT_TRUE(res.has_value());
+
+    ASSERT_EQ(this->loadedPluginName("first-plugin"), "NOT-FOUND");
+
+    ASSERT_TRUE(dir.exists("first-plugin"));
+    ASSERT_FALSE(dir.exists("first-plugin/init.lua"));
+    ASSERT_FALSE(dir.exists("first-plugin/info.json"));
+    ASSERT_TRUE(dir.exists("first-plugin/data/file.txt"));
+    ASSERT_TRUE(PluginController::isPluginEnabled("first-plugin"));
+}
+
+TEST_F(RemotePluginTest, removeEraseData)
+{
+    ASSERT_EQ(this->loadedPluginName("first-plugin"), "ex-first");
+    QDir dir(this->app->getPaths().pluginsDirectory);
+
+    ASSERT_TRUE(dir.exists("first-plugin"));
+    ASSERT_TRUE(dir.exists("first-plugin/init.lua"));
+    ASSERT_TRUE(dir.exists("first-plugin/info.json"));
+    ASSERT_TRUE(dir.exists("first-plugin/data/file.txt"));
+    ASSERT_TRUE(PluginController::isPluginEnabled("first-plugin"));
+
+    auto res = getApp()->getPlugins()->removePlugin("first-plugin",
+                                                    {
+                                                        .eraseData = true,
+                                                        .disable = false,
+                                                    });
+    ASSERT_TRUE(res.has_value());
+
+    ASSERT_EQ(this->loadedPluginName("first-plugin"), "NOT-FOUND");
+
+    ASSERT_FALSE(dir.exists("first-plugin"));
+    ASSERT_FALSE(dir.exists("first-plugin/init.lua"));
+    ASSERT_FALSE(dir.exists("first-plugin/info.json"));
+    ASSERT_FALSE(dir.exists("first-plugin/data/file.txt"));
+    ASSERT_TRUE(PluginController::isPluginEnabled("first-plugin"));
+}
+
+TEST_F(RemotePluginTest, removeDisable)
+{
+    ASSERT_EQ(this->loadedPluginName("first-plugin"), "ex-first");
+    QDir dir(this->app->getPaths().pluginsDirectory);
+
+    ASSERT_TRUE(dir.exists("first-plugin"));
+    ASSERT_TRUE(dir.exists("first-plugin/init.lua"));
+    ASSERT_TRUE(dir.exists("first-plugin/info.json"));
+    ASSERT_TRUE(dir.exists("first-plugin/data/file.txt"));
+    ASSERT_TRUE(PluginController::isPluginEnabled("first-plugin"));
+
+    auto res = getApp()->getPlugins()->removePlugin("first-plugin",
+                                                    {
+                                                        .eraseData = true,
+                                                        .disable = true,
+                                                    });
+    ASSERT_TRUE(res.has_value());
+
+    ASSERT_EQ(this->loadedPluginName("first-plugin"), "NOT-FOUND");
+
+    ASSERT_FALSE(dir.exists("first-plugin"));
+    ASSERT_FALSE(dir.exists("first-plugin/init.lua"));
+    ASSERT_FALSE(dir.exists("first-plugin/info.json"));
+    ASSERT_FALSE(dir.exists("first-plugin/data/file.txt"));
+    ASSERT_FALSE(PluginController::isPluginEnabled("first-plugin"));
 }
 
 #endif


### PR DESCRIPTION
This is the "backend" part of #7016. It implements all the functionality for remote plugins without any UI. You interact with it through a temporary command.

```sh
# List all remote plugins
/debug-plugin list
# Install plugin by ID
/debug-plugin install ID
# Update plugin by ID
/debug-plugin update ID
# Remove plugin by ID
/debug-plugin remove ID [--erase-data]
```

I also added tests for "downloading" and removing.

The schema for the remote metadata is the same as in #7016. You can also use the same test server script as in that PR.
Quick summary:

- We have remote "repositories" which store the plugin files.
- Each repository holds a `meta.json` that lists all available plugins and their files.
- Local plugins store their remote URL. This way we can detect "related" plugins.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
