### PR TITLE
fix: make announcements a single message

### DIFF
--- a/docs/lua-meta/globals.lua
+++ b/docs/lua-meta/globals.lua
@@ -873,6 +873,8 @@ c2.MessageElementFlag = {
     LowercaseLinks = 0,
     RepliedMessage = 0,
     ReplyButton = 0,
+    HeaderTimestamp = 0,
+    AnnouncementHeader = 0,
     Default = 0,
 }
 

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -1682,6 +1682,9 @@ std::pair<MessagePtrMut, HighlightAlert> MessageBuilder::makeIrcMessage(
     auto userID = tags.getOrEmpty("user-id");
 
     MessageBuilder builder;
+    // calculate timestamp
+    builder->serverReceivedTime = calculateMessageTime(ircMessage);
+
     builder.parseUsernameColor(tags, userID);
     builder->userID = userID;
 
@@ -1743,8 +1746,7 @@ std::pair<MessagePtrMut, HighlightAlert> MessageBuilder::makeIrcMessage(
     // reply threads
     builder.parseThread(content, tags, channel, thread, parent);
 
-    // timestamp
-    builder->serverReceivedTime = calculateMessageTime(ircMessage);
+    // add timestamp
     builder.emplace<TimestampElement>(builder->serverReceivedTime.time());
 
     bool shouldAddModerationElements = [&] {

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -2081,6 +2081,29 @@ void MessageBuilder::parseMessageTags(Communi::TagsRef tags)
                         *color, qmagicenum::CASE_INSENSITIVE)
                         .value_or(HelixAnnouncementColor::Primary);
             }
+
+            this->emplace<TimestampElement>(
+                    this->message().serverReceivedTime.time(),
+                    MessageElementFlags{
+                        MessageElementFlag::HeaderTimestamp,
+                        MessageElementFlag::AnnouncementHeader,
+                    })
+                ->exhaustiveFlags = true;
+
+            this->emplace<TextElement>(
+                    "Announcement",
+                    MessageElementFlags({
+                        MessageElementFlag::Text,
+                        MessageElementFlag::AnnouncementHeader,
+                    }),
+                    MessageColor::System, FontStyle::ChatMediumBold)
+                ->exhaustiveFlags = true;
+
+            this
+                ->emplace<LinebreakElement>(MessageElementFlags{
+                    MessageElementFlag::AnnouncementHeader,
+                })
+                ->exhaustiveFlags = true;
         }
         else if (messageType == "viewermilestone" ||
                  messageType == "modiversary")

--- a/src/messages/MessageElement.cpp
+++ b/src/messages/MessageElement.cpp
@@ -1330,6 +1330,24 @@ TimestampElement::TimestampElement(QTime time)
     assert(this->element_ != nullptr);
 }
 
