### PR TITLE
feat: add mouse button hotkey support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -225,6 +225,10 @@ set(SOURCE_FILES
         controllers/hotkeys/HotkeyHelpers.hpp
         controllers/hotkeys/HotkeyModel.cpp
         controllers/hotkeys/HotkeyModel.hpp
+        controllers/hotkeys/HotkeySequence.cpp
+        controllers/hotkeys/HotkeySequence.hpp
+        controllers/hotkeys/MouseShortcut.cpp
+        controllers/hotkeys/MouseShortcut.hpp
 
         controllers/ignores/IgnoreController.cpp
         controllers/ignores/IgnoreController.hpp
@@ -783,6 +787,8 @@ set(SOURCE_FILES
         widgets/helper/EditableModelView.hpp
         widgets/helper/FontSettingWidget.cpp
         widgets/helper/FontSettingWidget.hpp
+        widgets/helper/HotkeySequenceEdit.cpp
+        widgets/helper/HotkeySequenceEdit.hpp
         widgets/helper/IconDelegate.cpp
         widgets/helper/IconDelegate.hpp
         widgets/helper/InvisibleSizeGrip.cpp

--- a/src/controllers/hotkeys/Hotkey.cpp
+++ b/src/controllers/hotkeys/Hotkey.cpp
@@ -10,19 +10,24 @@
 
 namespace chatterino {
 
-Hotkey::Hotkey(HotkeyCategory category, QKeySequence keySequence,
-               QString action, std::vector<QString> arguments, QString name)
+Hotkey::Hotkey(HotkeyCategory category, HotkeySequence sequence, QString action,
+               std::vector<QString> arguments, QString name)
     : category_(category)
-    , keySequence_(keySequence)
+    , sequence_(std::move(sequence))
     , action_(action)
     , arguments_(arguments)
     , name_(name)
 {
 }
 
-const QKeySequence &Hotkey::keySequence() const
+QKeySequence Hotkey::keySequence() const
 {
-    return this->keySequence_;
+    return this->sequence_.keySequence();
+}
+
+const HotkeySequence &Hotkey::sequence() const
+{
+    return this->sequence_;
 }
 
 QString Hotkey::name() const
@@ -85,12 +90,12 @@ Qt::ShortcutContext Hotkey::getContext() const
 
 QString Hotkey::toString() const
 {
-    return this->keySequence().toString(QKeySequence::NativeText);
+    return this->sequence_.toString();
 }
 
 QString Hotkey::toPortableString() const
 {
-    return this->keySequence().toString(QKeySequence::PortableText);
+    return this->sequence_.toPortableString();
 }
 
 }  // namespace chatterino

--- a/src/controllers/hotkeys/Hotkey.hpp
+++ b/src/controllers/hotkeys/Hotkey.hpp
@@ -5,8 +5,8 @@
 #pragma once
 
 #include "controllers/hotkeys/HotkeyCategory.hpp"
+#include "controllers/hotkeys/HotkeySequence.hpp"
 
-#include <QKeySequence>
 #include <QString>
 
 #include <vector>
@@ -16,7 +16,7 @@ namespace chatterino {
 class Hotkey
 {
 public:
-    Hotkey(HotkeyCategory category, QKeySequence keySequence, QString action,
+    Hotkey(HotkeyCategory category, HotkeySequence sequence, QString action,
            std::vector<QString> arguments, QString name);
     virtual ~Hotkey() = default;
 
@@ -75,15 +75,20 @@ public:
     QString getCategory() const;
 
     /**
-     * @brief Returns the programmating key sequence of the hotkey
+     * @brief Returns the keyboard sequence of the hotkey
      *
-     * The actual key codes required for the hotkey to trigger specifically on e.g CTRL+F5
+     * Empty when this hotkey is bound to a mouse button.
      */
-    const QKeySequence &keySequence() const;
+    QKeySequence keySequence() const;
+
+    /**
+     * @brief Returns the keyboard or mouse sequence of the hotkey
+     */
+    const HotkeySequence &sequence() const;
 
 private:
     HotkeyCategory category_;
-    QKeySequence keySequence_;
+    HotkeySequence sequence_;
     QString action_;
     std::vector<QString> arguments_;
     QString name_;

--- a/src/controllers/hotkeys/HotkeyController.cpp
+++ b/src/controllers/hotkeys/HotkeyController.cpp
@@ -8,6 +8,8 @@
 #include "controllers/hotkeys/Hotkey.hpp"
 #include "controllers/hotkeys/HotkeyCategory.hpp"
 #include "controllers/hotkeys/HotkeyModel.hpp"
+#include "controllers/hotkeys/HotkeySequence.hpp"
+#include "controllers/hotkeys/MouseShortcut.hpp"
 #include "util/RapidJsonSerializeQString.hpp"  // IWYU pragma: keep
 
 #include <pajlada/settings.hpp>
@@ -78,6 +80,8 @@ static bool hotkeySortCompare_(const std::shared_ptr<Hotkey> &a,
 HotkeyController::HotkeyController()
     : hotkeys_(hotkeySortCompare_)
 {
+    installMouseShortcutFilter();
+
     this->loadHotkeys();
 
     this->clearRemovedDefaults();
@@ -96,12 +100,12 @@ HotkeyModel *HotkeyController::createModel(QObject *parent)
     return model;
 }
 
-std::vector<QShortcut *> HotkeyController::shortcutsForCategory(
+std::vector<QObject *> HotkeyController::shortcutsForCategory(
     HotkeyCategory category,
     std::map<QString, std::function<QString(std::vector<QString>)>> actionMap,
     QWidget *parent)
 {
-    std::vector<QShortcut *> output;
+    std::vector<QObject *> output;
     for (const auto &hotkey : this->hotkeys_)
     {
         if (hotkey->category() != category)
@@ -122,22 +126,32 @@ std::vector<QShortcut *> HotkeyController::shortcutsForCategory(
             // Widget has chosen to explicitly not handle this action
             continue;
         }
+        auto invokeHotkey = [functionPointer = target->second, hotkey, this]() {
+            QString error = functionPointer(hotkey->arguments());
+            if (!error.isEmpty())
+            {
+                this->showHotkeyError(hotkey, error);
+            }
+        };
+
         auto createShortcutFromKeySeq = [&](QKeySequence qs) {
             auto *s = new QShortcut(qs, parent);
             s->setContext(hotkey->getContext());
-            auto functionPointer = target->second;
-            QObject::connect(s, &QShortcut::activated, parent,
-                             [functionPointer, hotkey, this]() {
-                                 QString output =
-                                     functionPointer(hotkey->arguments());
-                                 if (!output.isEmpty())
-                                 {
-                                     this->showHotkeyError(hotkey, output);
-                                 }
-                             });
+            QObject::connect(s, &QShortcut::activated, parent, invokeHotkey);
             output.push_back(s);
         };
-        auto qs = QKeySequence(hotkey->keySequence());
+
+        if (hotkey->sequence().isMouse())
+        {
+            auto *s = new MouseShortcut(hotkey->sequence().mouseButton(),
+                                        hotkey->getContext(), parent);
+            QObject::connect(s, &MouseShortcut::activated, parent,
+                             invokeHotkey);
+            output.push_back(s);
+            continue;
+        }
+
+        auto qs = hotkey->keySequence();
 
         // Create shortcut for the original key sequence
         createShortcutFromKeySeq(qs);
@@ -223,7 +237,7 @@ bool HotkeyController::isDuplicate(std::shared_ptr<Hotkey> hotkey,
         }
 
         if (shared->category() == hotkey->category() &&
-            shared->keySequence() == hotkey->keySequence())
+            shared->sequence() == hotkey->sequence())
         {
             return true;
         }
@@ -287,8 +301,8 @@ void HotkeyController::loadHotkeys()
             continue;
         }
         this->hotkeys_.append(std::make_shared<Hotkey>(
-            *category, QKeySequence(keySequence), action, arguments,
-            QString::fromStdString(key)));
+            *category, HotkeySequence::fromPortableString(keySequence), action,
+            arguments, QString::fromStdString(key)));
     }
 
     if (numDefaultsFromSettings != numCombinedDefaults)
@@ -319,8 +333,8 @@ void HotkeyController::saveHotkeys()
         auto section = "/hotkeys/" + hotkey->name().toStdString();
         pajlada::Settings::Setting<QString>::set(section + "/action",
                                                  hotkey->action());
-        pajlada::Settings::Setting<QString>::set(
-            section + "/keySequence", hotkey->keySequence().toString());
+        pajlada::Settings::Setting<QString>::set(section + "/keySequence",
+                                                 hotkey->toPortableString());
 
         auto categoryName = hotkeyCategoryName(hotkey->category());
         pajlada::Settings::Setting<QString>::set(section + "/category",
@@ -648,36 +662,20 @@ QKeySequence HotkeyController::getDisplaySequence(
     HotkeyCategory category, const QString &action,
     const std::optional<std::vector<QString>> &arguments) const
 {
-    const auto &found = this->findLike(category, action, arguments);
-    if (found != nullptr)
+    for (const auto &other : this->hotkeys_)
     {
-        return found->keySequence();
+        if (other->category() != category || other->action() != action ||
+            other->sequence().isMouse())
+        {
+            continue;
+        }
+        if (arguments && other->arguments() != *arguments)
+        {
+            continue;
+        }
+        return other->keySequence();
     }
     return {};
-}
-
-std::shared_ptr<Hotkey> HotkeyController::findLike(
-    HotkeyCategory category, const QString &action,
-    const std::optional<std::vector<QString>> &arguments) const
-{
-    for (auto other : this->hotkeys_)
-    {
-        if (other->category() == category && other->action() == action)
-        {
-            if (arguments)
-            {
-                if (other->arguments() == *arguments)
-                {
-                    return other;
-                }
-            }
-            else
-            {
-                return other;
-            }
-        }
-    }
-    return nullptr;
 }
 
 }  // namespace chatterino

--- a/src/controllers/hotkeys/HotkeyController.hpp
+++ b/src/controllers/hotkeys/HotkeyController.hpp
@@ -9,11 +9,18 @@
 
 #include <pajlada/signals/signal.hpp>
 #include <pajlada/signals/signalholder.hpp>
+#include <QKeySequence>
+#include <QString>
 
+#include <functional>
+#include <map>
+#include <memory>
 #include <optional>
 #include <set>
+#include <vector>
 
-class QShortcut;
+class QObject;
+class QWidget;
 
 namespace chatterino {
 
@@ -50,9 +57,9 @@ public:
     HotkeyController();
     HotkeyModel *createModel(QObject *parent);
 
-    std::vector<QShortcut *> shortcutsForCategory(HotkeyCategory category,
-                                                  HotkeyMap actionMap,
-                                                  QWidget *parent);
+    std::vector<QObject *> shortcutsForCategory(HotkeyCategory category,
+                                                HotkeyMap actionMap,
+                                                QWidget *parent);
 
     void save();
     std::shared_ptr<Hotkey> getHotkeyByName(QString name);
@@ -156,17 +163,6 @@ private:
      **/
     static void showHotkeyError(const std::shared_ptr<Hotkey> &hotkey,
                                 QString warning);
-    /**
-     * @brief finds a Hotkey matching category, action and arguments.
-     * Accepted if and only if the category matches, the action matches and arguments match.
-     * When arguments is present, contents of arguments must match the checked hotkey, otherwise arguments are ignored.
-     * For example:
-     * - std::nullopt (or {}) will match any hotkey satisfying category, action values,
-     * - {{"foo", "bar"}} will only match a hotkey that has these arguments and these arguments only
-     */
-    std::shared_ptr<Hotkey> findLike(
-        HotkeyCategory category, const QString &action,
-        const std::optional<std::vector<QString>> &arguments = {}) const;
 
     friend class KeyboardSettingsPage;
 

--- a/src/controllers/hotkeys/HotkeySequence.cpp
+++ b/src/controllers/hotkeys/HotkeySequence.cpp
@@ -1,0 +1,206 @@
+// SPDX-FileCopyrightText: 2026 Contributors to Chatterino <https://chatterino.com>
+//
+// SPDX-License-Identifier: MIT
+
+#include "controllers/hotkeys/HotkeySequence.hpp"
+
+#include <QLatin1String>
+#include <QString>
+#include <QStringView>
+
+namespace {
+
+constexpr int MIN_EXTRA_BUTTON_NUMBER = 4;
+constexpr int MAX_EXTRA_BUTTON_NUMBER = 27;  // Qt::ExtraButton24
+
+}  // namespace
+
+namespace chatterino {
+
+std::optional<int> extraMouseButtonNumber(Qt::MouseButton button)
+{
+    if (button == Qt::NoButton)
+    {
+        return std::nullopt;
+    }
+
+    auto value = static_cast<unsigned>(button);
+    // Must be a single bit (one button, not a mask).
+    if ((value & (value - 1)) != 0)
+    {
+        return std::nullopt;
+    }
+
+    int number = 1;
+    while (value > 1)
+    {
+        value >>= 1;
+        number++;
+    }
+
+    if (number < MIN_EXTRA_BUTTON_NUMBER || number > MAX_EXTRA_BUTTON_NUMBER)
+    {
+        return std::nullopt;
+    }
+
+    return number;
+}
+
+bool isExtraMouseButton(Qt::MouseButton button)
+{
+    return extraMouseButtonNumber(button).has_value();
+}
+
+std::optional<Qt::MouseButton> extraMouseButtonFromNumber(int number)
+{
+    if (number < MIN_EXTRA_BUTTON_NUMBER || number > MAX_EXTRA_BUTTON_NUMBER)
+    {
+        return std::nullopt;
+    }
+
+    return static_cast<Qt::MouseButton>(1u << (number - 1));
+}
+
+namespace {
+
+std::optional<Qt::MouseButton> parseMouseButton(const QString &text)
+{
+    if (text.compare(u"MouseBack", Qt::CaseInsensitive) == 0)
+    {
+        return Qt::BackButton;
+    }
+    if (text.compare(u"MouseForward", Qt::CaseInsensitive) == 0)
+    {
+        return Qt::ForwardButton;
+    }
+
+    constexpr auto PREFIX = QLatin1String("MouseButton");
+    if (!text.startsWith(PREFIX, Qt::CaseInsensitive))
+    {
+        return std::nullopt;
+    }
+
+    bool ok = false;
+    int number = QStringView(text).sliced(PREFIX.size()).toInt(&ok);
+    if (!ok)
+    {
+        return std::nullopt;
+    }
+
+    return extraMouseButtonFromNumber(number);
+}
+
+bool looksLikeMouseBinding(const QString &text)
+{
+    return text.compare(u"MouseBack", Qt::CaseInsensitive) == 0 ||
+           text.compare(u"MouseForward", Qt::CaseInsensitive) == 0 ||
+           text.startsWith(QLatin1String("MouseButton"), Qt::CaseInsensitive);
+}
+
+QString extraMouseButtonName(Qt::MouseButton button, bool portable)
+{
+    if (button == Qt::BackButton)
+    {
+        return portable ? QStringLiteral("MouseBack")
+                        : QStringLiteral("Mouse Back");
+    }
+    if (button == Qt::ForwardButton)
+    {
+        return portable ? QStringLiteral("MouseForward")
+                        : QStringLiteral("Mouse Forward");
+    }
+
+    auto number = extraMouseButtonNumber(button);
+    if (!number)
+    {
+        return {};
+    }
+
+    return portable ? QStringLiteral("MouseButton%1").arg(*number)
+                    : QStringLiteral("Mouse Button %1").arg(*number);
+}
+
+}  // namespace
+
+HotkeySequence::HotkeySequence(const QKeySequence &keySequence)
+    : keySequence_(keySequence)
+{
+}
+
+HotkeySequence::HotkeySequence(Qt::MouseButton mouseButton)
+    : mouseButton_(isExtraMouseButton(mouseButton) ? mouseButton : Qt::NoButton)
+{
+}
+
+HotkeySequence HotkeySequence::fromPortableString(const QString &text)
+{
+    auto trimmed = text.trimmed();
+    if (trimmed.isEmpty())
+    {
+        return {};
+    }
+
+    if (looksLikeMouseBinding(trimmed))
+    {
+        if (auto button = parseMouseButton(trimmed))
+        {
+            return HotkeySequence(*button);
+        }
+        return {};
+    }
+
+    return {QKeySequence(trimmed, QKeySequence::PortableText)};
+}
+
+bool HotkeySequence::isEmpty() const
+{
+    return this->mouseButton_ == Qt::NoButton && this->keySequence_.isEmpty();
+}
+
+bool HotkeySequence::isMouse() const
+{
+    return this->mouseButton_ != Qt::NoButton;
+}
+
+QKeySequence HotkeySequence::keySequence() const
+{
+    return this->keySequence_;
+}
+
+Qt::MouseButton HotkeySequence::mouseButton() const
+{
+    return this->mouseButton_;
+}
+
+QString HotkeySequence::toString() const
+{
+    if (this->isMouse())
+    {
+        return extraMouseButtonName(this->mouseButton_, false);
+    }
+
+    return this->keySequence_.toString(QKeySequence::NativeText);
+}
+
+QString HotkeySequence::toPortableString() const
+{
+    if (this->isMouse())
+    {
+        return extraMouseButtonName(this->mouseButton_, true);
+    }
+
+    return this->keySequence_.toString(QKeySequence::PortableText);
+}
+
+bool HotkeySequence::operator==(const HotkeySequence &other) const
+{
+    return this->mouseButton_ == other.mouseButton_ &&
+           this->keySequence_ == other.keySequence_;
+}
+
+bool HotkeySequence::operator!=(const HotkeySequence &other) const
+{
+    return !(*this == other);
+}
+
+}  // namespace chatterino

--- a/src/controllers/hotkeys/HotkeySequence.hpp
+++ b/src/controllers/hotkeys/HotkeySequence.hpp
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2026 Contributors to Chatterino <https://chatterino.com>
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <QKeySequence>
+#include <QString>
+#include <Qt>
+
+#include <optional>
+
+namespace chatterino {
+
+/// True for extra buttons (Mouse Back/Forward and Mouse Button 6+).
+/// Left, Right, and Middle are not extra buttons.
+[[nodiscard]] bool isExtraMouseButton(Qt::MouseButton button);
+
+/// Physical button number (4 = Back, 5 = Forward, …) for an extra mouse button.
+[[nodiscard]] std::optional<int> extraMouseButtonNumber(Qt::MouseButton button);
+
+/// Extra mouse button for a physical button number (4–27).
+[[nodiscard]] std::optional<Qt::MouseButton> extraMouseButtonFromNumber(
+    int number);
+
+/**
+ * Keyboard chord or a single extra mouse button.
+ *
+ * Mouse bindings never include keyboard modifiers.
+ */
+class HotkeySequence
+{
+public:
+    HotkeySequence() = default;
+    HotkeySequence(const QKeySequence &keySequence);
+    explicit HotkeySequence(Qt::MouseButton mouseButton);
+
+    [[nodiscard]] static HotkeySequence fromPortableString(const QString &text);
+
+    [[nodiscard]] bool isEmpty() const;
+    [[nodiscard]] bool isMouse() const;
+
+    [[nodiscard]] QKeySequence keySequence() const;
+    [[nodiscard]] Qt::MouseButton mouseButton() const;
+
+    /// OS-specific text for the GUI (e.g. "Ctrl+F5" or "Mouse Back").
+    [[nodiscard]] QString toString() const;
+
+    /// Portable text for settings (e.g. "Ctrl+F5" or "MouseBack").
+    [[nodiscard]] QString toPortableString() const;
+
+    bool operator==(const HotkeySequence &other) const;
+    bool operator!=(const HotkeySequence &other) const;
+
+private:
+    QKeySequence keySequence_;
+    Qt::MouseButton mouseButton_ = Qt::NoButton;
+};
+
+}  // namespace chatterino

--- a/src/controllers/hotkeys/MouseShortcut.cpp
+++ b/src/controllers/hotkeys/MouseShortcut.cpp
@@ -1,0 +1,223 @@
+// SPDX-FileCopyrightText: 2026 Contributors to Chatterino <https://chatterino.com>
+//
+// SPDX-License-Identifier: MIT
+
+#include "controllers/hotkeys/MouseShortcut.hpp"
+
+#include "controllers/hotkeys/HotkeySequence.hpp"
+
+#include <QApplication>
+#include <QEvent>
+#include <QMouseEvent>
+#include <QPointer>
+#include <QWidget>
+
+#include <algorithm>
+#include <vector>
+
+namespace {
+
+using namespace chatterino;
+
+std::vector<MouseShortcut *> mouseShortcuts;
+std::function<void(Qt::MouseButton)> mouseCapture;
+QPointer<QObject> mouseCaptureOwner;
+QPointer<QObject> installedMouseShortcutFilter;
+
+int contextPriority(Qt::ShortcutContext context)
+{
+    switch (context)
+    {
+        case Qt::WidgetShortcut:
+            return 3;
+        case Qt::WidgetWithChildrenShortcut:
+            return 2;
+        case Qt::WindowShortcut:
+            return 1;
+        case Qt::ApplicationShortcut:
+            return 0;
+        default:
+            return -1;
+    }
+}
+
+bool isShortcutActive(const MouseShortcut *shortcut, QWidget *focusWidget)
+{
+    auto *parent = shortcut->parentWidget();
+    if (parent == nullptr || !parent->isEnabled() || !parent->isVisible())
+    {
+        return false;
+    }
+
+    switch (shortcut->context())
+    {
+        case Qt::WindowShortcut: {
+            auto *window = parent->window();
+            return window != nullptr && window->isActiveWindow();
+        }
+        case Qt::WidgetWithChildrenShortcut:
+            return focusWidget != nullptr &&
+                   (parent == focusWidget || parent->isAncestorOf(focusWidget));
+        case Qt::WidgetShortcut:
+            return focusWidget == parent;
+        case Qt::ApplicationShortcut:
+            return true;
+        default:
+            return false;
+    }
+}
+
+void unregisterMouseShortcut(MouseShortcut *shortcut)
+{
+    auto it = std::ranges::find(mouseShortcuts, shortcut);
+    if (it != mouseShortcuts.end())
+    {
+        mouseShortcuts.erase(it);
+    }
+}
+
+class MouseShortcutEventFilter : public QObject
+{
+public:
+    explicit MouseShortcutEventFilter(QObject *parent)
+        : QObject(parent)
+    {
+    }
+
+    ~MouseShortcutEventFilter() override
+    {
+        if (qApp != nullptr)
+        {
+            qApp->removeEventFilter(this);
+        }
+        installedMouseShortcutFilter.clear();
+    }
+
+    bool eventFilter(QObject * /*watched*/, QEvent *event) override
+    {
+        if (event->type() != QEvent::MouseButtonPress)
+        {
+            return false;
+        }
+
+        auto *mouseEvent = static_cast<QMouseEvent *>(event);
+        auto button = mouseEvent->button();
+        if (!isExtraMouseButton(button))
+        {
+            return false;
+        }
+
+        if (mouseCapture)
+        {
+            mouseCapture(button);
+            return true;
+        }
+
+        QWidget *focusWidget = QApplication::focusWidget();
+        MouseShortcut *best = nullptr;
+        int bestPriority = -1;
+        for (auto *shortcut : mouseShortcuts)
+        {
+            if (shortcut->button() != button)
+            {
+                continue;
+            }
+            if (!isShortcutActive(shortcut, focusWidget))
+            {
+                continue;
+            }
+            int priority = contextPriority(shortcut->context());
+            if (priority > bestPriority)
+            {
+                bestPriority = priority;
+                best = shortcut;
+            }
+        }
+
+        if (best != nullptr)
+        {
+            Q_EMIT best->activated();
+            return true;
+        }
+
+        return false;
+    }
+};
+
+}  // namespace
+
+namespace chatterino {
+
+void installMouseShortcutFilter()
+{
+    if (installedMouseShortcutFilter || qApp == nullptr)
+    {
+        return;
+    }
+
+    auto *filter = new MouseShortcutEventFilter(qApp);
+    installedMouseShortcutFilter = filter;
+    qApp->installEventFilter(filter);
+}
+
+void setMouseHotkeyCapture(QObject *owner,
+                           std::function<void(Qt::MouseButton)> callback)
+{
+    mouseCaptureOwner = owner;
+    mouseCapture = std::move(callback);
+}
+
+void clearMouseHotkeyCapture(QObject *owner)
+{
+    if (mouseCaptureOwner != owner)
+    {
+        return;
+    }
+
+    mouseCaptureOwner.clear();
+    mouseCapture = {};
+}
+
+MouseShortcut::MouseShortcut(Qt::MouseButton button,
+                             Qt::ShortcutContext context, QWidget *parent)
+    : QObject(parent)
+    , button_(button)
+    , context_(context)
+{
+    installMouseShortcutFilter();
+    mouseShortcuts.push_back(this);
+    this->registered_ = true;
+}
+
+MouseShortcut::~MouseShortcut()
+{
+    this->clear();
+}
+
+Qt::MouseButton MouseShortcut::button() const
+{
+    return this->button_;
+}
+
+Qt::ShortcutContext MouseShortcut::context() const
+{
+    return this->context_;
+}
+
+QWidget *MouseShortcut::parentWidget() const
+{
+    return qobject_cast<QWidget *>(this->parent());
+}
+
+void MouseShortcut::clear()
+{
+    if (!this->registered_)
+    {
+        return;
+    }
+
+    unregisterMouseShortcut(this);
+    this->registered_ = false;
+}
+
+}  // namespace chatterino

--- a/src/controllers/hotkeys/MouseShortcut.hpp
+++ b/src/controllers/hotkeys/MouseShortcut.hpp
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2026 Contributors to Chatterino <https://chatterino.com>
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <QObject>
+#include <Qt>
+
+#include <functional>
+
+class QWidget;
+
+namespace chatterino {
+
+/**
+ * Like QShortcut, but for extra mouse buttons (Back/Forward and button 6+).
+ *
+ * Keyboard modifiers are ignored. The shortcut is active according to
+ * Qt::ShortcutContext, matching QShortcut.
+ */
+class MouseShortcut : public QObject
+{
+    Q_OBJECT
+
+public:
+    MouseShortcut(Qt::MouseButton button, Qt::ShortcutContext context,
+                  QWidget *parent);
+    ~MouseShortcut() override;
+
+    MouseShortcut(const MouseShortcut &) = delete;
+    MouseShortcut(MouseShortcut &&) = delete;
+    MouseShortcut &operator=(const MouseShortcut &) = delete;
+    MouseShortcut &operator=(MouseShortcut &&) = delete;
+
+    [[nodiscard]] Qt::MouseButton button() const;
+    [[nodiscard]] Qt::ShortcutContext context() const;
+    [[nodiscard]] QWidget *parentWidget() const;
+
+    /// Unregister so this shortcut can no longer fire (e.g. before deleteLater).
+    void clear();
+
+Q_SIGNALS:
+    void activated();
+
+private:
+    Qt::MouseButton button_;
+    Qt::ShortcutContext context_;
+    bool registered_ = false;
+};
+
+/// Install the application event filter that dispatches MouseShortcut presses.
+void installMouseShortcutFilter();
+
+/// While set, extra mouse buttons are delivered here instead of MouseShortcuts.
+void setMouseHotkeyCapture(QObject *owner,
+                           std::function<void(Qt::MouseButton)> callback);
+
+/// Clears capture only if @p owner is the current capture owner.
+void clearMouseHotkeyCapture(QObject *owner);
+
+}  // namespace chatterino

--- a/src/controllers/hotkeys/README.md
+++ b/src/controllers/hotkeys/README.md
@@ -4,17 +4,18 @@
 
 - [Glossary](#Glossary)
 - [Adding new hotkeys](#Adding_new_hotkeys)
+- [Mouse buttons](#Mouse_buttons)
 - [Adding new hotkey categories](#Adding_new_hotkey_categories)
 
 ## Glossary
 
 | Word                    | Meaning                                                                                   |
 | ----------------------- | ----------------------------------------------------------------------------------------- |
-| Shortcut                | `QShortcut` object created from a hotkey.                                                 |
+| Shortcut                | `QShortcut` or `MouseShortcut` created from a hotkey.                                     |
 | Hotkey                  | Template for creating shortcuts in the right categories. See [Hotkey object][hotkey.hpp]. |
 | Category                | Place where hotkeys' actions are executed.                                                |
 | Action                  | Code that makes a hotkey do something.                                                    |
-| Keybinding or key combo | The keys you press on the keyboard to do something.                                       |
+| Keybinding or key combo | The keys or extra mouse button you press to do something.                                 |
 
 ## Adding new hotkeys
 
@@ -42,6 +43,12 @@ void HotkeyController::tryAddDefault(std::set<QString> &addedHotkeys,
 - `category` — same category that is in the `shortcutsForCategory` call
 - `name` — **unique** name of the default hotkey
 - `keySequence` - key combo for the hotkey
+
+## Mouse buttons
+
+Keyboard chords use `QShortcut`. Extra mouse buttons (Mouse Back, Mouse Forward, and Mouse Button 6+) are stored in the same `keySequence` settings field as `MouseBack` / `MouseForward` / `MouseButtonN` and dispatched with `MouseShortcut`. Left, Right, and Middle cannot be bound. Mouse bindings do not include keyboard modifiers.
+
+Users can bind extra mouse buttons in Settings → Keybindings. There are no default mouse bindings.
 
 ## Adding new hotkey categories
 

--- a/src/widgets/BaseWidget.cpp
+++ b/src/widgets/BaseWidget.cpp
@@ -7,6 +7,7 @@
 #include "Application.hpp"
 #include "common/QLogging.hpp"
 #include "controllers/hotkeys/HotkeyController.hpp"
+#include "controllers/hotkeys/MouseShortcut.hpp"
 #include "singletons/Theme.hpp"
 #include "widgets/BaseWindow.hpp"
 
@@ -14,6 +15,7 @@
 #include <QDebug>
 #include <QIcon>
 #include <QLayout>
+#include <QShortcut>
 #include <QtGlobal>
 
 #include <algorithm>
@@ -40,7 +42,14 @@ void BaseWidget::clearShortcuts()
 {
     for (auto *shortcut : this->shortcuts_)
     {
-        shortcut->setKey(QKeySequence());
+        if (auto *keyShortcut = qobject_cast<QShortcut *>(shortcut))
+        {
+            keyShortcut->setKey(QKeySequence());
+        }
+        else if (auto *mouseShortcut = qobject_cast<MouseShortcut *>(shortcut))
+        {
+            mouseShortcut->clear();
+        }
         shortcut->removeEventFilter(this);
         shortcut->deleteLater();
     }

--- a/src/widgets/BaseWidget.hpp
+++ b/src/widgets/BaseWidget.hpp
@@ -6,10 +6,10 @@
 
 #include <pajlada/signals/signal.hpp>
 #include <pajlada/signals/signalholder.hpp>
-#include <QShortcut>
 #include <QWidget>
 
 #include <optional>
+#include <vector>
 
 namespace chatterino {
 
@@ -53,7 +53,7 @@ protected:
 
     Theme *theme;
 
-    std::vector<QShortcut *> shortcuts_;
+    std::vector<QObject *> shortcuts_;
     void clearShortcuts();
     pajlada::Signals::SignalHolder signalHolder_;
 

--- a/src/widgets/dialogs/EditHotkeyDialog.cpp
+++ b/src/widgets/dialogs/EditHotkeyDialog.cpp
@@ -12,8 +12,6 @@
 #include "controllers/hotkeys/HotkeyHelpers.hpp"
 #include "ui_EditHotkeyDialog.h"
 
-#include <QSignalBlocker>
-
 namespace chatterino {
 
 EditHotkeyDialog::EditHotkeyDialog(const std::shared_ptr<Hotkey> hotkey,
@@ -23,18 +21,6 @@ EditHotkeyDialog::EditHotkeyDialog(const std::shared_ptr<Hotkey> hotkey,
     , data_(hotkey)
 {
     this->ui_->setupUi(this);
-    // normalize Key_Enter (numpad) to Key_Return so both Enter keys display and behave identically
-    QObject::connect(
-        this->ui_->keyComboEdit, &QKeySequenceEdit::keySequenceChanged, this,
-        [this](const QKeySequence &keySequence) {
-            auto normalized = normalizeKeySequence(keySequence);
-            if (normalized != keySequence)
-            {
-                // Block signals to prevent infinite loop
-                QSignalBlocker blocker(this->ui_->keyComboEdit);
-                this->ui_->keyComboEdit->setKeySequence(normalized);
-            }
-        });
     this->setStyleSheet(R"(QToolTip {
     padding: 2px;
     background-color: #333333;
@@ -77,8 +63,7 @@ void EditHotkeyDialog::setFromHotkey(std::shared_ptr<Hotkey> hotkey)
 
     // update pickers/input boxes to values from Hotkey object
     this->ui_->categoryPicker->setCurrentIndex(size_t(hotkey->category()));
-    this->ui_->keyComboEdit->setKeySequence(
-        QKeySequence::fromString(hotkey->keySequence().toString()));
+    this->ui_->keyComboEdit->setSequence(hotkey->sequence());
     this->ui_->nameEdit->setText(hotkey->name());
 
     auto def = findHotkeyActionDefinition(hotkey->category(), hotkey->action());
@@ -203,7 +188,8 @@ void EditHotkeyDialog::afterEdit()
         this->showEditError("Hotkey name is missing");
         return;
     }
-    if (this->ui_->keyComboEdit->keySequence().count() == 0)
+    auto sequence = this->ui_->keyComboEdit->sequence();
+    if (sequence.isEmpty())
     {
         this->showEditError("Key Sequence is missing");
         return;
@@ -214,21 +200,24 @@ void EditHotkeyDialog::afterEdit()
         return;
     }
 
-    auto firstKeyInt = this->ui_->keyComboEdit->keySequence()[0];
-    bool hasModifier = firstKeyInt.keyboardModifiers().testAnyFlags(
-        Qt::ControlModifier | Qt::AltModifier | Qt::MetaModifier);
-    bool isKeyExcempt = firstKeyInt.key() == Qt::Key_Escape ||
-                        firstKeyInt.key() == Qt::Key_Enter ||
-                        firstKeyInt.key() == Qt::Key_Return;
-
-    if (!isKeyExcempt && !hasModifier && !this->shownSingleKeyWarning)
+    if (!sequence.isMouse())
     {
-        this->showEditError(
-            "Warning: using keybindings without modifiers can lead to not "
-            "being\nable to use the key for the normal purpose.\nPress the "
-            "submit button again to do it anyway.");
-        this->shownSingleKeyWarning = true;
-        return;
+        auto firstKeyInt = sequence.keySequence()[0];
+        bool hasModifier = firstKeyInt.keyboardModifiers().testAnyFlags(
+            Qt::ControlModifier | Qt::AltModifier | Qt::MetaModifier);
+        bool isKeyExcempt = firstKeyInt.key() == Qt::Key_Escape ||
+                            firstKeyInt.key() == Qt::Key_Enter ||
+                            firstKeyInt.key() == Qt::Key_Return;
+
+        if (!isKeyExcempt && !hasModifier && !this->shownSingleKeyWarning)
+        {
+            this->showEditError(
+                "Warning: using keybindings without modifiers can lead to not "
+                "being\nable to use the key for the normal purpose.\nPress the "
+                "submit button again to do it anyway.");
+            this->shownSingleKeyWarning = true;
+            return;
+        }
     }
 
     // use raw name from item data if possible, otherwise fallback to what the user has entered.
@@ -247,12 +236,10 @@ void EditHotkeyDialog::afterEdit()
                 .second;
     }
 
-    auto hotkey = std::make_shared<Hotkey>(
-        *category, this->ui_->keyComboEdit->keySequence(), action, arguments,
-        nameText);
+    auto hotkey = std::make_shared<Hotkey>(*category, sequence, action,
+                                           arguments, nameText);
     auto keyComboWasEdited =
-        this->data() &&
-        this->ui_->keyComboEdit->keySequence() != this->data()->keySequence();
+        this->data() && sequence != this->data()->sequence();
     auto nameWasEdited = this->data() && nameText != this->data()->name();
 
     if (isEditing)

--- a/src/widgets/dialogs/EditHotkeyDialog.ui
+++ b/src/widgets/dialogs/EditHotkeyDialog.ui
@@ -113,7 +113,7 @@ see this message :)</string>
       </widget>
      </item>
      <item row="3" column="1">
-      <widget class="QKeySequenceEdit" name="keyComboEdit"/>
+      <widget class="chatterino::HotkeySequenceEdit" name="keyComboEdit"/>
      </item>
      <item row="4" column="0">
       <widget class="QLabel" name="easyArgsLabel">
@@ -179,6 +179,13 @@ see this message :)</string>
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>chatterino::HotkeySequenceEdit</class>
+   <extends>QKeySequenceEdit</extends>
+   <header>widgets/helper/HotkeySequenceEdit.hpp</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>nameEdit</tabstop>
   <tabstop>categoryPicker</tabstop>

--- a/src/widgets/helper/EditableModelView.cpp
+++ b/src/widgets/helper/EditableModelView.cpp
@@ -4,6 +4,7 @@
 
 #include "widgets/helper/EditableModelView.hpp"
 
+#include "controllers/hotkeys/HotkeySequence.hpp"
 #include "widgets/helper/RegExpItemDelegate.hpp"
 #include "widgets/helper/TableStyles.hpp"
 
@@ -11,6 +12,7 @@
 #include <QAbstractTableModel>
 #include <QHBoxLayout>
 #include <QHeaderView>
+#include <QKeySequence>
 #include <QLabel>
 #include <QModelIndex>
 #include <QPushButton>
@@ -191,20 +193,35 @@ bool EditableModelView::filterSearchResults(const QString &query,
     return searchFoundSomething;
 }
 
-void EditableModelView::filterSearchResultsHotkey(
-    const QKeySequence &keySequenceQuery)
+void EditableModelView::filterSearchResultsHotkey(const HotkeySequence &query)
 {
     auto rowAmount = this->model_->rowCount();
 
     for (int i = 0; i < rowAmount; i++)
     {
-        QModelIndex idx = this->model_->index(i, 1);
-        QVariant a = this->model_->data(idx);
-        auto seq = qvariant_cast<QKeySequence>(a);
+        if (query.isEmpty())
+        {
+            this->tableView_->showRow(i);
+            continue;
+        }
 
-        // todo: Make this fuzzy match, right now only exact matches happen
-        // so ctrl+f won't match ctrl+shift+f shortcuts
-        if (keySequenceQuery.matches(seq) != QKeySequence::NoMatch)
+        QModelIndex idx = this->model_->index(i, 1);
+        auto bindText = this->model_->data(idx).toString();
+        bool show = false;
+        if (query.isMouse())
+        {
+            show = bindText == query.toString();
+        }
+        else
+        {
+            auto seq =
+                QKeySequence::fromString(bindText, QKeySequence::NativeText);
+            // todo: Make this fuzzy match, right now only exact matches happen
+            // so ctrl+f won't match ctrl+shift+f shortcuts
+            show = query.keySequence().matches(seq) != QKeySequence::NoMatch;
+        }
+
+        if (show)
         {
             this->tableView_->showRow(i);
         }

--- a/src/widgets/helper/EditableModelView.hpp
+++ b/src/widgets/helper/EditableModelView.hpp
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <pajlada/signals/signal.hpp>
-#include <QKeySequence>
 #include <QWidget>
 
 #include <span>
@@ -15,6 +14,8 @@ class QTableView;
 class QHBoxLayout;
 
 namespace chatterino {
+
+class HotkeySequence;
 
 class EditableModelView : public QWidget
 {
@@ -34,7 +35,7 @@ public:
 
     bool filterSearchResults(const QString &query,
                              std::span<const int> columnSelect);
-    void filterSearchResultsHotkey(const QKeySequence &keySequenceQuery);
+    void filterSearchResultsHotkey(const HotkeySequence &query);
 
 private:
     QTableView *tableView_{};

--- a/src/widgets/helper/HotkeySequenceEdit.cpp
+++ b/src/widgets/helper/HotkeySequenceEdit.cpp
@@ -1,0 +1,188 @@
+// SPDX-FileCopyrightText: 2026 Contributors to Chatterino <https://chatterino.com>
+//
+// SPDX-License-Identifier: MIT
+
+#include "widgets/helper/HotkeySequenceEdit.hpp"
+
+#include "controllers/hotkeys/HotkeyHelpers.hpp"
+#include "controllers/hotkeys/MouseShortcut.hpp"
+
+#include <QFocusEvent>
+#include <QKeyEvent>
+#include <QLineEdit>
+#include <QSignalBlocker>
+
+namespace chatterino {
+
+HotkeySequenceEdit::HotkeySequenceEdit(QWidget *parent)
+    : QKeySequenceEdit(parent)
+{
+    if (auto *edit = this->lineEdit())
+    {
+        QObject::connect(
+            edit, &QLineEdit::textChanged, this, [this](const QString &text) {
+                if (this->updatingMouseDisplay_)
+                {
+                    return;
+                }
+                if (text.isEmpty() && this->mouseButton_ != Qt::NoButton)
+                {
+                    this->mouseButton_ = Qt::NoButton;
+                    this->emitSequenceChanged();
+                }
+            });
+    }
+
+    QObject::connect(
+        this, &QKeySequenceEdit::keySequenceChanged, this,
+        [this](const QKeySequence &seq) {
+            if (this->updatingMouseDisplay_)
+            {
+                return;
+            }
+
+            if (seq.isEmpty())
+            {
+                // QKeySequenceEdit::focusOutEvent calls finishEditing(), which
+                // emits an empty key sequence. Keep a recorded mouse button.
+                if (this->mouseButton_ != Qt::NoButton)
+                {
+                    return;
+                }
+                this->emitSequenceChanged();
+                return;
+            }
+
+            this->mouseButton_ = Qt::NoButton;
+            auto normalized = normalizeKeySequence(seq);
+            if (normalized != seq)
+            {
+                QSignalBlocker blocker(this);
+                this->setKeySequence(normalized);
+            }
+            this->emitSequenceChanged();
+        });
+}
+
+HotkeySequenceEdit::~HotkeySequenceEdit()
+{
+    this->stopMouseCapture();
+}
+
+HotkeySequence HotkeySequenceEdit::sequence() const
+{
+    if (this->mouseButton_ != Qt::NoButton)
+    {
+        return HotkeySequence(this->mouseButton_);
+    }
+    return {this->keySequence()};
+}
+
+void HotkeySequenceEdit::setSequence(const HotkeySequence &sequence)
+{
+    if (sequence.isMouse())
+    {
+        this->mouseButton_ = sequence.mouseButton();
+        this->applyMouseDisplay();
+        this->emitSequenceChanged();
+        return;
+    }
+
+    this->mouseButton_ = Qt::NoButton;
+    this->setKeySequence(sequence.keySequence());
+    if (sequence.isEmpty())
+    {
+        this->emitSequenceChanged();
+    }
+}
+
+void HotkeySequenceEdit::recordMouseButton(Qt::MouseButton button)
+{
+    if (!isExtraMouseButton(button))
+    {
+        return;
+    }
+
+    this->mouseButton_ = button;
+    this->applyMouseDisplay();
+    this->emitSequenceChanged();
+}
+
+void HotkeySequenceEdit::focusInEvent(QFocusEvent *event)
+{
+    QKeySequenceEdit::focusInEvent(event);
+    this->startMouseCapture();
+    if (this->mouseButton_ != Qt::NoButton)
+    {
+        this->applyMouseDisplay();
+    }
+}
+
+void HotkeySequenceEdit::focusOutEvent(QFocusEvent *event)
+{
+    auto savedMouse = this->mouseButton_;
+    // Qt's focusOutEvent calls finishEditing(), which emits keySequenceChanged.
+    // Swallow that only when restoring a mouse binding; keyboard chords must
+    // notify listeners of the finalized sequence.
+    this->updatingMouseDisplay_ = savedMouse != Qt::NoButton;
+    QKeySequenceEdit::focusOutEvent(event);
+    this->updatingMouseDisplay_ = false;
+    this->stopMouseCapture();
+
+    if (savedMouse != Qt::NoButton)
+    {
+        this->mouseButton_ = savedMouse;
+        this->applyMouseDisplay();
+    }
+}
+
+void HotkeySequenceEdit::keyPressEvent(QKeyEvent *event)
+{
+    const auto key = event->key();
+    const bool isModifier = key == Qt::Key_Control || key == Qt::Key_Shift ||
+                            key == Qt::Key_Meta || key == Qt::Key_Alt ||
+                            key == Qt::Key_unknown;
+    if (!isModifier && this->mouseButton_ != Qt::NoButton)
+    {
+        this->mouseButton_ = Qt::NoButton;
+    }
+    QKeySequenceEdit::keyPressEvent(event);
+}
+
+void HotkeySequenceEdit::applyMouseDisplay()
+{
+    this->updatingMouseDisplay_ = true;
+    if (!this->keySequence().isEmpty())
+    {
+        this->setKeySequence({});
+    }
+    if (auto *edit = this->lineEdit())
+    {
+        edit->setText(HotkeySequence(this->mouseButton_).toString());
+    }
+    this->updatingMouseDisplay_ = false;
+}
+
+void HotkeySequenceEdit::startMouseCapture()
+{
+    setMouseHotkeyCapture(this, [this](Qt::MouseButton button) {
+        this->recordMouseButton(button);
+    });
+}
+
+void HotkeySequenceEdit::stopMouseCapture()
+{
+    clearMouseHotkeyCapture(this);
+}
+
+void HotkeySequenceEdit::emitSequenceChanged()
+{
+    Q_EMIT this->sequenceChanged(this->sequence());
+}
+
+QLineEdit *HotkeySequenceEdit::lineEdit() const
+{
+    return this->findChild<QLineEdit *>();
+}
+
+}  // namespace chatterino

--- a/src/widgets/helper/HotkeySequenceEdit.hpp
+++ b/src/widgets/helper/HotkeySequenceEdit.hpp
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2026 Contributors to Chatterino <https://chatterino.com>
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "controllers/hotkeys/HotkeySequence.hpp"
+
+#include <QKeySequenceEdit>
+
+class QFocusEvent;
+class QKeyEvent;
+class QLineEdit;
+
+namespace chatterino {
+
+/**
+ * QKeySequenceEdit that can also record extra mouse buttons (Back/Forward, 6+).
+ *
+ * Left, Right, and Middle are ignored so they cannot steal clicking.
+ */
+class HotkeySequenceEdit : public QKeySequenceEdit
+{
+    Q_OBJECT
+
+public:
+    explicit HotkeySequenceEdit(QWidget *parent = nullptr);
+    ~HotkeySequenceEdit() override;
+
+    [[nodiscard]] HotkeySequence sequence() const;
+    void setSequence(const HotkeySequence &sequence);
+
+Q_SIGNALS:
+    void sequenceChanged(const HotkeySequence &sequence);
+
+protected:
+    void focusInEvent(QFocusEvent *event) override;
+    void focusOutEvent(QFocusEvent *event) override;
+    void keyPressEvent(QKeyEvent *event) override;
+
+private:
+    void recordMouseButton(Qt::MouseButton button);
+    void applyMouseDisplay();
+    void startMouseCapture();
+    void stopMouseCapture();
+    void emitSequenceChanged();
+    QLineEdit *lineEdit() const;
+
+    Qt::MouseButton mouseButton_ = Qt::NoButton;
+    bool updatingMouseDisplay_ = false;
+};
+
+}  // namespace chatterino

--- a/src/widgets/settingspages/KeyboardSettingsPage.cpp
+++ b/src/widgets/settingspages/KeyboardSettingsPage.cpp
@@ -8,18 +8,16 @@
 #include "common/QLogging.hpp"
 #include "controllers/hotkeys/Hotkey.hpp"
 #include "controllers/hotkeys/HotkeyController.hpp"
-#include "controllers/hotkeys/HotkeyHelpers.hpp"
 #include "controllers/hotkeys/HotkeyModel.hpp"
 #include "util/LayoutCreator.hpp"
 #include "widgets/dialogs/EditHotkeyDialog.hpp"
 #include "widgets/helper/EditableModelView.hpp"
+#include "widgets/helper/HotkeySequenceEdit.hpp"
 
-#include <QFormLayout>
 #include <QHeaderView>
-#include <QKeySequenceEdit>
 #include <QLabel>
 #include <QMessageBox>
-#include <QSignalBlocker>
+#include <QPushButton>
 #include <QTableView>
 
 #include <array>
@@ -88,22 +86,14 @@ KeyboardSettingsPage::KeyboardSettingsPage()
                          tableCellClicked(clicked, view, model);
                      });
 
-    auto *keySequenceInput = new QKeySequenceEdit(this);
+    auto *keySequenceInput = new HotkeySequenceEdit(this);
 
     keySequenceInput->setClearButtonEnabled(true);
     auto *searchText = new QLabel("Search keybind:", this);
 
-    QObject::connect(keySequenceInput, &QKeySequenceEdit::keySequenceChanged,
-                     this,
-                     [view, keySequenceInput](const QKeySequence &keySequence) {
-                         // Normalize Key_Enter (numpad) to Key_Return for consistent search
-                         auto normalized = normalizeKeySequence(keySequence);
-                         if (normalized != keySequence)
-                         {
-                             QSignalBlocker blocker(keySequenceInput);
-                             keySequenceInput->setKeySequence(normalized);
-                         }
-                         view->filterSearchResultsHotkey(normalized);
+    QObject::connect(keySequenceInput, &HotkeySequenceEdit::sequenceChanged,
+                     this, [view](const HotkeySequence &sequence) {
+                         view->filterSearchResultsHotkey(sequence);
                      });
     view->addCustomButton(searchText);
     view->addCustomButton(keySequenceInput);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ set(test_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/src/Helpers.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/RatelimitBucket.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/Hotkeys.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/HotkeySequence.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/UtilTwitch.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/IrcHelpers.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/TwitchPubSubClient.cpp

--- a/tests/src/HotkeySequence.cpp
+++ b/tests/src/HotkeySequence.cpp
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: 2026 Contributors to Chatterino <https://chatterino.com>
+//
+// SPDX-License-Identifier: MIT
+
+#include "controllers/hotkeys/HotkeySequence.hpp"
+
+#include "Test.hpp"
+
+using namespace chatterino;
+
+TEST(HotkeySequence, EmptyByDefault)
+{
+    HotkeySequence seq;
+    EXPECT_TRUE(seq.isEmpty());
+    EXPECT_FALSE(seq.isMouse());
+    EXPECT_EQ(seq.mouseButton(), Qt::NoButton);
+    EXPECT_TRUE(seq.keySequence().isEmpty());
+}
+
+TEST(HotkeySequence, KeyboardRoundTrip)
+{
+    HotkeySequence seq(QKeySequence(QStringLiteral("Ctrl+F")));
+    EXPECT_FALSE(seq.isEmpty());
+    EXPECT_FALSE(seq.isMouse());
+    EXPECT_EQ(seq.toPortableString(), QStringLiteral("Ctrl+F"));
+
+    auto parsed = HotkeySequence::fromPortableString(seq.toPortableString());
+    EXPECT_EQ(parsed, seq);
+}
+
+TEST(HotkeySequence, MouseBackAliases)
+{
+    auto fromAlias =
+        HotkeySequence::fromPortableString(QStringLiteral("MouseBack"));
+    auto fromNumber =
+        HotkeySequence::fromPortableString(QStringLiteral("MouseButton4"));
+    HotkeySequence fromButton(Qt::BackButton);
+
+    EXPECT_TRUE(fromAlias.isMouse());
+    EXPECT_EQ(fromAlias.mouseButton(), Qt::BackButton);
+    EXPECT_EQ(fromAlias, fromNumber);
+    EXPECT_EQ(fromAlias, fromButton);
+    EXPECT_EQ(fromAlias.toPortableString(), QStringLiteral("MouseBack"));
+    EXPECT_EQ(fromAlias.toString(), QStringLiteral("Mouse Back"));
+}
+
+TEST(HotkeySequence, MouseForwardAliases)
+{
+    auto fromAlias =
+        HotkeySequence::fromPortableString(QStringLiteral("MouseForward"));
+    auto fromNumber =
+        HotkeySequence::fromPortableString(QStringLiteral("MouseButton5"));
+    HotkeySequence fromButton(Qt::ForwardButton);
+
+    EXPECT_EQ(fromAlias, fromNumber);
+    EXPECT_EQ(fromAlias, fromButton);
+    EXPECT_EQ(fromAlias.toPortableString(), QStringLiteral("MouseForward"));
+    EXPECT_EQ(fromAlias.toString(), QStringLiteral("Mouse Forward"));
+}
+
+TEST(HotkeySequence, ExtraMouseButtonNumber)
+{
+    auto seq =
+        HotkeySequence::fromPortableString(QStringLiteral("MouseButton6"));
+    EXPECT_TRUE(seq.isMouse());
+    EXPECT_EQ(seq.mouseButton(), extraMouseButtonFromNumber(6));
+    EXPECT_EQ(seq.toPortableString(), QStringLiteral("MouseButton6"));
+    EXPECT_EQ(seq.toString(), QStringLiteral("Mouse Button 6"));
+}
+
+TEST(HotkeySequence, CaseInsensitiveMouseParse)
+{
+    auto seq = HotkeySequence::fromPortableString(QStringLiteral("mouseback"));
+    EXPECT_EQ(seq.mouseButton(), Qt::BackButton);
+}
+
+TEST(HotkeySequence, TrimsPortableString)
+{
+    auto seq =
+        HotkeySequence::fromPortableString(QStringLiteral("  MouseBack  "));
+    EXPECT_EQ(seq.mouseButton(), Qt::BackButton);
+}
+
+TEST(HotkeySequence, InvalidMouseButtonNumber)
+{
+    EXPECT_FALSE(extraMouseButtonFromNumber(1).has_value());
+    EXPECT_FALSE(extraMouseButtonFromNumber(3).has_value());
+    EXPECT_FALSE(extraMouseButtonFromNumber(28).has_value());
+    EXPECT_EQ(extraMouseButtonFromNumber(4), Qt::BackButton);
+    EXPECT_EQ(extraMouseButtonFromNumber(5), Qt::ForwardButton);
+    EXPECT_EQ(extraMouseButtonNumber(Qt::BackButton), 4);
+    EXPECT_EQ(extraMouseButtonNumber(Qt::ForwardButton), 5);
+    EXPECT_FALSE(extraMouseButtonNumber(Qt::LeftButton).has_value());
+    EXPECT_TRUE(extraMouseButtonFromNumber(27).has_value());
+
+    auto parsed =
+        HotkeySequence::fromPortableString(QStringLiteral("MouseButton2"));
+    EXPECT_TRUE(parsed.isEmpty());
+}
+
+TEST(HotkeySequence, RejectsPrimaryMouseButtons)
+{
+    HotkeySequence left(Qt::LeftButton);
+    HotkeySequence right(Qt::RightButton);
+    HotkeySequence middle(Qt::MiddleButton);
+
+    EXPECT_TRUE(left.isEmpty());
+    EXPECT_TRUE(right.isEmpty());
+    EXPECT_TRUE(middle.isEmpty());
+    EXPECT_FALSE(isExtraMouseButton(Qt::LeftButton));
+    EXPECT_FALSE(isExtraMouseButton(Qt::RightButton));
+    EXPECT_FALSE(isExtraMouseButton(Qt::MiddleButton));
+    EXPECT_TRUE(isExtraMouseButton(Qt::BackButton));
+    EXPECT_TRUE(isExtraMouseButton(Qt::ForwardButton));
+}
+
+TEST(HotkeySequence, KeyboardDoesNotCollideWithQtBackKey)
+{
+    auto mouse =
+        HotkeySequence::fromPortableString(QStringLiteral("MouseBack"));
+    auto key = HotkeySequence::fromPortableString(QStringLiteral("Back"));
+    EXPECT_TRUE(mouse.isMouse());
+    EXPECT_FALSE(key.isMouse());
+    EXPECT_NE(mouse, key);
+}
+
+TEST(HotkeySequence, Equality)
+{
+    HotkeySequence a(Qt::BackButton);
+    HotkeySequence b(Qt::ForwardButton);
+    HotkeySequence c(QKeySequence(QStringLiteral("Ctrl+F")));
+
+    EXPECT_EQ(a, HotkeySequence(Qt::BackButton));
+    EXPECT_NE(a, b);
+    EXPECT_NE(a, c);
+    EXPECT_NE(b, c);
+}


### PR DESCRIPTION
Adds mouse button support to the hotkey manager so users can bind Mouse Back/Forward (and other extra buttons) to any action.

Left, Right, and Middle clicks cannot be bound. Mouse bindings ignore keyboard modifiers.

AI generated/assisted