### PR TITLE
feat: add Twitch gifs as images

### DIFF
--- a/docs/chatterino.d.ts
+++ b/docs/chatterino.d.ts
@@ -536,6 +536,7 @@ declare namespace c2 {
         LowercaseLinks = 0,
         RepliedMessage = 0,
         ReplyButton = 0,
+        TwitchGif = 0,
         Default = 0,
     }
 

--- a/docs/lua-meta/globals.lua
+++ b/docs/lua-meta/globals.lua
@@ -846,6 +846,7 @@ c2.MessageElementFlag = {
     EmoteImage = 0,
     EmoteText = 0,
     Emote = 0,
+    TwitchGif = 0,
     ChannelPointReward = 0,
     ChannelPointRewardImage = 0,
     BitsStatic = 0,

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -2083,14 +2083,32 @@ void MessageBuilder::addTwitchGif(const QString &id, QStringView originalText)
 {
     auto original = originalText.toString();
     QString link = u"https://i.giphy.com/" % id % u".webp";
-    auto *el = this->emplace<LinkElement>(
-        LinkElement::Parsed{
-            .lowercase = original,
-            .original = original,
-        },
-        link, MessageElementFlag::Text, MessageColor::Link);
+    if (getSettings()->showTwitchGifs)
+    {
+        ImageSet set{
+            Image::fromUrl(
+                Url{u"https://media4.giphy.com/media/" % id % u"/100.webp"},
+                1.0, {100, 100}),
+            Image::fromUrl(
+                Url{u"https://media4.giphy.com/media/" % id % u"/200.webp"},
+                0.5, {200, 200}),
+        };
+        this->emplace<LinebreakElement>(MessageElementFlag::TwitchGif);
+        this->emplace<ScalingImageElement>(set, MessageElementFlag::TwitchGif)
+            ->setLink(Link{Link::Url, link})
+            ->setTooltip(original.toHtmlEscaped());
+    }
+    else
+    {
+        auto *el = this->emplace<LinkElement>(
+            LinkElement::Parsed{
+                .lowercase = original,
+                .original = original,
+            },
+            link, MessageElementFlag::Text, MessageColor::Link);
 
-    getApp()->getLinkResolver()->resolve(el->linkInfo());
+        getApp()->getLinkResolver()->resolve(el->linkInfo());
+    }
 }
 
 bool MessageBuilder::isEmpty() const

--- a/src/messages/MessageElement.cpp
+++ b/src/messages/MessageElement.cpp
@@ -1547,7 +1547,7 @@ std::unique_ptr<MessageElement> ScalingImageElement::clone() const
 {
     auto elem =
         std::make_unique<ScalingImageElement>(this->images_, this->getFlags());
-    elem->setTrailingSpace(this->hasTrailingSpace());
+    elem->cloneFrom(*this);
     return elem;
 }
 

--- a/src/messages/MessageElement.hpp
+++ b/src/messages/MessageElement.hpp
@@ -48,7 +48,7 @@ enum class MessageElementFlag : int64_t {
     EmoteText = (1LL << 5),
     Emote = EmoteImage | EmoteText,
 
-    // unused: (1LL << 7),
+    TwitchGif = (1LL << 7),
 
     ChannelPointReward = (1LL << 8),
     ChannelPointRewardImage = ChannelPointReward | EmoteImage,

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -200,6 +200,10 @@ public:
         "/appearance/messages/wrapAsciiArt",
         false,
     };
+    BoolSetting showTwitchGifs = {
+        "/appearance/messages/showTwitchGifs",
+        true,
+    };
     BoolSetting separateMessages = {"/appearance/messages/separateMessages",
                                     false};
     BoolSetting fadeMessageHistory = {"/appearance/messages/fadeMessageHistory",

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -280,6 +280,7 @@ void WindowManager::updateWordTypeMask()
     flags.set(MEF::Collapsed);
     flags.set(MEF::LowercaseLinks, settings->lowercaseDomains);
     flags.set(MEF::ChannelPointReward);
+    flags.set(MEF::TwitchGif);
 
     // update flags
     MessageElementFlags newFlags = static_cast<MessageElementFlags>(flags);

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -557,6 +557,11 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     SettingWidget::checkbox("Show watch streak header", s.showWatchStreakHeader)
         ->addTo(layout);
 
+    SettingWidget::checkbox("Show Twitch GIFs", s.showTwitchGifs)
+        ->setTooltip("Twitch GIFs will be shown inline. When disabled, they're "
+                     "shown as links.")
+        ->addTo(layout);
+
     layout.addDropdown<int>(
         "Limit message height",
         {"Never", "2 lines", "3 lines", "4 lines", "5 lines"},

--- a/tests/snapshots/IrcMessageHandler/gifs1-image.json
+++ b/tests/snapshots/IrcMessageHandler/gifs1-image.json
@@ -112,22 +112,25 @@
                     ]
                 },
                 {
-                    "color": "Link",
-                    "flags": "Text",
-                    "link": "https://i.giphy.com/joSNxeswxuc74Juo8X.webp",
-                    "lowercase": [
-                        "[Y A Y Yes GIF by Djemilah Birnie]"
-                    ],
-                    "original": [
-                        "[Y A Y Yes GIF by Djemilah Birnie]"
-                    ],
-                    "style": "ChatMedium",
+                    "flags": "TwitchGif",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "LinebreakElement"
+                },
+                {
+                    "flags": "TwitchGif",
+                    "image": "https://media4.giphy.com/media/joSNxeswxuc74Juo8X/100.webp",
+                    "link": {
+                        "type": "Url",
+                        "value": "https://i.giphy.com/joSNxeswxuc74Juo8X.webp"
+                    },
                     "tooltip": "[Y A Y Yes GIF by Djemilah Birnie]",
                     "trailingSpace": true,
-                    "type": "LinkElement",
-                    "words": [
-                        ""
-                    ]
+                    "type": "ScalingImageElement"
                 },
                 {
                     "background": "#ffa0a0a4",
@@ -168,7 +171,7 @@
     "settings": {
         "appearance": {
             "messages": {
-                "showTwitchGifs": false
+                "showTwitchGifs": true
             }
         }
     }

--- a/tests/snapshots/IrcMessageHandler/gifs2-image.json
+++ b/tests/snapshots/IrcMessageHandler/gifs2-image.json
@@ -1,5 +1,5 @@
 {
-    "input": "@badge-info=subscriber/30;badges=broadcaster/1,subscriber/0;color=#033700;display-name=TwitchDev;emotes=;first-msg=0;flags=;gifs=0-33|joSNxeswxuc74Juo8X|https://media4.giphy.com/media/joSNxeswxuc74Juo8X/giphy.gif?cid=095d7a5dzizsiwgabonagkmigggv8v1spfai91ac3x0dsiy0&ep=v1_gifs_trending&rid=giphy.gif&ct=g;id=401abf17-7e99-45d6-9bdf-43934e839327;mod=0;returning-chatter=0;room-id=11148817;subscriber=1;tmi-sent-ts=1783632907018;turbo=0;user-id=141981764;user-type= :twitchdev!twitchdev@twitchdev.tmi.twitch.tv PRIVMSG #pajlada :[Y A Y Yes GIF by Djemilah Birnie]",
+    "input": "@badge-info=subscriber/30;badges=broadcaster/1,subscriber/0;color=#033700;display-name=TwitchDev;emotes=;first-msg=0;flags=;gifs=7-40|joSNxeswxuc74Juo8X|https://media4.giphy.com/media/joSNxeswxuc74Juo8X/giphy.gif?cid=095d7a5dzizsiwgabonagkmigggv8v1spfai91ac3x0dsiy0&ep=v1_gifs_trending&rid=giphy.gif&ct=g;id=401abf17-7e99-45d6-9bdf-43934e839327;mod=0;returning-chatter=0;room-id=11148817;subscriber=1;tmi-sent-ts=1783632907018;turbo=0;user-id=141981764;user-type= :twitchdev!twitchdev@twitchdev.tmi.twitch.tv PRIVMSG #pajlada :before [Y A Y Yes GIF by Djemilah Birnie] after",
     "output": [
         {
             "channelName": "pajlada",
@@ -112,21 +112,54 @@
                     ]
                 },
                 {
-                    "color": "Link",
+                    "color": "Text",
                     "flags": "Text",
-                    "link": "https://i.giphy.com/joSNxeswxuc74Juo8X.webp",
-                    "lowercase": [
-                        "[Y A Y Yes GIF by Djemilah Birnie]"
-                    ],
-                    "original": [
-                        "[Y A Y Yes GIF by Djemilah Birnie]"
-                    ],
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
                     "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "before"
+                    ]
+                },
+                {
+                    "flags": "TwitchGif",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "LinebreakElement"
+                },
+                {
+                    "flags": "TwitchGif",
+                    "image": "https://media4.giphy.com/media/joSNxeswxuc74Juo8X/100.webp",
+                    "link": {
+                        "type": "Url",
+                        "value": "https://i.giphy.com/joSNxeswxuc74Juo8X.webp"
+                    },
                     "tooltip": "[Y A Y Yes GIF by Djemilah Birnie]",
                     "trailingSpace": true,
-                    "type": "LinkElement",
+                    "type": "ScalingImageElement"
+                },
+                {
+                    "color": "Text",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
                     "words": [
-                        ""
+                        "after"
                     ]
                 },
                 {
@@ -150,8 +183,8 @@
             "id": "401abf17-7e99-45d6-9bdf-43934e839327",
             "localizedName": "",
             "loginName": "twitchdev",
-            "messageText": "[Y A Y Yes GIF by Djemilah Birnie]",
-            "searchText": "twitchdev  twitchdev: [Y A Y Yes GIF by Djemilah Birnie] ",
+            "messageText": "before [Y A Y Yes GIF by Djemilah Birnie] after",
+            "searchText": "twitchdev  twitchdev: before [Y A Y Yes GIF by Djemilah Birnie] after ",
             "serverReceivedTime": "2026-07-09T21:35:07Z",
             "timeoutUser": "",
             "twitchBadgeInfos": {
@@ -168,7 +201,7 @@
     "settings": {
         "appearance": {
             "messages": {
-                "showTwitchGifs": false
+                "showTwitchGifs": true
             }
         }
     }

--- a/tests/snapshots/IrcMessageHandler/gifs2.json
+++ b/tests/snapshots/IrcMessageHandler/gifs2.json
@@ -194,5 +194,12 @@
             "userID": "141981764",
             "usernameColor": "#ff033700"
         }
-    ]
+    ],
+    "settings": {
+        "appearance": {
+            "messages": {
+                "showTwitchGifs": false
+            }
+        }
+    }
 }

--- a/tests/src/Plugins.cpp
+++ b/tests/src/Plugins.cpp
@@ -1004,6 +1004,7 @@ TEST_F(PluginTest, MessageElementFlag)
                          "SubscriptionHeader=0x10000000000,"
                          "Text=0x2,"
                          "Timestamp=0x8,"
+                         "TwitchGif=0x80,"
                          "Username=0x4,"
                          "WatchStreakHeader=0x20000000000";
 


### PR DESCRIPTION
This adds a setting to show Twitch GIFs as an inline image (default: on). It's similar to how it's shown in web chat: 

<img height="400" alt="Code_2026-09-02_15-23-53" src="https://github.com/user-attachments/assets/e7c23060-6275-4c72-929e-7a7d43f19cd2" />


*This is part of a stack*
1. #7219
2. #7220
3. #7221
4. #7222
5. #7223 ← this one

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