+TimestampElement::TimestampElement(QTime time,
+                                   const MessageElementFlags extraFlags)
+    : MessageElement(extraFlags | MessageElementFlag::Timestamp)
+    , time_(time)
+    , element_(this->formatTime(time))
+{
+    assert(this->element_ != nullptr);
+}
+
+TimestampElement::TimestampElement(TimestampElement::CloneConstructorTag,
+                                   QTime time, const MessageElementFlags flags)
+    : MessageElement(flags)
+    , time_(time)
+    , element_(this->formatTime(time))
+{
+    assert(this->element_ != nullptr);
+}
+
 void TimestampElement::addToContainer(MessageLayoutContainer &container,
                                       const MessageLayoutContext &ctx)
 {
@@ -1352,9 +1370,8 @@ TextElement *TimestampElement::formatTime(const QTime &time)
 
     QString format = locale.toString(time, getSettings()->timestampFormat);
 
-    auto *text =
-        new TextElement(format, MessageElementFlag::Timestamp,
-                        MessageColor::System, FontStyle::TimestampMedium);
+    auto *text = new TextElement(format, this->getFlags(), MessageColor::System,
+                                 FontStyle::TimestampMedium);
     text->setLink(this->getLink());
     text->setTooltip(this->getTooltip());
     return text;
@@ -1385,7 +1402,8 @@ std::string_view TimestampElement::type() const
 
 std::unique_ptr<MessageElement> TimestampElement::clone() const
 {
-    auto elem = std::make_unique<TimestampElement>(this->time_);
+    auto elem = std::make_unique<TimestampElement>(
+        TimestampElement::CloneConstructorTag{}, this->time_, this->getFlags());
     elem->cloneFrom(*this);
     return elem;
 }

--- a/src/messages/MessageElement.cpp
+++ b/src/messages/MessageElement.cpp
@@ -1495,6 +1495,7 @@ std::unique_ptr<MessageElement> LinebreakElement::clone() const
 {
     auto elem = std::make_unique<LinebreakElement>(this->getFlags());
     elem->setTrailingSpace(this->hasTrailingSpace());
+    elem->exhaustiveFlags = this->exhaustiveFlags;
     return elem;
 }
 

--- a/src/messages/MessageElement.hpp
+++ b/src/messages/MessageElement.hpp
@@ -10,7 +10,6 @@
 #include "messages/MessageColor.hpp"
 #include "providers/links/LinkInfo.hpp"
 #include "singletons/Fonts.hpp"
-#include "util/DebugCount.hpp"
 
 #include <magic_enum/magic_enum.hpp>
 #include <pajlada/signals/signalholder.hpp>

--- a/src/messages/MessageElement.hpp
+++ b/src/messages/MessageElement.hpp
@@ -158,6 +158,10 @@ enum class MessageElementFlag : int64_t {
 
     // (1LL << 36) is occupied by BadgeSevenTV
 
+    HeaderTimestamp = (1LL << 38),
+
+    AnnouncementHeader = (1LL << 39),
+
     Default = Timestamp | Badges | Username | BitsStatic | EmoteImage |
               BitsAmount | Text | AlwaysShow,
 };

--- a/src/messages/MessageElement.hpp
+++ b/src/messages/MessageElement.hpp
@@ -667,11 +667,19 @@ protected:
 // contains a text, formated depending on the preferences
 class TimestampElement : public MessageElement
 {
+protected:
+    struct CloneConstructorTag {
+    };
+
 public:
     static constexpr std::string_view TYPE = "timestamp";
 
     TimestampElement();
     TimestampElement(QTime time_);
+    TimestampElement(QTime time_, MessageElementFlags extraFlags);
+    /// This is intended only for cloning the element.
+    TimestampElement(TimestampElement::CloneConstructorTag, QTime time_,
+                     MessageElementFlags flags);
     ~TimestampElement() override = default;
 
     void addToContainer(MessageLayoutContainer &container,

--- a/src/messages/MessageElement.hpp
+++ b/src/messages/MessageElement.hpp
@@ -158,8 +158,10 @@ enum class MessageElementFlag : int64_t {
 
     // (1LL << 36) is occupied by BadgeSevenTV
 
+    /// The timestamp in the header (i.e. top part of the "Announcement" message)
     HeaderTimestamp = (1LL << 38),
 
+    /// Applied to all elements of the announcement header
     AnnouncementHeader = (1LL << 39),
 
     Default = Timestamp | Badges | Username | BitsStatic | EmoteImage |

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -811,7 +811,8 @@ void IrcMessageHandler::parseUserNoticeMessageInto(Communi::IrcMessage *message,
         }
         else if (msgType == "announcement")
         {
-            messageText = "Announcement";
+            // Early out - announcement headers are added in MessageBuilder
+            return;
         }
         else if (msgType == "subgift")
         {

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -159,6 +159,14 @@ public:
 
     /// Appearance
     BoolSetting showTimestamps = {"/appearance/messages/showTimestamps", true};
+    BoolSetting showHeaderTimestamps = {
+        "/appearance/messages/header/showTimestamps",
+        true,
+    };
+    BoolSetting showAnnouncementHeader = {
+        "/appearance/messages/announcements/showHeader",
+        true,
+    };
     BoolSetting animationsWhenFocused = {
         "/appearance/enableAnimationsWhenFocused", false};
     BoolSetting hideMessageTimestampsWhenLive = {

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -161,7 +161,7 @@ public:
     BoolSetting showTimestamps = {"/appearance/messages/showTimestamps", true};
     BoolSetting showHeaderTimestamps = {
         "/appearance/messages/header/showTimestamps",
-        true,
+        false,
     };
     BoolSetting showAnnouncementHeader = {
         "/appearance/messages/announcements/showHeader",

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -135,6 +135,8 @@ WindowManager::WindowManager(const Args &appArgs_, const Paths &paths,
     qCDebug(chatterinoWindowmanager) << "init WindowManager";
 
     this->updateWordTypeMaskListener.add(settings.showTimestamps);
+    this->updateWordTypeMaskListener.add(settings.showHeaderTimestamps);
+    this->updateWordTypeMaskListener.add(settings.showAnnouncementHeader);
     this->updateWordTypeMaskListener.add(settings.showBadgesGlobalAuthority);
     this->updateWordTypeMaskListener.add(settings.showBadgesPredictions);
     this->updateWordTypeMaskListener.add(settings.showBadgesChannelAuthority);
@@ -216,6 +218,14 @@ void WindowManager::updateWordTypeMask()
     if (settings->showTimestamps)
     {
         flags.set(MEF::Timestamp);
+    }
+    if (settings->showHeaderTimestamps)
+    {
+        flags.set(MEF::HeaderTimestamp);
+    }
+    if (settings->showAnnouncementHeader)
+    {
+        flags.set(MEF::AnnouncementHeader);
     }
 
     // emotes

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -537,6 +537,14 @@ void GeneralPage::initLayout(GeneralPageView &layout)
                                    : args.value;
         },
         true, "a = am/pm, zzz = milliseconds");
+
+    SettingWidget::checkbox("Show header timestamps", s.showHeaderTimestamps)
+        ->addTo(layout);
+
+    SettingWidget::checkbox("Show announcement header",
+                            s.showAnnouncementHeader)
+        ->addTo(layout);
+
     layout.addDropdown<int>(
         "Limit message height",
         {"Never", "2 lines", "3 lines", "4 lines", "5 lines"},

--- a/tests/snapshots/IrcMessageHandler/announcement-blue.json
+++ b/tests/snapshots/IrcMessageHandler/announcement-blue.json
@@ -38,6 +38,7 @@
                             "11:15"
                         ]
                     },
+                    "exhaustiveFlags": true,
                     "flags": "Timestamp|HeaderTimestamp|AnnouncementHeader",
                     "format": "",
                     "link": {
@@ -51,6 +52,7 @@
                 },
                 {
                     "color": "System",
+                    "exhaustiveFlags": true,
                     "flags": "Text|AnnouncementHeader",
                     "link": {
                         "type": "None",
@@ -65,6 +67,7 @@
                     ]
                 },
                 {
+                    "exhaustiveFlags": true,
                     "flags": "AnnouncementHeader",
                     "link": {
                         "type": "None",

--- a/tests/snapshots/IrcMessageHandler/announcement-blue.json
+++ b/tests/snapshots/IrcMessageHandler/announcement-blue.json
@@ -25,6 +25,58 @@
                 {
                     "element": {
                         "color": "System",
+                        "flags": "Timestamp|HeaderTimestamp|AnnouncementHeader",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "TimestampMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "11:15"
+                        ]
+                    },
+                    "flags": "Timestamp|HeaderTimestamp|AnnouncementHeader",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "11:15:08",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "System",
+                    "flags": "Text|AnnouncementHeader",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMediumBold",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "Announcement"
+                    ]
+                },
+                {
+                    "flags": "AnnouncementHeader",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "LinebreakElement"
+                },
+                {
+                    "element": {
+                        "color": "System",
                         "flags": "Timestamp",
                         "link": {
                             "type": "None",
@@ -160,73 +212,6 @@
             ],
             "userID": "11148817",
             "usernameColor": "#ffcc44ff"
-        },
-        {
-            "announcementColor": "Blue",
-            "channelName": "",
-            "count": 1,
-            "displayName": "",
-            "elements": [
-                {
-                    "element": {
-                        "color": "System",
-                        "flags": "Timestamp",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "TimestampMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "11:15"
-                        ]
-                    },
-                    "flags": "Timestamp",
-                    "format": "",
-                    "link": {
-                        "type": "None",
-                        "value": ""
-                    },
-                    "time": "11:15:08",
-                    "tooltip": "",
-                    "trailingSpace": true,
-                    "type": "TimestampElement"
-                },
-                {
-                    "color": "System",
-                    "flags": "Text",
-                    "link": {
-                        "type": "None",
-                        "value": ""
-                    },
-                    "style": "ChatMedium",
-                    "tooltip": "",
-                    "trailingSpace": true,
-                    "type": "TextElement",
-                    "words": [
-                        "Announcement"
-                    ]
-                }
-            ],
-            "externalBadges": [
-            ],
-            "flags": "System|DoNotTriggerNotification|Announcement",
-            "frozen": false,
-            "id": "",
-            "localizedName": "",
-            "loginName": "",
-            "messageText": "Announcement",
-            "searchText": "Announcement",
-            "serverReceivedTime": "",
-            "timeoutUser": "",
-            "twitchBadgeInfos": {
-            },
-            "twitchBadges": [
-            ],
-            "userID": "",
-            "usernameColor": "#ff000000"
         }
     ]
 }

--- a/tests/snapshots/IrcMessageHandler/announcement-green.json
+++ b/tests/snapshots/IrcMessageHandler/announcement-green.json
@@ -25,6 +25,58 @@
                 {
                     "element": {
                         "color": "System",
+                        "flags": "Timestamp|HeaderTimestamp|AnnouncementHeader",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "TimestampMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "11:15"
+                        ]
+                    },
+                    "flags": "Timestamp|HeaderTimestamp|AnnouncementHeader",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "11:15:20",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "System",
+                    "flags": "Text|AnnouncementHeader",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMediumBold",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "Announcement"
+                    ]
+                },
+                {
+                    "flags": "AnnouncementHeader",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "LinebreakElement"
+                },
+                {
+                    "element": {
+                        "color": "System",
                         "flags": "Timestamp",
                         "link": {
                             "type": "None",
@@ -160,73 +212,6 @@
             ],
             "userID": "11148817",
             "usernameColor": "#ffcc44ff"
-        },
-        {
-            "announcementColor": "Green",
-            "channelName": "",
-            "count": 1,
-            "displayName": "",
-            "elements": [
-                {
-                    "element": {
-                        "color": "System",
-                        "flags": "Timestamp",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "TimestampMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "11:15"
-                        ]
-                    },
-                    "flags": "Timestamp",
-                    "format": "",
-                    "link": {
-                        "type": "None",
-                        "value": ""
-                    },
-                    "time": "11:15:20",
-                    "tooltip": "",
-                    "trailingSpace": true,
-                    "type": "TimestampElement"
-                },
-                {
-                    "color": "System",
-                    "flags": "Text",
-                    "link": {
-                        "type": "None",
-                        "value": ""
-                    },
-                    "style": "ChatMedium",
-                    "tooltip": "",
-                    "trailingSpace": true,
-                    "type": "TextElement",
-                    "words": [
-                        "Announcement"
-                    ]
-                }
-            ],
-            "externalBadges": [
-            ],
-            "flags": "System|DoNotTriggerNotification|Announcement",
-            "frozen": false,
-            "id": "",
-            "localizedName": "",
-            "loginName": "",
-            "messageText": "Announcement",
-            "searchText": "Announcement",
-            "serverReceivedTime": "",
-            "timeoutUser": "",
-            "twitchBadgeInfos": {
-            },
-            "twitchBadges": [
-            ],
-            "userID": "",
-            "usernameColor": "#ff000000"
         }
     ]
 }

