### PR TITLE
refactor: Generalize Twitch emote parsing

### DIFF
--- a/src/controllers/ignores/IgnoreController.cpp
+++ b/src/controllers/ignores/IgnoreController.cpp
@@ -204,27 +204,27 @@ bool isIgnoredMessage(IgnoredMessageParameters &&params)
 
 void processIgnorePhrases(const std::vector<IgnorePhrase> &phrases,
                           QString &content,
-                          std::vector<TwitchEmoteOccurrence> &twitchEmotes)
+                          std::vector<TwitchSpecialOccurrence> &twitchSpecials)
 {
     using SizeType = QString::size_type;
 
-    auto removeEmotesInRange = [&twitchEmotes](SizeType pos, SizeType len) {
+    auto removeSpecialsInRange = [&twitchSpecials](SizeType pos, SizeType len) {
         // all emotes outside the range come before `it`
         // all emotes in the range start at `it`
         auto it = std::partition(
-            twitchEmotes.begin(), twitchEmotes.end(),
+            twitchSpecials.begin(), twitchSpecials.end(),
             [pos, len](const auto &item) {
                 // returns true for emotes outside the range
                 return !((item.start >= pos) && item.start < (pos + len));
             });
-        std::vector<TwitchEmoteOccurrence> emotesInRange(it,
-                                                         twitchEmotes.end());
-        twitchEmotes.erase(it, twitchEmotes.end());
-        return emotesInRange;
+        std::vector<TwitchSpecialOccurrence> specialsInRange(
+            it, twitchSpecials.end());
+        twitchSpecials.erase(it, twitchSpecials.end());
+        return specialsInRange;
     };
 
-    auto shiftIndicesAfter = [&twitchEmotes](int pos, int by) {
-        for (auto &item : twitchEmotes)
+    auto shiftIndicesAfter = [&twitchSpecials](int pos, int by) {
+        for (auto &item : twitchSpecials)
         {
             auto &index = item.start;
             if (index >= pos)
@@ -235,9 +235,9 @@ void processIgnorePhrases(const std::vector<IgnorePhrase> &phrases,
         }
     };
 
-    auto addReplEmotes = [&twitchEmotes](const IgnorePhrase &phrase,
-                                         const auto &midrepl,
-                                         SizeType startIndex) {
+    auto addReplEmotes = [&twitchSpecials](const IgnorePhrase &phrase,
+                                           const auto &midrepl,
+                                           SizeType startIndex) {
         if (!phrase.containsEmote())
         {
             return;
@@ -256,12 +256,15 @@ void processIgnorePhrases(const std::vector<IgnorePhrase> &phrases,
                         qCDebug(chatterinoTwitch)
                             << "emote null" << emote.first.string;
                     }
-                    twitchEmotes.push_back(TwitchEmoteOccurrence{
-                        static_cast<int>(startIndex + pos),
-                        static_cast<int>(startIndex + pos +
-                                         emote.first.string.length()),
-                        emote.second,
-                        emote.first,
+                    twitchSpecials.push_back(TwitchSpecialOccurrence{
+                        .start = static_cast<int>(startIndex + pos),
+                        .end = static_cast<int>(startIndex + pos +
+                                                emote.first.string.length()),
+                        .data =
+                            TwitchEmoteOccurrence{
+                                .ptr = emote.second,
+                                .name = emote.first,
+                            },
                     });
                 }
             }
@@ -271,7 +274,7 @@ void processIgnorePhrases(const std::vector<IgnorePhrase> &phrases,
 
     auto replaceMessageAt = [&](const IgnorePhrase &phrase, SizeType from,
                                 SizeType length, const QString &replacement) {
-        auto removedEmotes = removeEmotesInRange(from, length);
+        auto removedSpecials = removeSpecialsInRange(from, length);
         content.replace(from, length, replacement);
         auto wordStart = from;
         while (wordStart > 0)
@@ -298,23 +301,28 @@ void processIgnorePhrases(const std::vector<IgnorePhrase> &phrases,
         auto midExtendedRef =
             QStringView{content}.mid(wordStart, wordEnd - wordStart);
 
-        for (auto &emote : removedEmotes)
+        for (auto &emote : removedSpecials)
         {
-            if (emote.ptr == nullptr)
+            auto *data = std::get_if<TwitchEmoteOccurrence>(&emote.data);
+            if (!data)
+            {
+                continue;  // Nothing we can fix.
+            }
+            if (data->ptr == nullptr)
             {
                 qCDebug(chatterinoTwitch)
-                    << "Invalid emote occurrence" << emote.name.string;
+                    << "Invalid emote occurrence" << data->name.string;
                 continue;
             }
             QRegularExpression emoteregex(
-                "\\b" + emote.name.string + "\\b",
+                "\\b" + data->name.string + "\\b",
                 QRegularExpression::UseUnicodePropertiesOption);
             auto match = emoteregex.matchView(midExtendedRef);
             if (match.hasMatch())
             {
                 emote.start = static_cast<int>(from + match.capturedStart());
                 emote.end = static_cast<int>(from + match.capturedEnd());
-                twitchEmotes.push_back(std::move(emote));
+                twitchSpecials.push_back(std::move(emote));
             }
         }
 

--- a/src/controllers/ignores/IgnoreController.hpp
+++ b/src/controllers/ignores/IgnoreController.hpp
@@ -11,7 +11,7 @@
 namespace chatterino {
 
 class IgnorePhrase;
-struct TwitchEmoteOccurrence;
+struct TwitchSpecialOccurrence;
 
 enum class ShowIgnoredUsersMessages { Never, IfModerator, IfBroadcaster };
 
@@ -31,12 +31,12 @@ bool isIgnoredMessage(IgnoredMessageParameters &&params);
 /// @param phrases A list of IgnorePhrases to process. Block phrases as well as
 /// 	           invalid phrases are ignored.
 /// @param content The message text. This gets altered by replacements.
-/// @param twitchEmotes A list of emotes present in the message. Occurrences
+/// @param twitchSpecials A list of special items present in the message. Occurrences
 ///                     that have been removed from the message will also be
 ///                     removed in this list. Similarly, if new emotes are added
 ///                     from a replacement, this list gets updated as well.
 void processIgnorePhrases(const std::vector<IgnorePhrase> &phrases,
                           QString &content,
-                          std::vector<TwitchEmoteOccurrence> &twitchEmotes);
+                          std::vector<TwitchSpecialOccurrence> &twitchSpecials);
 
 }  // namespace chatterino

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -391,18 +391,19 @@ std::vector<TwitchBadge> appendSharedChatBadges(
     return appendedBadges;
 }
 
-bool doesWordContainATwitchEmote(
+bool doesWordContainATwitchSpecial(
     int cursor, const QString &word,
-    const std::vector<TwitchEmoteOccurrence> &twitchEmotes,
-    std::vector<TwitchEmoteOccurrence>::const_iterator &currentTwitchEmoteIt)
+    const std::vector<TwitchSpecialOccurrence> &twitchSpecials,
+    std::vector<TwitchSpecialOccurrence>::const_iterator
+        &currentTwitchSpecialIt)
 {
-    if (currentTwitchEmoteIt == twitchEmotes.end())
+    if (currentTwitchSpecialIt == twitchSpecials.end())
     {
         // No emote to add!
         return false;
     }
 
-    const auto &currentTwitchEmote = *currentTwitchEmoteIt;
+    const auto &currentTwitchEmote = *currentTwitchSpecialIt;
 
     auto wordEnd = cursor + word.length();
 
@@ -1795,21 +1796,21 @@ std::pair<MessagePtrMut, HighlightAlert> MessageBuilder::makeIrcMessage(
         }
 
         // Twitch emotes
-        auto twitchEmotes =
-            parseTwitchEmotes(tags, content, static_cast<int>(messageOffset));
+        auto twitchSpecials = parseTwitchOccurrences(
+            tags, content, static_cast<int>(messageOffset));
 
         // This runs through all ignored phrases and runs its replacements on content
         processIgnorePhrases(*getSettings()->ignoredMessages.readOnly(),
-                             content, twitchEmotes);
+                             content, twitchSpecials);
 
-        std::ranges::sort(twitchEmotes, [](const auto &a, const auto &b) {
+        std::ranges::sort(twitchSpecials, [](const auto &a, const auto &b) {
             return a.start < b.start;
         });
         auto uniqueEmotes = std::ranges::unique(
-            twitchEmotes, [](const auto &first, const auto &second) {
+            twitchSpecials, [](const auto &first, const auto &second) {
                 return first.start == second.start;
             });
-        twitchEmotes.erase(uniqueEmotes.begin(), uniqueEmotes.end());
+        twitchSpecials.erase(uniqueEmotes.begin(), uniqueEmotes.end());
 
         if (getSettings()->wrapAsciiArt && isAsciiArt(content))
         {
@@ -1819,7 +1820,7 @@ std::pair<MessagePtrMut, HighlightAlert> MessageBuilder::makeIrcMessage(
         // words
         QStringList splits = content.split(' ');
 
-        builder.addWords(splits, twitchEmotes, textState);
+        builder.addWords(splits, twitchSpecials, textState);
 
         QString stylizedUsername =
             stylizeUsername(builder->loginName, builder.message());
@@ -2684,11 +2685,12 @@ Outcome MessageBuilder::tryAppendEmote(TwitchChannel *twitchChannel,
 
 void MessageBuilder::addWords(
     const QStringList &words,
-    const std::vector<TwitchEmoteOccurrence> &twitchEmotes, TextState &state)
+    const std::vector<TwitchSpecialOccurrence> &twitchSpecials,
+    TextState &state)
 {
     // cursor currently indicates what character index we're currently operating in the full list of words
     int cursor = 0;
-    auto currentTwitchEmoteIt = twitchEmotes.begin();
+    auto currentTwitchSpecialIt = twitchSpecials.begin();
 
     for (auto word : words)
     {
@@ -2698,23 +2700,29 @@ void MessageBuilder::addWords(
             continue;
         }
 
-        while (doesWordContainATwitchEmote(cursor, word, twitchEmotes,
-                                           currentTwitchEmoteIt))
+        while (doesWordContainATwitchSpecial(cursor, word, twitchSpecials,
+                                             currentTwitchSpecialIt))
         {
-            const auto &currentTwitchEmote = *currentTwitchEmoteIt;
+            const auto &currentSpecial = *currentTwitchSpecialIt;
 
-            if (currentTwitchEmote.start == cursor)
+            if (currentSpecial.start == cursor)
             {
-                // This emote exists right at the start of the word!
-                this->emplace<EmoteElement>(currentTwitchEmote.ptr,
-                                            MessageElementFlag::Emote,
-                                            this->textColor_);
+                std::visit(
+                    variant::Overloaded{
+                        [&](const TwitchEmoteOccurrence &emote) {
+                            // This emote exists right at the start of the word!
+                            this->emplace<EmoteElement>(
+                                emote.ptr, MessageElementFlag::Emote,
+                                this->textColor_);
 
-                auto len = currentTwitchEmote.name.string.length();
-                cursor += len;
-                word = word.mid(len);
+                            auto len = emote.name.string.length();
+                            cursor += len;
+                            word = word.mid(len);
+                        },
+                    },
+                    currentSpecial.data);
 
-                ++currentTwitchEmoteIt;
+                ++currentTwitchSpecialIt;
 
                 if (word.isEmpty())
                 {
@@ -2733,7 +2741,7 @@ void MessageBuilder::addWords(
             // Emote is not at the start
 
             // 1. Add text before the emote
-            QString preText = word.left(currentTwitchEmote.start - cursor);
+            QString preText = word.left(currentSpecial.start - cursor);
             for (auto variant :
                  getApp()->getEmotes()->getEmojis()->parse(preText))
             {

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -2716,7 +2716,7 @@ void MessageBuilder::addWords(
                                 this->textColor_);
 
                             auto len = emote.name.string.length();
-                            cursor += len;
+                            cursor += static_cast<int>(len);
                             word = word.mid(len);
                         },
                     },

--- a/src/messages/MessageBuilder.hpp
+++ b/src/messages/MessageBuilder.hpp
@@ -41,7 +41,7 @@ class IgnorePhrase;
 struct HelixVip;
 using HelixModerator = HelixVip;
 struct ChannelPointReward;
-struct TwitchEmoteOccurrence;
+struct TwitchSpecialOccurrence;
 struct HelixPinnedChatMessage;
 
 namespace linkparser {
@@ -317,7 +317,7 @@ private:
     void appendUsername(Communi::TagsRef tags, const MessageParseArgs &args);
 
     void addWords(const QStringList &words,
-                  const std::vector<TwitchEmoteOccurrence> &twitchEmotes,
+                  const std::vector<TwitchSpecialOccurrence> &twitchSpecials,
                   TextState &state);
 
     void appendTwitchBadges(Communi::TagsRef tags,

--- a/src/providers/twitch/TwitchIrc.cpp
+++ b/src/providers/twitch/TwitchIrc.cpp
@@ -92,8 +92,8 @@ void appendTwitchEmoteOccurrences(QStringView emote,
             [&](QStringView nameStr) -> std::optional<TwitchEmoteOccurrence> {
                 auto name = EmoteName{nameStr.toString()};
                 auto ptr =
-                    getApp()->getEmotes()->getTwitchEmotes()->getOrCreateEmote(
-                        id, name);
+                    app->getEmotes()->getTwitchEmotes()->getOrCreateEmote(id,
+                                                                          name);
                 if (!ptr)
                 {
                     qCDebug(chatterinoTwitch) << "Invalid emote:" << id.string;

--- a/src/providers/twitch/TwitchIrc.cpp
+++ b/src/providers/twitch/TwitchIrc.cpp
@@ -18,8 +18,58 @@ namespace {
 
 using namespace chatterino;
 
+void createSpecialOccurrence(QStringView occurrence,
+                             std::vector<TwitchSpecialOccurrence> &out,
+                             std::span<const uint16_t> codepointToUtf16Idx,
+                             QStringView originalMessage, int messageOffset,
+                             auto &&factory)
+{
+    auto [fromStr, toStr] = splitOnce(occurrence, u'-');
+    bool fromOk = false;
+    bool toOk = false;
+    uint16_t from = fromStr.toUShort(&fromOk);
+    uint16_t to = toStr.toUShort(&toOk);
+    if (!fromOk || !toOk)
+    {
+        qCDebug(chatterinoTwitch) << "Invalid range:" << occurrence;
+        return;
+    }
+    if (from > to || std::cmp_less(from, messageOffset))
+    {
+        qCDebug(chatterinoTwitch) << "Out of bounds range:" << occurrence
+                                  << "offset:" << messageOffset;
+        return;
+    }
+    to -= messageOffset;
+    from -= messageOffset;
+    if (to >= codepointToUtf16Idx.size())
+    {
+        qCDebug(chatterinoTwitch)
+            << "Out of bounds range:" << occurrence
+            << "max-codepoints:" << codepointToUtf16Idx.size();
+        return;
+    }
+
+    auto start = codepointToUtf16Idx[from];
+    auto end = codepointToUtf16Idx[to];
+    assert(start <= end && end < originalMessage.length() &&
+           "Bad codepointToUtf16Idx list");
+
+    auto created = factory(originalMessage.sliced(start, end - start + 1));
+    if (!created.has_value())
+    {
+        return;
+    }
+
+    out.emplace_back(TwitchSpecialOccurrence{
+        .start = start,
+        .end = end,
+        .data = *std::move(created),
+    });
+}
+
 void appendTwitchEmoteOccurrences(QStringView emote,
-                                  std::vector<TwitchEmoteOccurrence> &out,
+                                  std::vector<TwitchSpecialOccurrence> &out,
                                   std::span<const uint16_t> codepointToUtf16Idx,
                                   QStringView originalMessage,
                                   int messageOffset)
@@ -36,54 +86,21 @@ void appendTwitchEmoteOccurrences(QStringView emote,
 
     for (const auto occurrence : ranges.tokenize(u','))
     {
-        auto [fromStr, toStr] = splitOnce(occurrence, u'-');
-        bool fromOk = false;
-        bool toOk = false;
-        uint16_t from = fromStr.toUShort(&fromOk);
-        uint16_t to = toStr.toUShort(&toOk);
-        if (!fromOk || !toOk)
-        {
-            qCDebug(chatterinoTwitch) << "Invalid emote range:" << occurrence;
-            continue;
-        }
-        if (from > to || std::cmp_less(from, messageOffset))
-        {
-            qCDebug(chatterinoTwitch)
-                << "Out of bounds emote range:" << occurrence
-                << "offset:" << messageOffset;
-            continue;
-        }
-        to -= messageOffset;
-        from -= messageOffset;
-        if (to >= codepointToUtf16Idx.size())
-        {
-            qCDebug(chatterinoTwitch)
-                << "Out of bounds emote range:" << occurrence
-                << "max-codepoints:" << codepointToUtf16Idx.size();
-            return;
-        }
-
-        auto start = codepointToUtf16Idx[from];
-        auto end = codepointToUtf16Idx[to];
-        assert(start <= end && end < originalMessage.length() &&
-               "Bad codepointToUtf16Idx list");
-
-        auto name = EmoteName{
-            originalMessage.sliced(start, end - start + 1).toString()};
-        auto ptr =
-            app->getEmotes()->getTwitchEmotes()->getOrCreateEmote(id, name);
-        if (!ptr)
-        {
-            qCDebug(chatterinoTwitch) << "Invalid emote:" << id.string;
-            continue;
-        }
-
-        out.emplace_back(TwitchEmoteOccurrence{
-            .start = start,
-            .end = end,
-            .ptr = ptr,
-            .name = name,
-        });
+        createSpecialOccurrence(
+            occurrence, out, codepointToUtf16Idx, originalMessage,
+            messageOffset,
+            [&](QStringView nameStr) -> std::optional<TwitchEmoteOccurrence> {
+                auto name = EmoteName{nameStr.toString()};
+                auto ptr =
+                    getApp()->getEmotes()->getTwitchEmotes()->getOrCreateEmote(
+                        id, name);
+                if (!ptr)
+                {
+                    qCDebug(chatterinoTwitch) << "Invalid emote:" << id.string;
+                    return std::nullopt;
+                }
+                return TwitchEmoteOccurrence{.ptr = ptr, .name = name};
+            });
     }
 }
 
@@ -138,19 +155,18 @@ std::vector<TwitchBadge> parseBadgeTag(Communi::TagsRef tags,
     return b;
 }
 
-std::vector<TwitchEmoteOccurrence> parseTwitchEmotes(Communi::TagsRef tags,
-                                                     QStringView content,
-                                                     int messageOffset)
+std::vector<TwitchSpecialOccurrence> parseTwitchOccurrences(
+    Communi::TagsRef tags, QStringView content, int messageOffset)
 {
     // Twitch emotes
-    std::vector<TwitchEmoteOccurrence> twitchEmotes;
+    std::vector<TwitchSpecialOccurrence> occurrences;
 
     auto emotesTag = tags.getOrEmpty("emotes");
 
     if (emotesTag.isEmpty() ||
         content.size() > std::numeric_limits<uint16_t>::max())
     {
-        return twitchEmotes;
+        return occurrences;
     }
 
     QVarLengthArray<uint16_t, 128> codepointToUtf16Idx;
@@ -166,11 +182,11 @@ std::vector<TwitchEmoteOccurrence> parseTwitchEmotes(Communi::TagsRef tags,
     }
     for (const auto emote : emotesTag.tokenize(u'/'))
     {
-        appendTwitchEmoteOccurrences(emote, twitchEmotes, codepointToUtf16Idx,
+        appendTwitchEmoteOccurrences(emote, occurrences, codepointToUtf16Idx,
                                      content, messageOffset);
     }
 
-    return twitchEmotes;
+    return occurrences;
 }
 
 }  // namespace chatterino

--- a/src/providers/twitch/TwitchIrc.hpp
+++ b/src/providers/twitch/TwitchIrc.hpp
@@ -12,6 +12,7 @@
 #include <QVariantMap>
 
 #include <unordered_map>
+#include <variant>
 
 namespace chatterino {
 

--- a/src/providers/twitch/TwitchIrc.hpp
+++ b/src/providers/twitch/TwitchIrc.hpp
@@ -16,16 +16,18 @@
 namespace chatterino {
 
 struct TwitchEmoteOccurrence {
-    int start;
-    int end;
     EmotePtr ptr;
     EmoteName name;
 
-    bool operator==(const TwitchEmoteOccurrence &other) const
-    {
-        return std::tie(this->start, this->end, this->ptr, this->name) ==
-               std::tie(other.start, other.end, other.ptr, other.name);
-    }
+    bool operator==(const TwitchEmoteOccurrence &rhs) const = default;
+};
+
+struct TwitchSpecialOccurrence {
+    int start;
+    int end;
+    std::variant<TwitchEmoteOccurrence> data;
+
+    bool operator==(const TwitchSpecialOccurrence &other) const = default;
 };
 
 /// @brief Parses the `badge-info` tag of an IRC message
@@ -55,7 +57,7 @@ std::unordered_map<QString, QString> parseBadgeInfoTag(Communi::TagsRef tags);
 std::vector<TwitchBadge> parseBadgeTag(Communi::TagsRef tags,
                                        const QString &tagName = "badges");
 
-/// @brief Parses Twitch emotes in an IRC message
+/// @brief Parses special Twitch occurrences (e.g. emotes) in an IRC message
 ///
 /// @param tags The tags of the IRC message
 /// @param content The message text. This might be shortened due to skipping
@@ -66,9 +68,8 @@ std::vector<TwitchBadge> parseBadgeTag(Communi::TagsRef tags,
 ///                      `content` excludes the first three characters of the
 ///                      original message (`@a foo` (original message) -> `foo`
 ///                      (content)).
-/// @returns A list of emotes and their positions
-std::vector<TwitchEmoteOccurrence> parseTwitchEmotes(Communi::TagsRef tags,
-                                                     QStringView content,
-                                                     int messageOffset);
+/// @returns A list of their positions
+std::vector<TwitchSpecialOccurrence> parseTwitchOccurrences(
+    Communi::TagsRef tags, QStringView content, int messageOffset);
 
 }  // namespace chatterino

--- a/tests/src/IgnoreController.cpp
+++ b/tests/src/IgnoreController.cpp
@@ -57,20 +57,23 @@ TEST_F(TestIgnoreController, processIgnorePhrases)
     struct TestCase {
         std::vector<IgnorePhrase> phrases;
         QString input;
-        std::vector<TwitchEmoteOccurrence> twitchEmotes;
+        std::vector<TwitchSpecialOccurrence> twitchSpecials;
         QString expectedMessage;
-        std::vector<TwitchEmoteOccurrence> expectedTwitchEmotes;
+        std::vector<TwitchSpecialOccurrence> expectedTwitchSpecials;
     };
 
     auto *twitchEmotes = this->mockApplication->getEmotes()->getTwitchEmotes();
 
     auto emoteAt = [&](int at, const QString &name) {
-        return TwitchEmoteOccurrence{
+        return TwitchSpecialOccurrence{
             .start = at,
             .end = static_cast<int>(at + name.size() - 1),
-            .ptr =
-                twitchEmotes->getOrCreateEmote(EmoteId{name}, EmoteName{name}),
-            .name = EmoteName{name},
+            .data =
+                TwitchEmoteOccurrence{
+                    .ptr = twitchEmotes->getOrCreateEmote(EmoteId{name},
+                                                          EmoteName{name}),
+                    .name = EmoteName{name},
+                },
         };
     };
 
@@ -184,14 +187,14 @@ TEST_F(TestIgnoreController, processIgnorePhrases)
     for (const auto &test : testCases)
     {
         auto message = test.input;
-        auto emotes = test.twitchEmotes;
+        auto emotes = test.twitchSpecials;
         processIgnorePhrases(test.phrases, message, emotes);
 
         EXPECT_EQ(message, test.expectedMessage)
             << "Message not equal for input '" << test.input
             << "' - expected: '" << test.expectedMessage << "' got: '"
             << message << "'";
-        EXPECT_EQ(emotes, test.expectedTwitchEmotes)
+        EXPECT_EQ(emotes, test.expectedTwitchSpecials)
             << "Twitch emotes not equal for input '" << test.input
             << "' and output '" << message << "'";
     }

--- a/tests/src/TwitchIrc.cpp
+++ b/tests/src/TwitchIrc.cpp
@@ -180,8 +180,8 @@ TEST_F(TestTwitchIrc, ParseTwitchSpecials)
                     4,  // end
                     TwitchEmoteOccurrence{
                         .ptr = twitchEmotes->getOrCreateEmote(
-                            EmoteId{"25"}, EmoteName{"Kappa"}),  // ptr
-                        .name = EmoteName{"Kappa"},              // name
+                            EmoteId{"25"}, EmoteName{"Kappa"}),
+                        .name = EmoteName{"Kappa"},
                     },
                 }},
             },
@@ -194,8 +194,8 @@ TEST_F(TestTwitchIrc, ParseTwitchSpecials)
                     4,  // end
                     TwitchEmoteOccurrence{
                         .ptr = twitchEmotes->getOrCreateEmote(
-                            EmoteId{"25"}, EmoteName{"Kappa"}),  // ptr
-                        .name = EmoteName{"Kappa"},              // name
+                            EmoteId{"25"}, EmoteName{"Kappa"}),
+                        .name = EmoteName{"Kappa"},
                     },
                 }},
             },
@@ -208,8 +208,8 @@ TEST_F(TestTwitchIrc, ParseTwitchSpecials)
                     4,  // end
                     TwitchEmoteOccurrence{
                         .ptr = twitchEmotes->getOrCreateEmote(
-                            EmoteId{"1902"}, EmoteName{"Keepo"}),  // ptr
-                        .name = EmoteName{"Keepo"},                // name
+                            EmoteId{"1902"}, EmoteName{"Keepo"}),
+                        .name = EmoteName{"Keepo"},
                     },
                 }},
             },
@@ -223,8 +223,8 @@ TEST_F(TestTwitchIrc, ParseTwitchSpecials)
                         4,  // end
                         TwitchEmoteOccurrence{
                             .ptr = twitchEmotes->getOrCreateEmote(
-                                EmoteId{"25"}, EmoteName{"Kappa"}),  // ptr
-                            .name = EmoteName{"Kappa"},              // name
+                                EmoteId{"25"}, EmoteName{"Kappa"}),
+                            .name = EmoteName{"Kappa"},
                         },
                     },
                     {
@@ -232,8 +232,8 @@ TEST_F(TestTwitchIrc, ParseTwitchSpecials)
                         10,  // end
                         TwitchEmoteOccurrence{
                             .ptr = twitchEmotes->getOrCreateEmote(
-                                EmoteId{"1902"}, EmoteName{"Keepo"}),  // ptr
-                            .name = EmoteName{"Keepo"},                // name
+                                EmoteId{"1902"}, EmoteName{"Keepo"}),
+                            .name = EmoteName{"Keepo"},
                         },
                     },
                     {
@@ -241,9 +241,8 @@ TEST_F(TestTwitchIrc, ParseTwitchSpecials)
                         19,  // end
                         TwitchEmoteOccurrence{
                             .ptr = twitchEmotes->getOrCreateEmote(
-                                EmoteId{"305954156"},
-                                EmoteName{"PogChamp"}),     // ptr
-                            .name = EmoteName{"PogChamp"},  // name
+                                EmoteId{"305954156"}, EmoteName{"PogChamp"}),
+                            .name = EmoteName{"PogChamp"},
                         },
                     },
                 },
@@ -258,8 +257,8 @@ TEST_F(TestTwitchIrc, ParseTwitchSpecials)
                         4,  // end
                         TwitchEmoteOccurrence{
                             .ptr = twitchEmotes->getOrCreateEmote(
-                                EmoteId{"25"}, EmoteName{"Kappa"}),  // ptr
-                            .name = EmoteName{"Kappa"},              // name
+                                EmoteId{"25"}, EmoteName{"Kappa"}),
+                            .name = EmoteName{"Kappa"},
                         },
                     },
                     {
@@ -267,8 +266,8 @@ TEST_F(TestTwitchIrc, ParseTwitchSpecials)
                         10,  // end
                         TwitchEmoteOccurrence{
                             .ptr = twitchEmotes->getOrCreateEmote(
-                                EmoteId{"25"}, EmoteName{"Kappa"}),  // ptr
-                            .name = EmoteName{"Kappa"},              // name
+                                EmoteId{"25"}, EmoteName{"Kappa"}),
+                            .name = EmoteName{"Kappa"},
                         },
                     },
                 },
@@ -283,8 +282,8 @@ TEST_F(TestTwitchIrc, ParseTwitchSpecials)
                         4,  // end
                         TwitchEmoteOccurrence{
                             .ptr = twitchEmotes->getOrCreateEmote(
-                                EmoteId{"25"}, EmoteName{"Kappa"}),  // ptr
-                            .name = EmoteName{"Kappa"},              // name
+                                EmoteId{"25"}, EmoteName{"Kappa"}),
+                            .name = EmoteName{"Kappa"},
                         },
                     },
                     {
@@ -292,8 +291,8 @@ TEST_F(TestTwitchIrc, ParseTwitchSpecials)
                         13,  // end - modified due to emoji
                         TwitchEmoteOccurrence{
                             .ptr = twitchEmotes->getOrCreateEmote(
-                                EmoteId{"25"}, EmoteName{"Kappa"}),  // ptr
-                            .name = EmoteName{"Kappa"},              // name
+                                EmoteId{"25"}, EmoteName{"Kappa"}),
+                            .name = EmoteName{"Kappa"},
                         },
                     },
                 },
@@ -312,9 +311,9 @@ TEST_F(TestTwitchIrc, ParseTwitchSpecials)
                     0,  // start
                     0,  // end
                     TwitchEmoteOccurrence{
-                        .ptr = twitchEmotes->getOrCreateEmote(
-                            EmoteId{"84608"}, EmoteName{"f"}),  // ptr
-                        .name = EmoteName{"f"},                 // name
+                        .ptr = twitchEmotes->getOrCreateEmote(EmoteId{"84608"},
+                                                              EmoteName{"f"}),
+                        .name = EmoteName{"f"},
                     },
                 },
             },
@@ -327,9 +326,9 @@ TEST_F(TestTwitchIrc, ParseTwitchSpecials)
                     0,  // start
                     1,  // end
                     TwitchEmoteOccurrence{
-                        .ptr = twitchEmotes->getOrCreateEmote(
-                            EmoteId{"84609"}, EmoteName{"fo"}),  // ptr
-                        .name = EmoteName{"fo"},                 // name
+                        .ptr = twitchEmotes->getOrCreateEmote(EmoteId{"84609"},
+                                                              EmoteName{"fo"}),
+                        .name = EmoteName{"fo"},
                     },
                 },
             },

