### PR TITLE
fix: make Notebook::findItem safe

### DIFF
--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -368,8 +368,8 @@ void Notebook::select(QWidget *page, bool focusPage, bool recordInHistory)
         // Hide the previously selected page
         this->selectedPage_->hide();
 
-        auto item = std::ranges::find_if(
-            this->items_.begin(), this->items_.end(), [this](const auto &item) {
+        auto item =
+            std::ranges::find_if(this->items_, [this](const auto &item) {
                 return this->selectedPage_ == item.page;
             });
         if (item == this->items_.end())

--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -212,9 +212,9 @@ void Notebook::removePage(QWidget *page)
 
 void Notebook::duplicatePage(QWidget *page)
 {
-    auto *item = this->findItem(page);
-    assert(item != nullptr);
-    if (item == nullptr)
+    auto item = this->findItem(page);
+    assert(item.has_value());
+    if (!item.has_value())
     {
         return;
     }
@@ -331,8 +331,8 @@ void Notebook::select(QWidget *page, bool focusPage, bool recordInHistory)
     if (page)
     {
         // A new page has been selected, mark it as selected & focus one of its splits
-        auto *item = this->findItem(page);
-        if (!item)
+        auto item = this->findItem(page);
+        if (!item.has_value())
         {
             return;
         }
@@ -368,8 +368,11 @@ void Notebook::select(QWidget *page, bool focusPage, bool recordInHistory)
         // Hide the previously selected page
         this->selectedPage_->hide();
 
-        auto *item = this->findItem(this->selectedPage_);
-        if (!item)
+        auto item = std::ranges::find_if(
+            this->items_.begin(), this->items_.end(), [this](const auto &item) {
+                return this->selectedPage_ == item.page;
+            });
+        if (item == this->items_.end())
         {
             return;
         }
@@ -476,7 +479,7 @@ bool Notebook::containsPage(QWidget *page) const
                        });
 }
 
-Notebook::Item *Notebook::findItem(QWidget *page)
+std::optional<Notebook::Item> Notebook::findItem(QWidget *page)
 {
     auto it = std::find_if(this->items_.begin(), this->items_.end(),
                            [page](const auto &item) {
@@ -484,9 +487,9 @@ Notebook::Item *Notebook::findItem(QWidget *page)
                            });
     if (it != this->items_.end())
     {
-        return &(*it);
+        return *it;
     }
-    return nullptr;
+    return std::nullopt;
 }
 
 bool Notebook::containsChild(const QObject *obj, const QObject *child)

--- a/src/widgets/Notebook.hpp
+++ b/src/widgets/Notebook.hpp
@@ -16,6 +16,7 @@
 #include <QWidget>
 
 #include <functional>
+#include <optional>
 #include <span>
 #include <vector>
 
@@ -216,7 +217,7 @@ private:
     void resizeAddButton();
 
     bool containsPage(QWidget *page) const;
-    Item *findItem(QWidget *page);
+    std::optional<Item> findItem(QWidget *page);
 
     void pruneInvalidHistoryEntries();
 


### PR DESCRIPTION
Closes #7131

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
