### PR TITLE
build(windows): Enable segment heap if possible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,10 @@ include(CMakeDependentOption)
 list(APPEND CMAKE_MODULE_PATH
     "${CMAKE_SOURCE_DIR}/cmake"
     )
-include(EnableSegmentHeap)
+
+if(WIN32 AND NOT MINGW)
+    include(EnableSegmentHeap)
+endif()
 
 option(BUILD_APP "Build Chatterino" ON)
 option(BUILD_TESTS "Build the tests for Chatterino" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ include(CMakeDependentOption)
 list(APPEND CMAKE_MODULE_PATH
     "${CMAKE_SOURCE_DIR}/cmake"
     )
+include(EnableSegmentHeap)
 
 option(BUILD_APP "Build Chatterino" ON)
 option(BUILD_TESTS "Build the tests for Chatterino" OFF)

--- a/cmake/EnableSegmentHeap.cmake
+++ b/cmake/EnableSegmentHeap.cmake
@@ -1,0 +1,17 @@
+if (NOT WIN32 OR MINGW)
+    return()
+endif()
+
+if(NOT DEFINED ENV{VSINSTALLDIR})
+    message(WARNING "Missing VSINSTALLDIR environment variable - not enabling segment heap.")
+    return()
+endif()
+
+set(segment_heap_path "$ENV{VSINSTALLDIR}Common7/IDE/CommonExtensions/Microsoft/CMake/cmake/Microsoft/SegmentHeap.cmake")
+if (NOT EXISTS "${segment_heap_path}")
+    message(STATUS "Missing '${segment_heap_path}'. Segment heap will be disabled - consider updating Visual Studio.")
+    return()
+endif()
+
+message(STATUS "Including segment heap script from '${segment_heap_path}'.")
+include("${segment_heap_path}")

--- a/cmake/EnableSegmentHeap.cmake
+++ b/cmake/EnableSegmentHeap.cmake
@@ -1,6 +1,6 @@
-if (NOT WIN32 OR MINGW)
-    return()
-endif()
+# SPDX-FileCopyrightText: 2026 Contributors to Chatterino <https://chatterino.com>
+#
+# SPDX-License-Identifier: CC0-1.0
 
 if(NOT DEFINED ENV{VSINSTALLDIR})
     message(WARNING "Missing VSINSTALLDIR environment variable - not enabling segment heap.")


### PR DESCRIPTION
With Visual Studio 2026 18.6, Microsoft included a script to easily enable the segment heap for apps ([blog](https://devblogs.microsoft.com/cppblog/segment-heap-support-for-c-projects-in-visual-studio/)). The segment heap was already available for some years, but it hasn't been enabled by default. With the provided script we can add a manifest to enable it. In my basic testing it reduced the memory usage from ~75MiB to ~70MiB with one tab and 4 messages. So it should be a free win for us.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