--- a/tests/src/TwitchIrc.cpp
+++ b/tests/src/TwitchIrc.cpp
@@ -161,11 +161,11 @@ TEST(TwitchIrc, BadgeInfoParsing)
     }
 }
 
-TEST_F(TestTwitchIrc, ParseTwitchEmotes)
+TEST_F(TestTwitchIrc, ParseTwitchSpecials)
 {
     struct TestCase {
         QByteArray input;
-        std::vector<TwitchEmoteOccurrence> expectedTwitchEmotes;
+        std::vector<TwitchSpecialOccurrence> expectedTwitchSpecials;
     };
 
     auto *twitchEmotes = this->mockApplication->getEmotes()->getTwitchEmotes();
@@ -178,9 +178,11 @@ TEST_F(TestTwitchIrc, ParseTwitchEmotes)
                 {{
                     0,  // start
                     4,  // end
-                    twitchEmotes->getOrCreateEmote(EmoteId{"25"},
-                                                   EmoteName{"Kappa"}),  // ptr
-                    EmoteName{"Kappa"},                                  // name
+                    TwitchEmoteOccurrence{
+                        .ptr = twitchEmotes->getOrCreateEmote(
+                            EmoteId{"25"}, EmoteName{"Kappa"}),  // ptr
+                        .name = EmoteName{"Kappa"},              // name
+                    },
                 }},
             },
         },
