### PR TITLE
fix: hide completion popup when recalling input history

### DIFF
--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -688,6 +688,7 @@ void SplitInput::addShortcuts()
              QTextCursor cursor = this->ui_.textEdit->textCursor();
              cursor.movePosition(QTextCursor::End);
              this->ui_.textEdit->setTextCursor(cursor);
+             this->hideCompletionPopup();
 
              return "";
          }},
@@ -740,6 +741,7 @@ void SplitInput::addShortcuts()
                  QTextCursor cursor = this->ui_.textEdit->textCursor();
                  cursor.movePosition(QTextCursor::End);
                  this->ui_.textEdit->setTextCursor(cursor);
+                 this->hideCompletionPopup();
              }
              return "";
          }},


### PR DESCRIPTION
Fixes #5366.

>When navigating through input history with the arrow keys, messages ending in @usernames without a trailing space hijack the navigation.
>
>This doesn't occur when normally tab/return-completing usernames - instead the automatically added space has to be removed (usually by moving the cursor elsewhere in the message and pressing return)

Fixed by hiding the completion popup after recalling a message from input history.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->