### PR TITLE
feat: manual registration for browser integration in portable chatterino

### DIFF
--- a/mocks/include/mocks/EmptyApplication.hpp
+++ b/mocks/include/mocks/EmptyApplication.hpp
@@ -44,6 +44,11 @@ public:
         return this->args_;
     }
 
+    const Modes &getModes() override
+    {
+        return this->modes_;
+    }
+
     Theme *getThemes() override
     {
         assert(

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -153,9 +153,11 @@ IApplication::~IApplication()
 // to each other
 
 Application::Application(Settings &_settings, const Paths &paths,
-                         const Args &_args, Updates &_updates)
+                         const Args &_args, const Modes &modes,
+                         Updates &_updates)
     : paths_(paths)
     , args_(_args)
+    , modes_(modes)
     , themes(new Theme(paths))
     , fonts(new Fonts(_settings))
     , logging(new Logging(_settings))
@@ -207,8 +209,7 @@ Application::~Application()
     INSTANCE = nullptr;
 }
 
-void Application::initialize(Settings &settings, const Modes &modes,
-                             const Paths &paths)
+void Application::initialize(Settings &settings, const Paths &paths)
 {
     assert(!this->initialized);
 
@@ -285,7 +286,7 @@ void Application::initialize(Settings &settings, const Modes &modes,
 
     if (!this->args_.isFramelessEmbed)
     {
-        this->initNm(modes, paths);
+        this->initNm(this->modes_, paths);
     }
 
     this->twitch->initEventAPIs(this->bttvLiveUpdates.get(),

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -6,6 +6,7 @@
 
 #include "common/Args.hpp"
 #include "common/Channel.hpp"
+#include "common/Modes.hpp"
 #include "common/Version.hpp"
 #include "controllers/accounts/AccountController.hpp"
 #include "controllers/commands/Command.hpp"

--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -81,6 +81,7 @@ public:
 
     virtual const Paths &getPaths() = 0;
     virtual const Args &getArgs() = 0;
+    virtual const Modes &getModes() = 0;
     virtual Theme *getThemes() = 0;
     virtual Fonts *getFonts() = 0;
     virtual EmoteController *getEmotes() = 0;
@@ -126,12 +127,13 @@ class Application : public IApplication
 {
     const Paths &paths_;
     const Args &args_;
+    const Modes &modes_;
     int argc_{};
     char **argv_{};
 
 public:
     Application(Settings &_settings, const Paths &paths, const Args &_args,
-                Updates &_updates);
+                const Modes &modes, Updates &_updates);
     ~Application() override;
 
     Application(const Application &) = delete;
@@ -144,7 +146,7 @@ public:
         return false;
     }
 
-    void initialize(Settings &settings, const Modes &modes, const Paths &paths);
+    void initialize(Settings &settings, const Paths &paths);
     void load();
     void aboutToQuit();
     void stop();
@@ -203,6 +205,10 @@ public:
     const Args &getArgs() override
     {
         return this->args_;
+    }
+    const Modes &getModes() override
+    {
+        return this->modes_;
     }
     Theme *getThemes() override;
     Fonts *getFonts() override;

--- a/src/RunGui.cpp
+++ b/src/RunGui.cpp
@@ -289,8 +289,8 @@ void runGui(QApplication &a, const Modes &modes, const Paths &paths,
         app->stop();
     });
 
-    Application app(settings, paths, args, updates);
-    app.initialize(settings, modes, paths);
+    Application app(settings, paths, args, modes, updates);
+    app.initialize(settings, paths);
     app.run();
 
     chatterino::NetworkManager::deinit();

--- a/src/singletons/NativeMessaging.cpp
+++ b/src/singletons/NativeMessaging.cpp
@@ -79,14 +79,16 @@ const Config CHROME{
 #endif
 };
 
-bool registerNmManifest([[maybe_unused]] const Paths &paths,
-                        const Config &config, const QJsonDocument &document)
+ExpectedStr<void> registerNmManifest([[maybe_unused]] const Paths &paths,
+                                     const Config &config,
+                                     const QJsonDocument &document)
 {
 #ifdef Q_OS_WIN
-    if (!writeManifestTo(paths.miscDirectory, u"."_s, config.fileName,
-                         document))
+    auto result =
+        writeManifestTo(paths.miscDirectory, u"."_s, config.fileName, document);
+    if (!result)
     {
-        return false;
+        return makeUnexpected(result.error());
     }
 
     QSettings registry(config.registryKey, QSettings::NativeFormat);
@@ -95,16 +97,15 @@ bool registerNmManifest([[maybe_unused]] const Paths &paths,
     registry.sync();
     if (registry.status() != QSettings::NoError)
     {
-        qCWarning(chatterinoNativeMessage)
-            << "Failed to register native messaging host in"
-            << config.registryKey;
-        return false;
+        return makeUnexpected(
+            QString(u"Failed to register native messaging host in "_s %
+                    config.registryKey));
     }
 #else
-    return bool(writeManifestTo(config.browserDirectory, config.nmDirectory,
-                                u"com.chatterino.chatterino.json"_s, document));
+    return writeManifestTo(config.browserDirectory, config.nmDirectory,
+                           u"com.chatterino.chatterino.json"_s, document);
 #endif
-    return true;
+    return {};
 }
 
 QJsonObject buildBaseDocument()
@@ -184,10 +185,9 @@ void writeManifestToCustomPath(const QJsonDocument &manifest)
 
 namespace chatterino::nm::detail {
 
-Expected<void, WriteManifestError> writeManifestTo(QString directory,
-                                                   const QString &nmDirectory,
-                                                   const QString &filename,
-                                                   const QJsonDocument &json)
+ExpectedStr<void> writeManifestTo(QString directory, const QString &nmDirectory,
+                                  const QString &filename,
+                                  const QJsonDocument &json)
 {
     if (directory.startsWith('~'))
     {
@@ -197,25 +197,22 @@ Expected<void, WriteManifestError> writeManifestTo(QString directory,
     QDir dir(directory);
     if (!dir.exists(nmDirectory) && !dir.mkdir(nmDirectory))
     {
-        qCWarning(chatterinoNativeMessage)
-            << "Failed to create" << nmDirectory << "in" << directory;
-        return makeUnexpected(WriteManifestError::FailedToCreateDirectory);
+        return makeUnexpected(QString(u"Failed to create "_s % nmDirectory %
+                                      u" in "_s % directory));
     }
     dir.cd(nmDirectory);
 
     QFile file(dir.filePath(filename));
     if (!file.open(QFile::WriteOnly | QFile::Truncate))
     {
-        qCWarning(chatterinoNativeMessage)
-            << "Failed to open" << filename << "in" << directory;
-        return makeUnexpected(WriteManifestError::FailedToCreateFile);
+        return makeUnexpected(
+            QString(u"Failed to open "_s % filename % u" in "_s % directory));
     }
     const auto data = json.toJson();
     if (file.write(data) != data.size() || !file.flush())
     {
-        qCWarning(chatterinoNativeMessage)
-            << "Failed to write" << filename << "in" << directory;
-        return makeUnexpected(WriteManifestError::FailedToWriteFile);
+        return makeUnexpected(
+            QString(u"Failed to write "_s % filename % u" in "_s % directory));
     }
 
     return {};
@@ -266,10 +263,22 @@ bool registerNmHost(const Paths &paths)
     QJsonDocument chromeManifest = buildChromeManifest(extensionIDs);
     QJsonDocument firefoxManifest = buildFirefoxManifest(extensionIDs);
 
-    const bool chromeRegistered =
+    const auto chromeRegistered =
         registerNmManifest(paths, CHROME, chromeManifest);
-    const bool firefoxRegistered =
+    if (!chromeRegistered)
+    {
+        qCDebug(chatterinoNativeMessage)
+            << "Chrome native messaging registration:"
+            << chromeRegistered.error();
+    }
+    const auto firefoxRegistered =
         registerNmManifest(paths, FIREFOX, firefoxManifest);
+    if (!firefoxRegistered)
+    {
+        qCDebug(chatterinoNativeMessage)
+            << "Firefox native messaging registration:"
+            << firefoxRegistered.error();
+    }
 
 #ifndef Q_OS_WIN
     switch (getSettings()->customNativeMessagingManifestFormat.getEnum())
@@ -282,7 +291,7 @@ bool registerNmHost(const Paths &paths)
             break;
     }
 #endif
-    return chromeRegistered && firefoxRegistered;
+    return bool(chromeRegistered) && bool(firefoxRegistered);
 }
 
 void registerNmHost(Modes modes, const Paths &paths)

--- a/src/singletons/NativeMessaging.cpp
+++ b/src/singletons/NativeMessaging.cpp
@@ -197,8 +197,8 @@ ExpectedStr<void> writeManifestTo(QString directory, const QString &nmDirectory,
     QDir dir(directory);
     if (!dir.exists(nmDirectory) && !dir.mkdir(nmDirectory))
     {
-        return makeUnexpected(QString(u"Failed to create "_s % nmDirectory %
-                                      u" in "_s % directory));
+        return makeUnexpected(
+            QString(u"Failed to create " % nmDirectory % u" in " % directory));
     }
     dir.cd(nmDirectory);
 
@@ -206,13 +206,13 @@ ExpectedStr<void> writeManifestTo(QString directory, const QString &nmDirectory,
     if (!file.open(QFile::WriteOnly | QFile::Truncate))
     {
         return makeUnexpected(
-            QString(u"Failed to open "_s % filename % u" in "_s % directory));
+            QString(u"Failed to open " % filename % u" in " % directory));
     }
     const auto data = json.toJson();
     if (file.write(data) != data.size() || !file.flush())
     {
         return makeUnexpected(
-            QString(u"Failed to write "_s % filename % u" in "_s % directory));
+            QString(u"Failed to write " % filename % u" in " % directory));
     }
 
     return {};

--- a/src/singletons/NativeMessaging.cpp
+++ b/src/singletons/NativeMessaging.cpp
@@ -79,21 +79,32 @@ const Config CHROME{
 #endif
 };
 
-void registerNmManifest([[maybe_unused]] const Paths &paths,
+bool registerNmManifest([[maybe_unused]] const Paths &paths,
                         const Config &config, const QJsonDocument &document)
 {
 #ifdef Q_OS_WIN
-    std::ignore =
-        writeManifestTo(paths.miscDirectory, u"."_s, config.fileName, document);
+    if (!writeManifestTo(paths.miscDirectory, u"."_s, config.fileName,
+                         document))
+    {
+        return false;
+    }
 
     QSettings registry(config.registryKey, QSettings::NativeFormat);
     registry.setValue("Default",
                       QString(paths.miscDirectory % u'/' % config.fileName));
+    registry.sync();
+    if (registry.status() != QSettings::NoError)
+    {
+        qCWarning(chatterinoNativeMessage)
+            << "Failed to register native messaging host in"
+            << config.registryKey;
+        return false;
+    }
 #else
-    std::ignore =
-        writeManifestTo(config.browserDirectory, config.nmDirectory,
-                        u"com.chatterino.chatterino.json"_s, document);
+    return bool(writeManifestTo(config.browserDirectory, config.nmDirectory,
+                                u"com.chatterino.chatterino.json"_s, document));
 #endif
+    return true;
 }
 
 QJsonObject buildBaseDocument()
@@ -199,7 +210,13 @@ Expected<void, WriteManifestError> writeManifestTo(QString directory,
             << "Failed to open" << filename << "in" << directory;
         return makeUnexpected(WriteManifestError::FailedToCreateFile);
     }
-    file.write(json.toJson());
+    const auto data = json.toJson();
+    if (file.write(data) != data.size() || !file.flush())
+    {
+        qCWarning(chatterinoNativeMessage)
+            << "Failed to write" << filename << "in" << directory;
+        return makeUnexpected(WriteManifestError::FailedToWriteFile);
+    }
 
     return {};
 }
@@ -240,13 +257,8 @@ namespace chatterino {
 using namespace chatterino::nm::detail;
 using namespace literals;
 
-void registerNmHost(const Modes &modes, const Paths &paths)
+bool registerNmHost(const Paths &paths)
 {
-    if (modes.isPortable)
-    {
-        return;
-    }
-
     QStringList extensionIDs =
         getSettings()->additionalExtensionIDs.getValue().split(
             ';', Qt::SkipEmptyParts);
@@ -254,8 +266,10 @@ void registerNmHost(const Modes &modes, const Paths &paths)
     QJsonDocument chromeManifest = buildChromeManifest(extensionIDs);
     QJsonDocument firefoxManifest = buildFirefoxManifest(extensionIDs);
 
-    registerNmManifest(paths, CHROME, chromeManifest);
-    registerNmManifest(paths, FIREFOX, firefoxManifest);
+    const bool chromeRegistered =
+        registerNmManifest(paths, CHROME, chromeManifest);
+    const bool firefoxRegistered =
+        registerNmManifest(paths, FIREFOX, firefoxManifest);
 
 #ifndef Q_OS_WIN
     switch (getSettings()->customNativeMessagingManifestFormat.getEnum())
@@ -268,6 +282,17 @@ void registerNmHost(const Modes &modes, const Paths &paths)
             break;
     }
 #endif
+    return chromeRegistered && firefoxRegistered;
+}
+
+void registerNmHost(Modes modes, const Paths &paths)
+{
+    if (modes.isPortable)
+    {
+        return;
+    }
+
+    std::ignore = registerNmHost(paths);
 }
 
 std::string &getNmQueueName(const Paths &paths)

--- a/src/singletons/NativeMessaging.hpp
+++ b/src/singletons/NativeMessaging.hpp
@@ -15,16 +15,9 @@
 
 namespace chatterino::nm::detail {
 
-enum class WriteManifestError : std::uint8_t {
-    FailedToCreateDirectory,
-    FailedToCreateFile,
-    FailedToWriteFile,
-};
-
-Expected<void, WriteManifestError> writeManifestTo(QString directory,
-                                                   const QString &nmDirectory,
-                                                   const QString &filename,
-                                                   const QJsonDocument &json);
+ExpectedStr<void> writeManifestTo(QString directory, const QString &nmDirectory,
+                                  const QString &filename,
+                                  const QJsonDocument &json);
 
 #ifndef Q_OS_WIN
 /// Parse `path` by replacing '~', '$XDG_CONFIG_HOME' and '$XDG_DATA_HOME'

--- a/src/singletons/NativeMessaging.hpp
+++ b/src/singletons/NativeMessaging.hpp
@@ -18,6 +18,7 @@ namespace chatterino::nm::detail {
 enum class WriteManifestError : std::uint8_t {
     FailedToCreateDirectory,
     FailedToCreateFile,
+    FailedToWriteFile,
 };
 
 Expected<void, WriteManifestError> writeManifestTo(QString directory,
@@ -43,7 +44,8 @@ class Modes;
 
 using ChannelPtr = std::shared_ptr<Channel>;
 
-void registerNmHost(const Modes &modes, const Paths &paths);
+void registerNmHost(Modes modes, const Paths &paths);
+bool registerNmHost(const Paths &paths);
 std::string &getNmQueueName(const Paths &paths);
 
 Atomic<std::optional<QString>> &nmIpcError();

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -950,7 +950,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         formatRichNamedLink(FIREFOX_EXTENSION_LINK, "Download for Firefox"));
 
 #ifdef Q_OS_WIN
-    if (Modes{getApp()->getArgs()}.isPortable)
+    if (getApp()->getModes().isPortable)
     {
         layout.addDescription(
             "Portable Chatterino does not register browser integration "

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -6,6 +6,7 @@
 
 #include "Application.hpp"
 #include "common/Literals.hpp"  // IWYU pragma: keep
+#include "common/Modes.hpp"
 #include "common/Version.hpp"
 #include "controllers/hotkeys/HotkeyCategory.hpp"
 #include "controllers/hotkeys/HotkeyController.hpp"
@@ -949,6 +950,27 @@ void GeneralPage::initLayout(GeneralPageView &layout)
         formatRichNamedLink(FIREFOX_EXTENSION_LINK, "Download for Firefox"));
 
 #ifdef Q_OS_WIN
+    if (Modes{getApp()->getArgs()}.isPortable)
+    {
+        layout.addDescription(
+            "Portable Chatterino does not register browser integration "
+            "automatically. Registration writes to your Windows user registry "
+            "to point your browser extension to this copy of Chatterino. "
+            "You may manually register it below.");
+        layout.addButton("Register browser integration", [this] {
+            if (registerNmHost(getApp()->getPaths()))
+            {
+                QMessageBox::information(this, "Registration Successful",
+                                         "Browser integration registered.");
+            }
+            else
+            {
+                QMessageBox::warning(this, "Registration Failed",
+                                     "Failed to register browser integration.");
+            }
+        });
+    }
+
     layout.addDescription("Chatterino only attaches to known browsers to avoid "
                           "attaching to other windows by accident.");
     SettingWidget::checkbox("Attach to any browser (may cause issues)",

--- a/tests/src/NativeMessaging.cpp
+++ b/tests/src/NativeMessaging.cpp
@@ -51,7 +51,8 @@ TEST_F(NativeMessagingFixture, writeManifestToSubDirNotCreated)
     ASSERT_EQ(writeManifestTo(this->dir.path(), "native-messaging-hosts",
                               "test.json", QJsonDocument())
                   .error(),
-              WriteManifestError::FailedToCreateDirectory);
+              QString("Failed to create native-messaging-hosts in %1")
+                  .arg(this->dir.path()));
 }
 
 TEST_F(NativeMessagingFixture, writeManifestToWindowsCurrentDir)


### PR DESCRIPTION
Chatterino skips registration for browser integration in portable mode, presumably because the registration writes to Windows registry.

Added a button in settings to manually register for browser integration. It only appears on Windows in portable mode.

<img width="544" height="401" alt="image" src="https://github.com/user-attachments/assets/b8a18cf1-61dc-4d39-bb5b-5cfad5ceb3f8" />

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