--- a/tests/snapshots/IrcMessageHandler/announcement-green.json
+++ b/tests/snapshots/IrcMessageHandler/announcement-green.json
@@ -38,6 +38,7 @@
                             "11:15"
                         ]
                     },
+                    "exhaustiveFlags": true,
                     "flags": "Timestamp|HeaderTimestamp|AnnouncementHeader",
                     "format": "",
                     "link": {
@@ -51,6 +52,7 @@
                 },
                 {
                     "color": "System",
+                    "exhaustiveFlags": true,
                     "flags": "Text|AnnouncementHeader",
                     "link": {
                         "type": "None",
@@ -65,6 +67,7 @@
                     ]
                 },
                 {
+                    "exhaustiveFlags": true,
                     "flags": "AnnouncementHeader",
                     "link": {
                         "type": "None",

--- a/tests/snapshots/IrcMessageHandler/announcement-orange.json
+++ b/tests/snapshots/IrcMessageHandler/announcement-orange.json
@@ -25,6 +25,58 @@
                 {
                     "element": {
                         "color": "System",
+                        "flags": "Timestamp|HeaderTimestamp|AnnouncementHeader",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "TimestampMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "11:15"
+                        ]
+                    },
+                    "flags": "Timestamp|HeaderTimestamp|AnnouncementHeader",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "11:15:25",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "System",
+                    "flags": "Text|AnnouncementHeader",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMediumBold",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "Announcement"
+                    ]
+                },
+                {
+                    "flags": "AnnouncementHeader",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "LinebreakElement"
+                },
+                {
+                    "element": {
+                        "color": "System",
                         "flags": "Timestamp",
                         "link": {
                             "type": "None",
@@ -160,73 +212,6 @@
             ],
             "userID": "11148817",
             "usernameColor": "#ffcc44ff"
-        },
-        {
-            "announcementColor": "Orange",
-            "channelName": "",
-            "count": 1,
-            "displayName": "",
-            "elements": [
-                {
-                    "element": {
-                        "color": "System",
-                        "flags": "Timestamp",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "TimestampMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "11:15"
-                        ]
-                    },
-                    "flags": "Timestamp",
-                    "format": "",
-                    "link": {
-                        "type": "None",
-                        "value": ""
-                    },
-                    "time": "11:15:25",
-                    "tooltip": "",
-                    "trailingSpace": true,
-                    "type": "TimestampElement"
-                },
-                {
-                    "color": "System",
-                    "flags": "Text",
-                    "link": {
-                        "type": "None",
-                        "value": ""
-                    },
-                    "style": "ChatMedium",
-                    "tooltip": "",
-                    "trailingSpace": true,
-                    "type": "TextElement",
-                    "words": [
-                        "Announcement"
-                    ]
-                }
-            ],
-            "externalBadges": [
-            ],
-            "flags": "System|DoNotTriggerNotification|Announcement",
-            "frozen": false,
-            "id": "",
-            "localizedName": "",
-            "loginName": "",
-            "messageText": "Announcement",
-            "searchText": "Announcement",
-            "serverReceivedTime": "",
-            "timeoutUser": "",
-            "twitchBadgeInfos": {
-            },
-            "twitchBadges": [
-            ],
-            "userID": "",
-            "usernameColor": "#ff000000"
         }
     ]
 }

