### PR TITLE
fix(ci): persist credentials for nightly-build tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -373,7 +373,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0 # allows for tags access
-          persist-credentials: false
+          persist-credentials: true # Required to update the nightly-build tag.
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         name: Download artifacts


### PR DESCRIPTION
The nightly release is failing, because it can't update the tag. Re-enable `persist-credentials` to make it work.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
