### PR TITLE
fix: Crash when releasing only split in container

### DIFF
--- a/src/widgets/splits/SplitContainer.cpp
+++ b/src/widgets/splits/SplitContainer.cpp
@@ -1217,7 +1217,7 @@ SplitContainer::Position SplitContainer::Node::releaseSplit()
 {
     assert(this->type_ == Type::Split);
 
-    if (this->parent_ == nullptr)
+    if (this->parent_ == nullptr || this->parent_->children_.empty())
     {
         this->type_ = Type::EmptyRoot;
         this->split_ = nullptr;
@@ -1275,7 +1275,10 @@ SplitContainer::Position SplitContainer::Node::releaseSplit()
                     ? SplitDirection::Below
                     : SplitDirection::Right;
             siblings.erase(it);
-            position.relativeNode_ = siblings.back().get();
+            if (!siblings.empty())
+            {
+                position.relativeNode_ = siblings.back().get();
+            }
         }
         else
         {


### PR DESCRIPTION
Found this when testing #7254 - if you compile with a hardened/debug STL and close the only split in a container, there will be an assertion failure when trying to access `back()` of an empty vector. We never access that pointer, but are still calling the function.

Steps to reproduce:
1. Create a new tab with the + button.
2. Click in the empty container to open the channel selection dialog
3. Click "cancel"

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
