### PR TITLE
fix: add missing vector include

### DIFF
--- a/src/common/websockets/WebSocketPool.hpp
+++ b/src/common/websockets/WebSocketPool.hpp
@@ -9,6 +9,7 @@
 #include <QUrl>
 
 #include <memory>
+#include <vector>
 
 namespace chatterino::ws::detail {
 class WebSocketPoolImpl;

--- a/src/util/VectorMessageSink.hpp
+++ b/src/util/VectorMessageSink.hpp
@@ -6,6 +6,8 @@
 
 #include "messages/MessageSink.hpp"
 
+#include <vector>
+
 namespace chatterino {
 
 class VectorMessageSink final : public MessageSink


### PR DESCRIPTION
`WebSocketPool.hpp` and `VectorMessageSink.hpp` use `std::vector`, but don't include `<vector>` which causes a build failure  with libc++ 23 since it's dropping a lot of transitive includes.

```
In file included from src/controllers/plugins/api/WebSocket.cpp:5:
In file included from src/controllers/plugins/api/WebSocket.hpp:8:
src/common/websockets/WebSocketPool.hpp:76:5: error: no template named 'vector' in namespace 'std'; did you mean 'QVector'?
   76 |     std::vector<std::pair<std::string, std::string>> headers;
      |     ^~~~~~~~~~~
      |     QVector
/usr/include/qt6/QtCore/qcontainerfwd.h:40:22: note: 'QVector' declared here
   40 | template<typename T> using QVector = QList<T>;
      |                     

In file included from src/util/VectorMessageSink.cpp:5:
src/util/VectorMessageSink.hpp:34:16: error: no template named 'vector' in namespace 'std'
   34 |     const std::vector<MessagePtr> &messages() const;
      |           ~~~~~^
src/util/VectorMessageSink.hpp:35:10: error: no template named 'vector' in namespace 'std'
   35 |     std::vector<MessagePtr> takeMessages() &&;
      |     ~~~~~^
src/util/VectorMessageSink.hpp:38:10: error: no template named 'vector' in namespace 'std'
   38 |     std::vector<MessagePtr> messages_;
      |     ~~~~~^

```

See also: https://discourse.llvm.org/t/rfc-remove-unused-transitive-includes-from-the-libc-headers/90157
<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
