### PR TITLE
feat: add global filters that apply to all channels/splits

### DIFF
--- a/benchmarks/src/Filters.cpp
+++ b/benchmarks/src/Filters.cpp
@@ -40,7 +40,7 @@ public:
             // ensure deterministic order
             auto id = QUuid(static_cast<uint>(i), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
             auto filter = std::make_shared<FilterRecord>(
-                QString::number(i), this->filterTexts.at(i), id);
+                QString::number(i), this->filterTexts.at(i), false, id);
             if (!filter->valid())
             {
                 qCDebug(chatterinoApp) << i << this->filterTexts[i];

--- a/src/controllers/filters/FilterModel.cpp
+++ b/src/controllers/filters/FilterModel.cpp
@@ -13,7 +13,7 @@ namespace chatterino {
 
 // commandmodel
 FilterModel::FilterModel(QObject *parent)
-    : SignalVectorModel<FilterRecordPtr>(3, parent)
+    : SignalVectorModel<FilterRecordPtr>(4, parent)
 {
 }
 
@@ -21,10 +21,11 @@ FilterModel::FilterModel(QObject *parent)
 FilterRecordPtr FilterModel::getItemFromRow(std::vector<QStandardItem *> &row,
                                             const FilterRecordPtr &original)
 {
-    auto item =
-        std::make_shared<FilterRecord>(row[0]->data(Qt::DisplayRole).toString(),
-                                       row[1]->data(Qt::DisplayRole).toString(),
-                                       original->getId());  // persist id
+    auto item = std::make_shared<FilterRecord>(
+        row[0]->data(Qt::DisplayRole).toString(),
+        row[1]->data(Qt::DisplayRole).toString(),
+        row[3]->data(Qt::CheckStateRole).toBool(),
+        original->getId());  // persist id
 
     // force 'valid' column to update
     setBoolItem(row[2], item->valid(), false, false);
@@ -41,6 +42,7 @@ void FilterModel::getRowFromItem(const FilterRecordPtr &item,
     setStringItem(row[1], item->getFilter());
     setBoolItem(row[2], item->valid(), false, false);
     setStringItem(row[2], item->valid() ? "Valid" : "Show errors");
+    setBoolItem(row[3], item->isGlobal());
 }
 
 }  // namespace chatterino

--- a/src/controllers/filters/FilterRecord.cpp
+++ b/src/controllers/filters/FilterRecord.cpp
@@ -30,13 +30,16 @@ static std::unique_ptr<filters::Filter> buildFilter(const QString &filterText)
 }
 
 FilterRecord::FilterRecord(QString name, QString filter)
-    : FilterRecord(std::move(name), std::move(filter), QUuid::createUuid())
+    : FilterRecord(std::move(name), std::move(filter), false,
+                   QUuid::createUuid())
 {
 }
 
-FilterRecord::FilterRecord(QString name, QString filter, const QUuid &id)
+FilterRecord::FilterRecord(QString name, QString filter, bool global,
+                           const QUuid &id)
     : name_(std::move(name))
     , filterText_(std::move(filter))
+    , global_(global)
     , id_(id)
     , filter_(buildFilter(this->filterText_))
 {
@@ -60,6 +63,11 @@ const QUuid &FilterRecord::getId() const
 bool FilterRecord::valid() const
 {
     return this->filter_ != nullptr;
+}
+
+bool FilterRecord::isGlobal() const
+{
+    return this->global_;
 }
 
 bool FilterRecord::filter(filters::RunContext context) const

--- a/src/controllers/filters/FilterRecord.hpp
+++ b/src/controllers/filters/FilterRecord.hpp
@@ -22,7 +22,7 @@ class FilterRecord
 public:
     FilterRecord(QString name, QString filter);
 
-    FilterRecord(QString name, QString filter, const QUuid &id);
+    FilterRecord(QString name, QString filter, bool global, const QUuid &id);
 
     const QString &getName() const;
 
@@ -32,6 +32,8 @@ public:
 
     bool valid() const;
 
+    bool isGlobal() const;
+
     bool filter(filters::RunContext context) const;
 
     bool operator==(const FilterRecord &other) const;
@@ -39,6 +41,7 @@ public:
 private:
     const QString name_;
     const QString filterText_;
+    const bool global_;
     const QUuid id_;
 
     const std::unique_ptr<filters::Filter> filter_;
@@ -59,6 +62,7 @@ struct Serialize<chatterino::FilterRecordPtr> {
 
         chatterino::rj::set(ret, "name", value->getName(), a);
         chatterino::rj::set(ret, "filter", value->getFilter(), a);
+        chatterino::rj::set(ret, "global", value->isGlobal(), a);
         chatterino::rj::set(ret, "id",
                             value->getId().toString(QUuid::WithoutBraces), a);
 
@@ -79,13 +83,15 @@ struct Deserialize<chatterino::FilterRecordPtr> {
         }
 
         QString _name, _filter, _id;
+        bool _global;
 
         chatterino::rj::getSafe(value, "name", _name);
         chatterino::rj::getSafe(value, "filter", _filter);
+        chatterino::rj::getSafe(value, "global", _global);
         chatterino::rj::getSafe(value, "id", _id);
 
         return std::make_shared<chatterino::FilterRecord>(
-            _name, _filter, QUuid::fromString(_id));
+            _name, _filter, _global, QUuid::fromString(_id));
     }
 };
 