@@ -190,9 +192,11 @@ TEST_F(TestTwitchIrc, ParseTwitchEmotes)
                 {{
                     0,  // start
                     4,  // end
-                    twitchEmotes->getOrCreateEmote(EmoteId{"25"},
-                                                   EmoteName{"Kappa"}),  // ptr
-                    EmoteName{"Kappa"},                                  // name
+                    TwitchEmoteOccurrence{
+                        .ptr = twitchEmotes->getOrCreateEmote(
+                            EmoteId{"25"}, EmoteName{"Kappa"}),  // ptr
+                        .name = EmoteName{"Kappa"},              // name
+                    },
                 }},
             },
         },
@@ -202,9 +206,11 @@ TEST_F(TestTwitchIrc, ParseTwitchEmotes)
                 {{
                     0,  // start
                     4,  // end
-                    twitchEmotes->getOrCreateEmote(EmoteId{"1902"},
-                                                   EmoteName{"Keepo"}),  // ptr
-                    EmoteName{"Keepo"},                                  // name
+                    TwitchEmoteOccurrence{
+                        .ptr = twitchEmotes->getOrCreateEmote(
+                            EmoteId{"1902"}, EmoteName{"Keepo"}),  // ptr
+                        .name = EmoteName{"Keepo"},                // name
+                    },
                 }},
             },
         },
