### PR TITLE
Respect preferred username display mode for participants in shared chat

### DIFF
--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -2534,7 +2534,8 @@ bool TwitchChannel::isLoadingRecentMessages() const
     return this->loadingRecentMessages_.test();
 }
 
-const QStringList &TwitchChannel::getSharedChatSessionParticipants() const
+const std::vector<HelixMinimalUser> &
+    TwitchChannel::getSharedChatSessionParticipants() const
 {
     return this->sharedChatSessionParticipants_;
 }
@@ -2629,7 +2630,7 @@ void TwitchChannel::refreshSharedChatSessionState()
                             this->sharedChatSessionParticipantIds_.insert(
                                 user.id);
                             this->sharedChatSessionParticipants_.push_back(
-                                user.displayName);
+                                {user.id, user.login, user.displayName});
                         }
                     }
 

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -12,6 +12,7 @@
 #include "common/UniqueAccess.hpp"
 #include "providers/ffz/FfzBadges.hpp"
 #include "providers/ffz/FfzEmotes.hpp"
+#include "providers/twitch/api/Helix.hpp"
 #include "providers/twitch/eventsub/SubscriptionHandle.hpp"
 #include "providers/twitch/TwitchEmotes.hpp"
 #include "util/QStringHash.hpp"
@@ -356,7 +357,8 @@ public:
 
     pajlada::Signals::Signal<const QString &> sendWaitUpdate;
 
-    pajlada::Signals::Signal<const QStringList &> sharedChatStatusChanged;
+    pajlada::Signals::Signal<const std::vector<HelixMinimalUser> &>
+        sharedChatStatusChanged;
 
     // Channel point rewards
     void addQueuedRedemption(const QString &rewardId,
@@ -403,7 +405,8 @@ public:
 
     bool isLoadingRecentMessages() const;
 
-    const QStringList &getSharedChatSessionParticipants() const;
+    const std::vector<HelixMinimalUser> &getSharedChatSessionParticipants()
+        const;
     // Pinned message
     /**
      * Fetches the currently pinned message for this channel via the Helix API.
@@ -628,7 +631,7 @@ private:
      * the broadcaster who owns the channel.
      * This list is passed to the UI for display.
      */
-    QStringList sharedChatSessionParticipants_;
+    std::vector<HelixMinimalUser> sharedChatSessionParticipants_;
 
     /**
      * Set of broadcasterIDs of broadcasters participating in a

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -865,7 +865,8 @@ void Split::setChannel(IndirectChannel newChannel)
             });
 
         this->channelSignalHolder_.managedConnect(
-            tc->sharedChatStatusChanged, [this](const QStringList &) {
+            tc->sharedChatStatusChanged,
+            [this](const std::vector<HelixMinimalUser> &) {
                 this->header_->updateChannelText();
             });
         this->pinnedBanner_->setChannel(tc);

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -208,8 +208,7 @@ auto formatTitle(const TwitchChannel::StreamStatus &s, Settings &settings,
         }
         else
         {
-            const auto mode = static_cast<UsernameDisplayMode>(
-                getSettings()->usernameDisplayMode.getValue());
+            const auto mode = getSettings()->usernameDisplayMode.getEnum();
             QStringList names;
             for (const auto &p : sharedChatParticipants)
             {

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -14,6 +14,7 @@
 #include "controllers/hotkeys/HotkeyCategory.hpp"
 #include "controllers/hotkeys/HotkeyController.hpp"
 #include "controllers/notifications/NotificationController.hpp"
+#include "providers/twitch/api/Helix.hpp"
 #include "providers/twitch/TwitchAccount.hpp"
 #include "providers/twitch/TwitchChannel.hpp"
 #include "providers/twitch/TwitchIrcServer.hpp"
@@ -186,7 +187,7 @@ auto formatOfflineTooltip(const TwitchChannel::StreamStatus &s)
 }
 
 auto formatTitle(const TwitchChannel::StreamStatus &s, Settings &settings,
-                 const QStringList &sharedChatParticipants)
+                 const std::vector<HelixMinimalUser> &sharedChatParticipants)
 {
     auto title = QString();
 
@@ -201,13 +202,22 @@ auto formatTitle(const TwitchChannel::StreamStatus &s, Settings &settings,
     }
     else
     {
-        if (sharedChatParticipants.isEmpty())
+        if (sharedChatParticipants.empty())
         {
             title += " (live)";
         }
         else
         {
-            title += " (live with " + sharedChatParticipants.join(", ") + ")";
+            const auto mode = static_cast<UsernameDisplayMode>(
+                getSettings()->usernameDisplayMode.getValue());
+            QStringList names;
+            for (const auto &p : sharedChatParticipants)
+            {
+                auto name = p.formatted(mode);
+                names.push_back(std::move(name));
+            }
+
+            title += " (live with " + names.join(", ") + ")";
         }
     }
 


### PR DESCRIPTION
As a follow-up to the shared chat PR, this fixes up the issue where the names of the participants did not respect the preferred username display format.

I'm not sure how I feel about using the HelixMinimalUser directly like that. Is it worth factoring it out?

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
