### PR TITLE
refactor: extract image frame storage

### DIFF
--- a/src/messages/Image.cpp
+++ b/src/messages/Image.cpp
@@ -26,6 +26,8 @@
 #include <QTimer>
 
 #include <atomic>
+#include <numeric>
+#include <utility>
 
 // Duration between each check of every Image instance
 const auto IMAGE_POOL_CLEANUP_INTERVAL = std::chrono::minutes(1);
@@ -34,13 +36,149 @@ const auto IMAGE_POOL_IMAGE_LIFETIME = std::chrono::minutes(10);
 
 namespace chatterino::detail {
 
+struct Frames::Storage {
+    Storage() = default;
+    virtual ~Storage()
+    {
+        this->gifTimerConnection.disconnect();
+    }
+    Storage(const Storage &) = delete;
+    Storage &operator=(const Storage &) = delete;
+    Storage(Storage &&) = delete;
+    Storage &operator=(Storage &&) = delete;
+
+    virtual int64_t memoryUsage() const = 0;
+    virtual bool empty() const = 0;
+    virtual bool animated() const = 0;
+    virtual void start(GIFTimer *timer) = 0;
+    virtual std::optional<QPixmap> current() const = 0;
+    virtual std::optional<QSize> size() const = 0;
+
+    pajlada::Signals::Connection gifTimerConnection;
+};
+
+struct Frames::CachedFrames : Storage {
+    CachedFrames() = default;
+    explicit CachedFrames(QList<Frame> frames)
+        : items(std::move(frames))
+    {
+    }
+    ~CachedFrames() override = default;
+    CachedFrames(const CachedFrames &) = delete;
+    CachedFrames &operator=(const CachedFrames &) = delete;
+    CachedFrames(CachedFrames &&) = delete;
+    CachedFrames &operator=(CachedFrames &&) = delete;
+
+    int64_t memoryUsage() const override
+    {
+        int64_t usage = 0;
+        for (const auto &frame : this->items)
+        {
+            auto sz = frame.image.size();
+            auto area = sz.width() * sz.height();
+            auto memory = area * frame.image.depth() / 8;
+            usage += memory;
+        }
+        return usage;
+    }
+
+    bool empty() const override
+    {
+        return this->items.empty();
+    }
+
+    bool animated() const override
+    {
+        return this->items.size() > 1;
+    }
+
+    void start(GIFTimer *timer) override
+    {
+        if (!this->animated())
+        {
+            return;
+        }
+
+        this->gifTimerConnection = timer->signal.connect([this] {
+            this->advance();
+        });
+
+        const auto totalLength =
+            std::accumulate(this->items.begin(), this->items.end(), 0UL,
+                            [](auto init, auto &&frame) {
+                                return init + frame.duration;
+                            });
+        if (totalLength == 0)
+        {
+            this->durationOffset = 0;
+        }
+        else
+        {
+            this->durationOffset =
+                std::min<int>(int(timer->position() % totalLength), 60000);
+        }
+        this->processOffset();
+    }
+
+    void advance()
+    {
+        this->durationOffset += GIF_FRAME_LENGTH;
+        this->processOffset();
+    }
+
+    void processOffset()
+    {
+        if (this->items.isEmpty())
+        {
+            return;
+        }
+
+        while (true)
+        {
+            this->index %= this->items.size();
+            if (this->durationOffset > this->items.at(this->index).duration)
+            {
+                this->durationOffset -= this->items.at(this->index).duration;
+                this->index = (this->index + 1) % this->items.size();
+            }
+            else
+            {
+                break;
+            }
+        }
+    }
+
+    std::optional<QPixmap> current() const override
+    {
+        if (this->empty())
+        {
+            return std::nullopt;
+        }
+        return this->items[this->index].image;
+    }
+
+    std::optional<QSize> size() const override
+    {
+        if (this->empty())
+        {
+            return std::nullopt;
+        }
+        return this->items.front().image.size();
+    }
+
+    QList<Frame> items;
+    QList<Frame>::size_type index{0};
+    int durationOffset{0};
+};
+
 Frames::Frames()
+    : storage_(std::make_unique<CachedFrames>())
 {
     DebugCount::increase(DebugObject::Image);
 }
 
 Frames::Frames(QList<Frame> &&frames)
-    : items_(std::move(frames))
+    : storage_(std::make_unique<CachedFrames>(std::move(frames)))
 {
     assertInGuiThread();
     auto *app = tryGetApp();
@@ -61,28 +199,7 @@ Frames::Frames(QList<Frame> &&frames)
     {
         DebugCount::increase(DebugObject::AnimatedImage);
 
-        this->gifTimerConnection_ =
-            app->getEmotes()->getGIFTimer()->signal.connect([this] {
-                this->advance();
-            });
-
-        auto totalLength =
-            std::accumulate(this->items_.begin(), this->items_.end(), 0UL,
-                            [](auto init, auto &&frame) {
-                                return init + frame.duration;
-                            });
-
-        if (totalLength == 0)
-        {
-            this->durationOffset_ = 0;
-        }
-        else
-        {
-            this->durationOffset_ = std::min<int>(
-                int(app->getEmotes()->getGIFTimer()->position() % totalLength),
-                60000);
-        }
-        this->processOffset();
+        this->storage_->start(app->getEmotes()->getGIFTimer());
     }
 
     DebugCount::increase(DebugObject::BytesImageCurrent, this->memoryUsage());
@@ -104,51 +221,11 @@ Frames::~Frames()
     }
     DebugCount::decrease(DebugObject::BytesImageCurrent, this->memoryUsage());
     DebugCount::increase(DebugObject::BytesImageUnloaded, this->memoryUsage());
-
-    this->gifTimerConnection_.disconnect();
 }
 
 int64_t Frames::memoryUsage() const
 {
-    int64_t usage = 0;
-    for (const auto &frame : this->items_)
-    {
-        auto sz = frame.image.size();
-        auto area = sz.width() * sz.height();
-        auto memory = area * frame.image.depth() / 8;
-
-        usage += memory;
-    }
-    return usage;
-}
-
-void Frames::advance()
-{
-    this->durationOffset_ += GIF_FRAME_LENGTH;
-    this->processOffset();
-}
-
-void Frames::processOffset()
-{
-    if (this->items_.isEmpty())
-    {
-        return;
-    }
-
-    while (true)
-    {
-        this->index_ %= this->items_.size();
-
-        if (this->durationOffset_ > this->items_[this->index_].duration)
-        {
-            this->durationOffset_ -= this->items_[this->index_].duration;
-            this->index_ = (this->index_ + 1) % this->items_.size();
-        }
-        else
-        {
-            break;
-        }
-    }
+    return this->storage_->memoryUsage();
 }
 
 void Frames::clear()
