### PR TITLE
feat: add setting to individually always show a tab

### DIFF
--- a/src/common/WindowDescriptors.cpp
+++ b/src/common/WindowDescriptors.cpp
@@ -238,6 +238,8 @@ TabDescriptor TabDescriptor::loadFromJSON(const QJsonObject &tabObj)
     // Load tab "highlightsEnabled" state
     tab.highlightsEnabled_ = tabObj.value("highlightsEnabled").toBool(true);
 
+    tab.alwaysShow_ = tabObj.value("alwaysShow").toBool(false);
+
     QJsonObject splitRoot = tabObj.value("splits2").toObject();
 
     // Load tab splits

--- a/src/common/WindowDescriptors.hpp
+++ b/src/common/WindowDescriptors.hpp
@@ -95,6 +95,7 @@ struct TabDescriptor {
     QString customTitle_;
     bool selected_{false};
     bool highlightsEnabled_{true};
+    bool alwaysShow_{false};
 
     std::optional<NodeDescriptor> rootNode_;
 

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -699,6 +699,8 @@ void WindowManager::encodeTab(SplitContainer *tab, bool isSelected,
     // highlighting on new messages
     obj.insert("highlightsEnabled", tab->getTab()->hasHighlightsEnabled());
 
+    obj.insert("alwaysShow", tab->getTab()->alwaysShow());
+
     // splits
     obj.insert("splits2", std::visit(
                               [](auto &&it) {
@@ -824,6 +826,8 @@ void WindowManager::applyWindowLayout(const WindowLayout &layout)
 
             // highlighting on new messages
             page->getTab()->setHighlightsEnabled(tab.highlightsEnabled_);
+
+            page->getTab()->setAlwaysShow(tab.alwaysShow_);
 
             if (tab.rootNode_)
             {

--- a/src/widgets/Notebook.cpp
+++ b/src/widgets/Notebook.cpp
@@ -1455,6 +1455,10 @@ SplitNotebook::SplitNotebook(Window *parent)
             {
                 case NotebookTabVisibility::LiveOnly:
                     this->setTabVisibilityFilter([](const NotebookTab *tab) {
+                        if (tab->alwaysShow())
+                        {
+                            return true;
+                        }
                         return tab->isLive();
                     });
                     break;

--- a/src/widgets/helper/NotebookTab.cpp
+++ b/src/widgets/helper/NotebookTab.cpp
@@ -166,7 +166,8 @@ NotebookTab::NotebookTab(Notebook *notebook)
                      });
     this->menu_.addAction(this->highlightNewMessagesAction_);
 
-    this->alwaysShowAction_ = new QAction("Show tab while offline", &this->menu_);
+    this->alwaysShowAction_ =
+        new QAction("Show tab while offline", &this->menu_);
     this->alwaysShowAction_->setToolTip("Show the tab while offline even if "
                                         "\"Only show live tabs\" is selected");
     this->alwaysShowAction_->setCheckable(true);

--- a/src/widgets/helper/NotebookTab.cpp
+++ b/src/widgets/helper/NotebookTab.cpp
@@ -166,6 +166,17 @@ NotebookTab::NotebookTab(Notebook *notebook)
                      });
     this->menu_.addAction(this->highlightNewMessagesAction_);
 
+    this->alwaysShowAction_ =
+        new QAction("Always show Tab", &this->menu_);
+    this->alwaysShowAction_->setCheckable(true);
+    this->alwaysShowAction_->setChecked(this->alwaysShow_);
+    QObject::connect(this->alwaysShowAction_, &QAction::triggered,
+                     [this](bool checked) {
+                         this->alwaysShow_ = checked;
+                         this->notebook_->refresh();
+                     });
+    this->menu_.addAction(this->alwaysShowAction_);
+
     this->menu_.addSeparator();
 
     this->notebook_->addNotebookActionsToMenu(&this->menu_);
@@ -828,6 +839,17 @@ void NotebookTab::setHighlightsEnabled(const bool &newVal)
 bool NotebookTab::hasHighlightsEnabled() const
 {
     return this->highlightEnabled_;
+}
+
+void NotebookTab::setAlwaysShow(const bool &newVal)
+{
+    this->alwaysShowAction_->setChecked(newVal);
+    this->alwaysShow_ = newVal;
+}
+
+bool NotebookTab::alwaysShow() const
+{
+    return this->alwaysShow_;
 }
 
 QRect NotebookTab::getDesiredRect() const

--- a/src/widgets/helper/NotebookTab.cpp
+++ b/src/widgets/helper/NotebookTab.cpp
@@ -166,7 +166,9 @@ NotebookTab::NotebookTab(Notebook *notebook)
                      });
     this->menu_.addAction(this->highlightNewMessagesAction_);
 
-    this->alwaysShowAction_ = new QAction("Always show Tab", &this->menu_);
+    this->alwaysShowAction_ = new QAction("Show tab while offline", &this->menu_);
+    this->alwaysShowAction_->setToolTip("Show the tab while offline even if "
+                                        "\"Only show live tabs\" is selected");
     this->alwaysShowAction_->setCheckable(true);
     this->alwaysShowAction_->setChecked(this->alwaysShow_);
     QObject::connect(this->alwaysShowAction_, &QAction::triggered,
@@ -175,6 +177,8 @@ NotebookTab::NotebookTab(Notebook *notebook)
                          this->notebook_->refresh();
                      });
     this->menu_.addAction(this->alwaysShowAction_);
