### PR TITLE
fix: use full timestamps for live update grouping

### DIFF
--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -939,13 +939,14 @@ MessageBuilder::MessageBuilder(TimeoutMessageTag, const QString &username,
 
 MessageBuilder::MessageBuilder(LiveUpdatesAddEmoteMessageTag /*unused*/,
                                const QString &platform, const QString &actor,
-                               const std::vector<QString> &emoteNames)
+                               const std::vector<QString> &emoteNames,
+                               const QDateTime &time)
     : MessageBuilder()
 {
     auto text =
         formatUpdatedEmoteList(platform, emoteNames, true, actor.isEmpty());
 
-    this->emplace<TimestampElement>();
+    this->emplace<TimestampElement>(time.time());
     if (!actor.isEmpty())
     {
         this->emplace<TextElement>(actor, MessageElementFlag::Username,
@@ -968,6 +969,7 @@ MessageBuilder::MessageBuilder(LiveUpdatesAddEmoteMessageTag /*unused*/,
     this->message().loginName = actor;
     this->message().messageText = finalText;
     this->message().searchText = finalText;
+    this->message().serverReceivedTime = time;
 
     this->message().flags.set(MessageFlag::System);
     this->message().flags.set(MessageFlag::LiveUpdatesAdd);
@@ -976,13 +978,14 @@ MessageBuilder::MessageBuilder(LiveUpdatesAddEmoteMessageTag /*unused*/,
 
 MessageBuilder::MessageBuilder(LiveUpdatesRemoveEmoteMessageTag /*unused*/,
                                const QString &platform, const QString &actor,
-                               const std::vector<QString> &emoteNames)
+                               const std::vector<QString> &emoteNames,
+                               const QDateTime &time)
     : MessageBuilder()
 {
     auto text =
         formatUpdatedEmoteList(platform, emoteNames, false, actor.isEmpty());
 
-    this->emplace<TimestampElement>();
+    this->emplace<TimestampElement>(time.time());
     if (!actor.isEmpty())
     {
         this->emplace<TextElement>(actor, MessageElementFlag::Username,
@@ -1005,6 +1008,7 @@ MessageBuilder::MessageBuilder(LiveUpdatesRemoveEmoteMessageTag /*unused*/,
     this->message().loginName = actor;
     this->message().messageText = finalText;
     this->message().searchText = finalText;
+    this->message().serverReceivedTime = time;
 
     this->message().flags.set(MessageFlag::System);
     this->message().flags.set(MessageFlag::LiveUpdatesRemove);

--- a/src/messages/MessageBuilder.hpp
+++ b/src/messages/MessageBuilder.hpp
@@ -102,10 +102,12 @@ public:
 
     MessageBuilder(LiveUpdatesAddEmoteMessageTag, const QString &platform,
                    const QString &actor,
-                   const std::vector<QString> &emoteNames);
+                   const std::vector<QString> &emoteNames,
+                   const QDateTime &time);
     MessageBuilder(LiveUpdatesRemoveEmoteMessageTag, const QString &platform,
                    const QString &actor,
-                   const std::vector<QString> &emoteNames);
+                   const std::vector<QString> &emoteNames,
+                   const QDateTime &time);
     MessageBuilder(LiveUpdatesUpdateEmoteMessageTag, const QString &platform,
                    const QString &actor, const QString &emoteName,
                    const QString &oldEmoteName);

--- a/src/messages/MessageBuilder.hpp
+++ b/src/messages/MessageBuilder.hpp
@@ -101,12 +101,10 @@ public:
                    const QDateTime &time);
 
     MessageBuilder(LiveUpdatesAddEmoteMessageTag, const QString &platform,
-                   const QString &actor,
-                   const std::vector<QString> &emoteNames,
+                   const QString &actor, const std::vector<QString> &emoteNames,
                    const QDateTime &time);
     MessageBuilder(LiveUpdatesRemoveEmoteMessageTag, const QString &platform,
-                   const QString &actor,
-                   const std::vector<QString> &emoteNames,
+                   const QString &actor, const std::vector<QString> &emoteNames,
                    const QDateTime &time);
     MessageBuilder(LiveUpdatesUpdateEmoteMessageTag, const QString &platform,
                    const QString &actor, const QString &emoteName,

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -48,6 +48,7 @@
 #include "widgets/Window.hpp"
 
 #include <IrcConnection>
+#include <QDateTime>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -1306,12 +1307,13 @@ void TwitchChannel::updateSeventvData(const QString &newUserID,
 void TwitchChannel::addOrReplaceLiveUpdatesAddRemove(bool isEmoteAdd,
                                                      const QString &platform,
                                                      const QString &actor,
-                                                     const QString &emoteName)
+                                                     const QString &emoteName,
+                                                     const QDateTime &now)
 {
     if (this->tryReplaceLastLiveUpdateAddOrRemove(
             isEmoteAdd ? MessageFlag::LiveUpdatesAdd
                        : MessageFlag::LiveUpdatesRemove,
-            platform, actor, emoteName))
+            platform, actor, emoteName, now))
     {
         return;
     }
@@ -1322,13 +1324,13 @@ void TwitchChannel::addOrReplaceLiveUpdatesAddRemove(bool isEmoteAdd,
     if (isEmoteAdd)
     {
         msg = MessageBuilder(liveUpdatesAddEmoteMessage, platform, actor,
-                             this->lastLiveUpdateEmoteNames_)
+                             this->lastLiveUpdateEmoteNames_, now)
                   .release();
     }
     else
     {
         msg = MessageBuilder(liveUpdatesRemoveEmoteMessage, platform, actor,
-                             this->lastLiveUpdateEmoteNames_)
+                             this->lastLiveUpdateEmoteNames_, now)
                   .release();
     }
     this->lastLiveUpdateEmotePlatform_ = platform;
@@ -1339,7 +1341,7 @@ void TwitchChannel::addOrReplaceLiveUpdatesAddRemove(bool isEmoteAdd,
 
 bool TwitchChannel::tryReplaceLastLiveUpdateAddOrRemove(
     MessageFlag op, const QString &platform, const QString &actor,
-    const QString &emoteName)
+    const QString &emoteName, const QDateTime &now)
 {
     if (this->lastLiveUpdateEmotePlatform_ != platform)
     {
@@ -1347,8 +1349,7 @@ bool TwitchChannel::tryReplaceLastLiveUpdateAddOrRemove(
     }
     auto last = this->lastLiveUpdateMessage_.lock();
     if (!last || !last->flags.has(op) ||
-        last->parseTime < QTime::currentTime().addSecs(-5) ||
-        last->loginName != actor)
+        last->serverReceivedTime < now.addSecs(-5) || last->loginName != actor)
     {
         return false;
     }
@@ -1359,19 +1360,15 @@ bool TwitchChannel::tryReplaceLastLiveUpdateAddOrRemove(
         if (op == MessageFlag::LiveUpdatesAdd)
         {
             return {
-                liveUpdatesAddEmoteMessage,
-                platform,
-                last->loginName,
-                this->lastLiveUpdateEmoteNames_,
+                liveUpdatesAddEmoteMessage,      platform, last->loginName,
+                this->lastLiveUpdateEmoteNames_, now,
             };
         }
 
         // op == RemoveEmoteMessage
         return {
-            liveUpdatesRemoveEmoteMessage,
-            platform,
-            last->loginName,
-            this->lastLiveUpdateEmoteNames_,
+            liveUpdatesRemoveEmoteMessage,   platform, last->loginName,
+            this->lastLiveUpdateEmoteNames_, now,
         };
     };
 

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -512,11 +512,12 @@ private:
      * @param platform The platform the emote was updated on ("7TV", "BTTV", "FFZ")
      * @param actor The actor performing the update (possibly empty)
      * @param emoteName The emote's name
+     * @param now The time the update was received
      */
-    void addOrReplaceLiveUpdatesAddRemove(bool isEmoteAdd,
-                                          const QString &platform,
-                                          const QString &actor,
-                                          const QString &emoteName);
+    void addOrReplaceLiveUpdatesAddRemove(
+        bool isEmoteAdd, const QString &platform, const QString &actor,
+        const QString &emoteName,
+        const QDateTime &now = QDateTime::currentDateTime());
 
     /**
      * Tries to replace the last emote update message.
@@ -531,12 +532,14 @@ private:
      * @param platform The emote platform  ("7TV", "BTTV", "FFZ")
      * @param actor The actor performing the action (possibly empty)
      * @param emoteName The updated emote's name
+     * @param now The time the update was received
      * @return true, if the last message was replaced
      */
     bool tryReplaceLastLiveUpdateAddOrRemove(MessageFlag op,
                                              const QString &platform,
                                              const QString &actor,
-                                             const QString &emoteName);
+                                             const QString &emoteName,
+                                             const QDateTime &now);
 
     void pinOrUpdateMessage(bool update, const QString &messageID,
                             std::optional<std::chrono::seconds> duration,
@@ -674,6 +677,7 @@ private:
     friend class MessageBuilder;
     friend class IrcMessageHandler;
     friend class Commands_E2E_Test;
+    friend class TwitchChannel_LiveUpdateGrouping_Test;
     friend class ::TestIrcMessageHandlerP;
     friend class ::TestEventSubMessagesP;
 

--- a/tests/src/TwitchChannel.cpp
+++ b/tests/src/TwitchChannel.cpp
@@ -4,11 +4,84 @@
 
 #include "providers/twitch/TwitchChannel.hpp"
 
+#include "controllers/accounts/AccountController.hpp"
+#include "messages/Message.hpp"
+#include "mocks/BaseApplication.hpp"
+#include "mocks/Logging.hpp"
+#include "mocks/TwitchIrcServer.hpp"
 #include "Test.hpp"
 
+#include <QDateTime>
 #include <QString>
 
+#include <memory>
 #include <vector>
+
+namespace chatterino {
+
+namespace {
+
+class LiveUpdateApplication : public mock::BaseApplication
+{
+public:
+    AccountController *getAccounts() override
+    {
+        return &this->accounts;
+    }
+
+    ITwitchIrcServer *getTwitch() override
+    {
+        return &this->twitch;
+    }
+
+    ILogging *getChatLogger() override
+    {
+        return &this->logging;
+    }
+
+    AccountController accounts;
+    mock::MockTwitchIrcServer twitch;
+    mock::EmptyLogging logging;
+};
+
+}  // namespace
+
+TEST(TwitchChannel, LiveUpdateGrouping)
+{
+    LiveUpdateApplication app;
+    auto channel = std::make_shared<TwitchChannel>("testchannel");
+    const auto addEmote = [&](const QString &name, const QDateTime &time) {
+        channel->addOrReplaceLiveUpdatesAddRemove(true, "BTTV", {}, name, time);
+    };
+    const auto time =
+        QDateTime::fromString("1984-04-20T21:37:00Z", Qt::ISODate);
+
+    addEmote("FirstEmote", time);
+    ASSERT_EQ(channel->countMessages(), 1);
+    auto first = channel->getLastMessage();
+    EXPECT_EQ(first->serverReceivedTime, time);
+
+    // Grouping considers the date, not only the time.
+    const auto nextDay = time.addDays(1);
+    addEmote("SecondEmote", nextDay);
+    ASSERT_EQ(channel->countMessages(), 2);
+    EXPECT_EQ(channel->getMessageSnapshot().at(0), first);
+    EXPECT_FALSE(first->messageText.contains("SecondEmote"));
+
+    // An update less than 5 seconds later joins the group.
+    addEmote("ThirdEmote", nextDay.addSecs(4));
+    ASSERT_EQ(channel->countMessages(), 2);
+    auto grouped = channel->getLastMessage();
+    EXPECT_TRUE(grouped->messageText.contains("SecondEmote"));
+    EXPECT_TRUE(grouped->messageText.contains("ThirdEmote"));
+    EXPECT_EQ(grouped->serverReceivedTime, nextDay.addSecs(4));
+
+    // Updates more than five seconds apart start a new group.
+    addEmote("FourthEmote", nextDay.addSecs(10));
+    EXPECT_EQ(channel->countMessages(), 3);
+}
+
+}  // namespace chatterino
 
 namespace chatterino::detail {
 


### PR DESCRIPTION
Fixes #5121.

> So this is a pretty rare bug to encounter, but lets say you add an emote at around the same time, exactly one day ago, and add one now. The is:system message will be grouped with the one from the day prior, instead of creating a new one, making it seem like no EventAPI message was sent and chatterino wasn't refreshed (when there are logs), but both occurred.

Fixed by using full timestamps when grouping live emote updates, so messages from different dates aren't grouped just because their times of day are close.

Added tests covering the grouping.

The message builders and grouping helpers now accept a `QDateTime`, so that everything can share a single timestamp. That also lets the test supply fixed timestamps.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->