### PR TITLE
fix: unlock badge sets map before calling pending callbacks

### DIFF
--- a/src/providers/twitch/TwitchBadges.cpp
+++ b/src/providers/twitch/TwitchBadges.cpp
@@ -38,29 +38,31 @@ void TwitchBadges::loadTwitchBadges()
 
     getHelix()->getGlobalBadges(
         [this](auto globalBadges) {
-            auto badgeSets = this->badgeSets_.access();
-
-            for (const auto &badgeSet : globalBadges.badgeSets)
             {
-                const auto &setID = badgeSet.setID;
-                for (const auto &version : badgeSet.versions)
+                auto badgeSets = this->badgeSets_.access();
+
+                for (const auto &badgeSet : globalBadges.badgeSets)
                 {
-                    const auto &emote = Emote{
-                        .name = EmoteName{},
-                        .images =
-                            ImageSet{
-                                Image::fromUrl(version.imageURL1x, 1,
-                                               BADGE_BASE_SIZE),
-                                Image::fromUrl(version.imageURL2x, .5,
-                                               BADGE_BASE_SIZE * 2),
-                                Image::fromUrl(version.imageURL4x, .25,
-                                               BADGE_BASE_SIZE * 4),
-                            },
-                        .tooltip = Tooltip{version.title},
-                        .homePage = version.clickURL,
-                    };
-                    (*badgeSets)[setID][version.id] =
-                        std::make_shared<Emote>(emote);
+                    const auto &setID = badgeSet.setID;
+                    for (const auto &version : badgeSet.versions)
+                    {
+                        const auto &emote = Emote{
+                            .name = EmoteName{},
+                            .images =
+                                ImageSet{
+                                    Image::fromUrl(version.imageURL1x, 1,
+                                                   BADGE_BASE_SIZE),
+                                    Image::fromUrl(version.imageURL2x, .5,
+                                                   BADGE_BASE_SIZE * 2),
+                                    Image::fromUrl(version.imageURL4x, .25,
+                                                   BADGE_BASE_SIZE * 4),
+                                },
+                            .tooltip = Tooltip{version.title},
+                            .homePage = version.clickURL,
+                        };
+                        (*badgeSets)[setID][version.id] =
+                            std::make_shared<Emote>(emote);
+                    }
                 }
             }
 


### PR DESCRIPTION
Not really reproducible easily, but if you're on a slow system or if you're using the highlights rework & move to the highlights page really quick with some badge there, you could reach a deadlock in the badge sets access.

This change ensures that the lock of badge sets is released before we start calling pending badge callbacks.

<!--
    Make sure you read the contribution guidelines:
    https://github.com/Chatterino/chatterino2/blob/master/CONTRIBUTING.md

    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