@@ -215,24 +221,30 @@ TEST_F(TestTwitchIrc, ParseTwitchEmotes)
                     {
                         0,  // start
                         4,  // end
-                        twitchEmotes->getOrCreateEmote(
-                            EmoteId{"25"}, EmoteName{"Kappa"}),  // ptr
-                        EmoteName{"Kappa"},                      // name
+                        TwitchEmoteOccurrence{
+                            .ptr = twitchEmotes->getOrCreateEmote(
+                                EmoteId{"25"}, EmoteName{"Kappa"}),  // ptr
+                            .name = EmoteName{"Kappa"},              // name
+                        },
                     },
                     {
                         6,   // start
                         10,  // end
-                        twitchEmotes->getOrCreateEmote(
-                            EmoteId{"1902"}, EmoteName{"Keepo"}),  // ptr
-                        EmoteName{"Keepo"},                        // name
+                        TwitchEmoteOccurrence{
+                            .ptr = twitchEmotes->getOrCreateEmote(
+                                EmoteId{"1902"}, EmoteName{"Keepo"}),  // ptr
+                            .name = EmoteName{"Keepo"},                // name
+                        },
                     },
                     {
                         12,  // start
                         19,  // end
-                        twitchEmotes->getOrCreateEmote(
-                            EmoteId{"305954156"},
-                            EmoteName{"PogChamp"}),  // ptr
-                        EmoteName{"PogChamp"},       // name
+                        TwitchEmoteOccurrence{
+                            .ptr = twitchEmotes->getOrCreateEmote(
+                                EmoteId{"305954156"},
+                                EmoteName{"PogChamp"}),     // ptr
+                            .name = EmoteName{"PogChamp"},  // name
+                        },
                     },
                 },
             },