+
+    this->menu_.setToolTipsVisible(true);
 
     this->menu_.addSeparator();
 

--- a/src/widgets/helper/NotebookTab.cpp
+++ b/src/widgets/helper/NotebookTab.cpp
@@ -840,7 +840,7 @@ bool NotebookTab::hasHighlightsEnabled() const
     return this->highlightEnabled_;
 }
 
-void NotebookTab::setAlwaysShow(const bool &newVal)
+void NotebookTab::setAlwaysShow(bool newVal)
 {
     this->alwaysShowAction_->setChecked(newVal);
     this->alwaysShow_ = newVal;

--- a/src/widgets/helper/NotebookTab.cpp
+++ b/src/widgets/helper/NotebookTab.cpp
@@ -166,8 +166,7 @@ NotebookTab::NotebookTab(Notebook *notebook)
                      });
     this->menu_.addAction(this->highlightNewMessagesAction_);
 
-    this->alwaysShowAction_ =
-        new QAction("Always show Tab", &this->menu_);
+    this->alwaysShowAction_ = new QAction("Always show Tab", &this->menu_);
     this->alwaysShowAction_->setCheckable(true);
     this->alwaysShowAction_->setChecked(this->alwaysShow_);
     QObject::connect(this->alwaysShowAction_, &QAction::triggered,

--- a/src/widgets/helper/NotebookTab.hpp
+++ b/src/widgets/helper/NotebookTab.hpp
@@ -82,6 +82,8 @@ public:
     void newHighlightSourceAdded(const ChannelView &channelViewSource);
     bool hasHighlightsEnabled() const;
     HighlightState highlightState() const;
+    void setAlwaysShow(const bool &newVal);
+    bool alwaysShow() const;
 
     void moveAnimated(QPoint targetPos, bool animated = true);
 
@@ -157,6 +159,9 @@ private:
     HighlightState highlightState_ = HighlightState::None;
     bool highlightEnabled_ = true;
     QAction *highlightNewMessagesAction_;
+
+    bool alwaysShow_ = false;
+    QAction *alwaysShowAction_;
 
     bool isLive_{};
     bool isRerun_{};

--- a/src/widgets/helper/NotebookTab.hpp
+++ b/src/widgets/helper/NotebookTab.hpp
@@ -82,7 +82,7 @@ public:
     void newHighlightSourceAdded(const ChannelView &channelViewSource);
     bool hasHighlightsEnabled() const;
     HighlightState highlightState() const;
-    void setAlwaysShow(const bool &newVal);
+    void setAlwaysShow(bool newVal);
     bool alwaysShow() const;
 
     void moveAnimated(QPoint targetPos, bool animated = true);

--- a/src/widgets/splits/SplitContainer.cpp
+++ b/src/widgets/splits/SplitContainer.cpp
@@ -833,6 +833,8 @@ void SplitContainer::popup()
     // highlighting on new messages
     popupContainer->getTab()->setHighlightsEnabled(tab.highlightsEnabled_);
 
+    popupContainer->getTab()->setAlwaysShow(tab.alwaysShow_);
+
     // splits
     if (tab.rootNode_)
     {


### PR DESCRIPTION
Resolves #7193 

I was not sure how to handle the `Hide all tabs` visibility setting because "Hide all" and "Always show" contradict each other. For now tabs are hidden when `Hide all tabs` is selected even if they have `Always show Tab` checked.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
