### PR TITLE
add indicator for account switcher and settings menu to make error mo…

### DIFF
--- a/docs/ChatterinoTheme.schema.json
+++ b/docs/ChatterinoTheme.schema.json
@@ -266,6 +266,17 @@
       "additionalProperties": false,
       "properties": {
         "accent": { "$ref": "#/definitions/qt-color" },
+        "accounts": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "expired": {
+              "$comment": "Marks an account whose login has expired.",
+              "$ref": "#/definitions/qt-color"
+            }
+          },
+          "required": ["expired"]
+        },
         "messages": {
           "type": "object",
           "additionalProperties": false,
@@ -423,6 +434,7 @@
       },
       "required": [
         "accent",
+        "accounts",
         "messages",
         "overlayMessages",
         "scrollbars",

--- a/resources/themes/Black.json
+++ b/resources/themes/Black.json
@@ -5,6 +5,9 @@
   },
   "colors": {
     "accent": "#00aeef",
+    "accounts": {
+      "expired": "#ff0000"
+    },
     "messages": {
       "backgrounds": {
         "alternate": "#0a0a0a",

--- a/resources/themes/Dark.json
+++ b/resources/themes/Dark.json
@@ -5,6 +5,9 @@
   },
   "colors": {
     "accent": "#00aeef",
+    "accounts": {
+      "expired": "#ff0000"
+    },
     "messages": {
       "backgrounds": {
         "alternate": "#222222",

--- a/resources/themes/Light.json
+++ b/resources/themes/Light.json
@@ -5,6 +5,9 @@
   },
   "colors": {
     "accent": "#00aeef",
+    "accounts": {
+      "expired": "#ff0000"
+    },
     "messages": {
       "backgrounds": {
         "alternate": "#dddddd",

--- a/resources/themes/White.json
+++ b/resources/themes/White.json
@@ -5,6 +5,9 @@
   },
   "colors": {
     "accent": "#00aeef",
+    "accounts": {
+      "expired": "#ff0000"
+    },
     "messages": {
       "backgrounds": {
         "alternate": "#f5f5f5",

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -780,6 +780,8 @@ set(SOURCE_FILES
         widgets/helper/EditableModelView.hpp
         widgets/helper/FontSettingWidget.cpp
         widgets/helper/FontSettingWidget.hpp
+        widgets/helper/ForegroundItemDelegate.cpp
+        widgets/helper/ForegroundItemDelegate.hpp
         widgets/helper/IconDelegate.cpp
         widgets/helper/IconDelegate.hpp
         widgets/helper/InvisibleSizeGrip.cpp

--- a/src/controllers/accounts/Account.hpp
+++ b/src/controllers/accounts/Account.hpp
@@ -17,6 +17,16 @@ public:
     virtual ~Account() = default;
 
     virtual QString toString() const = 0;
+
+    /// Whether this account's credentials are known to have expired.
+    ///
+    /// Providers that can detect this override it; the default is to assume
+    /// the credentials are still good.
+    virtual bool isExpired() const
+    {
+        return false;
+    }
+
     const QString &getCategory() const;
     ProviderId getProviderId() const;
 

--- a/src/controllers/accounts/AccountModel.cpp
+++ b/src/controllers/accounts/AccountModel.cpp
@@ -5,6 +5,7 @@
 #include "controllers/accounts/AccountModel.hpp"
 
 #include "controllers/accounts/Account.hpp"
+#include "singletons/Theme.hpp"
 #include "util/StandardItemHelper.hpp"
 
 namespace chatterino {
@@ -27,6 +28,39 @@ void AccountModel::getRowFromItem(const std::shared_ptr<Account> &item,
 {
     setStringItem(row[0], item->toString(), false);
     row[0]->setData(QFont("Segoe UI", 10), Qt::FontRole);
+
+    if (item->isExpired())
+    {
+        row[0]->setData(item->toString() + " (expired)", Qt::DisplayRole);
+        row[0]->setData(getTheme()->accounts.expired, Qt::ForegroundRole);
+        row[0]->setData(
+            "This account's login has expired - sign in again to use it",
+            Qt::ToolTipRole);
+    }
+    else
+    {
+        row[0]->setData({}, Qt::ForegroundRole);
+        row[0]->setData({}, Qt::ToolTipRole);
+    }
+}
+
+void AccountModel::refreshExpiredState()
+{
+    int rowIndex = 0;
+    for (const auto &row : this->rows())
+    {
+        if (!row.isCustomRow && row.original)
+        {
+            // A copy of the pointers is enough - the items they point at are
+            // the ones the model reads from
+            auto items = row.items;
+            this->getRowFromItem(*row.original, items);
+
+            auto index = this->index(rowIndex, 0);
+            this->dataChanged(index, index);
+        }
+        rowIndex++;
+    }
 }
 
 int AccountModel::beforeInsert(const std::shared_ptr<Account> &item,

--- a/src/controllers/accounts/AccountModel.hpp
+++ b/src/controllers/accounts/AccountModel.hpp
@@ -19,6 +19,9 @@ class AccountModel : public SignalVectorModel<std::shared_ptr<Account>>
 public:
     AccountModel(QObject *parent);
 
+    /// Re-reads the expired state of every account and updates the rows
+    void refreshExpiredState();
+
 protected:
     // turn a vector item into a model row
     std::shared_ptr<Account> getItemFromRow(

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -900,7 +900,7 @@ void IrcMessageHandler::handleNoticeMessage(Communi::IrcNoticeMessage *message)
 
     if (message->content().startsWith("Login auth", Qt::CaseInsensitive))
     {
-        getApp()->getAccounts()->twitch.loginExpired.invoke();
+        getApp()->getAccounts()->twitch.markCurrentAsExpired();
     }
 
     QString channelName;

--- a/src/providers/twitch/TwitchAccount.cpp
+++ b/src/providers/twitch/TwitchAccount.cpp
@@ -108,6 +108,23 @@ bool TwitchAccount::isAnon() const
     return this->isAnon_;
 }
 
+bool TwitchAccount::isExpired() const
+{
+    return this->expired_;
+}
+
+bool TwitchAccount::setExpired(bool expired)
+{
+    if (this->expired_ == expired)
+    {
+        return false;
+    }
+
+    this->expired_ = expired;
+
+    return true;
+}
+
 void TwitchAccount::loadBlocks()
 {
     assertInGuiThread();

--- a/src/providers/twitch/TwitchAccount.hpp
+++ b/src/providers/twitch/TwitchAccount.hpp
@@ -44,6 +44,19 @@ public:
 
     QString toString() const override;
 
+    /// Whether Twitch has rejected this account's OAuth token.
+    ///
+    /// This is not persisted - it's detected at runtime from an IRC
+    /// "Login authentication failed" notice or a 401 from Helix, and cleared
+    /// once the account is signed in again.
+    bool isExpired() const override;
+
+    /// Updates whether this account's token is known to be expired.
+    /// Returns true if the value changed, otherwise false.
+    ///
+    /// Prefer going through TwitchAccountManager, which also notifies the UI.
+    bool setExpired(bool expired);
+
     const QString &getUserName() const;
     const QString &getOAuthToken() const;
     const QString &getOAuthClient() const;
@@ -123,6 +136,7 @@ private:
     QString userName_;
     QString userId_;
     const bool isAnon_;
+    bool expired_ = false;
     Atomic<QColor> color_;
 
     QStringList userstateEmoteSets_;

--- a/src/providers/twitch/TwitchAccountManager.cpp
+++ b/src/providers/twitch/TwitchAccountManager.cpp
@@ -425,7 +425,7 @@ void TwitchAccountManager::markCurrentAsExpired()
 
 bool TwitchAccountManager::hasExpiredAccount() const
 {
-    std::lock_guard<std::mutex> lock(this->mutex_);
+    std::scoped_lock lock(this->mutex_);
 
     return std::ranges::any_of(this->accounts, [](const auto &account) {
         return account->isExpired();

--- a/src/providers/twitch/TwitchAccountManager.cpp
+++ b/src/providers/twitch/TwitchAccountManager.cpp
@@ -23,6 +23,8 @@
 
 #include <QStringBuilder>
 
+#include <algorithm>
+
 namespace {
 
 using namespace chatterino;
@@ -408,6 +410,28 @@ bool TwitchAccountManager::isLoggedIn() const
     return !this->currentUser_->isAnon();
 }
 
+void TwitchAccountManager::markCurrentAsExpired()
+{
+    if (!this->isLoggedIn())
+    {
+        return;
+    }
+
+    if (this->getCurrent()->setExpired(true))
+    {
+        this->loginExpiryChanged.invoke();
+    }
+}
+
+bool TwitchAccountManager::hasExpiredAccount() const
+{
+    std::lock_guard<std::mutex> lock(this->mutex_);
+
+    return std::ranges::any_of(this->accounts, [](const auto &account) {
+        return account->isExpired();
+    });
+}
+
 bool TwitchAccountManager::removeUser(TwitchAccount *account)
 {
     static const QString accountFormat("/accounts/uid%1");
@@ -451,6 +475,13 @@ TwitchAccountManager::AddUserResponse TwitchAccountManager::addUser(
 
         if (userUpdated)
         {
+            // A new token means the account was signed in again, so whatever
+            // made us mark it as expired no longer applies.
+            if (previousUser->setExpired(false))
+            {
+                this->loginExpiryChanged.invoke();
+            }
+
             return AddUserResponse::UserValuesUpdated;
         }
         else

--- a/src/providers/twitch/TwitchAccountManager.hpp
+++ b/src/providers/twitch/TwitchAccountManager.hpp
@@ -57,6 +57,16 @@ public:
 
     bool isLoggedIn() const;
 
+    /// Marks the account we're currently signed in as as having an expired
+    /// OAuth token, and notifies the UI if that's a change.
+    ///
+    /// Does nothing when signed out or when the account is already marked, so
+    /// it's safe to call this for every request Twitch rejects.
+    void markCurrentAsExpired();
+
+    /// Returns true if any of the added accounts has an expired OAuth token.
+    bool hasExpiredAccount() const;
+
     pajlada::Settings::Setting<QString> currentUsername{"/accounts/current",
                                                         ""};
 
@@ -72,9 +82,10 @@ public:
     pajlada::Signals::NoArgSignal userListUpdated;
     pajlada::Signals::NoArgSignal currentUserNameChanged;
 
-    /// Fired when the IRC server sends a "Login authentication failed" notice,
-    /// indicating the current OAuth token has expired.
-    pajlada::Signals::NoArgSignal loginExpired;
+    /// Fired when an account's expired state changes in either direction -
+    /// when Twitch rejects an account's OAuth token, and when that account is
+    /// signed in again. Listeners should re-read TwitchAccount::isExpired.
+    pajlada::Signals::NoArgSignal loginExpiryChanged;
 
     SignalVector<std::shared_ptr<TwitchAccount>> accounts;
 

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -208,10 +208,9 @@ void Helix::fetchStreams(
         })
         .onError([failureCallback](const auto &result) {
             // TODO: make better xd
-            if (getApp()->getAccounts()->twitch.isLoggedIn() &&
-                result.status().value_or(0) == 401)
+            if (result.status().value_or(0) == 401)
             {
-                getApp()->getAccounts()->twitch.loginExpired.invoke();
+                getApp()->getAccounts()->twitch.markCurrentAsExpired();
             }
             failureCallback();
         })
@@ -487,10 +486,9 @@ void Helix::fetchChannels(
             successCallback(channels);
         })
         .onError([failureCallback](const auto &result) {
-            if (getApp()->getAccounts()->twitch.isLoggedIn() &&
-                result.status().value_or(0) == 401)
+            if (result.status().value_or(0) == 401)
             {
-                getApp()->getAccounts()->twitch.loginExpired.invoke();
+                getApp()->getAccounts()->twitch.markCurrentAsExpired();
             }
             failureCallback();
         })

--- a/src/singletons/Theme.cpp
+++ b/src/singletons/Theme.cpp
@@ -85,6 +85,13 @@ void parseWindow(const QJsonObject &window, const QJsonObject &windowFallback,
     parseColor(theme, window, text);
 }
 
+void parseAccounts(const QJsonObject &accounts,
+                   const QJsonObject &accountsFallback,
+                   chatterino::Theme &theme)
+{
+    parseColor(theme, accounts, expired);
+}
+
 void parseTabs(const QJsonObject &tabs, const QJsonObject &tabsFallback,
                chatterino::Theme &theme)
 {
@@ -224,6 +231,8 @@ void parseColors(const QJsonObject &root, const QJsonObject &fallbackTheme,
 
     parseWindow(colors["window"_L1].toObject(),
                 fallbackColors["window"_L1].toObject(), theme);
+    parseAccounts(colors["accounts"_L1].toObject(),
+                  fallbackColors["accounts"_L1].toObject(), theme);
     parseTabs(colors["tabs"_L1].toObject(),
               fallbackColors["tabs"_L1].toObject(), theme);
     parseMessages(colors["messages"_L1].toObject(),

--- a/src/singletons/Theme.hpp
+++ b/src/singletons/Theme.hpp
@@ -88,6 +88,12 @@ public:
         QColor text;
     } window;
 
+    /// ACCOUNTS
+    struct {
+        /// Marks an account whose login has expired
+        QColor expired;
+    } accounts;
+
     /// TABS
     struct {
         TabColors regular;

--- a/src/widgets/AccountSwitchWidget.cpp
+++ b/src/widgets/AccountSwitchWidget.cpp
@@ -10,6 +10,8 @@
 #include "providers/twitch/TwitchAccount.hpp"
 #include "providers/twitch/TwitchCommon.hpp"
 #include "singletons/Settings.hpp"
+#include "singletons/Theme.hpp"
+#include "widgets/helper/ForegroundItemDelegate.hpp"
 
 namespace chatterino {
 
@@ -18,33 +20,25 @@ AccountSwitchWidget::AccountSwitchWidget(QWidget *parent)
 {
     auto *app = getApp();
 
-    this->addItem(ANONYMOUS_USERNAME_LABEL);
+    // Keeps the expired marker red while that account is the selected one
+    this->setItemDelegate(new ForegroundItemDelegate(this));
 
-    for (const auto &userName : app->getAccounts()->twitch.getUsernames())
-    {
-        this->addItem(userName);
-    }
+    this->refreshList();
 
     this->managedConnections_.managedConnect(
-        app->getAccounts()->twitch.userListUpdated, [=, this]() {
-            this->blockSignals(true);
-
-            this->clear();
-
-            this->addItem(ANONYMOUS_USERNAME_LABEL);
-
-            for (const auto &userName :
-                 app->getAccounts()->twitch.getUsernames())
-            {
-                this->addItem(userName);
-            }
-
-            this->refreshSelection();
-
-            this->blockSignals(false);
+        app->getAccounts()->twitch.userListUpdated, [this]() {
+            this->refreshList();
         });
 
-    this->refreshSelection();
+    this->managedConnections_.managedConnect(
+        app->getAccounts()->twitch.loginExpiryChanged, [this]() {
+            this->refreshList();
+        });
+
+    // The expired marker is a themed color, so it has to be re-applied
+    this->managedConnections_.managedConnect(getTheme()->updated, [this]() {
+        this->refreshList();
+    });
 
     QObject::connect(this, &QListWidget::clicked, [=, this] {
         if (!this->selectedItems().isEmpty())
@@ -68,6 +62,40 @@ AccountSwitchWidget::AccountSwitchWidget(QWidget *parent)
 void AccountSwitchWidget::refresh()
 {
     this->refreshSelection();
+}
+
+void AccountSwitchWidget::refreshList()
+{
+    this->blockSignals(true);
+
+    this->clear();
+
+    this->addAccountItem(ANONYMOUS_USERNAME_LABEL, false);
+
+    for (const auto &userName : getApp()->getAccounts()->twitch.getUsernames())
+    {
+        auto account =
+            getApp()->getAccounts()->twitch.findUserByUsername(userName);
+        this->addAccountItem(userName, account && account->isExpired());
+    }
+
+    this->refreshSelection();
+
+    this->blockSignals(false);
+}
+
+void AccountSwitchWidget::addAccountItem(const QString &userName, bool expired)
+{
+    auto *item = new QListWidgetItem(userName, this);
+
+    if (expired)
+    {
+        // Only the color marks this - spelling it out would widen the popup
+        // enough to make it scroll for long usernames
+        item->setForeground(getTheme()->accounts.expired);
+        item->setToolTip(
+            "This account's login has expired - sign in again to use it");
+    }
 }
 
 void AccountSwitchWidget::refreshSelection()

--- a/src/widgets/AccountSwitchWidget.hpp
+++ b/src/widgets/AccountSwitchWidget.hpp
@@ -20,6 +20,9 @@ public:
     void refresh();
 
 private:
+    /// Rebuilds the list from the current accounts, marking expired ones
+    void refreshList();
+    void addAccountItem(const QString &userName, bool expired);
     void refreshSelection();
 
     pajlada::Signals::SignalHolder managedConnections_;

--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -1619,29 +1619,46 @@ void SplitNotebook::addCustomButtons()
         },
         this->signalHolder_, false);
 
-    this->signalHolder_.managedConnect(
-        getApp()->getAccounts()->twitch.loginExpired,
-        [this, userBtn, expiredAccountSrc] {
+    auto updateUserButtonExpiry = [this, userBtn, normalAccountSrc,
+                                   expiredAccountSrc] {
+        if (getApp()->getAccounts()->twitch.hasExpiredAccount())
+        {
             userBtn->setSource(expiredAccountSrc);
+            userBtn->setToolTip("A login has expired - click to sign in again");
+
+            // Force the button visible, otherwise a user who hides it would
+            // never find out their login stopped working.
             if (!userBtn->isVisible())
             {
                 userBtn->setVisible(true);
                 this->performLayout();
             }
-        });
+            return;
+        }
+
+        userBtn->setSource(normalAccountSrc);
+        userBtn->setToolTip({});
+
+        auto oldVisibility = userBtn->isVisible();
+        auto newVisibility = !getSettings()->hideUserButton.getValue();
+        userBtn->setVisible(newVisibility);
+        if (oldVisibility != newVisibility)
+        {
+            this->performLayout();
+        }
+    };
 
     this->signalHolder_.managedConnect(
-        getApp()->getAccounts()->twitch.currentUserChanged,
-        [this, userBtn, normalAccountSrc] {
-            userBtn->setSource(normalAccountSrc);
-            auto oldVisibility = userBtn->isVisible();
-            auto newVisibility = !getSettings()->hideUserButton.getValue();
-            userBtn->setVisible(newVisibility);
-            if (oldVisibility != newVisibility)
-            {
-                this->performLayout();
-            }
-        });
+        getApp()->getAccounts()->twitch.loginExpiryChanged,
+        updateUserButtonExpiry);
+
+    // Removing an expired account should clear the warning too
+    this->signalHolder_.managedConnect(
+        getApp()->getAccounts()->twitch.userListUpdated,
+        updateUserButtonExpiry);
+
+    // Windows opened after a login expired should show the warning right away
+    updateUserButtonExpiry();
 
     QObject::connect(userBtn, &Button::leftClicked, [this, userBtn] {
         getApp()->getWindows()->showAccountSelectPopup(

--- a/src/widgets/helper/ForegroundItemDelegate.cpp
+++ b/src/widgets/helper/ForegroundItemDelegate.cpp
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2026 Contributors to Chatterino <https://chatterino.com>
+//
+// SPDX-License-Identifier: MIT
+
+#include "widgets/helper/ForegroundItemDelegate.hpp"
+
+#include <QApplication>
+#include <QBrush>
+#include <QPainter>
+#include <QStyle>
+
+namespace chatterino {
+
+void ForegroundItemDelegate::paint(QPainter *painter,
+                                   const QStyleOptionViewItem &option,
+                                   const QModelIndex &index) const
+{
+    auto foreground = index.data(Qt::ForegroundRole);
+    if (!option.state.testFlag(QStyle::State_Selected) ||
+        !foreground.canConvert<QBrush>())
+    {
+        QStyledItemDelegate::paint(painter, option, index);
+        return;
+    }
+
+    QStyleOptionViewItem opt(option);
+    this->initStyleOption(&opt, index);
+
+    auto brush = qvariant_cast<QBrush>(foreground);
+    if (opt.state.testFlag(QStyle::State_MouseOver))
+    {
+        // Keep a hover cue, since the view's own hover color is one of the
+        // things being painted over here
+        brush = QBrush(brush.color().lighter(115));
+    }
+
+    // Views can set their selection and hover backgrounds through a
+    // stylesheet, which wins over anything we put in the palette. So fill the
+    // row ourselves and take both states away from the style.
+    painter->fillRect(opt.rect, brush);
+    opt.backgroundBrush = brush;
+    opt.state &= ~(QStyle::State_Selected | QStyle::State_MouseOver);
+
+    // The row is now the marker color in every theme, so the text has to be
+    // readable on that rather than on the usual selection color.
+    opt.palette.setBrush(QPalette::Text, Qt::white);
+
+    const auto *style =
+        opt.widget ? opt.widget->style() : QApplication::style();
+    style->drawControl(QStyle::CE_ItemViewItem, &opt, painter, opt.widget);
+}
+
+}  // namespace chatterino

--- a/src/widgets/helper/ForegroundItemDelegate.hpp
+++ b/src/widgets/helper/ForegroundItemDelegate.hpp
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2026 Contributors to Chatterino <https://chatterino.com>
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <QStyledItemDelegate>
+
+namespace chatterino {
+
+/// An item delegate that keeps an item's Qt::ForegroundRole color visible
+/// while the item is selected, by using it as the selection color.
+///
+/// By default a selected item is painted in the usual selection colors, which
+/// hides any color an item uses to mark itself - exactly when the user has
+/// that item selected.
+class ForegroundItemDelegate : public QStyledItemDelegate
+{
+public:
+    using QStyledItemDelegate::QStyledItemDelegate;
+
+    void paint(QPainter *painter, const QStyleOptionViewItem &option,
+               const QModelIndex &index) const override;
+};
+
+}  // namespace chatterino

--- a/src/widgets/settingspages/AccountsPage.cpp
+++ b/src/widgets/settingspages/AccountsPage.cpp
@@ -8,9 +8,11 @@
 #include "controllers/accounts/AccountController.hpp"
 #include "controllers/accounts/AccountModel.hpp"
 #include "providers/twitch/TwitchCommon.hpp"
+#include "singletons/Theme.hpp"
 #include "util/LayoutCreator.hpp"
 #include "widgets/dialogs/LoginDialog.hpp"
 #include "widgets/helper/EditableModelView.hpp"
+#include "widgets/helper/ForegroundItemDelegate.hpp"
 
 #include <QDialogButtonBox>
 #include <QHeaderView>
@@ -28,14 +30,27 @@ AccountsPage::AccountsPage()
     LayoutCreator<AccountsPage> layoutCreator(this);
     auto layout = layoutCreator.emplace<QVBoxLayout>().withoutMargin();
 
+    auto *model = app->getAccounts()->createModel(nullptr);
+
     EditableModelView *view =
-        layout
-            .emplace<EditableModelView>(
-                app->getAccounts()->createModel(nullptr), false)
-            .getElement();
+        layout.emplace<EditableModelView>(model, false).getElement();
+
+    this->signalHolder_.managedConnect(
+        app->getAccounts()->twitch.loginExpiryChanged, [model] {
+            model->refreshExpiredState();
+        });
+
+    // The expired marker is a themed color, so it has to be re-applied
+    this->signalHolder_.managedConnect(getTheme()->updated, [model] {
+        model->refreshExpiredState();
+    });
 
     view->getTableView()->horizontalHeader()->setVisible(false);
     view->getTableView()->horizontalHeader()->setStretchLastSection(true);
+
+    // Keeps the expired marker red while that account's row is selected
+    view->getTableView()->setItemDelegate(
+        new ForegroundItemDelegate(view->getTableView()));
 
     // We can safely ignore this signal connection since we own the view
     std::ignore = view->addButtonPressed.connect([this] {

--- a/src/widgets/settingspages/AccountsPage.hpp
+++ b/src/widgets/settingspages/AccountsPage.hpp
@@ -6,6 +6,8 @@
 
 #include "widgets/settingspages/SettingsPage.hpp"
 
+#include <pajlada/signals/signalholder.hpp>
+
 namespace chatterino {
 
 class AccountSwitchWidget;
@@ -14,6 +16,9 @@ class AccountsPage : public SettingsPage
 {
 public:
     AccountsPage();
+
+private:
+    pajlada::Signals::SignalHolder signalHolder_;
 };
 
 }  // namespace chatterino


### PR DESCRIPTION
…re apparent

This pull addressees concerns brought up by #7155.

AI Disclaimer:
I would like to be completely transparent that I have only rudimentary knowledge of C++ and as such have no idea how the actual code base works.
This code was 100% AI Generated by Opus 5 through Claude Code.

This pull requests adds visual indicators to the account switcher popup, and the accounts tab in the settings menu to make it more apparent what the indicator added in #6919 actually is implying to the user, as brought up by @jupjohn in #7155. 

When an account expires, either through the Helix API or the IRC connection, the account icon turns red and is crossed out, indicating an error (#6919). Then, clicking on that brings up the account switcher menu, which now has the account highlight turn red when selected, or text turn red, indicating that there is an issue with that account. Hovering over it displays "This account's login has expired - sign in again to use it." In the settings menu, that also displays the account name in red with (expired) appended to the end, making it clear at a glance that the user needs to sign in again to that account for the issue to be resolved. 

In line with the contribution standards:
To the best of my ability, I have checked that no other functionality has broken, and will be running this branch's build for a period of time before finalizing this pull request. 
To the best of my ability, I have reviewed this code myself, and asked a friend who is more familiar with C++ to review it as well.
This description was written by hand, colours were based upon previous theme precedent, and no additional UI elements have been added in this PR. 

I have run the test suite and all tests pass. 
I have also, using a MITM proxy setup made sure that this also catches the "zombie" state that I outlined in #6919, specifics which are more detailed in that request. 

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
