### PR TITLE
fix: explicitly set QT desktop file name

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,6 +45,11 @@ int main(int argc, char **argv)
     QCoreApplication::setApplicationName("chatterino");
     QCoreApplication::setApplicationVersion(CHATTERINO_VERSION);
     QCoreApplication::setOrganizationDomain("chatterino.com");
+    // On some Linux distros such as NixOS, Qt's automatic setting of the desktop file name
+    // leads to a wrong desktop file name ("com.chatterino." instead of "com.chatterino.chatterino"),
+    // which further leads to GNOME not being able to match the window to the desktop file,
+    // so it shows up without any name or icon.
+    QGuiApplication::setDesktopFileName("com.chatterino.chatterino");
 #ifdef Q_OS_WIN
     SetCurrentProcessExplicitAppUserModelID(
         Version::instance().appUserModelID().c_str());


### PR DESCRIPTION
This fixes an issue with GNOME not being able to display the application
icon, because in a rare edge case QT would set an incorrect wayland app_id.

Link: https://github.com/NixOS/nixpkgs/issues/542967

<!--
    Make sure you read the contribution guidelines:
    https://github.com/Chatterino/chatterino2/blob/master/CONTRIBUTING.md

    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
