### PR TITLE
fix: respect username style in live notifications

### DIFF
--- a/src/controllers/notifications/NotificationController.cpp
+++ b/src/controllers/notifications/NotificationController.cpp
@@ -159,8 +159,13 @@ void NotificationController::notifyTwitchChannelLive(
 
     // Message in /live channel
     getApp()->getTwitch()->getLiveChannel()->addMessage(
-        MessageBuilder::makeLiveMessage(payload.displayName, payload.channelId,
-                                        payload.title),
+        MessageBuilder::makeLiveMessage(
+            {
+                .id = payload.channelId,
+                .login = payload.channelName,
+                .displayName = payload.displayName,
+            },
+            payload.title),
         MessageContext::Original);
 
     // Notify on all channels with a ping sound

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -1356,18 +1356,20 @@ MessagePtr MessageBuilder::makeChannelPointRewardMessage(
     return builder.release();
 }
 
-MessagePtr MessageBuilder::makeLiveMessage(const QString &channelName,
-                                           const QString &channelID,
+MessagePtr MessageBuilder::makeLiveMessage(const HelixMinimalUser &channel,
                                            const QString &title,
                                            MessageFlags extraFlags)
 {
     MessageBuilder builder;
 
+    const auto channelName =
+        channel.displayName.compare(channel.login, Qt::CaseInsensitive) == 0
+            ? channel.displayName
+            : channel.formatted(getSettings()->usernameDisplayMode.getEnum());
     builder.emplace<TimestampElement>();
-    builder
-        .emplace<TextElement>(channelName, MessageElementFlag::Username,
-                              MessageColor::Text, FontStyle::ChatMediumBold)
-        ->setLink({Link::UserInfo, channelName});
+    builder.emplace<MentionElement>(channelName, channel.login,
+                                    MessageColor::Text, MessageColor::Text,
+                                    MessageElementFlag::Username);
 
     QString text;
     if (getSettings()->showTitleInLiveMessage)
@@ -1387,7 +1389,7 @@ MessagePtr MessageBuilder::makeLiveMessage(const QString &channelName,
 
     builder.message().messageText = text;
     builder.message().searchText = text;
-    builder.message().id = channelID;
+    builder.message().id = channel.id;
 
     if (!extraFlags.isEmpty())
     {
@@ -1397,23 +1399,26 @@ MessagePtr MessageBuilder::makeLiveMessage(const QString &channelName,
     return builder.release();
 }
 
-MessagePtr MessageBuilder::makeOfflineSystemMessage(const QString &channelName,
-                                                    const QString &channelID)
+MessagePtr MessageBuilder::makeOfflineSystemMessage(
+    const HelixMinimalUser &channel)
 {
     MessageBuilder builder;
+    const auto channelName =
+        channel.displayName.compare(channel.login, Qt::CaseInsensitive) == 0
+            ? channel.displayName
+            : channel.formatted(getSettings()->usernameDisplayMode.getEnum());
     builder.emplace<TimestampElement>();
     builder.message().flags.set(MessageFlag::System);
     builder.message().flags.set(MessageFlag::DoNotTriggerNotification);
-    builder
-        .emplace<TextElement>(channelName, MessageElementFlag::Username,
-                              MessageColor::System, FontStyle::ChatMediumBold)
-        ->setLink({Link::UserInfo, channelName});
+    builder.emplace<MentionElement>(channelName, channel.login,
+                                    MessageColor::System, MessageColor::System,
+                                    MessageElementFlag::Username);
     builder.emplace<TextElement>("is now offline.", MessageElementFlag::Text,
                                  MessageColor::System);
     auto text = QString("%1 is now offline.").arg(channelName);
     builder.message().messageText = text;
     builder.message().searchText = text;
-    builder.message().id = channelID;
+    builder.message().id = channel.id;
 
     return builder.release();
 }

--- a/src/messages/MessageBuilder.hpp
+++ b/src/messages/MessageBuilder.hpp
@@ -38,6 +38,7 @@ class Channel;
 class TwitchChannel;
 class MessageThread;
 class IgnorePhrase;
+struct HelixMinimalUser;
 struct HelixVip;
 using HelixModerator = HelixVip;
 struct ChannelPointReward;
@@ -171,14 +172,12 @@ public:
         const ChannelPointReward &reward, bool isMod, bool isBroadcaster);
 
     /// Make a "CHANNEL_NAME has gone live!" message
-    static MessagePtr makeLiveMessage(const QString &channelName,
-                                      const QString &channelID,
+    static MessagePtr makeLiveMessage(const HelixMinimalUser &channel,
                                       const QString &title,
                                       MessageFlags extraFlags = {});
 
     // Messages in normal chat for channel stuff
-    static MessagePtr makeOfflineSystemMessage(const QString &channelName,
-                                               const QString &channelID);
+    static MessagePtr makeOfflineSystemMessage(const HelixMinimalUser &channel);
     static MessagePtr makeHostingSystemMessage(const QString &channelName,
                                                bool hostOn);
     static MessagePtr makeDeletionMessageFromIRC(

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -609,6 +609,10 @@ void TwitchChannel::updateStreamStatus(
     if (helixStream)
     {
         auto stream = *helixStream;
+        if (!stream.userName.isEmpty())
+        {
+            this->updateDisplayName(stream.userName);
+        }
         {
             auto status = this->streamStatus_.access();
             status->streamId = stream.id;
@@ -655,6 +659,11 @@ void TwitchChannel::onLiveStatusChanged(bool isLive, bool isInitialUpdate)
 {
     // Similar code exists in NotificationController::updateFakeChannel.
     // Since we're a TwitchChannel, we also send a message here.
+    const HelixMinimalUser channel{
+        .id = this->roomId(),
+        .login = this->getName(),
+        .displayName = this->nameOptions.actualDisplayName,
+    };
     if (isLive)
     {
         qCDebug(chatterinoTwitch).nospace().noquote()
@@ -671,7 +680,7 @@ void TwitchChannel::onLiveStatusChanged(bool isLive, bool isInitialUpdate)
             .channelId = this->roomId(),
             .streamId = streamId,
             .channelName = this->getName(),
-            .displayName = this->getDisplayName(),
+            .displayName = channel.displayName,
             .title = title,
             .isInitialUpdate = isInitialUpdate,
         });
@@ -679,7 +688,7 @@ void TwitchChannel::onLiveStatusChanged(bool isLive, bool isInitialUpdate)
         // Channel live message
         this->addMessage(
             MessageBuilder::makeLiveMessage(
-                this->getDisplayName(), this->roomId(), title,
+                channel, title,
                 {MessageFlag::System, MessageFlag::DoNotTriggerNotification}),
             MessageContext::Original);
     }
@@ -689,8 +698,7 @@ void TwitchChannel::onLiveStatusChanged(bool isLive, bool isInitialUpdate)
             << "[TwitchChannel " << this->getName() << "] Offline";
 
         // Channel offline message
-        this->addMessage(MessageBuilder::makeOfflineSystemMessage(
-                             this->getDisplayName(), this->roomId()),
+        this->addMessage(MessageBuilder::makeOfflineSystemMessage(channel),
                          MessageContext::Original);
 
         getApp()->getNotifications()->notifyTwitchChannelOffline(

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -678,6 +678,7 @@ private:
     friend class IrcMessageHandler;
     friend class Commands_E2E_Test;
     friend class TwitchChannel_LiveUpdateGrouping_Test;
+    friend class NotificationController_StatusMessagesRespectUsernameStyle_Test;
     friend class ::TestIrcMessageHandlerP;
     friend class ::TestEventSubMessagesP;
 

--- a/tests/src/NotificationController.cpp
+++ b/tests/src/NotificationController.cpp
@@ -4,11 +4,24 @@
 
 #include "controllers/notifications/NotificationController.hpp"
 
+#include "common/enums/UsernameDisplayMode.hpp"
+#include "controllers/accounts/AccountController.hpp"
+#include "messages/Link.hpp"
 #include "messages/Message.hpp"
+#include "messages/MessageElement.hpp"
 #include "mocks/BaseApplication.hpp"
 #include "mocks/Logging.hpp"
 #include "mocks/TwitchIrcServer.hpp"
+#include "providers/twitch/api/Helix.hpp"
+#include "providers/twitch/TwitchChannel.hpp"
+#include "singletons/Settings.hpp"
 #include "Test.hpp"
+
+#include <array>
+#include <memory>
+#include <optional>
+
+using namespace Qt::Literals;
 
 namespace chatterino {
 
@@ -17,6 +30,11 @@ namespace {
 class MockApplication : public mock::BaseApplication
 {
 public:
+    AccountController *getAccounts() override
+    {
+        return &this->accounts;
+    }
+
     NotificationController *getNotifications() override
     {
         return &this->notifications;
@@ -32,6 +50,7 @@ public:
         return &this->logging;
     }
 
+    AccountController accounts;
     mock::EmptyLogging logging;
     mock::MockTwitchIrcServer twitch;
     NotificationController notifications;
@@ -83,6 +102,134 @@ TEST(NotificationController, DeduplicatesLiveStreams)
     notifyLive("forsen", "stream-3");
     ASSERT_EQ(messages().size(), 4);
     EXPECT_FALSE(messages().at(3)->flags.has(MessageFlag::Disabled));
+}
+
+TEST(NotificationController, StatusMessagesRespectUsernameStyle)
+{
+    struct TestCase {
+        UsernameDisplayMode mode;
+        QString displayName;
+        QString expected;
+    };
+
+    const std::array<TestCase, 6> cases{{
+        // Localized usernames respect the username display mode setting
+        {
+            .mode = UsernameDisplayMode::Username,
+            .displayName = u"福森"_s,
+            .expected = u"chinese_forsen"_s,
+        },
+        {
+            .mode = UsernameDisplayMode::LocalizedName,
+            .displayName = u"福森"_s,
+            .expected = u"福森"_s,
+        },
+        {
+            .mode = UsernameDisplayMode::UsernameAndLocalizedName,
+            .displayName = u"福森"_s,
+            .expected = u"chinese_forsen (福森)"_s,
+        },
+
+        // Capitalization survives
+        {
+            .mode = UsernameDisplayMode::Username,
+            .displayName = u"cHiNeSe_FoRsEn"_s,
+            .expected = u"cHiNeSe_FoRsEn"_s,
+        },
+        {
+            .mode = UsernameDisplayMode::LocalizedName,
+            .displayName = u"cHiNeSe_FoRsEn"_s,
+            .expected = u"cHiNeSe_FoRsEn"_s,
+        },
+        {
+            .mode = UsernameDisplayMode::UsernameAndLocalizedName,
+            .displayName = u"cHiNeSe_FoRsEn"_s,
+            .expected = u"cHiNeSe_FoRsEn"_s,
+        },
+    }};
+
+    for (const auto &test : cases)
+    {
+        // Usernames are formatted the same with and without the stream title
+        for (bool showTitle : {false, true})
+        {
+            SCOPED_TRACE(::testing::Message()
+                         << test.mode << ", " << test.displayName << ", "
+                         << showTitle);
+            MockApplication app;
+            app.settings.usernameDisplayMode.setValue(test.mode);
+            app.settings.showTitleInLiveMessage.setValue(showTitle);
+
+            // Live notifications for fake channels use the selected display mode
+            app.notifications.notifyTwitchChannelLive({
+                .channelId = u"22484632"_s,
+                .streamId = u"stream-1"_s,
+                .channelName = u"chinese_forsen"_s,
+                .displayName = test.displayName,
+                .title = u"游戏与便便！"_s,
+            });
+
+            const auto checkMessage = [&](const MessagePtr &message,
+                                          const QString &text) {
+                ASSERT_NE(message, nullptr);
+                ASSERT_GE(message->elements.size(), 2);
+
+                // The displayed name matches the selected display mode
+                const auto *name = dynamic_cast<const TextElement *>(
+                    message->elements.at(1).get());
+                ASSERT_NE(name, nullptr);
+                EXPECT_EQ(name->words().join(' '), test.expected);
+
+                // The link always points at channel login
+                EXPECT_EQ(name->getLink().type, Link::UserInfo);
+                EXPECT_EQ(name->getLink().value, u"chinese_forsen"_s);
+
+                // The name is a username element
+                EXPECT_EQ(name->getFlags(),
+                          MessageElementFlags{MessageElementFlag::Username});
+
+                // The displayed name is used in the plain and searchable message text
+                EXPECT_EQ(message->messageText, text);
+                EXPECT_EQ(message->searchText, text);
+
+                // Channel ID survives
+                EXPECT_EQ(message->id, u"22484632"_s);
+            };
+
+            const auto liveText =
+                test.expected +
+                (showTitle ? u" is live: 游戏与便便！"_s : u" is live!"_s);
+            const auto messages =
+                app.twitch.getLiveChannel()->getMessageSnapshot();
+            ASSERT_EQ(messages.size(), 1);
+            checkMessage(messages.at(0), liveText);
+
+            auto channel = std::make_shared<TwitchChannel>(u"chinese_forsen"_s);
+            channel->setRoomId(u"22484632"_s);
+            HelixStream stream;
+            stream.id = u"stream-2"_s;
+            stream.userId = u"22484632"_s;
+            stream.userLogin = u"chinese_forsen"_s;
+            stream.userName = test.displayName;
+            stream.title = u"游戏与便便！"_s;
+            stream.startedAt = u"1984-04-20T21:37:00Z"_s;
+
+            // Live status messages in real channels use the selected display mode
+            channel->updateStreamStatus(stream, true);
+            checkMessage(channel->getLastMessage(), liveText);
+
+            // Events mirrored to the /live tab use the selected display mode
+            const auto joinedMessages =
+                app.twitch.getLiveChannel()->getMessageSnapshot();
+            ASSERT_EQ(joinedMessages.size(), 2);
+            checkMessage(joinedMessages.at(1), liveText);
+
+            // Offline status messages use the selected display mode
+            channel->updateStreamStatus(std::nullopt, false);
+            const auto offline = channel->getLastMessage();
+            checkMessage(offline, test.expected + u" is now offline."_s);
+        }
+    }
 }
 
 }  // namespace chatterino


### PR DESCRIPTION
Fixes #6529.

> /live tab displays localized name instead of username when added to "Selected Channels" in "Live Notifications". It displays correctly username when joining the channel. 

Fixed by using `MentionElement` to respect the username display mode setting

Added tests

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