--- a/tests/snapshots/IrcMessageHandler/announcement-orange.json
+++ b/tests/snapshots/IrcMessageHandler/announcement-orange.json
@@ -38,6 +38,7 @@
                             "11:15"
                         ]
                     },
+                    "exhaustiveFlags": true,
                     "flags": "Timestamp|HeaderTimestamp|AnnouncementHeader",
                     "format": "",
                     "link": {
@@ -51,6 +52,7 @@
                 },
                 {
                     "color": "System",
+                    "exhaustiveFlags": true,
                     "flags": "Text|AnnouncementHeader",
                     "link": {
                         "type": "None",
@@ -65,6 +67,7 @@
                     ]
                 },
                 {
+                    "exhaustiveFlags": true,
                     "flags": "AnnouncementHeader",
                     "link": {
                         "type": "None",

--- a/tests/snapshots/IrcMessageHandler/announcement-purple.json
+++ b/tests/snapshots/IrcMessageHandler/announcement-purple.json
@@ -38,6 +38,7 @@
                             "11:15"
                         ]
                     },
+                    "exhaustiveFlags": true,
                     "flags": "Timestamp|HeaderTimestamp|AnnouncementHeader",
                     "format": "",
                     "link": {
@@ -51,6 +52,7 @@
                 },
                 {
                     "color": "System",
+                    "exhaustiveFlags": true,
                     "flags": "Text|AnnouncementHeader",
                     "link": {
                         "type": "None",
@@ -65,6 +67,7 @@
                     ]
                 },
                 {
+                    "exhaustiveFlags": true,
                     "flags": "AnnouncementHeader",
                     "link": {
                         "type": "None",

--- a/tests/snapshots/IrcMessageHandler/announcement-purple.json
+++ b/tests/snapshots/IrcMessageHandler/announcement-purple.json
@@ -25,6 +25,58 @@
                 {
                     "element": {
                         "color": "System",
+                        "flags": "Timestamp|HeaderTimestamp|AnnouncementHeader",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "TimestampMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "11:15"
+                        ]
+                    },
+                    "flags": "Timestamp|HeaderTimestamp|AnnouncementHeader",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "11:15:32",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "System",
+                    "flags": "Text|AnnouncementHeader",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMediumBold",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "Announcement"
+                    ]
+                },
+                {
+                    "flags": "AnnouncementHeader",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "LinebreakElement"
+                },
+                {
+                    "element": {
+                        "color": "System",
                         "flags": "Timestamp",
                         "link": {
                             "type": "None",
@@ -160,73 +212,6 @@
             ],
             "userID": "11148817",
             "usernameColor": "#ffcc44ff"
-        },
-        {
-            "announcementColor": "Purple",
-            "channelName": "",
-            "count": 1,
-            "displayName": "",
-            "elements": [
-                {
-                    "element": {
-                        "color": "System",
-                        "flags": "Timestamp",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "TimestampMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "11:15"
-                        ]
-                    },
-                    "flags": "Timestamp",
-                    "format": "",
-                    "link": {
-                        "type": "None",
-                        "value": ""
-                    },
-                    "time": "11:15:32",
-                    "tooltip": "",
-                    "trailingSpace": true,
-                    "type": "TimestampElement"
-                },
-                {
-                    "color": "System",
-                    "flags": "Text",
-                    "link": {
-                        "type": "None",
-                        "value": ""
-                    },
-                    "style": "ChatMedium",
-                    "tooltip": "",
-                    "trailingSpace": true,
-                    "type": "TextElement",
-                    "words": [
-                        "Announcement"
-                    ]
-                }
-            ],
-            "externalBadges": [
-            ],
-            "flags": "System|DoNotTriggerNotification|Announcement",
-            "frozen": false,
-            "id": "",
-            "localizedName": "",
-            "loginName": "",
-            "messageText": "Announcement",
-            "searchText": "Announcement",
-            "serverReceivedTime": "",
-            "timeoutUser": "",
-            "twitchBadgeInfos": {
-            },
-            "twitchBadges": [
-            ],
-            "userID": "",
-            "usernameColor": "#ff000000"
         }
     ]
 }

