### PR TITLE
fix: return plain text from incremental history search

### DIFF
--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -1760,7 +1760,7 @@ void SplitInput::updateSelectedHistorySearchMatch()
         this->historySearchResultIndex)];
 
     this->prevIndex_ = static_cast<int>(current.messageIdx);
-    this->ui_.textEdit->setText(current.message);
+    this->ui_.textEdit->setPlainText(current.message);
 
     this->updateHistorySearchStatus(
         false, QString::number(this->historySearchResults.size() -


### PR DESCRIPTION
Fixes a bug where incremental history search could parse messages containing HTML as rich text instead of plain text

Steps to reproduce:
1. Bind `Incrementally search through the input history` to a hotkey (Hotkeys -> Add -> Category: Split input box)
2. Send a message containing html tags, e.g. `<b>test</b>`
<img width="381" height="91" alt="image" src="https://github.com/user-attachments/assets/965a7373-1c4c-4e99-9b2f-b750f172428c" />

3. Press the hotkey and search for the sent message
4. Observe that it displays formatted text rather than plain text

<img width="383" height="90" alt="image" src="https://github.com/user-attachments/assets/d43d8f44-dab4-4f62-9cdf-70614be67712" />

Fixed by using `textEdit->setPlainText()` instead of `textEdit->setText()`
<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
