### PR TITLE
fix: remove hype chat functionality

### DIFF
--- a/docs/chatterino.d.ts
+++ b/docs/chatterino.d.ts
@@ -468,7 +468,6 @@ declare namespace c2 {
         ShowInMentions = 0,
         FirstMessage = 0,
         ReplyMessage = 0,
-        ElevatedMessage = 0,
         SubscribedThread = 0,
         CheerMessage = 0,
         LiveUpdatesAdd = 0,

--- a/docs/lua-meta/globals.lua
+++ b/docs/lua-meta/globals.lua
@@ -833,7 +833,6 @@ c2.MessageFlag = {
     ShowInMentions = 0,
     FirstMessage = 0,
     ReplyMessage = 0,
-    ElevatedMessage = 0,
     SubscribedThread = 0,
     CheerMessage = 0,
     LiveUpdatesAdd = 0,

--- a/src/controllers/filters/lang/Tokenizer.cpp
+++ b/src/controllers/filters/lang/Tokenizer.cpp
@@ -40,10 +40,10 @@ const QMap<QString, QString> VALID_IDENTIFIERS_MAP{
     {"flags.system_message", "system message?"},
     {"flags.reward_message", "channel point reward message?"},
     {"flags.first_message", "first message?"},
-    {"flags.elevated_message", "hype chat message?"},
+    {"flags.elevated_message", "deprecated"},
     // Ideally these values are unique, because ChannelFilterEditorDialog::ValueSpecifier::expressionText depends on
     // std::map layout in Qt 6 and internal implementation in Qt 5.
-    {"flags.hype_chat", "hype chat message?"},
+    {"flags.hype_chat", "deprecated"},
     {"flags.cheer_message", "cheer message?"},
     {"flags.whisper", "whisper message?"},
     {"flags.reply", "reply message?"},

--- a/src/controllers/filters/lang/expressions/IdentifierExpression.cpp
+++ b/src/controllers/filters/lang/expressions/IdentifierExpression.cpp
@@ -268,11 +268,27 @@ const AccessorMap &accessorMap()
         },
         {
             u"flags.elevated_message"_s,
-            {Type::Bool, flagAccessor<MessageFlag::ElevatedMessage>},
+            {
+                Type::Bool,
+
+                [](RunContext /*ctx*/) {
+                    // Feature deprecated by Twitch in 2023
+                    return false;
+                },
+
+            },
         },
         {
             u"flags.hype_chat"_s,
-            {Type::Bool, flagAccessor<MessageFlag::ElevatedMessage>},
+            {
+                Type::Bool,
+
+                [](RunContext /*ctx*/) {
+                    // Feature deprecated by Twitch in 2023
+                    return false;
+                },
+
+            },
         },
         {
             u"flags.cheer_message"_s,

--- a/src/controllers/highlights/HighlightModel.cpp
+++ b/src/controllers/highlights/HighlightModel.cpp
@@ -181,33 +181,6 @@ void HighlightModel::afterInit()
     this->insertCustomRow(firstMessageRow,
                           HighlightRowIndexes::FirstMessageRow);
 
-    // Highlight settings for hype chats
-    std::vector<QStandardItem *> elevatedMessageRow = this->createRow();
-    setBoolItem(elevatedMessageRow[Column::Pattern],
-                getSettings()->enableElevatedMessageHighlight.getValue(), true,
-                false);
-    elevatedMessageRow[Column::Pattern]->setData("Hype Chats", Qt::DisplayRole);
-    elevatedMessageRow[Column::ShowInMentions]->setFlags({});
-    //    setBoolItem(elevatedMessageRow[Column::FlashTaskbar],
-    //                getSettings()->enableElevatedMessageHighlightTaskbar.getValue(),
-    //                true, false);
-    //    setBoolItem(elevatedMessageRow[Column::PlaySound],
-    //                getSettings()->enableElevatedMessageHighlightSound.getValue(),
-    //                true, false);
-    elevatedMessageRow[Column::FlashTaskbar]->setFlags({});
-    elevatedMessageRow[Column::PlaySound]->setFlags({});
-    elevatedMessageRow[Column::UseRegex]->setFlags({});
-    elevatedMessageRow[Column::CaseSensitive]->setFlags({});
-    elevatedMessageRow[Column::SoundPath]->setFlags(Qt::NoItemFlags);
-
-    auto elevatedMessageColor =
-        ColorProvider::instance().color(ColorType::ElevatedMessageHighlight);
-    setColorItem(elevatedMessageRow[Column::Color], *elevatedMessageColor,
-                 false);
-
-    this->insertCustomRow(elevatedMessageRow,
-                          HighlightRowIndexes::ElevatedMessageRow);
-
     // Highlight settings for reply threads
     std::vector<QStandardItem *> threadMessageRow = this->createRow();
     setBoolItem(threadMessageRow[Column::Pattern],
@@ -356,11 +329,6 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
                     getSettings()->enableFirstMessageHighlight.setValue(
                         value.toBool());
                 }
-                else if (rowIndex == HighlightRowIndexes::ElevatedMessageRow)
-                {
-                    getSettings()->enableElevatedMessageHighlight.setValue(
-                        value.toBool());
-                }
                 else if (rowIndex == HighlightRowIndexes::ThreadMessageRow)
                 {
                     getSettings()->enableThreadHighlight.setValue(
@@ -434,12 +402,6 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
                     // getSettings()->enableFirstMessageHighlightTaskbar.setValue(
                     //     value.toBool());
                 }
-                else if (rowIndex == HighlightRowIndexes::ElevatedMessageRow)
-                {
-                    // getSettings()
-                    //     ->enableElevatedMessageHighlightTaskbar.setvalue(
-                    //         value.toBool());
-                }
                 else if (rowIndex == HighlightRowIndexes::ThreadMessageRow)
                 {
                     getSettings()->enableThreadHighlightTaskbar.setValue(
@@ -479,11 +441,6 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
                 else if (rowIndex == HighlightRowIndexes::FirstMessageRow)
                 {
                     // getSettings()->enableFirstMessageHighlightSound.setValue(
-                    //     value.toBool());
-                }
-                else if (rowIndex == HighlightRowIndexes::ElevatedMessageRow)
-                {
-                    // getSettings()->enableElevatedMessageHighlightSound.setValue(
                     //     value.toBool());
                 }
                 else if (rowIndex == HighlightRowIndexes::ThreadMessageRow)
@@ -577,11 +534,6 @@ void HighlightModel::customRowSetData(const std::vector<QStandardItem *> &row,
                 {
                     setColor(getSettings()->firstMessageHighlightColor,
                              ColorType::FirstMessageHighlight);
-                }
-                else if (rowIndex == HighlightRowIndexes::ElevatedMessageRow)
-                {
-                    setColor(getSettings()->elevatedMessageHighlightColor,
-                             ColorType::ElevatedMessageHighlight);
                 }
                 else if (rowIndex == HighlightRowIndexes::ThreadMessageRow)
                 {

--- a/src/controllers/highlights/HighlightModel.hpp
+++ b/src/controllers/highlights/HighlightModel.hpp
@@ -36,12 +36,11 @@ public:
         SubRow = 2,
         RedeemedRow = 3,
         FirstMessageRow = 4,
-        ElevatedMessageRow = 5,
-        ThreadMessageRow = 6,
-        AutomodRow = 7,
-        WatchStreakRow = 8,
-        AnnouncementRow = 9,
-        ColoredAnnouncementRow = 10,
+        ThreadMessageRow = 5,
+        AutomodRow = 6,
+        WatchStreakRow = 7,
+        AnnouncementRow = 8,
+        ColoredAnnouncementRow = 9,
     };
 
     enum UserHighlightRowIndexes {

--- a/src/messages/Message.cpp
+++ b/src/messages/Message.cpp
@@ -69,18 +69,6 @@ ScrollbarHighlight Message::getScrollBarHighlight() const
         };
     }
 
-    if (this->flags.has(MessageFlag::ElevatedMessage))
-    {
-        return {
-            ColorProvider::instance().color(
-                ColorType::ElevatedMessageHighlight),
-            ScrollbarHighlight::Default,
-            false,
-            false,
-            true,
-        };
-    }
-
     if (this->flags.has(MessageFlag::FirstMessage))
     {
         return {

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -1504,47 +1504,6 @@ MessagePtr MessageBuilder::makeListOfUsersMessage(
     return builder.release();
 }
 
-MessagePtr MessageBuilder::buildHypeChatMessage(
-    Communi::IrcPrivateMessage *message)
-{
-    auto levelID = message->tag(u"pinned-chat-paid-level"_s).toString();
-    auto currency = message->tag(u"pinned-chat-paid-currency"_s).toString();
-    bool okAmount = false;
-    auto amount = message->tag(u"pinned-chat-paid-amount"_s).toInt(&okAmount);
-    bool okExponent = false;
-    auto exponent =
-        message->tag(u"pinned-chat-paid-exponent"_s).toInt(&okExponent);
-    if (!okAmount || !okExponent || currency.isEmpty())
-    {
-        return {};
-    }
-    // additionally, there's `pinned-chat-paid-is-system-message` which isn't used by Chatterino.
-
-    QString subtitle;
-    auto levelIt = HYPE_CHAT_PAID_LEVEL.find(levelID);
-    if (levelIt != HYPE_CHAT_PAID_LEVEL.end())
-    {
-        const auto &level = levelIt->second;
-        subtitle = u"Level %1 Hype Chat (%2) "_s.arg(level.numeric)
-                       .arg(formatTime(level.duration));
-    }
-    else
-    {
-        subtitle = u"Hype Chat "_s;
-    }
-
-    // actualAmount = amount * 10^(-exponent)
-    double actualAmount = std::pow(10.0, double(-exponent)) * double(amount);
-
-    auto locale = getSystemLocale();
-    subtitle += locale.toCurrencyString(actualAmount, currency);
-
-    auto dt = calculateMessageTime(message);
-    MessageBuilder builder(systemMessage, parseTagString(subtitle), dt.time());
-    builder->flags.set(MessageFlag::ElevatedMessage);
-    return builder.release();
-}
-
 MessagePtrMut MessageBuilder::makeMissingScopesMessage(
     const QString &missingScopes)
 {
@@ -1776,11 +1735,6 @@ std::pair<MessagePtrMut, HighlightAlert> MessageBuilder::makeIrcMessage(
     if (tags.contains("first-msg") && tags["first-msg"].toString() == "1")
     {
         builder->flags.set(MessageFlag::FirstMessage);
-    }
-
-    if (tags.contains("pinned-chat-paid-amount"))
-    {
-        builder->flags.set(MessageFlag::ElevatedMessage);
     }
 
     if (tags.contains("bits"))

--- a/src/messages/MessageBuilder.hpp
+++ b/src/messages/MessageBuilder.hpp
@@ -196,8 +196,6 @@ public:
         QString prefix, const std::vector<HelixModerator> &users,
         Channel *channel, MessageFlags extraFlags = {});
 
-    static MessagePtr buildHypeChatMessage(Communi::IrcPrivateMessage *message);
-
     /// @brief Builds a message out of an `ircMessage`.
     ///
     /// Building a message won't cause highlights to be triggered. They will

--- a/src/messages/MessageFlag.hpp
+++ b/src/messages/MessageFlag.hpp
@@ -38,7 +38,7 @@ enum class MessageFlag : std::int64_t {
     ShowInMentions = (1LL << 22),
     FirstMessage = (1LL << 23),
     ReplyMessage = (1LL << 24),
-    ElevatedMessage = (1LL << 25),
+    //
     SubscribedThread = (1LL << 26),
     CheerMessage = (1LL << 27),
     LiveUpdatesAdd = (1LL << 28),

--- a/src/messages/layouts/MessageLayout.cpp
+++ b/src/messages/layouts/MessageLayout.cpp
@@ -386,7 +386,7 @@ void MessageLayout::updateBuffer(QPixmap *buffer,
     }();
 
     if (this->message_->flags.has(MessageFlag::FirstMessage) &&
-             ctx.preferences.enableFirstMessageHighlight)
+        ctx.preferences.enableFirstMessageHighlight)
     {
         backgroundColor = blendColors(
             backgroundColor,

--- a/src/messages/layouts/MessageLayout.cpp
+++ b/src/messages/layouts/MessageLayout.cpp
@@ -385,15 +385,7 @@ void MessageLayout::updateBuffer(QPixmap *buffer,
         return ctx.messageColors.regularBg;
     }();
 
-    if (this->message_->flags.has(MessageFlag::ElevatedMessage) &&
-        ctx.preferences.enableElevatedMessageHighlight)
-    {
-        backgroundColor = blendColors(
-            backgroundColor,
-            *ctx.colorProvider.color(ColorType::ElevatedMessageHighlight));
-    }
-
-    else if (this->message_->flags.has(MessageFlag::FirstMessage) &&
+    if (this->message_->flags.has(MessageFlag::FirstMessage) &&
              ctx.preferences.enableFirstMessageHighlight)
     {
         backgroundColor = blendColors(

--- a/src/messages/layouts/MessageLayoutContext.cpp
+++ b/src/messages/layouts/MessageLayoutContext.cpp
@@ -56,12 +56,6 @@ void MessagePreferences::connectSettings(Settings *settings,
         },
         holder);
 
-    settings->enableElevatedMessageHighlight.connect(
-        [this](const auto &newValue) {
-            this->enableElevatedMessageHighlight = newValue;
-        },
-        holder);
-
     settings->enableFirstMessageHighlight.connect(
         [this](const auto &newValue) {
             this->enableFirstMessageHighlight = newValue;

--- a/src/messages/layouts/MessageLayoutContext.hpp
+++ b/src/messages/layouts/MessageLayoutContext.hpp
@@ -51,7 +51,6 @@ struct MessagePreferences {
     Qt::BrushStyle lastMessagePattern{};
 
     bool enableRedeemedHighlight{};
-    bool enableElevatedMessageHighlight{};
     bool enableFirstMessageHighlight{};
     bool enableSubHighlight{};
     bool enableWatchStreakHighlight{};

--- a/src/messages/search/MessageFlagsPredicate.cpp
+++ b/src/messages/search/MessageFlagsPredicate.cpp
@@ -37,10 +37,6 @@ MessageFlagsPredicate::MessageFlagsPredicate(const QString &flags, bool negate)
         {
             this->flags_.set(MessageFlag::FirstMessage);
         }
-        else if (flag == "elevated-msg" || flag == "hype-chat")
-        {
-            this->flags_.set(MessageFlag::ElevatedMessage);
-        }
         else if (flag == "cheer-msg")
         {
             this->flags_.set(MessageFlag::CheerMessage);

--- a/src/providers/colors/ColorProvider.cpp
+++ b/src/providers/colors/ColorProvider.cpp
@@ -130,10 +130,6 @@ void ColorProvider::initTypeColorMap()
               getSettings()->firstMessageHighlightColor,
               HighlightPhrase::FALLBACK_FIRST_MESSAGE_HIGHLIGHT_COLOR);
 
-    initColor(ColorType::ElevatedMessageHighlight,
-              getSettings()->elevatedMessageHighlightColor,
-              HighlightPhrase::FALLBACK_ELEVATED_MESSAGE_HIGHLIGHT_COLOR);
-
     initColor(ColorType::ThreadMessageHighlight,
               getSettings()->threadHighlightColor,
               HighlightPhrase::FALLBACK_THREAD_HIGHLIGHT_COLOR);

--- a/src/providers/colors/ColorProvider.hpp
+++ b/src/providers/colors/ColorProvider.hpp
@@ -21,7 +21,6 @@ enum class ColorType {
     RedeemedHighlight,
     WatchStreak,
     FirstMessageHighlight,
-    ElevatedMessageHighlight,
     ThreadMessageHighlight,
     // Used in automatic highlights of your own messages
     SelfMessageHighlight,

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -436,15 +436,6 @@ void IrcMessageHandler::parsePrivMessageInto(
                                   {
                                       .isAction = message->isAction(),
                                   });
-
-    if (message->tags().contains(u"pinned-chat-paid-amount"_s))
-    {
-        auto ptr = MessageBuilder::buildHypeChatMessage(message);
-        if (ptr)
-        {
-            sink.addMessage(ptr, MessageContext::Original);
-        }
-    }
 }
 
 void IrcMessageHandler::handleRoomStateMessage(Communi::IrcMessage *message)

--- a/src/widgets/Scrollbar.cpp
+++ b/src/widgets/Scrollbar.cpp
@@ -300,8 +300,6 @@ void Scrollbar::paintEvent(QPaintEvent * /*event*/)
     bool enableRedeemedHighlights = getSettings()->enableRedeemedHighlight;
     bool enableFirstMessageHighlights =
         getSettings()->enableFirstMessageHighlight;
-    bool enableElevatedMessageHighlights =
-        getSettings()->enableElevatedMessageHighlight;
 
     if (this->shouldShowThumb())
     {
@@ -345,12 +343,6 @@ void Scrollbar::paintEvent(QPaintEvent * /*event*/)
 
             if (highlight.isFirstMessageHighlight() &&
                 !enableFirstMessageHighlights)
-            {
-                continue;
-            }
-
-            if (highlight.isElevatedMessageHighlight() &&
-                !enableElevatedMessageHighlights)
             {
                 continue;
             }

--- a/src/widgets/helper/ScrollbarHighlight.cpp
+++ b/src/widgets/helper/ScrollbarHighlight.cpp
@@ -18,13 +18,11 @@ ScrollbarHighlight::ScrollbarHighlight()
 
 ScrollbarHighlight::ScrollbarHighlight(const std::shared_ptr<QColor> color,
                                        Style style, bool isRedeemedHighlight,
-                                       bool isFirstMessageHighlight,
-                                       bool isElevatedMessageHighlight)
+                                       bool isFirstMessageHighlight)
     : color_(color)
     , style_(style)
     , isRedeemedHighlight_(isRedeemedHighlight)
     , isFirstMessageHighlight_(isFirstMessageHighlight)
-    , isElevatedMessageHighlight_(isElevatedMessageHighlight)
 {
 }
 
@@ -47,11 +45,6 @@ bool ScrollbarHighlight::isRedeemedHighlight() const
 bool ScrollbarHighlight::isFirstMessageHighlight() const
 {
     return this->isFirstMessageHighlight_;
-}
-
-bool ScrollbarHighlight::isElevatedMessageHighlight() const
-{
-    return this->isElevatedMessageHighlight_;
 }
 
 bool ScrollbarHighlight::isNull() const

--- a/src/widgets/helper/ScrollbarHighlight.hpp
+++ b/src/widgets/helper/ScrollbarHighlight.hpp
@@ -26,14 +26,12 @@ public:
 
     ScrollbarHighlight(const std::shared_ptr<QColor> color,
                        Style style = Default, bool isRedeemedHighlight = false,
-                       bool isFirstMessageHighlight = false,
-                       bool isElevatedMessageHighlight = false);
+                       bool isFirstMessageHighlight = false);
 
     QColor getColor() const;
     Style getStyle() const;
     bool isRedeemedHighlight() const;
     bool isFirstMessageHighlight() const;
-    bool isElevatedMessageHighlight() const;
     bool isNull() const;
 
 private:
@@ -41,7 +39,6 @@ private:
     Style style_;
     bool isRedeemedHighlight_{};
     bool isFirstMessageHighlight_{};
-    bool isElevatedMessageHighlight_{};
 };
 
 }  // namespace chatterino

--- a/tests/snapshots/IrcMessageHandler/hype-chat-invalid.json
+++ b/tests/snapshots/IrcMessageHandler/hype-chat-invalid.json
@@ -143,7 +143,7 @@
             ],
             "externalBadges": [
             ],
-            "flags": "Collapsed|ElevatedMessage",
+            "flags": "Collapsed",
             "frozen": false,
             "id": "8779a9e5-cf1b-47b3-b9fe-67a5b1b605f6",
             "localizedName": "",

--- a/tests/snapshots/IrcMessageHandler/hype-chat0.json
+++ b/tests/snapshots/IrcMessageHandler/hype-chat0.json
@@ -143,7 +143,7 @@
             ],
             "externalBadges": [
             ],
-            "flags": "Collapsed|ElevatedMessage",
+            "flags": "Collapsed",
             "frozen": false,
             "id": "8779a9e5-cf1b-47b3-b9fe-67a5b1b605f6",
             "localizedName": "",
@@ -161,74 +161,6 @@
             ],
             "userID": "136881249",
             "usernameColor": "#ff0000ff"
-        },
-        {
-            "channelName": "",
-            "count": 1,
-            "displayName": "",
-            "elements": [
-                {
-                    "element": {
-                        "color": "System",
-                        "flags": "Timestamp",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "TimestampMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "2:46"
-                        ]
-                    },
-                    "flags": "Timestamp",
-                    "format": "",
-                    "link": {
-                        "type": "None",
-                        "value": ""
-                    },
-                    "time": "02:46:14",
-                    "tooltip": "",
-                    "trailingSpace": true,
-                    "type": "TimestampElement"
-                },
-                {
-                    "color": "System",
-                    "flags": "Text",
-                    "link": {
-                        "type": "None",
-                        "value": ""
-                    },
-                    "style": "ChatMedium",
-                    "tooltip": "",
-                    "trailingSpace": true,
-                    "type": "TextElement",
-                    "words": [
-                        "Hype",
-                        "Chat",
-                        "USD5.00"
-                    ]
-                }
-            ],
-            "externalBadges": [
-            ],
-            "flags": "System|DoNotTriggerNotification|ElevatedMessage",
-            "frozen": false,
-            "id": "",
-            "localizedName": "",
-            "loginName": "",
-            "messageText": "Hype Chat USD5.00",
-            "searchText": "Hype Chat USD5.00",
-            "serverReceivedTime": "",
-            "timeoutUser": "",
-            "twitchBadgeInfos": {
-            },
-            "twitchBadges": [
-            ],
-            "userID": "",
-            "usernameColor": "#ff000000"
         }
     ]
 }

--- a/tests/snapshots/IrcMessageHandler/hype-chat1.json
+++ b/tests/snapshots/IrcMessageHandler/hype-chat1.json
@@ -150,7 +150,7 @@
             ],
             "externalBadges": [
             ],
-            "flags": "Collapsed|ElevatedMessage",
+            "flags": "Collapsed",
             "frozen": false,
             "id": "e6681ba0-cdc6-4482-93a3-515b74361e8b",
             "localizedName": "",
@@ -170,77 +170,6 @@
             ],
             "userID": "26753388",
             "usernameColor": "#ff9da364"
-        },
-        {
-            "channelName": "",
-            "count": 1,
-            "displayName": "",
-            "elements": [
-                {
-                    "element": {
-                        "color": "System",
-                        "flags": "Timestamp",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "TimestampMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "16:43"
-                        ]
-                    },
-                    "flags": "Timestamp",
-                    "format": "",
-                    "link": {
-                        "type": "None",
-                        "value": ""
-                    },
-                    "time": "16:43:51",
-                    "tooltip": "",
-                    "trailingSpace": true,
-                    "type": "TimestampElement"
-                },
-                {
-                    "color": "System",
-                    "flags": "Text",
-                    "link": {
-                        "type": "None",
-                        "value": ""
-                    },
-                    "style": "ChatMedium",
-                    "tooltip": "",
-                    "trailingSpace": true,
-                    "type": "TextElement",
-                    "words": [
-                        "Level",
-                        "1",
-                        "Hype",
-                        "Chat",
-                        "(30s)",
-                        "NOK14.00"
-                    ]
-                }
-            ],
-            "externalBadges": [
-            ],
-            "flags": "System|DoNotTriggerNotification|ElevatedMessage",
-            "frozen": false,
-            "id": "",
-            "localizedName": "",
-            "loginName": "",
-            "messageText": "Level 1 Hype Chat (30s) NOK14.00",
-            "searchText": "Level 1 Hype Chat (30s) NOK14.00",
-            "serverReceivedTime": "",
-            "timeoutUser": "",
-            "twitchBadgeInfos": {
-            },
-            "twitchBadges": [
-            ],
-            "userID": "",
-            "usernameColor": "#ff000000"
         }
     ]
 }

