### PR TITLE
feat: improve memory usage of FFZ badges

### DIFF
--- a/src/providers/ffz/FfzBadges.cpp
+++ b/src/providers/ffz/FfzBadges.cpp
@@ -107,7 +107,8 @@ void FfzBadges::load()
                     auto userIDString = QString::number(user.toInt());
 
                     auto [userBadges, created] = this->userBadges.emplace(
-                        std::move(userIDString), badgeID);
+                        std::move(userIDString),
+                        QVarLengthArray<int, 2>{badgeID});
                     if (!created)
                     {
                         // User already had a badge assigned
@@ -147,7 +148,8 @@ void FfzBadges::assignBadgeToUser(const UserId &userID, int badgeID)
     }
     else
     {
-        this->userBadges.emplace(userID.string, badgeID);
+        this->userBadges.emplace(userID.string,
+                                 QVarLengthArray<int, 2>{badgeID});
     }
 }
 

--- a/src/providers/ffz/FfzBadges.cpp
+++ b/src/providers/ffz/FfzBadges.cpp
@@ -107,12 +107,14 @@ void FfzBadges::load()
                     auto userIDString = QString::number(user.toInt());
 
                     auto [userBadges, created] = this->userBadges.emplace(
-                        std::make_pair<QString, std::set<int>>(
-                            std::move(userIDString), {badgeID}));
+                        std::move(userIDString), badgeID);
                     if (!created)
                     {
                         // User already had a badge assigned
-                        userBadges->second.emplace(badgeID);
+                        if (!userBadges->second.contains(badgeID))
+                        {
+                            userBadges->second.emplace_back(badgeID);
+                        }
                     }
                 }
             }
@@ -138,11 +140,14 @@ void FfzBadges::assignBadgeToUser(const UserId &userID, int badgeID)
     auto it = this->userBadges.find(userID.string);
     if (it != this->userBadges.end())
     {
-        it->second.emplace(badgeID);
+        if (!it->second.contains(badgeID))
+        {
+            it->second.emplace_back(badgeID);
+        }
     }
     else
     {
-        this->userBadges.emplace(userID.string, std::set{badgeID});
+        this->userBadges.emplace(userID.string, badgeID);
     }
 }
 

--- a/src/providers/ffz/FfzBadges.hpp
+++ b/src/providers/ffz/FfzBadges.hpp
@@ -5,16 +5,17 @@
 #pragma once
 
 #include "common/Aliases.hpp"
+#include "util/QStringHash.hpp"  // IWYU pragma: keep
 #include "util/ThreadGuard.hpp"
 
+#include <boost/unordered/unordered_flat_map.hpp>
 #include <QColor>
 #include <QString>
+#include <QVarLengthArray>
 
 #include <memory>
 #include <optional>
-#include <set>
 #include <shared_mutex>
-#include <unordered_map>
 #include <vector>
 
 namespace chatterino {
@@ -44,10 +45,10 @@ private:
     std::shared_mutex mutex_;
 
     // userBadges points a user ID to the list of badges they have
-    std::unordered_map<QString, std::set<int>> userBadges;
+    boost::unordered_flat_map<QString, QVarLengthArray<int, 2>> userBadges;
 
     // badges points a badge ID to the information about the badge
-    std::unordered_map<int, Badge> badges;
+    boost::unordered_flat_map<int, Badge> badges;
     ThreadGuard tgBadges;
 };
 


### PR DESCRIPTION
FFZ badges consume a decent amount of memory in Chatterino. Before this PR, they consumed 18.4 MiB. 

We can do two cheap optimizations that cut the use in half:
- Use [`QVarLengthArray`](https://doc.qt.io/qt-6/qvarlengtharray.html) to store the badges for a user instead of `std::set`. `std::set` always allocates, even if there's only one badge. Since most users only have one, we create many small allocations. With `QVarLengthArray<T, N>`, `N` elements are stored inline. This reduced the memory usage to 11.9 MiB.
- Use `boost::unordered_flat_map` instead of `std::unordered_map`. Because of relaxed requirements for the Boost map, it doesn't need to store as much auxiliary data. This reduced the memory usage to 9.3 MiB.

A further optimization could be the use of a `boost::container::flat_multimap<std::string, int>`. This gets us to 4.6 MiB. I haven't measured the performance of this. We'd have to assume that FFZ returns us unique users per badge. The comparison with `QString` for the lookup can be done by comparing `QString < QLatin1StringView` (as we know badge IDs are latin1).

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