@@ -244,16 +256,20 @@ TEST_F(TestTwitchIrc, ParseTwitchEmotes)
                     {
                         0,  // start
                         4,  // end
-                        twitchEmotes->getOrCreateEmote(
-                            EmoteId{"25"}, EmoteName{"Kappa"}),  // ptr
-                        EmoteName{"Kappa"},                      // name
+                        TwitchEmoteOccurrence{
+                            .ptr = twitchEmotes->getOrCreateEmote(
+                                EmoteId{"25"}, EmoteName{"Kappa"}),  // ptr
+                            .name = EmoteName{"Kappa"},              // name
+                        },
                     },
                     {
                         6,   // start
                         10,  // end
-                        twitchEmotes->getOrCreateEmote(
-                            EmoteId{"25"}, EmoteName{"Kappa"}),  // ptr
-                        EmoteName{"Kappa"},                      // name
+                        TwitchEmoteOccurrence{
+                            .ptr = twitchEmotes->getOrCreateEmote(
+                                EmoteId{"25"}, EmoteName{"Kappa"}),  // ptr
+                            .name = EmoteName{"Kappa"},              // name
+                        },
                     },
                 },
             },
@@ -265,16 +281,20 @@ TEST_F(TestTwitchIrc, ParseTwitchEmotes)
                     {
                         0,  // start
                         4,  // end
-                        twitchEmotes->getOrCreateEmote(
-                            EmoteId{"25"}, EmoteName{"Kappa"}),  // ptr
-                        EmoteName{"Kappa"},                      // name
+                        TwitchEmoteOccurrence{
+                            .ptr = twitchEmotes->getOrCreateEmote(
+                                EmoteId{"25"}, EmoteName{"Kappa"}),  // ptr
+                            .name = EmoteName{"Kappa"},              // name
+                        },
                     },
                     {
                         9,   // start - modified due to emoji
                         13,  // end - modified due to emoji
-                        twitchEmotes->getOrCreateEmote(
-                            EmoteId{"25"}, EmoteName{"Kappa"}),  // ptr
-                        EmoteName{"Kappa"},                      // name
+                        TwitchEmoteOccurrence{
+                            .ptr = twitchEmotes->getOrCreateEmote(
+                                EmoteId{"25"}, EmoteName{"Kappa"}),  // ptr
+                            .name = EmoteName{"Kappa"},              // name
+                        },
                     },
                 },
             },
