### PR TITLE
chore: scaffold setting migration system

### DIFF
--- a/mocks/include/mocks/BaseApplication.hpp
+++ b/mocks/include/mocks/BaseApplication.hpp
@@ -19,10 +19,11 @@ namespace chatterino::mock {
 class BaseApplication : public EmptyApplication
 {
 public:
-    BaseApplication()
+    BaseApplication(bool runMigrations = false)
         : settings(this->modes_, this->args_, this->settingsDir.path(),
                    {
                        .isTest = true,
+                       .runMigrations = runMigrations,
                    })
         , updates(this->modes_, this->paths_, this->settings)
         , theme(this->paths_)
@@ -30,11 +31,12 @@ public:
     {
     }
 
-    explicit BaseApplication(const QString &settingsData)
+    BaseApplication(const QString &settingsData, bool runMigrations = false)
         : EmptyApplication(settingsData)
         , settings(this->modes_, this->args_, this->settingsDir.path(),
                    {
                        .isTest = true,
+                       .runMigrations = runMigrations,
                    })
         , updates(this->modes_, this->paths_, this->settings)
         , theme(this->paths_)

--- a/src/singletons/Settings.cpp
+++ b/src/singletons/Settings.cpp
@@ -7,6 +7,7 @@
 #include "Application.hpp"
 #include "common/Args.hpp"
 #include "common/Modes.hpp"
+#include "common/QLogging.hpp"
 #include "controllers/filters/FilterRecord.hpp"
 #include "controllers/highlights/HighlightBadge.hpp"
 #include "controllers/highlights/HighlightBlacklistUser.hpp"
@@ -47,6 +48,13 @@ void initializeSignalVector(pajlada::Signals::SignalHolder &signalHolder,
 
 namespace chatterino {
 
+namespace {
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+const auto &LOG = chatterinoSettings;
+
+}  // namespace
+
 std::vector<std::weak_ptr<pajlada::Settings::SettingData>> _settings;
 
 void _actuallyRegisterSetting(
@@ -68,6 +76,10 @@ bool Settings::isHighlightedUser(const QString &username)
     }
 
     return false;
+}
+
+void Settings::migrate(bool isTest)
+{
 }
 
 bool Settings::isBlacklistedUser(const QString &username)
@@ -167,6 +179,7 @@ Settings::Settings(const Modes &modes, const Args &args,
 
     if (settingsArgs.isTest)
     {
+        qCInfo(LOG) << "Loading settings from" << settingsPath;
         settingsInstance->load(qPrintable(settingsPath));
     }
     else
@@ -211,6 +224,12 @@ Settings::Settings(const Modes &modes, const Args &args,
             pajlada::Settings::SettingManager::SaveMethod::SaveManually) |
         static_cast<uint64_t>(
             pajlada::Settings::SettingManager::SaveMethod::OnlySaveIfChanged));
+
+    // Run setting migrations
+    if (settingsArgs.runMigrations)
+    {
+        this->migrate(settingsArgs.isTest);
+    }
 
     initializeSignalVector(this->signalHolder, this->highlightedMessagesSetting,
                            this->highlightedMessages);

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -116,6 +116,7 @@ constexpr std::optional<std::string_view> qmagicenumDisplayName(
 
 struct SettingsArgs {
     bool isTest = false;
+    bool runMigrations = true;
 };
 
 /// Settings which are available for reading and writing on the gui thread.
@@ -873,6 +874,13 @@ private:
     ChatterinoSetting<std::vector<ChannelLog>> loggedChannelsSetting = {
         "/logging/channels"};
     SignalVector<QString> mutedChannels;
+
+    IntSetting settingsVersion = {
+        "/misc/settingsVersion",
+        0,
+    };
+
+    void migrate(bool isTest);
 
 public:
     SignalVector<HighlightPhrase> highlightedMessages;

--- a/tests/src/IrcMessageHandler.cpp
+++ b/tests/src/IrcMessageHandler.cpp
@@ -67,13 +67,8 @@ const QString IRC_CATEGORY = u"IrcMessageHandler"_s;
 class MockApplication : public mock::BaseApplication
 {
 public:
-    MockApplication()
-        : highlights(this->settings, &this->accounts)
-    {
-    }
-
     MockApplication(const QString &settingsData)
-        : mock::BaseApplication(settingsData)
+        : mock::BaseApplication(settingsData, /*runMigrations*/ true)
         , highlights(this->settings, &this->accounts)
     {
     }


### PR DESCRIPTION
From #6695

These changes don't do anything on their own other than add a setting that contains the version of the `settings.json` file that can be used to see if certain migrations need to be run.

The first migration I plan is from #6695 where we will read old highlights and convert them to the new format.

<!--
    Make sure you read the contribution guidelines:
    https://github.com/Chatterino/chatterino2/blob/master/CONTRIBUTING.md

    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
