### PR TITLE
refactor: Tagged enum names

### DIFF
--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-14
+          - os: macos-15
             qt-version: 6.8.3
           - os: macos-26
             qt-version: 6.11.1

--- a/src/util/QMagicEnumTagged.hpp
+++ b/src/util/QMagicEnumTagged.hpp
@@ -149,70 +149,132 @@ template <detail::IsEnum E, typename Tag>
     return {};
 }
 
-}  // namespace detail
-
-/// Get the display name of a specific enum value as a QStringView at compile time.
-///
-/// If the enum type provides a qmagicenumDisplayName specialization, it is used. Otherwise, fall back to magic_enum's name.
-///
-/// @tparam V Enum value
-/// @returns Display name as QStringView, or name as fallback.
-template <detail::IsEnum auto V>
-[[nodiscard]] consteval QStringView enumDisplayName() noexcept
-{
-    if constexpr (requires { qmagicenumDisplayName(V); })
+template <typename Tag, template <typename T> typename IsTagged>
+struct TaggedResolver {
+    /// Get the tagged enum value as a QStringView at compile time.
+    ///
+    /// If the enum type doesn't have a specialization for the tag, this falls
+    /// back to magic_enum's name.
+    ///
+    /// \tparam V Enum value
+    /// \returns Tagged name or a fallback.
+    template <detail::IsEnum auto V>
+    [[nodiscard]] static consteval QStringView enumName() noexcept
     {
-        return detail::enumTaggedData<V, detail::tag::DisplayName>();
+        if constexpr (IsTagged<std::decay_t<decltype(V)>>::value)
+        {
+            return detail::enumTaggedData<V, Tag>();
+        }
+        else
+        {
+            return qmagicenum::enumName<V>();
+        }
     }
 
-    // Fall back to our qmagicenum "enum name" implementation
-    return enumName<V>();
-}
+    /// Get the tagged enum value as a QStringView.
+    ///
+    /// If the enum type doesn't have a specialization for the tag, this falls
+    /// back to magic_enum's name.
+    template <detail::IsEnum E>
+    [[nodiscard]] static constexpr QStringView enumName(E value) noexcept
+    {
+        using D = std::decay_t<E>;
+        if constexpr (IsTagged<D>::value)
+        {
+            return detail::enumTaggedData<D, Tag>(value);
+        }
+        else
+        {
+            return qmagicenum::enumName<D>(value);
+        }
+    }
 
-/// Get the display name of a runtime enum value as a QStringView.
-///
-/// If the enum type provides a qmagicenumDisplayName specialization, it is used. Otherwise, fall back to magic_enum's name.
-///
-/// @param value Enum value
-/// @returns Display name as QStringView, or name as fallback, or an empty string if not available.
-template <detail::IsEnum E>
-[[nodiscard]] constexpr QStringView enumDisplayName(E value) noexcept
-{
-    if constexpr (requires { qmagicenumDisplayName(value); })
+    /// Get the tagged enum value as a QString.
+    ///
+    /// If the enum type doesn't have a specialization for the tag, this falls
+    /// back to magic_enum's name.
+    template <detail::IsEnum auto V>
+    [[nodiscard]] static QString enumNameString() noexcept
+    {
+        return detail::staticString(TaggedResolver::enumName<V>());
+    }
+
+    /// Get the tagged enum value as a QString.
+    ///
+    /// If the enum type doesn't have a specialization for the tag, this falls
+    /// back to magic_enum's name.
+    template <detail::IsEnum E>
+    [[nodiscard]] static QString enumNameString(E value) noexcept
+    {
+        return detail::staticString(TaggedResolver::enumName<E>(value));
+    }
+
+    /// Get the enum value from a name.
+    ///
+    /// If the enum is tagged, the tagged names will be checked. Otherwise,
+    /// magic_enum's name is checked.
+    template <detail::IsEnum E, typename BinaryPredicate = std::equal_to<>>
+    [[nodiscard]] static constexpr std::optional<std::decay_t<E>>
+        enumCast(QStringView name, BinaryPredicate p = {}) noexcept(
+            detail::isNothrowInvocable<BinaryPredicate>())
+        requires std::is_invocable_r_v<bool, BinaryPredicate, QChar, QChar>
     {
         using D = std::decay_t<E>;
 
-        return detail::enumTaggedData<D, detail::tag::DisplayName>(value);
+        if constexpr (IsTagged<D>::value)
+        {
+            for (std::size_t i = 0; i < magic_enum::enum_count<D>(); i++)
+            {
+                if (detail::eq(name, detail::INDEXED_TAGGED_DATA<E, Tag>[i], p))
+                {
+                    return magic_enum::enum_value<D>(i);
+                }
+            }
+            return std::nullopt;  // Invalid value or out of range.
+        }
+        else
+        {
+            return qmagicenum::enumCast<D, BinaryPredicate>(name, p);
+        }
     }
 
-    // Fall back to our qmagicenum "enum name" implementation
-    return enumName(value);
-}
+    /// Get the enum names.
+    ///
+    /// If the enum is tagged, the tagged names will be returned. Otherwise,
+    /// magic_enum's names.
+    template <detail::IsEnum E>
+    [[nodiscard]] static constexpr auto enumNames() noexcept
+    {
+        using D = std::decay_t<E>;
+        if constexpr (IsTagged<D>::value)
+        {
+            return detail::INDEXED_TAGGED_DATA<D, Tag>;
+        }
+        else
+        {
+            return qmagicenum::enumNames<D>();
+        }
+    }
+};
 
