### PR TITLE
feat(twitch): Fetch moderated channels on reconnect

### DIFF
--- a/mocks/include/mocks/Helix.hpp
+++ b/mocks/include/mocks/Helix.hpp
@@ -541,6 +541,12 @@ public:
                       failureCallback)),
                 (override));
 
+    MOCK_METHOD(void, getModeratedChannels,
+                (QString userID, ResultCallback<QSet<QString>> successCallback,
+                 (FailureCallback<QString> failureCallback),
+                 CancellationToken &&token),
+                (override));
+
     MOCK_METHOD(void, update, (QString clientId, QString oauthToken),
                 (override));
 

--- a/mocks/include/mocks/TwitchIrcServer.hpp
+++ b/mocks/include/mocks/TwitchIrcServer.hpp
@@ -160,6 +160,11 @@ public:
         return this->automodChannel;
     }
 
+    bool isModeratorIn(const QString & /* login */) const override
+    {
+        return false;
+    }
+
     ChannelPtr watchingChannelInner;
     IndirectChannel watchingChannel;
     ChannelPtr whispersChannel;

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -120,6 +120,7 @@ TwitchChannel::TwitchChannel(const QString &name)
     , bttvEmotes_(std::make_shared<EmoteMap>())
     , ffzEmotes_(std::make_shared<EmoteMap>())
     , seventvEmotes_(std::make_shared<EmoteMap>())
+    , mod_(getApp()->getTwitch()->isModeratorIn(name))
     , nextSharedChatSessionProbe_(QDateTime::currentDateTime())
 {
     qCDebug(chatterinoTwitch) << "[TwitchChannel" << name << "] Opened";

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -26,6 +26,7 @@
 #include "providers/twitch/PubSubManager.hpp"
 #include "providers/twitch/TwitchAccount.hpp"
 #include "providers/twitch/TwitchChannel.hpp"
+#include "providers/twitch/TwitchCommon.hpp"
 #include "singletons/Settings.hpp"
 #include "singletons/WindowManager.hpp"
 #include "util/PostToThread.hpp"
@@ -1165,6 +1166,7 @@ void TwitchIrcServer::connect()
                                ConnectionType::Write);
     this->initializeConnection(this->readConnection_.get(),
                                ConnectionType::Read);
+    this->refreshModeratedChannels();
 }
 
 void TwitchIrcServer::disconnect()
@@ -1284,6 +1286,55 @@ void TwitchIrcServer::open(ConnectionType type)
     if (type == ConnectionType::Read)
     {
         this->readConnection_->open();
+    }
+}
+
+bool TwitchIrcServer::isModeratorIn(const QString &broadcasterLogin) const
+{
+    return this->moderatedChannels.contains(broadcasterLogin);
+}
+
+void TwitchIrcServer::refreshModeratedChannels()
+{
+    auto currentUser = getApp()->getAccounts()->twitch.getCurrent();
+    if (currentUser->isAnon())
+    {
+        return;
+    }
+    CancellationToken token{false};
+    this->moderatedChannelFetchToken = token;
+    getHelix()->getModeratedChannels(
+        currentUser->getUserId(),
+        [this](auto &&set) {
+            this->moderatedChannels = std::forward<decltype(set)>(set);
+            this->applyModeratedChannelInfo();
+        },
+        [](const auto &message) {
+            qCWarning(chatterinoTwitch)
+                << "Failed to fetch moderated channels:" << message;
+        },
+        std::move(token));
+}
+
+void TwitchIrcServer::applyModeratedChannelInfo()
+{
+    if (this->moderatedChannels.empty())
+    {
+        return;
+    }
+
+    auto currentUserName =
+        getApp()->getAccounts()->twitch.getCurrent()->getUserName();
+    std::lock_guard g(this->channelMutex);
+    for (const auto &weak : this->channels)
+    {
+        if (auto chan = std::dynamic_pointer_cast<TwitchChannel>(weak.lock()))
+        {
+            if (chan->getName() != currentUserName)
+            {
+                chan->setMod(this->moderatedChannels.contains(chan->getName()));
+            }
+        }
     }
 }
 

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -1325,8 +1325,8 @@ void TwitchIrcServer::applyModeratedChannelInfo()
 
     auto currentUserName =
         getApp()->getAccounts()->twitch.getCurrent()->getUserName();
