### PR TITLE
win32: Link against Crypt32.lib when building with vcpkg

### DIFF
--- a/cmake/FindBoostCertify.cmake
+++ b/cmake/FindBoostCertify.cmake
@@ -9,6 +9,11 @@ if (BoostCertify_FOUND)
     set_target_properties(BoostCertify PROPERTIES
         INTERFACE_INCLUDE_DIRECTORIES "${BoostCertify_INCLUDE_DIR}"
             )
+
+    target_link_libraries(
+        BoostCertify INTERFACE
+        $<$<AND:$<BOOL:${WIN32}>,$<BOOL:${VCPKG_TARGET_TRIPLET}>>:Crypt32>
+    )
 endif ()
 
 mark_as_advanced(BoostCertify_INCLUDE_DIR)

--- a/cmake/FindBoostCertify.cmake
+++ b/cmake/FindBoostCertify.cmake
@@ -12,7 +12,7 @@ if (BoostCertify_FOUND)
 
     target_link_libraries(
         BoostCertify INTERFACE
-        $<$<AND:$<BOOL:${WIN32}>,$<BOOL:${VCPKG_TARGET_TRIPLET}>>:Crypt32>
+        $<$<BOOL:${WIN32}>:Crypt32>
     )
 endif ()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -972,7 +972,6 @@ target_link_libraries(${LIBRARY_PROJECT}
         LRUCache
         MagicEnum
         $<$<BOOL:${WIN32}>:Wtsapi32>
-        $<$<AND:$<BOOL:${WIN32}>,$<BOOL:${VCPKG_TARGET_TRIPLET}>>:Crypt32>
         twitch-eventsub-ws
         BoostCertify
         )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -972,6 +972,7 @@ target_link_libraries(${LIBRARY_PROJECT}
         LRUCache
         MagicEnum
         $<$<BOOL:${WIN32}>:Wtsapi32>
+        $<$<AND:$<BOOL:${WIN32}>,$<BOOL:${VCPKG_TARGET_TRIPLET}>>:Crypt32>
         twitch-eventsub-ws
         BoostCertify
         )


### PR DESCRIPTION
When bulilding with vcpkg, the build fails with a bunch for linking errors referencing WinAPI certificate manipulation functions. Linking against Crypt32.lib fixes the issue.

<!--
    Make sure you read the contribution guidelines:
    https://github.com/Chatterino/chatterino2/blob/master/CONTRIBUTING.md

    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