@@ -161,40 +238,27 @@ void Frames::clear()
     DebugCount::decrease(DebugObject::BytesImageCurrent, this->memoryUsage());
     DebugCount::increase(DebugObject::BytesImageUnloaded, this->memoryUsage());
 
-    this->items_.clear();
-    this->index_ = 0;
-    this->durationOffset_ = 0;
-    this->gifTimerConnection_.disconnect();
+    this->storage_ = std::make_unique<CachedFrames>();
 }
 
 bool Frames::empty() const
 {
-    return this->items_.empty();
+    return this->storage_->empty();
 }
 
 bool Frames::animated() const
 {
-    return this->items_.size() > 1;
+    return this->storage_->animated();
 }
 
 std::optional<QPixmap> Frames::current() const
 {
-    if (this->items_.empty())
-    {
-        return std::nullopt;
-    }
-
-    return this->items_[this->index_].image;
+    return this->storage_->current();
 }
 
 std::optional<QSize> Frames::size() const
 {
-    if (this->items_.empty())
-    {
-        return std::nullopt;
-    }
-
-    return this->items_.front().image.size();
+    return this->storage_->size();
 }
 
 QList<Frame> readFrames(QImageReader &reader, const Url &url)

--- a/src/messages/Image.cpp
+++ b/src/messages/Image.cpp
@@ -50,7 +50,7 @@ struct Frames::Storage {
     virtual bool animated() const = 0;
     virtual void start(GIFTimer *timer) = 0;
     virtual std::optional<QPixmap> current() const = 0;
-    virtual std::optional<QSize> size() const = 0;
+    virtual std::optional<QSize> frameSize() const = 0;
 
     pajlada::Signals::ScopedConnection gifTimerConnection;
 };
@@ -155,7 +155,7 @@ struct Frames::CachedFrames : Storage {
         return this->items[this->index].image;
     }
 