-    std::lock_guard g(this->channelMutex);
-    for (const auto &weak : this->channels)
+    std::scoped_lock g(this->channelMutex);
+    for (const auto &weak : std::as_const(this->channels))
     {
         if (auto chan = std::dynamic_pointer_cast<TwitchChannel>(weak.lock()))
         {

--- a/src/providers/twitch/TwitchIrcServer.hpp
+++ b/src/providers/twitch/TwitchIrcServer.hpp
@@ -8,6 +8,7 @@
 #include "common/Channel.hpp"
 #include "common/Common.hpp"
 #include "providers/irc/IrcConnection2.hpp"
+#include "util/CancellationToken.hpp"
 #include "util/RatelimitBucket.hpp"
 
 #include <IrcMessage>
@@ -77,6 +78,8 @@ public:
     virtual void initEventAPIs(BttvLiveUpdates *bttvLiveUpdates,
                                SeventvEventAPI *seventvEventAPI) = 0;
 
+    virtual bool isModeratorIn(const QString &broadcasterLogin) const = 0;
+
     // Update this interface with TwitchIrcServer methods as needed
 };
 
@@ -143,6 +146,8 @@ public:
 
     ChannelPtr getChannelOrEmpty(const QString &dirtyChannelName) override;
 
+    bool isModeratorIn(const QString &broadcasterLogin) const override;
+
     void open(ConnectionType type);
 
 private:
@@ -192,6 +197,9 @@ private:
 
     bool prepareToSend(const std::shared_ptr<TwitchChannel> &channel);
 
+    void refreshModeratedChannels();
+    void applyModeratedChannelInfo();
+
     QMap<QString, std::weak_ptr<Channel>> channels;
     std::mutex channelMutex;
 
@@ -214,6 +222,9 @@ private:
     std::queue<std::chrono::steady_clock::time_point> lastMessageMod_;
     std::chrono::steady_clock::time_point lastErrorTimeSpeed_;
     std::chrono::steady_clock::time_point lastErrorTimeAmount_;
+
+    QSet</* login */ QString> moderatedChannels;
+    ScopedCancellationToken moderatedChannelFetchToken;
 };
 
 }  // namespace chatterino

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -3840,6 +3840,39 @@ void Helix::getSharedChatSession(
         .execute();
 }
 
+void Helix::getModeratedChannels(QString userID,
+                                 ResultCallback<QSet<QString>> successCallback,
+                                 FailureCallback<QString> failureCallback,
+                                 CancellationToken &&token)
+{
+    this->paginate(
+        "moderation/channels", {{"first", "100"}, {"user_id", userID}},
+        [successCallback, ids = QSet<QString>{}](
+            const QJsonObject &page,
+            const HelixPaginationState &state) mutable {
+            const auto data = page["data"_L1].toArray();
+            for (const auto user : data)
+            {
+                auto login =
+                    user.toObject().value("broadcaster_login").toString();
+                if (!login.isEmpty())
+                {
+                    ids.insert(std::move(login));
+                }
+            }
+
+            if (state.done)
+            {
+                successCallback(std::move(ids));
+            }
+            return true;
+        },
+        [failureCallback](const NetworkResult &res) {
+            failureCallback(res.formatError());
+        },
+        std::move(token));
+}
+
 QDebug &operator<<(QDebug &dbg,
                    const HelixCreateEventSubSubscriptionResponse &data)
 {

--- a/src/providers/twitch/api/Helix.cpp
+++ b/src/providers/twitch/api/Helix.cpp
@@ -3848,8 +3848,7 @@ void Helix::getModeratedChannels(QString userID,
     this->paginate(
         "moderation/channels", {{"first", "100"}, {"user_id", userID}},
         [successCallback, ids = QSet<QString>{}](
-            const QJsonObject &page,
-            const HelixPaginationState &state) mutable {
+            const QJsonObject &page, HelixPaginationState state) mutable {
             const auto data = page["data"_L1].toArray();
             for (const auto user : data)
             {

--- a/src/providers/twitch/api/Helix.hpp
+++ b/src/providers/twitch/api/Helix.hpp
@@ -1204,6 +1204,13 @@ public:
         FailureCallback<HelixGetSharedChatSessionError, QString>
             failureCallback) = 0;
 
+    // https://dev.twitch.tv/docs/api/reference/#get-moderated-channels
+    virtual void getModeratedChannels(
+        QString userID,
+        ResultCallback<QSet</* logins */ QString>> successCallback,
+        FailureCallback<QString> failureCallback,
+        CancellationToken &&token) = 0;
+
     virtual void update(QString clientId, QString oauthToken) = 0;
 
 protected:
@@ -1639,6 +1646,13 @@ public:
         ResultCallback<HelixSharedChatSession> successCallback,
         FailureCallback<HelixGetSharedChatSessionError, QString>
             failureCallback) final;
+
+    // https://dev.twitch.tv/docs/api/reference/#get-moderated-channels
+    void getModeratedChannels(
+        QString userID,
+        ResultCallback<QSet</* logins */ QString>> successCallback,
+        FailureCallback<QString> failureCallback,
+        CancellationToken &&token) final;
 
     void update(QString clientId, QString oauthToken) final;
 


### PR DESCRIPTION
This works towards #1817 (specifically addressing https://github.com/Chatterino/chatterino2/issues/1817#issuecomment-908496344). When joining channels in parallel, we have to use anonymous connections as the overall rate limit is still imposed per user (probably oauth token). When joining chat as anonymous, we won't get a `USERSTATE` telling us whether we're a moderator or not.

However, there's a helix endpoint, [Get Moderated Channels](https://dev.twitch.tv/docs/api/reference/#get-moderated-channels), which tells us the channels we're moderating. This PR adds that endpoint and fetches the status when we reconnect.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