-/// Get the display name of a specific enum value as a static QString.
-///
-/// If the enum type provides a qmagicenumDisplayName specialization, it is used. Otherwise, fall back to magic_enum's name.
-///
-/// @tparam V Enum value
-/// @returns Display name as QString. The returned string is static.
-template <detail::IsEnum auto V>
-[[nodiscard]] inline QString enumDisplayNameString() noexcept
-{
-    return detail::staticString(enumDisplayName<V>());
-}
+namespace tag {
 
-/// Get the display name of a runtime enum value as a static QString.
-///
-/// If the enum type provides a qmagicenumDisplayName specialization, it is used. Otherwise, fall back to magic_enum's name.
-///
-/// @param value Enum value
-/// @returns Display name as QString. Returns an empty string if value is invalid. The returned string is static.
-template <detail::IsEnum E>
-[[nodiscard]] inline QString enumDisplayNameString(E value) noexcept
-{
-    using D = std::decay_t<E>;
+template <typename T>
+struct HasDisplayName : std::false_type {
+};
+template <typename T>
+    requires(requires(T v) { qmagicenumDisplayName(v); })
+struct HasDisplayName<T> : std::true_type {
+};
 
-    return detail::staticString(enumDisplayName<D>(value));
-}
+struct DisplayNameResolver : TaggedResolver<DisplayName, HasDisplayName> {
+};
+
+}  // namespace tag
+
+}  // namespace detail
+
+/// Display names specialized with `qmagicenumDisplayName()`.
+using DisplayName = detail::tag::DisplayNameResolver;
 
 }  // namespace chatterino::qmagicenum

