### PR TITLE
refactor: move JSON serialization to descriptors

### DIFF
--- a/src/common/WindowDescriptors.cpp
+++ b/src/common/WindowDescriptors.cpp
@@ -15,6 +15,8 @@
 #include <QJsonArray>
 #include <QJsonDocument>
 
+using namespace Qt::Literals;
+
 namespace chatterino {
 
 namespace {
@@ -49,6 +51,16 @@ QList<QUuid> loadFilters(const QJsonValue &val)
     return filterIds;
 }
 
+QJsonArray encodeFilters(std::span<const QUuid> filters)
+{
+    QJsonArray arr;
+    for (const auto &f : filters)
+    {
+        arr.append(f.toString(QUuid::WithoutBraces));
+    }
+    return arr;
+}
+
 }  // namespace
 
 SplitDescriptor SplitDescriptor::loadFromJSON(const QJsonObject &root)
@@ -76,6 +88,29 @@ SplitDescriptor SplitDescriptor::loadFromJSON(const QJsonObject &root)
     }
 
     return descriptor;
+}
+
+QJsonObject SplitDescriptor::toJson() const
+{
+    QJsonObject obj;
+
+    obj.insert("type", "split");
+    obj.insert("moderationMode", this->moderationMode_);
+
+    QJsonObject data{{"type"_L1, this->type_}};
+    if (!this->channelName_.isEmpty())
+    {
+        data.insert("name"_L1, this->channelName_);
+    }
+    obj.insert("data", data);
+
+    obj.insert("filters", encodeFilters(this->filters_));
+
+    if (this->spellCheckOverride.has_value())
+    {
+        obj["checkSpelling"] = *this->spellCheckOverride;
+    }
+    return obj;
 }
 
 IndirectChannel SplitDescriptor::decodeChannel() const
@@ -127,6 +162,14 @@ SplitNodeDescriptor SplitNodeDescriptor::loadFromJSON(const QJsonObject &root)
     return descriptor;
 }
 
+QJsonObject SplitNodeDescriptor::toJson() const
+{
+    QJsonObject obj = SplitDescriptor::toJson();
+    obj.insert("flexh", this->flexH_);
+    obj.insert("flexv", this->flexV_);
+    return obj;
+}
+
 ContainerNodeDescriptor ContainerNodeDescriptor::loadFromJSON(
     const QJsonObject &root)
 {
@@ -155,6 +198,26 @@ ContainerNodeDescriptor ContainerNodeDescriptor::loadFromJSON(
     }
 
     return descriptor;
+}
+
+QJsonObject ContainerNodeDescriptor::toJson() const
+{
+    QJsonObject obj;
+    obj.insert("type", this->vertical_ ? "vertical" : "horizontal");
+    obj.insert("flexh", this->flexH_);
+    obj.insert("flexv", this->flexV_);
+
+    QJsonArray itemsArr;
+    for (const auto &n : this->items_)
+    {
+        itemsArr.append(std::visit(
+            [](auto &&it) {
+                return it.toJson();
+            },
+            n));
+    }
+    obj.insert("items", itemsArr);
+    return obj;
 }
 
 TabDescriptor TabDescriptor::loadFromJSON(const QJsonObject &tabObj)

--- a/src/common/WindowDescriptors.hpp
+++ b/src/common/WindowDescriptors.hpp
@@ -56,6 +56,8 @@ struct SplitDescriptor {
 
     static SplitDescriptor loadFromJSON(const QJsonObject &root);
 
+    QJsonObject toJson() const;
+
     IndirectChannel decodeChannel() const;
 };
 
@@ -67,6 +69,8 @@ struct SplitNodeDescriptor : SplitDescriptor {
     qreal flexV_ = 1;
 
     static SplitNodeDescriptor loadFromJSON(const QJsonObject &root);
+
+    QJsonObject toJson() const;
 };
 
 struct ContainerNodeDescriptor;
@@ -83,6 +87,8 @@ struct ContainerNodeDescriptor {
     std::vector<NodeDescriptor> items_;
 
     static ContainerNodeDescriptor loadFromJSON(const QJsonObject &root);
+
+    QJsonObject toJson() const;
 };
 
 struct TabDescriptor {

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -700,68 +700,11 @@ void WindowManager::encodeTab(SplitContainer *tab, bool isSelected,
     obj.insert("highlightsEnabled", tab->getTab()->hasHighlightsEnabled());
 
     // splits
-    QJsonObject splits;
-
-    WindowManager::encodeNodeRecursively(tab->buildDescriptor(), splits);
-
-    obj.insert("splits2", splits);
-}
-
-void WindowManager::encodeNodeRecursively(const NodeDescriptor &descriptor,
-                                          QJsonObject &obj)
-{
-    std::visit(variant::Overloaded{
-                   [&](const SplitNodeDescriptor &split) {
-                       obj.insert("type", "split");
-                       obj.insert("flexh", split.flexH_);
-                       obj.insert("flexv", split.flexV_);
-
-                       obj.insert("moderationMode", split.moderationMode_);
-
-                       QJsonObject data{{"type"_L1, split.type_}};
-                       if (!split.channelName_.isEmpty())
-                       {
-                           data.insert("name"_L1, split.channelName_);
-                       }
-                       obj.insert("data", data);
-
-                       QJsonArray filters;
-                       WindowManager::encodeFilters(split.filters_, filters);
-                       obj.insert("filters", filters);
-
-                       if (split.spellCheckOverride.has_value())
-                       {
-                           obj["checkSpelling"] = *split.spellCheckOverride;
-                       }
-                   },
-                   [&](const ContainerNodeDescriptor &container) {
-                       obj.insert("type", container.vertical_ ? "vertical"
-                                                              : "horizontal");
-                       obj.insert("flexh", container.flexH_);
-                       obj.insert("flexv", container.flexV_);
-
-                       QJsonArray itemsArr;
-                       for (const auto &n : container.items_)
-                       {
-                           QJsonObject subObj;
-                           WindowManager::encodeNodeRecursively(n, subObj);
-                           itemsArr.append(subObj);
-                       }
-                       obj.insert("items", itemsArr);
-                   },
-               },
-               descriptor);
-}
-
-void WindowManager::encodeFilters(std::span<const QUuid> filters,
-                                  QJsonArray &arr)
-{
-    assertInGuiThread();
-
-    for (const auto &f : filters)
-    {
-        arr.append(f.toString(QUuid::WithoutBraces));
-    }
+    obj.insert("splits2", std::visit(
+                              [](auto &&it) {
+                                  return it.toJson();
+                              },
+                              tab->buildDescriptor()));
 }
 
 void WindowManager::closeAll()

--- a/src/singletons/WindowManager.hpp
+++ b/src/singletons/WindowManager.hpp
@@ -69,7 +69,6 @@ public:
 
     static void encodeTab(SplitContainer *tab, bool isSelected,
                           QJsonObject &obj);
-    static void encodeFilters(std::span<const QUuid> filters, QJsonArray &arr);
 
     void showSettingsDialog(
         QWidget *parent,
@@ -172,9 +171,6 @@ public:
     pajlada::Signals::Signal<const MessagePtr &> scrollToMessageSignal;
 
 private:
-    static void encodeNodeRecursively(const NodeDescriptor &descriptor,
-                                      QJsonObject &obj);
-
     // Load window layout from the window-layout.json file
     WindowLayout loadWindowLayoutFromFile() const;
 


### PR DESCRIPTION
The last main part from #6906: Produce the JSON in the descriptors instead of in the window layout. This mainly moves the content from `encodeNodeRecursively` into `toJson` functions on the descriptors.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
