### PR TITLE
fix: respect "Don't stack" timeout setting

### DIFF
--- a/src/util/ChannelHelpers.hpp
+++ b/src/util/ChannelHelpers.hpp
@@ -87,8 +87,12 @@ void addOrReplaceChannelTimeout(const Buf &buffer, MessagePtr message,
             if (!message->flags.has(MessageFlag::PubSub) &&
                 s->flags.has(MessageFlag::PubSub))
             {
-                shouldAddMessage =
-                    timeoutStackStyle == TimeoutStackStyle::DontStack;
+                shouldAddMessage = false;
+                break;
+            }
+
+            if (timeoutStackStyle == TimeoutStackStyle::DontStack)
+            {
                 break;
             }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,6 +3,7 @@ project(chatterino-test)
 option(CHATTERINO_TEST_USE_PUBLIC_HTTPBIN "Use public httpbin for testing network requests" OFF)
 
 set(test_SOURCES
+    ${CMAKE_CURRENT_LIST_DIR}/src/ChannelHelpers.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/main.cpp
     ${CMAKE_CURRENT_LIST_DIR}/resources/test-resources.qrc
     ${CMAKE_CURRENT_LIST_DIR}/src/Test.hpp

--- a/tests/snapshots/IrcMessageHandler/timeout-stack-never.json
+++ b/tests/snapshots/IrcMessageHandler/timeout-stack-never.json
@@ -3,7 +3,7 @@
     "output": [
         {
             "channelName": "",
-            "count": 3,
+            "count": 1,
             "displayName": "",
             "elements": [
                 {
@@ -28,7 +28,7 @@
                         "type": "None",
                         "value": ""
                     },
-                    "time": "19:22:47",
+                    "time": "19:22:44",
                     "tooltip": "",
                     "trailingSpace": true,
                     "type": "TimestampElement"
@@ -65,9 +65,7 @@
                         "timed",
                         "out",
                         "for",
-                        "10m.",
-                        "(3",
-                        "times)"
+                        "10m."
                     ]
                 }
             ],
@@ -78,9 +76,9 @@
             "id": "",
             "localizedName": "",
             "loginName": "",
-            "messageText": "twitchdev has been timed out for 10m. (3 times) ",
-            "searchText": "twitchdev has been timed out for 10m. (3 times) ",
-            "serverReceivedTime": "2025-01-15T19:22:47Z",
+            "messageText": "twitchdev has been timed out for 10m. ",
+            "searchText": "twitchdev has been timed out for 10m. ",
+            "serverReceivedTime": "2025-01-15T19:22:44Z",
             "timeoutUser": "twitchdev",
             "twitchBadgeInfos": {
             },
@@ -207,10 +205,182 @@
             ],
             "userID": "141981764",
             "usernameColor": "#ffff0000"
+        },
+        {
+            "channelName": "",
+            "count": 1,
+            "displayName": "",
+            "elements": [
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "TimestampMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "19:22"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "19:22:47",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "twitchdev"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "twitchdev"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "has",
+                        "been",
+                        "timed",
+                        "out",
+                        "for",
+                        "10m."
+                    ]
+                }
+            ],
+            "externalBadges": [
+            ],
+            "flags": "System|Timeout|DoNotTriggerNotification|ModerationAction",
+            "frozen": false,
+            "id": "",
+            "localizedName": "",
+            "loginName": "",
+            "messageText": "twitchdev has been timed out for 10m. ",
+            "searchText": "twitchdev has been timed out for 10m. ",
+            "serverReceivedTime": "2025-01-15T19:22:47Z",
+            "timeoutUser": "twitchdev",
+            "twitchBadgeInfos": {
+            },
+            "twitchBadges": [
+            ],
+            "userID": "",
+            "usernameColor": "#ff000000"
+        },
+        {
+            "channelName": "",
+            "count": 1,
+            "displayName": "",
+            "elements": [
+                {
+                    "element": {
+                        "color": "System",
+                        "flags": "Timestamp",
+                        "link": {
+                            "type": "None",
+                            "value": ""
+                        },
+                        "style": "TimestampMedium",
+                        "tooltip": "",
+                        "trailingSpace": true,
+                        "type": "TextElement",
+                        "words": [
+                            "19:22"
+                        ]
+                    },
+                    "flags": "Timestamp",
+                    "format": "",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "time": "19:22:47",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TimestampElement"
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "UserInfo",
+                        "value": "twitchdev"
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "twitchdev"
+                    ]
+                },
+                {
+                    "color": "System",
+                    "flags": "Text",
+                    "link": {
+                        "type": "None",
+                        "value": ""
+                    },
+                    "style": "ChatMedium",
+                    "tooltip": "",
+                    "trailingSpace": true,
+                    "type": "TextElement",
+                    "words": [
+                        "has",
+                        "been",
+                        "timed",
+                        "out",
+                        "for",
+                        "10m."
+                    ]
+                }
+            ],
+            "externalBadges": [
+            ],
+            "flags": "System|Timeout|DoNotTriggerNotification|ModerationAction",
+            "frozen": false,
+            "id": "",
+            "localizedName": "",
+            "loginName": "",
+            "messageText": "twitchdev has been timed out for 10m. ",
+            "searchText": "twitchdev has been timed out for 10m. ",
+            "serverReceivedTime": "2025-01-15T19:22:47Z",
+            "timeoutUser": "twitchdev",
+            "twitchBadgeInfos": {
+            },
+            "twitchBadges": [
+            ],
+            "userID": "",
+            "usernameColor": "#ff000000"
         }
     ],
     "params": {
-        "nAdditional": 2,
+        "nAdditional": 3,
         "prevMessages": [
             "@historical=1;rm-received-ts=1736968964054;room-id=111448817;target-user-id=141981764;ban-duration=600;tmi-sent-ts=1736968963960 :tmi.twitch.tv CLEARCHAT #pajlada twitchdev",
             "@turbo=0;rm-received-ts=1736968965148;mod=0;color=#FF0000;badges=;id=aa1baade-c9c7-4932-b518-07c6b0226914;badge-info=;tmi-sent-ts=1736968965009;display-name=TwitchDev;first-msg=0;emotes=;user-id=141981764;room-id=111448817;returning-chatter=0;historical=1;user-type=;subscriber=0;flags= :twitchdev!twitchdev@twitchdev.tmi.twitch.tv PRIVMSG #pajlada 1",

--- a/tests/src/ChannelHelpers.cpp
+++ b/tests/src/ChannelHelpers.cpp
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: 2026 Contributors to Chatterino <https://chatterino.com>
+//
+// SPDX-License-Identifier: MIT
+
+#include "util/ChannelHelpers.hpp"
+
+#include "mocks/BaseApplication.hpp"
+#include "Test.hpp"
+
+#include <memory>
+#include <vector>
+
+namespace chatterino {
+
+TEST(ChannelHelpers, DontStackTimeouts)
+{
+    mock::BaseApplication app;
+    app.settings.timeoutStackStyle =
+        static_cast<int>(TimeoutStackStyle::DontStack);
+    const auto time =
+        QDateTime::fromString("1984-04-20T21:37:00Z", Qt::ISODate);
+
+    struct Case {
+        const char *name;
+        bool firstPubSub;
+        bool secondPubSub;
+    };
+    const Case cases[] = {
+        {"IRC then IRC", false, false},
+        {"EventSub then EventSub", true, true},
+        {"IRC then EventSub", false, true},
+        {"EventSub then IRC", true, false},
+    };
+    for (const auto &test : cases)
+    {
+        SCOPED_TRACE(test.name);
+        auto userMessage = std::make_shared<Message>();
+        userMessage->loginName = "user";
+        userMessage->serverReceivedTime = time;
+        std::vector<MessagePtr> messages{userMessage};
+
+        const auto addTimeout = [&](bool pubSub) {
+            auto message = std::make_shared<Message>();
+            message->timeoutUser = "user";
+            message->serverReceivedTime = time;
+            message->flags.set(MessageFlag::Timeout,
+                               MessageFlag::ModerationAction);
+            if (pubSub)
+            {
+                message->flags.set(MessageFlag::PubSub);
+            }
+            addOrReplaceChannelTimeout(
+                messages, message, time,
+                [&](auto index, auto /*oldMessage*/, auto replacement) {
+                    messages.at(index) = replacement;
+                },
+                [&](auto added) {
+                    messages.push_back(added);
+                },
+                true);
+            return message;
+        };
+
+        auto first = addTimeout(test.firstPubSub);
+        auto second = addTimeout(test.secondPubSub);
+        EXPECT_TRUE(userMessage->flags.has(MessageFlag::Disabled));
+        EXPECT_TRUE(userMessage->flags.has(MessageFlag::InvalidReplyTarget));
+
+        if (test.firstPubSub == test.secondPubSub)
+        {
+            ASSERT_EQ(messages.size(), 3);
+            EXPECT_EQ(messages.at(1), first);
+            EXPECT_EQ(messages.at(2), second);
+        }
+        else
+        {
+            ASSERT_EQ(messages.size(), 2);
+            EXPECT_EQ(messages.at(1), test.firstPubSub ? first : second);
+        }
+    }
+}
+
+}  // namespace chatterino

--- a/tests/src/ChannelHelpers.cpp
+++ b/tests/src/ChannelHelpers.cpp
@@ -7,6 +7,7 @@
 #include "mocks/BaseApplication.hpp"
 #include "Test.hpp"
 
+#include <array>
 #include <memory>
 #include <vector>
 
@@ -25,11 +26,19 @@ TEST(ChannelHelpers, DontStackTimeouts)
         bool firstPubSub;
         bool secondPubSub;
     };
-    const Case cases[] = {
-        {"IRC then IRC", false, false},
-        {"EventSub then EventSub", true, true},
-        {"IRC then EventSub", false, true},
-        {"EventSub then IRC", true, false},
+    const std::array cases = {
+        Case{.name = "IRC then IRC",
+             .firstPubSub = false,
+             .secondPubSub = false},
+        Case{.name = "EventSub then EventSub",
+             .firstPubSub = true,
+             .secondPubSub = true},
+        Case{.name = "IRC then EventSub",
+             .firstPubSub = false,
+             .secondPubSub = true},
+        Case{.name = "EventSub then IRC",
+             .firstPubSub = true,
+             .secondPubSub = false},
     };
     for (const auto &test : cases)
     {
@@ -51,10 +60,11 @@ TEST(ChannelHelpers, DontStackTimeouts)
             }
             addOrReplaceChannelTimeout(
                 messages, message, time,
-                [&](auto index, auto /*oldMessage*/, auto replacement) {
+                [&](auto index, const auto & /*oldMessage*/,
+                    const auto &replacement) {
                     messages.at(index) = replacement;
                 },
-                [&](auto added) {
+                [&](const auto &added) {
                     messages.push_back(added);
                 },
                 true);


### PR DESCRIPTION
Fixes #5826.

> Setting the `Stack timeouts` setting to `Don't stack` will still cause timeouts to stack in channels where the user isn't mod. In channels where the user is a mod, only the PubSub messages don't stack and the IRC messages are swallowed.

Fixed by... fixing it

Updated timeout stacking snapshot to expect separate timeout messages

Added tests covering `Don't stack` setting

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
