### PR TITLE
fix(windows): deploy OpenSSL TLS plugin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -287,7 +287,7 @@ jobs:
         if: startsWith(matrix.os, 'windows')
         run: |
           cd build
-          windeployqt bin/chatterino.exe --release --no-compiler-runtime --no-translations --no-opengl-sw --dir Chatterino2/
+          windeployqt bin/chatterino.exe --release --no-compiler-runtime --no-translations --no-opengl-sw --force-openssl --dir Chatterino2/
           cp bin/chatterino.exe Chatterino2/
           ..\.CI\deploy-crt.ps1 Chatterino2
 


### PR DESCRIPTION
Since #7009, our Windows nightly builds were missing the OpenSSL TLS plugin for Qt. Qt 6.8+ only deploys the OpenSSL plugin if it sees `libcrypto.dll` or `libssl.dll`. However, our OpenSSL is named `lib{ssl,crypto}-3-x64.dll`. `--force-openssl` will deploy the SSL plugin regardless.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