-    std::optional<QSize> size() const override
+    std::optional<QSize> frameSize() const override
     {
         if (this->empty())
         {
@@ -254,9 +254,9 @@ std::optional<QPixmap> Frames::current() const
     return this->storage_->current();
 }
 
-std::optional<QSize> Frames::size() const
+std::optional<QSize> Frames::frameSize() const
 {
-    return this->storage_->size();
+    return this->storage_->frameSize();
 }
 
 QList<Frame> readFrames(QImageReader &reader, const Url &url)
@@ -553,7 +553,7 @@ int Image::width() const
         return 0;
     }
 
-    if (auto size = this->frames_->size())
+    if (auto size = this->frames_->frameSize())
     {
         return static_cast<int>(size->width() * this->scale_);
     }
@@ -571,7 +571,7 @@ int Image::height() const
         return 0;
     }
 
-    if (auto size = this->frames_->size())
+    if (auto size = this->frames_->frameSize())
     {
         return static_cast<int>(size->height() * this->scale_);
     }
@@ -589,7 +589,7 @@ QSizeF Image::size() const
         return {0, 0};
     }
 
-    if (auto size = this->frames_->size())
+    if (auto size = this->frames_->frameSize())
     {
         return size->toSizeF() * this->scale_;
     }

--- a/src/messages/Image.cpp
+++ b/src/messages/Image.cpp
@@ -55,6 +55,7 @@ struct Frames::Storage {
     pajlada::Signals::ScopedConnection gifTimerConnection;
 };
 
+/// Stores all decoded frames in memory.
 struct Frames::CachedFrames : Storage {
     CachedFrames() = default;
     explicit CachedFrames(QList<Frame> frames)

--- a/src/messages/Image.cpp
+++ b/src/messages/Image.cpp
@@ -187,14 +187,14 @@ std::optional<QPixmap> Frames::current() const
     return this->items_[this->index_].image;
 }
 
-std::optional<QPixmap> Frames::first() const
+std::optional<QSize> Frames::size() const
 {
     if (this->items_.empty())
     {
         return std::nullopt;
     }
 
-    return this->items_.front().image;
+    return this->items_.front().image.size();
 }
 
 QList<Frame> readFrames(QImageReader &reader, const Url &url)
@@ -491,9 +491,9 @@ int Image::width() const
         return 0;
     }
 
-    if (auto pixmap = this->frames_->first())
+    if (auto size = this->frames_->size())
     {
-        return static_cast<int>(pixmap->width() * this->scale_);
+        return static_cast<int>(size->width() * this->scale_);
     }
 
     // No frames loaded, use the expected size
@@ -509,9 +509,9 @@ int Image::height() const
         return 0;
     }
 
-    if (auto pixmap = this->frames_->first())
+    if (auto size = this->frames_->size())
     {
-        return static_cast<int>(pixmap->height() * this->scale_);
+        return static_cast<int>(size->height() * this->scale_);
     }
 
     // No frames loaded, use the expected size
@@ -527,9 +527,9 @@ QSizeF Image::size() const
         return {0, 0};
     }
 
-    if (auto pixmap = this->frames_->first())
+    if (auto size = this->frames_->size())
     {
-        return pixmap->size().toSizeF() * this->scale_;
+        return size->toSizeF() * this->scale_;
     }
 
     // No frames loaded, use the expected size

--- a/src/messages/Image.cpp
+++ b/src/messages/Image.cpp
@@ -18,6 +18,7 @@
 #include "util/PostToThread.hpp"
 
 #include <boost/functional/hash.hpp>
+#include <pajlada/signals/scoped-connection.hpp>
 #include <QBuffer>
 #include <QImageReader>
 #include <QNetworkAccessManager>
