### PR TITLE
fix: round start offset when painting messages

### DIFF
--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1637,8 +1637,8 @@ void ChannelView::drawMessages(QPainter &painter, const QRect &area)
                       getApp()->getTwitch()->getMentionsChannel(),
 
         .y = -static_cast<int>(
-            messagesSnapshot[start]->getHeight() *
-            (fmod(this->scrollBar_->getRelativeCurrentValue(), 1))),
+            std::round(messagesSnapshot[start]->getHeight() *
+                       (fmod(this->scrollBar_->getRelativeCurrentValue(), 1)))),
         .messageIndex = start,
         .isLastReadMessage = false,
 


### PR DESCRIPTION
This intends to fix the small jumping when resizing a channel view (https://github.com/Chatterino/chatterino2/pull/7240#issuecomment-5560784616).

We're always rounding the y-position to ensure that the text stays sharp and doesn't blend between two pixels. But when resizing the window, precision loss _somewhere_ may lead to us being slightly above/below a whole number (e.g. 1.001 → 0.9998). 
Rounding doesn't always fix this (we could just shift by 0.5 and have a similar issue). My assumption is that we're always close to a whole number, so rounding will yield the correct result.

Reproducing this depends on the messages in the view, the font, and the font engine. So you may have to experiment a bit.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
