### PR TITLE
feat: add customizable recent-messages fallback list

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -430,6 +430,10 @@ set(SOURCE_FILES
         providers/recentmessages/Api.hpp
         providers/recentmessages/Impl.cpp
         providers/recentmessages/Impl.hpp
+        providers/recentmessages/Provider.cpp
+        providers/recentmessages/Provider.hpp
+        providers/recentmessages/ProviderModel.cpp
+        providers/recentmessages/ProviderModel.hpp
 
         providers/seventv/SeventvAPI.cpp
         providers/seventv/SeventvAPI.hpp

--- a/src/common/Env.cpp
+++ b/src/common/Env.cpp
@@ -74,9 +74,7 @@ bool readBoolEnv(const char *envName, bool defaultValue)
 
 Env::Env()
     : recentMessagesApiUrl(
-          qEnvironmentVariable("CHATTERINO2_RECENT_MESSAGES_URL",
-                               "https://recent-messages.robotty.de/api/v2/"
-                               "recent-messages/%1"))
+          qEnvironmentVariable("CHATTERINO2_RECENT_MESSAGES_URL"))
     , linkResolverUrl(qEnvironmentVariable(
           "CHATTERINO2_LINK_RESOLVER_URL",
           "https://braize.pajlada.com/chatterino/link_resolver/%1"))

--- a/src/providers/recentmessages/Api.cpp
+++ b/src/providers/recentmessages/Api.cpp
@@ -5,22 +5,243 @@
 #include "providers/recentmessages/Api.hpp"
 
 #include "Application.hpp"
+#include "common/Env.hpp"
 #include "common/network/NetworkRequest.hpp"
 #include "common/network/NetworkResult.hpp"
 #include "common/QLogging.hpp"
 #include "providers/recentmessages/Impl.hpp"
+#include "providers/recentmessages/Provider.hpp"
+#include "singletons/Settings.hpp"
 #include "util/PostToThread.hpp"