--- a/tests/snapshots/IrcMessageHandler/announcement.json
+++ b/tests/snapshots/IrcMessageHandler/announcement.json
@@ -38,6 +38,7 @@
                             "21:30"
                         ]
                     },
+                    "exhaustiveFlags": true,
                     "flags": "Timestamp|HeaderTimestamp|AnnouncementHeader",
                     "format": "",
                     "link": {
@@ -51,6 +52,7 @@
                 },
                 {
                     "color": "System",
+                    "exhaustiveFlags": true,
                     "flags": "Text|AnnouncementHeader",
                     "link": {
                         "type": "None",
@@ -65,6 +67,7 @@
                     ]
                 },
                 {
+                    "exhaustiveFlags": true,
                     "flags": "AnnouncementHeader",
                     "link": {
                         "type": "None",

--- a/tests/snapshots/IrcMessageHandler/announcement.json
+++ b/tests/snapshots/IrcMessageHandler/announcement.json
@@ -25,6 +25,58 @@
                 {
                     "element": {
                         "color": "System",
+                        "flags": "Timestamp|HeaderTimestamp|AnnouncementHeader",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "TimestampMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "21:30"
+                        ]
+                    },
+                    "flags": "Timestamp|HeaderTimestamp|AnnouncementHeader",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "21:30:19",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "System",
+                    "flags": "Text|AnnouncementHeader",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMediumBold",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "Announcement"
+                    ]
+                },
+                {
+                    "flags": "AnnouncementHeader",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "LinebreakElement"
+                },
+                {
+                    "element": {
+                        "color": "System",
                         "flags": "Timestamp",
                         "link": {
                             "type": "None",
@@ -152,73 +204,6 @@
             ],
             "userID": "31400525",
             "usernameColor": "#ffff0000"
-        },
-        {
-            "announcementColor": "Primary",
-            "channelName": "",
-            "count": 1,
-            "displayName": "",
-            "elements": [
-                {
-                    "element": {
-                        "color": "System",
-                        "flags": "Timestamp",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "TimestampMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "21:30"
-                        ]
-                    },
-                    "flags": "Timestamp",
-                    "format": "",
-                    "link": {
-                        "type": "None",
-                        "value": ""
-                    },
-                    "time": "21:30:19",
-                    "tooltip": "",
-                    "trailingSpace": true,
-                    "type": "TimestampElement"
-                },
-                {
-                    "color": "System",
-                    "flags": "Text",
-                    "link": {
-                        "type": "None",
-                        "value": ""
-                    },
-                    "style": "ChatMedium",
-                    "tooltip": "",
-                    "trailingSpace": true,
-                    "type": "TextElement",
-                    "words": [
-                        "Announcement"
-                    ]
-                }
-            ],
-            "externalBadges": [
-            ],
-            "flags": "System|DoNotTriggerNotification|Announcement",
-            "frozen": false,
-            "id": "",
-            "localizedName": "",
-            "loginName": "",
-            "messageText": "Announcement",
-            "searchText": "Announcement",
-            "serverReceivedTime": "",
-            "timeoutUser": "",
-            "twitchBadgeInfos": {
-            },
-            "twitchBadges": [
-            ],
-            "userID": "",
-            "usernameColor": "#ff000000"
         }
     ]
 }

