### PR TITLE
feat(commands): add element.copytext placeholder

### DIFF
--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -266,6 +266,7 @@ const std::unordered_map<QString, VariableReplacer> COMMAND_VARS{
     },
     // variables used in mod buttons and the like, these make no sense in normal commands, so they are left empty
     {"input.text", NO_OP_PLACEHOLDER},
+    {"element.copytext", NO_OP_PLACEHOLDER},
 };
 
 }  // namespace

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -2962,16 +2962,11 @@ void ChannelView::addCommandExecutionContextMenuItems(
     auto *cmdMenu = new QMenu(menu);
     executeAction->setMenu(cmdMenu);
 
-    QString elementCopyText = "";
+    QString elementCopyText;
     if (hoveredElement != nullptr)
     {
         hoveredElement->addCopyTextToString(elementCopyText);
-        // remove trailing space which addCopyTextToString adds if the hovered
-        // element is followed by a space
-        if (elementCopyText.endsWith(' '))
-        {
-            elementCopyText.truncate(elementCopyText.length() - 1);
-        }
+        elementCopyText = elementCopyText.trimmed();
     }
 
     for (auto &cmd : cmds)
@@ -2997,8 +2992,10 @@ void ChannelView::addCommandExecutionContextMenuItems(
             // Execute command through right-clicking a message -> Execute command
             QString value = getApp()->getCommands()->execCustomCommand(
                 inputText.split(' '), cmd, true, channel, layout->getMessage(),
-                {{"input.text", userText},
-                 {"element.copytext", elementCopyText}});
+                {
+                    {"input.text", userText},
+                    {"element.copytext", elementCopyText},
+                });
 
             value = getApp()->getCommands()->execCommand(value, channel, false);
 

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -2635,7 +2635,7 @@ void ChannelView::addContextMenuItems(
     addHiddenContextMenuItems(menu, hoveredElement, layout, event);
 
     // Add executable command options
-    this->addCommandExecutionContextMenuItems(menu, layout);
+    this->addCommandExecutionContextMenuItems(menu, hoveredElement, layout);
 
     this->messageMenuCreated.invoke(menu, hoveredElement);
 
@@ -2938,7 +2938,8 @@ void ChannelView::addTwitchLinkContextMenuItems(
 }
 
 void ChannelView::addCommandExecutionContextMenuItems(
-    QMenu *menu, const MessageLayoutPtr &layout)
+    QMenu *menu, const MessageLayoutElement *hoveredElement,
+    const MessageLayoutPtr &layout)
 {
     /* Get commands to be displayed in context menu;
      * only those that had the showInMsgContextMenu check box marked in the Commands page */
@@ -2961,6 +2962,18 @@ void ChannelView::addCommandExecutionContextMenuItems(
     auto *cmdMenu = new QMenu(menu);
     executeAction->setMenu(cmdMenu);
 
+    QString elementCopyText = "";
+    if (hoveredElement != nullptr)
+    {
+        hoveredElement->addCopyTextToString(elementCopyText);
+        // remove trailing space which addCopyTextToString adds if the hovered
+        // element is followed by a space
+        if (elementCopyText.endsWith(' '))
+        {
+            elementCopyText.truncate(elementCopyText.length() - 1);
+        }
+    }
+
     for (auto &cmd : cmds)
     {
         QString inputText = this->selection_.isEmpty()
@@ -2969,7 +2982,8 @@ void ChannelView::addCommandExecutionContextMenuItems(
 
         inputText.push_front(cmd.name + " ");
 
-        cmdMenu->addAction(cmd.name, [this, layout, cmd, inputText] {
+        cmdMenu->addAction(cmd.name, [this, layout, cmd, inputText,
+                                      elementCopyText] {
             /* Search popups and user message history's underlyingChannels aren't of type TwitchChannel, but
              * we would still like to execute commands from them. Use their source channel instead if applicable. */
             ChannelPtr channel = this->effectiveSourceChannel();
@@ -2983,9 +2997,8 @@ void ChannelView::addCommandExecutionContextMenuItems(
             // Execute command through right-clicking a message -> Execute command
             QString value = getApp()->getCommands()->execCustomCommand(
                 inputText.split(' '), cmd, true, channel, layout->getMessage(),
-                {
-                    {"input.text", userText},
-                });
+                {{"input.text", userText},
+                 {"element.copytext", elementCopyText}});
 
             value = getApp()->getCommands()->execCommand(value, channel, false);
 

--- a/src/widgets/helper/ChannelView.hpp
+++ b/src/widgets/helper/ChannelView.hpp
@@ -317,8 +317,9 @@ private:
                                     const MessageLayoutPtr &layout);
     void addTwitchLinkContextMenuItems(
         QMenu *menu, const MessageLayoutElement *hoveredElement);
-    void addCommandExecutionContextMenuItems(QMenu *menu,
-                                             const MessageLayoutPtr &layout);
+    void addCommandExecutionContextMenuItems(
+        QMenu *menu, const MessageLayoutElement *hoveredElement,
+        const MessageLayoutPtr &layout);
 
     int getLayoutWidth() const;
     void updatePauses();


### PR DESCRIPTION
This adds a `element.copytext` placeholder for commands that are executed through the right click menu.

Resolves #7145

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