@@ -38,10 +39,7 @@ namespace chatterino::detail {
 
 struct Frames::Storage {
     Storage() = default;
-    virtual ~Storage()
-    {
-        this->gifTimerConnection.disconnect();
-    }
+    virtual ~Storage() = default;
     Storage(const Storage &) = delete;
     Storage &operator=(const Storage &) = delete;
     Storage(Storage &&) = delete;
@@ -54,7 +52,7 @@ struct Frames::Storage {
     virtual std::optional<QPixmap> current() const = 0;
     virtual std::optional<QSize> size() const = 0;
 
-    pajlada::Signals::Connection gifTimerConnection;
+    pajlada::Signals::ScopedConnection gifTimerConnection;
 };
 
 struct Frames::CachedFrames : Storage {

--- a/src/messages/Image.hpp
+++ b/src/messages/Image.hpp
@@ -7,7 +7,6 @@
 #include "common/Aliases.hpp"
 #include "util/DebugCount.hpp"
 
-#include <pajlada/signals/signal.hpp>
 #include <QList>
 #include <QPixmap>
 #include <QString>

--- a/src/messages/Image.hpp
+++ b/src/messages/Image.hpp
@@ -51,7 +51,8 @@ public:
     bool empty() const;
     bool animated() const;
     std::optional<QPixmap> current() const;
-    std::optional<QSize> size() const;
+    /// Returns the size of the first frame, if one has been loaded.
+    std::optional<QSize> frameSize() const;
 
 private:
     struct Storage;

--- a/src/messages/Image.hpp
+++ b/src/messages/Image.hpp
@@ -50,17 +50,15 @@ public:
     void clear();
     bool empty() const;
     bool animated() const;
-    void advance();
     std::optional<QPixmap> current() const;
     std::optional<QSize> size() const;
 
 private:
+    struct Storage;
+    struct CachedFrames;
+
     int64_t memoryUsage() const;
-    void processOffset();
-    QList<Frame> items_;
-    QList<Frame>::size_type index_{0};
-    int durationOffset_{0};
-    pajlada::Signals::Connection gifTimerConnection_;
+    std::unique_ptr<Storage> storage_;
 };
 
 QList<Frame> readFrames(QImageReader &reader, const Url &url);

--- a/src/messages/Image.hpp
+++ b/src/messages/Image.hpp
@@ -52,7 +52,7 @@ public:
     bool animated() const;
     void advance();
     std::optional<QPixmap> current() const;
-    std::optional<QPixmap> first() const;
+    std::optional<QSize> size() const;
 
 private:
     int64_t memoryUsage() const;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -60,6 +60,7 @@ set(test_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/src/NativeMessaging.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/NotificationController.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/ImageUploader.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/Image.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/TwitchChannel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/TwitchUserColor.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/FunctionRef.cpp

--- a/tests/src/Image.cpp
+++ b/tests/src/Image.cpp
@@ -55,7 +55,8 @@ TEST(Image, StaticCachedFrame)
 {
     ImageApplication app;
     detail::Frames frames(QList<detail::Frame>{
-        {.image = makePixmap({1, 1}, Qt::red), .duration = 20}});
+        {.image = makePixmap({1, 1}, Qt::red), .duration = 20},
+    });
     EXPECT_FALSE(frames.empty());
     EXPECT_FALSE(frames.animated());
 
@@ -68,7 +69,8 @@ TEST(Image, CachedFramesUseSharedTimer)
     ImageApplication app;
     detail::Frames frames(QList<detail::Frame>{
         {.image = makePixmap({1, 1}, Qt::red), .duration = 20},
-        {.image = makePixmap({2, 2}, Qt::blue), .duration = 60}});
+        {.image = makePixmap({2, 2}, Qt::blue), .duration = 60},
+    });
     ASSERT_TRUE(frames.animated());
     ASSERT_EQ(frames.frameSize(), QSize(1, 1));
 
@@ -87,7 +89,8 @@ TEST(Image, CachedFramesClearDisconnectsTimer)
     {
         detail::Frames frames(QList<detail::Frame>{
             {.image = makePixmap({1, 1}, Qt::red), .duration = 20},
-            {.image = makePixmap({1, 1}, Qt::blue), .duration = 60}});
+            {.image = makePixmap({1, 1}, Qt::blue), .duration = 60},
+        });
         frames.clear();
         EXPECT_TRUE(frames.empty());
         EXPECT_FALSE(frames.animated());

