### PR TITLE
fix: increase wait and timeout in OnceFlag test

### DIFF
--- a/tests/src/OnceFlag.cpp
+++ b/tests/src/OnceFlag.cpp
@@ -41,7 +41,7 @@ TEST(OnceFlag, waitFor)
         startedFlag.set();
         startedAckFlag.wait();
 
-        std::this_thread::sleep_for(std::chrono::milliseconds{100});
+        std::this_thread::sleep_for(std::chrono::milliseconds{1000});
         stoppedFlag.set();
     });
 
@@ -49,10 +49,10 @@ TEST(OnceFlag, waitFor)
     startedAckFlag.set();
 
     auto start = std::chrono::system_clock::now();
-    ASSERT_TRUE(stoppedFlag.waitFor(std::chrono::milliseconds{200}));
+    ASSERT_TRUE(stoppedFlag.waitFor(std::chrono::milliseconds{2000}));
     auto stop = std::chrono::system_clock::now();
 
-    ASSERT_LT(stop - start, std::chrono::milliseconds{200});
+    ASSERT_LT(stop - start, std::chrono::milliseconds{2000});
 
     start = std::chrono::system_clock::now();
     ASSERT_TRUE(stoppedFlag.waitFor(std::chrono::milliseconds{1000}));


### PR DESCRIPTION
In hopes to not land a PR for #7116, this increases the wait + timeout as described in https://github.com/Chatterino/chatterino2/issues/7116#issuecomment-5015316981.

I think the issue is that macOS runners on GitHub Actions are so incredibly slow sometimes that we get these weird timings. And if that's the cause, the overhead (e.g. from switching tasks) should be constant. Then, if we increase the wait and timeout, we also increase the accepted jitter (timeout - wait) from 100ms to 1s. So if the lag we get is at about 150ms, that is now accepted.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
