### PR TITLE
fix(ignores): Remove partially overlapped emotes

### DIFF
--- a/src/controllers/ignores/IgnoreController.cpp
+++ b/src/controllers/ignores/IgnoreController.cpp
@@ -209,17 +209,19 @@ void processIgnorePhrases(const std::vector<IgnorePhrase> &phrases,
     using SizeType = QString::size_type;
 
     auto removeSpecialsInRange = [&twitchSpecials](SizeType pos, SizeType len) {
-        // all emotes outside the range come before `it`
-        // all emotes in the range start at `it`
-        auto it = std::partition(
-            twitchSpecials.begin(), twitchSpecials.end(),
-            [pos, len](const auto &item) {
-                // returns true for emotes outside the range
-                return !((item.start >= pos) && item.start < (pos + len));
-            });
+        // all specials outside the range come before `it`
+        // all specials in the range start at `it`
+        auto it = std::ranges::partition(twitchSpecials, [&](const auto &item) {
+            // returns true for specials outside the range
+            if (item.start < pos)
+            {
+                return item.start + item.length <= pos;
+            }
+            return item.start >= pos + len;
+        });
         std::vector<TwitchSpecialOccurrence> specialsInRange(
-            it, twitchSpecials.end());
-        twitchSpecials.erase(it, twitchSpecials.end());
+            it.begin(), twitchSpecials.end());
+        twitchSpecials.erase(it.begin(), twitchSpecials.end());
         return specialsInRange;
     };
 

--- a/tests/src/IgnoreController.cpp
+++ b/tests/src/IgnoreController.cpp
@@ -182,6 +182,48 @@ TEST_F(TestIgnoreController, processIgnorePhrases)
             "fo fo fo fo Kappa",
             {emoteAt(11, "Kappa")},
         },
+        {
+            .phrases = {regularReplace("pp", "p")},
+            .input = "foo Kappa bar",
+            .twitchSpecials = {emoteAt(4, "Kappa")},
+            .expectedMessage = "foo Kapa bar",
+            .expectedTwitchSpecials = {},
+        },
+        {
+            .phrases = {regularReplace("pa", "a")},
+            .input = "foo Kappa bar",
+            .twitchSpecials = {emoteAt(4, "Kappa")},
+            .expectedMessage = "foo Kapa bar",
+            .expectedTwitchSpecials = {},
+        },
+        {
+            .phrases = {regularReplace("Ka", "a")},
+            .input = "foo Kappa bar",
+            .twitchSpecials = {emoteAt(4, "Kappa")},
+            .expectedMessage = "foo appa bar",
+            .expectedTwitchSpecials = {},
+        },
+        {
+            .phrases = {regularReplace("Ka", "a")},
+            .input = "Kappa",
+            .twitchSpecials = {emoteAt(0, "Kappa")},
+            .expectedMessage = "appa",
+            .expectedTwitchSpecials = {},
+        },
+        {
+            .phrases = {regularReplace("pa", "a")},
+            .input = "Kappa",
+            .twitchSpecials = {emoteAt(0, "Kappa")},
+            .expectedMessage = "Kapa",
+            .expectedTwitchSpecials = {},
+        },
+        {
+            .phrases = {regularReplace("Word", "wor")},
+            .input = "[Multi Word Emote]",
+            .twitchSpecials = {emoteAt(0, "[Multi Word Emote]")},
+            .expectedMessage = "[Multi wor Emote]",
+            .expectedTwitchSpecials = {},
+        },
     };
 
     for (const auto &test : testCases)


### PR DESCRIPTION
When an ignore-replace phrase starts in an emote, we didn't remove the special item. It's best illustrated by the tests. If we replace `pp` → `p` in `Kappa`, we didn't remove the emote even though it's no longer there. The same is (eventually) true for GIFs (https://github.com/Chatterino/chatterino2/pull/7223#discussion_r3915396893).

This PR fixes that by removing all specials that overlap the removed range.


*This is part of a stack*
1. #7219
2. #7220
2.5. #7224 ← this one (not required for 3)

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
