### PR TITLE
fix: ignore phrase replacements break with some pattern/replacement c…

### DIFF
--- a/src/controllers/ignores/IgnoreController.cpp
+++ b/src/controllers/ignores/IgnoreController.cpp
@@ -354,7 +354,7 @@ void processIgnorePhrases(const std::vector<IgnorePhrase> &phrases,
 
                 replaceMessageAt(phrase, from, match.capturedLength(),
                                  replacement);
-                from += phrase.getReplace().length();
+                from += replacement.length();
                 iterations++;
                 if (iterations >= 128)
                 {

--- a/tests/src/IgnoreController.cpp
+++ b/tests/src/IgnoreController.cpp
@@ -172,6 +172,13 @@ TEST_F(TestIgnoreController, processIgnorePhrases)
             "Kappa",
             {emoteAt(127, "Kappa")},
         },
+        {
+            {regexReplace("(f)o(o)", "\\1\\2", false)},
+            "foo foo foo foo Kappa",
+            {emoteAt(15, "Kappa")},
+            "fo fo fo fo Kappa",
+            {emoteAt(11, "Kappa")},
+        },
     };
 
     for (const auto &test : testCases)


### PR DESCRIPTION
**Description**
Currently, when processing ignore phrases, if the ignore phrase uses a regex pattern, and the pattern has multiple consecutive matches in a message, the index of where to start matching again after the first replacement has been performed is incremented by the length of the replacement pattern. But for some regex pattern/replacement combinations (specifically, when using capturing groups in the pattern and reinserting the captured groups in the replacement string), this can result in that index going over the start of the next substring that should be a match, since after being computed, the actual replacement string can end up being a shorter length than the replacement pattern.

**Steps to reproduce:**
1. Set pattern to `(f)o(o)`.
2. Set replacement to `\1\2`.
3. `Regex` checkbox should be checked.
4. `Block` checkbox should be unchecked.
5. `Case-sensitive` should be unchecked.
6. Send the message `foo foo foo foo` in a channel.

**Expected behavior**
Message should appear in chat as `fo fo fo fo`.

**Actual behavior**
Message appears as `fo foo fo foo` (or `fo fo foo fo` if the same message has been sent before, because of the space added in [TwitchChannel::prepareMessage](https://github.com/Chatterino/chatterino2/blob/bc772c5b2bf4f545d7ace315e0b6efdc40dd48cc/src/providers/twitch/TwitchChannel.cpp#L813))

**Fix**
Increment the index used to start the next match from by the length of `replacement` so the right length is used always, regardless of whether it has been recomputed or not.