--- a/tests/snapshots/IrcMessageHandler/shared-chat-announcement.json
+++ b/tests/snapshots/IrcMessageHandler/shared-chat-announcement.json
@@ -25,6 +25,58 @@
                 {
                     "element": {
                         "color": "System",
+                        "flags": "Timestamp|HeaderTimestamp|AnnouncementHeader",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "TimestampMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "5:19"
+                        ]
+                    },
+                    "flags": "Timestamp|HeaderTimestamp|AnnouncementHeader",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "05:19:38",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "System",
+                    "flags": "Text|AnnouncementHeader",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMediumBold",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "Announcement"
+                    ]
+                },
+                {
+                    "flags": "AnnouncementHeader",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "LinebreakElement"
+                },
+                {
+                    "element": {
+                        "color": "System",
                         "flags": "Timestamp",
                         "link": {
                             "type": "None",
@@ -206,73 +258,6 @@
             ],
             "userID": "612865661",
             "usernameColor": "#ffdaa520"
-        },
-        {
-            "announcementColor": "Primary",
-            "channelName": "",
-            "count": 1,
-            "displayName": "",
-            "elements": [
-                {
-                    "element": {
-                        "color": "System",
-                        "flags": "Timestamp",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "TimestampMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "5:19"
-                        ]
-                    },
-                    "flags": "Timestamp",
-                    "format": "",
-                    "link": {
-                        "type": "None",
-                        "value": ""
-                    },
-                    "time": "05:19:38",
-                    "tooltip": "",
-                    "trailingSpace": true,
-                    "type": "TimestampElement"
-                },
-                {
-                    "color": "System",
-                    "flags": "Text",
-                    "link": {
-                        "type": "None",
-                        "value": ""
-                    },
-                    "style": "ChatMedium",
-                    "tooltip": "",
-                    "trailingSpace": true,
-                    "type": "TextElement",
-                    "words": [
-                        "Announcement"
-                    ]
-                }
-            ],
-            "externalBadges": [
-            ],
-            "flags": "System|DoNotTriggerNotification|SharedMessage|Announcement",
-            "frozen": false,
-            "id": "",
-            "localizedName": "",
-            "loginName": "",
-            "messageText": "Announcement",
-            "searchText": "Announcement",
-            "serverReceivedTime": "",
-            "timeoutUser": "",
-            "twitchBadgeInfos": {
-            },
-            "twitchBadges": [
-            ],
-            "userID": "",
-            "usernameColor": "#ff000000"
         }
     ],
     "params": {

--- a/tests/snapshots/IrcMessageHandler/shared-chat-announcement.json
+++ b/tests/snapshots/IrcMessageHandler/shared-chat-announcement.json
@@ -38,6 +38,7 @@
                             "5:19"
                         ]
                     },
