### PR TITLE
fix(buttons): Disable smooth pixmap transform for cached content

### DIFF
--- a/src/widgets/buttons/Button.cpp
+++ b/src/widgets/buttons/Button.cpp
@@ -397,8 +397,12 @@ void Button::paintButton(QPainter &painter)
 
             this->pixmapValid_ = true;
         }
+        // Disable smooth transformation, as we know the drawn pixmap has the
+        // same size as the target area (in pixels).
+        painter.setRenderHint(QPainter::SmoothPixmapTransform, false);
         painter.drawPixmap(this->rect(), this->cachedPixmap_,
                            {{}, this->cachedPixmap_.size()});
+        painter.setRenderHint(QPainter::SmoothPixmapTransform);
     }
     else
     {


### PR DESCRIPTION
On a high-DPI monitor, (some) SVG buttons would look a bit blurry. I didn't notice that before on 125% - only when I enabled the custom buttons in the notebook.

| Before| After|
|--------|--------|
| <img width="309" src="https://github.com/user-attachments/assets/8b965ba7-ce71-423b-8225-49b824e53cb2" /> | <img width="309" src="https://github.com/user-attachments/assets/17ad85fa-0583-4f4d-a841-0e5a13fe4597" /> |

When we enable `QPainter::SmoothPixmapTransform`, Qt will still use a transformation algorithm when the source and target size match. We know that the source and target sizes match because we calculate them before. Thus, we know there's no image smoothing needed. You can test this by setting `QT_SCALE_FACTOR=1.25` when starting on a monitor with 100% scaling.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
