### PR TITLE
refactor(app): Separate connecting and reload emotes in Twitch IRC server

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -295,32 +295,21 @@ void Application::initialize(Settings &settings, const Modes &modes,
     this->initialized = true;
 }
 
-int Application::run()
+void Application::connect()
 {
     assert(this->initialized);
 
     this->twitch->connect();
+}
+
+int Application::run()
+{
+    this->connect();
 
     if (!this->args_.isFramelessEmbed)
     {
         this->windows->getMainWindow().show();
     }
-
-    getSettings()->enableBTTVChannelEmotes.connect(
-        [this] {
-            this->twitch->reloadAllBTTVChannelEmotes();
-        },
-        false);
-    getSettings()->enableFFZChannelEmotes.connect(
-        [this] {
-            this->twitch->reloadAllFFZChannelEmotes();
-        },
-        false);
-    getSettings()->enableSevenTVChannelEmotes.connect(
-        [this] {
-            this->twitch->reloadAllSevenTVChannelEmotes();
-        },
-        false);
 
     return QApplication::exec();
 }

--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -149,6 +149,8 @@ public:
     void aboutToQuit();
     void stop();
 
+    void connect();
+
     int run();
 
     friend void test();

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -286,6 +286,22 @@ void TwitchIrcServer::initialize()
                 }
             });
         });
+
+    getSettings()->enableBTTVChannelEmotes.connect(
+        [this] {
+            this->reloadAllBTTVChannelEmotes();
+        },
+        this->signalHolder, false);
+    getSettings()->enableFFZChannelEmotes.connect(
+        [this] {
+            this->reloadAllFFZChannelEmotes();
+        },
+        this->signalHolder, false);
+    getSettings()->enableSevenTVChannelEmotes.connect(
+        [this] {
+            this->reloadAllSevenTVChannelEmotes();
+        },
+        this->signalHolder, false);
 }
 
 void TwitchIrcServer::aboutToQuit()


### PR DESCRIPTION
The application now provides a `connect` method to connect to all required services (i.e. Twitch). Furthermore, the listeners for emotes are moved to the Twitch IRC server as they belong to it.

Both are intended to make the app usable in an embedded context where the host already runs the Qt event loop.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