+                    "exhaustiveFlags": true,
                     "flags": "Timestamp|HeaderTimestamp|AnnouncementHeader",
                     "format": "",
                     "link": {
@@ -51,6 +52,7 @@
                 },
                 {
                     "color": "System",
+                    "exhaustiveFlags": true,
                     "flags": "Text|AnnouncementHeader",
                     "link": {
                         "type": "None",
@@ -65,6 +67,7 @@
                     ]
                 },
                 {
+                    "exhaustiveFlags": true,
                     "flags": "AnnouncementHeader",
                     "link": {
                         "type": "None",

--- a/tests/src/Plugins.cpp
+++ b/tests/src/Plugins.cpp
@@ -973,6 +973,7 @@ TEST_F(PluginTest, MessageElementFlag)
     )lua");
 
     const char *VALUES = "AlwaysShow=0x2000000,"
+                         "AnnouncementHeader=0x8000000000,"
                          "BadgeBttv=0x40,"
                          "BadgeChannelAuthority=0x8000,"
                          "BadgeChatterino=0x40000,"
@@ -993,6 +994,7 @@ TEST_F(PluginTest, MessageElementFlag)
                          "EmojiText=0x1000000,"
                          "EmoteImage=0x10,"
                          "EmoteText=0x20,"
+                         "HeaderTimestamp=0x4000000000,"
                          "LowercaseLinks=0x20000000,"
                          "Mention=0x8000000,"
                          "Misc=0x1,"


### PR DESCRIPTION
This change is part of the Highlights rework, where it's a lot easier to work with messages if they're not split up into multiple parts.
My intent is to go through other "multi-message messages" and make the same change.

This changes the "Announcement" footer to a header instead.

OLD:
<img width="602" height="502" alt="image" src="https://github.com/user-attachments/assets/ed3044ab-0078-4c94-acd1-d6ab4cc30263" />

NEW:
<img width="602" height="502" alt="image" src="https://github.com/user-attachments/assets/1b3aa81c-a9a9-4c6a-8204-ae83d7276d0c" />



Because Announcements are now a single message, you can no longer filter out the header/footer part.
Because of this, I have added two new settings:
1. "Show header timestamps" (disabled by default). Once hidden, the header timestamp is removed  
<img width="602" height="502" alt="image" src="https://github.com/user-attachments/assets/ef300f85-20d4-41a4-b107-006547ad941b" />

2. "Show announcement header" (enabled by default). Once hidden, the header is removed  
<img width="602" height="502" alt="image" src="https://github.com/user-attachments/assets/6d52d022-83e7-4993-b9dc-5cda44384b03" />




<!--
    Make sure you read the contribution guidelines:
    https://github.com/Chatterino/chatterino2/blob/master/CONTRIBUTING.md

    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
