### PR TITLE
refactor: remove unused parseTime from Message

### DIFF
--- a/docs/chatterino.d.ts
+++ b/docs/chatterino.d.ts
@@ -193,7 +193,6 @@ declare namespace c2 {
     interface Message {
         flags: MessageFlag;
         id: string;
-        parse_time: number;
         search_text: string;
         message_text: string;
         login_name: string;
@@ -218,7 +217,6 @@ declare namespace c2 {
     interface MessageInit {
         flags?: MessageFlag;
         id?: string;
-        parse_time?: number;
         search_text?: string;
         message_text?: string;
         login_name?: string;

--- a/docs/lua-meta/globals.lua
+++ b/docs/lua-meta/globals.lua
@@ -745,7 +745,6 @@ function c2.MessageElementBase:add_flags(flags) end
 ---A chat message
 ---@class c2.Message
 ---@field flags c2.MessageFlag The message's flags
----@field parse_time number Time the message was parsed (in milliseconds since epoch)
 ---@field id string The message ID
 ---@field search_text string Text to check when searching for messages
 ---@field message_text string Text content of this message (used for filters for example)
@@ -779,7 +778,6 @@ function c2.Message:clone() end
 ---@class MessageInit
 ---@field flags? c2.MessageFlag Message flags (see `c2.MessageFlags`)
 ---@field id? string The (ideally unique) message ID
----@field parse_time? number Time the message was parsed (in milliseconds since epoch)
 ---@field search_text? string Text to that is compared when searching for messages
 ---@field message_text? string The message text (used for filters for example)
 ---@field login_name? string The login name of the sender

--- a/src/controllers/plugins/api/Message.cpp
+++ b/src/controllers/plugins/api/Message.cpp
@@ -712,16 +712,6 @@ void createUserType(sol::table &c2)
                 // flags are always mutable
                 msg->flags = f;
             }),
-        "parse_time",
-        sol::property(
-            [](Message *msg) {
-                return QDateTime(QDate::currentDate(), msg->parseTime)
-                    .toMSecsSinceEpoch();
-            },
-            [](Message *msg, qint64 ms) {
-                checkWritable(msg);
-                msg->parseTime = datetimeFromOffset(ms).time();
-            }),
         "id", memberAccessor<&Message::id>(),                         //
         "search_text", memberAccessor<&Message::searchText>(),        //
         "message_text", memberAccessor<&Message::messageText>(),      //
@@ -811,13 +801,6 @@ std::shared_ptr<Message> messageFromTable(const sol::table &tbl)
 {
     auto msg = std::make_shared<Message>();
     msg->flags = tbl.get_or("flags", MessageFlag::None);
-
-    // This takes a UTC offset (not the milliseconds since the start of the day)
-    auto parseTime = tbl.get<std::optional<qint64>>("parse_time");
-    if (parseTime)
-    {
-        msg->parseTime = datetimeFromOffset(*parseTime).time();
-    }
 
     msg->id = tbl.get_or("id", QString{});
     msg->searchText = tbl.get_or("search_text", QString{});

--- a/src/controllers/plugins/api/Message.hpp
+++ b/src/controllers/plugins/api/Message.hpp
@@ -177,7 +177,6 @@ function c2.MessageElementBase:add_flags(flags) end
 ---A chat message
 ---@class c2.Message
 ---@field flags c2.MessageFlag The message's flags
----@field parse_time number Time the message was parsed (in milliseconds since epoch)
 ---@field id string The message ID
 ---@field search_text string Text to check when searching for messages
 ---@field message_text string Text content of this message (used for filters for example)
@@ -211,7 +210,6 @@ function c2.Message:clone() end
 ---@class MessageInit
 ---@field flags? c2.MessageFlag Message flags (see `c2.MessageFlags`)
 ---@field id? string The (ideally unique) message ID
----@field parse_time? number Time the message was parsed (in milliseconds since epoch)
 ---@field search_text? string Text to that is compared when searching for messages
 ---@field message_text? string The message text (used for filters for example)
 ---@field login_name? string The login name of the sender

--- a/src/messages/Message.cpp
+++ b/src/messages/Message.cpp
@@ -4,7 +4,6 @@
 
 #include "messages/Message.hpp"
 
-#include "Application.hpp"
 #include "common/Literals.hpp"
 #include "messages/MessageThread.hpp"
 #include "providers/colors/ColorProvider.hpp"
@@ -23,7 +22,6 @@ namespace chatterino {
 using namespace literals;
 
 Message::Message()
-    : parseTime(QTime::currentTime())
 {
     DebugCount::increase(DebugObject::Message);
 }
@@ -112,7 +110,6 @@ std::shared_ptr<Message> Message::clone() const
 {
     auto cloned = std::make_shared<Message>();
     cloned->flags = this->flags;
-    cloned->parseTime = this->parseTime;
     cloned->id = this->id;
     cloned->searchText = this->searchText;
     cloned->messageText = this->messageText;
@@ -206,12 +203,6 @@ QJsonObject Message::toJson() const
     {
         msg["announcementColor"_L1] =
             qmagicenum::enumNameString(this->announcementColor);
-    }
-
-    // XXX: figure out if we can add this in tests
-    if (!getApp()->isTest())
-    {
-        msg["parseTime"_L1] = this->parseTime.toString(Qt::ISODate);
     }
 
     QJsonArray elements;

--- a/src/messages/Message.hpp
+++ b/src/messages/Message.hpp
@@ -11,7 +11,7 @@
 #include "util/QStringHash.hpp"
 
 #include <QColor>
-#include <QTime>
+#include <QDateTime>
 
 #include <cinttypes>
 #include <memory>
@@ -46,7 +46,6 @@ struct Message {
     // const-correct way to deal with this is.
     // This might bring race conditions with it
     mutable MessageFlags flags;
-    QTime parseTime;
     QString id;
     QString searchText;
     QString messageText;

--- a/tests/lua/message/clone.lua
+++ b/tests/lua/message/clone.lua
@@ -10,7 +10,6 @@ local tests = {
         local msg = c2.Message.new({
             flags = c2.MessageFlag.DoNotTriggerNotification,
             id = "123",
-            parse_time = 12345678,
             search_text = "search",
             message_text = "message text",
             login_name = "login",
@@ -35,7 +34,6 @@ local tests = {
         assert(msg ~= clone)
         assert(msg.flags == clone.flags)
         assert(msg.id == clone.id)
-        assert(msg.parse_time == clone.parse_time)
         assert(msg.search_text == clone.search_text)
         assert(msg.message_text == clone.message_text)
         assert(msg.login_name == clone.login_name)

--- a/tests/snapshots/PluginMessageCtor/properties.json
+++ b/tests/snapshots/PluginMessageCtor/properties.json
@@ -3,7 +3,6 @@
         "msg = {",
         "  flags = c2.MessageFlag.System | c2.MessageFlag.Disabled,",
         "  id = 'foo-bar',",
-        "  parse_time = 420000,",
         "  search_text = 'search',",
         "  message_text = 'message',",
         "  login_name = 'login',",

--- a/tests/src/Plugins.cpp
+++ b/tests/src/Plugins.cpp
@@ -1134,9 +1134,6 @@ TEST_F(PluginTest, MessageModification)
     sol::table tests = lua->script(R"lua(
         return {
             function(msg)
-                msg.parse_time = 1234567
-            end,
-            function(msg)
                 assert(msg.id == "abc")
                 msg.id = "1234"
                 assert(msg.id == "1234")


### PR DESCRIPTION
`parseTime` no longer has any consumers and has been the source of a few bugs when consumers expected it to function like a timestamp.

Discussion from #7248:

>If this and #7244 are merged, then all consumers of `parseTime` will have been removed (aside from the plugin API). At that point I think it would make sense to consider removing `parseTime` entirely, or else replacing it with a full timestamp, to avoid similar bugs in future.
>
>_Originally posted by @3r01 in https://github.com/Chatterino/chatterino2/issues/7248#issuecomment-5566889394_
            

>I don't think there's any use for `parseTime` - even in plugins. Removing `parseTime` and renaming `serverReceivedTime` to `timestamp` is something we could do.
>
> _Originally posted by @Nerixyz in https://github.com/Chatterino/chatterino2/issues/7248#issuecomment-5567319892_
            
I will create a separate PR for renaming `serverReceivedTime` to `timestamp`.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->