### PR TITLE
refactor: Allocate less in parseTwitchEmotes

### DIFF
--- a/src/providers/twitch/TwitchIrc.cpp
+++ b/src/providers/twitch/TwitchIrc.cpp
@@ -9,80 +9,79 @@
 #include "common/QLogging.hpp"
 #include "controllers/emotes/EmoteController.hpp"
 #include "providers/twitch/TwitchEmotes.hpp"
+#include "util/Helpers.hpp"
 #include "util/IrcHelpers.hpp"
 
 namespace {
 
 using namespace chatterino;
 
-void appendTwitchEmoteOccurrences(const QString &emote,
-                                  std::vector<TwitchEmoteOccurrence> &vec,
-                                  const std::vector<int> &correctPositions,
-                                  const QString &originalMessage,
+void appendTwitchEmoteOccurrences(QStringView emote,
+                                  std::vector<TwitchEmoteOccurrence> &out,
+                                  std::span<const uint16_t> codepointToUtf16Idx,
+                                  QStringView originalMessage,
                                   int messageOffset)
 {
     auto *app = getApp();
-    if (!emote.contains(':'))
+
+    auto [idRef, ranges] = splitOnce(emote, u':');
+    if (ranges.empty())
     {
         return;
     }
+    // FIXME: Add an EmoteIdView.
+    auto id = EmoteId{idRef.toString()};
 
-    auto parameters = emote.split(':');
-
-    if (parameters.length() < 2)
+    for (const auto occurrence : ranges.tokenize(u','))
     {
-        return;
-    }
-
-    auto id = EmoteId{parameters.at(0)};
-
-    auto occurrences = parameters.at(1).split(',');
-
-    for (const QString &occurrence : occurrences)
-    {
-        auto coords = occurrence.split('-');
-
-        if (coords.length() < 2)
+        auto [fromStr, toStr] = splitOnce(occurrence, u'-');
+        bool fromOk = false;
+        bool toOk = false;
+        uint16_t from = fromStr.toUShort(&fromOk);
+        uint16_t to = toStr.toUShort(&toOk);
+        if (!fromOk || !toOk)
         {
-            return;
+            qCDebug(chatterinoTwitch) << "Invalid emote range:" << occurrence;
+            continue;
         }
-
-        auto from = coords.at(0).toUInt() - messageOffset;
-        auto to = coords.at(1).toUInt() - messageOffset;
-        auto maxPositions = correctPositions.size();
-        if (from > to || to >= maxPositions)
-        {
-            // Emote coords are out of range
-            qCDebug(chatterinoTwitch)
-                << "Emote coords" << from << "-" << to << "are out of range ("
-                << maxPositions << ")";
-            return;
-        }
-
-        auto start = correctPositions[from];
-        auto end = correctPositions[to];
-        if (start > end || start < 0 || end > originalMessage.length())
-        {
-            // Emote coords are out of range from the modified character positions
-            qCDebug(chatterinoTwitch) << "Emote coords" << from << "-" << to
-                                      << "are out of range after offsets ("
-                                      << originalMessage.length() << ")";
-            return;
-        }
-
-        auto name = EmoteName{originalMessage.mid(start, end - start + 1)};
-        TwitchEmoteOccurrence emoteOccurrence{
-            start,
-            end,
-            app->getEmotes()->getTwitchEmotes()->getOrCreateEmote(id, name),
-            name,
-        };
-        if (emoteOccurrence.ptr == nullptr)
+        if (from > to || from < messageOffset)
         {
             qCDebug(chatterinoTwitch)
-                << "nullptr" << emoteOccurrence.name.string;
+                << "Out of bounds emote range:" << occurrence
+                << "offset:" << messageOffset;
+            continue;
         }
-        vec.push_back(std::move(emoteOccurrence));
+        to -= messageOffset;
+        from -= messageOffset;
+        if (to >= codepointToUtf16Idx.size())
+        {
+            qCDebug(chatterinoTwitch)
+                << "Out of bounds emote range:" << occurrence
+                << "max-codepoints:" << codepointToUtf16Idx.size();
+            return;
+        }
+
+        auto start = codepointToUtf16Idx[from];
+        auto end = codepointToUtf16Idx[to];
+        assert(start <= end && end < originalMessage.length() &&
+               "Bad codepointToUtf16Idx list");
+
+        auto name = EmoteName{
+            originalMessage.sliced(start, end - start + 1).toString()};
+        auto ptr =
+            app->getEmotes()->getTwitchEmotes()->getOrCreateEmote(id, name);
+        if (!ptr)
+        {
+            qCDebug(chatterinoTwitch) << "Invalid emote:" << id.string;
+            continue;
+        }
+
+        out.emplace_back(TwitchEmoteOccurrence{
+            .start = start,
+            .end = end,
+            .ptr = ptr,
+            .name = name,
+        });
     }
 }
 
@@ -138,31 +137,34 @@ std::vector<TwitchBadge> parseBadgeTag(Communi::TagsRef tags,
 }
 
 std::vector<TwitchEmoteOccurrence> parseTwitchEmotes(Communi::TagsRef tags,
-                                                     const QString &content,
+                                                     QStringView content,
                                                      int messageOffset)
 {
     // Twitch emotes
     std::vector<TwitchEmoteOccurrence> twitchEmotes;
 
-    auto emotesTag = tags.get("emotes");
+    auto emotesTag = tags.getOrEmpty("emotes");
 
-    if (!emotesTag)
+    if (emotesTag.isEmpty() ||
+        content.size() > std::numeric_limits<uint16_t>::max())
     {
         return twitchEmotes;
     }
 
-    QStringList emoteString = emotesTag->split('/');
-    std::vector<int> correctPositions;
-    for (int i = 0; i < content.size(); ++i)
+    QVarLengthArray<uint16_t, 128> codepointToUtf16Idx;
+    // We know the maximum length for the message, because
+    // `#code-points <= #utf16-code-units` is always true.
+    codepointToUtf16Idx.reserve(content.size());
+    for (qsizetype i = 0; i < content.size(); ++i)
     {
         if (!content.at(i).isLowSurrogate())
         {
-            correctPositions.push_back(i);
+            codepointToUtf16Idx.push_back(i);
         }
     }
-    for (const QString &emote : emoteString)
+    for (const auto emote : emotesTag.tokenize(u'/'))
     {
-        appendTwitchEmoteOccurrences(emote, twitchEmotes, correctPositions,
+        appendTwitchEmoteOccurrences(emote, twitchEmotes, codepointToUtf16Idx,
                                      content, messageOffset);
     }
 

--- a/src/providers/twitch/TwitchIrc.cpp
+++ b/src/providers/twitch/TwitchIrc.cpp
@@ -44,7 +44,7 @@ void appendTwitchEmoteOccurrences(QStringView emote,
             qCDebug(chatterinoTwitch) << "Invalid emote range:" << occurrence;
             continue;
         }
-        if (from > to || static_cast<int>(from) < messageOffset)
+        if (from > to || std::cmp_less(from, messageOffset))
         {
             qCDebug(chatterinoTwitch)
                 << "Out of bounds emote range:" << occurrence

--- a/src/providers/twitch/TwitchIrc.cpp
+++ b/src/providers/twitch/TwitchIrc.cpp
@@ -44,7 +44,7 @@ void appendTwitchEmoteOccurrences(QStringView emote,
             qCDebug(chatterinoTwitch) << "Invalid emote range:" << occurrence;
             continue;
         }
-        if (from > to || from < messageOffset)
+        if (from > to || static_cast<int>(from) < messageOffset)
         {
             qCDebug(chatterinoTwitch)
                 << "Out of bounds emote range:" << occurrence

--- a/src/providers/twitch/TwitchIrc.hpp
+++ b/src/providers/twitch/TwitchIrc.hpp
@@ -68,7 +68,7 @@ std::vector<TwitchBadge> parseBadgeTag(Communi::TagsRef tags,
 ///                      (content)).
 /// @returns A list of emotes and their positions
 std::vector<TwitchEmoteOccurrence> parseTwitchEmotes(Communi::TagsRef tags,
-                                                     const QString &content,
+                                                     QStringView content,
                                                      int messageOffset);
 
 }  // namespace chatterino


### PR DESCRIPTION
`parseTwitchEmotes` and `appendTwitchEmoteOccurrences` do some string parsing. Notably they split the emote range strings (`<emote-id>:<ranges...>/<emote-id>:...`) into owned `QString`s. They don't have to do that.

This PR moves the parsing from using `QString`s to `QStringView`s and using `tokenize` (lazy split) and `splitOnce`. Furthermore, the message indices are now stack-allocated if possible and use 16 bits (enough for Twitch messages).

One might think of a further optimization: Storing only the emote ID in `TwitchEmoteOccurrence` and resolving the part in the message later. But we do need the name for processing ignore phrases.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
