### PR TITLE
messageelement: allow for exhaustive flag test

### DIFF
--- a/docs/lua-meta/globals.lua
+++ b/docs/lua-meta/globals.lua
@@ -587,7 +587,7 @@ function c2.Menu:insert_separator(before) end
 ---@field flags c2.MessageElementFlag The element's flags
 ---@field tooltip string The tooltip (if any)
 ---@field trailing_space boolean Whether to add a trailing space after the element
----@field exhaustive_flags boolean Whether the element checks all of its flags for existance when performing a layout
+---@field exhaustive_flags boolean Whether the element checks all of its flags for existence when performing a layout
 ---@field link c2.Link An action when clicking on this element. Mention and Link elements don't support this. They manage the link themselves.
 c2.MessageElementBase = {}
 -- ^^^ this is kinda fake - this table doesn't exist in Lua, we only declare it to add methods

--- a/docs/lua-meta/globals.lua
+++ b/docs/lua-meta/globals.lua
@@ -587,6 +587,7 @@ function c2.Menu:insert_separator(before) end
 ---@field flags c2.MessageElementFlag The element's flags
 ---@field tooltip string The tooltip (if any)
 ---@field trailing_space boolean Whether to add a trailing space after the element
+---@field exhaustive_flags boolean Whether the element checks all of its flags for existance when performing a layout
 ---@field link c2.Link An action when clicking on this element. Mention and Link elements don't support this. They manage the link themselves.
 c2.MessageElementBase = {}
 -- ^^^ this is kinda fake - this table doesn't exist in Lua, we only declare it to add methods

--- a/src/controllers/plugins/api/Message.cpp
+++ b/src/controllers/plugins/api/Message.cpp
@@ -220,6 +220,10 @@ std::unique_ptr<MessageElement> elementFromTable(const sol::table &tbl)
     assert(el);
 
     el->setTrailingSpace(tbl.get_or("trailing_space", true));
+    if (auto exhaustiveFlags = tbl.get<std::optional<bool>>("exhaustive_flags"))
+    {
+        el->exhaustiveFlags = *exhaustiveFlags;
+    }
 
     auto link = tbl.get<sol::optional<Link>>("link");
     if (link)
@@ -606,6 +610,9 @@ void createUserType(sol::table &c2)
                 }
                 setLinkOn(&el.ref(), link);
             }),
