### PR TITLE
refactor(notebook): Move saving to `SplitNotebook`

### DIFF
--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -124,9 +124,6 @@ NotebookTab *Notebook::addPage(QWidget *page, QString title, bool select)
 NotebookTab *Notebook::addPageAt(QWidget *page, int position, QString title,
                                  bool select)
 {
-    // Queue up save because: Tab added
-    getApp()->getWindows()->queueSave();
-
     auto *tab = new NotebookTab(this);
     tab->page = page;
 
@@ -156,14 +153,12 @@ NotebookTab *Notebook::addPageAt(QWidget *page, int position, QString title,
 
     this->performLayout();
     tab->setVisible(this->shouldShowTab(tab));
+    this->afterPageAdded();
     return tab;
 }
 
 void Notebook::removePage(QWidget *page)
 {
-    // Queue up save because: Tab removed
-    getApp()->getWindows()->queueSave();
-
     int removingIndex = this->indexOf(page);
     assert(removingIndex != -1);
 
@@ -208,6 +203,7 @@ void Notebook::removePage(QWidget *page)
     this->items_.removeAt(removingIndex);
 
     this->performLayout(true);
+    this->afterPageRemoved();
 }
 
 void Notebook::duplicatePage(QWidget *page)
@@ -689,12 +685,10 @@ void Notebook::rearrangePage(QWidget *page, int index)
         return;
     }
 
-    // Queue up save because: Tab rearranged
-    getApp()->getWindows()->queueSave();
-
     this->items_.move(this->indexOf(page), index);
 
     this->performLayout(true);
+    this->afterPageMoved();
 }
 
 bool Notebook::getAllowUserTabManagement() const
@@ -1355,8 +1349,8 @@ void Notebook::sortTabsAlphabetically()
         return lhs.compare(rhs, Qt::CaseInsensitive) < 0;
     });
 
-    getApp()->getWindows()->queueSave();
     this->performLayout(true);
+    this->afterPageMoved();
 }
 
 SplitNotebook::SplitNotebook(Window *parent)
@@ -1771,6 +1765,21 @@ void SplitNotebook::setLockNotebookLayout(bool value)
 {
     Notebook::setLockNotebookLayout(value);
     this->sortTabsAlphabeticallyAction_->setEnabled(!value);
+}
+
+void SplitNotebook::afterPageAdded()
+{
+    getApp()->getWindows()->queueSave();
+}
+
+void SplitNotebook::afterPageRemoved()
+{
+    getApp()->getWindows()->queueSave();
+}
+
+void SplitNotebook::afterPageMoved()
+{
+    getApp()->getWindows()->queueSave();
 }
 
 }  // namespace chatterino

--- a/src/widgets/Notebook.hpp
+++ b/src/widgets/Notebook.hpp
@@ -144,6 +144,16 @@ protected:
     void mousePressEvent(QMouseEvent *event) override;
     void paintEvent(QPaintEvent *) override;
 
+    virtual void afterPageAdded()
+    {
+    }
+    virtual void afterPageRemoved()
+    {
+    }
+    virtual void afterPageMoved()
+    {
+    }
+
     DrawnButton *addButton_;
 
     template <typename T>
@@ -282,6 +292,10 @@ public:
 
 protected:
     void showEvent(QShowEvent *event) override;
+
+    void afterPageAdded() override;
+    void afterPageRemoved() override;
+    void afterPageMoved() override;
 
 private:
     QAction *sortTabsAlphabeticallyAction_;


### PR DESCRIPTION
`Notebook` should be a reusable component not tied to splits. We should be able to use `Notebook` similar to a `QTabLayout` to implement tabs. This has the upside that we control the painting. Whereas with `QTabLayout`, much of the colors are chosen in the theme.

This is the first part where `getApp()->getWindows()->queueSave()` is moved out to `SplitNotebook`. I added "events" when pages are modified where it hooks into.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
