### PR TITLE
chore: clarify r9k references as "unique chat"

### DIFF
--- a/src/controllers/filters/lang/Tokenizer.cpp
+++ b/src/controllers/filters/lang/Tokenizer.cpp
@@ -51,7 +51,7 @@ const QMap<QString, QString> VALID_IDENTIFIERS_MAP{
     {"flags.restricted", "restricted message?"},
     {"flags.monitored", "monitored message?"},
     {"flags.shared", "shared message?"},
-    {"flags.similar", "r9k filtered message?"},
+    {"flags.similar", "unique chat (r9k) filtered message?"},
     {"flags.watch_streak", "watch streak message?"},
     {"flags.announcement", "announcement message?"},
     {"message.content", "message text"},

--- a/src/controllers/hotkeys/ActionNames.hpp
+++ b/src/controllers/hotkeys/ActionNames.hpp
@@ -355,7 +355,7 @@ inline const std::map<HotkeyCategory, ActionDefinitionMap> actionNames{
                   "Should streamer mode be enabled, disabled, toggled (on/off) "
                   "or set to auto",
           }},
-         {"toggleLocalR9K", ActionDefinition{"Toggle local R9K"}},
+         {"toggleLocalR9K", ActionDefinition{"Toggle local unique chat (R9K)"}},
          {"zoom",
           ActionDefinition{
               .displayName = "Zoom in/out",

--- a/src/controllers/hotkeys/HotkeyController.cpp
+++ b/src/controllers/hotkeys/HotkeyController.cpp
@@ -542,8 +542,7 @@ void HotkeyController::addDefaults(std::set<QString> &addedHotkeys)
 #ifndef Q_OS_MACOS
         this->tryAddDefault(addedHotkeys, HotkeyCategory::Window,
                             QKeySequence("Ctrl+H"), "toggleLocalR9K",
-                            std::vector<QString>(),
-                            "toggle local unique chat (r9k)");
+                            std::vector<QString>(), "toggle local r9k");
 #endif
 
         this->tryAddDefault(addedHotkeys, HotkeyCategory::Window,

--- a/src/controllers/hotkeys/HotkeyController.cpp
+++ b/src/controllers/hotkeys/HotkeyController.cpp
@@ -542,7 +542,8 @@ void HotkeyController::addDefaults(std::set<QString> &addedHotkeys)
 #ifndef Q_OS_MACOS
         this->tryAddDefault(addedHotkeys, HotkeyCategory::Window,
                             QKeySequence("Ctrl+H"), "toggleLocalR9K",
-                            std::vector<QString>(), "toggle local r9k");
+                            std::vector<QString>(),
+                            "toggle local unique chat (r9k)");
 #endif
 
         this->tryAddDefault(addedHotkeys, HotkeyCategory::Window,

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1074,7 +1074,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     auto toggleLocalr9kSeq = getApp()->getHotkeys()->getDisplaySequence(
         HotkeyCategory::Window, "toggleLocalR9K");
     QString toggleLocalr9kShortcut =
-        "an assigned hotkey (Window -> Toggle local R9K)";
+        "an assigned hotkey (Window -> Toggle local unique chat (R9K))";
     if (!toggleLocalr9kSeq.isEmpty())
     {
         toggleLocalr9kShortcut = toggleLocalr9kSeq.toString(

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -1070,7 +1070,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         ->setTooltip("Show the stream title")
         ->addTo(layout);
 
-    layout.addSubtitle("R9K");
+    layout.addSubtitle("Unique chat (R9K)");
     auto toggleLocalr9kSeq = getApp()->getHotkeys()->getDisplaySequence(
         HotkeyCategory::Window, "toggleLocalR9K");
     QString toggleLocalr9kShortcut =

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -66,7 +66,7 @@ auto formatRoomModeUnclean(
 
     if (modes->r9k)
     {
-        text += "r9k, ";
+        text += "unique, ";
     }
     if (modes->slowMode > 0)
     {
@@ -709,7 +709,7 @@ std::unique_ptr<QMenu> SplitHeader::createChatModeMenu()
     this->modeActionSetSub = new QAction("Subscriber only", this);
     this->modeActionSetEmote = new QAction("Emote only", this);
     this->modeActionSetSlow = new QAction("Slow", this);
-    this->modeActionSetR9k = new QAction("R9K", this);
+    this->modeActionSetR9k = new QAction("Unique chat (R9K)", this);
     this->modeActionSetFollowers = new QAction("Followers only", this);
 
     this->modeActionSetFollowers->setCheckable(true);


### PR DESCRIPTION
<!--
    Make sure you read the contribution guidelines:
    https://github.com/Chatterino/chatterino2/blob/master/CONTRIBUTING.md

    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

This PR aims to align user-facing references to "R9K" with "Unique chat," which is Twitch's current name for the feature (outside of backend bits.) Zneix and I think "_Unique chat (R9K)_" is a good on-ramp name for new & old users alike. 

Perhaps "R9K" could fully be removed a few releases down the line too.

## Screenshots

### Split header + mode selector:
<details><summary>Expand</summary>
<p>
<img width="507" height="237" alt="image" src="https://github.com/user-attachments/assets/894dafd1-a9a8-4c91-aee7-d79b00442687" />
</p>
</details> 

### Filter variable option
<details><summary>Expand</summary>
<p>
<img width="262" height="179" alt="image" src="https://github.com/user-attachments/assets/52303c74-e35a-4213-bf77-7eeddf45844c" />
</p>
</details> 

### ~~Hotkey list~~
> [!NOTE]
> Removed, see https://github.com/Chatterino/chatterino2/pull/7112#discussion_r3607019919
<details><summary>Expand</summary>
<p>
<img width="919" height="602" alt="image" src="https://github.com/user-attachments/assets/089a8be1-aad9-4a16-a5bf-d62e6d28b350" />
</p>
</details> 

### Hotkey definition
<details><summary>Expand</summary>
<p>
<img width="404" height="402" alt="image" src="https://github.com/user-attachments/assets/f2fc02e4-d19d-4d8c-a06f-9012096e2c52" />
</p>
</details> 

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