--- a/src/controllers/filters/FilterSet.cpp
+++ b/src/controllers/filters/FilterSet.cpp
@@ -22,7 +22,7 @@ FilterSet::FilterSet(const QList<QUuid> &filterIds)
     auto filters = getSettings()->filterRecords.readOnly();
     for (const auto &f : *filters)
     {
-        if (filterIds.contains(f->getId()))
+        if (f->isGlobal() || filterIds.contains(f->getId()))
         {
             this->filters_.insert(f->getId(), f);
         }
@@ -74,7 +74,7 @@ void FilterSet::reloadFilters()
         bool found = false;
         for (const auto &f : *filters)
         {
-            if (f->getId() == key)
+            if (f->isGlobal() || f->getId() == key)
             {
                 found = true;
                 this->filters_.insert(key, f);

--- a/src/widgets/dialogs/SelectChannelFiltersDialog.cpp
+++ b/src/widgets/dialogs/SelectChannelFiltersDialog.cpp
@@ -65,13 +65,23 @@ SelectChannelFiltersDialog::SelectChannelFiltersDialog(
         for (const auto &f : *availableFilters)
         {
             auto *checkbox = new QCheckBox(f->getName(), this);
-            bool alreadySelected = previousSelection.contains(f->getId());
-            checkbox->setCheckState(alreadySelected
-                                        ? Qt::CheckState::Checked
-                                        : Qt::CheckState::Unchecked);
-            if (alreadySelected)
+
+            if (f->isGlobal())
             {
-                this->currentSelection_.append(f->getId());
+                checkbox->setEnabled(false);
+                checkbox->setCheckState(Qt::CheckState::Checked);
+                checkbox->setText(checkbox->text() + " (global)");
+            }
+            else
+            {
+                bool alreadySelected = previousSelection.contains(f->getId());
+                checkbox->setCheckState(alreadySelected
+                                            ? Qt::CheckState::Checked
+                                            : Qt::CheckState::Unchecked);
+                if (alreadySelected)
+                {
+                    this->currentSelection_.append(f->getId());
+                }
             }
 
             QObject::connect(checkbox, &QCheckBox::stateChanged,

--- a/src/widgets/settingspages/FiltersPage.cpp
+++ b/src/widgets/settingspages/FiltersPage.cpp
@@ -38,7 +38,7 @@ FiltersPage::FiltersPage()
             .getElement();
     this->view_ = view;
 
-    view->setTitles({"Name", "Filter", "Valid"});
+    view->setTitles({"Name", "Filter", "Valid", "Global"});
     view->getTableView()->horizontalHeader()->setSectionResizeMode(
         QHeaderView::Interactive);
     view->getTableView()->horizontalHeader()->setSectionResizeMode(
@@ -48,6 +48,7 @@ FiltersPage::FiltersPage()
         view->getTableView()->resizeColumnsToContents();
         view->getTableView()->setColumnWidth(0, 150);
         view->getTableView()->setColumnWidth(2, 125);
+        view->getTableView()->setColumnWidth(3, 50);
     });
 
     // We can safely ignore this signal connection since we own the view

--- a/src/widgets/settingspages/FiltersPage.cpp
+++ b/src/widgets/settingspages/FiltersPage.cpp
@@ -48,7 +48,7 @@ FiltersPage::FiltersPage()
         view->getTableView()->resizeColumnsToContents();
         view->getTableView()->setColumnWidth(0, 150);
         view->getTableView()->setColumnWidth(2, 125);
-        view->getTableView()->setColumnWidth(3, 50);
+        view->getTableView()->setColumnWidth(3, 75);
     });
 
     // We can safely ignore this signal connection since we own the view

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -1257,6 +1257,20 @@ QList<QUuid> Split::getFilters() const
     return this->view_->getFilterIds();
 }
 
+bool Split::hasGlobalFiltersOnly() const
+{
+    const auto allFilters = getSettings()->filterRecords.readOnly();
+    const auto viewFilters = getFilters();
+
+    for (const auto &f : *allFilters)
+    {
+        if (!f->isGlobal() && viewFilters.contains(f->getId()))
+            return false;
+    }
+
+    return true;
+}
+
 void Split::showSearch(bool singleChannel)
 {
     auto *popup = new SearchPopup(this, this);

--- a/src/widgets/splits/Split.hpp
+++ b/src/widgets/splits/Split.hpp
@@ -63,6 +63,7 @@ public:
 
     void setFilters(const QList<QUuid> ids);
     QList<QUuid> getFilters() const;
+    bool hasGlobalFiltersOnly() const;
 
     void setModerationMode(bool value);
     bool getModerationMode() const;

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -997,7 +997,8 @@ void SplitHeader::updateChannelText()
         }
     }
 
-    if (!title.isEmpty() && !this->split_->getFilters().empty())
+    if (!title.isEmpty() && !this->split_->getFilters().empty() &&
+        !this->split_->hasGlobalFiltersOnly())
     {
         title += " - filtered";
     }

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -282,6 +282,11 @@ SplitHeader::SplitHeader(Split *split)
     getSettings()->headerGame.connect(_, this->managedConnections_);
     getSettings()->headerUptime.connect(_, this->managedConnections_);
 
+    this->filtersChanged_ =
+        getSettings()->filterRecords.delayedItemsChanged.connect([this] {
+            this->updateChannelText();
+        });
+
     auto *window = dynamic_cast<BaseWindow *>(this->window());
     if (window)
     {
@@ -297,6 +302,11 @@ SplitHeader::SplitHeader(Split *split)
     }
 
     this->scaleChangedEvent(this->scale());
+}
+
+SplitHeader::~SplitHeader()
+{
+    this->filtersChanged_.disconnect();
 }
 
 void SplitHeader::initializeLayout()