+        "exhaustive_flags", sol::property([](const ElementRef &el) {
+            return el.cref().exhaustiveFlags;
+        }),
         "tooltip",
         sol::property(
             [](const ElementRef &el) {

--- a/src/controllers/plugins/api/Message.hpp
+++ b/src/controllers/plugins/api/Message.hpp
@@ -19,7 +19,7 @@ namespace chatterino::lua::api::message {
 ---@field flags c2.MessageElementFlag The element's flags
 ---@field tooltip string The tooltip (if any)
 ---@field trailing_space boolean Whether to add a trailing space after the element
----@field exhaustive_flags boolean Whether the element checks all of its flags for existance when performing a layout
+---@field exhaustive_flags boolean Whether the element checks all of its flags for existence when performing a layout
 ---@field link c2.Link An action when clicking on this element. Mention and Link elements don't support this. They manage the link themselves.
 c2.MessageElementBase = {}
 -- ^^^ this is kinda fake - this table doesn't exist in Lua, we only declare it to add methods

--- a/src/controllers/plugins/api/Message.hpp
+++ b/src/controllers/plugins/api/Message.hpp
@@ -19,6 +19,7 @@ namespace chatterino::lua::api::message {
 ---@field flags c2.MessageElementFlag The element's flags
 ---@field tooltip string The tooltip (if any)
 ---@field trailing_space boolean Whether to add a trailing space after the element
+---@field exhaustive_flags boolean Whether the element checks all of its flags for existance when performing a layout
 ---@field link c2.Link An action when clicking on this element. Mention and Link elements don't support this. They manage the link themselves.
 c2.MessageElementBase = {}
 -- ^^^ this is kinda fake - this table doesn't exist in Lua, we only declare it to add methods

--- a/src/messages/MessageElement.cpp
+++ b/src/messages/MessageElement.cpp
@@ -117,6 +117,12 @@ void MessageElement::cloneFrom(const MessageElement &source)
     this->trailingSpace = source.trailingSpace;
 }
 
+bool MessageElement::matchesFlags(const MessageElementFlags &contextFlags) const
+{
+    return this->exhaustiveFlags ? contextFlags.hasAll(this->getFlags())
+                                 : contextFlags.hasAny(this->getFlags());
+}
+
 QJsonObject MessageElement::toJson() const
 {
     return {
@@ -143,7 +149,7 @@ ImageElement::ImageElement(ImagePtr image, MessageElementFlags flags)
 void ImageElement::addToContainer(MessageLayoutContainer &container,
                                   const MessageLayoutContext &ctx)
 {
-    if (ctx.flags.hasAny(this->getFlags()))
+    if (this->matchesFlags(ctx.flags))
     {
         container.addElement(new ImageLayoutElement(
             *this, this->image_, this->image_->size() * container.getScale()));
@@ -189,7 +195,7 @@ CircularImageElement::CircularImageElement(ImagePtr image, int padding,
 void CircularImageElement::addToContainer(MessageLayoutContainer &container,
                                           const MessageLayoutContext &ctx)
 {
-    if (ctx.flags.hasAny(this->getFlags()))
+    if (this->matchesFlags(ctx.flags))
     {
         auto imgSize = QSize(this->image_->width(), this->image_->height()) *
                        container.getScale();
@@ -343,7 +349,7 @@ void LayeredEmoteElement::addEmoteLayer(const LayeredEmoteElement::Emote &emote)
 void LayeredEmoteElement::addToContainer(MessageLayoutContainer &container,
                                          const MessageLayoutContext &ctx)
 {
-    if (ctx.flags.hasAny(this->getFlags()))
+    if (this->matchesFlags(ctx.flags))
     {
         if (ctx.flags.has(MessageElementFlag::EmoteImage))
         {
@@ -544,7 +550,7 @@ BadgeElement::BadgeElement(const EmotePtr &emote, MessageElementFlags flags)
 void BadgeElement::addToContainer(MessageLayoutContainer &container,
                                   const MessageLayoutContext &ctx)
 {
-    if (ctx.flags.hasAny(this->getFlags()))
+    if (this->matchesFlags(ctx.flags))
     {
         auto image =
             this->emote_->images.getImageOrLoaded(container.getImageScale());
@@ -729,7 +735,7 @@ void TextElement::addToContainer(MessageLayoutContainer &container,
 {
     auto *app = getApp();
 
-    if (ctx.flags.hasAny(this->getFlags()))
+    if (this->matchesFlags(ctx.flags))
     {
         auto metrics =
             app->getFonts()->getFontMetrics(this->style_, container.getScale());
@@ -988,7 +994,7 @@ void SingleLineTextElement::addToContainer(MessageLayoutContainer &container,
 {
     auto *app = getApp();
 
-    if (ctx.flags.hasAny(this->getFlags()))
+    if (this->matchesFlags(ctx.flags))
     {
         auto metrics =
             app->getFonts()->getFontMetrics(this->style_, container.getScale());
@@ -1318,7 +1324,7 @@ TimestampElement::TimestampElement(QTime time)
 void TimestampElement::addToContainer(MessageLayoutContainer &container,
                                       const MessageLayoutContext &ctx)
 {
-    if (ctx.flags.hasAny(this->getFlags()))
+    if (this->matchesFlags(ctx.flags))
     {
         this->setTooltip(this->getTooltip());
         if (getSettings()->timestampFormat != this->format_)
@@ -1439,7 +1445,7 @@ LinebreakElement::LinebreakElement(MessageElementFlags flags)
 void LinebreakElement::addToContainer(MessageLayoutContainer &container,
                                       const MessageLayoutContext &ctx)
 {
-    if (ctx.flags.hasAny(this->getFlags()))
+    if (this->matchesFlags(ctx.flags))
     {
         container.breakLine();
     }
@@ -1475,7 +1481,7 @@ ScalingImageElement::ScalingImageElement(ImageSet images,
 void ScalingImageElement::addToContainer(MessageLayoutContainer &container,
                                          const MessageLayoutContext &ctx)
 {
-    if (ctx.flags.hasAny(this->getFlags()))
+    if (this->matchesFlags(ctx.flags))
     {
         const auto &image =
             this->images_.getImageOrLoaded(container.getImageScale());
@@ -1528,7 +1534,7 @@ void ReplyCurveElement::addToContainer(MessageLayoutContainer &container,
     static const int radius = 6;         // Radius of the top left corner
     static const int margin = 2;         // Top/Left/Bottom margin
 
-    if (ctx.flags.hasAny(this->getFlags()))
+    if (this->matchesFlags(ctx.flags))
     {
         float scale = container.getScale();
         container.addElement(

--- a/src/messages/MessageElement.cpp
+++ b/src/messages/MessageElement.cpp
@@ -144,6 +144,7 @@ ImageElement::ImageElement(ImagePtr image, MessageElementFlags flags)
     : MessageElement(flags)
     , image_(std::move(image))
 {
+    assert(image_ != nullptr);
 }
 
 void ImageElement::addToContainer(MessageLayoutContainer &container,

--- a/src/messages/MessageElement.cpp
+++ b/src/messages/MessageElement.cpp
@@ -117,7 +117,7 @@ void MessageElement::cloneFrom(const MessageElement &source)
     this->trailingSpace = source.trailingSpace;
 }
 
-bool MessageElement::matchesFlags(const MessageElementFlags &contextFlags) const
+bool MessageElement::matchesFlags(MessageElementFlags contextFlags) const
 {
     return this->exhaustiveFlags ? contextFlags.hasAll(this->getFlags())
                                  : contextFlags.hasAny(this->getFlags());

--- a/src/messages/MessageElement.hpp
+++ b/src/messages/MessageElement.hpp
@@ -199,12 +199,22 @@ public:
     /// Creates a new identical message element.
     virtual std::unique_ptr<MessageElement> clone() const = 0;
 
+    /// When this element is added to a container, this decides whether the flag check
+    /// should require the context flags to contain all flags of this element (true), as opposed
+    /// to the context flag containing at least one of the flags of this element (false).
+    bool exhaustiveFlags = false;
+
 protected:
     MessageElement(MessageElementFlags flags);
     bool trailingSpace = true;
 
     /// Copy MessageElement private data from `source` to this MessageElement
     void cloneFrom(const MessageElement &source);
+
+    /// Checks if the given flags from the layout context matches the flags of this element.
+    ///
+    /// Takes `exhaustiveFlags` into consideration.
+    bool matchesFlags(const MessageElementFlags &contextFlags) const;
 
 private:
     Link link_;

--- a/src/messages/MessageElement.hpp
+++ b/src/messages/MessageElement.hpp
@@ -214,7 +214,7 @@ protected:
     /// Checks if the given flags from the layout context matches the flags of this element.
     ///
     /// Takes `exhaustiveFlags` into consideration.
-    bool matchesFlags(const MessageElementFlags &contextFlags) const;
+    bool matchesFlags(MessageElementFlags contextFlags) const;
 
 private:
     Link link_;

--- a/src/messages/layouts/MessageLayoutContainer.hpp
+++ b/src/messages/layouts/MessageLayoutContainer.hpp
@@ -386,6 +386,7 @@ private:
 
 #ifdef FRIEND_TEST
     FRIEND_TEST(MessageLayoutContainerTest, RtlReordering);
+    FRIEND_TEST(MessageLayoutContainer, ExhaustiveFlags);
 #endif
 };
 

--- a/tests/lua/message/element.lua
+++ b/tests/lua/message/element.lua
@@ -36,6 +36,30 @@ local tests = {
         assert(new_msg:elements()[2])
         assert(new_msg:elements()[2].type == 'text' and new_msg:elements()[2].words[1] == 'abcde')
     end,
+    exhaustive_flags = function()
+        local msg = c2.Message.new({
+            elements = {
+                {
+                    type = "text",
+                    text = "a",
+                    -- default
+                },
+                {
+                    type = "text",
+                    text = "b",
+                    exhaustive_flags = false,
+                },
+                {
+                    type = "text",
+                    text = "c",
+                    exhaustive_flags = true,
+                },
+            },
+        })
+        assert(msg:elements()[1].type == "text" and msg:elements()[1].exhaustive_flags == false)
+        assert(msg:elements()[2].type == "text" and msg:elements()[2].exhaustive_flags == false)
+        assert(msg:elements()[3].type == "text" and msg:elements()[3].exhaustive_flags == true)
+    end,
 }
 
 for name, fn in pairs(tests) do

--- a/tests/src/MessageLayoutContainer.cpp
+++ b/tests/src/MessageLayoutContainer.cpp
@@ -245,4 +245,51 @@ INSTANTIATE_TEST_SUITE_P(
             TextDirection::LTR,
         }));
 
+TEST(MessageLayoutContainer, ExhaustiveFlags)
+{
+    MockApplication app;
+
+    MessageLayoutContainer container;
+
+    ImageElement imageElement(Image::getEmpty(), MessageElementFlags{
+                                                     MessageElementFlag::Text,
+                                                 });
+
+    ImageElement imageHeaderElement(Image::getEmpty(),
+                                    MessageElementFlags{
+                                        MessageElementFlag::Text,
+                                        MessageElementFlag::RepliedMessage,
+                                    });
+
+    ASSERT_EQ(container.elements_.size(), 0);
+
+    MessageLayoutContext ctx{
+        .messageColors = {},
+    };
+
+    // No flags matching, nothing was added
+    imageElement.addToContainer(container, ctx);
+    ASSERT_EQ(container.elements_.size(), 0);
+
+    ctx.flags = {
+        MessageElementFlag::Text,
+    };
+
+    imageElement.addToContainer(container, ctx);
+    ASSERT_EQ(container.elements_.size(), 1);
+
+    imageHeaderElement.addToContainer(container, ctx);
+    ASSERT_EQ(container.elements_.size(), 2);
+
+    imageElement.exhaustiveFlags = true;
+    imageHeaderElement.exhaustiveFlags = true;
+
+    imageElement.addToContainer(container, ctx);
+    ASSERT_EQ(container.elements_.size(), 3);
+
+    // This was not added, because ctx.flags only contains Text, not RepliedMessage
+    imageHeaderElement.addToContainer(container, ctx);
+    ASSERT_EQ(container.elements_.size(), 3);
+}
+
 }  // namespace chatterino


### PR DESCRIPTION
this allows most elements to be configured with the "exhaustiveFlags"
flag which ensures that _all_ of the element's flags must be set in the
context for it to be laid out.

<!--
    Make sure you read the contribution guidelines:
    https://github.com/Chatterino/chatterino2/blob/master/CONTRIBUTING.md

    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
