### PR TITLE
refactor: extract SplitBanner from PinnedMessageWidget

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -865,6 +865,8 @@ set(SOURCE_FILES
         widgets/splits/InputHighlighter.hpp
         widgets/splits/Split.cpp
         widgets/splits/Split.hpp
+        widgets/splits/SplitBanner.cpp
+        widgets/splits/SplitBanner.hpp
         widgets/splits/SplitCommon.hpp
         widgets/splits/SplitContainer.cpp
         widgets/splits/SplitContainer.hpp

--- a/src/widgets/splits/PinnedMessageWidget.cpp
+++ b/src/widgets/splits/PinnedMessageWidget.cpp
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2026 Contributors to Chatterino <https://chatterino.com>
+// SPDX-FileCopyrightText: 2026 Contributors to Chatterino <https://chatterino.com>
 //
 // SPDX-License-Identifier: MIT
 
@@ -10,17 +10,13 @@
 #include "providers/twitch/TwitchAccount.hpp"
 #include "providers/twitch/TwitchChannel.hpp"
 #include "singletons/Settings.hpp"
-#include "singletons/Theme.hpp"
 #include "widgets/buttons/DrawnButton.hpp"
 
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QMenu>
-#include <QPainter>
-#include <QPaintEvent>
 #include <QScrollArea>
 #include <QShowEvent>
-#include <QTimer>
 #include <QVBoxLayout>
 
 using namespace std::chrono_literals;
@@ -32,46 +28,19 @@ using namespace Qt::Literals;
 
 namespace chatterino {
 
-namespace {
-
-constexpr auto MUTED_STYLE = "color: #adadb8;";
-
-}  // namespace
-
 PinnedMessageWidget::PinnedMessageWidget(QWidget *parent)
-    : BaseWidget(parent)
-    , pinnedByLabel_(new QLabel(this))
-    , countdownLabel_(new QLabel(this))
+    : SplitBanner(parent)
     , menuButton_(new DrawnButton(DrawnButton::Symbol::Kebab, {}, this))
     , messageScrollArea_(new QScrollArea(this))
     , messageLabel_(new QLabel(this))
     , footerLabel_(new QLabel(this))
-    , progressTimer_(new QTimer(this))
-    , autoHideTimer_(new QTimer(this))
 {
-    this->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
-
-    auto *outerBox = new QVBoxLayout(this);
-    outerBox->setContentsMargins(0, 0, 0, 0);
-    outerBox->setSpacing(0);
-
-    auto *contentBox = new QVBoxLayout();
-    contentBox->setContentsMargins(8, 6, 8, 6);
-    contentBox->setSpacing(3);
-
     // Header row: "Pinned by <user>"  [⋮]
-    auto *headerRow = new QHBoxLayout();
-    headerRow->setSpacing(4);
-
-    headerRow->addWidget(this->pinnedByLabel_);
-    headerRow->addStretch(1);
     this->menuButton_->setScaleIndependentSize(28, 28);
     this->menuButton_->setToolTip(u"Mod options"_s);
     this->menuButton_->setMenu(this->buildModMenu());
     this->menuButton_->hide();
-    headerRow->addWidget(this->menuButton_);
-
-    contentBox->addLayout(headerRow);
+    this->headerRow()->addWidget(this->menuButton_);
 
     // Message body
     this->messageLabel_->setWordWrap(true);
@@ -95,7 +64,7 @@ PinnedMessageWidget::PinnedMessageWidget(QWidget *parent)
     this->messageScrollArea_->setSizePolicy(QSizePolicy::Expanding,
                                             QSizePolicy::Fixed);
     this->messageScrollArea_->setWidget(this->messageLabel_);
-    contentBox->addWidget(this->messageScrollArea_);
+    this->contentBox()->addWidget(this->messageScrollArea_);
 
     // Footer: [sender · time] ... [countdown]
     auto *footerRow = new QHBoxLayout();
@@ -106,53 +75,22 @@ PinnedMessageWidget::PinnedMessageWidget(QWidget *parent)
     footerRow->addWidget(this->footerLabel_);
     footerRow->addStretch(1);
 
-    this->countdownLabel_->setStyleSheet(MUTED_STYLE);
-    this->countdownLabel_->hide();
-    footerRow->addWidget(this->countdownLabel_);
-    contentBox->addLayout(footerRow);
-
-    outerBox->addLayout(contentBox);
-
-    // 1px bottom border - separates pin widget from the chat view below
-    auto *bottomBorder = new QWidget(this);
-    bottomBorder->setFixedHeight(1);
-    bottomBorder->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
-    bottomBorder->setAutoFillBackground(true);
-    {
-        QPalette pal = bottomBorder->palette();
-        pal.setColor(QPalette::Window, pal.color(QPalette::Mid));
-        bottomBorder->setPalette(pal);
-    }
-    outerBox->addWidget(bottomBorder);
-
-    // Countdown timer (fires every second)
-    this->progressTimer_->setInterval(1s);
-    QObject::connect(this->progressTimer_, &QTimer::timeout, this, [this] {
-        this->tickProgress();
-    });
-
-    // auto-hide timer
-    this->autoHideTimer_->setSingleShot(true);
-    QObject::connect(this->autoHideTimer_, &QTimer::timeout, this, [this] {
-        if (!this->userToggled_)
-        {
-            this->hide();
-        }
-    });
+    footerRow->addWidget(this->countdownLabel());
+    this->contentBox()->addLayout(footerRow);
 
     this->scaleChangedEvent(this->scale());
     this->hide();
 }
 
-void PinnedMessageWidget::tickProgress()
+void PinnedMessageWidget::tickCountdown()
 {
     const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
     const qint64 endsMs = this->pinEndsAt_.toMSecsSinceEpoch();
 
     if (nowMs >= endsMs)
     {
-        this->progressTimer_->stop();
-        this->countdownLabel_->hide();
+        this->stopCountdown();
+        this->countdownLabel()->hide();
         if (this->channel_)
         {
             this->channel_->clearPinnedMessage();
@@ -160,40 +98,17 @@ void PinnedMessageWidget::tickProgress()
         return;
     }
 
-    const qint64 remainingMs = endsMs - nowMs;
-    const qint64 totalSecs = (remainingMs + 999) / 1000;  // round up
-    const qint64 hours = totalSecs / 3600;
-    const qint64 mins = (totalSecs % 3600) / 60;
-    const qint64 secs = totalSecs % 60;
-
-    QString timeStr;
-    if (hours > 0)
-    {
-        timeStr = u"\u23F1 %1:%2:%3"_s.arg(hours)
-                      .arg(mins, 2, 10, QChar(u'0'))
-                      .arg(secs, 2, 10, QChar(u'0'));
-    }
-    else
-    {
-        timeStr = u"\u23F1 %1:%2"_s.arg(mins, 2, 10, QChar(u'0'))
-                      .arg(secs, 2, 10, QChar(u'0'));
-    }
-
-    this->countdownLabel_->setText(timeStr);
-    this->countdownLabel_->show();
+    this->countdownLabel()->setText(
+        u"\u23F1 %1"_s.arg(formatCountdown(endsMs - nowMs)));
+    this->countdownLabel()->show();
 }
 
-void PinnedMessageWidget::paintEvent(QPaintEvent *event)
+void PinnedMessageWidget::autoHide()
 {
-    QPainter painter(this);
-    auto *theme = getTheme();
-
-    // Fill background (same color as the split header above)
-    painter.fillRect(event->rect(), theme->splits.header.background);
-
-    // Draw 1px top border
-    painter.setPen(theme->splits.header.border);
-    painter.drawLine(0, 0, this->width() - 1, 0);
+    if (!this->userToggled_)
+    {
+        this->hide();
+    }
 }
 
 void PinnedMessageWidget::setChannel(TwitchChannel *channel)
@@ -201,7 +116,7 @@ void PinnedMessageWidget::setChannel(TwitchChannel *channel)
     this->signalHolder_.clear();
     this->channel_ = channel;
     this->userToggled_ = false;
-    this->autoHideTimer_->stop();
+    this->stopAutoHide();
 
     if (channel)
     {
@@ -274,8 +189,8 @@ void PinnedMessageWidget::refresh()
 {
     if (!this->channel_)
     {
-        this->progressTimer_->stop();
-        this->autoHideTimer_->stop();
+        this->stopCountdown();
+        this->stopAutoHide();
         this->userToggled_ = false;
         this->hide();
         return;
@@ -284,8 +199,8 @@ void PinnedMessageWidget::refresh()
     const auto *pin = this->channel_->getPinnedMessage();
     if (!pin)
     {
-        this->progressTimer_->stop();
-        this->autoHideTimer_->stop();
+        this->stopCountdown();
+        this->stopAutoHide();
         this->userToggled_ = false;
         this->hide();
         return;
@@ -293,7 +208,7 @@ void PinnedMessageWidget::refresh()
 
     const auto mode = static_cast<UsernameDisplayMode>(
         getSettings()->usernameDisplayMode.getValue());
-    this->pinnedByLabel_->setText(u"Pinned by <b>%1</b>"_s.arg(
+    this->headerLabel()->setText(u"Pinned by <b>%1</b>"_s.arg(
         pin->pinnedBy.formatted(mode).toHtmlEscaped()));
 
     this->messageLabel_->setText(pin->messageText);
@@ -306,13 +221,12 @@ void PinnedMessageWidget::refresh()
             pin->sender.formatted(mode).toHtmlEscaped(), sentAt));
     }
 
-    this->progressTimer_->stop();
-    this->countdownLabel_->hide();
+    this->stopCountdown();
+    this->countdownLabel()->hide();
     if (pin->endsAt.has_value() && pin->endsAt->isValid())
     {
         this->pinEndsAt_ = *pin->endsAt;
-        this->tickProgress();  // set initial text immediately
-        this->progressTimer_->start();
+        this->startCountdown();
     }
 
     const bool isMod = this->channel_->hasModRights();
@@ -321,10 +235,10 @@ void PinnedMessageWidget::refresh()
     this->show();
     this->updateMessageHeightIfNeeded();
 
-    this->autoHideTimer_->stop();
+    this->stopAutoHide();
     if (!getSettings()->alwaysShowPinnedMessage && !this->userToggled_)
     {
-        this->autoHideTimer_->start(30s);
+        this->startAutoHide(30s);
     }
 }
 
@@ -333,13 +247,13 @@ void PinnedMessageWidget::toggleUserPinned()
     if (this->isVisible())
     {
         this->userToggled_ = false;
-        this->autoHideTimer_->stop();
+        this->stopAutoHide();
         this->hide();
     }
     else
     {
         this->userToggled_ = true;
-        this->autoHideTimer_->stop();
+        this->stopAutoHide();
         this->show();
         this->updateMessageHeightIfNeeded();
     }
@@ -377,28 +291,25 @@ void PinnedMessageWidget::updateMessageHeightIfNeeded()
 
 void PinnedMessageWidget::resizeEvent(QResizeEvent *event)
 {
-    BaseWidget::resizeEvent(event);
+    SplitBanner::resizeEvent(event);
     this->updateMessageHeight();
 }
 
 void PinnedMessageWidget::showEvent(QShowEvent *event)
 {
-    BaseWidget::showEvent(event);
+    SplitBanner::showEvent(event);
     this->visibilityChanged.invoke();
 }
 
 void PinnedMessageWidget::hideEvent(QHideEvent *event)
 {
-    BaseWidget::hideEvent(event);
+    SplitBanner::hideEvent(event);
     this->visibilityChanged.invoke();
 }
 
 void PinnedMessageWidget::scaleChangedEvent(float newScale)
 {
-    QFont headerFont = this->pinnedByLabel_->font();
-    headerFont.setPointSizeF(9.5F * newScale);
-    this->pinnedByLabel_->setFont(headerFont);
-    this->countdownLabel_->setFont(headerFont);
+    SplitBanner::scaleChangedEvent(newScale);
 
     QFont bodyFont = this->messageLabel_->font();
     bodyFont.setPointSizeF(11.0F * newScale);
@@ -409,11 +320,6 @@ void PinnedMessageWidget::scaleChangedEvent(float newScale)
     QFont footerFont = this->footerLabel_->font();
     footerFont.setPointSizeF(9.0F * newScale);
     this->footerLabel_->setFont(footerFont);
-}
-
-void PinnedMessageWidget::mousePressEvent(QMouseEvent *event)
-{
-    // ignore to disable the parent's right click menu
 }
 
 }  // namespace chatterino

--- a/src/widgets/splits/PinnedMessageWidget.hpp
+++ b/src/widgets/splits/PinnedMessageWidget.hpp
@@ -1,14 +1,13 @@
-﻿// SPDX-FileCopyrightText: 2026 Contributors to Chatterino <https://chatterino.com>
+// SPDX-FileCopyrightText: 2026 Contributors to Chatterino <https://chatterino.com>
 //
 // SPDX-License-Identifier: MIT
 
 #pragma once
 
-#include "widgets/BaseWidget.hpp"
+#include "widgets/splits/SplitBanner.hpp"
 
 #include <pajlada/signals/signalholder.hpp>
 #include <QDateTime>
-#include <QTimer>
 
 #include <memory>
 
@@ -25,7 +24,7 @@ class DrawnButton;
  * Banner shown between the split header and the chat view that
  * displays the channel's currently pinned message.
  */
-class PinnedMessageWidget final : public BaseWidget
+class PinnedMessageWidget final : public SplitBanner
 {
     Q_OBJECT
 
@@ -46,14 +45,14 @@ protected:
     void hideEvent(QHideEvent *event) override;
     void resizeEvent(QResizeEvent *event) override;
     void scaleChangedEvent(float newScale) override;
-    void mousePressEvent(QMouseEvent *event) override;
+
+    void tickCountdown() override;
+    void autoHide() override;
 
 private:
-    void paintEvent(QPaintEvent *event) override;
     void refresh();
     /// Builds the moderator menu shown when clicking the menu button.
     std::unique_ptr<QMenu> buildModMenu();
-    void tickProgress();
     /// Sizes the message scroll area to its wrapped content, capped at the
     /// (scaled) maximum height. A vertical scrollbar appears past the cap.
     void updateMessageHeight();
@@ -68,8 +67,6 @@ private:
     pajlada::Signals::SignalHolder signalHolder_;
 
     // Header row
-    QLabel *pinnedByLabel_ = nullptr;
-    QLabel *countdownLabel_ = nullptr;
     /// Mod Menu.
     DrawnButton *menuButton_ = nullptr;
 
@@ -78,8 +75,6 @@ private:
     QLabel *messageLabel_ = nullptr;
     QLabel *footerLabel_ = nullptr;
 
-    QTimer *progressTimer_ = nullptr;
-    QTimer *autoHideTimer_ = nullptr;
     /// Scaled cap for the message body.
     int messageMaxHeight_ = 110;
     /// True while user manually pinned the widget.

--- a/src/widgets/splits/SplitBanner.cpp
+++ b/src/widgets/splits/SplitBanner.cpp
@@ -22,6 +22,8 @@ SplitBanner::SplitBanner(QWidget *parent)
     : BaseWidget(parent)
     , headerLabel_(new QLabel(this))
     , countdownLabel_(new QLabel(this))
+    , headerRow_(new QHBoxLayout())
+    , contentBox_(new QVBoxLayout())
     , countdownTimer_(new QTimer(this))
     , autoHideTimer_(new QTimer(this))
 {
@@ -31,11 +33,9 @@ SplitBanner::SplitBanner(QWidget *parent)
     outerBox->setContentsMargins(0, 0, 0, 0);
     outerBox->setSpacing(0);
 
-    this->contentBox_ = new QVBoxLayout();
     this->contentBox_->setContentsMargins(8, 6, 8, 6);
     this->contentBox_->setSpacing(3);
 
-    this->headerRow_ = new QHBoxLayout();
     this->headerRow_->setSpacing(4);
     this->headerRow_->addWidget(this->headerLabel_);
     this->headerRow_->addStretch(1);

--- a/src/widgets/splits/SplitBanner.cpp
+++ b/src/widgets/splits/SplitBanner.cpp
@@ -1,0 +1,166 @@
+// SPDX-FileCopyrightText: 2026 Contributors to Chatterino <https://chatterino.com>
+//
+// SPDX-License-Identifier: MIT
+
+#include "widgets/splits/SplitBanner.hpp"
+
+#include "singletons/Theme.hpp"
+
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPainter>
+#include <QPaintEvent>
+#include <QTimer>
+#include <QVBoxLayout>
+
+using namespace std::chrono_literals;
+using namespace Qt::Literals;
+
+namespace chatterino {
+
+SplitBanner::SplitBanner(QWidget *parent)
+    : BaseWidget(parent)
+    , headerLabel_(new QLabel(this))
+    , countdownLabel_(new QLabel(this))
+    , countdownTimer_(new QTimer(this))
+    , autoHideTimer_(new QTimer(this))
+{
+    this->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
+
+    auto *outerBox = new QVBoxLayout(this);
+    outerBox->setContentsMargins(0, 0, 0, 0);
+    outerBox->setSpacing(0);
+
+    this->contentBox_ = new QVBoxLayout();
+    this->contentBox_->setContentsMargins(8, 6, 8, 6);
+    this->contentBox_->setSpacing(3);
+
+    this->headerRow_ = new QHBoxLayout();
+    this->headerRow_->setSpacing(4);
+    this->headerRow_->addWidget(this->headerLabel_);
+    this->headerRow_->addStretch(1);
+    this->contentBox_->addLayout(this->headerRow_);
+
+    outerBox->addLayout(this->contentBox_);
+
+    // 1px bottom border - separates the banner from the chat view below
+    auto *bottomBorder = new QWidget(this);
+    bottomBorder->setFixedHeight(1);
+    bottomBorder->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    bottomBorder->setAutoFillBackground(true);
+    {
+        QPalette pal = bottomBorder->palette();
+        pal.setColor(QPalette::Window, pal.color(QPalette::Mid));
+        bottomBorder->setPalette(pal);
+    }
+    outerBox->addWidget(bottomBorder);
+
+    this->countdownLabel_->setStyleSheet(MUTED_STYLE);
+    this->countdownLabel_->hide();
+
+    this->countdownTimer_->setInterval(1s);
+    QObject::connect(this->countdownTimer_, &QTimer::timeout, this, [this] {
+        this->tickCountdown();
+    });
+
+    this->autoHideTimer_->setSingleShot(true);
+    QObject::connect(this->autoHideTimer_, &QTimer::timeout, this, [this] {
+        this->autoHide();
+    });
+}
+
+QLabel *SplitBanner::headerLabel() const
+{
+    return this->headerLabel_;
+}
+
+QHBoxLayout *SplitBanner::headerRow() const
+{
+    return this->headerRow_;
+}
+
+QVBoxLayout *SplitBanner::contentBox() const
+{
+    return this->contentBox_;
+}
+
+QLabel *SplitBanner::countdownLabel() const
+{
+    return this->countdownLabel_;
+}
+
+void SplitBanner::startCountdown()
+{
+    this->tickCountdown();
+    this->countdownTimer_->start();
+}
+
+void SplitBanner::stopCountdown()
+{
+    this->countdownTimer_->stop();
+}
+
+void SplitBanner::startAutoHide(std::chrono::milliseconds delay)
+{
+    this->autoHideTimer_->start(delay);
+}
+
+void SplitBanner::stopAutoHide()
+{
+    this->autoHideTimer_->stop();
+}
+
+void SplitBanner::tickCountdown()
+{
+}
+
+void SplitBanner::autoHide()
+{
+    this->hide();
+}
+
+QString SplitBanner::formatCountdown(qint64 millis)
+{
+    const qint64 totalSecs = (millis + 999) / 1000;  // round up
+    const qint64 hours = totalSecs / 3600;
+    const qint64 mins = (totalSecs % 3600) / 60;
+    const qint64 secs = totalSecs % 60;
+
+    if (hours > 0)
+    {
+        return u"%1:%2:%3"_s.arg(hours)
+            .arg(mins, 2, 10, QChar(u'0'))
+            .arg(secs, 2, 10, QChar(u'0'));
+    }
+
+    return u"%1:%2"_s.arg(mins, 2, 10, QChar(u'0'))
+        .arg(secs, 2, 10, QChar(u'0'));
+}
+
+void SplitBanner::scaleChangedEvent(float newScale)
+{
+    QFont headerFont = this->headerLabel_->font();
+    headerFont.setPointSizeF(9.5F * newScale);
+    this->headerLabel_->setFont(headerFont);
+    this->countdownLabel_->setFont(headerFont);
+}
+
+void SplitBanner::mousePressEvent(QMouseEvent *event)
+{
+    // ignore to disable the parent's right click menu
+}
+
+void SplitBanner::paintEvent(QPaintEvent *event)
+{
+    QPainter painter(this);
+    auto *theme = getTheme();
+
+    // Fill background (same color as the split header above)
+    painter.fillRect(event->rect(), theme->splits.header.background);
+
+    // Draw 1px top border
+    painter.setPen(theme->splits.header.border);
+    painter.drawLine(0, 0, this->width() - 1, 0);
+}
+
+}  // namespace chatterino

--- a/src/widgets/splits/SplitBanner.hpp
+++ b/src/widgets/splits/SplitBanner.hpp
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2026 Contributors to Chatterino <https://chatterino.com>
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "widgets/BaseWidget.hpp"
+
+#include <chrono>
+
+class QHBoxLayout;
+class QLabel;
+class QTimer;
+class QVBoxLayout;
+
+namespace chatterino {
+
+/// Base for banners shown between the split header and the chat view.
+/// Subclasses must call scaleChangedEvent() at the end of their constructor,
+/// once their own widgets exist.
+class SplitBanner : public BaseWidget
+{
+    Q_OBJECT
+
+public:
+    explicit SplitBanner(QWidget *parent = nullptr);
+
+protected:
+    static constexpr auto MUTED_STYLE = "color: #adadb8;";
+
+    QLabel *headerLabel() const;
+    /// Widgets added here sit after the leading label and a stretch.
+    QHBoxLayout *headerRow() const;
+    /// Content added here sits below the header row.
+    QVBoxLayout *contentBox() const;
+    /// Not placed in a layout - subclasses add it to the row they want.
+    QLabel *countdownLabel() const;
+
+    /// Ticks once immediately, then every second.
+    void startCountdown();
+    void stopCountdown();
+
+    void startAutoHide(std::chrono::milliseconds delay);
+    void stopAutoHide();
+
+    virtual void tickCountdown();
+    virtual void autoHide();
+
+    /// `H:MM:SS` from an hour up, `M:SS` below it. Rounds up.
+    static QString formatCountdown(qint64 millis);
+
+    /// Scales the header and countdown labels. Overrides have to call this.
+    void scaleChangedEvent(float newScale) override;
+    void mousePressEvent(QMouseEvent *event) override;
+    void paintEvent(QPaintEvent *event) override;
+
+private:
+    QLabel *headerLabel_ = nullptr;
+    QLabel *countdownLabel_ = nullptr;
+    QHBoxLayout *headerRow_ = nullptr;
+    QVBoxLayout *contentBox_ = nullptr;
+
+    QTimer *countdownTimer_ = nullptr;
+    QTimer *autoHideTimer_ = nullptr;
+};
+
+}  // namespace chatterino


### PR DESCRIPTION
Moves the generic banner out of `PinnedMessageWidget`  into a new `SplitBanner` base class, so future banners shown between the split header and the chat don't have to reimplement it.

`SplitBanner` provides:
- the header label, header row and content box layout
- countdown label
- the shared scale and paint handling

`PinnedMessageWidget` now derives from it and keeps only its usage specific parts.

No behavior change - the pinned message banner looks and behaves as before.