### PR TITLE
refactor: use string views for emote lookup

### DIFF
--- a/src/controllers/commands/builtin/twitch/SendWhisper.cpp
+++ b/src/controllers/commands/builtin/twitch/SendWhisper.cpp
@@ -117,7 +117,7 @@ bool appendWhisperMessageWordsLocally(const QStringList &words)
     for (int i = 2; i < words.length(); i++)
     {
         {  // Twitch emote
-            auto it = accemotes->find({words[i]});
+            auto it = accemotes->find(EmoteNameView{words[i]});
             if (it != accemotes->end())
             {
                 b.emplace<EmoteElement>(it->second, MessageElementFlag::Emote);
@@ -126,10 +126,10 @@ bool appendWhisperMessageWordsLocally(const QStringList &words)
         }  // Twitch emote
 
         {  // bttv/ffz emote
-            emote = bttvemotes->emote({words[i]});
+            emote = bttvemotes->emote(EmoteNameView{words[i]});
             if (!emote)
             {
-                emote = ffzemotes->emote({words[i]});
+                emote = ffzemotes->emote(EmoteNameView{words[i]});
             }
             // TODO: Load 7tv global emotes
             if (emote)

--- a/src/messages/Emote.hpp
+++ b/src/messages/Emote.hpp
@@ -47,7 +47,8 @@ bool operator==(const Emote &a, const Emote &b);
 
 using EmotePtr = std::shared_ptr<const Emote>;
 
-class EmoteMap : public std::unordered_map<EmoteName, EmotePtr>
+class EmoteMap : public std::unordered_map<EmoteName, EmotePtr, EmoteNameHash,
+                                           std::equal_to<>>
 {
 public:
     /**

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -461,7 +461,7 @@ EmotePtr makeSharedChatBadge(const QString &sourceName,
     });
 }
 
-EmotePtr parseEmote(TwitchChannel *twitchChannel, const EmoteName &name)
+EmotePtr parseEmote(TwitchChannel *twitchChannel, EmoteNameView name)
 {
     // Emote order:
     //  - FrankerFaceZ Channel
@@ -1876,7 +1876,7 @@ void MessageBuilder::addTextOrEmote(TextState &state, QString string)
     // Emote name: "forsenPuke" - if string in ignoredEmotes
     // Will match emote regardless of source (i.e. bttv, ffz)
     // Emote source + name: "bttv:nyanPls"
-    if (this->tryAppendEmote(state.twitchChannel, {string}))
+    if (this->tryAppendEmote(state.twitchChannel, EmoteNameView{string}))
     {
         // Successfully appended an emote
         return;
@@ -2419,7 +2419,7 @@ void MessageBuilder::appendUsername(Communi::TagsRef tags,
 }
 
 Outcome MessageBuilder::tryAppendEmote(TwitchChannel *twitchChannel,
-                                       const EmoteName &name)
+                                       EmoteNameView name)
 {
     auto emote = parseEmote(twitchChannel, name);
 

--- a/src/messages/MessageBuilder.hpp
+++ b/src/messages/MessageBuilder.hpp
@@ -271,7 +271,7 @@ private:
     void addTextOrEmote(TextState &state, QString string);
 
     Outcome tryAppendCheermote(TextState &state, const QString &string);
-    Outcome tryAppendEmote(TwitchChannel *twitchChannel, const EmoteName &name);
+    Outcome tryAppendEmote(TwitchChannel *twitchChannel, EmoteNameView name);
 
     bool isEmpty() const;
     MessageElement &back();

--- a/src/providers/bttv/BttvEmotes.cpp
+++ b/src/providers/bttv/BttvEmotes.cpp
@@ -217,7 +217,7 @@ std::shared_ptr<const EmoteMap> BttvEmotes::emotes() const
     return this->global_.get();
 }
 
-std::optional<EmotePtr> BttvEmotes::emote(const EmoteName &name) const
+std::optional<EmotePtr> BttvEmotes::emote(EmoteNameView name) const
 {
     auto emotes = this->global_.get();
     auto it = emotes->find(name);

--- a/src/providers/bttv/BttvEmotes.hpp
+++ b/src/providers/bttv/BttvEmotes.hpp
@@ -44,7 +44,7 @@ public:
     BttvEmotes();
 
     std::shared_ptr<const EmoteMap> emotes() const;
-    std::optional<EmotePtr> emote(const EmoteName &name) const;
+    std::optional<EmotePtr> emote(EmoteNameView name) const;
     void loadEmotes();
     void setEmotes(std::shared_ptr<const EmoteMap> emotes);
     static void loadChannel(std::weak_ptr<Channel> channel,

--- a/src/providers/ffz/FfzEmotes.cpp
+++ b/src/providers/ffz/FfzEmotes.cpp
@@ -223,7 +223,7 @@ std::shared_ptr<const EmoteMap> FfzEmotes::emotes() const
     return this->global_.get();
 }
 
-std::optional<EmotePtr> FfzEmotes::emote(const EmoteName &name) const
+std::optional<EmotePtr> FfzEmotes::emote(EmoteNameView name) const
 {
     auto emotes = this->global_.get();
     auto it = emotes->find(name);

--- a/src/providers/ffz/FfzEmotes.hpp
+++ b/src/providers/ffz/FfzEmotes.hpp
@@ -44,7 +44,7 @@ public:
     FfzEmotes();
 
     std::shared_ptr<const EmoteMap> emotes() const;
-    std::optional<EmotePtr> emote(const EmoteName &name) const;
+    std::optional<EmotePtr> emote(EmoteNameView name) const;
     void loadEmotes();
     void setEmotes(std::shared_ptr<const EmoteMap> emotes);
     static void loadChannel(

--- a/src/providers/seventv/SeventvEmotes.cpp
+++ b/src/providers/seventv/SeventvEmotes.cpp
@@ -214,7 +214,7 @@ std::shared_ptr<const EmoteMap> SeventvEmotes::globalEmotes() const
     return this->global_.get();
 }
 
-std::optional<EmotePtr> SeventvEmotes::globalEmote(const EmoteName &name) const
+std::optional<EmotePtr> SeventvEmotes::globalEmote(EmoteNameView name) const
 {
     auto emotes = this->global_.get();
     auto it = emotes->find(name);

--- a/src/providers/seventv/SeventvEmotes.hpp
+++ b/src/providers/seventv/SeventvEmotes.hpp
@@ -106,7 +106,7 @@ public:
     SeventvEmotes();
 
     std::shared_ptr<const EmoteMap> globalEmotes() const;
-    std::optional<EmotePtr> globalEmote(const EmoteName &name) const;
+    std::optional<EmotePtr> globalEmote(EmoteNameView name) const;
     void loadGlobalEmotes();
     void setGlobalEmotes(std::shared_ptr<const EmoteMap> emotes);
     static void loadChannelEmotes(

--- a/src/providers/twitch/TwitchAccount.cpp
+++ b/src/providers/twitch/TwitchAccount.cpp
@@ -401,7 +401,7 @@ void TwitchAccount::setEmotes(std::shared_ptr<const EmoteMap> emotes)
     *this->emotes_.access() = std::move(emotes);
 }
 
-std::optional<EmotePtr> TwitchAccount::twitchEmote(const EmoteName &name) const
+std::optional<EmotePtr> TwitchAccount::twitchEmote(EmoteNameView name) const
 {
     auto emotes = this->emotes_.accessConst();
     auto it = (*emotes)->find(name);

--- a/src/providers/twitch/TwitchAccount.hpp
+++ b/src/providers/twitch/TwitchAccount.hpp
@@ -111,7 +111,7 @@ public:
     void setEmotes(std::shared_ptr<const EmoteMap> emotes);
 
     /// Return the emote by emote name if the account has access to the emote
-    std::optional<EmotePtr> twitchEmote(const EmoteName &name) const;
+    std::optional<EmotePtr> twitchEmote(EmoteNameView name) const;
 
     /// Once emotes are reloaded, TwitchAccountManager::emotesReloaded is
     /// invoked with @a caller and an optional error.

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -1052,7 +1052,7 @@ SharedAccessGuard<const TwitchChannel::StreamStatus>
     return this->streamStatus_.accessConst();
 }
 
-std::optional<EmotePtr> TwitchChannel::twitchEmote(const EmoteName &name) const
+std::optional<EmotePtr> TwitchChannel::twitchEmote(EmoteNameView name) const
 {
     auto emotes = this->localTwitchEmotes();
     auto it = emotes->find(name);
@@ -1064,7 +1064,7 @@ std::optional<EmotePtr> TwitchChannel::twitchEmote(const EmoteName &name) const
     return it->second;
 }
 
-std::optional<EmotePtr> TwitchChannel::bttvEmote(const EmoteName &name) const
+std::optional<EmotePtr> TwitchChannel::bttvEmote(EmoteNameView name) const
 {
     auto emotes = this->bttvEmotes_.get();
     auto it = emotes->find(name);
@@ -1076,7 +1076,7 @@ std::optional<EmotePtr> TwitchChannel::bttvEmote(const EmoteName &name) const
     return it->second;
 }
 
-std::optional<EmotePtr> TwitchChannel::ffzEmote(const EmoteName &name) const
+std::optional<EmotePtr> TwitchChannel::ffzEmote(EmoteNameView name) const
 {
     auto emotes = this->ffzEmotes_.get();
     auto it = emotes->find(name);
@@ -1088,7 +1088,7 @@ std::optional<EmotePtr> TwitchChannel::ffzEmote(const EmoteName &name) const
     return it->second;
 }
 
-std::optional<EmotePtr> TwitchChannel::seventvEmote(const EmoteName &name) const
+std::optional<EmotePtr> TwitchChannel::seventvEmote(EmoteNameView name) const
 {
     auto emotes = this->seventvEmotes_.get();
     auto it = emotes->find(name);

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -233,10 +233,10 @@ public:
     void markConnected();
 
     // Emotes
-    std::optional<EmotePtr> twitchEmote(const EmoteName &name) const;
-    std::optional<EmotePtr> bttvEmote(const EmoteName &name) const;
-    std::optional<EmotePtr> ffzEmote(const EmoteName &name) const;
-    std::optional<EmotePtr> seventvEmote(const EmoteName &name) const;
+    std::optional<EmotePtr> twitchEmote(EmoteNameView name) const;
+    std::optional<EmotePtr> bttvEmote(EmoteNameView name) const;
+    std::optional<EmotePtr> ffzEmote(EmoteNameView name) const;
+    std::optional<EmotePtr> seventvEmote(EmoteNameView name) const;
 
     std::shared_ptr<const EmoteMap> localTwitchEmotes() const;
     std::shared_ptr<const EmoteMap> bttvEmotes() const;

--- a/src/widgets/splits/InputHighlighter.cpp
+++ b/src/widgets/splits/InputHighlighter.cpp
@@ -24,9 +24,9 @@ namespace {
 
 using namespace chatterino;
 
-bool isEmote(TwitchChannel *twitch, const QString &word)
+bool isEmote(TwitchChannel *twitch, QStringView word)
 {
-    EmoteName name{word};
+    EmoteNameView name{word};
     if (twitch)
     {
         if (twitch->bttvEmote(name) || twitch->ffzEmote(name) ||


### PR DESCRIPTION
#7194 added view types for our aliases and this PR uses them for emote lookup. Most of this only changes the parameter types. Notably, it makes `MessageBuilder::tryAppendEmote` and the input highlighter's `isEmote` accept a view.

It's not much yet, since other parts still expect owned strings.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
