### PR TITLE
fix: disable scrollbar animations when resizing

### DIFF
--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -664,11 +664,11 @@ void ChannelView::invalidateBuffers()
     this->update();
 }
 
-void ChannelView::queueLayout()
+void ChannelView::queueLayout(bool disableAnimation)
 {
     if (this->isVisible())
     {
-        this->performLayout();
+        this->performLayout(/*causedByScrollbar=*/false, disableAnimation);
     }
     else
     {
@@ -680,11 +680,12 @@ void ChannelView::showEvent(QShowEvent * /*event*/)
 {
     if (this->layoutQueued_)
     {
-        this->performLayout(false, true);
+        this->performLayout(/*causedByScrollbar=*/false,
+                            /*disableAnimation=*/true);
     }
 }
 
-void ChannelView::performLayout(bool causedByScrollbar, bool causedByShow)
+void ChannelView::performLayout(bool causedByScrollbar, bool disableAnimation)
 {
     // BenchmarkGuard benchmark("layout");
 
@@ -701,7 +702,7 @@ void ChannelView::performLayout(bool causedByScrollbar, bool causedByShow)
     this->layoutVisibleMessages(messages);
 
     /// Update scrollbar
-    this->updateScrollbar(messages, causedByScrollbar, causedByShow);
+    this->updateScrollbar(messages, causedByScrollbar, disableAnimation);
 
     this->goToBottom_->setVisible(this->enableScrollingToBottom_ &&
                                   this->scrollBar_->isVisible() &&
@@ -748,7 +749,7 @@ void ChannelView::layoutVisibleMessages(
 }
 
 void ChannelView::updateScrollbar(const std::vector<MessageLayoutPtr> &messages,
-                                  bool causedByScrollbar, bool causedByShow)
+                                  bool causedByScrollbar, bool disableAnimation)
 {
     if (messages.size() == 0)
     {
@@ -806,7 +807,7 @@ void ChannelView::updateScrollbar(const std::vector<MessageLayoutPtr> &messages,
         showScrollbar && !causedByScrollbar)
     {
         this->scrollBar_->scrollToBottom(
-            !causedByShow &&
+            !disableAnimation &&
             getSettings()->enableSmoothScrollingNewMessages.getValue());
     }
 }
@@ -1393,7 +1394,7 @@ void ChannelView::resizeEvent(QResizeEvent * /*event*/)
 
     this->scrollBar_->raise();
 
-    this->queueLayout();
+    this->queueLayout(/*disableAnimation=*/true);
 
     this->update();
 }

--- a/src/widgets/helper/ChannelView.hpp
+++ b/src/widgets/helper/ChannelView.hpp
@@ -190,7 +190,7 @@ public:
 
     std::vector<MessageLayoutPtr> &getMessagesSnapshot();
 
-    void queueLayout();
+    void queueLayout(bool disableAnimation = false);
     void invalidateBuffers();
 
     void clearMessages();
@@ -298,10 +298,10 @@ private:
     void messagesUpdated();
 
     void performLayout(bool causedByScrollbar = false,
-                       bool causedByShow = false);
+                       bool disableAnimation = false);
     void layoutVisibleMessages(const std::vector<MessageLayoutPtr> &messages);
     void updateScrollbar(const std::vector<MessageLayoutPtr> &messages,
-                         bool causedByScrollbar, bool causedByShow);
+                         bool causedByScrollbar, bool disableAnimation);
 
     void drawMessages(QPainter &painter, const QRect &area);
     void setSelection(const SelectionItem &start, const SelectionItem &end);


### PR DESCRIPTION
When a channel view is resized, we queue a layout and perform that for the visible views. By default, that will use an animation if smooth scrolling on new messages is enabled.

As mentioned in #7239, this is undesired. This PR disables the animation when we perform a layout because of a resize. I repurposed `causedByShow` for this. It was already used as a flag to disable scrollbar animations.

Fixes #7239.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
