### PR TITLE
chore: Add backup functionality to window layout

### DIFF
--- a/src/common/Args.cpp
+++ b/src/common/Args.cpp
@@ -342,17 +342,19 @@ std::optional<WindowLayout> Args::makeCustomChannelLayout(
 
     // Load main window layout from config file so we can use the same geometry
     const QRect configMainLayout = [windowLayoutFile] {
-        const WindowLayout configLayout =
-            WindowLayout::loadFromFile(windowLayoutFile);
+        const auto configLayout = WindowLayout::loadFromFile(windowLayoutFile);
 
-        for (const WindowDescriptor &window : configLayout.windows_)
+        if (configLayout)
         {
-            if (window.type_ != WindowType::Main)
+            for (const WindowDescriptor &window : configLayout->windows_)
             {
-                continue;
-            }
+                if (window.type_ != WindowType::Main)
+                {
+                    continue;
+                }
 
-            return window.geometry_;
+                return window.geometry_;
+            }
         }
 
         return QRect(-1, -1, -1, -1);

--- a/src/common/WindowDescriptors.cpp
+++ b/src/common/WindowDescriptors.cpp
@@ -8,6 +8,7 @@
 #include "common/QLogging.hpp"
 #include "debug/AssertInGuiThread.hpp"
 #include "providers/twitch/TwitchIrcServer.hpp"
+#include "util/Backup.hpp"
 #include "util/QMagicEnum.hpp"
 #include "widgets/Window.hpp"
 
@@ -23,17 +24,32 @@ namespace chatterino {
 
 namespace {
 
-QJsonArray loadWindowArray(const QString &settingsPath)
+ExpectedStr<QJsonArray> loadWindowArray(const QString &settingsPath)
 {
     QFile file(settingsPath);
     if (!file.open(QIODevice::ReadOnly))
     {
-        return {};
+        return makeUnexpected(u"Failed to open file: " % file.errorString());
     }
     QByteArray data = file.readAll();
-    QJsonDocument document = QJsonDocument::fromJson(data);
-    QJsonArray windows_arr = document.object().value("windows").toArray();
-    return windows_arr;
+    QJsonParseError err;
+    QJsonDocument document = QJsonDocument::fromJson(data, &err);
+    if (err.error != QJsonParseError::NoError)
+    {
+        return makeUnexpected(u"Failed to parse JSON: " % err.errorString());
+    }
+    if (!document.isObject())
+    {
+        return makeUnexpected(u"Root element is not an object"_s);
+    }
+    const auto rootObj = document.object();
+    const auto windowsEl = rootObj["windows"_L1];
+    if (!windowsEl.isArray())
+    {
+        return makeUnexpected(
+            u"Root object does not contain a 'windows' array"_s);
+    }
+    return windowsEl.toArray();
 }
 
 QList<QUuid> loadFilters(const QJsonValue &val)
@@ -258,14 +274,19 @@ TabDescriptor TabDescriptor::loadFromJSON(const QJsonObject &tabObj)
     return tab;
 }
 
-WindowLayout WindowLayout::loadFromFile(const QString &path)
+ExpectedStr<WindowLayout> WindowLayout::loadFromFile(const QString &path)
 {
     WindowLayout layout;
 
     bool hasSetAMainWindow = false;
 
-    // "deserialize"
-    for (const auto windowVal : loadWindowArray(path))
+    auto rootArray = loadWindowArray(path);
+    if (!rootArray)
+    {
+        return makeUnexpected(std::move(rootArray).error());
+    }
+
+    for (const auto windowVal : *rootArray)
     {
         const QJsonObject windowObj = windowVal.toObject();
 

--- a/src/common/WindowDescriptors.cpp
+++ b/src/common/WindowDescriptors.cpp
@@ -286,7 +286,7 @@ ExpectedStr<WindowLayout> WindowLayout::loadFromFile(const QString &path)
         return makeUnexpected(std::move(rootArray).error());
     }
 
-    for (const auto windowVal : *rootArray)
+    for (const auto windowVal : std::as_const(*rootArray))
     {
         const QJsonObject windowObj = windowVal.toObject();
 

--- a/src/common/WindowDescriptors.hpp
+++ b/src/common/WindowDescriptors.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "common/ProviderId.hpp"
+#include "util/Expected.hpp"
 
 #include <QJsonObject>
 #include <QList>
@@ -135,7 +136,7 @@ public:
     /// If no split with the channel exists, a new one is added.
     /// If no window exists, a new one is added.
     void activateOrAddChannel(ProviderId provider, const QString &name);
-    static WindowLayout loadFromFile(const QString &path);
+    static ExpectedStr<WindowLayout> loadFromFile(const QString &path);
 };
 
 }  // namespace chatterino

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -13,6 +13,7 @@
 #include "singletons/Paths.hpp"
 #include "singletons/Settings.hpp"
 #include "singletons/Theme.hpp"
+#include "util/Backup.hpp"
 #include "util/CombinePath.hpp"
 #include "util/FilesystemHelpers.hpp"
 #include "util/SignalListener.hpp"
@@ -478,7 +479,23 @@ void WindowManager::initialize()
         }
         else
         {
-            windowLayout = this->loadWindowLayoutFromFile();
+            backup::loadWithBackups(
+                backup::FileData{
+                    .fileName = WindowManager::WINDOW_LAYOUT_FILENAME,
+                    .directory = getApp()->getPaths().settingsDirectory,
+                    .fileKind = u"Window layout"_s,
+                    .fileDescription =
+                        u"This file contains the positions of open windows, their tabs and splits."_s,
+                },
+                [&]() -> ExpectedStr<void> {
+                    auto res = this->loadWindowLayoutFromFile();
+                    if (!res)
+                    {
+                        return makeUnexpected(std::move(res).error());
+                    }
+                    windowLayout = *std::move(res);
+                    return {};
+                });
         }
 
         auto desired = this->appArgs.activateChannel;
@@ -755,7 +772,7 @@ void WindowManager::incGeneration()
     this->generation_++;
 }
 
-WindowLayout WindowManager::loadWindowLayoutFromFile() const
+ExpectedStr<WindowLayout> WindowManager::loadWindowLayoutFromFile() const
 {
     return WindowLayout::loadFromFile(this->windowLayoutFilePath);
 }

--- a/src/singletons/WindowManager.hpp
+++ b/src/singletons/WindowManager.hpp
@@ -180,7 +180,7 @@ public:
 
 private:
     // Load window layout from the window-layout.json file
-    WindowLayout loadWindowLayoutFromFile() const;
+    ExpectedStr<WindowLayout> loadWindowLayoutFromFile() const;
 
     // Apply a window layout for this window manager.
     void applyWindowLayout(const WindowLayout &layout);


### PR DESCRIPTION
Someone on Discord mentioned that their window layout reset occasionally. We already have some backup restoration functionality for settings, so this PR uses that for the window layout. Most of this PR is switching to `ExpectedStr` and passing the errors on.

When parsing command line arguments, we also check the window layout for the initial bounds. But here I opted to not do restoration, as it's only a hint to where the window should be placed.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