+
+#include <algorithm>
 
 namespace {
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 const auto &LOG = chatterinoRecentMessages;
+constexpr int REQUEST_TIMEOUT_MS = 10 * 1000;
 
 }  // namespace
 
 namespace chatterino::recentmessages {
 
 using namespace recentmessages::detail;
+
+namespace {
+
+struct PartialResponse {
+    QJsonObject root;
+    QString providerUrl;
+};
+
+struct LoadContext {
+    QString channelName;
+    std::weak_ptr<Channel> channelPtr;
+    ResultCallback onLoaded;
+    ErrorCallback onError;
+    int limit;
+    std::optional<std::chrono::time_point<std::chrono::system_clock>> after;
+    std::optional<std::chrono::time_point<std::chrono::system_clock>> before;
+    std::vector<Provider> providers;
+    size_t nextProvider{};
+    size_t failedProviders{};
+    QString lastError = "No valid providers enabled";
+    std::optional<PartialResponse> partialResponse;
+};
+
+bool hasRemainingEnabledProvider(const std::shared_ptr<LoadContext> &context)
+{
+    return std::ranges::any_of(
+        context->providers.begin() +
+            static_cast<std::ptrdiff_t>(context->nextProvider),
+        context->providers.end(), &Provider::enabled);
+}
+
+void reportProviderIssue(const std::shared_ptr<LoadContext> &context,
+                         QString message)
+{
+    auto shared = context->channelPtr.lock();
+    if (!shared)
+    {
+        return;
+    }
+
+    if (hasRemainingEnabledProvider(context))
+    {
+        message += QStringLiteral(" Trying the next provider.");
+    }
+    shared->addSystemMessage(message);
+}
+
+void reportProviderFailure(const std::shared_ptr<LoadContext> &context,
+                           const QString &providerUrl, const QString &error)
+{
+    reportProviderIssue(
+        context,
+        QStringLiteral("Message history request to %1 failed (Error: %2).")
+            .arg(providerUrl, error));
+}
+
+void finishLoad(const std::shared_ptr<LoadContext> &context,
+                const QJsonObject &root, const QString &providerUrl,
+                bool showGapWarning)
+{
+    auto shared = context->channelPtr.lock();
+    if (!shared)
+    {
+        return;
+    }
+
+    qCDebug(LOG) << "Successfully loaded recent messages for"
+                 << shared->getName() << "from" << providerUrl;
+
+    auto parsedMessages = parseRecentMessages(root);
+    auto builtMessages = buildRecentMessages(parsedMessages, shared.get());
+    const bool usedFallback = context->failedProviders > 0;
+
+    postToThread([shared = std::move(shared),
+                  messages = std::move(builtMessages),
+                  onLoaded = context->onLoaded, providerUrl, showGapWarning,
+                  usedFallback]() mutable {
+        assert(!isAppAboutToQuit());
+        if (usedFallback && !showGapWarning)
+        {
+            shared->addSystemMessage(
+                QStringLiteral("Message history was loaded from %1")
+                    .arg(providerUrl));
+        }
+        if (showGapWarning && !messages.empty())
+        {
+            shared->addSystemMessage(
+                "Message history service recovering, there may be gaps in "
+                "the message history.");
+        }
+        onLoaded(messages);
+    });
+}
+
+void tryLoad(const std::shared_ptr<LoadContext> &context)
+{
+    if (isAppAboutToQuit() || context->channelPtr.expired())
+    {
+        return;
+    }
+
+    const auto nextProvider = recentmessages::nextEnabledProvider(
+        context->providers, context->nextProvider);
+    if (!nextProvider)
+    {
+        if (context->partialResponse)
+        {
+            finishLoad(context, context->partialResponse->root,
+                       context->partialResponse->providerUrl, true);
+            return;
+        }
+
+        auto shared = context->channelPtr.lock();
+        if (!shared)
+        {
+            return;
+        }
+
+        shared->addSystemMessage(
+            QStringLiteral("Message history service unavailable (Error: %1)")
+                .arg(context->lastError));
+        context->onError();
+        return;
+    }
+
+    const auto &provider = *nextProvider;
+    if (!provider.isValid())
+    {
+        context->lastError = QStringLiteral("Invalid provider URL");
+        context->failedProviders++;
+        reportProviderIssue(
+            context,
+            QStringLiteral("Message history provider URL is invalid: %1.")
+                .arg(provider.url()));
+        tryLoad(context);
+        return;
+    }
+
+    const auto url = constructRecentMessagesUrl(
+        provider.url(), context->channelName, context->limit, context->after,
+        context->before);
+
+    qCDebug(LOG) << "Loading recent messages for" << context->channelName
+                 << "from" << provider.url();
+
+    NetworkRequest(url)
+        .timeout(REQUEST_TIMEOUT_MS)
+        .onSuccess([context, provider](const auto &result) {
+            assert(!isAppAboutToQuit());
+
+            auto root = result.parseJson();
+            const auto responseType = classifyRecentMessagesResponse(root);
+            if (responseType != ResponseType::Complete)
+            {
+                const auto errorCode = root.value("error_code").toString();
+                const auto error = root.value("error").toString();
+                if (!errorCode.isEmpty())
+                {
+                    context->lastError = errorCode;
+                }
+                else if (!error.isEmpty())
+                {
+                    context->lastError = error;
+                }
+                else
+                {
+                    context->lastError = QStringLiteral("Invalid response");
+                }
+                if (responseType == ResponseType::Partial &&
+                    !context->partialResponse)
+                {
+                    context->partialResponse = PartialResponse{
+                        .root = root,
+                        .providerUrl = provider.url(),
+                    };
+                }
+                qCDebug(LOG) << "Failed to load recent messages for"
+                             << context->channelName << "from" << provider.url()
+                             << context->lastError;
+                context->failedProviders++;
+                reportProviderFailure(context, provider.url(),
+                                      context->lastError);
+                tryLoad(context);
+                return;
+            }
+
+            finishLoad(context, root, provider.url(), false);
+        })
+        .onError([context, provider](const NetworkResult &result) {
+            assert(!isAppAboutToQuit());
+
+            context->lastError = result.formatError();
+            qCDebug(LOG) << "Failed to load recent messages for"
+                         << context->channelName << "from" << provider.url()
+                         << context->lastError;
+            context->failedProviders++;
+            reportProviderFailure(context, provider.url(), context->lastError);
+            tryLoad(context);
+        })
+        .execute();
+}
+
+std::vector<Provider> configuredProviders()
+{
+    const auto &env = Env::get();
+    if (!env.recentMessagesApiUrl.isEmpty())
+    {
+        return {{env.recentMessagesApiUrl, true}};
+    }
+
+    const auto configured = getSettings()->recentMessagesProviders.readOnly();
+    return {configured->begin(), configured->end()};
+}
+
+}  // namespace
 
 void load(
     const QString &channelName, std::weak_ptr<Channel> channelPtr,
@@ -31,85 +252,23 @@ void load(
         before,
     const bool jitter)
 {
-    qCDebug(LOG) << "Loading recent messages for" << channelName;
+    auto context = std::make_shared<LoadContext>(LoadContext{
+        .channelName = channelName,
+        .channelPtr = std::move(channelPtr),
+        .onLoaded = std::move(onLoaded),
+        .onError = std::move(onError),
+        .limit = limit,
+        .after = after,
+        .before = before,
+        .providers = configuredProviders(),
+        .partialResponse = std::nullopt,
+    });
 
-    const auto url =
-        constructRecentMessagesUrl(channelName, limit, after, before);
-
+    // we don't need a strong RNG here
+    // NOLINTNEXTLINE(cert-*)
     const long delayMs = jitter ? std::rand() % 100 : 0;
-    QTimer::singleShot(delayMs, [=] {
-        if (isAppAboutToQuit())
-        {
-            return;
-        }
-
-        NetworkRequest(url)
-            .onSuccess([channelPtr, onLoaded](const auto &result) {
-                assert(!isAppAboutToQuit());
-
-                auto shared = channelPtr.lock();
-                if (!shared)
-                {
-                    return;
-                }
-
-                qCDebug(LOG) << "Successfully loaded recent messages for"
-                             << shared->getName();
-
-                auto root = result.parseJson();
-                auto parsedMessages = parseRecentMessages(root);
-
-                // build the Communi messages into chatterino messages
-                auto builtMessages =
-                    buildRecentMessages(parsedMessages, shared.get());
-
-                postToThread(
-                    [shared = std::move(shared), root = std::move(root),
-                     messages = std::move(builtMessages), onLoaded]() mutable {
-                        assert(!isAppAboutToQuit());
-
-                        // Notify user about a possible gap in logs if it returned some messages
-                        // but isn't currently joined to a channel
-                        const auto errorCode =
-                            root.value("error_code").toString();
-                        if (!errorCode.isEmpty())
-                        {
-                            qCDebug(LOG)
-                                << QString("Got error from API: error_code=%1, "
-                                           "channel=%2")
-                                       .arg(errorCode, shared->getName());
-                            if (errorCode == "channel_not_joined" &&
-                                !messages.empty())
-                            {
-                                shared->addSystemMessage(
-                                    "Message history service recovering, there "
-                                    "may "
-                                    "be gaps in the message history.");
-                            }
-                        }
-
-                        onLoaded(messages);
-                    });
-            })
-            .onError([channelPtr, onError](const NetworkResult &result) {
-                auto shared = channelPtr.lock();
-                if (!shared)
-                {
-                    return;
-                }
-                assert(!isAppAboutToQuit());
-
-                qCDebug(LOG) << "Failed to load recent messages for"
-                             << shared->getName();
-
-                shared->addSystemMessage(
-                    QStringLiteral(
-                        "Message history service unavailable (Error: %1)")
-                        .arg(result.formatError()));
-
-                onError();
-            })
-            .execute();
+    QTimer::singleShot(delayMs, [context = std::move(context)] {
+        tryLoad(context);
     });
 }
 

--- a/src/providers/recentmessages/Api.hpp
+++ b/src/providers/recentmessages/Api.hpp
@@ -33,7 +33,7 @@ using ErrorCallback = std::function<void()>;
  * @param channelName Name of Twitch channel
  * @param channelPtr Weak pointer to Channel to use to build messages
  * @param onLoaded Callback taking the built messages as a const std::vector<MessagePtr> &
- * @param onError Callback called when the network request fails
+ * @param onError Callback called when message history cannot be loaded
  * @param limit Maximum number of messages to query
  * @param after Only return messages that were received after this timestamp; ignored if `std::nullopt`
  * @param before Only return messages that were received before this timestamp; ignored if `std::nullopt`

--- a/src/providers/recentmessages/Impl.cpp
+++ b/src/providers/recentmessages/Impl.cpp
@@ -4,7 +4,6 @@
 
 #include "providers/recentmessages/Impl.hpp"
 
-#include "common/Env.hpp"
 #include "messages/MessageBuilder.hpp"
 #include "providers/twitch/IrcMessageHandler.hpp"
 #include "providers/twitch/TwitchChannel.hpp"
@@ -85,13 +84,13 @@ std::vector<MessagePtr> buildRecentMessages(
 // Returns the URL to be used for querying the Recent Messages API for the
 // given channel.
 QUrl constructRecentMessagesUrl(
-    const QString &name, const int limit,
+    const QString &providerUrl, const QString &name, const int limit,
     const std::optional<std::chrono::time_point<std::chrono::system_clock>>
         after,
     const std::optional<std::chrono::time_point<std::chrono::system_clock>>
         before)
 {
-    QUrl url(Env::get().recentMessagesApiUrl.arg(name));
+    QUrl url(providerUrl.arg(name));
     QUrlQuery urlQuery(url);
     if (!urlQuery.hasQueryItem("limit"))
     {
@@ -115,6 +114,38 @@ QUrl constructRecentMessagesUrl(
     }
     url.setQuery(urlQuery);
     return url;
+}
+
+ResponseType classifyRecentMessagesResponse(const QJsonObject &root)
+{
+    const auto messagesValue = root.value("messages");
+    if (!messagesValue.isArray())
+    {
+        return ResponseType::Invalid;
+    }
+
+    const auto messages = messagesValue.toArray();
+    for (const auto &message : messages)
+    {
+        if (!message.isString())
+        {
+            return ResponseType::Invalid;
+        }
+    }
+
+    const auto error = root.value("error");
+    const auto errorCode = root.value("error_code");
+    const bool hasError = !error.isUndefined() && !error.isNull();
+    const bool hasErrorCode = !errorCode.isUndefined() && !errorCode.isNull();
+    if (!hasError && !hasErrorCode)
+    {
+        return ResponseType::Complete;
+    }
+    if (errorCode.toString() == "channel_not_joined" && !messages.isEmpty())
+    {
+        return ResponseType::Partial;
+    }
+    return ResponseType::Invalid;
 }
 
 }  // namespace chatterino::recentmessages::detail

--- a/src/providers/recentmessages/Impl.hpp
+++ b/src/providers/recentmessages/Impl.hpp
@@ -31,8 +31,16 @@ std::vector<MessagePtr> buildRecentMessages(
 // Returns the URL to be used for querying the Recent Messages API for the
 // given channel.
 QUrl constructRecentMessagesUrl(
-    const QString &name, int limit,
+    const QString &providerUrl, const QString &name, int limit,
     std::optional<std::chrono::time_point<std::chrono::system_clock>> after,
     std::optional<std::chrono::time_point<std::chrono::system_clock>> before);
+
+enum class ResponseType {
+    Complete,
+    Partial,
+    Invalid,
+};
+
+ResponseType classifyRecentMessagesResponse(const QJsonObject &root);
 
 }  // namespace chatterino::recentmessages::detail

--- a/src/providers/recentmessages/Provider.cpp
+++ b/src/providers/recentmessages/Provider.cpp
@@ -1,0 +1,173 @@
+// SPDX-FileCopyrightText: 2026 Contributors to Chatterino <https://chatterino.com>
+//
+// SPDX-License-Identifier: MIT
+
+#include "providers/recentmessages/Provider.hpp"
+
+#include <QUrl>
+
+#include <algorithm>
+#include <iterator>
+#include <ranges>
+#include <utility>
+
+namespace chatterino::recentmessages {
+
+Provider::Provider(QString url, bool enabled, QString id)
+    : id_(std::move(id))
+    , url_(std::move(url))
+    , enabled_(enabled)
+{
+}
+
+const QString &Provider::id() const
+{
+    return this->id_;
+}
+
+const QString &Provider::url() const
+{
+    return this->url_;
+}
+
+bool Provider::enabled() const
+{
+    return this->enabled_;
+}
+
+bool Provider::isBuiltIn() const
+{
+    return !this->id_.isEmpty();
+}
+
+bool Provider::isValid() const
+{
+    const QUrl url(this->url_.arg("channel"));
+    return url.isValid() && !url.host().isEmpty() &&
+           (url.scheme() == "http" || url.scheme() == "https") &&
+           this->url_.contains("%1");
+}
+
+std::vector<Provider> defaultProviders()
+{
+    return {
+        {"https://recent-messages.robotty.de/api/v2/recent-messages/%1", true,
+         "robotty"},
+        {"https://recentmessages.ivr.fi/api/v2/recent-messages/%1", true,
+         "ivr"},
+        {"https://rm.iore.tv/api/%1", true, "iore"},
+        {"https://recent-messages.zneix.eu/api/v2/recent-messages/%1", true,
+         "zneix"},
+        {"https://rm.lilb.dev/api/v2/recent-messages/%1", true, "lilb"},
+        {"https://logs.zonian.dev/rm/%1", true, "zonian"},
+    };
+}
+
+std::vector<Provider> reconcileProviders(
+    const std::vector<Provider> &providers,
+    const std::vector<Provider> &builtInProviders)
+{
+    const auto findBuiltIn = [&builtInProviders](const QString &id) {
+        return std::ranges::find(builtInProviders, id, &Provider::id);
+    };
+    const auto containsId = [](const std::vector<QString> &ids,
+                               const QString &id) {
+        return std::ranges::find(ids, id) != ids.end();
+    };
+
+    std::vector<QString> existingBuiltInIds;
+    std::vector<Provider> result;
+    for (const auto &provider : providers)
+    {
+        if (!provider.isBuiltIn())
+        {
+            result.push_back(provider);
+            continue;
+        }
+
+        const auto builtIn = findBuiltIn(provider.id());
+        if (builtIn == builtInProviders.end() ||
+            containsId(existingBuiltInIds, provider.id()))
+        {
+            continue;
+        }
+
+        existingBuiltInIds.push_back(provider.id());
+        result.emplace_back(builtIn->url(), provider.enabled(), builtIn->id());
+    }
+
+    std::vector<QString> defaultExistingBuiltInIds;
+    for (const auto &provider : builtInProviders)
+    {
+        if (containsId(existingBuiltInIds, provider.id()))
+        {
+            defaultExistingBuiltInIds.push_back(provider.id());
+        }
+    }
+    const bool usesDefaultOrder =
+        existingBuiltInIds == defaultExistingBuiltInIds;
+
+    // keep new built-ins in the default order unless the user has reordered
+    // the existing built-ins. in that case, just append new built-ins instead.
+    for (auto builtIn = builtInProviders.begin();
+         builtIn != builtInProviders.end(); ++builtIn)
+    {
+        if (containsId(existingBuiltInIds, builtIn->id()))
+        {
+            continue;
+        }
+
+        if (!usesDefaultOrder)
+        {
+            result.push_back(*builtIn);
+            continue;
+        }
+
+        auto insertion = result.end();
+        for (auto next = std::next(builtIn); next != builtInProviders.end();
+             ++next)
+        {
+            insertion = std::ranges::find(result, next->id(), &Provider::id);
+            if (insertion != result.end())
+            {
+                break;
+            }
+        }
+        if (insertion == result.end())
+        {
+            const auto lastBuiltIn = std::ranges::find_if(
+                result | std::views::reverse, [](const Provider &provider) {
+                    return provider.isBuiltIn();
+                });
+            if (lastBuiltIn != result.rend())
+            {
+                insertion = lastBuiltIn.base();
+            }
+            else
+            {
+                insertion = result.begin();
+            }
+        }
+        result.insert(insertion, *builtIn);
+        existingBuiltInIds.push_back(builtIn->id());
+    }
+
+    return result;
+}
+
+std::optional<Provider> nextEnabledProvider(
+    const std::vector<Provider> &providers, std::size_t &index)
+{
+    while (index < providers.size())
+    {
+        const auto &provider = providers[index++];
+        if (provider.enabled())
+        {
+            return provider;
+        }
+    }
+
+    return std::nullopt;
+}
+
+}  // namespace chatterino::recentmessages

--- a/src/providers/recentmessages/Provider.hpp
+++ b/src/providers/recentmessages/Provider.hpp
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2026 Contributors to Chatterino <https://chatterino.com>
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "util/RapidjsonHelpers.hpp"
+
+#include <pajlada/serialize.hpp>
+#include <QString>
+
+#include <cstddef>
+#include <optional>
+#include <vector>
+
+namespace chatterino::recentmessages {
+
+class Provider
+{
+public:
+    // built-in providers have a stable ID so their URLs can be updated across
+    // releases. custom providers have an empty ID.
+    Provider(QString url, bool enabled, QString id = {});
+
+    [[nodiscard]] const QString &id() const;
+    [[nodiscard]] const QString &url() const;
+    [[nodiscard]] bool enabled() const;
+    [[nodiscard]] bool isBuiltIn() const;
+    [[nodiscard]] bool isValid() const;
+
+    bool operator==(const Provider &other) const = default;
+
+private:
+    QString id_;
+    QString url_;
+    bool enabled_;
+};
+
+std::vector<Provider> defaultProviders();
+// updates the built-in providers in a list while preserving
+// any customizations
+std::vector<Provider> reconcileProviders(
+    const std::vector<Provider> &providers,
+    const std::vector<Provider> &builtInProviders);
+std::optional<Provider> nextEnabledProvider(
+    const std::vector<Provider> &providers, std::size_t &index);
+
+}  // namespace chatterino::recentmessages
+
+namespace pajlada {
+
+template <>
+struct Serialize<chatterino::recentmessages::Provider> {
+    static rapidjson::Value get(
+        const chatterino::recentmessages::Provider &value,
+        rapidjson::Document::AllocatorType &a)
+    {
+        rapidjson::Value ret(rapidjson::kObjectType);
+
+        chatterino::rj::set(ret, "id", value.id(), a);
+        chatterino::rj::set(ret, "url", value.url(), a);
+        chatterino::rj::set(ret, "enabled", value.enabled(), a);
+
+        return ret;
+    }
+};
+
+template <>
+struct Deserialize<chatterino::recentmessages::Provider> {
+    static chatterino::recentmessages::Provider get(
+        const rapidjson::Value &value, bool *error = nullptr)
+    {
+        if (!value.IsObject())
+        {
+            PAJLADA_REPORT_ERROR(error);
+            return {{}, false};
+        }
+
+        QString id;
+        QString url;
+        bool enabled{};
+
+        if (!chatterino::rj::getSafe(value, "id", id) ||
+            !chatterino::rj::getSafe(value, "url", url) ||
+            !chatterino::rj::getSafe(value, "enabled", enabled))
+        {
+            PAJLADA_REPORT_ERROR(error);
+            return {{}, false};
+        }
+
+        return {url, enabled, id};
+    }
+};
+
+}  // namespace pajlada

--- a/src/providers/recentmessages/ProviderModel.cpp
+++ b/src/providers/recentmessages/ProviderModel.cpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2026 Contributors to Chatterino <https://chatterino.com>
+//
+// SPDX-License-Identifier: MIT
+
+#include "providers/recentmessages/ProviderModel.hpp"
+
+#include "util/StandardItemHelper.hpp"
+
+#include <utility>
+
+namespace chatterino::recentmessages {
+
+ProviderModel::ProviderModel(QObject *parent)
+    : SignalVectorModel(Column::Count, parent)
+{
+}
+
+bool ProviderModel::canRemoveRow(int row) const
+{
+    if (row < 0 || std::cmp_greater_equal(row, this->rows().size()))
+    {
+        return false;
+    }
+
+    const auto &original = this->rows()[row].original;
+    return original && !original->isBuiltIn();
+}
+
+bool ProviderModel::removeRows(int row, int count, const QModelIndex &parent)
+{
+    if (count != 1 || !this->canRemoveRow(row))
+    {
+        return false;
+    }
+
+    return SignalVectorModel::removeRows(row, count, parent);
+}
+
+Provider ProviderModel::getItemFromRow(std::vector<QStandardItem *> &row,
+                                       const Provider &original)
+{
+    // keep the stable ID when a built-in provider is enabled or disabled
+    return {
+        row[Column::Url]->data(Qt::DisplayRole).toString().trimmed(),
+        row[Column::Enabled]->data(Qt::CheckStateRole).toBool(),
+        original.id(),
+    };
+}
+
+void ProviderModel::getRowFromItem(const Provider &item,
+                                   std::vector<QStandardItem *> &row)
+{
+    setBoolItem(row[Column::Enabled], item.enabled());
+    setStringItem(row[Column::Url], item.url(), !item.isBuiltIn());
+}
+
+}  // namespace chatterino::recentmessages

--- a/src/providers/recentmessages/ProviderModel.hpp
+++ b/src/providers/recentmessages/ProviderModel.hpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2026 Contributors to Chatterino <https://chatterino.com>
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "common/SignalVectorModel.hpp"
+#include "providers/recentmessages/Provider.hpp"
+
+#include <QObject>
+
+namespace chatterino::recentmessages {
+
+class ProviderModel : public SignalVectorModel<Provider>
+{
+public:
+    explicit ProviderModel(QObject *parent);
+
+    [[nodiscard]] bool canRemoveRow(int row) const;
+    bool removeRows(int row, int count,
+                    const QModelIndex &parent = QModelIndex()) override;
+
+protected:
+    Provider getItemFromRow(std::vector<QStandardItem *> &row,
+                            const Provider &original) override;
+    void getRowFromItem(const Provider &item,
+                        std::vector<QStandardItem *> &row) override;
+
+private:
+    enum Column {
+        Enabled,
+        Url,
+        Count,
+    };
+};
+
+}  // namespace chatterino::recentmessages

--- a/src/singletons/Settings.cpp
+++ b/src/singletons/Settings.cpp
@@ -232,6 +232,16 @@ Settings::Settings(const Modes &modes, const Args &args,
                            this->moderationActions);
     initializeSignalVector(this->signalHolder, this->loggedChannelsSetting,
                            this->loggedChannels);
+    const auto reconciledProviders = recentmessages::reconcileProviders(
+        this->recentMessagesProvidersSetting.getValue(),
+        recentmessages::defaultProviders());
+    if (reconciledProviders != this->recentMessagesProvidersSetting.getValue())
+    {
+        this->recentMessagesProvidersSetting.setValue(reconciledProviders);
+    }
+    initializeSignalVector(this->signalHolder,
+                           this->recentMessagesProvidersSetting,
+                           this->recentMessagesProviders);
 
     instance_ = this;
 

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -22,6 +22,7 @@
 #include "controllers/nicknames/Nickname.hpp"
 #include "controllers/sound/ISoundController.hpp"
 #include "providers/emoji/EmojiStyle.hpp"
+#include "providers/recentmessages/Provider.hpp"
 #include "singletons/NativeMessaging.hpp"
 #include "singletons/Toasts.hpp"
 #include "util/RapidJsonSerializeQString.hpp"  // IWYU pragma: keep
@@ -867,6 +868,11 @@ private:
         {"/moderation/actions"};
     ChatterinoSetting<std::vector<ChannelLog>> loggedChannelsSetting = {
         "/logging/channels"};
+    ChatterinoSetting<std::vector<recentmessages::Provider>>
+        recentMessagesProvidersSetting = {
+            "/misc/twitch/recentMessageProviders",
+            recentmessages::defaultProviders(),
+    };
     SignalVector<QString> mutedChannels;
 
 public:
@@ -879,6 +885,7 @@ public:
     SignalVector<Nickname> nicknames;
     SignalVector<ModerationAction> moderationActions;
     SignalVector<ChannelLog> loggedChannels;
+    SignalVector<recentmessages::Provider> recentMessagesProviders;
 
     bool isHighlightedUser(const QString &username);
     bool isBlacklistedUser(const QString &username);

--- a/src/widgets/helper/EditableModelView.cpp
+++ b/src/widgets/helper/EditableModelView.cpp
@@ -11,11 +11,14 @@
 #include <QAbstractTableModel>
 #include <QHBoxLayout>
 #include <QHeaderView>
+#include <QItemSelectionModel>
 #include <QLabel>
 #include <QModelIndex>
 #include <QPushButton>
 #include <QTableView>
 #include <QVBoxLayout>
+
+#include <utility>
 
 namespace chatterino {
 
@@ -54,9 +57,9 @@ EditableModelView::EditableModelView(QAbstractTableModel *model, bool movable)
     });
 
     // remove
-    QPushButton *remove = new QPushButton("Remove");
-    buttons->addWidget(remove);
-    QObject::connect(remove, &QPushButton::clicked, [this] {
+    this->removeButton_ = new QPushButton("Remove");
+    buttons->addWidget(this->removeButton_);
+    QObject::connect(this->removeButton_, &QPushButton::clicked, [this] {
         auto selected = this->getTableView()->selectionModel()->selectedRows(0);
 
         // Remove rows backwards so indices don't shift.
@@ -70,7 +73,10 @@ EditableModelView::EditableModelView(QAbstractTableModel *model, bool movable)
 
         for (auto &&row : rows)
         {
-            this->model_->removeRow(row);
+            if (!this->rowRemovalPredicate_ || this->rowRemovalPredicate_(row))
+            {
+                this->model_->removeRow(row);
+            }
         }
     });
 
@@ -103,6 +109,10 @@ EditableModelView::EditableModelView(QAbstractTableModel *model, bool movable)
     QObject::connect(this->model_, &QAbstractTableModel::rowsInserted, this,
                      [this](const QModelIndex &parent, int first, int last) {
                          this->tableView_->selectRow(last);
+                     });
+    QObject::connect(this->tableView_->selectionModel(),
+                     &QItemSelectionModel::selectionChanged, this, [this] {
+                         this->updateRemoveButton();
                      });
 
     // add tableview
@@ -154,6 +164,26 @@ void EditableModelView::addRegexHelpLink()
                    "<span style='color:#99f'>regex info</span></a>");
     regexHelpLabel->setOpenExternalLinks(true);
     this->addCustomButton(regexHelpLabel);
+}
+
+void EditableModelView::setRowRemovalPredicate(
+    std::function<bool(int)> predicate)
+{
+    this->rowRemovalPredicate_ = std::move(predicate);
+    this->updateRemoveButton();
+}
+
+void EditableModelView::updateRemoveButton()
+{
+    if (!this->rowRemovalPredicate_)
+    {
+        this->removeButton_->setEnabled(true);
+        return;
+    }
+
+    const auto selected = this->tableView_->selectionModel()->selectedRows(0);
+    this->removeButton_->setEnabled(
+        selected.size() == 1 && this->rowRemovalPredicate_(selected[0].row()));
 }
 
 bool EditableModelView::filterSearchResults(const QString &query,

--- a/src/widgets/helper/EditableModelView.hpp
+++ b/src/widgets/helper/EditableModelView.hpp
@@ -8,11 +8,13 @@
 #include <QKeySequence>
 #include <QWidget>
 
+#include <functional>
 #include <span>
 
 class QAbstractTableModel;
 class QTableView;
 class QHBoxLayout;
+class QPushButton;
 
 namespace chatterino {
 
@@ -31,6 +33,7 @@ public:
 
     void addCustomButton(QWidget *widget);
     void addRegexHelpLink();
+    void setRowRemovalPredicate(std::function<bool(int)> predicate);
 
     bool filterSearchResults(const QString &query,
                              std::span<const int> columnSelect);
@@ -40,8 +43,11 @@ private:
     QTableView *tableView_{};
     QAbstractTableModel *model_{};
     QHBoxLayout *buttons_{};
+    QPushButton *removeButton_{};
+    std::function<bool(int)> rowRemovalPredicate_;
 
     void moveRow(int dir);
+    void updateRemoveButton();
 };
 
 }  // namespace chatterino

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -5,10 +5,13 @@
 #include "widgets/settingspages/GeneralPage.hpp"
 
 #include "Application.hpp"
+#include "common/Env.hpp"
 #include "common/Literals.hpp"  // IWYU pragma: keep
 #include "common/Version.hpp"
 #include "controllers/hotkeys/HotkeyCategory.hpp"
 #include "controllers/hotkeys/HotkeyController.hpp"
+#include "providers/recentmessages/Provider.hpp"
+#include "providers/recentmessages/ProviderModel.hpp"
 #include "providers/twitch/TwitchChannel.hpp"
 #include "providers/twitch/TwitchIrcServer.hpp"
 #include "singletons/CrashHandler.hpp"
@@ -21,6 +24,7 @@
 #include "util/Helpers.hpp"
 #include "util/IncognitoBrowser.hpp"
 #include "widgets/BaseWindow.hpp"
+#include "widgets/helper/EditableModelView.hpp"
 #include "widgets/helper/FontSettingWidget.hpp"
 #include "widgets/settingspages/GeneralPageView.hpp"
 #include "widgets/settingspages/SettingWidget.hpp"
@@ -29,10 +33,13 @@
 #include <QFileDialog>
 #include <QFontDialog>
 #include <QFormLayout>
+#include <QHeaderView>
 #include <QLabel>
 #include <QMessageBox>
 #include <QPalette>
+#include <QPushButton>
 #include <QSignalBlocker>
+#include <QTableView>
 
 namespace {
 
@@ -1547,6 +1554,8 @@ void GeneralPage::initLayout(GeneralPageView &layout)
             "will use your \"Subscribed Reply Threads\" highlight settings.")
         ->addTo(layout);
 
+    layout.addSubtitle("Message history");
+
     SettingWidget::checkbox("Load message history on connect",
                             s.loadTwitchMessageHistoryOnConnect)
         ->addTo(layout);
@@ -1560,6 +1569,72 @@ void GeneralPage::initLayout(GeneralPageView &layout)
                                 .singleStep = 10,
                             })
         ->addTo(layout);
+
+    layout.addDescription(
+        "Message history is fetched from the list of " +
+        formatRichNamedLink("https://github.com/robotty/recent-messages2",
+                            "robotty/recent-messages2") +
+        " instances below. If a request to a provider fails, the next "
+        "provider in the list is tried. You can add custom instances and "
+        "reorder the list. Use %1 where the channel name should be inserted.");
+
+    const bool providerListOverridden =
+        !Env::get().recentMessagesApiUrl.isEmpty();
+    if (providerListOverridden)
+    {
+        layout.addDescription(
+            "CHATTERINO2_RECENT_MESSAGES_URL is set. The provider list below "
+            "is not used.");
+    }
+
+    auto *providerModel = new recentmessages::ProviderModel(nullptr);
+    providerModel->initialize(&s.recentMessagesProviders);
+    auto *providerView = new EditableModelView(providerModel);
+    providerView->setRowRemovalPredicate([providerModel](int row) {
+        return providerModel->canRemoveRow(row);
+    });
+    providerView->setTitles({"Enabled", "URL"});
+    providerView->setMinimumHeight(220);
+    providerView->getTableView()->horizontalHeader()->setSectionResizeMode(
+        QHeaderView::ResizeToContents);
+    providerView->getTableView()->horizontalHeader()->setSectionResizeMode(
+        1, QHeaderView::Stretch);
+    s.loadTwitchMessageHistoryOnConnect.connect(
+        [providerView, providerListOverridden](const bool &enabled) {
+            providerView->setEnabled(enabled && !providerListOverridden);
+        },
+        this->managedConnections_);
+
+    std::ignore = providerView->addButtonPressed.connect([] {
+        getSettings()->recentMessagesProviders.append(recentmessages::Provider{
+            "https://example.com/api/v2/recent-messages/%1", true});
+    });
+
+    auto *resetProviders = new QPushButton("Reset to defaults");
+    providerView->addCustomButton(resetProviders);
+    QObject::connect(resetProviders, &QPushButton::clicked, [providerView] {
+        const auto reply = QMessageBox::question(
+            providerView, "Reset recent message providers",
+            "Reset recent message providers to their defaults?",
+            QMessageBox::Yes | QMessageBox::Cancel);
+        if (reply != QMessageBox::Yes)
+        {
+            return;
+        }
+
+        auto &providers = getSettings()->recentMessagesProviders;
+        while (!providers.raw().empty())
+        {
+            providers.removeAt(static_cast<int>(providers.raw().size() - 1));
+        }
+        for (const auto &provider : recentmessages::defaultProviders())
+        {
+            providers.append(provider);
+        }
+    });
+
+    layout.addWidget(providerView,
+                     {"message history", "recent messages", "providers"});
 
     SettingWidget::intInput("Split message scrollback limit (requires restart)",
                             s.scrollbackSplitLimit,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -63,6 +63,7 @@ set(test_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/src/InputHighlighter.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/BalancedResolverResults.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/UtilSerializeList.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/RecentMessages.cpp
 
     ${CMAKE_CURRENT_LIST_DIR}/src/lib/Snapshot.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/lib/Snapshot.hpp

--- a/tests/src/RecentMessages.cpp
+++ b/tests/src/RecentMessages.cpp
@@ -1,0 +1,308 @@
+// SPDX-FileCopyrightText: 2026 Contributors to Chatterino <https://chatterino.com>
+//
+// SPDX-License-Identifier: MIT
+
+#include "providers/recentmessages/Impl.hpp"
+#include "providers/recentmessages/Provider.hpp"
+#include "providers/recentmessages/ProviderModel.hpp"
+#include "Test.hpp"
+
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QUrlQuery>
+
+#include <array>
+#include <set>
+#include <vector>
+
+using namespace chatterino::recentmessages;
+
+TEST(RecentMessages, DefaultProvidersAreValid)
+{
+    const auto providers = defaultProviders();
+
+    ASSERT_FALSE(providers.empty());
+    bool hasEnabledProvider = false;
+    std::set<QString> ids;
+    for (const auto &provider : providers)
+    {
+        EXPECT_TRUE(provider.isBuiltIn());
+        EXPECT_FALSE(provider.id().isEmpty());
+        EXPECT_TRUE(ids.insert(provider.id()).second);
+        EXPECT_TRUE(provider.isValid()) << provider.url();
+        hasEnabledProvider |= provider.enabled();
+    }
+    EXPECT_TRUE(hasEnabledProvider);
+}
+
+TEST(RecentMessages, ProviderValidation)
+{
+    struct TestCase {
+        const char *url;
+        bool expectedValid;
+    };
+
+    const std::array<TestCase, 6> cases{
+        TestCase{.url = "https://example.com/recent-messages/%1",
+                 .expectedValid = true},
+        TestCase{.url = "http://localhost:8080/%1", .expectedValid = true},
+        TestCase{.url = "https://example.com/recent-messages",
+                 .expectedValid = false},
+        TestCase{.url = "ftp://example.com/%1", .expectedValid = false},
+        TestCase{.url = "https:///recent-messages/%1", .expectedValid = false},
+        TestCase{.url = "not a URL %1", .expectedValid = false},
+    };
+
+    for (const auto &test : cases)
+    {
+        const Provider provider{test.url, true};
+        EXPECT_EQ(provider.isValid(), test.expectedValid) << test.url;
+    }
+}
+
+TEST(RecentMessages, ProviderSerialization)
+{
+    rapidjson::Document document;
+    const std::array<Provider, 2> providers{
+        Provider{"https://built-in.example/%1", false, "built-in"},
+        Provider{"https://custom.example/%1", true},
+    };
+
+    for (const auto &input : providers)
+    {
+        const auto json =
+            pajlada::Serialize<Provider>::get(input, document.GetAllocator());
+
+        ASSERT_TRUE(json.IsObject());
+        ASSERT_TRUE(json.HasMember("id"));
+        ASSERT_TRUE(json.HasMember("url"));
+        ASSERT_TRUE(json.HasMember("enabled"));
+        EXPECT_EQ(QString::fromUtf8(json["id"].GetString()), input.id());
+        EXPECT_EQ(QString::fromUtf8(json["url"].GetString()), input.url());
+        EXPECT_EQ(json["enabled"].GetBool(), input.enabled());
+
+        bool error = false;
+        const auto output = pajlada::Deserialize<Provider>::get(json, &error);
+
+        EXPECT_FALSE(error);
+        EXPECT_EQ(output, input);
+    }
+}
+
+TEST(RecentMessages, ReconcileUpdatesAddsAndRemovesBuiltIns)
+{
+    const Provider updatedBuiltIn{"https://current.example/%1", true,
+                                  "existing"};
+    const Provider addedBuiltIn{"https://new.example/%1", true, "new"};
+    const std::vector<Provider> builtIns{updatedBuiltIn, addedBuiltIn};
+
+    const Provider savedBuiltIn{"https://old.example/%1", false, "existing"};
+    const Provider removedBuiltIn{"https://retired.example/%1", true,
+                                  "retired"};
+    // the custom provider has the same URL as the removed built-in provider
+    // and should survive reconcile
+    const Provider customProvider{"https://retired.example/%1", true};
+    const std::vector<Provider> saved{
+        savedBuiltIn,
+        removedBuiltIn,
+        customProvider,
+    };
+
+    const auto result = reconcileProviders(saved, builtIns);
+
+    const Provider updatedButStillDisabled{updatedBuiltIn.url(), false,
+                                           updatedBuiltIn.id()};
+    const std::vector<Provider> expected{
+        updatedButStillDisabled,
+        addedBuiltIn,
+        customProvider,
+    };
+    EXPECT_EQ(result, expected);
+}
+
+TEST(RecentMessages, ReconcileProvidersIsIdempotent)
+{
+    const Provider first{"https://first.example/%1", true, "first"};
+    const Provider second{"https://second.example/%1", true, "second"};
+    const Provider third{"https://third.example/%1", true, "third"};
+    const Provider custom{"https://custom.example/%1", true};
+    const std::vector<Provider> builtIns{first, second, third};
+    const std::vector<Provider> saved{first, custom, second, third};
+
+    const auto result = reconcileProviders(saved, builtIns);
+
+    EXPECT_EQ(result, saved);
+}
+
+TEST(RecentMessages, ReconcileNewBuiltInsInDefaultOrder)
+{
+    const Provider first{"https://first.example/%1", true, "first"};
+    const Provider second{"https://second.example/%1", true, "second"};
+    const Provider third{"https://third.example/%1", true, "third"};
+    const Provider fourth{"https://fourth.example/%1", true, "fourth"};
+    const Provider fifth{"https://fifth.example/%1", true, "fifth"};
+    const Provider custom{"https://custom.example/%1", true};
+    const std::vector<Provider> builtIns{first, second, third, fourth, fifth};
+
+    // second and fourth are still in their default order, so missing
+    // built-ins should be restored to their default positions
+    const std::vector<Provider> saved{second, custom, fourth};
+
+    const auto result = reconcileProviders(saved, builtIns);
+
+    const std::vector<Provider> expected{first, second, custom,
+                                         third, fourth, fifth};
+    EXPECT_EQ(result, expected);
+}
+
+TEST(RecentMessages, ReconcileNewBuiltInsAfterCustomizedOrder)
+{
+    const Provider first{"https://first.example/%1", true, "first"};
+    const Provider second{"https://second.example/%1", true, "second"};
+    const Provider third{"https://third.example/%1", true, "third"};
+    const Provider fourth{"https://fourth.example/%1", true, "fourth"};
+    const Provider fifth{"https://fifth.example/%1", true, "fifth"};
+    const Provider custom{"https://custom.example/%1", true};
+    const std::vector<Provider> builtIns{first, second, third, fourth, fifth};
+
+    // third, first, second is a custom order, so missing built-ins should be
+    // appended instead of interfering with that order
+    const std::vector<Provider> saved{third, first, custom, second};
+
+    const auto result = reconcileProviders(saved, builtIns);
+
+    const std::vector<Provider> expected{third,  first,  custom,
+                                         second, fourth, fifth};
+    EXPECT_EQ(result, expected);
+}
+
+TEST(RecentMessages, ProviderModelBuiltInPermissions)
+{
+    chatterino::SignalVector<Provider> providers;
+    providers.append({"https://built-in.example/%1", true, "built-in"});
+
+    ProviderModel model(nullptr);
+    model.initialize(&providers);
+
+    // enabled can be changed, but the URL cannot
+    EXPECT_TRUE(model.flags(model.index(0, 0)) & Qt::ItemIsUserCheckable);
+    EXPECT_FALSE(model.flags(model.index(0, 1)) & Qt::ItemIsEditable);
+
+    EXPECT_TRUE(
+        model.setData(model.index(0, 0), Qt::Unchecked, Qt::CheckStateRole));
+    EXPECT_FALSE(providers.raw()[0].enabled());
+    EXPECT_EQ(providers.raw()[0].id(), "built-in");
+
+    // built-ins cannot be removed
+    EXPECT_FALSE(model.removeRow(0));
+    EXPECT_EQ(providers.raw().size(), 1);
+}
+
+TEST(RecentMessages, ProviderModelCustomPermissions)
+{
+    chatterino::SignalVector<Provider> providers;
+    providers.append({"https://custom.example/%1", true});
+
+    ProviderModel model(nullptr);
+    model.initialize(&providers);
+
+    EXPECT_TRUE(model.flags(model.index(0, 1)) & Qt::ItemIsEditable);
+    EXPECT_TRUE(model.setData(model.index(0, 1), "https://changed.example/%1",
+                              Qt::DisplayRole));
+    EXPECT_EQ(providers.raw()[0].url(), "https://changed.example/%1");
+    EXPECT_FALSE(providers.raw()[0].isBuiltIn());
+    EXPECT_TRUE(model.removeRow(0));
+    EXPECT_TRUE(providers.raw().empty());
+}
+
+TEST(RecentMessages, ProviderSelectionSkipsDisabledProviders)
+{
+    const std::vector<Provider> providers{
+        {"https://disabled.example/%1", false},
+        {"https://invalid.example/no-placeholder", true},
+        {"https://first.example/%1", true},
+        {"https://second.example/%1", true},
+    };
+    std::size_t index = 0;
+
+    const auto invalid = nextEnabledProvider(providers, index);
+    EXPECT_EQ(invalid,
+              Provider("https://invalid.example/no-placeholder", true));
+
+    const auto first = nextEnabledProvider(providers, index);
+    EXPECT_EQ(first, Provider("https://first.example/%1", true));
+
+    const auto second = nextEnabledProvider(providers, index);
+    EXPECT_EQ(second, Provider("https://second.example/%1", true));
+
+    EXPECT_FALSE(nextEnabledProvider(providers, index).has_value());
+    EXPECT_EQ(index, providers.size());
+}
+
+TEST(RecentMessages, ConstructUrl)
+{
+    const auto url = detail::constructRecentMessagesUrl(
+        "https://example.com/api/v2/recent-messages/%1?source=test&limit=20",
+        "forsen", 100, std::nullopt, std::nullopt);
+    const QUrlQuery query(url);
+
+    EXPECT_EQ(url.path(), "/api/v2/recent-messages/forsen");
+    EXPECT_EQ(query.queryItemValue("source"), "test");
+    EXPECT_EQ(query.queryItemValue("limit"), "20");
+}
+
+TEST(RecentMessages, ResponseClassification)
+{
+    struct TestCase {
+        const char *description;
+        QJsonObject response;
+        detail::ResponseType expectedType;
+    };
+
+    const std::array<TestCase, 9> cases{
+        TestCase{.description = "empty messages array",
+                 .response = QJsonObject{{"messages", QJsonArray{}}},
+                 .expectedType = detail::ResponseType::Complete},
+        TestCase{.description = "messages with null error fields",
+                 .response = QJsonObject{{"messages", QJsonArray{"message"}},
+                                         {"error", QJsonValue::Null},
+                                         {"error_code", QJsonValue::Null}},
+                 .expectedType = detail::ResponseType::Complete},
+        TestCase{.description = "API error code",
+                 .response = QJsonObject{{"messages", QJsonArray{}},
+                                         {"error_code", "unrelated_error"}},
+                 .expectedType = detail::ResponseType::Invalid},
+        TestCase{.description = "provider is not joined and has no messages",
+                 .response = QJsonObject{{"messages", QJsonArray{}},
+                                         {"error", "The bot is not joined"},
+                                         {"error_code", "channel_not_joined"}},
+                 .expectedType = detail::ResponseType::Invalid},
+        TestCase{
+            .description = "provider is not joined but has partial history",
+            .response = QJsonObject{{"messages", QJsonArray{"message"}},
+                                    {"error", "The bot is not joined"},
+                                    {"error_code", "channel_not_joined"}},
+            .expectedType = detail::ResponseType::Partial},
+        TestCase{.description = "API error message",
+                 .response = QJsonObject{{"messages", QJsonArray{}},
+                                         {"error", "Provider error"}},
+                 .expectedType = detail::ResponseType::Invalid},
+        TestCase{.description = "missing messages field",
+                 .response = QJsonObject{},
+                 .expectedType = detail::ResponseType::Invalid},
+        TestCase{.description = "messages field is not an array",
+                 .response = QJsonObject{{"messages", "not an array"}},
+                 .expectedType = detail::ResponseType::Invalid},
+        TestCase{
+            .description = "messages array contains a non-string value",
+            .response = QJsonObject{{"messages", QJsonArray{QJsonObject{}}}},
+            .expectedType = detail::ResponseType::Invalid},
+    };
+
+    for (const auto &test : cases)
+    {
+        EXPECT_EQ(detail::classifyRecentMessagesResponse(test.response),
+                  test.expectedType)
+            << test.description;
+    }
+}


### PR DESCRIPTION
Recent message history is currently dependent upon a single instance of [robotty/recent-messages2](https://github.com/robotty/recent-messages2) hosted by @RAnders00 at `https://recent-messages.robotty.de/`. This instance does not have perfect uptime and users are not easily able to change to another instance if it fails (currently they can only switch using an env variable).

This PR addresses that problem by introducing several fallback instances in a configurable list, and a mechanism for querying them in order should any fail. When a failure happens, the fallback tries are shown in the chat, so that the user can see/audit their list if they wish.

<img width="336" height="127" alt="image" src="https://github.com/user-attachments/assets/b12e5b8f-650a-4c62-80ee-4fb5604d78c1" />

---

The built-in provider list is as follows:

- https://recent-messages.robotty.de/api/v2/recent-messages/%1 - the existing instance by @RAnders00 
- https://recentmessages.ivr.fi/api/v2/recent-messages/%1 - by @Leppunen, for which I have obtained explicit permission.
- https://rm.iore.tv/api/%1 - by myself, given with my permission.
- https://recent-messages.zneix.eu/api/v2/recent-messages/%1 - by @zneix
- https://rm.lilb.dev/api/v2/recent-messages/%1 - by twitch user lilb_lxryer, for which I have obtained explicit permission.
- https://logs.zonian.dev/rm/%1 - by @ZonianMidian 

I have reached out to @zneix and @ZonianMidian to ask for their explicit permission to include their instances in the built-in list, but have not received a response at the time of writing (perhaps they could comment here). [The documentation](https://recent-messages.zneix.eu/api) states `You are free to use this API from client-side web apps and applications`, but I can remove those without explicit permission if that decision is reached in this PR.

---

Users can customize the list in the advanced settings UI. They are able to enable/disable individual providers, reorder them, and add/remove their own providers. Users can reorder the built-in providers but cannot edit or remove them.

<img width="549" height="384" alt="image" src="https://github.com/user-attachments/assets/096080e1-74b2-4112-b1b3-00f7b292282b" />

In case we need to update the list of built-in providers in future, each built-in provider has a stable identity so that chatterino can reconcile updates with the user's configured list. It does this according to the following policy: if the built-ins remain in the default relative order within the user's settings, then any new entries are added in their default relative position. However, if the user has re-ordered the built-in providers, then any new entries are simply appended, to avoid unexpected changes to the user's custom order. Built-in providers that are removed from the list of defaults will also be removed from the user's settings upon load, using their stable id.

---

Backwards compatibility with `CHATTERINO2_RECENT_MESSAGES_URL` is supported - if the env variable is set, then it overrides the fallback list to act as sole provider, and displays a notice in the advanced settings UI.

<img width="545" height="261" alt="image" src="https://github.com/user-attachments/assets/08a47e2a-fd5b-4da6-9e2e-b055eec4865a" />

---

I have added tests, with the exception that no network tests are included, so the fallback behaviour must be tested manually. To do that, you can insert an invalid provider at the top of the list, and a working one below, then connect to a channel and observe the fallback results. See the first screenshot in this PR for an example using `https://example.invalid.host/recent-messages/%1`.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->