@@ -291,9 +311,11 @@ TEST_F(TestTwitchIrc, ParseTwitchEmotes)
                 {
                     0,  // start
                     0,  // end
-                    twitchEmotes->getOrCreateEmote(EmoteId{"84608"},
-                                                   EmoteName{"f"}),  // ptr
-                    EmoteName{"f"},                                  // name
+                    TwitchEmoteOccurrence{
+                        .ptr = twitchEmotes->getOrCreateEmote(
+                            EmoteId{"84608"}, EmoteName{"f"}),  // ptr
+                        .name = EmoteName{"f"},                 // name
+                    },
                 },
             },
         },
@@ -304,9 +326,11 @@ TEST_F(TestTwitchIrc, ParseTwitchEmotes)
                 {
                     0,  // start
                     1,  // end
-                    twitchEmotes->getOrCreateEmote(EmoteId{"84609"},
-                                                   EmoteName{"fo"}),  // ptr
-                    EmoteName{"fo"},                                  // name
+                    TwitchEmoteOccurrence{
+                        .ptr = twitchEmotes->getOrCreateEmote(
+                            EmoteId{"84609"}, EmoteName{"fo"}),  // ptr
+                        .name = EmoteName{"fo"},                 // name
+                    },
                 },
             },
         },
@@ -330,10 +354,10 @@ TEST_F(TestTwitchIrc, ParseTwitchEmotes)
         QString originalMessage = privmsg->content();
 
         // TODO: Add tests with replies
-        auto actualTwitchEmotes =
-            parseTwitchEmotes(privmsg->tags(), originalMessage, 0);
+        auto actualTwitchSpecials =
+            parseTwitchOccurrences(privmsg->tags(), originalMessage, 0);
 
-        EXPECT_EQ(actualTwitchEmotes, test.expectedTwitchEmotes)
+        EXPECT_EQ(actualTwitchSpecials, test.expectedTwitchSpecials)
             << "Input for twitch emotes " << test.input << " failed";
 
         delete privmsg;


### PR DESCRIPTION
Gif in chat (#7186) are specified like emotes as a range of codepoints. We can reuse much of the code we have for Twitch emotes. This PR prepares us. It generalizes `TwitchEmoteOccurrence` into a `TwitchSpecialOccurrence` that holds a variant. To make the final diff easier, this is separated.

*This is part of a stack*
1. #7219 ← this one
2. #7220
3. #7221
4. #7222
5. #7223 

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
