### PR TITLE
ci: check generated LuaLS metadata

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,6 +25,8 @@ jobs:
       - name: Check formatting with Prettier
         run: |
           npx prettier@3.8.1 --write .
+      - name: Generate LuaLS metadata
+        run: python3 scripts/make_luals_meta.py
       - name: Show diff
         run: git --no-pager diff --exit-code --color=never
         shell: bash

--- a/docs/lua-meta/globals.lua
+++ b/docs/lua-meta/globals.lua
@@ -932,6 +932,7 @@ c2.MessageFlag = {
     WatchStreak = 0,
     Announcement = 0,
     UncategorizedNotification = 0,
+    AsciiArt = 0,
 }
 
 -- End src/messages/MessageFlag.hpp


### PR DESCRIPTION
Run `scripts/make_luals_meta.py` in the lint job so ci fails when the generated LuaLS metadata differs from the committed file

Also add missing `AsciiArt` entry to `c2.MessageFlag` in `docs/lua-meta/globals.lua`

I have tested both the pass/fail cases

Fixes #7204

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->