### PR TITLE
fix: use channel type from `IndirectChannel`

### DIFF
--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -1367,13 +1367,13 @@ SplitDescriptor Split::buildDescriptor() const
     descriptor.filters_ = this->getFilters();
     descriptor.spellCheckOverride = this->checkSpellingOverride();
 
-    auto chan = this->getChannel();
-    descriptor.type_ = qmagicenum::enumNameString(chan->getType());
-    switch (this->channel_.getType())
+    auto chan = this->getIndirectChannel();
+    descriptor.type_ = qmagicenum::enumNameString(chan.getType());
+    switch (chan.getType())
     {
         case Channel::Type::Twitch:
         case Channel::Type::Misc:
-            descriptor.channelName_ = chan->getName();
+            descriptor.channelName_ = chan.get()->getName();
             break;
 
         case Channel::Type::TwitchWhispers:

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -1369,7 +1369,7 @@ SplitDescriptor Split::buildDescriptor() const
 
     auto chan = this->getChannel();
     descriptor.type_ = qmagicenum::enumNameString(chan->getType());
-    switch (chan->getType())
+    switch (this->channel_.getType())
     {
         case Channel::Type::Twitch:
         case Channel::Type::Misc:

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -828,7 +828,7 @@ void Split::openChannelInCustomPlayer(const QString channelName)
     openInCustomPlayer(channelName);
 }
 
-IndirectChannel Split::getIndirectChannel()
+IndirectChannel Split::getIndirectChannel() const
 {
     return this->channel_;
 }

--- a/src/widgets/splits/Split.hpp
+++ b/src/widgets/splits/Split.hpp
@@ -59,7 +59,7 @@ public:
     SplitInput &getInput();
     [[nodiscard]] PinnedMessageWidget *getPinnedBanner() const;
 
-    IndirectChannel getIndirectChannel();
+    IndirectChannel getIndirectChannel() const;
     ChannelPtr getChannel() const;
     void setChannel(IndirectChannel newChannel);
 


### PR DESCRIPTION
We need to use the type from the indirect channel, otherwise the `Watching` type won't be retained.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
