### PR TITLE
fix: Clear connection cache when we hit a timeout in eventsub::SubscriptionRequest

### DIFF
--- a/src/common/network/NetworkTask.cpp
+++ b/src/common/network/NetworkTask.cpp
@@ -194,6 +194,8 @@ void NetworkTask::timeout()
         << this->data_->typeString() << "[timed out]"
         << this->data_->request.url().toString();
 
+    NetworkManager::accessManager->clearConnectionCache();
+
     this->data_->emitError({NetworkResult::NetworkError::TimeoutError, {}, {}});
     this->data_->emitFinally();
 }

--- a/src/common/network/NetworkTask.cpp
+++ b/src/common/network/NetworkTask.cpp
@@ -194,6 +194,19 @@ void NetworkTask::timeout()
         << this->data_->typeString() << "[timed out]"
         << this->data_->request.url().toString();
 
+    // If we have a stuck connection, QNetworkAccessManager does not have
+    // any means to detect it as stuck and may try to keep using it to issue
+    // HTTP requests. This will cause all issued requests to fail with
+    // a timeout and no indication that they were probably never delivered
+    // to the remote server.
+    //
+    // Calling clearConnectionCache() removes all connections from cache,
+    // forcing QNetworkAccessManager internals to open up a new healthy
+    // connection.
+    //
+    // Since we have no good way of detecting if the request timed out because
+    // of a stuck connection, clearing the connection cache on every timeout
+    // seems like the only way how to reliably recover from such a situation.
     NetworkManager::accessManager->clearConnectionCache();
 
     this->data_->emitError({NetworkResult::NetworkError::TimeoutError, {}, {}});


### PR DESCRIPTION
If the IP address of the machine changes while Chatterino is running, the connection that is used to issue subscription requests can get stuck in an unusable state from which it may not recover. When that happens, subscription attempts keep throwing errors like:

```
chatterino.twitch.eventsub: Unhandled error, retrying subscription "TimeoutError" eventsub::SubscriptionRequest[channel.chat.user_message_hold.1]{broadcaster_user_id=110240192, user_id=503262342}
```
The broken connection will still be using the old IP address and its outbound queue will keep growing.

```
      ESTAB 0      0      192.168.1.198:45778   34.212.92.60:443  users:(("chatterino",pid=7037,fd=61))
      ESTAB 0      594    192.168.1.196:53678    78.47.52.88:443  users:(("chatterino",pid=7037,fd=74))
      ESTAB 0      0      192.168.1.198:54988  172.67.68.177:443  users:(("chatterino",pid=7037,fd=44))
      ESTAB 0      0      192.168.1.198:36384  37.27.171.119:443  users:(("chatterino",pid=7037,fd=46))
-->   ESTAB 0      130572 192.168.1.196:34568  13.227.192.16:443  users:(("chatterino",pid=7037,fd=48))
      ESTAB 0      0      192.168.1.198:48480 199.232.18.214:443  users:(("chatterino",pid=7037,fd=49))
```

After sufficient time the outbound queue eventually fills up, next attempt to write to it will fail, allowing Chatterino to detect an error and create a new connection. That, however, is not very reliable and can take a long time.

Since the problematic connection is handled internally by QNetworkAccessManager, options how to deal with this are limited. What seems to work is calling `clearConnectionCache()` when a network request made through QNetworkAccessManager fails with a timeout.

I can reproduce the issue reliably by adjusting connection options in NetworkManager to make my computer appear like a different machine every time it connects to my WiFi router. DHCP then assigns it a different IP when I disconnect and connect back, triggering the issue.

This might solve https://github.com/Chatterino/chatterino2/issues/6205

<!--
    Make sure you read the contribution guidelines:
    https://github.com/Chatterino/chatterino2/blob/master/CONTRIBUTING.md

    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
