### PR TITLE
refactor: move MessageParseArgs to its own file

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -346,6 +346,7 @@ set(SOURCE_FILES
         messages/MessageElement.cpp
         messages/MessageElement.hpp
         messages/MessageFlag.hpp
+        messages/MessageParseArgs.hpp
         messages/MessageSimilarity.cpp
         messages/MessageSimilarity.hpp
         messages/MessageSink.hpp

--- a/src/messages/MessageBuilder.hpp
+++ b/src/messages/MessageBuilder.hpp
@@ -9,6 +9,7 @@
 #include "messages/MessageColor.hpp"
 #include "messages/MessageElement.hpp"
 #include "messages/MessageFlag.hpp"
+#include "messages/MessageParseArgs.hpp"
 
 #include <IrcMessage>
 #include <IrcTagsRef>
@@ -77,17 +78,6 @@ const ImageUploaderResultTag imageUploaderResultMessage{};
 
 MessagePtr makeSystemMessage(const QString &text);
 MessagePtr makeSystemMessage(const QString &text, const QTime &time);
-
-struct MessageParseArgs {
-    bool disablePingSounds = false;
-    bool isReceivedWhisper = false;
-    bool isSentWhisper = false;
-    bool trimSubscriberUsername = false;
-    bool isSubscriptionMessage = false;
-    bool allowIgnore = true;
-    bool isAction = false;
-    QString channelPointRewardId = "";
-};
 
 struct HighlightAlert {
     QUrl customSound;

--- a/src/messages/MessageParseArgs.hpp
+++ b/src/messages/MessageParseArgs.hpp
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2026 Contributors to Chatterino <https://chatterino.com>
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <QString>
+
+namespace chatterino {
+
+struct MessageParseArgs {
+    bool disablePingSounds = false;
+    bool isReceivedWhisper = false;
+    bool isSentWhisper = false;
+    bool trimSubscriberUsername = false;
+    bool isSubscriptionMessage = false;
+    bool allowIgnore = true;
+    bool isAction = false;
+    QString channelPointRewardId = "";
+};
+
+}  // namespace chatterino


### PR DESCRIPTION
<!--
    Make sure you read the contribution guidelines:
    https://github.com/Chatterino/chatterino2/blob/master/CONTRIBUTING.md

    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
