### PR TITLE
fix: show window on creation if specified

### DIFF
--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -374,7 +374,7 @@ Window &WindowManager::createWindow(WindowType type,
     }
 
     this->windows_.push_back(window);
-    if (args.parent)
+    if (args.show)
     {
         window->show();
     }


### PR DESCRIPTION
I noticed that the popup window was not shown when choosing `Open channel in a new popup window` in the right-click menu of the user avatar in the UserInfoPopup and then found that `createWindow` did not use `args.show`. This also affected the `/popup [channel]` command.

The bug was introduced in #7058.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: 7058
-->