--- a/src/widgets/settingspages/SettingWidget.cpp
+++ b/src/widgets/settingspages/SettingWidget.cpp
@@ -197,7 +197,7 @@ SettingWidget *SettingWidget::dropdown(const QString &label,
 
     for (const auto value : magic_enum::enum_values<T>())
     {
-        combo->addItem(qmagicenum::enumDisplayNameString(value),
+        combo->addItem(qmagicenum::DisplayName::enumNameString(value),
                        QVariant(static_cast<std::underlying_type_t<T>>(value)));
     }
 
@@ -273,7 +273,7 @@ SettingWidget *SettingWidget::dropdown(const QString &label,
 
     for (const auto value : magic_enum::enum_values<T>())
     {
-        combo->addItem(qmagicenum::enumDisplayNameString(value),
+        combo->addItem(qmagicenum::DisplayName::enumNameString(value),
                        QVariant(static_cast<std::underlying_type_t<T>>(value)));
     }
 

--- a/tests/src/QMagicEnum.cpp
+++ b/tests/src/QMagicEnum.cpp
@@ -13,9 +13,8 @@
 using namespace chatterino;
 using namespace literals;
 
+using qmagicenum::DisplayName;
 using qmagicenum::enumCast;
-using qmagicenum::enumDisplayName;
-using qmagicenum::enumDisplayNameString;
 using qmagicenum::enumFlagsName;
 using qmagicenum::enumName;
 using qmagicenum::enumNames;
@@ -223,47 +222,48 @@ TEST(QMagicEnum, caseInsensitive)
 TEST(QMagicEnumTagged, displayName)
 {
     // MyCustom has a display name specialization for First, but not for Default or Second
-    static_assert(eq(enumDisplayName<MyCustom::Default>(), u"Default"));
-    static_assert(eq(enumDisplayName(MyCustom::Default), u"Default"));
-    static_assert(eq(enumDisplayName(static_cast<MyCustom>(1)), u"Default"));
+    static_assert(eq(DisplayName::enumName<MyCustom::Default>(), u"Default"));
+    static_assert(eq(DisplayName::enumName(MyCustom::Default), u"Default"));
     static_assert(
-        eq(enumDisplayName<MyCustom::First>(), u"First (Display Name)"));
+        eq(DisplayName::enumName(static_cast<MyCustom>(1)), u"Default"));
     static_assert(
-        eq(enumDisplayName(MyCustom::First), u"First (Display Name)"));
+        eq(DisplayName::enumName<MyCustom::First>(), u"First (Display Name)"));
     static_assert(
-        eq(enumDisplayName(static_cast<MyCustom>(4)), u"First (Display Name)"));
-    static_assert(eq(enumDisplayName<MyCustom::Second>(), u"mysecond.*"));
-    static_assert(eq(enumDisplayName(MyCustom::Second), u"mysecond.*"));
-    static_assert(eq(enumDisplayName(static_cast<MyCustom>(9)), u"mysecond.*"));
+        eq(DisplayName::enumName(MyCustom::First), u"First (Display Name)"));
+    static_assert(eq(DisplayName::enumName(static_cast<MyCustom>(4)),
+                     u"First (Display Name)"));
+    static_assert(eq(DisplayName::enumName<MyCustom::Second>(), u"mysecond.*"));
+    static_assert(eq(DisplayName::enumName(MyCustom::Second), u"mysecond.*"));
+    static_assert(
+        eq(DisplayName::enumName(static_cast<MyCustom>(9)), u"mysecond.*"));
 
     // MyFlag does not have a display name specialization
-    static_assert(eq(enumDisplayName<MyFlag::None>(), u"None"));
-    static_assert(eq(enumDisplayName<MyFlag::One>(), u"One"));
-    static_assert(eq(enumDisplayName<MyFlag::Two>(), u"Two"));
-    static_assert(eq(enumDisplayName<MyFlag::Four>(), u"Four"));
+    static_assert(eq(DisplayName::enumName<MyFlag::None>(), u"None"));
+    static_assert(eq(DisplayName::enumName<MyFlag::One>(), u"One"));
+    static_assert(eq(DisplayName::enumName<MyFlag::Two>(), u"Two"));
+    static_assert(eq(DisplayName::enumName<MyFlag::Four>(), u"Four"));
 }
 
 TEST(QMagicEnumTagged, enumDisplayNameString)
 {
-    auto withSpecDN = enumDisplayNameString<MyCustom::First>();
+    auto withSpecDN = DisplayName::enumNameString<MyCustom::First>();
     ASSERT_EQ(withSpecDN, u"First (Display Name)");
 
     auto withSpec = enumName<MyCustom::First>();
     ASSERT_EQ(withSpec, u"myfirst");
 
-    auto withoutSpecDN = enumDisplayNameString<MyFlag::Eight>();
+    auto withoutSpecDN = DisplayName::enumNameString<MyFlag::Eight>();
     ASSERT_EQ(withoutSpecDN, u"Eight");
 
     auto withoutSpec = enumName<MyFlag::Eight>();
     ASSERT_EQ(withoutSpec, u"Eight");
 
-    auto secondWithSpecDN = enumDisplayNameString<MyCustom::Second>();
+    auto secondWithSpecDN = DisplayName::enumNameString<MyCustom::Second>();
     ASSERT_EQ(secondWithSpecDN, u"mysecond.*");
 
     auto secondWithSpec = enumName<MyCustom::Second>();
     ASSERT_EQ(secondWithSpec, u"mysecond.*");
 
-    ASSERT_EQ(
-        qmagicenum::enumDisplayNameString<ThumbnailPreviewMode::DontShow>(),
-        u"Don't show");
+    ASSERT_EQ(DisplayName::enumNameString<ThumbnailPreviewMode::DontShow>(),
+              u"Don't show");
 }


### PR DESCRIPTION
Tl;dr: Less duplication when adding tags.

To fix #7127, I want to add another tag. I noticed that this would require (essentially) duplicating the `enumDisplayName{,String}` functions. This puts the functions into a class, so we can reuse them with different tags.

Using the functions for a tag is slightly different now, as you need to name the tag.

AppleClang 15.0 crashed when compiling the `QMagicEnum` test, so I bumped it to 17.0.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
