### PR TITLE
fix: Plugin API: passing a MessageElement to Message:append_element

### DIFF
--- a/src/controllers/plugins/api/Message.cpp
+++ b/src/controllers/plugins/api/Message.cpp
@@ -767,6 +767,12 @@ void createUserType(sol::table &c2)
         },
         "append_element",
         sol::overload(
+            // Message:append_element(MessageElement)
+            // Create a clone of the given element and add it to the message
+            [](Message *msg, ElementRef &element) {
+                checkWritable(msg);
+                msg->elements.emplace_back(element.constElement()->clone());
+            },
             // Message:append_element(MessageElementInit)
             // Create a new element
             [](Message *msg, const sol::table &tbl) {
@@ -776,12 +782,6 @@ void createUserType(sol::table &c2)
                 {
                     msg->elements.emplace_back(std::move(el));
                 }
-            },
-            // Message:append_element(MessageElement)
-            // Create a clone of the given element and add it to the message
-            [](Message *msg, ElementRef &element) {
-                checkWritable(msg);
-                msg->elements.emplace_back(element.constElement()->clone());
             }),
         "clone",
         [](const Message &message) {

--- a/tests/lua/message/element.lua
+++ b/tests/lua/message/element.lua
@@ -1,0 +1,44 @@
+-- SPDX-FileCopyrightText: 2026 Contributors to Chatterino <https://chatterino.com>
+--
+-- SPDX-License-Identifier: CC0-1.0
+
+local chan = c2.Channel.by_name("mm2pl")
+assert(chan)
+
+local tests = {
+    append_element = function()
+        local msg = c2.Message.new({
+            elements = {
+                {
+                    type = "text",
+                    text = "abcde",
+                },
+                { type = "twitch-moderation" },
+            },
+        })
+        chan:add_message(msg)
+        local new_msg = c2.Message.new(msg)
+        local append_init_ok, append_init_err = pcall(function()
+            new_msg:append_element({
+                type = 'text',
+                text = 'foo'
+            })
+        end)
+        assert(append_init_ok)
+        local append_element_ok, append_element_err = pcall(function()
+            for index, element in ipairs(msg:elements()) do
+                new_msg:append_element(element)
+            end
+        end)
+        assert(append_element_ok)
+    end,
+}
+
+for name, fn in pairs(tests) do
+    chan:clear_messages() -- start off without any messages
+
+    local ok, res = pcall(fn)
+    if not ok then
+        error(name .. " failed: " .. res)
+    end
+end

--- a/tests/lua/message/element.lua
+++ b/tests/lua/message/element.lua
@@ -25,12 +25,16 @@ local tests = {
             })
         end)
         assert(append_init_ok)
+        assert(new_msg:elements()[1])
+        assert(new_msg:elements()[1].type == 'text' and new_msg:elements()[1].words[1] == 'foo')
         local append_element_ok, append_element_err = pcall(function()
             for index, element in ipairs(msg:elements()) do
                 new_msg:append_element(element)
             end
         end)
         assert(append_element_ok)
+        assert(new_msg:elements()[2])
+        assert(new_msg:elements()[2].type == 'text' and new_msg:elements()[2].words[1] == 'abcde')
     end,
 }
 


### PR DESCRIPTION
When passing a `MessageElement` instead of an init table to `Message:append_element` in a lua plugin, it would error with "Invalid message type" suggesting that it calls `elementFromTable`, i.e. acts as if a `MessageElementInit` table was passed.

Reordering the sol::overload so that the `Message:append_element(MessageElement)` one comes fixes this. I'm not 100% sure on this but it seems that the passed message element somehow matches as a `sol::table` under the hood so the MessageElementInit overload matches before MessageElement gets checked. With the order from this pr both passing a MessageElement and a MessageElementInit works as should.

Small example to test:

```lua
---@param msg c2.Message
local function change_message(msg)
    -- not :clone()ing here to get an empty elements array
    local newMessage = c2.Message.new(msg)
    newMessage:append_element({
        type = 'text'
        text = 'foo'
    })
    for index, element in ipairs(msg:elements()) do
        newMessage:append_element(element)
    end
end

c2.Channel.by_name('myChannel'):on_message_appended(change_message)
```

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
