### PR TITLE
fix: use message timestamps for R9K similarity check

### DIFF
--- a/src/messages/MessageSimilarity.cpp
+++ b/src/messages/MessageSimilarity.cpp
@@ -68,7 +68,7 @@ float inMessages(const MessagePtr &msg, const T &messages)
          messages | std::views::reverse |
              std::views::take(getSettings()->hideSimilarMaxMessagesToCheck))
     {
-        if (prevMsg->parseTime.secsTo(QTime::currentTime()) >=
+        if (prevMsg->serverReceivedTime.secsTo(msg->serverReceivedTime) >=
             getSettings()->hideSimilarMaxDelay)
         {
             break;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ set(test_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/src/SplitInput.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/LinkInfo.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/MessageLayout.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/MessageSimilarity.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/QMagicEnum.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/ModerationAction.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/Scrollbar.cpp

--- a/tests/src/MessageSimilarity.cpp
+++ b/tests/src/MessageSimilarity.cpp
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2026 Contributors to Chatterino <https://chatterino.com>
+//
+// SPDX-License-Identifier: MIT
+
+#include "messages/MessageSimilarity.hpp"
+
+#include "controllers/accounts/AccountController.hpp"
+#include "messages/Message.hpp"
+#include "mocks/BaseApplication.hpp"
+#include "Test.hpp"
+
+#include <QDateTime>
+
+#include <memory>
+#include <vector>
+
+namespace chatterino {
+
+namespace {
+
+class MockApplication : public mock::BaseApplication
+{
+public:
+    AccountController *getAccounts() override
+    {
+        return &this->accounts;
+    }
+
+    AccountController accounts;
+};
+
+MessagePtr makeMessage(const QDateTime &time)
+{
+    auto message = std::make_shared<Message>();
+    message->loginName = "forsen";
+    message->messageText = "i'm chicken";
+    message->serverReceivedTime = time;
+    return message;
+}
+
+}  // namespace
+
+TEST(MessageSimilarity, R9KUsesMessageTimestamps)
+{
+    MockApplication app;
+    app.settings.similarityEnabled = true;
+    app.settings.hideSimilarMyself = true;
+    app.settings.hideSimilarBySameUser = true;
+    app.settings.hideSimilarMaxDelay = 5;
+    app.settings.hideSimilarMaxMessagesToCheck = 10;
+    app.settings.similarityPercentage = 0.9F;
+
+    const auto time =
+        QDateTime::fromString("1984-04-20T23:59:58Z", Qt::ISODate);
+    auto previous = makeMessage(time);
+    std::vector<MessagePtr> messages{previous};
+
+    auto withinDelay = makeMessage(time.addSecs(4));
+    setSimilarityFlags(withinDelay, messages);
+    EXPECT_TRUE(withinDelay->flags.has(MessageFlag::Similar));
+
+    auto beyondDelay = makeMessage(time.addSecs(6));
+    setSimilarityFlags(beyondDelay, messages);
+    EXPECT_FALSE(beyondDelay->flags.has(MessageFlag::Similar));
+}
+
+}  // namespace chatterino


### PR DESCRIPTION
The R9K filter currently checks the delay between messages using the time they were parsed rather than their timestamps. This means that messages loaded from Recent Messages history can be erroneously treated as close because they're all parsed together. `parseTime` also only contains the time of day, so the check can give incorrect results across midnight.

Fixed by comparing `serverReceivedTime` from both messages instead.

Added a test covering this.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->