--- a/src/widgets/splits/SplitHeader.hpp
+++ b/src/widgets/splits/SplitHeader.hpp
@@ -31,6 +31,7 @@ class SplitHeader final : public BaseWidget
 
 public:
     explicit SplitHeader(Split *split);
+    ~SplitHeader() override;
 
     void setAddButtonVisible(bool value);
 
@@ -102,6 +103,8 @@ private:
     // and don't change when the parent Split changes its underlying channel
     pajlada::Signals::SignalHolder managedConnections_;
     pajlada::Signals::SignalHolder channelConnections_;
+
+    pajlada::Signals::Connection filtersChanged_;
 
 public Q_SLOTS:
     void reloadChannelEmotes();


### PR DESCRIPTION
<!--
    Make sure you read the contribution guidelines:
    https://github.com/Chatterino/chatterino2/blob/master/CONTRIBUTING.md

    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

These changes aim to bring [global filters](https://github.com/Chatterino/chatterino2/issues/7044#issuecomment-4881587337) that would apply to all channels and splits.
There are numerous use cases this could apply to for users. I'm sure people will get creative.

I added a `Global` property to filters, checking this property automatically applies the filter to all channels and splits.

<details>
<summary>Example: Only show users joined/parted messages on a specific channel.</summary>
Fixes #7044.</br></br>

Adding the following as a global filter: `!(flags.system_message && message.content startswith "Users " && channel.name != "MyChannel")`, user join/part messages will only show on `MyChannel`.

Here is what it looks like in the filter settings:
<img width="1220" height="601" alt="image" src="https://github.com/user-attachments/assets/6e08dd6a-737f-4a2b-9f57-cbead9788258" />
</details>

I have tested my changes on Arch Linux and Windows, I do not own a Mac to test my changes there.

Let me know if this format works for you.
I'm also willing to modify the filter documentation page should this PR be approved.

Thank you!

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