--- a/tests/snapshots/IrcMessageHandler/hype-chat2.json
+++ b/tests/snapshots/IrcMessageHandler/hype-chat2.json
@@ -149,7 +149,7 @@
             ],
             "externalBadges": [
             ],
-            "flags": "Collapsed|ElevatedMessage",
+            "flags": "Collapsed",
             "frozen": false,
             "id": "39a80a3d-c16e-420f-9bbb-faba4976a3bb",
             "localizedName": "",
@@ -167,78 +167,6 @@
             ],
             "userID": "518404689",
             "usernameColor": "#ffff69b4"
-        },
-        {
-            "channelName": "",
-            "count": 1,
-            "displayName": "",
-            "elements": [
-                {
-                    "element": {
-                        "color": "System",
-                        "flags": "Timestamp",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "TimestampMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "16:43"
-                        ]
-                    },
-                    "flags": "Timestamp",
-                    "format": "",
-                    "link": {
-                        "type": "None",
-                        "value": ""
-                    },
-                    "time": "16:43:54",
-                    "tooltip": "",
-                    "trailingSpace": true,
-                    "type": "TimestampElement"
-                },
-                {
-                    "color": "System",
-                    "flags": "Text",
-                    "link": {
-                        "type": "None",
-                        "value": ""
-                    },
-                    "style": "ChatMedium",
-                    "tooltip": "",
-                    "trailingSpace": true,
-                    "type": "TextElement",
-                    "words": [
-                        "Level",
-                        "2",
-                        "Hype",
-                        "Chat",
-                        "(2m",
-                        "30s)",
-                        "USD5.00"
-                    ]
-                }
-            ],
-            "externalBadges": [
-            ],
-            "flags": "System|DoNotTriggerNotification|ElevatedMessage",
-            "frozen": false,
-            "id": "",
-            "localizedName": "",
-            "loginName": "",
-            "messageText": "Level 2 Hype Chat (2m 30s) USD5.00",
-            "searchText": "Level 2 Hype Chat (2m 30s) USD5.00",
-            "serverReceivedTime": "",
-            "timeoutUser": "",
-            "twitchBadgeInfos": {
-            },
-            "twitchBadges": [
-            ],
-            "userID": "",
-            "usernameColor": "#ff000000"
         }
     ]
 }


### PR DESCRIPTION
Hype Chat was deprecated by Twitch in 2023

From #6695

<!--
Parent-pr: 6695
-->
