### PR TITLE
perf: reduce startup lag by reusing 7TV user response data

### DIFF
--- a/src/providers/seventv/SeventvAPI.cpp
+++ b/src/providers/seventv/SeventvAPI.cpp
@@ -22,7 +22,8 @@ const QString API_URL_PRESENCES = u"https://7tv.io/v3/users/%1/presences"_s;
 namespace chatterino {
 
 void SeventvAPI::getUserByTwitchID(
-    const QString &twitchID, SuccessCallback<const QJsonObject &> &&onSuccess,
+    const QString &twitchID,
+    SuccessCallback<const QJsonObject &, const QByteArray &> &&onSuccess,
     ErrorCallback &&onError)
 {
     NetworkRequest(API_URL_USER.arg(twitchID), NetworkRequestType::Get)
@@ -30,7 +31,7 @@ void SeventvAPI::getUserByTwitchID(
         .onSuccess(
             [callback = std::move(onSuccess)](const NetworkResult &result) {
                 auto json = result.parseJson();
-                callback(json);
+                callback(json, result.getData());
             })
         .onError([callback = std::move(onError)](const NetworkResult &result) {
             callback(result);
@@ -38,16 +39,17 @@ void SeventvAPI::getUserByTwitchID(
         .execute();
 }
 
-void SeventvAPI::getEmoteSet(const QString &emoteSet,
-                             SuccessCallback<const QJsonObject &> &&onSuccess,
-                             ErrorCallback &&onError)
+void SeventvAPI::getEmoteSet(
+    const QString &emoteSet,
+    SuccessCallback<const QJsonObject &, const QByteArray &> &&onSuccess,
+    ErrorCallback &&onError)
 {
     NetworkRequest(API_URL_EMOTE_SET.arg(emoteSet), NetworkRequestType::Get)
         .timeout(25000)
         .onSuccess(
             [callback = std::move(onSuccess)](const NetworkResult &result) {
                 auto json = result.parseJson();
-                callback(json);
+                callback(json, result.getData());
             })
         .onError([callback = std::move(onError)](const NetworkResult &result) {
             callback(result);

--- a/src/providers/seventv/SeventvAPI.hpp
+++ b/src/providers/seventv/SeventvAPI.hpp
@@ -8,6 +8,7 @@
 
 class QString;
 class QJsonObject;
+class QByteArray;
 
 namespace chatterino {
 

--- a/src/providers/seventv/SeventvAPI.hpp
+++ b/src/providers/seventv/SeventvAPI.hpp
@@ -28,12 +28,14 @@ public:
     SeventvAPI &operator=(const SeventvAPI &) = delete;
     SeventvAPI &operator=(SeventvAPI &&) = delete;
 
-    void getUserByTwitchID(const QString &twitchID,
-                           SuccessCallback<const QJsonObject &> &&onSuccess,
-                           ErrorCallback &&onError);
-    void getEmoteSet(const QString &emoteSet,
-                     SuccessCallback<const QJsonObject &> &&onSuccess,
-                     ErrorCallback &&onError);
+    void getUserByTwitchID(
+        const QString &twitchID,
+        SuccessCallback<const QJsonObject &, const QByteArray &> &&onSuccess,
+        ErrorCallback &&onError);
+    void getEmoteSet(
+        const QString &emoteSet,
+        SuccessCallback<const QJsonObject &, const QByteArray &> &&onSuccess,
+        ErrorCallback &&onError);
 
     void updatePresence(const QString &twitchChannelID,
                         const QString &seventvUserID,

--- a/src/providers/seventv/SeventvEmotes.cpp
+++ b/src/providers/seventv/SeventvEmotes.cpp
@@ -243,9 +243,8 @@ void SeventvEmotes::loadGlobalEmotes()
 
     getApp()->getSeventvAPI()->getEmoteSet(
         u"global"_s,
-        [this](const auto &json) {
-            writeProviderEmotesCache("global", "seventv",
-                                     QJsonDocument(json).toJson());
+        [this](const auto &json, const auto &raw) {
+            writeProviderEmotesCache("global", "seventv", raw);
             QJsonArray parsedEmotes = json["emotes"].toArray();
 
             auto emoteMap = parseEmotes(parsedEmotes, true);
@@ -275,10 +274,9 @@ void SeventvEmotes::loadChannelEmotes(
 
     getApp()->getSeventvAPI()->getUserByTwitchID(
         channelId,
-        [callback = std::move(callback), channel, channelId,
-         manualRefresh](const auto &json) {
-            writeProviderEmotesCache(channelId, "seventv",
-                                     QJsonDocument(json).toJson());
+        [callback = std::move(callback), channel, channelId, manualRefresh](
+            const auto &json, const auto &raw) {
+            writeProviderEmotesCache(channelId, "seventv", raw);
             const auto emoteSet = json["emote_set"].toObject();
             const auto parsedEmotes = emoteSet["emotes"].toArray();
 
@@ -441,7 +439,8 @@ void SeventvEmotes::getEmoteSet(
 
     getApp()->getSeventvAPI()->getEmoteSet(
         emoteSetId,
-        [callback = std::move(successCallback), emoteSetId](const auto &json) {
+        [callback = std::move(successCallback), emoteSetId](
+            const auto &json, const auto & /*raw*/) {
             assert(!isAppAboutToQuit());
 
             auto parsedEmotes = json["emotes"].toArray();

--- a/src/providers/twitch/TwitchAccount.cpp
+++ b/src/providers/twitch/TwitchAccount.cpp
@@ -364,7 +364,7 @@ void TwitchAccount::loadSeventvUserID()
 
     seventv->getUserByTwitchID(
         this->getUserId(),
-        [this](const auto &json) {
+        [this](const auto &json, const auto & /*raw*/) {
             const auto id = json["user"]["id"].toString();
             if (!id.isEmpty())
             {


### PR DESCRIPTION
I noticed that we were re-serializing the JSON we got from 7TV to write to the emote provider cache. Even worse, it was indented (default for QJsonDocument). With this PR, we reuse the raw data we get from the network. That's what we do for the other providers already.

The 7TV emotes still show up in a profile. Notably, parsing the JSON takes a large chunk of that. I wonder if using Boost.Json helps here. Their parser is a lot faster. I have a wrapper for it in a fork with an API similar to the QJson* one (forgiving). Could try to include it here.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
