### PR TITLE
fix: Use Websocket ping - pong to detect a stuck connection

### DIFF
--- a/src/common/websockets/detail/WebSocketConnectionImpl.cpp
+++ b/src/common/websockets/detail/WebSocketConnectionImpl.cpp
@@ -10,6 +10,7 @@
 #include <boost/asio/strand.hpp>
 #include <boost/beast/core/bind_handler.hpp>
 #include <boost/beast/websocket/ssl.hpp>
+#include <boost/bind/bind.hpp>
 
 using namespace std::literals::string_view_literals;
 
@@ -17,6 +18,15 @@ namespace chatterino::ws::detail {
 
 namespace asio = boost::asio;
 namespace beast = boost::beast;
+
+// Use a long ping probe interval when there is regular traffic
+// going through the socket
+static constexpr std::chrono::seconds HEALTH_CHECK_INTERVAL_LONG =
+    std::chrono::seconds{60};
+// Use a short intervat when there is no traffic except for the
+// ping probe so that we can detect a failed socket quickly
+static constexpr std::chrono::seconds HEALTH_CHECK_INTERVAL_SHORT =
+    std::chrono::seconds{5};
 
 // MARK: WebSocketConnectionHelper
 
@@ -28,6 +38,8 @@ WebSocketConnectionHelper<Derived, Inner>::WebSocketConnectionHelper(
     : WebSocketConnection(std::move(options), id, std::move(listener), pool,
                           ioc)
     , stream(std::move(stream))
+    , healthCheckTimer(this->stream.get_executor())
+    , pingProbesTried(0)
 {
 }
 
@@ -247,6 +259,54 @@ void WebSocketConnectionHelper<Derived, Inner>::onWsHandshake(
         this->readBuffer,
         beast::bind_front_handler(&WebSocketConnectionHelper::onReadDone,
                                   this->shared_from_this()));
+
+    this->stream.control_callback(
+        boost::bind(&WebSocketConnectionHelper::onControlFrame, this,
+                    boost::placeholders::_1, boost::placeholders::_2));
+    this->healthCheckTimer.expires_after(HEALTH_CHECK_INTERVAL_LONG);
+    this->healthCheckTimer.async_wait(
+        boost::bind(&WebSocketConnectionHelper::onHealthCheck,
+                    this->shared_from_this(), boost::placeholders::_1));
+}
+
+template <typename Derived, typename Inner>
+void WebSocketConnectionHelper<Derived, Inner>::onHealthCheck(
+    const boost::system::error_code &ec)
+{
+    if (ec == boost::asio::error::operation_aborted || this->isClosing)
+    {
+        return;
+    }
+
+    if (this->pingProbesTried >= 3)
+    {
+        this->fail(boost::asio::error::network_down, u"ping");
+        return;
+    }
+
+    this->stream.async_ping({}, [](const boost::system::error_code ec) {
+        (void)ec;
+    });
+    this->pingProbesTried++;
+
+    // Use the short intervat so that we can detect a failed connection quickly
+    this->healthCheckTimer.expires_after(HEALTH_CHECK_INTERVAL_SHORT);
+    this->healthCheckTimer.async_wait(
+        boost::bind(&WebSocketConnectionHelper::onHealthCheck,
+                    this->shared_from_this(), boost::placeholders::_1));
+}
+
+template <typename Derived, typename Inner>
+void WebSocketConnectionHelper<Derived, Inner>::onControlFrame(
+    boost::beast::websocket::frame_type frame_type, std::string_view payload)
+{
+    (void)payload;
+
+    if (frame_type == boost::beast::websocket::frame_type::pong)
+    {
+        this->pingProbesTried = 0;
+        this->healthCheckTimer.expires_after(HEALTH_CHECK_INTERVAL_LONG);
+    }
 }
 
 template <typename Derived, typename Inner>
@@ -278,6 +338,10 @@ void WebSocketConnectionHelper<Derived, Inner>::onReadDone(
     {
         this->listener->onBinaryMessage(std::move(data));
     }
+
+    // We got data, push the health check back because the socket
+    // is obviously alive
+    this->healthCheckTimer.expires_after(HEALTH_CHECK_INTERVAL_LONG);
 
     this->stream.async_read(
         this->readBuffer,
@@ -339,6 +403,7 @@ void WebSocketConnectionHelper<Derived, Inner>::closeImpl()
     // cancel all pending operations
     this->resolver.cancel();
     beast::get_lowest_layer(this->stream).cancel();
+    this->healthCheckTimer.cancel();
 
     this->stream.async_close(
         beast::websocket::close_code::normal,

--- a/src/common/websockets/detail/WebSocketConnectionImpl.cpp
+++ b/src/common/websockets/detail/WebSocketConnectionImpl.cpp
@@ -336,6 +336,7 @@ void WebSocketConnectionHelper<Derived, Inner>::onReadDone(
     // We got data, push the health check back because the socket
     // is obviously alive
     this->scheduleHealthCheck(HEALTH_CHECK_INTERVAL_LONG);
+    this->pingProbesTried = 0;
 
     this->stream.async_read(
         this->readBuffer,

--- a/src/common/websockets/detail/WebSocketConnectionImpl.cpp
+++ b/src/common/websockets/detail/WebSocketConnectionImpl.cpp
@@ -22,8 +22,8 @@ namespace beast = boost::beast;
 // going through the socket
 static constexpr std::chrono::seconds HEALTH_CHECK_INTERVAL_LONG =
     std::chrono::seconds{60};
-// Use a short interval when there is no traffic except for the
-// ping probe so that we can detect a failed socket quickly
+// Use a short ping probe interval when we suspect that the connection
+// might be stuck so that we can fail and try to recover quickly
 static constexpr std::chrono::seconds HEALTH_CHECK_INTERVAL_SHORT =
     std::chrono::seconds{5};
 
@@ -38,7 +38,6 @@ WebSocketConnectionHelper<Derived, Inner>::WebSocketConnectionHelper(
                           ioc)
     , stream(std::move(stream))
     , healthCheckTimer(this->stream.get_executor())
-    , pingProbesTried(0)
 {
 }
 
@@ -289,7 +288,9 @@ void WebSocketConnectionHelper<Derived, Inner>::onHealthCheck(
     });
     this->pingProbesTried++;
 
-    // Use the short interval so that we can detect a failed connection quickly
+    // Since we needed to issue a ping check, there is a chance that the
+    // connection might be stuck. Use the short check interval so that
+    // we can fail quickly and try to recover
     this->healthCheckTimer.expires_after(HEALTH_CHECK_INTERVAL_SHORT);
     this->healthCheckTimer.async_wait(
         [self{this->shared_from_this()}](auto ec) {

--- a/src/common/websockets/detail/WebSocketConnectionImpl.cpp
+++ b/src/common/websockets/detail/WebSocketConnectionImpl.cpp
@@ -23,7 +23,7 @@ namespace beast = boost::beast;
 // going through the socket
 static constexpr std::chrono::seconds HEALTH_CHECK_INTERVAL_LONG =
     std::chrono::seconds{60};
-// Use a short intervat when there is no traffic except for the
+// Use a short interval when there is no traffic except for the
 // ping probe so that we can detect a failed socket quickly
 static constexpr std::chrono::seconds HEALTH_CHECK_INTERVAL_SHORT =
     std::chrono::seconds{5};
@@ -289,7 +289,7 @@ void WebSocketConnectionHelper<Derived, Inner>::onHealthCheck(
     });
     this->pingProbesTried++;
 
-    // Use the short intervat so that we can detect a failed connection quickly
+    // Use the short interval so that we can detect a failed connection quickly
     this->healthCheckTimer.expires_after(HEALTH_CHECK_INTERVAL_SHORT);
     this->healthCheckTimer.async_wait(
         boost::bind(&WebSocketConnectionHelper::onHealthCheck,

--- a/src/common/websockets/detail/WebSocketConnectionImpl.cpp
+++ b/src/common/websockets/detail/WebSocketConnectionImpl.cpp
@@ -10,7 +10,6 @@
 #include <boost/asio/strand.hpp>
 #include <boost/beast/core/bind_handler.hpp>
 #include <boost/beast/websocket/ssl.hpp>
-#include <boost/bind/bind.hpp>
 
 using namespace std::literals::string_view_literals;
 
@@ -260,13 +259,14 @@ void WebSocketConnectionHelper<Derived, Inner>::onWsHandshake(
         beast::bind_front_handler(&WebSocketConnectionHelper::onReadDone,
                                   this->shared_from_this()));
 
-    this->stream.control_callback(
-        boost::bind(&WebSocketConnectionHelper::onControlFrame, this,
-                    boost::placeholders::_1, boost::placeholders::_2));
+    this->stream.control_callback([this](auto frame_type, auto payload) {
+        this->onControlFrame(frame_type, payload);
+    });
     this->healthCheckTimer.expires_after(HEALTH_CHECK_INTERVAL_LONG);
     this->healthCheckTimer.async_wait(
-        boost::bind(&WebSocketConnectionHelper::onHealthCheck,
-                    this->shared_from_this(), boost::placeholders::_1));
+        [self{this->shared_from_this()}](auto ec) {
+            self->onHealthCheck(ec);
+        });
 }
 
 template <typename Derived, typename Inner>
@@ -284,7 +284,7 @@ void WebSocketConnectionHelper<Derived, Inner>::onHealthCheck(
         return;
     }
 
-    this->stream.async_ping({}, [](const boost::system::error_code ec) {
+    this->stream.async_ping({}, [](auto ec) {
         (void)ec;
     });
     this->pingProbesTried++;
@@ -292,8 +292,9 @@ void WebSocketConnectionHelper<Derived, Inner>::onHealthCheck(
     // Use the short interval so that we can detect a failed connection quickly
     this->healthCheckTimer.expires_after(HEALTH_CHECK_INTERVAL_SHORT);
     this->healthCheckTimer.async_wait(
-        boost::bind(&WebSocketConnectionHelper::onHealthCheck,
-                    this->shared_from_this(), boost::placeholders::_1));
+        [self{this->shared_from_this()}](auto ec) {
+            self->onHealthCheck(ec);
+        });
 }
 
 template <typename Derived, typename Inner>

--- a/src/common/websockets/detail/WebSocketConnectionImpl.cpp
+++ b/src/common/websockets/detail/WebSocketConnectionImpl.cpp
@@ -261,11 +261,7 @@ void WebSocketConnectionHelper<Derived, Inner>::onWsHandshake(
     this->stream.control_callback([this](auto frame_type, auto payload) {
         this->onControlFrame(frame_type, payload);
     });
-    this->healthCheckTimer.expires_after(HEALTH_CHECK_INTERVAL_LONG);
-    this->healthCheckTimer.async_wait(
-        [self{this->shared_from_this()}](auto ec) {
-            self->onHealthCheck(ec);
-        });
+    this->scheduleHealthCheck(HEALTH_CHECK_INTERVAL_LONG);
 }
 
 template <typename Derived, typename Inner>
@@ -291,11 +287,7 @@ void WebSocketConnectionHelper<Derived, Inner>::onHealthCheck(
     // Since we needed to issue a ping check, there is a chance that the
     // connection might be stuck. Use the short check interval so that
     // we can fail quickly and try to recover
-    this->healthCheckTimer.expires_after(HEALTH_CHECK_INTERVAL_SHORT);
-    this->healthCheckTimer.async_wait(
-        [self{this->shared_from_this()}](auto ec) {
-            self->onHealthCheck(ec);
-        });
+    this->scheduleHealthCheck(HEALTH_CHECK_INTERVAL_SHORT);
 }
 
 template <typename Derived, typename Inner>
@@ -307,7 +299,7 @@ void WebSocketConnectionHelper<Derived, Inner>::onControlFrame(
     if (frame_type == boost::beast::websocket::frame_type::pong)
     {
         this->pingProbesTried = 0;
-        this->healthCheckTimer.expires_after(HEALTH_CHECK_INTERVAL_LONG);
+        this->scheduleHealthCheck(HEALTH_CHECK_INTERVAL_LONG);
     }
 }
 
@@ -343,7 +335,7 @@ void WebSocketConnectionHelper<Derived, Inner>::onReadDone(
 
     // We got data, push the health check back because the socket
     // is obviously alive
-    this->healthCheckTimer.expires_after(HEALTH_CHECK_INTERVAL_LONG);
+    this->scheduleHealthCheck(HEALTH_CHECK_INTERVAL_LONG);
 
     this->stream.async_read(
         this->readBuffer,
@@ -372,6 +364,18 @@ void WebSocketConnectionHelper<Derived, Inner>::onWriteDone(
     }
 
     this->trySend();
+}
+
+template <typename Derived, typename Inner>
+template <typename Duration>
+void WebSocketConnectionHelper<Derived, Inner>::scheduleHealthCheck(
+    std::chrono::duration<Duration> timeout)
+{
+    this->healthCheckTimer.expires_after(timeout);
+    this->healthCheckTimer.async_wait(
+        [self{this->shared_from_this()}](auto ec) {
+            self->onHealthCheck(ec);
+        });
 }
 
 template <typename Derived, typename Inner>

--- a/src/common/websockets/detail/WebSocketConnectionImpl.hpp
+++ b/src/common/websockets/detail/WebSocketConnectionImpl.hpp
@@ -81,6 +81,8 @@ private:
     void onHealthCheck(const boost::system::error_code &ec);
     void onControlFrame(boost::beast::websocket::frame_type frame_type,
                         std::string_view payload);
+    template <typename Duration>
+    void scheduleHealthCheck(std::chrono::duration<Duration> timeout);
 
     friend Derived;
 

--- a/src/common/websockets/detail/WebSocketConnectionImpl.hpp
+++ b/src/common/websockets/detail/WebSocketConnectionImpl.hpp
@@ -9,6 +9,7 @@
 
 #include <boost/asio/ssl/context.hpp>
 #include <boost/asio/ssl/stream.hpp>
+#include <boost/asio/steady_timer.hpp>
 #include <boost/beast/core/tcp_stream.hpp>
 #include <boost/beast/websocket/stream.hpp>
 
@@ -77,6 +78,9 @@ private:
 
     void onReadDone(boost::system::error_code ec, size_t bytesRead);
     void onWriteDone(boost::system::error_code ec, size_t bytesWritten);
+    void onHealthCheck(const boost::system::error_code &ec);
+    void onControlFrame(boost::beast::websocket::frame_type frame_type,
+                        std::string_view payload);
 
     friend Derived;
 
@@ -85,6 +89,9 @@ private:
     /// When we successfully resolve the host, we try to connect by
     /// iterating over these results.
     BalancedResolverResults resolvedEndpoints;
+
+    boost::asio::steady_timer healthCheckTimer;
+    int pingProbesTried;
 };
 
 /// A WebSocket connection over TLS (wss://).

--- a/src/common/websockets/detail/WebSocketConnectionImpl.hpp
+++ b/src/common/websockets/detail/WebSocketConnectionImpl.hpp
@@ -91,7 +91,7 @@ private:
     BalancedResolverResults resolvedEndpoints;
 
     boost::asio::steady_timer healthCheckTimer;
-    int pingProbesTried;
+    unsigned int pingProbesTried = 0;
 };
 
 /// A WebSocket connection over TLS (wss://).


### PR DESCRIPTION
If a Websocket connection fails in a way that the connection appears serviceable from the application's perspective but cannot really transfer any data, there is currently no way for us to detect this. This may happen after some network configuration changes or if there is an issue somewhere along the way between us and the remote peer.
We can leverage Websocket ping and pong frames to periodically probe the remote peer if we do not see any other traffic going through the Websocket connection.



<!--
    Make sure you read the contribution guidelines:
    https://github.com/Chatterino/chatterino2/blob/master/CONTRIBUTING.md

    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
