### PR TITLE
refactor: make env::readBool public

### DIFF
--- a/src/common/Env.cpp
+++ b/src/common/Env.cpp
@@ -59,7 +59,11 @@ uint16_t readPortEnv(const char *envName, uint16_t defaultValue)
     return defaultValue;
 }
 
-bool readBoolEnv(const char *envName, bool defaultValue)
+}  // namespace
+
+namespace env {
+
+bool readBool(const char *envName, bool defaultValue)
 {
     auto envString = qEnvironmentVariable(envName);
     if (!envString.isEmpty())
@@ -70,7 +74,7 @@ bool readBoolEnv(const char *envName, bool defaultValue)
     return defaultValue;
 }
 
-}  // namespace
+}  // namespace env
 
 Env::Env()
     : recentMessagesApiUrl(
@@ -83,7 +87,8 @@ Env::Env()
     , twitchServerHost(qEnvironmentVariable("CHATTERINO2_TWITCH_SERVER_HOST",
                                             "irc.chat.twitch.tv"))
     , twitchServerPort(readPortEnv("CHATTERINO2_TWITCH_SERVER_PORT", 443))
-    , twitchServerSecure(readBoolEnv("CHATTERINO2_TWITCH_SERVER_SECURE", true))
+    , twitchServerSecure(
+          env::readBool("CHATTERINO2_TWITCH_SERVER_SECURE", true))
     , proxyUrl(readOptionalStringEnv("CHATTERINO2_PROXY_URL"))
     , logToFile(qEnvironmentVariable(env::LOG_TO_FILE, ""))
 {

--- a/src/common/Env.hpp
+++ b/src/common/Env.hpp
@@ -15,6 +15,8 @@ namespace env {
 
 constexpr const char *LOG_TO_FILE = "CHATTERINO_LOG_TO_FILE";
 
+bool readBool(const char *envName, bool defaultValue);
+
 }  // namespace env
 
 class Env


### PR DESCRIPTION
From #6695

<!--
    Make sure you read the contribution guidelines:
    https://github.com/Chatterino/chatterino2/blob/master/CONTRIBUTING.md

    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