--- a/tests/src/Image.cpp
+++ b/tests/src/Image.cpp
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: 2026 Contributors to Chatterino <https://chatterino.com>
+//
+// SPDX-License-Identifier: MIT
+
+#include "messages/Image.hpp"
+
+#include "controllers/emotes/EmoteController.hpp"
+#include "mocks/BaseApplication.hpp"
+#include "singletons/helper/GifTimer.hpp"
+#include "Test.hpp"
+
+#include <QColor>
+
+using namespace chatterino;
+
+namespace {
+
+class ImageApplication : public mock::BaseApplication
+{
+public:
+    EmoteController *getEmotes() override
+    {
+        return &this->emotes;
+    }
+
+    EmoteController emotes;
+};
+
+QPixmap makePixmap(QSize size, Qt::GlobalColor color)
+{
+    QPixmap pixmap(size);
+    pixmap.fill(color);
+    return pixmap;
+}
+
+bool hasColor(const detail::Frames &frames, QColor color)
+{
+    const auto pixmap = frames.current();
+    return pixmap && pixmap->toImage().pixelColor(0, 0) == color;
+}
+
+}  // namespace
+
+TEST(Image, EmptyCachedFrames)
+{
+    ImageApplication app;
+    detail::Frames frames;
+    EXPECT_TRUE(frames.empty());
+    EXPECT_FALSE(frames.animated());
+    EXPECT_FALSE(frames.current());
+    EXPECT_FALSE(frames.size());
+}
+
+TEST(Image, StaticCachedFrame)
+{
+    ImageApplication app;
+    detail::Frames frames(QList<detail::Frame>{
+        {.image = makePixmap({1, 1}, Qt::red), .duration = 20}});
+    EXPECT_FALSE(frames.empty());
+    EXPECT_FALSE(frames.animated());
+
+    app.emotes.getGIFTimer()->signal.invoke();
+    EXPECT_TRUE(hasColor(frames, Qt::red));
+}
+
+TEST(Image, CachedFramesUseSharedTimer)
+{
+    ImageApplication app;
+    detail::Frames frames(QList<detail::Frame>{
+        {.image = makePixmap({1, 1}, Qt::red), .duration = 20},
+        {.image = makePixmap({2, 2}, Qt::blue), .duration = 60}});
+    ASSERT_TRUE(frames.animated());
+    ASSERT_EQ(frames.size(), QSize(1, 1));
+
+    auto *timer = app.emotes.getGIFTimer();
+    timer->signal.invoke();
+    EXPECT_TRUE(hasColor(frames, Qt::red));
+    timer->signal.invoke();
+    EXPECT_TRUE(hasColor(frames, Qt::blue));
+    EXPECT_EQ(frames.size(), QSize(1, 1));
+}
+
+TEST(Image, CachedFramesClearDisconnectsTimer)
+{
+    ImageApplication app;
+    auto *timer = app.emotes.getGIFTimer();
+    {
+        detail::Frames frames(QList<detail::Frame>{
+            {.image = makePixmap({1, 1}, Qt::red), .duration = 20},
+            {.image = makePixmap({1, 1}, Qt::blue), .duration = 60}});
+        frames.clear();
+        EXPECT_TRUE(frames.empty());
+        EXPECT_FALSE(frames.animated());
+        EXPECT_FALSE(frames.current());
+        EXPECT_FALSE(frames.size());
+        timer->signal.invoke();
+    }
+    timer->signal.invoke();
+}

--- a/tests/src/Image.cpp
+++ b/tests/src/Image.cpp
@@ -48,7 +48,7 @@ TEST(Image, EmptyCachedFrames)
     EXPECT_TRUE(frames.empty());
     EXPECT_FALSE(frames.animated());
     EXPECT_FALSE(frames.current());
-    EXPECT_FALSE(frames.size());
+    EXPECT_FALSE(frames.frameSize());
 }
 
 TEST(Image, StaticCachedFrame)
@@ -70,14 +70,14 @@ TEST(Image, CachedFramesUseSharedTimer)
         {.image = makePixmap({1, 1}, Qt::red), .duration = 20},
         {.image = makePixmap({2, 2}, Qt::blue), .duration = 60}});
     ASSERT_TRUE(frames.animated());
-    ASSERT_EQ(frames.size(), QSize(1, 1));
+    ASSERT_EQ(frames.frameSize(), QSize(1, 1));
 
     auto *timer = app.emotes.getGIFTimer();
     timer->signal.invoke();
     EXPECT_TRUE(hasColor(frames, Qt::red));
     timer->signal.invoke();
     EXPECT_TRUE(hasColor(frames, Qt::blue));
-    EXPECT_EQ(frames.size(), QSize(1, 1));
+    EXPECT_EQ(frames.frameSize(), QSize(1, 1));
 }
 
 TEST(Image, CachedFramesClearDisconnectsTimer)
@@ -92,7 +92,7 @@ TEST(Image, CachedFramesClearDisconnectsTimer)
         EXPECT_TRUE(frames.empty());
         EXPECT_FALSE(frames.animated());
         EXPECT_FALSE(frames.current());
-        EXPECT_FALSE(frames.size());
+        EXPECT_FALSE(frames.frameSize());
         timer->signal.invoke();
     }
     timer->signal.invoke();


### PR DESCRIPTION
Extract frame storage into `Frames::CachedFrames` behind a `Frames::Storage` interface in preparation for adding a dynamically decoded storage type

Added tests

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
