### PR TITLE
feat: custom recent-messages URL in settings UI

### DIFF
--- a/src/common/Env.cpp
+++ b/src/common/Env.cpp
@@ -74,9 +74,7 @@ bool readBoolEnv(const char *envName, bool defaultValue)
 
 Env::Env()
     : recentMessagesApiUrl(
-          qEnvironmentVariable("CHATTERINO2_RECENT_MESSAGES_URL",
-                               "https://recent-messages.robotty.de/api/v2/"
-                               "recent-messages/%1"))
+          qEnvironmentVariable("CHATTERINO2_RECENT_MESSAGES_URL"))
     , linkResolverUrl(qEnvironmentVariable(
           "CHATTERINO2_LINK_RESOLVER_URL",
           "https://braize.pajlada.com/chatterino/link_resolver/%1"))

--- a/src/providers/recentmessages/Api.hpp
+++ b/src/providers/recentmessages/Api.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <QString>
+#include <QStringView>
 
 #include <chrono>
 #include <functional>
@@ -23,6 +24,9 @@ using MessagePtr = std::shared_ptr<const Message>;
 }  // namespace chatterino
 
 namespace chatterino::recentmessages {
+
+inline constexpr QStringView DEFAULT_API_URL =
+    u"https://recent-messages.robotty.de/api/v2/recent-messages/%1";
 
 using ResultCallback = std::function<void(const std::vector<MessagePtr> &)>;
 using ErrorCallback = std::function<void()>;

--- a/src/providers/recentmessages/Impl.cpp
+++ b/src/providers/recentmessages/Impl.cpp
@@ -6,8 +6,10 @@
 
 #include "common/Env.hpp"
 #include "messages/MessageBuilder.hpp"
+#include "providers/recentmessages/Api.hpp"
 #include "providers/twitch/IrcMessageHandler.hpp"
 #include "providers/twitch/TwitchChannel.hpp"
+#include "singletons/Settings.hpp"
 #include "util/Helpers.hpp"
 #include "util/VectorMessageSink.hpp"
 
@@ -91,7 +93,18 @@ QUrl constructRecentMessagesUrl(
     const std::optional<std::chrono::time_point<std::chrono::system_clock>>
         before)
 {
-    QUrl url(Env::get().recentMessagesApiUrl.arg(name));
+    const auto &env = Env::get();
+    auto urlTemplate = env.recentMessagesApiUrl;
+    if (urlTemplate.isEmpty() && getSettings()->useCustomMessageHistoryUrl)
+    {
+        urlTemplate = getSettings()->messageHistoryUrl.getValue();
+    }
+    if (urlTemplate.isEmpty())
+    {
+        urlTemplate = DEFAULT_API_URL.toString();
+    }
+
+    QUrl url(urlTemplate.arg(name));
     QUrlQuery urlQuery(url);
     if (!urlQuery.hasQueryItem("limit"))
     {

--- a/src/providers/recentmessages/Impl.cpp
+++ b/src/providers/recentmessages/Impl.cpp
@@ -6,8 +6,10 @@
 
 #include "common/Env.hpp"
 #include "messages/MessageBuilder.hpp"
+#include "providers/recentmessages/Api.hpp"
 #include "providers/twitch/IrcMessageHandler.hpp"
 #include "providers/twitch/TwitchChannel.hpp"
+#include "singletons/Settings.hpp"
 #include "util/Helpers.hpp"
 #include "util/VectorMessageSink.hpp"
 
@@ -91,7 +93,18 @@ QUrl constructRecentMessagesUrl(
     const std::optional<std::chrono::time_point<std::chrono::system_clock>>
         before)
 {
-    QUrl url(Env::get().recentMessagesApiUrl.arg(name));
+    const auto &env = Env::get();
+    auto urlTemplate = env.recentMessagesApiUrl;
+    if (urlTemplate.isEmpty() && getSettings()->useCustomRecentMessagesUrl)
+    {
+        urlTemplate = getSettings()->recentMessagesUrl.getValue();
+    }
+    if (urlTemplate.isEmpty())
+    {
+        urlTemplate = DEFAULT_API_URL.toString();
+    }
+
+    QUrl url(urlTemplate.arg(name));
     QUrlQuery urlQuery(url);
     if (!urlQuery.hasQueryItem("limit"))
     {

--- a/src/providers/recentmessages/Impl.cpp
+++ b/src/providers/recentmessages/Impl.cpp
@@ -95,9 +95,9 @@ QUrl constructRecentMessagesUrl(
 {
     const auto &env = Env::get();
     auto urlTemplate = env.recentMessagesApiUrl;
-    if (urlTemplate.isEmpty() && getSettings()->useCustomRecentMessagesUrl)
+    if (urlTemplate.isEmpty())
     {
-        urlTemplate = getSettings()->recentMessagesUrl.getValue();
+        urlTemplate = getSettings()->messageHistoryUrl.getValue();
     }
     if (urlTemplate.isEmpty())
     {

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -738,6 +738,9 @@ public:
 
     BoolSetting loadTwitchMessageHistoryOnConnect = {
         "/misc/twitch/loadMessageHistoryOnConnect", true};
+    BoolSetting useCustomMessageHistoryUrl = {
+        "/misc/twitch/useCustomMessageHistoryUrl", false};
+    QStringSetting messageHistoryUrl = {"/misc/twitch/messageHistoryUrl", ""};
     IntSetting twitchMessageHistoryLimit = {
         "/misc/twitch/messageHistoryLimit",
         800,

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -22,6 +22,7 @@
 #include "controllers/nicknames/Nickname.hpp"
 #include "controllers/sound/ISoundController.hpp"
 #include "providers/emoji/EmojiStyle.hpp"
+#include "providers/recentmessages/Api.hpp"
 #include "singletons/NativeMessaging.hpp"
 #include "singletons/Toasts.hpp"
 #include "util/RapidJsonSerializeQString.hpp"  // IWYU pragma: keep
@@ -738,7 +739,10 @@ public:
 
     BoolSetting loadTwitchMessageHistoryOnConnect = {
         "/misc/twitch/loadMessageHistoryOnConnect", true};
-    QStringSetting messageHistoryUrl = {"/misc/twitch/messageHistoryUrl", ""};
+    QStringSetting messageHistoryUrl = {
+        "/misc/twitch/messageHistoryUrl",
+        recentmessages::DEFAULT_API_URL.toString(),
+    };
     IntSetting twitchMessageHistoryLimit = {
         "/misc/twitch/messageHistoryLimit",
         800,

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -22,6 +22,7 @@
 #include "controllers/nicknames/Nickname.hpp"
 #include "controllers/sound/ISoundController.hpp"
 #include "providers/emoji/EmojiStyle.hpp"
+#include "providers/recentmessages/Api.hpp"
 #include "singletons/NativeMessaging.hpp"
 #include "singletons/Toasts.hpp"
 #include "util/RapidJsonSerializeQString.hpp"  // IWYU pragma: keep
@@ -738,9 +739,10 @@ public:
 
     BoolSetting loadTwitchMessageHistoryOnConnect = {
         "/misc/twitch/loadMessageHistoryOnConnect", true};
-    BoolSetting useCustomRecentMessagesUrl = {
-        "/misc/twitch/useCustomRecentMessagesUrl", false};
-    QStringSetting recentMessagesUrl = {"/misc/twitch/recentMessagesUrl", ""};
+    QStringSetting messageHistoryUrl = {
+        "/misc/twitch/messageHistoryUrl",
+        recentmessages::DEFAULT_API_URL.toString(),
+    };
     IntSetting twitchMessageHistoryLimit = {
         "/misc/twitch/messageHistoryLimit",
         800,

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -22,7 +22,6 @@
 #include "controllers/nicknames/Nickname.hpp"
 #include "controllers/sound/ISoundController.hpp"
 #include "providers/emoji/EmojiStyle.hpp"
-#include "providers/recentmessages/Api.hpp"
 #include "singletons/NativeMessaging.hpp"
 #include "singletons/Toasts.hpp"
 #include "util/RapidJsonSerializeQString.hpp"  // IWYU pragma: keep
@@ -739,10 +738,7 @@ public:
 
     BoolSetting loadTwitchMessageHistoryOnConnect = {
         "/misc/twitch/loadMessageHistoryOnConnect", true};
-    QStringSetting messageHistoryUrl = {
-        "/misc/twitch/messageHistoryUrl",
-        recentmessages::DEFAULT_API_URL.toString(),
-    };
+    QStringSetting messageHistoryUrl = {"/misc/twitch/messageHistoryUrl", ""};
     IntSetting twitchMessageHistoryLimit = {
         "/misc/twitch/messageHistoryLimit",
         800,

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -738,6 +738,9 @@ public:
 
     BoolSetting loadTwitchMessageHistoryOnConnect = {
         "/misc/twitch/loadMessageHistoryOnConnect", true};
+    BoolSetting useCustomRecentMessagesUrl = {
+        "/misc/twitch/useCustomRecentMessagesUrl", false};
+    QStringSetting recentMessagesUrl = {"/misc/twitch/recentMessagesUrl", ""};
     IntSetting twitchMessageHistoryLimit = {
         "/misc/twitch/messageHistoryLimit",
         800,

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -9,6 +9,7 @@
 #include "common/Version.hpp"
 #include "controllers/hotkeys/HotkeyCategory.hpp"
 #include "controllers/hotkeys/HotkeyController.hpp"
+#include "providers/recentmessages/Api.hpp"
 #include "providers/twitch/TwitchChannel.hpp"
 #include "providers/twitch/TwitchIrcServer.hpp"
 #include "singletons/CrashHandler.hpp"
@@ -1549,6 +1550,18 @@ void GeneralPage::initLayout(GeneralPageView &layout)
 
     SettingWidget::checkbox("Load message history on connect",
                             s.loadTwitchMessageHistoryOnConnect)
+        ->addTo(layout);
+
+    SettingWidget::checkbox("Use custom message history URL",
+                            s.useCustomMessageHistoryUrl)
+        ->addTo(layout);
+
+    SettingWidget::lineEdit("URL", s.messageHistoryUrl,
+                            recentmessages::DEFAULT_API_URL.toString())
+        ->setTooltip(
+            "Use %1 where the channel name should be inserted, for example: " +
+            recentmessages::DEFAULT_API_URL.toString())
+        ->conditionallyEnabledBy(s.useCustomMessageHistoryUrl)
         ->addTo(layout);
 
     // TODO: Change phrasing to use better english once we can tag settings, right now it's kept as history instead of historical so that the setting shows up when the user searches for history

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1552,7 +1552,8 @@ void GeneralPage::initLayout(GeneralPageView &layout)
                             s.loadTwitchMessageHistoryOnConnect)
         ->addTo(layout);
 
-    SettingWidget::lineEdit("Message history URL", s.messageHistoryUrl)
+    SettingWidget::lineEdit("Message history URL", s.messageHistoryUrl,
+                            recentmessages::DEFAULT_API_URL.toString())
         ->setTooltip(
             "Use %1 where the channel name should be inserted, for example: " +
             recentmessages::DEFAULT_API_URL.toString())

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -9,6 +9,7 @@
 #include "common/Version.hpp"
 #include "controllers/hotkeys/HotkeyCategory.hpp"
 #include "controllers/hotkeys/HotkeyController.hpp"
+#include "providers/recentmessages/Api.hpp"
 #include "providers/twitch/TwitchChannel.hpp"
 #include "providers/twitch/TwitchIrcServer.hpp"
 #include "singletons/CrashHandler.hpp"
@@ -1549,6 +1550,18 @@ void GeneralPage::initLayout(GeneralPageView &layout)
 
     SettingWidget::checkbox("Load message history on connect",
                             s.loadTwitchMessageHistoryOnConnect)
+        ->addTo(layout);
+
+    SettingWidget::checkbox("Use custom message history URL",
+                            s.useCustomRecentMessagesUrl)
+        ->addTo(layout);
+
+    SettingWidget::lineEdit("Custom message history URL", s.recentMessagesUrl,
+                            recentmessages::DEFAULT_API_URL.toString())
+        ->setTooltip(
+            "Use %1 where the channel name should be inserted, for example: " +
+            recentmessages::DEFAULT_API_URL.toString())
+        ->conditionallyEnabledBy(s.useCustomRecentMessagesUrl)
         ->addTo(layout);
 
     // TODO: Change phrasing to use better english once we can tag settings, right now it's kept as history instead of historical so that the setting shows up when the user searches for history

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1552,16 +1552,10 @@ void GeneralPage::initLayout(GeneralPageView &layout)
                             s.loadTwitchMessageHistoryOnConnect)
         ->addTo(layout);
 
-    SettingWidget::checkbox("Use custom message history URL",
-                            s.useCustomRecentMessagesUrl)
-        ->addTo(layout);
-
-    SettingWidget::lineEdit("Custom message history URL", s.recentMessagesUrl,
-                            recentmessages::DEFAULT_API_URL.toString())
+    SettingWidget::lineEdit("Message history URL", s.messageHistoryUrl)
         ->setTooltip(
             "Use %1 where the channel name should be inserted, for example: " +
             recentmessages::DEFAULT_API_URL.toString())
-        ->conditionallyEnabledBy(s.useCustomRecentMessagesUrl)
         ->addTo(layout);
 
     // TODO: Change phrasing to use better english once we can tag settings, right now it's kept as history instead of historical so that the setting shows up when the user searches for history


### PR DESCRIPTION
Adds a checkbox and text field for a custom message history URL (instance of [robotty/recent-messages2](https://github.com/robotty/recent-messages2))

Keeps backwards compatibility with the env variable `CHATTERINO2_RECENT_MESSAGES_URL`.  The priority order is:

1. `CHATTERINO2_RECENT_MESSAGES_URL` if populated.
2. The custom URL in settings, if populated and checkbox checked.
3. Chatterino default

<details>
<summary>screenshot</summary>
<img width="687" height="149" alt="image" src="https://github.com/user-attachments/assets/4c4c916d-b241-45ea-9bb5-151ad53b13e0" /></details>
<details>
<summary>screenshot with populated example</summary>
<img width="547" height="87" alt="image" src="https://github.com/user-attachments/assets/765bd396-ba76-4647-bffe-76eb62aee2b0" /></details>

I have manually tested this.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->